### PR TITLE
Don't use locale-dependent error message in test

### DIFF
--- a/hummingbird-client/src/test-gwt/java/com/vaadin/client/hummingbird/GwtRouterLinkHandlerTest.java
+++ b/hummingbird-client/src/test-gwt/java/com/vaadin/client/hummingbird/GwtRouterLinkHandlerTest.java
@@ -149,7 +149,7 @@ public class GwtRouterLinkHandlerTest extends ClientEngineTestBase {
             fireClickEvent(target);
         } catch (JavaScriptException e) {
             // Happens because localhost:120 does not answer
-            assertTrue(e.getMessage().contains("failed: Connection refused"));
+            assertTrue(e.getMessage().contains("HttpHostConnectException"));
         }
 
         assertInvocations(0);


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/515)

<!-- Reviewable:end -->
