### PR TITLE
Distinguish between "foo" and "foo/" when parsing locations

### DIFF
--- a/hummingbird-server/src/main/java/com/vaadin/hummingbird/router/Location.java
+++ b/hummingbird-server/src/main/java/com/vaadin/hummingbird/router/Location.java
@@ -16,6 +16,7 @@
 package com.vaadin.hummingbird.router;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -29,6 +30,7 @@ import java.util.List;
  */
 public class Location implements Serializable {
 
+    private static final String PATH_SEPARATOR = "/";
     private List<String> segments;
 
     /**
@@ -38,9 +40,9 @@ public class Location implements Serializable {
      *            the relative path, not <code>null</code>
      */
     public Location(String path) {
-        this(Arrays.asList(path.split("/")));
+        this(parsePath(path));
 
-        assert !path.startsWith("/") : "path should be relative";
+        assert !path.startsWith(PATH_SEPARATOR) : "path should be relative";
         assert !path.contains("?") : "query string not yet supported";
     }
 
@@ -100,6 +102,20 @@ public class Location implements Serializable {
             throw new IllegalStateException("Location has no path segments");
         } else {
             return new Location(segments.subList(1, segments.size()));
+        }
+    }
+
+    private static List<String> parsePath(String path) {
+        List<String> splitList = Arrays.asList(path.split(PATH_SEPARATOR));
+        if (path.endsWith(PATH_SEPARATOR)) {
+            // Explicitly add "" to the end even though it's ignored by
+            // String.split
+            ArrayList<String> result = new ArrayList<>(splitList.size() + 1);
+            result.addAll(splitList);
+            result.add("");
+            return result;
+        } else {
+            return splitList;
         }
     }
 }

--- a/hummingbird-server/src/test/java/com/vaadin/hummingbird/router/LocationTest.java
+++ b/hummingbird-server/src/test/java/com/vaadin/hummingbird/router/LocationTest.java
@@ -30,6 +30,14 @@ public class LocationTest {
                 location.getSegments());
     }
 
+    @Test
+    public void parseLocationWithEndingSlash() {
+        Location location = new Location("foo/bar/");
+
+        Assert.assertEquals(Arrays.asList("foo", "bar", ""),
+                location.getSegments());
+    }
+
     @Test(expected = AssertionError.class)
     public void parseLocationStartingWithSlash() {
         new Location("/foo/bar");


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/311)

<!-- Reviewable:end -->
