### PR TITLE
Add @Include/@Exclude for TemplateModel setters

### DIFF
--- a/hummingbird-server/src/main/java/com/vaadin/annotations/Exclude.java
+++ b/hummingbird-server/src/main/java/com/vaadin/annotations/Exclude.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.vaadin.hummingbird.template.model.TemplateModel;
+
+/**
+ * Defines which properties to exclude when importing a bean into a template
+ * model.
+ * <p>
+ * Use this annotation on bean setters in your {@link TemplateModel} class to
+ * restrict which properties of the beans are imported into the model.
+ * <p>
+ * You can only define exact matches using this filter. If you need more
+ * control, you can use
+ * {@link TemplateModel#importBean(String, Object, java.util.function.Predicate)}
+ * and define a custom filter.
+ * <p>
+ * Note that <code>@Exclude</code> annotations are not inherited.
+ *
+ * @see Include
+ *
+ * @author Vaadin Ltd
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Documented
+public @interface Exclude {
+
+    /**
+     * Properties to exclude from a bean when importing into a template model.
+     * <p>
+     * By default no properties are excluded.
+     *
+     * @return
+     */
+    String[] value();
+}

--- a/hummingbird-server/src/main/java/com/vaadin/annotations/Include.java
+++ b/hummingbird-server/src/main/java/com/vaadin/annotations/Include.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.vaadin.hummingbird.template.model.TemplateModel;
+
+/**
+ * Defines which properties to include when importing a bean into a template
+ * model.
+ * <p>
+ * Use this annotation on bean setters in your {@link TemplateModel} class to
+ * restrict which properties of the beans are imported into the model.
+ * <p>
+ * You can only define exact matches using this filter. If you need more
+ * control, you can use
+ * {@link TemplateModel#importBean(String, Object, java.util.function.Predicate)}
+ * and define a custom filter.
+ * <p>
+ * Note that <code>@Include</code> annotations are not inherited.
+ *
+ * @see Exclude
+ *
+ * @author Vaadin Ltd
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Documented
+public @interface Include {
+
+    /**
+     * Properties to include from a bean when importing into a template model.
+     * <p>
+     * By default all properties are included.
+     *
+     * @return
+     */
+    String[] value();
+}

--- a/hummingbird-server/src/main/java/com/vaadin/hummingbird/nodefeature/ModelMap.java
+++ b/hummingbird-server/src/main/java/com/vaadin/hummingbird/nodefeature/ModelMap.java
@@ -16,6 +16,7 @@
 package com.vaadin.hummingbird.nodefeature;
 
 import java.io.Serializable;
+import java.util.Set;
 
 import com.vaadin.hummingbird.StateNode;
 
@@ -86,5 +87,10 @@ public class ModelMap extends NodeMap {
      */
     public boolean hasValue(String key) {
         return super.contains(key);
+    }
+
+    @Override
+    public Set<String> keySet() {
+        return super.keySet();
     }
 }

--- a/hummingbird-server/src/test/java/com/vaadin/hummingbird/template/model/BeanContainingBeans.java
+++ b/hummingbird-server/src/test/java/com/vaadin/hummingbird/template/model/BeanContainingBeans.java
@@ -1,0 +1,26 @@
+package com.vaadin.hummingbird.template.model;
+
+public class BeanContainingBeans {
+    private Bean bean1;
+    private Bean bean2;
+
+    public BeanContainingBeans() {
+    }
+
+    public Bean getBean1() {
+        return bean1;
+    }
+
+    public void setBean1(Bean bean1) {
+        this.bean1 = bean1;
+    }
+
+    public Bean getBean2() {
+        return bean2;
+    }
+
+    public void setBean2(Bean bean2) {
+        this.bean2 = bean2;
+    }
+
+}

--- a/hummingbird-server/src/test/java/com/vaadin/hummingbird/template/model/TemplateModelTest.java
+++ b/hummingbird-server/src/test/java/com/vaadin/hummingbird/template/model/TemplateModelTest.java
@@ -1,21 +1,24 @@
 package com.vaadin.hummingbird.template.model;
 
-import java.io.ByteArrayInputStream;
 import java.io.Serializable;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.vaadin.annotations.Exclude;
+import com.vaadin.annotations.Include;
 import com.vaadin.hummingbird.StateNode;
 import com.vaadin.hummingbird.change.NodeChange;
 import com.vaadin.hummingbird.nodefeature.ModelMap;
 import com.vaadin.hummingbird.template.InlineTemplate;
 import com.vaadin.ui.Template;
