### PR TITLE
Routes must be mapped starting with /

### DIFF
--- a/hummingbird-documentation/src/main/java/com/vaadin/humminbird/tutorial/routing/Routing.java
+++ b/hummingbird-documentation/src/main/java/com/vaadin/humminbird/tutorial/routing/Routing.java
@@ -39,7 +39,7 @@ public class Routing {
         @Override
         public void configure(RouterConfiguration configuration) {
             configuration.setRoute("", HomeView.class);
-            configuration.setRoute("company", CompanyView.class);
+            configuration.setRoute("/company", CompanyView.class);
         }
 
     }

--- a/hummingbird-documentation/src/main/java/com/vaadin/humminbird/tutorial/routing/RoutingViewHierarchy.java
+++ b/hummingbird-documentation/src/main/java/com/vaadin/humminbird/tutorial/routing/RoutingViewHierarchy.java
@@ -40,7 +40,7 @@ public class RoutingViewHierarchy {
         @Override
         public void configure(RouterConfiguration configuration) {
             //@formatter:off - custom line wrapping
-            configuration.setRoute("company", CompanyView.class, MainLayout.class);
+            configuration.setRoute("/company", CompanyView.class, MainLayout.class);
             //@formatter:on
         }
     }
@@ -49,7 +49,7 @@ public class RoutingViewHierarchy {
         @Override
         public void configure(RouterConfiguration configuration) {
             //@formatter:off - custom line wrapping
-            configuration.setRoute("company", CompanyView.class, CompanySideBarView.class);
+            configuration.setRoute("/company", CompanyView.class, CompanySideBarView.class);
             configuration.setParentView(CompanySideBarView.class, MainLayout.class);
             //@formatter:on
         }

--- a/hummingbird-documentation/tutorial-routing-view-hierarchy.asciidoc
+++ b/hummingbird-documentation/tutorial-routing-view-hierarchy.asciidoc
@@ -10,7 +10,7 @@ When defining routes using `setRoute(String, Class)`, the view will be rendered 
 ----
 @Override
 public void configure(RouterConfiguration configuration) {
-  configuration.setRoute("company", CompanyView.class, MainLayout.class);
+  configuration.setRoute("/company", CompanyView.class, MainLayout.class);
 }
 ----
 
@@ -26,7 +26,7 @@ public class MainLayout extends Div implements HasChildView {
     // Initialize the main layout DOM
     Div header = new Div();
     header.setText("This header will always be shown");
-    
+
     childContainer = new Div();
     add(header, childContainer);
   }
@@ -51,7 +51,7 @@ To define multiple view levels, you can use the method `setParentView(Class<? ex
 ----
 @Override
 public void configure(RouterConfiguration configuration) {
-  configuration.setRoute("company", CompanyView.class, CompanySideBarView.class);
+  configuration.setRoute("/company", CompanyView.class, CompanySideBarView.class);
   configuration.setParentView(CompanySideBarView.class, MainLayout.class);
 }
 ----

--- a/hummingbird-documentation/tutorial-routing.asciidoc
+++ b/hummingbird-documentation/tutorial-routing.asciidoc
@@ -18,14 +18,14 @@ Your `RouterConfigurator` class needs to override one method, where the actual c
 @Override
 public void configure(RouterConfiguration configuration) {
   configuration.setRoute("", HomeView.class);
-  configuration.setRoute("company", CompanyView.class);
+  configuration.setRoute("/company", CompanyView.class);
 }
 ----
 
 This will set up routing so that `HomeView` is used when the base URL (servlet path) is opened, e.g. `http://mysite.com/` and  `CompanyView` is used when `/company` is opened, e.g. using `http://mysite.com/company`.
 
 [NOTE]
-Do not start routes with a `/` as the URLs are relative to the servlet path.
+The routes are relative to the servlet path and must start with a `/` unless mapping to servlet root with `""``.
 
 All views must implement the `View` interface and override one method: `getElement()`. This method must return the root element of the view and cannot be changed while the view is visible. You can extend some existing component class which already has this method. The HomeView class could thus look like:
 [source,java]

--- a/hummingbird-server/src/main/java/com/vaadin/hummingbird/router/RouterConfiguration.java
+++ b/hummingbird-server/src/main/java/com/vaadin/hummingbird/router/RouterConfiguration.java
@@ -192,6 +192,9 @@ public class RouterConfiguration
      * routed before without a parent, it will from now on always use the parent
      * set in this method.
      * <p>
+     * The path must start with a <code>/</code>, unless mapping to root with an
+     * empty path <code>""</code>.
+     * <p>
      * The path is made up of segments separated by <code>/</code>. A segment
      * name enclosed in <code>{</code> and <code>}</code> is interpreted as a
      * placeholder segment. If no exact match is found when resolving a URL but
@@ -222,10 +225,12 @@ public class RouterConfiguration
     }
 
     private void mapViewToRoute(Class<? extends View> viewType, String path) {
+        assert !path.startsWith("/");
         viewToRoute.computeIfAbsent(viewType, t -> new ArrayList<>()).add(path);
     }
 
     private void removeViewToRouteMapping(String route) {
+        assert !route.startsWith("/");
         viewToRoute.values().forEach(routes -> routes.remove(route));
     }
 
@@ -251,7 +256,11 @@ public class RouterConfiguration
         assert path != null;
         assert viewType != null;
 
-        mapViewToRoute(viewType, path);
+        verifyValidPath(path);
+
+        String relativePath = path.startsWith("/") ? path.substring(1) : path;
+        mapViewToRoute(viewType, relativePath);
+
         setRoute(path, new ViewRenderer() {
             @Override
             public Class<? extends View> getViewType() {
@@ -265,7 +274,7 @@ public class RouterConfiguration
 
             @Override
             protected String getRoute() {
-                return path;
+                return relativePath;
             }
         });
     }
@@ -367,12 +376,21 @@ public class RouterConfiguration
     public void setRoute(String path, NavigationHandler navigationHandler) {
         assert path != null;
         assert navigationHandler != null;
-        assert !path.startsWith("/");
         assert !path.contains("://");
 
+        verifyValidPath(path);
+
+        String relativePath = path.startsWith("/") ? path.substring(1) : path;
         // Start the recursion
-        setRoute(new RouteLocation(new Location(path)), routeTreeRoot,
+        setRoute(new RouteLocation(new Location(relativePath)), routeTreeRoot,
                 navigationHandler);
+    }
+
+    private static void verifyValidPath(String path) {
+        if (!path.startsWith("/") && !path.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Path should always start with / unless mapping to root context with an empty path");
+        }
     }
 
     private void setRoute(RouteLocation location, RouteTreeNode node,
@@ -415,9 +433,14 @@ public class RouterConfiguration
     public void removeRoute(String path) {
         assert path != null;
 
-        removeViewToRouteMapping(path);
+        verifyValidPath(path);
+
+        String relativePath = path.startsWith("/") ? path.substring(1) : path;
+
+        removeViewToRouteMapping(relativePath);
         // Start the recursion
-        removeRoute(new RouteLocation(new Location(path)), routeTreeRoot);
+        removeRoute(new RouteLocation(new Location(relativePath)),
+                routeTreeRoot);
     }
 
     private void removeRoute(RouteLocation location, RouteTreeNode node) {

--- a/hummingbird-server/src/main/java/com/vaadin/hummingbird/router/ViewRenderer.java
+++ b/hummingbird-server/src/main/java/com/vaadin/hummingbird/router/ViewRenderer.java
@@ -156,6 +156,9 @@ public abstract class ViewRenderer implements NavigationHandler {
         String route = getRoute();
         Map<String, String> routePlaceholders;
         if (route != null) {
+            if (route.startsWith("/")) {
+                route = route.substring(1);
+            }
             routePlaceholders = extractRoutePlaceholders(event.getLocation(),
                     new RouteLocation(new Location(route)));
         } else {

--- a/hummingbird-server/src/test/java/com/vaadin/hummingbird/router/RouterLinkTest.java
+++ b/hummingbird-server/src/test/java/com/vaadin/hummingbird/router/RouterLinkTest.java
@@ -83,7 +83,7 @@ public class RouterLinkTest {
     @Test
     public void buildUrlWithRouter() {
         Router router = new Router();
-        router.reconfigure(c -> c.setRoute("foo/{bar}", TestView.class));
+        router.reconfigure(c -> c.setRoute("/foo/{bar}", TestView.class));
 
         String url = RouterLink.buildUrl(router, TestView.class, "asdf");
 
@@ -111,8 +111,8 @@ public class RouterLinkTest {
     public void buildUrlWithRouter_multipleRoutes() {
         Router router = new Router();
         router.reconfigure(c -> {
-            c.setRoute("foo/{bar}", TestView.class);
-            c.setRoute("another/route", TestView.class);
+            c.setRoute("/foo/{bar}", TestView.class);
+            c.setRoute("/another/route", TestView.class);
         });
 
         RouterLink.buildUrl(router, TestView.class, "asdf");
@@ -124,7 +124,7 @@ public class RouterLinkTest {
         // Router from the UI.
         RouterTestUI ui = createUI();
         ui.getRouter().get()
-                .reconfigure(c -> c.setRoute("show/{bar}", TestView.class));
+                .reconfigure(c -> c.setRoute("/show/{bar}", TestView.class));
 
         RouterLink link = new RouterLink("Show something", TestView.class,
                 "something");
@@ -142,7 +142,7 @@ public class RouterLinkTest {
     public void setRoute_attachedLink() {
         RouterTestUI ui = new RouterTestUI(new Router());
         ui.getRouter().get()
-                .reconfigure(c -> c.setRoute("show/{bar}", TestView.class));
+                .reconfigure(c -> c.setRoute("/show/{bar}", TestView.class));
 
         RouterLink link = new RouterLink();
 
@@ -157,7 +157,7 @@ public class RouterLinkTest {
     @Test
     public void createRouterLink_explicitRouter() {
         Router router = new Router();
-        router.reconfigure(c -> c.setRoute("show/{bar}", TestView.class));
+        router.reconfigure(c -> c.setRoute("/show/{bar}", TestView.class));
 
         RouterLink link = new RouterLink(router, "Show something",
                 TestView.class, "something");
@@ -177,7 +177,7 @@ public class RouterLinkTest {
         // Router from the UI.
         RouterTestUI ui = createUI();
         ui.getRouter().get()
-                .reconfigure(c -> c.setRoute("show/{bar}", TestView.class));
+                .reconfigure(c -> c.setRoute("/show/{bar}", TestView.class));
 
         RouterLink link = new RouterLink("Show something", TestView.class,
                 "something");
@@ -196,7 +196,7 @@ public class RouterLinkTest {
     @Test
     public void createReconfigureRouterLink_explicitRouter() {
         Router router = new Router();
-        router.reconfigure(c -> c.setRoute("show/{bar}", TestView.class));
+        router.reconfigure(c -> c.setRoute("/show/{bar}", TestView.class));
 
         RouterLink link = new RouterLink(router, "Show something",
                 TestView.class, "something");
@@ -216,7 +216,7 @@ public class RouterLinkTest {
     public void reconfigureRouterLink_attachedLink() {
         Router router = new Router();
         RouterTestUI ui = new RouterTestUI(router);
-        router.reconfigure(c -> c.setRoute("show/{bar}", TestView.class));
+        router.reconfigure(c -> c.setRoute("/show/{bar}", TestView.class));
 
         RouterLink link = new RouterLink();
         ui.add(link);
@@ -238,7 +238,7 @@ public class RouterLinkTest {
         // Router from the UI.
         RouterTestUI ui = createUI();
         ui.getRouter().get()
-                .reconfigure(c -> c.setRoute("show/{bar}", TestView.class));
+                .reconfigure(c -> c.setRoute("/show/{bar}", TestView.class));
 
         new RouterLink("Show something", TestView.class);
     }
@@ -246,7 +246,7 @@ public class RouterLinkTest {
     @Test(expected = IllegalArgumentException.class)
     public void invalidRoute_explicitRouter() {
         Router router = new Router();
-        router.reconfigure(c -> c.setRoute("show/{bar}", TestView.class));
+        router.reconfigure(c -> c.setRoute("/show/{bar}", TestView.class));
 
         new RouterLink(router, "Show something", TestView.class);
     }
@@ -255,7 +255,7 @@ public class RouterLinkTest {
     public void invalidRoute_attachedLink() {
         Router router = new Router();
         RouterTestUI ui = new RouterTestUI(router);
-        router.reconfigure(c -> c.setRoute("show/{bar}", TestView.class));
+        router.reconfigure(c -> c.setRoute("/show/{bar}", TestView.class));
 
         RouterLink link = new RouterLink();
         ui.add(link);
@@ -270,8 +270,8 @@ public class RouterLinkTest {
         try {
             VaadinService.setCurrent(servlet.getService());
 
-            servlet.getService().getRouter()
-                    .reconfigure(c -> c.setRoute("show/{bar}", TestView.class));
+            servlet.getService().getRouter().reconfigure(
+                    c -> c.setRoute("/show/{bar}", TestView.class));
 
             new RouterLink("Show something", TestView.class);
         } finally {

--- a/hummingbird-server/src/test/java/com/vaadin/hummingbird/router/RouterTest.java
+++ b/hummingbird-server/src/test/java/com/vaadin/hummingbird/router/RouterTest.java
@@ -255,7 +255,7 @@ public class RouterTest {
                         usedHandler.set("resolver");
                     }));
 
-            configuration.setRoute("*", e -> {
+            configuration.setRoute("/*", e -> {
                 usedHandler.set("route");
             });
         });
@@ -274,7 +274,7 @@ public class RouterTest {
         router.reconfigure(configuration -> {
             configuration.setResolver(resolveEvent -> Optional.empty());
 
-            configuration.setRoute("*", e -> {
+            configuration.setRoute("/*", e -> {
                 usedHandler.set("route");
             });
         });
@@ -336,8 +336,8 @@ public class RouterTest {
 
         Router router = new Router();
         router.reconfigure(c -> {
-            c.setRoute("foo/{name}", TestView.class);
-            c.setRoute("bar/*", TestView.class);
+            c.setRoute("/foo/{name}", TestView.class);
+            c.setRoute("/bar/*", TestView.class);
         });
 
         router.navigate(ui, new Location("foo/bar/"));

--- a/hummingbird-server/src/test/java/com/vaadin/hummingbird/router/ViewRendererTest.java
+++ b/hummingbird-server/src/test/java/com/vaadin/hummingbird/router/ViewRendererTest.java
@@ -246,7 +246,7 @@ public class ViewRendererTest {
 
     @Test
     public void routeParamtersInEvent() {
-        router.reconfigure(c -> c.setRoute("foo/{name}/*", TestView.class));
+        router.reconfigure(c -> c.setRoute("/foo/{name}/*", TestView.class));
         router.navigate(ui, new Location("foo/bar/baz/"));
         TestView testView = (TestView) ui.getInternals().getActiveViewChain()
                 .get(0);

--- a/hummingbird-server/src/test/java/com/vaadin/ui/TemplateTest.java
+++ b/hummingbird-server/src/test/java/com/vaadin/ui/TemplateTest.java
@@ -257,7 +257,7 @@ public class TemplateTest {
         Router router = new Router();
         router.reconfigure(c -> {
             c.setRoute("", TestView.class, TemplateParentView.class);
-            c.setRoute("empty", TemplateParentView.class);
+            c.setRoute("/empty", TemplateParentView.class);
         });
 
         UI ui = new UI();


### PR DESCRIPTION
Only makes sure that routes are mapped starting with / unless mapping an empty string to root path.
Doesn't change how the framework internals use the path as relative without a slash.

Fixes #570

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/1035)

<!-- Reviewable:end -->
