### PR TITLE
Ignore special attributes when generating attribute names

### DIFF
--- a/hummingbird-server/src/main/java/com/vaadin/hummingbird/dom/impl/ClassAttributeHandler.java
+++ b/hummingbird-server/src/main/java/com/vaadin/hummingbird/dom/impl/ClassAttributeHandler.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.hummingbird.dom.impl;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.vaadin.hummingbird.dom.Element;
+
+/**
+ * Emulates the <code>class</code> attribute by delegating to
+ * {@link Element#getClassList()}.
+ */
+public class ClassAttributeHandler extends CustomAttribute {
+    @Override
+    public boolean hasAttribute(Element element) {
+        return !element.getClassList().isEmpty();
+    }
+
+    @Override
+    public String getAttribute(Element element) {
+        Set<String> classList = element.getClassList();
+        if (classList.isEmpty()) {
+            return null;
+        } else {
+            return classList.stream().collect(Collectors.joining(" "));
+        }
+    }
+
+    @Override
+    public void setAttribute(Element element, String value) {
+        Set<String> classList = element.getClassList();
+        classList.clear();
+
+        if (value.isEmpty()) {
+            return;
+        }
+
+        String[] parts = value.split("\\s+");
+        classList.addAll(Arrays.asList(parts));
+    }
+
+    @Override
+    public void removeAttribute(Element element) {
+        element.getClassList().clear();
+    }
+}

--- a/hummingbird-server/src/main/java/com/vaadin/hummingbird/dom/impl/CustomAttribute.java
+++ b/hummingbird-server/src/main/java/com/vaadin/hummingbird/dom/impl/CustomAttribute.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.hummingbird.dom.impl;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import com.vaadin.hummingbird.dom.Element;
+
+/**
+ * Callback for handling attributes with special semantics. This is used for
+ * e.g. <code>class</code> which is assembled from a separate list of tokens
+ * instead of being stored as a regular attribute string.
+ */
+public abstract class CustomAttribute implements Serializable {
+
+    static {
+        Map<String, CustomAttribute> map = new HashMap<>();
+
+        map.put("class", new ClassAttributeHandler());
+        map.put("style", new StyleAttributeHandler());
+
+        customAttributes = Collections.unmodifiableMap(map);
+    }
+
+    private static final Map<String, CustomAttribute> customAttributes;
+
+    /**
+     * Gets the custom attribute with the provided name, if present.
+     *
+     * @param name
+     *            the name of the attribute
+     * @return and optional custom attribute, or an emtpy optional if there is
+     *         no attribute with the given name
+     */
+    public static Optional<CustomAttribute> get(String name) {
+        return Optional.ofNullable(customAttributes.get(name));
+    }
+
+    /**
+     * Gets an unmodifiable set of custom attribute names.
+     *
+     * @return a set of attribute names
+     */
+    public static Set<String> getNames() {
+        return customAttributes.keySet();
+    }
+
+    /**
+     * Checks what {@link Element#hasAttribute(String)} should return for this
+     * attribute.
+     *
+     * @param element
+     *            the element to check, not <code>null</code>
+     * @return <code>true</code> if the element has a value for this attribute,
+     *         otherwise <code>false</code>
+     */
+    public abstract boolean hasAttribute(Element element);
+
+    /**
+     * Gets the value that should be returned by
+     * {@link Element#getAttribute(String)} for this attribute.
+     *
+     * @param element
+     *            the element to check, not <code>null</code>
+     * @return the attribute value
+     */
+    public abstract String getAttribute(Element element);
+
+    /**
+     * Sets the value when {@link Element#setAttribute(String, String)} is
+     * called for this attribute.
+     *
+     * @param element
+     *            the element for which to set the value, not <code>null</code>
+     * @param value
+     *            the new attribute value, not <code>null</code>
+     */
+    public abstract void setAttribute(Element element, String value);
+
+    /**
+     * Removes the attribute when {@link Element#removeAttribute(String)} is
+     * called for this attribute.
+     *
+     * @param element
+     *            the element for which to remove the attribute, not
+     *            <code>null</code>
+     */
+    public abstract void removeAttribute(Element element);
+}

