### PR TITLE
Don't require a RouterLink parameter for terminating wildcards

### DIFF
--- a/hummingbird-server/src/main/java/com/vaadin/hummingbird/router/RouterLink.java
+++ b/hummingbird-server/src/main/java/com/vaadin/hummingbird/router/RouterLink.java
@@ -169,19 +169,32 @@ public class RouterLink extends Component implements HasText, HasComponents {
                 location.getSegments().size());
 
         while (true) {
-            if (location.startsWithPlaceholder()
-                    || location.startsWithWildcard()) {
+            String segment;
+            if (location.startsWithPlaceholder()) {
                 if (paramPos >= parameters.length) {
                     throw new IllegalArgumentException(
                             route + " has more placeholders than the number of given parameters: "
                                     + Arrays.toString(parameters));
                 }
-                String parameter = parameters[paramPos++];
-                assert parameter != null;
-                urlSegments.add(parameter);
+                segment = parameters[paramPos++];
+            } else if (location.startsWithWildcard()) {
+                if (location.getSegments().size() != 1) {
+                    throw new IllegalArgumentException(
+                            route + " wildcard is not at the end of the route");
+                }
+
+                if (paramPos == parameters.length) {
+                    // Optional to provide a value for a wildcard
+                    segment = "";
+                } else {
+                    segment = parameters[paramPos++];
+                }
             } else {
-                urlSegments.add(location.getFirstSegment());
+                segment = location.getFirstSegment();
             }
+
+            assert segment != null;
+            urlSegments.add(segment);
 
             Optional<RouteLocation> maybeSubLocation = location
                     .getRouteSubLocation();

--- a/hummingbird-server/src/test/java/com/vaadin/hummingbird/router/RouterLinkTest.java
+++ b/hummingbird-server/src/test/java/com/vaadin/hummingbird/router/RouterLinkTest.java
@@ -38,9 +38,21 @@ public class RouterLinkTest {
         Assert.assertEquals("param1/bar/param2/param3", url);
     }
 
+    @Test
+    public void buildUrlWithEmptyWildcard() {
+        String url = RouterLink.buildUrl("{foo}/bar/*", "param1", "");
+        Assert.assertEquals("param1/bar/", url);
+    }
+
+    @Test
+    public void buildUrlWithOmittedWildcard() {
+        String url = RouterLink.buildUrl("{foo}/bar/*", "param1");
+        Assert.assertEquals("param1/bar/", url);
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void buildUrlWithTooFewParameters() {
-        RouterLink.buildUrl("{foo}/bar/*", "param1");
+        RouterLink.buildUrl("{foo}/bar/{baz}", "param1");
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Routes mapped as "name/*" are usually useful when accessed as just
"name/" without any explicit value for the wildcard parameter. For such
cases, it would be convenient to create a router link without having to
explicitly set "" as a parameter value.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/534)

<!-- Reviewable:end -->
