### PR TITLE
Make sure AtmosphereFramework is always properly destroyed

### DIFF
--- a/hummingbird-server/src/main/java/com/vaadin/server/communication/JSR356WebsocketInitializer.java
+++ b/hummingbird-server/src/main/java/com/vaadin/server/communication/JSR356WebsocketInitializer.java
@@ -183,6 +183,21 @@ public class JSR356WebsocketInitializer implements ServletContextListener {
     }
 
     /**
+     * Checks if the given attribute name matches the convention used for
+     * storing AtmosphereFramework references.
+     *
+     * @param attributeName
+     *            the attribute name to check
+     * @return <code>true</code> if the attribute name matches the convention,
+     *         <code>false</code> otherwise
+     */
+    private static boolean isAtmosphereFrameworkAttribute(
+            String attributeName) {
+        return attributeName
+                .startsWith(JSR356WebsocketInitializer.class.getName() + ".");
+    }
+
+    /**
      * Tries to determine if the given servlet registration refers to a Vaadin
      * servlet.
      *
@@ -214,7 +229,22 @@ public class JSR356WebsocketInitializer implements ServletContextListener {
 
     @Override
     public void contextDestroyed(ServletContextEvent sce) {
-        // Nothing to do here
+        // Destroy any AtmosphereFramework instance we have initialized.
+        // This must be done here to ensure that we cleanup Atmosphere instances
+        // related to servlets which are never initialized
+        ServletContext servletContext = sce.getServletContext();
+        Enumeration<String> attributeNames = servletContext.getAttributeNames();
+        while (attributeNames.hasMoreElements()) {
+            String attributeName = attributeNames.nextElement();
+            if (isAtmosphereFrameworkAttribute(attributeName)) {
+                Object value = servletContext.getAttribute(attributeName);
+                if (value instanceof AtmosphereFramework) {
+                    // This might result in calling destroy() twice, once from
+                    // here and once from PushRequestHandler but
+                    // AtmosphereFramework.destroy() deals with that
+                    ((AtmosphereFramework) value).destroy();
+                }
+            }
+        }
     }
-
 }

--- a/hummingbird-tests/pom.xml
+++ b/hummingbird-tests/pom.xml
@@ -18,6 +18,7 @@
 		<module>test-subcontext</module>
 		<module>test-performance</module>
 		<module>test-scalability</module>
+		<module>test-memory-leaks</module>
 	</modules>
 
 	<properties>

--- a/hummingbird-tests/test-memory-leaks/pom.xml
+++ b/hummingbird-tests/test-memory-leaks/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.vaadin</groupId>
+		<artifactId>hummingbird-tests</artifactId>
+		<version>0.0.11-SNAPSHOT</version>
+	</parent>
+	<artifactId>hummingbird-test-memory-leaks</artifactId>
+	<name>Hummingbird memory leak tests</name>
+	<packaging>war</packaging>
+	<properties>
+		<maven.deploy.skip>true</maven.deploy.skip>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-server</artifactId>
+			<version>${jetty.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-webapp</artifactId>
+			<version>${jetty.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-http</artifactId>
+			<version>${jetty.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-annotations</artifactId>
+			<version>${jetty.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-util</artifactId>
+			<version>${jetty.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jetty.websocket</groupId>
+			<artifactId>websocket-server</artifactId>
+			<version>${jetty.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+		</dependency>
+	</dependencies>
+</project>

--- a/hummingbird-tests/test-memory-leaks/src/main/java/com/vaadin/hummingbird/memoryleaks/ui/MemoryLeakUI.java
+++ b/hummingbird-tests/test-memory-leaks/src/main/java/com/vaadin/hummingbird/memoryleaks/ui/MemoryLeakUI.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.hummingbird.memoryleaks.ui;
+
+import javax.servlet.annotation.WebServlet;
+
+import com.vaadin.annotations.VaadinServletConfiguration;
+import com.vaadin.hummingbird.html.Button;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.server.VaadinServlet;
+import com.vaadin.ui.Text;
+import com.vaadin.ui.UI;
+
+public class MemoryLeakUI extends UI {
+
+    @WebServlet(asyncSupported = true, urlPatterns = { "/*" })
+    @VaadinServletConfiguration(productionMode = false, ui = MemoryLeakUI.class)
+    public static class MemoryLeakServlet extends VaadinServlet {
+
+    }
+
+    @Override
+    protected void init(VaadinRequest request) {
+        Button button = new Button("Hello", e -> add(new Text("Hello")));
+        button.setId("hello");
+        add(button);
+    }
+}

--- a/hummingbird-tests/test-memory-leaks/src/test/java/com/vaadin/hummingbird/memoryleaks/ui/RedeployLeakIT.java
+++ b/hummingbird-tests/test-memory-leaks/src/test/java/com/vaadin/hummingbird/memoryleaks/ui/RedeployLeakIT.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2000-2014 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.hummingbird.memoryleaks.ui;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.lang.ref.WeakReference;
+
+import org.eclipse.jetty.annotations.AnnotationConfiguration;
+import org.eclipse.jetty.plus.webapp.EnvConfiguration;
+import org.eclipse.jetty.plus.webapp.PlusConfiguration;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.log.JavaUtilLog;
+import org.eclipse.jetty.webapp.Configuration;
+import org.eclipse.jetty.webapp.FragmentConfiguration;
+import org.eclipse.jetty.webapp.MetaInfConfiguration;
+import org.eclipse.jetty.webapp.WebAppContext;
+import org.eclipse.jetty.webapp.WebInfConfiguration;
+import org.eclipse.jetty.webapp.WebXmlConfiguration;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.remote.DesiredCapabilities;
+
+import com.vaadin.hummingbird.testutil.FixedPhantomJSDriver;
+import com.vaadin.testbench.By;
+
+/**
+ * Test that verifies no leaks happen during redeployment of a war. Uses Jetty
+ * to deploy/undeploy the war file this module produces.
+ *
+ * If you run this from Eclipse it might not produce the correct result as it
+ * uses files from the target folder.
+ */
+public class RedeployLeakIT {
+
+    private static final String testClass = "com.vaadin.server.VaadinServlet";
+    private Server server;
+    private WebAppContext context;
+    private WeakReference<Class<?>> testReference;
+
+    @Test
+    public void deployUndeployCheck() throws Exception {
+        // DO NOT RUN FROM ECLIPSE
+        // The test uses files from the target folder
+        setup(7777);
+        shutdownAndVerify();
+    }
+
+    @Test
+    public void deployUseUndeployCheck() throws Exception {
+        // DO NOT RUN FROM ECLIPSE
+        // The test uses files from the target folder
+        setup(7778);
+        FixedPhantomJSDriver driver = new FixedPhantomJSDriver(
+                DesiredCapabilities.phantomjs());
+        try {
+            driver.get("http://localhost:7778/");
+            Assert.assertNotNull(driver.findElement(By.id("hello")));
+        } finally {
+            driver.close();
+        }
+        shutdownAndVerify();
+    }
+
+    public void setup(int port) throws Exception {
+        System.setProperty("java.awt.headless", "true");
+        System.setProperty("org.eclipse.jetty.util.log.class",
+                JavaUtilLog.class.getName());
+
+        server = new Server();
+
+        final ServerConnector connector = new ServerConnector(server);
+
+        connector.setPort(port);
+        server.setConnectors(new ServerConnector[] { connector });
+
+        File[] warDirs = new File("target").listFiles((FileFilter) file -> {
+            return file.getName()
+                    .matches("hummingbird-test-memory-leaks-.*-SNAPSHOT");
+        });
+        String wardir = "target/" + warDirs[0].getName();
+
+        context = new WebAppContext();
+        context.setResourceBase(wardir);
+        context.setContextPath("/");
+        context.setConfigurations(
+                new Configuration[] { new AnnotationConfiguration(),
+                        new WebXmlConfiguration(), new WebInfConfiguration(),
+                        // new TagLibConfiguration(),
+                        new PlusConfiguration(), new MetaInfConfiguration(),
+                        new FragmentConfiguration(), new EnvConfiguration() });
+        server.setHandler(context);
+        server.start();
+
+        testReference = new WeakReference<>(
+                Class.forName(testClass, true, context.getClassLoader()));
+        Assert.assertNotNull(testReference.get());
+
+    }
+
+    public void shutdownAndVerify() throws Exception {
+        try {
+            context.stop();
+            context.destroy();
+            context = null;
+
+            // This is needed for the class to be actually GCed
+            for (int i = 0; i < 10; i++) {
+                System.gc();
+                Thread.sleep(100);
+                if (testReference.get() == null) {
+                    break;
+                }
+            }
+
+            Assert.assertNull(testReference.get());
+
+        } finally {
+            server.stop();
+        }
+
+    }
+
+}


### PR DESCRIPTION
If servlets have never been initialized, then destroy must happen in the
context destroy method

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/1004)

<!-- Reviewable:end -->
