### PR TITLE
Handle RouterLink with fragment properly

### DIFF
--- a/hummingbird-client/src/main/java/com/vaadin/client/hummingbird/FragmentHandler.java
+++ b/hummingbird-client/src/main/java/com/vaadin/client/hummingbird/FragmentHandler.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.client.hummingbird;
+
+import java.util.Objects;
+
+import com.google.web.bindery.event.shared.HandlerRegistration;
+import com.vaadin.client.Registry;
+import com.vaadin.client.communication.ResponseHandlingEndedEvent;
+
+import elemental.client.Browser;
+
+/**
+ * Handler that makes sure that scroll to fragment and hash change event work
+ * when there has been navigation via {@link RouterLinkHandler router link} to a
+ * path with fragment.
+ * <p>
+ * This class will trigger scroll to fragment and hash change event once the
+ * response from server has been processed, but only if the server did not
+ * override the location.
+ *
+ * @author Vaadin Ltd
+ */
+public class FragmentHandler {
+
+    private final String previousHref;
+    private final String newHref;
+
+    private HandlerRegistration handlerRegistration;
+
+    /**
+     * Creates a new fragment handler for the given locations.
+     *
+     * @param previousHref
+     *            the href before the navigation
+     * @param newHref
+     *            the href being navigated into
+     */
+    public FragmentHandler(String previousHref, String newHref) {
+        assert previousHref != null;
+        assert newHref != null;
+
+        this.previousHref = previousHref;
+        this.newHref = newHref;
+    }
+
+    /**
+     * Adds a request response tracker to the given registry for making sure the
+     * fragment is handled correctly if the location has not been updated during
+     * the response.
+     *
+     * @param registry
+     *            the registry to bind to
+     */
+    public void bind(Registry registry) {
+        handlerRegistration = registry.getRequestResponseTracker()
+                .addResponseHandlingEndedHandler(this::onResponseHandlingEnded);
+    }
+
+    private void onResponseHandlingEnded(
+            ResponseHandlingEndedEvent responseHandlingEndedEvent) {
+        assert handlerRegistration != null;
+
+        String currentHref = Browser.getWindow().getLocation().getHref();
+
+        if (Objects.equals(currentHref, newHref)) {
+            // trigger possible scroll to fragment identifier
+            Browser.getWindow().getLocation().replace(newHref);
+            // fire fragment change event
+            fireHashChangeEvent(previousHref, newHref);
+        }
+
+        handlerRegistration.removeHandler();
+    }
+
+    /*
+     * This method is used instead because Elemental's
+     * HashChangeEvent.initHashChange gives errors.
+     */
+    private static native void fireHashChangeEvent(String oldUrl, String newUrl)
+    /*-{
+        var event = new HashChangeEvent('hashchange', {
+            'view': window,
+            'bubbles': true,
+            'cancelable': false,
+            'oldURL': oldUrl,
+            'newURL': newUrl
+        });
+        window.dispatchEvent(event);
+     }-*/;
+}

