### PR TITLE
Removes unnecessary event bus creation on fireEvent

### DIFF
--- a/hummingbird-server/src/main/java/com/vaadin/hummingbird/event/ComponentEventBus.java
+++ b/hummingbird-server/src/main/java/com/vaadin/hummingbird/event/ComponentEventBus.java
@@ -92,6 +92,22 @@ public class ComponentEventBus implements Serializable {
     }
 
     /**
+     * Checks if there is at least one listener registered for the given event
+     * type.
+     *
+     * @param eventType
+     *            the component event type
+     * @return <code>true</code> if at least one listener is registered,
+     *         <code>false</code> otherwise
+     */
+    public boolean hasListener(Class<? extends ComponentEvent> eventType) {
+        if (eventType == null) {
+            throw new IllegalArgumentException("Event type cannot be null");
+        }
+        return componentEventData.containsKey(eventType);
+    }
+
+    /**
      * Dispatches the event to all listeners registered for the event type.
      *
      * @param event
@@ -124,19 +140,6 @@ public class ComponentEventBus implements Serializable {
 
         ComponentEventBusUtil.getDomEventType(eventType)
                 .ifPresent(e -> addDomTrigger(eventType, e));
-    }
-
-    /**
-     * Checks if there is at least one listener registered for the given event
-     * type.
-     *
-     * @param eventType
-     *            the component event type
-     * @return <code>true</code> if at least one listener is registered,
-     *         <code>false</code> otherwise
-     */
-    private boolean hasListener(Class<? extends ComponentEvent> eventType) {
-        return componentEventData.containsKey(eventType);
     }
 
     /**

--- a/hummingbird-server/src/main/java/com/vaadin/ui/Component.java
+++ b/hummingbird-server/src/main/java/com/vaadin/ui/Component.java
@@ -206,13 +206,28 @@ public abstract class Component
     }
 
     /**
+     * Checks if there is at least one listener registered for the given event
+     * type for this component.
+     *
+     * @param eventType
+     *            the component event type
+     * @return <code>true</code> if at least one listener is registered,
+     *         <code>false</code> otherwise
+     */
+    protected boolean hasListener(Class<? extends ComponentEvent> eventType) {
+        return eventBus != null && eventBus.hasListener(eventType);
+    }
+
+    /**
      * Dispatches the event to all listeners registered for the event type.
      *
      * @param componentEvent
      *            the event to fire
      */
     protected void fireEvent(ComponentEvent componentEvent) {
-        getEventBus().fireEvent(componentEvent);
+        if (hasListener(componentEvent.getClass())) {
+            getEventBus().fireEvent(componentEvent);
+        }
     }
 
     /**

--- a/hummingbird-server/src/test/java/com/vaadin/hummingbird/event/ComponentEventBusTest.java
+++ b/hummingbird-server/src/test/java/com/vaadin/hummingbird/event/ComponentEventBusTest.java
@@ -375,4 +375,24 @@ public class ComponentEventBusTest {
         });
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void hasListeners_nullEventType_throws() {
+        new ComponentEventBus(new TestComponent()).hasListener(null);
+    }
+
+    @Test
+    public void testFireEvent_noListeners_eventBusNotCreated() {
+        AtomicInteger eventBusCreated = new AtomicInteger();
+        TestComponent c = new TestComponent() {
+            @Override
+            public ComponentEventBus getEventBus() {
+                eventBusCreated.incrementAndGet();
+                return super.getEventBus();
+            }
+        };
+        c.fireEvent(new ServerEvent(c, new BigDecimal(0)));
+
+        Assert.assertEquals(0, eventBusCreated.get());
+    }
+
 }


### PR DESCRIPTION
Makes it possible to implement #492 more efficiently

<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/498)

<!-- Reviewable:end -->