+import com.vaadin.util.ReflectTools;
 
 public class TemplateModelTest {
 
@@ -159,10 +162,14 @@ public class TemplateModelTest {
         SubBean getBeanClass();
     }
 
-    public static class SubBeansTemplate extends InlineTemplate {
-        public SubBeansTemplate() {
+    public static class EmptyDivTemplate extends InlineTemplate {
+        public EmptyDivTemplate() {
             super("<div></div>");
         }
+
+    }
+
+    public static class SubBeansTemplate extends EmptyDivTemplate {
 
         @Override
         protected SubBeansModel getModel() {
@@ -170,11 +177,7 @@ public class TemplateModelTest {
         }
     }
 
-    public static class NoModelTemplate extends Template {
-        public NoModelTemplate() {
-            super(new ByteArrayInputStream(
-                    "<div>foo</div>".getBytes(StandardCharsets.UTF_8)));
-        }
+    public static class NoModelTemplate extends EmptyDivTemplate {
 
         @Override
         public TemplateModel getModel() {
@@ -233,6 +236,95 @@ public class TemplateModelTest {
         public ModelWithList getModel() {
             return (ModelWithList) super.getModel();
         }
+    }
+
+    public static class TemplateWithInclude extends EmptyDivTemplate {
+        public interface ModelWithInclude extends TemplateModel {
+            public Bean getBean();
+
+            @Include({ "doubleValue", "booleanObject" })
+            public void setBean(Bean bean);
+        }
+
+        @Override
+        protected ModelWithInclude getModel() {
+            return (ModelWithInclude) super.getModel();
+        }
+    }
+
+    public static class TemplateWithExclude extends EmptyDivTemplate {
+
+        public interface ModelWithExclude extends TemplateModel {
+            public Bean getBean();
+
+            @Exclude({ "doubleValue", "booleanObject" })
+            public void setBean(Bean bean);
+        }
+
+        @Override
+        protected ModelWithExclude getModel() {
+            return (ModelWithExclude) super.getModel();
+        }
+    }
+
+    public static class TemplateWithExcludeAndInclude extends EmptyDivTemplate {
+
+        public interface ModelWithExcludeAndInclude extends TemplateModel {
+            public Bean getBean();
+
+            @Include({ "doubleValue", "booleanObject" })
+            @Exclude("doubleValue")
+            public void setBean(Bean bean);
+        }
+
+        @Override
+        protected ModelWithExcludeAndInclude getModel() {
+            return (ModelWithExcludeAndInclude) super.getModel();
+        }
+    }
+
+    public static class TemplateWithExcludeAndIncludeSubclass
+            extends TemplateWithExcludeAndInclude {
+        // Should work exactly the same way as the parent class
+    }
+
+    public static class TemplateWithExcludeAndIncludeSubclassOverrides
+            extends TemplateWithExcludeAndInclude {
+
+        public interface ModelWithExcludeAndIncludeSubclass
+                extends ModelWithExcludeAndInclude {
+
+            /*
+             * Super class has annotations for this method to only include
+             * 'booleanObject'. This tests that includes can be overridden in a
+             * sub class (and parent class annotations are ignored).
+             */
+            @Override
+            @Include("doubleValue")
+            public void setBean(Bean bean);
+        }
+
+        @Override
+        protected ModelWithExcludeAndIncludeSubclass getModel() {
+            return (ModelWithExcludeAndIncludeSubclass) super.getModel();
+        }
+    }
+
+    public static class TemplateWithExcludeForSubBean extends EmptyDivTemplate {
+
+        public interface ModelWithExcludeForSubBean extends TemplateModel {
+            public BeanContainingBeans getBeanContainingBeans();
+
+            @Exclude({ "bean1.booleanObject", "bean2" })
+            public void setBeanContainingBeans(
+                    BeanContainingBeans beanContainingBeans);
+        }
+
+        @Override
+        protected ModelWithExcludeForSubBean getModel() {
+            return (ModelWithExcludeForSubBean) super.getModel();
+        }
+
     }
 
     @Test
@@ -806,4 +898,98 @@ public class TemplateModelTest {
                 template.getModel().getBeans(), new Bean(100), new Bean(200),
                 new Bean(300));
     }
+
+    @Test
+    public void setBeanIncludeProperties() {
+        TemplateWithInclude template = new TemplateWithInclude();
+        template.getModel().setBean(new Bean(123));
+
+        ModelMap modelMap = getModelMap(template, "bean");
+        Set<String> mapKeys = new HashSet<>(modelMap.keySet());
+        Assert.assertTrue("Model should contain included 'doubleValue'",
+                mapKeys.remove("doubleValue"));
+        Assert.assertTrue("Model should contain included 'booleanObject'",
+                mapKeys.remove("booleanObject"));
+        Assert.assertTrue("model should be empty but contains: " + mapKeys,
+                mapKeys.isEmpty());
+    }
+
+    @Test
+    public void setBeanExcludeProperties() {
+        TemplateWithExclude template = new TemplateWithExclude();
+        template.getModel().setBean(new Bean(123));
+
+        ModelMap modelMap = getModelMap(template, "bean");
+        Set<String> mapKeys = new HashSet<>(modelMap.keySet());
+        HashSet<String> excluded = new HashSet<>();
+        excluded.add("doubleValue");
+        excluded.add("booleanObject");
+
+        for (String excludedPropertyName : excluded) {
+            Assert.assertFalse("Model should not contain excluded '"
+                    + excludedPropertyName + "'",
+                    mapKeys.contains(excludedPropertyName));
+        }
+
+        ReflectTools.getSetterMethods(Bean.class)
+                .map(method -> ReflectTools.getPropertyName(method))
+                .forEach(propertyName -> {
+                    if (!excluded.contains(propertyName)) {
+                        Assert.assertTrue(
+                                "Model should contain the property '"
+                                        + propertyName + "'",
+                                mapKeys.remove(propertyName));
+                    }
+                });
+        Assert.assertTrue("model should be empty but contains: " + mapKeys,
+                mapKeys.isEmpty());
+    }
+
+    @Test
+    public void setBeanIncludeAndExcludeProperties() {
+        TemplateWithExcludeAndInclude template = new TemplateWithExcludeAndInclude();
+        template.getModel().setBean(new Bean(123));
+        ModelMap modelMap = getModelMap(template, "bean");
+        Assert.assertTrue(modelMap.hasValue("booleanObject"));
+        Assert.assertEquals(1, modelMap.keySet().size());
+    }
+
+    @Test
+    public void includeExcludeWhenUsingSubclass() {
+        TemplateWithExcludeAndIncludeSubclass template = new TemplateWithExcludeAndIncludeSubclass();
+        template.getModel().setBean(new Bean(123));
+        ModelMap modelMap = getModelMap(template, "bean");
+        Assert.assertTrue(modelMap.hasValue("booleanObject"));
+        Assert.assertEquals(1, modelMap.keySet().size());
+    }
+
+    @Test
+    public void includeExcludeOverrideInSubclass() {
+        TemplateWithExcludeAndIncludeSubclassOverrides template = new TemplateWithExcludeAndIncludeSubclassOverrides();
+        template.getModel().setBean(new Bean(123));
+        ModelMap modelMap = getModelMap(template, "bean");
+        Assert.assertTrue(modelMap.hasValue("doubleValue"));
+        Assert.assertEquals(1, modelMap.keySet().size());
+    }
+
+    @Test
+    public void setBeanExcludeSubBeanProperties() {
+        TemplateWithExcludeForSubBean template = new TemplateWithExcludeForSubBean();
+        BeanContainingBeans beanContainer = new BeanContainingBeans();
+        beanContainer.setBean1(new Bean(1));
+        beanContainer.setBean2(new Bean(2));
+
+        template.getModel().setBeanContainingBeans(beanContainer);
+
+        Assert.assertNotNull(
+                template.getModel().getBeanContainingBeans().getBean1());
+        Assert.assertTrue(getModelMap(template, "beanContainingBeans.bean1")
+                .hasValue("booleanValue"));
+        // bean1.booleanObject is excluded
+        Assert.assertFalse(getModelMap(template, "beanContainingBeans.bean1")
+                .hasValue("booleanObject"));
+        Assert.assertNull(
+                template.getModel().getBeanContainingBeans().getBean2());
+    }
+
 }


### PR DESCRIPTION
@Include/@Exclude is used to control which properties of a bean are
imported into the model

Fixes #743

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/996)

<!-- Reviewable:end -->