--- a/hummingbird-tests/test-root-context/src/main/java/com/vaadin/hummingbird/uitest/ui/FragmentLinkView.java
+++ b/hummingbird-tests/test-root-context/src/main/java/com/vaadin/hummingbird/uitest/ui/FragmentLinkView.java
@@ -1,0 +1,78 @@
+package com.vaadin.hummingbird.uitest.ui;
+
+import com.vaadin.hummingbird.dom.Element;
+import com.vaadin.hummingbird.dom.ElementFactory;
+import com.vaadin.ui.History.HistoryStateChangeHandler;
+
+public class FragmentLinkView extends AbstractDivView {
+
+    public FragmentLinkView() {
+        Element bodyElement = getElement();
+        bodyElement.getStyle().set("margin", "1em");
+
+        Element scrollLocator = ElementFactory.createDiv()
+                .setAttribute("id", "scrollLocator")
+                .setTextContent("Scroll locator");
+        scrollLocator.getStyle().set("position", "fixed").set("top", "0")
+                .set("right", "0");
+
+        Element placeholder = ElementFactory.createDiv("Hash Change Events")
+                .setAttribute("id", "placeholder");
+
+        bodyElement.appendChild(scrollLocator, placeholder, new Element("p"));
+
+        Element scrollToLink = ElementFactory.createRouterLink(
+                "/view/com.vaadin.hummingbird.uitest.ui.FragmentLinkView#Scroll_Target",
+                "Scroller link");
+        Element scrollToLink2 = ElementFactory.createRouterLink(
+                "/view/com.vaadin.hummingbird.uitest.ui.FragmentLinkView#Scroll_Target2",
+                "Scroller link 2");
+        Element scrollToLinkAnotherView = ElementFactory.createRouterLink(
+                "/view/com.vaadin.hummingbird.uitest.ui.FragmentLinkView2#Scroll_Target",
+                "Scroller link with different view");
+        Element linkThatIsOverridden = ElementFactory.createRouterLink(
+                "./override#Scroll_Target", "Link that server overrides");
+
+        Element scrollTarget = ElementFactory.createHeading1("Scroll Target")
+                .setAttribute("id", "Scroll_Target");
+        Element scrollTarget2 = ElementFactory.createHeading2("Scroll Target 2")
+                .setAttribute("id", "Scroll_Target2");
+
+        bodyElement.appendChild(scrollToLink, new Element("p"), scrollToLink2,
+                new Element("p"), scrollToLinkAnotherView, new Element("p"),
+                linkThatIsOverridden, new Element("p"), createSpacer(),
+                scrollTarget, createSpacer(), scrollTarget2, createSpacer());
+
+    }
+
+    @Override
+    protected void onAttach() {
+        getUI().get().getPage()
+                .executeJavaScript("var i = 0;"
+                        + "window.addEventListener('hashchange', function(event) {"
+                        + "var x = document.createElement('span');"
+                        + "x.textContent = ' ' + i;" + "i++;"
+                        + "x.class = 'hashchange';"
+                        + "document.getElementById('placeholder').appendChild(x);},"
+                        + " false);");
+
+        HistoryStateChangeHandler current = getUI().get().getPage().getHistory()
+                .getHistoryStateChangeHandler();
+        getUI().get().getPage().getHistory()
+                .setHistoryStateChangeHandler(event -> {
+                    if (event.getLocation().equals("override")) {
+                        event.getSource().replaceState(null,
+                                "overridden#Scroll_Target2");
+                    } else {
+                        current.onHistoryStateChange(event);
+                    }
+                });
+    }
+
+    private Element createSpacer() {
+        Element spacer = ElementFactory.createDiv().setTextContent("spacer");
+        spacer.getStyle().set("height", "1000px");
+        return spacer;
+    }
+
+}

--- a/hummingbird-tests/test-root-context/src/main/java/com/vaadin/hummingbird/uitest/ui/FragmentLinkView2.java
+++ b/hummingbird-tests/test-root-context/src/main/java/com/vaadin/hummingbird/uitest/ui/FragmentLinkView2.java
@@ -1,0 +1,16 @@
+package com.vaadin.hummingbird.uitest.ui;
+
+import com.vaadin.hummingbird.dom.Element;
+
+public class FragmentLinkView2 extends FragmentLinkView {
+
+    public FragmentLinkView2() {
+        getElement().insertChild(0, new Element("div").setTextContent("VIEW 2")
+                .setAttribute("id", "view2"));
+    }
+
+    @Override
+    protected void onAttach() {
+        // do not call super onAttach since it adds a hashchangelistener
+    }
+}

