### PR TITLE
Avoid empty ArrayList and HashMap instances in node features

### DIFF
--- a/hummingbird-server/src/main/java/com/vaadin/hummingbird/nodefeature/ElementListenerMap.java
+++ b/hummingbird-server/src/main/java/com/vaadin/hummingbird/nodefeature/ElementListenerMap.java
@@ -40,7 +40,7 @@ import elemental.json.JsonValue;
  */
 public class ElementListenerMap extends NodeMap {
     // Server-side only data
-    private HashMap<String, ArrayList<DomEventListener>> listeners = new HashMap<>();
+    private HashMap<String, ArrayList<DomEventListener>> listeners;
 
     /**
      * Creates a new element listener map for the given node.
@@ -69,6 +69,10 @@ public class ElementListenerMap extends NodeMap {
         assert eventType != null;
         assert listener != null;
         assert eventDataExpressions != null;
+
+        if (listeners == null) {
+            listeners = new HashMap<>();
+        }
 
         // Could optimize slightly by integrating the initialization into the
         // main logic, but that would make the code much harder to read
@@ -99,6 +103,9 @@ public class ElementListenerMap extends NodeMap {
     }
 
     private void removeListener(String eventType, DomEventListener listener) {
+        if (listeners == null) {
+            return;
+        }
         ArrayList<DomEventListener> listenerList = listeners.get(eventType);
         if (listenerList != null) {
             listenerList.remove(listener);
@@ -106,6 +113,10 @@ public class ElementListenerMap extends NodeMap {
             // No more listeners of this type?
             if (listenerList.isEmpty()) {
                 listeners.remove(eventType);
+
+                if (listeners.isEmpty()) {
+                    listeners = null;
+                }
 
                 // Remove from the set that is synchronized with the client
                 remove(eventType);
@@ -120,6 +131,9 @@ public class ElementListenerMap extends NodeMap {
      *            the event to fire
      */
     public void fireEvent(DomEvent event) {
+        if (listeners == null) {
+            return;
+        }
         ArrayList<DomEventListener> typeListeners = listeners
                 .get(event.getType());
         if (typeListeners == null) {

--- a/hummingbird-server/src/main/java/com/vaadin/hummingbird/nodefeature/NodeList.java
+++ b/hummingbird-server/src/main/java/com/vaadin/hummingbird/nodefeature/NodeList.java
@@ -103,7 +103,7 @@ public abstract class NodeList<T extends Serializable> extends NodeFeature {
         }
     }
 
-    private List<T> values = new ArrayList<>();
+    private List<T> values;
 
     /**
      * Creates a new list for the given node.
@@ -122,7 +122,16 @@ public abstract class NodeList<T extends Serializable> extends NodeFeature {
      */
     protected int size() {
         setAccessed();
+        if (values == null) {
+            return 0;
+        }
         return values.size();
+    }
+
+    private void ensureValues() {
+        if (values == null) {
+            values = new ArrayList<>();
+        }
     }
 
     /**
@@ -134,6 +143,9 @@ public abstract class NodeList<T extends Serializable> extends NodeFeature {
      */
     protected T get(int index) {
         setAccessed();
+        if (values == null) {
+            throw new IndexOutOfBoundsException();
+        }
         return values.get(index);
     }
 
@@ -144,6 +156,7 @@ public abstract class NodeList<T extends Serializable> extends NodeFeature {
      *            the item to add
      */
     protected void add(T item) {
+        ensureValues();
         add(values.size(), item);
     }
 
@@ -156,6 +169,7 @@ public abstract class NodeList<T extends Serializable> extends NodeFeature {
      *            the item to insert
      */
     protected void add(int index, T item) {
+        ensureValues();
         values.add(index, item);
 
         addChange(new ListSpliceChange(this, isNodeValues(), index, 0,
@@ -170,10 +184,18 @@ public abstract class NodeList<T extends Serializable> extends NodeFeature {
      * @return the element previously at the specified position
      */
     protected T remove(int index) {
+        if (values == null) {
+            throw new IndexOutOfBoundsException();
+        }
+
         T removed = values.remove(index);
 
         addChange(new ListSpliceChange(this, isNodeValues(), index, 1,
                 Collections.emptyList()));
+
+        if (values.isEmpty()) {
+            values = null;
+        }
         return removed;
     }
 
@@ -213,7 +235,8 @@ public abstract class NodeList<T extends Serializable> extends NodeFeature {
 
     @Override
     public void generateChangesFromEmpty() {
-        if (!values.isEmpty()) {
+        if (values != null) {
+            assert !values.isEmpty();
             getChangeTracker().add(new ListSpliceChange(this, isNodeValues(), 0,
                     0, new ArrayList<>(values)));
         }
@@ -247,6 +270,9 @@ public abstract class NodeList<T extends Serializable> extends NodeFeature {
      */
     protected int indexOf(T value) {
         setAccessed();
+        if (values == null) {
+            return -1;
+        }
         return values.indexOf(value);
     }
 
@@ -256,6 +282,9 @@ public abstract class NodeList<T extends Serializable> extends NodeFeature {
      * @return an iterator returning all items
      */
     protected Iterator<T> iterator() {
+        if (values == null) {
+            return Collections.<T> emptyList().iterator();
+        }
         Iterator<T> arrayIterator = values.iterator();
         return new Iterator<T>() {
             int index = -1;

--- a/hummingbird-server/src/main/java/com/vaadin/hummingbird/nodefeature/NodeMap.java
+++ b/hummingbird-server/src/main/java/com/vaadin/hummingbird/nodefeature/NodeMap.java
@@ -18,6 +18,7 @@ package com.vaadin.hummingbird.nodefeature;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -39,7 +40,7 @@ public abstract class NodeMap extends NodeFeature {
     private static final Serializable REMOVED_MARKER = new UniqueSerializable() {
     };
 
-    private HashMap<String, Serializable> values = new HashMap<>();
+    private HashMap<String, Serializable> values;
 
     /**
      * Creates a new map feature for the given node.
@@ -64,6 +65,12 @@ public abstract class NodeMap extends NodeFeature {
         doPut(key, value, true);
     }
 
+    private void ensureValues() {
+        if (values == null) {
+            values = new HashMap<>();
+        }
+    }
+
     /**
      * Stores a value with the given key, replacing any value previously stored
      * with the same key.
@@ -86,6 +93,7 @@ public abstract class NodeMap extends NodeFeature {
         } else {
             setUnChanged(key);
         }
+        ensureValues();
         Object oldValue = values.put(key, value);
 
         detatchPotentialChild(oldValue);
@@ -103,6 +111,9 @@ public abstract class NodeMap extends NodeFeature {
      */
     protected Object get(String key) {
         setAccessed(key);
+        if (values == null) {
+            return null;
+        }
         return values.get(key);
     }
 
@@ -184,6 +195,9 @@ public abstract class NodeMap extends NodeFeature {
      * @return a set containing all the defined keys
      */
     protected Set<String> keySet() {
+        if (values == null) {
+            return Collections.emptySet();
+        }
         return values.keySet();
     }
 
@@ -197,6 +211,9 @@ public abstract class NodeMap extends NodeFeature {
      */
     protected boolean contains(String key) {
         setAccessed(key);
+        if (values == null) {
+            return false;
+        }
         return values.containsKey(key);
     }
 
@@ -208,8 +225,14 @@ public abstract class NodeMap extends NodeFeature {
      */
     protected void remove(String key) {
         setChanged(key);
+        if (values == null) {
+            return;
+        }
         Object oldValue = values.remove(key);
         detatchPotentialChild(oldValue);
+        if (values.isEmpty()) {
+            values = null;
+        }
     }
 
     /**
@@ -235,7 +258,7 @@ public abstract class NodeMap extends NodeFeature {
 
         if (!changes.containsKey(key)) {
             // Record this as changed for the collection logic
-            if (values.containsKey(key)) {
+            if (values != null && values.containsKey(key)) {
                 Serializable oldValue = values.get(key);
                 changes.put(key, oldValue);
             } else {
@@ -259,7 +282,7 @@ public abstract class NodeMap extends NodeFeature {
     @Override
     public void collectChanges(Consumer<NodeChange> collector) {
         getChangeTracker().forEach((key, earlierValue) -> {
-            boolean containsNow = values.containsKey(key);
+            boolean containsNow = values != null && values.containsKey(key);
             boolean containedEarlier = earlierValue != REMOVED_MARKER;
             if (containedEarlier && !containsNow) {
                 collector.accept(new MapRemoveChange(this, key));
@@ -276,12 +299,22 @@ public abstract class NodeMap extends NodeFeature {
 
     @Override
     public void generateChangesFromEmpty() {
+        if (values == null) {
+            return;
+        }
+        assert !values.isEmpty();
+
         Map<String, Serializable> changes = getChangeTracker();
         values.keySet().forEach(k -> changes.put(k, REMOVED_MARKER));
     }
 
     @Override
     public void forEachChild(Consumer<StateNode> action) {
+        if (values == null) {
+            return;
+        }
+        assert !values.isEmpty();
+
         values.values().stream().filter(v -> v instanceof StateNode)
                 .forEach(v -> action.accept((StateNode) v));
     }


### PR DESCRIPTION
An empty ArrayList uses between 32 and 136 bytes depending on how it has
been used. The corresponding range for a HashMap is 64 to 216 bytes.

This reduces the memory usage for a simple button with around 23%, from
2314 to 1776 bytes.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/855)

<!-- Reviewable:end -->
