### PR TITLE
Exclude gwt-user to reduce final war size

### DIFF
--- a/hummingbird-server/pom.xml
+++ b/hummingbird-server/pom.xml
@@ -47,6 +47,12 @@
 		<dependency>
 			<groupId>com.google.gwt</groupId>
 			<artifactId>gwt-elemental</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.gwt</groupId>
+					<artifactId>gwt-user</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<!-- Grid, BootstrapHandler, ... uses -->


### PR DESCRIPTION
The gwt-user package is officially a dependency of gwt-elemental but
is only used for client side JS code.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/261)

<!-- Reviewable:end -->
