### PR TITLE
Make sure cast checks for JS collections work

### DIFF
--- a/hummingbird-client/src/main/java/com/vaadin/client/hummingbird/collection/JsArray.java
+++ b/hummingbird-client/src/main/java/com/vaadin/client/hummingbird/collection/JsArray.java
@@ -20,6 +20,7 @@ import com.google.gwt.core.client.GWT;
 import com.vaadin.client.hummingbird.collection.jre.JreJsArray;
 
 import jsinterop.annotations.JsOverlay;
+import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 
@@ -32,7 +33,7 @@ import jsinterop.annotations.JsType;
  * @param <T>
  *            the type of the array items
  */
-@JsType(isNative = true)
+@JsType(isNative = true, name = "Array", namespace = JsPackage.GLOBAL)
 public class JsArray<T> {
     /*
      * Don't look at this class as an example of how to integrate a JS API with

--- a/hummingbird-client/src/main/java/com/vaadin/client/hummingbird/collection/JsCollections.java
+++ b/hummingbird-client/src/main/java/com/vaadin/client/hummingbird/collection/JsCollections.java
@@ -103,7 +103,7 @@ public class JsCollections {
 
     private static native <T> JsArray<T> createNativeArray()
     /*-{
-        return [];
+        return new $wnd.Array();
     }-*/;
 
     private static native <K, V> JsMap<K, V> createNativeMap()

--- a/hummingbird-client/src/test-gwt/java/com/vaadin/client/hummingbird/collection/GwtJsArrayTest.java
+++ b/hummingbird-client/src/test-gwt/java/com/vaadin/client/hummingbird/collection/GwtJsArrayTest.java
@@ -19,6 +19,7 @@ package com.vaadin.client.hummingbird.collection;
 import org.junit.Test;
 
 import com.vaadin.client.ClientEngineTestBase;
+import com.vaadin.client.WidgetUtil;
 
 public class GwtJsArrayTest extends ClientEngineTestBase {
 
@@ -155,6 +156,10 @@ public class GwtJsArrayTest extends ClientEngineTestBase {
         } catch (IllegalArgumentException e) {
             // Expected
         }
+    }
 
+    public void testCanCast() {
+        // Ok if this doesn't throw ClassCastException
+        JsArray<Object> array = WidgetUtil.crazyJsCast(JsCollections.array());
     }
 }

--- a/hummingbird-client/src/test-gwt/java/com/vaadin/client/hummingbird/collection/GwtJsMapTest.java
+++ b/hummingbird-client/src/test-gwt/java/com/vaadin/client/hummingbird/collection/GwtJsMapTest.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.vaadin.client.ClientEngineTestBase;
+import com.vaadin.client.WidgetUtil;
 
 public class GwtJsMapTest extends ClientEngineTestBase {
 
@@ -86,6 +87,11 @@ public class GwtJsMapTest extends ClientEngineTestBase {
         map.clear();
         values = JsCollections.mapValues(map);
         assertEquals(0, values.length());
+    }
+
+    public void testCanCast() {
+        // Ok if this doesn't throw ClassCastException
+        JsMap<Object, Object> map = WidgetUtil.crazyJsCast("foo");
     }
 
 }

--- a/hummingbird-client/src/test-gwt/java/com/vaadin/client/hummingbird/collection/GwtJsSetTest.java
+++ b/hummingbird-client/src/test-gwt/java/com/vaadin/client/hummingbird/collection/GwtJsSetTest.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import com.vaadin.client.ClientEngineTestBase;
+import com.vaadin.client.WidgetUtil;
 
 public class GwtJsSetTest extends ClientEngineTestBase {
 
@@ -85,5 +86,10 @@ public class GwtJsSetTest extends ClientEngineTestBase {
         assertTrue(copy.has("1"));
         assertTrue(copy.has("2"));
         assertFalse(copy.has("3"));
+    }
+
+    public void testCanCast() {
+        // Ok if this doesn't throw ClassCastException
+        JsSet<Object> set = WidgetUtil.crazyJsCast(JsCollections.set());
     }
 }


### PR DESCRIPTION
GWT generates explicit cast checks for JsArray because it's implemented as a class instead of an interface. These checks are based on the name and namespace from @JsType, as evaluated in $wnd.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/134)

<!-- Reviewable:end -->