--- a/hummingbird-tests/test-root-context/src/test/java/com/vaadin/hummingbird/uitest/ui/FragmentLinkIT.java
+++ b/hummingbird-tests/test-root-context/src/test/java/com/vaadin/hummingbird/uitest/ui/FragmentLinkIT.java
@@ -1,0 +1,142 @@
+package com.vaadin.hummingbird.uitest.ui;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.hummingbird.testutil.PhantomJSTest;
+
+public class FragmentLinkIT extends PhantomJSTest {
+
+    @Test
+    public void testInsidePageNavigation_noRouterLinkHandling() {
+        open();
+
+        clickScrollerLink2();
+
+        verifyInsideServletLocation(
+                "com.vaadin.hummingbird.uitest.ui.FragmentLinkView#Scroll_Target2");
+        verifyHashChangeEvents(1);
+        verifyScrollTarget2Visible();
+
+        clickScrollerLink();
+
+        verifyInsideServletLocation(
+                "com.vaadin.hummingbird.uitest.ui.FragmentLinkView#Scroll_Target");
+        verifyHashChangeEvents(2);
+        verifyScrollTargetVisible();
+    }
+
+    @Test
+    public void testViewChangeWithFragment_scrollToPageAndHashChangeEventWorks() {
+        open();
+
+        clickAnotherViewLink();
+
+        verifyInsideServletLocation(
+                "com.vaadin.hummingbird.uitest.ui.FragmentLinkView2#Scroll_Target");
+        verifyHashChangeEvents(1);
+        verifyScrollTargetVisible();
+        verifyView2Open();
+    }
+
+    @Test
+    public void testViewChangeWithFragment_serverOverridesLocation_noScrollOrHashChange() {
+        open();
+
+        clickOverriddenLink();
+
+        verifyInsideServletLocation("overridden#Scroll_Target2");
+        // history.replaceState won't fire fragment change
+        verifyHashChangeEvents(0);
+        verifyTopOfThePage();
+    }
+
+    // @Test Will work after prerendering is implemented
+    public void testInitialPageWithFragment_scrollLocationUpdated() {
+        String url = getRootURL();
+        while (url.endsWith("/")) {
+            url = url.substring(0, url.length() - 1);
+        }
+        url = url + getTestPath() + "#Scroll_Target2";
+        getDriver().get(url);
+
+        verifyInsideServletLocation(
+                "com.vaadin.hummingbird.uitest.ui.FragmentLinkView#Scroll_Target2");
+        verifyHashChangeEvents(0);
+        verifyScrollTarget2Visible();
+    }
+
+    private void clickScrollerLink() {
+        clickLink("Scroller link");
+    }
+
+    private void clickScrollerLink2() {
+        clickLink("Scroller link 2");
+    }
+
+    private void clickAnotherViewLink() {
+        clickLink("Scroller link with different view");
+    }
+
+    private void clickOverriddenLink() {
+        clickLink("Link that server overrides");
+    }
+
+    private void clickLink(String linkText) {
+        findElement(By.linkText(linkText)).click();
+    }
+
+    private void verifyScrollTargetVisible() {
+        int scrollPos = findElement(By.id("Scroll_Target")).getLocation()
+                .getY();
+        int expected = getScrollLocatorPosition();
+        assertScrollPosition(expected, scrollPos);
+    }
+
+    private void verifyScrollTarget2Visible() {
+        int scrollPos = findElement(By.id("Scroll_Target2")).getLocation()
+                .getY();
+        int expected = getScrollLocatorPosition();
+        assertScrollPosition(expected, scrollPos);
+    }
+
+    private int getScrollLocatorPosition() {
+        return findElement(By.id("scrollLocator")).getLocation().getY();
+    }
+
+    private void verifyTopOfThePage() {
+        assertScrollPosition(0, getScrollLocatorPosition());
+    }
+
+    private void verifyView2Open() {
+        Assert.assertNotNull("FragmentView2 not opened",
+                findElement(By.id("view2")));
+    }
+
+    private void assertScrollPosition(int expected, int actual) {
+        int lowerBound = expected - 2 > 0 ? expected - 2 : 0;
+        int higherBound = expected + 2;
+        Assert.assertTrue(
+                "Invalid scroll position, expected " + expected
+                        + " +-2px. actual " + actual,
+                lowerBound <= expected && expected <= higherBound);
+    }
+
+    private void verifyHashChangeEvents(int numberOfEvents) {
+        List<WebElement> spans = findElement(By.id("placeholder"))
+                .findElements(By.tagName("span"));
+        Assert.assertEquals("Invalid amount of hash change events",
+                numberOfEvents, spans.size());
+    }
+
+    private void verifyInsideServletLocation(String pathAfterServletMapping) {
+        Assert.assertEquals("Invalid URL",
+                getRootURL() + "/view/" + pathAfterServletMapping,
+                getDriver().getCurrentUrl());
+    }
+
+}

--- a/hummingbird-tests/test-root-context/src/test/java/com/vaadin/hummingbird/uitest/ui/RouterLinkIT.java
+++ b/hummingbird-tests/test-root-context/src/test/java/com/vaadin/hummingbird/uitest/ui/RouterLinkIT.java
@@ -19,7 +19,7 @@ public class RouterLinkIT extends PhantomJSTest {
 
         testInsideServlet("./foobar", "foobar");
         testInsideServlet("./foobar?what=not", "foobar?what=not");
-        testInsideServlet("./foobar?what=not#fragment",
+        testInsideServlet("./foobar?what=not#fragment", "foobar?what=not",
                 "foobar?what=not#fragment");
 
         testInsideServlet("/run/baz", "baz");
@@ -54,9 +54,15 @@ public class RouterLinkIT extends PhantomJSTest {
 
     private void testInsideServlet(String linkToTest,
             String pathAfterServletMapping) {
+        testInsideServlet(linkToTest, pathAfterServletMapping,
+                pathAfterServletMapping);
+    }
+
+    private void testInsideServlet(String linkToTest, String popStateLocation,
+            String pathAfterServletMapping) {
         clickLink(linkToTest);
         verifyInsideServletLocation(pathAfterServletMapping);
-        verifyPopStateEvent(pathAfterServletMapping);
+        verifyPopStateEvent(popStateLocation);
         verifySamePage();
     }
 


### PR DESCRIPTION
RouterLinks with inside page navigation don't go to server.
RouterLinks with fragment trigger scroll to fragment and hashchangeevent.
Does not handle initial page scroll to fragment, that is handled by prerending.

Fixes #339

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/641)

<!-- Reviewable:end -->
