### PR TITLE
allow PhantomJS version 2.x - not only 2.1

### DIFF
--- a/hummingbird-tests/test-root-context/src/test/java/com/vaadin/hummingbird/uitest/ui/PhantomJSVersionIT.java
+++ b/hummingbird-tests/test-root-context/src/test/java/com/vaadin/hummingbird/uitest/ui/PhantomJSVersionIT.java
@@ -34,6 +34,6 @@ public class PhantomJSVersionIT extends PhantomJSTest {
                 "return navigator.userAgent;");
         // Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/538.1 (KHTML,
         // like Gecko) PhantomJS/2.1.1 Safari/538.1
-        Assert.assertTrue(userAgent.contains(" PhantomJS/2.1."));
+        Assert.assertTrue(userAgent.contains(" PhantomJS/2."));
     }
 }


### PR DESCRIPTION
Hey guys,

can you merge my fix for the phantomjs version plz. My box runs 2.2-dev version causing the test to fail.

Cheers,
 Paul

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/520)

<!-- Reviewable:end -->
