### PR TITLE
Rename createHorizontalRule to createHr

### DIFF
--- a/hummingbird-server/src/main/java/com/vaadin/hummingbird/dom/ElementFactory.java
+++ b/hummingbird-server/src/main/java/com/vaadin/hummingbird/dom/ElementFactory.java
@@ -249,7 +249,7 @@ public interface ElementFactory {
      *
      * @return an {@code &lt;hr>} element.
      */
-    static Element createHorizontalRule() {
+    static Element createHr() {
         return new Element("hr");
     }
 

--- a/hummingbird-tests/test-root-context/src/main/java/com/vaadin/hummingbird/uitest/servlet/ViewTestLayout.java
+++ b/hummingbird-tests/test-root-context/src/main/java/com/vaadin/hummingbird/uitest/servlet/ViewTestLayout.java
@@ -62,7 +62,7 @@ public class ViewTestLayout implements HasChildView {
             ui.navigateTo(viewSelect.getProperty("value"));
         });
 
-        element.appendChild(viewSelect, ElementFactory.createHorizontalRule(),
+        element.appendChild(viewSelect, ElementFactory.createHr(),
                 viewContainer);
         viewContainer.appendChild(ElementFactory.createDiv());
     }

--- a/hummingbird-tests/test-root-context/src/main/java/com/vaadin/hummingbird/uitest/ui/RouterTestServlet.java
+++ b/hummingbird-tests/test-root-context/src/main/java/com/vaadin/hummingbird/uitest/ui/RouterTestServlet.java
@@ -91,7 +91,7 @@ public class RouterTestServlet extends VaadinServlet {
                     "sessionId");
             element.appendChild(sessionId);
             element.appendChild(ElementFactory.createDiv());
-            element.appendChild(ElementFactory.createHorizontalRule());
+            element.appendChild(ElementFactory.createHr());
         }
 
         @Override
@@ -138,7 +138,7 @@ public class RouterTestServlet extends VaadinServlet {
                     div.appendChild(ElementFactory.createRouterLink(viewName,
                             viewName));
                 }
-                div.appendChild(ElementFactory.createHorizontalRule());
+                div.appendChild(ElementFactory.createHr());
             });
         }
 

--- a/hummingbird-tests/test-root-context/src/main/java/com/vaadin/hummingbird/uitest/ui/push/ClientServerCounterUI.java
+++ b/hummingbird-tests/test-root-context/src/main/java/com/vaadin/hummingbird/uitest/ui/push/ClientServerCounterUI.java
@@ -96,7 +96,7 @@ public class ClientServerCounterUI extends UI {
     }
 
     protected void spacer() {
-        getElement().appendChild(ElementFactory.createHorizontalRule());
+        getElement().appendChild(ElementFactory.createHr());
     }
 
     @Override

--- a/hummingbird-tests/test-subcontext/src/main/java/com/vaadin/hummingbird/contexttest/ui/DependencyUI.java
+++ b/hummingbird-tests/test-subcontext/src/main/java/com/vaadin/hummingbird/contexttest/ui/DependencyUI.java
@@ -26,7 +26,7 @@ public class DependencyUI extends UI {
     protected void init(VaadinRequest request) {
         getElement().appendChild(ElementFactory.createDiv(
                 "This test initially loads a stylesheet which makes all text red and a javascript which listens to body clicks"));
-        getElement().appendChild(ElementFactory.createHorizontalRule());
+        getElement().appendChild(ElementFactory.createHr());
         getPage().addStyleSheet("context://test-files/css/allred.css");
         getPage().addJavaScript(getServletToContextPath(
                 "test-files/js/body-click-listener.js"));
@@ -49,7 +49,7 @@ public class DependencyUI extends UI {
                     "context://test-files/css/allblueimportant.css");
 
         });
-        getElement().appendChild(jsOrder, allBlue, ElementFactory.createHorizontalRule());
+        getElement().appendChild(jsOrder, allBlue, ElementFactory.createHr());
     }
 
     protected String getServletToContextPath(String url) {


### PR DESCRIPTION
HTML5 defines <hr> as a "paragraph-level thematic break" without any
references to its typical graphical representation. "horizontal rule" is
only used in HTML4 and older.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/490)

<!-- Reviewable:end -->
