### PR TITLE
Fix tests for JS collections

### DIFF
--- a/hummingbird-client/src/test-gwt/java/com/vaadin/client/hummingbird/collection/GwtJsArrayTest.java
+++ b/hummingbird-client/src/test-gwt/java/com/vaadin/client/hummingbird/collection/GwtJsArrayTest.java
@@ -158,6 +158,14 @@ public class GwtJsArrayTest extends ClientEngineTestBase {
         }
     }
 
+    /**
+     * Tests that it's possible to cast an instance to its own type.
+     *
+     * Most of the JS produced by GWT does not make any assertions about types,
+     * but explicit casts and some use of generics leads to code that might do a
+     * JavaScript instanceof check for @JsType classes, thus failing if the type
+     * defined in the annotation doesn't match the runtime type.
+     */
     public void testCanCast() {
         // Ok if this doesn't throw ClassCastException
         JsArray<Object> array = WidgetUtil.crazyJsCast(JsCollections.array());

--- a/hummingbird-client/src/test-gwt/java/com/vaadin/client/hummingbird/collection/GwtJsMapTest.java
+++ b/hummingbird-client/src/test-gwt/java/com/vaadin/client/hummingbird/collection/GwtJsMapTest.java
@@ -89,9 +89,17 @@ public class GwtJsMapTest extends ClientEngineTestBase {
         assertEquals(0, values.length());
     }
 
+    /**
+     * Tests that it's possible to cast an instance to its own type.
+     *
+     * Most of the JS produced by GWT does not make any assertions about types,
+     * but explicit casts and some use of generics leads to code that might do a
+     * JavaScript instanceof check for @JsType classes, thus failing if the type
+     * defined in the annotation doesn't match the runtime type.
+     */
     public void testCanCast() {
         // Ok if this doesn't throw ClassCastException
-        JsMap<Object, Object> map = WidgetUtil.crazyJsCast("foo");
+        JsMap<Object, Object> map = WidgetUtil.crazyJsCast(JsCollections.map());
     }
 
 }

--- a/hummingbird-client/src/test-gwt/java/com/vaadin/client/hummingbird/collection/GwtJsSetTest.java
+++ b/hummingbird-client/src/test-gwt/java/com/vaadin/client/hummingbird/collection/GwtJsSetTest.java
@@ -88,6 +88,14 @@ public class GwtJsSetTest extends ClientEngineTestBase {
         assertFalse(copy.has("3"));
     }
 
+    /**
+     * Tests that it's possible to cast an instance to its own type.
+     *
+     * Most of the JS produced by GWT does not make any assertions about types,
+     * but explicit casts and some use of generics leads to code that might do a
+     * JavaScript instanceof check for @JsType classes, thus failing if the type
+     * defined in the annotation doesn't match the runtime type.
+     */
     public void testCanCast() {
         // Ok if this doesn't throw ClassCastException
         JsSet<Object> set = WidgetUtil.crazyJsCast(JsCollections.set());

--- a/hummingbird-client/src/test/java/com/vaadin/client/hummingbird/collection/JreMapTest.java
+++ b/hummingbird-client/src/test/java/com/vaadin/client/hummingbird/collection/JreMapTest.java
@@ -40,7 +40,7 @@ public class JreMapTest {
 
         Assert.assertEquals(1, (int) map.get("One"));
         Assert.assertEquals(2, (int) map.get("Two"));
-        Assert.assertNull(map.get("Threee"));
+        Assert.assertNull(map.get("Three"));
 
         Assert.assertTrue(map.delete("One"));
         Assert.assertFalse(map.delete("Three"));
@@ -49,6 +49,30 @@ public class JreMapTest {
         map.clear();
         Assert.assertEquals(0, map.size());
         Assert.assertFalse(map.has("Two"));
+    }
+
+    @Test
+    public void testMapValues() {
+        JsMap<String, Integer> map = JsCollections.map();
+
+        map.set("One", 1).set("Two", 2);
+
+        JsArray<Integer> values = JsCollections.mapValues(map);
+
+        Assert.assertEquals(2, values.length());
+
+        Assert.assertEquals(1, values.get(0).intValue());
+        Assert.assertEquals(2, values.get(1).intValue());
+
+        map.delete("One");
+
+        values = JsCollections.mapValues(map);
+        Assert.assertEquals(1, values.length());
+        Assert.assertEquals(2, values.get(0).intValue());
+
+        map.clear();
+        values = JsCollections.mapValues(map);
+        Assert.assertEquals(0, values.length());
     }
 
     @Test


### PR DESCRIPTION
- Test JsCollections.mapValues in the JRE as well
- Fix typo in map test
- Make the map cast test actually test something
- Clarify the purpose of the cast check

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/145)

<!-- Reviewable:end -->
