### PR TITLE
Use different ports for IT module servers

### DIFF
--- a/hummingbird-test-util/src/main/java/com/vaadin/hummingbird/testutil/AbstractTestBenchTest.java
+++ b/hummingbird-test-util/src/main/java/com/vaadin/hummingbird/testutil/AbstractTestBenchTest.java
@@ -31,7 +31,22 @@ import com.vaadin.ui.UI;
  */
 public abstract class AbstractTestBenchTest extends TestBenchHelpers {
 
-    private String hostnameAndPort = "http://localhost:8888";
+    /**
+     * Default port for test server, possibly overridden with system property.
+     */
+    private static final String DEFAULT_SERVER_PORT = "8888";
+
+    /** System property key for the test server port. */
+    public static final String SERVER_PORT_PROPERTY_KEY = "serverPort";
+    /**
+     * Server port resolved by system property
+     * {@value #SERVER_PORT_PROPERTY_KEY} or the default
+     * {@value #DEFAULT_SERVER_PORT}.
+     */
+    public static final String SERVER_PORT = System
+            .getProperty(SERVER_PORT_PROPERTY_KEY, DEFAULT_SERVER_PORT);
+
+    private String hostnameAndPort = "http://localhost:" + SERVER_PORT;
 
     protected void open() {
         open((String[]) null);

--- a/hummingbird-tests/pom.xml
+++ b/hummingbird-tests/pom.xml
@@ -22,6 +22,10 @@
 		<jetty.plugin.version>9.2.15.v20160210</jetty.plugin.version>
 		<!-- Don't care about coding style for tests -->
 		<sonar.skip>true</sonar.skip>
+		<!-- Used in the tests, should be overridden for each module to support 
+			concurrent running of test modules. -->
+		<server.port>8888</server.port>
+		<server.stop.port>8889</server.stop.port>
 	</properties>
 
 	<dependencies>
@@ -55,6 +59,12 @@
 						</goals>
 					</execution>
 				</executions>
+				<configuration>
+					<!-- export test server port to integration tests -->
+					<systemPropertyVariables>
+						<serverPort>${server.port}</serverPort>
+					</systemPropertyVariables>
+				</configuration>
 			</plugin>
 			<!-- jetty plugin for those child modules that need it -->
 			<plugin>
@@ -69,9 +79,9 @@
 					</webAppConfig>
 					<scanIntervalSeconds>-1</scanIntervalSeconds>
 					<httpConnector>
-						<port>8888</port>
+						<port>${server.port}</port>
 					</httpConnector>
-					<stopPort>8889</stopPort>
+					<stopPort>${server.stop.port}</stopPort>
 					<stopKey>foo</stopKey>
 					<stopWait>5</stopWait>
 				</configuration>
@@ -103,6 +113,11 @@
 									<resourceBase>${project.basedir}/../test-resources/src/main/resources/META-INF/resources</resourceBase>
 								</resourceBases>
 							</webAppConfig>
+							<!-- force default ports so that running IT tests from IDE work -->
+							<httpConnector>
+								<port>8888</port>
+							</httpConnector>
+							<stopPort>8889</stopPort>
 						</configuration>
 					</plugin>
 				</plugins>

--- a/hummingbird-tests/test-root-context/pom.xml
+++ b/hummingbird-tests/test-root-context/pom.xml
@@ -10,6 +10,9 @@
 	<artifactId>test-root-context</artifactId>
 	<name>Hummingbird root context tests</name>
 	<packaging>war</packaging>
+
+	<!-- uses default ports 8888 and 8889 -->
+
 	<dependencies>
 		<dependency>
 			<groupId>com.vaadin</groupId>

--- a/hummingbird-tests/test-subcontext/pom.xml
+++ b/hummingbird-tests/test-subcontext/pom.xml
@@ -11,6 +11,11 @@
 	<name>Hummingbird tests mapped for /context</name>
 	<packaging>war</packaging>
 
+	<properties>
+		<server.port>9999</server.port>
+		<server.stop.port>9998</server.stop.port>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>com.vaadin</groupId>


### PR DESCRIPTION
Makes it possible to run tests for multiple IT modules simultaneously.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/298)

<!-- Reviewable:end -->