--- a/hummingbird-server/src/main/java/com/vaadin/hummingbird/dom/impl/StyleAttributeHandler.java
+++ b/hummingbird-server/src/main/java/com/vaadin/hummingbird/dom/impl/StyleAttributeHandler.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.hummingbird.dom.impl;
+
+import java.util.stream.Collectors;
+
+import com.helger.css.ECSSVersion;
+import com.helger.css.decl.CSSDeclaration;
+import com.helger.css.decl.CSSDeclarationList;
+import com.helger.css.reader.CSSReaderDeclarationList;
+import com.helger.css.reader.errorhandler.CollectingCSSParseErrorHandler;
+import com.helger.css.writer.CSSWriterSettings;
+import com.vaadin.hummingbird.dom.Element;
+import com.vaadin.hummingbird.dom.Style;
+import com.vaadin.hummingbird.dom.StyleUtil;
+
+/**
+ * Emulates the <code>style</code> attribute by delegating to
+ * {@link Element#getStyle()}.
+ */
+public class StyleAttributeHandler extends CustomAttribute {
+    private static final String ERROR_PARSING_STYLE = "Error parsing style '%s': %s";
+
+    @Override
+    public boolean hasAttribute(Element element) {
+        return element.getStyle().getNames().findAny().isPresent();
+    }
+
+    @Override
+    public String getAttribute(Element element) {
+        if (!hasAttribute(element)) {
+            return null;
+        }
+        Style style = element.getStyle();
+
+        return style.getNames().map(styleName -> {
+            return StyleUtil.stylePropertyToAttribute(styleName) + ":"
+                    + style.get(styleName);
+        }).collect(Collectors.joining(";"));
+    }
+
+    @Override
+    public void setAttribute(Element element, String attributeValue) {
+        Style style = element.getStyle();
+        CollectingCSSParseErrorHandler errorCollector = new CollectingCSSParseErrorHandler();
+        CSSDeclarationList parsed = CSSReaderDeclarationList.readFromString(
+                attributeValue, ECSSVersion.LATEST, errorCollector);
+        if (errorCollector.hasParseErrors()) {
+            throw new IllegalArgumentException(String
+                    .format(ERROR_PARSING_STYLE, attributeValue, errorCollector
+                            .getAllParseErrors().get(0).getErrorMessage()));
+        }
+        if (parsed == null) {
+            // Did not find any styles
+            throw new IllegalArgumentException(String.format(
+                    ERROR_PARSING_STYLE, attributeValue, "No styles found"));
+        }
+        for (CSSDeclaration declaration : parsed.getAllDeclarations()) {
+            String key = declaration.getProperty();
+            String value = declaration.getExpression()
+                    .getAsCSSString(new CSSWriterSettings(ECSSVersion.LATEST)
+                            .setOptimizedOutput(true), 0);
+            style.set(StyleUtil.styleAttributeToProperty(key), value);
+        }
+    }
+
+    @Override
+    public void removeAttribute(Element element) {
+        element.getStyle().clear();
+    }
+}

--- a/hummingbird-server/src/main/java/com/vaadin/hummingbird/dom/impl/TemplateElementStateProvider.java
+++ b/hummingbird-server/src/main/java/com/vaadin/hummingbird/dom/impl/TemplateElementStateProvider.java
@@ -141,6 +141,9 @@ public class TemplateElementStateProvider implements ElementStateProvider {
                     SynchronizedPropertyEventsList.class)
             .toArray(Class[]::new);
 
