### PR TITLE
Show client side exception messages when not in production

### DIFF
--- a/hummingbird-client/src/main/java/com/vaadin/client/ApplicationConnection.java
+++ b/hummingbird-client/src/main/java/com/vaadin/client/ApplicationConnection.java
@@ -16,6 +16,7 @@
 
 package com.vaadin.client;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
 import com.vaadin.client.communication.PollConfigurator;
 import com.vaadin.client.communication.Poller;
@@ -47,6 +48,9 @@ public class ApplicationConnection {
             ApplicationConfiguration applicationConfiguration) {
 
         registry = new DefaultRegistry(this, applicationConfiguration);
+        GWT.setUncaughtExceptionHandler(
+                registry.getSystemErrorHandler()::handleError);
+
         StateNode rootNode = registry.getStateTree().getRootNode();
 
         // Bind UI configuration objects

--- a/hummingbird-client/src/main/java/com/vaadin/client/ResourceLoader.java
+++ b/hummingbird-client/src/main/java/com/vaadin/client/ResourceLoader.java
@@ -462,8 +462,8 @@ public class ResourceLoader {
     }
 
     private void fireError(ResourceLoadEvent event) {
-        Console.error("Error loading " + event.getResourceUrl());
-        showLoadingError(event);
+        registry.getSystemErrorHandler()
+                .handleError("Error loading " + event.getResourceUrl());
         String resource = event.getResourceUrl();
 
         JsArray<ResourceLoadListener> listeners = loadListeners.get(resource);
@@ -476,22 +476,6 @@ public class ResourceLoader {
                 }
             }
         }
