### PR TITLE
Use Command instead of Runnable for access methods

### DIFF
--- a/hummingbird-server/src/main/java/com/vaadin/server/Command.java
+++ b/hummingbird-server/src/main/java/com/vaadin/server/Command.java
@@ -15,24 +15,16 @@
  */
 package com.vaadin.server;
 
-import java.io.Serializable;
-
 /**
- * Defines the interface to handle exceptions thrown during the execution of a
- * FutureAccess.
+ * A generic command interface meant to be used for passing lambdas around.
  *
- * @since 7.1.8
- * @author Vaadin Ltd
+ * @author Vaadin
+ * @since
  */
-public interface ErrorHandlingRunnable extends Runnable, Serializable {
-
+@FunctionalInterface
+public interface Command {
     /**
-     * Handles exceptions thrown during the execution of a FutureAccess.
-     *
-     * @since 7.1.8
-     * @param exception
-     *            the thrown exception.
+     * Runs the given command.
      */
-    public void handleError(Exception exception);
-
+    void execute();
 }

--- a/hummingbird-server/src/main/java/com/vaadin/server/ErrorHandlingCommand.java
+++ b/hummingbird-server/src/main/java/com/vaadin/server/ErrorHandlingCommand.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.server;
+
+import java.io.Serializable;
+
+/**
+ * Defines the interface to handle exceptions thrown during the execution of a
+ * FutureAccess.
+ *
+ * @since 7.1.8
+ * @author Vaadin Ltd
+ */
+public interface ErrorHandlingCommand extends Command, Serializable {
+
+    /**
+     * Handles exceptions thrown during the execution of a FutureAccess.
+     *
+     * @since 7.1.8
+     * @param exception
+     *            the thrown exception.
+     */
+    void handleError(Exception exception);
+
+}

--- a/hummingbird-server/src/main/java/com/vaadin/server/RequestHandler.java
+++ b/hummingbird-server/src/main/java/com/vaadin/server/RequestHandler.java
@@ -37,8 +37,8 @@ public interface RequestHandler extends Serializable {
      * using VaadinSession or anything inside the VaadinSession you must ensure
      * the session is locked. This can be done by extending
      * {@link SynchronizedRequestHandler} or by using
-     * {@link VaadinSession#accessSynchronously(Runnable)} or
-     * {@link UI#accessSynchronously(Runnable)}.
+     * {@link VaadinSession#accessSynchronously(Command)} or
+     * {@link UI#accessSynchronously(Command)}.
      * </p>
      *
      * @param session

--- a/hummingbird-server/src/main/java/com/vaadin/util/CurrentInstance.java
+++ b/hummingbird-server/src/main/java/com/vaadin/util/CurrentInstance.java
@@ -26,6 +26,7 @@ import java.util.Map.Entry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.vaadin.server.Command;
 import com.vaadin.server.VaadinRequest;
 import com.vaadin.server.VaadinResponse;
 import com.vaadin.server.VaadinService;
@@ -37,7 +38,7 @@ import com.vaadin.ui.UI;
  * instances are automatically cleared after handling a request from the client
  * to avoid leaking memory. The inheritable values are also maintained when
  * execution is moved to another thread, both when a new thread is created and
- * when {@link VaadinSession#access(Runnable)} or {@link UI#access(Runnable)} is
+ * when {@link VaadinSession#access(Command)} or {@link UI#access(Command)} is
  * used.
  * <p>
  * Please note that the instances are stored using {@link WeakReference}. This
@@ -168,8 +169,8 @@ public class CurrentInstance implements Serializable {
     /**
      * Sets the current inheritable instance of the given type. A current
      * instance that is inheritable will be available for child threads and in
-     * code run by {@link VaadinSession#access(Runnable)} and
-     * {@link UI#access(Runnable)}.
+     * code run by {@link VaadinSession#access(Command)} and
+     * {@link UI#access(Command)}.
      *
      * @see #set(Class, Object)
      * @see InheritableThreadLocal

--- a/hummingbird-server/src/test/java/com/vaadin/hummingbird/namespace/MapNamespaceTest.java
+++ b/hummingbird-server/src/test/java/com/vaadin/hummingbird/namespace/MapNamespaceTest.java
@@ -29,6 +29,7 @@ import com.vaadin.hummingbird.StateNodeTest;
 import com.vaadin.hummingbird.change.MapPutChange;
 import com.vaadin.hummingbird.change.MapRemoveChange;
 import com.vaadin.hummingbird.change.NodeChange;
+import com.vaadin.server.Command;
 
 import elemental.json.Json;
 import elemental.json.JsonValue;
@@ -159,10 +160,10 @@ public class MapNamespaceTest
         assertFailsAssert("remove(null)", () -> namespace.remove(null));
     }
 
-    private static void assertFailsAssert(String name, Runnable runnable) {
+    private static void assertFailsAssert(String name, Command command) {
         boolean threw = false;
         try {
-            runnable.run();
+            command.execute();
         } catch (AssertionError expected) {
             threw = true;
         }


### PR DESCRIPTION
Runnable is defined as "The Runnable interface should be implemented by any
class whose instances are intended to be executed by a thread."

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/242)

<!-- Reviewable:end -->