+    private static final Predicate<? super String> excludeCustomAttributes = name -> !CustomAttribute
+            .getNames().contains(name);
+
     private ElementTemplateNode templateNode;
 
     /**
@@ -249,7 +252,11 @@ public class TemplateElementStateProvider implements ElementStateProvider {
 
     @Override
     public Stream<String> getAttributeNames(StateNode node) {
-        Stream<String> templateAttributes = templateNode.getAttributeNames();
+        // Exclude custom attributes since those are included on demand by
+        // Element.getAttributeNames().
+        Stream<String> templateAttributes = templateNode.getAttributeNames()
+                .filter(excludeCustomAttributes);
+
         Optional<StateNode> overrideNode = getOverrideNode(node);
         if (overrideNode.isPresent()) {
             Predicate<String> isStaticBinding = this::isStaticBindingAttribute;
@@ -512,6 +519,7 @@ public class TemplateElementStateProvider implements ElementStateProvider {
              */
             templateNode.getAttributeNames()
                     .filter(this::isStaticBindingAttribute)
+                    .filter(excludeCustomAttributes)
                     .forEach(attribute -> BasicElementStateProvider.get()
                             .setAttribute(overrideNode, attribute,
                                     templateNode.getAttributeBinding(attribute)

--- a/hummingbird-server/src/test/java/com/vaadin/hummingbird/dom/TemplateElementStateProviderTest.java
+++ b/hummingbird-server/src/test/java/com/vaadin/hummingbird/dom/TemplateElementStateProviderTest.java
@@ -441,12 +441,42 @@ public class TemplateElementStateProviderTest {
     }
 
     @Test
+    public void testHardcodedStyleAttribute() {
+        Element element = createElement("<div style='display:none'></div>");
+
+        /*
+         * Currently empty since getStyle() is implemented to always be empty.
+         *
+         * Should be updated to make sure getAttributeNames() still doesn't
+         * throw after actual style support has been implemented.
+         */
+        Assert.assertEquals(0, element.getAttributeNames().count());
+
+        // Test the same after attributes have been migrated to an override node
+        element.setProperty("foo", "bar");
+
+        Assert.assertEquals(0, element.getAttributeNames().count());
+    }
+
+    @Test
     public void templateBoundClassAttribute() {
         Element element = createElement("<div class='foo bar'></div>");
 
         Assert.assertEquals("foo bar", element.getAttribute("class"));
+        Assert.assertArrayEquals(new Object[] { "class" },
+                element.getAttributeNames().toArray());
 
         assertClassList(element.getClassList(), "foo", "bar");
+
+        // Test the same after attributes have been migrated to an override node
+        element.setProperty("foo", "bar");
+
+        Assert.assertEquals("foo bar", element.getAttribute("class"));
+        Assert.assertArrayEquals(new Object[] { "class" },
+                element.getAttributeNames().toArray());
+
+        assertClassList(element.getClassList(), "foo", "bar");
+
     }
 
     @Test

--- a/hummingbird-tests/test-root-context/src/test/java/com/vaadin/hummingbird/ui/ToStringTest.java
+++ b/hummingbird-tests/test-root-context/src/test/java/com/vaadin/hummingbird/ui/ToStringTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.hummingbird.ui;
+
+import java.util.Collection;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.hummingbird.router.View;
+import com.vaadin.hummingbird.uitest.servlet.ViewClassLocator;
+
+public class ToStringTest {
+    @Test
+    public void testViewsElementsStringable() throws Exception {
+        Collection<Class<? extends View>> viewClasses = new ViewClassLocator(
+                getClass().getClassLoader()).getAllViewClasses();
+        for (Class<? extends View> viewClass : viewClasses) {
+            View view = viewClass.newInstance();
+            String string = view.getElement().toString();
+            Assert.assertNotNull(string);
+            Assert.assertNotEquals("", string);
+        }
+    }
+
+}


### PR DESCRIPTION
Also add a test that does Element.toString on elements with a wide range
of configurations, which would have caught this issue from the
beginning.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/924)

<!-- Reviewable:end -->