-    }
-
-    protected void showLoadingError(ResourceLoadEvent event) {
-        if (registry.getApplicationConfiguration().isProductionMode()) {
-            // Only show error message when not in production
-            return;
-        }
-        Document document = Browser.getDocument();
-        Element errorContainer = document.createDivElement();
-        errorContainer.setClassName("v-system-error");
-        errorContainer
-                .setTextContent("Error loading " + event.getResourceUrl());
-        errorContainer.addEventListener("click", e -> {
-            errorContainer.getParentElement().removeChild(errorContainer);
-        });
-        document.getBody().appendChild(errorContainer);
     }
 
     private void fireLoad(ResourceLoadEvent event) {

--- a/hummingbird-client/src/main/java/com/vaadin/client/communication/DefaultConnectionStateHandler.java
+++ b/hummingbird-client/src/main/java/com/vaadin/client/communication/DefaultConnectionStateHandler.java
@@ -141,7 +141,7 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
 
         if (statusCode == Response.SC_GONE) {
             // Session expired
-            registry.getSystemErrorHandler().showSessionExpiredError(null);
+            registry.getSystemErrorHandler().handleSessionExpiredError(null);
             stopApplication();
         } else if (statusCode == Response.SC_NOT_FOUND) {
             // UI closed, do nothing as the UI will react to this
@@ -460,7 +460,7 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
          * Authorization has failed (401). Could be that the session has timed
          * out.
          */
-        registry.getSystemErrorHandler().showAuthenticationError("");
+        registry.getSystemErrorHandler().handleAuthenticationError("");
         stopApplication();
     }
 
@@ -492,7 +492,8 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
      * @param statusCode
      */
     protected void handleCommunicationError(String details, int statusCode) {
-        registry.getSystemErrorHandler().showError("", details, "", null);
+        registry.getSystemErrorHandler().handleUnrecoverableError("", details,
+                "", null);
 
     }
 

--- a/hummingbird-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
+++ b/hummingbird-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
@@ -375,13 +375,13 @@ public class MessageHandler {
                         nextResponseSessionExpiredHandler.execute();
                     } else {
                         registry.getSystemErrorHandler()
-                                .showSessionExpiredError(null);
+                                .handleSessionExpiredError(null);
                         registry.getUILifecycle().setState(UIState.TERMINATED);
                     }
                 } else if (meta.containsKey("appError")) {
                     ValueMap error = meta.getValueMap("appError");
 
-                    registry.getSystemErrorHandler().showError(
+                    registry.getSystemErrorHandler().handleUnrecoverableError(
                             error.getString("caption"),
                             error.getString("message"),
                             error.getString("details"), error.getString("url"));

--- a/hummingbird-client/src/main/java/com/vaadin/client/hummingbird/RouterLinkHandler.java
+++ b/hummingbird-client/src/main/java/com/vaadin/client/hummingbird/RouterLinkHandler.java
@@ -172,7 +172,8 @@ public class RouterLinkHandler {
 
         Element target = (Element) clickEvent.getTarget();
         EventTarget eventListenerElement = clickEvent.getCurrentTarget();
-        while (target != eventListenerElement) {
+        // Target can become null if another click handler detaches the element
+        while (target != null && target != eventListenerElement) {
             if (isRouterLinkAnchorElement(target)) {
                 return (AnchorElement) target;
             }

--- a/hummingbird-server/src/main/java/com/vaadin/server/BootstrapHandler.java
+++ b/hummingbird-server/src/main/java/com/vaadin/server/BootstrapHandler.java
@@ -312,6 +312,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
         // Basic system error dialog style just to make it visible and outside
         // of normal flow
         styles.appendText(".v-system-error {" //
+                + "color: red;" //
                 + "background: white;" //
                 + "position: absolute;" //
                 + "top: 1em;" //

--- a/hummingbird-tests/test-root-context/src/main/java/com/vaadin/hummingbird/uitest/ui/ClientSideExceptionHandlingView.java
+++ b/hummingbird-tests/test-root-context/src/main/java/com/vaadin/hummingbird/uitest/ui/ClientSideExceptionHandlingView.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.hummingbird.uitest.ui;
+
+import com.vaadin.hummingbird.html.Button;
+import com.vaadin.hummingbird.html.Div;
+import com.vaadin.hummingbird.router.View;
+
+public class ClientSideExceptionHandlingView extends Div implements View {
+
+    static final String CAUSE_EXCEPTION_ID = "causeException";
+    private Button causeException;
+
+    public ClientSideExceptionHandlingView() {
+        causeException = new Button("Cause client side exception", e -> {
+            getUI().get().getPage().executeJavaScript("null.foo");
+        });
+        causeException.setId(CAUSE_EXCEPTION_ID);
+        add(causeException);
+    }
+}

--- a/hummingbird-tests/test-root-context/src/test/java/com/vaadin/hummingbird/uitest/ui/ClientSideExceptionHandlingIT.java
+++ b/hummingbird-tests/test-root-context/src/test/java/com/vaadin/hummingbird/uitest/ui/ClientSideExceptionHandlingIT.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.hummingbird.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.hummingbird.testutil.PhantomJSTest;
+
+public class ClientSideExceptionHandlingIT extends PhantomJSTest {
+
+    private static final By ERROR_LOCATOR = By.className("v-system-error");
+
+    @Test
+    public void developmentModeExceptions() {
+        open();
+        causeException();
+
+        WebElement errorMessage = findElement(ERROR_LOCATOR);
+        Assert.assertTrue(errorMessage.getText(),
+                errorMessage.getText().contains("null is not an object"));
+    }
+
+    @Test
+    public void productionModeExceptions() {
+        openProduction();
+        causeException();
+
+        Assert.assertFalse(isElementPresent(ERROR_LOCATOR));
+    }
+
+    private void causeException() {
+        findElement(By.id(ClientSideExceptionHandlingView.CAUSE_EXCEPTION_ID))
+                .click();
+    }
+
+}


### PR DESCRIPTION
When not in production mode, this causes any exception which happens
in the browser to be shown to the developer so it is clear that
something is wrong.

Client side exceptions are always logged to the browser console,
regardless of the production mode status.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/1030)

<!-- Reviewable:end -->
