### PR TITLE
Load @HTMLImport before @JavaScript

### DIFF
--- a/hummingbird-server/src/main/java/com/vaadin/ui/UIInternals.java
+++ b/hummingbird-server/src/main/java/com/vaadin/ui/UIInternals.java
@@ -651,13 +651,13 @@ public class UIInternals implements Serializable {
     public void addComponentDependencies(
             Class<? extends Component> componentClass) {
         Page page = ui.getPage();
-        List<JavaScript> javaScripts = AnnotationReader
-                .getJavaScriptAnnotations(componentClass);
-        javaScripts.forEach(js -> page.addJavaScript(js.value()));
-
         List<HtmlImport> htmlImports = AnnotationReader
                 .getHtmlImportAnnotations(componentClass);
         htmlImports.forEach(html -> page.addHtmlImport(html.value()));
+
+        List<JavaScript> javaScripts = AnnotationReader
+                .getJavaScriptAnnotations(componentClass);
+        javaScripts.forEach(js -> page.addJavaScript(js.value()));
 
         List<StyleSheet> styleSheets = AnnotationReader
                 .getStyleSheetAnnotations(componentClass);

--- a/hummingbird-server/src/test/java/com/vaadin/server/communication/UidlWriterTest.java
+++ b/hummingbird-server/src/test/java/com/vaadin/server/communication/UidlWriterTest.java
@@ -177,29 +177,24 @@ public class UidlWriterTest {
                 DependencyList.TYPE_JAVASCRIPT);
         assertDependency("UI-", dependencies.get(idx++),
                 DependencyList.TYPE_JAVASCRIPT);
-        assertDependency("super-", dependencies.get(idx++),
-                DependencyList.TYPE_JAVASCRIPT);
-
-        assertDependency("anotherinterface-", dependencies.get(idx++),
-                DependencyList.TYPE_JAVASCRIPT);
-
-        assertDependency("interface-", dependencies.get(idx++),
-                DependencyList.TYPE_JAVASCRIPT);
-
-        assertDependency("", dependencies.get(idx++),
-                DependencyList.TYPE_JAVASCRIPT);
 
         assertDependency("super-", dependencies.get(idx++),
                 DependencyList.TYPE_HTML_IMPORT);
-
         assertDependency("anotherinterface-", dependencies.get(idx++),
                 DependencyList.TYPE_HTML_IMPORT);
-
         assertDependency("interface-", dependencies.get(idx++),
                 DependencyList.TYPE_HTML_IMPORT);
-
         assertDependency("", dependencies.get(idx++),
                 DependencyList.TYPE_HTML_IMPORT);
+
+        assertDependency("super-", dependencies.get(idx++),
+                DependencyList.TYPE_JAVASCRIPT);
+        assertDependency("anotherinterface-", dependencies.get(idx++),
+                DependencyList.TYPE_JAVASCRIPT);
+        assertDependency("interface-", dependencies.get(idx++),
+                DependencyList.TYPE_JAVASCRIPT);
+        assertDependency("", dependencies.get(idx++),
+                DependencyList.TYPE_JAVASCRIPT);
 
         assertDependency("super-", dependencies.get(idx++),
                 DependencyList.TYPE_STYLESHEET);
@@ -229,30 +224,31 @@ public class UidlWriterTest {
         JsonArray dependencies = response
                 .getArray(DependencyList.DEPENDENCY_KEY);
 
+        int idx = 0;
         Assert.assertEquals(12, dependencies.length());
-        assertDependency("childinterface1-", dependencies.getObject(0),
-                DependencyList.TYPE_JAVASCRIPT);
-        assertDependency("childinterface2-", dependencies.getObject(1),
-                DependencyList.TYPE_JAVASCRIPT);
-        assertDependency("child1-", dependencies.getObject(2),
-                DependencyList.TYPE_JAVASCRIPT);
-        assertDependency("child2-", dependencies.getObject(3),
-                DependencyList.TYPE_JAVASCRIPT);
-        assertDependency("childinterface1-", dependencies.getObject(4),
+        assertDependency("childinterface1-", dependencies.getObject(idx++),
                 DependencyList.TYPE_HTML_IMPORT);
-        assertDependency("childinterface2-", dependencies.getObject(5),
+        assertDependency("childinterface2-", dependencies.getObject(idx++),
                 DependencyList.TYPE_HTML_IMPORT);
-        assertDependency("child1-", dependencies.getObject(6),
+        assertDependency("child1-", dependencies.getObject(idx++),
                 DependencyList.TYPE_HTML_IMPORT);
-        assertDependency("child2-", dependencies.getObject(7),
+        assertDependency("child2-", dependencies.getObject(idx++),
                 DependencyList.TYPE_HTML_IMPORT);
-        assertDependency("childinterface1-", dependencies.getObject(8),
+        assertDependency("childinterface1-", dependencies.getObject(idx++),
+                DependencyList.TYPE_JAVASCRIPT);
+        assertDependency("childinterface2-", dependencies.getObject(idx++),
+                DependencyList.TYPE_JAVASCRIPT);
+        assertDependency("child1-", dependencies.getObject(idx++),
+                DependencyList.TYPE_JAVASCRIPT);
+        assertDependency("child2-", dependencies.getObject(idx++),
+                DependencyList.TYPE_JAVASCRIPT);
+        assertDependency("childinterface1-", dependencies.getObject(idx++),
                 DependencyList.TYPE_STYLESHEET);
-        assertDependency("childinterface2-", dependencies.getObject(9),
+        assertDependency("childinterface2-", dependencies.getObject(idx++),
                 DependencyList.TYPE_STYLESHEET);
-        assertDependency("child1-", dependencies.getObject(10),
+        assertDependency("child1-", dependencies.getObject(idx++),
                 DependencyList.TYPE_STYLESHEET);
-        assertDependency("child2-", dependencies.getObject(11),
+        assertDependency("child2-", dependencies.getObject(idx++),
                 DependencyList.TYPE_STYLESHEET);
     }
 

--- a/hummingbird-tests/test-resources/src/main/resources/META-INF/resources/test-files/html/htmlimport4-js.js
+++ b/hummingbird-tests/test-resources/src/main/resources/META-INF/resources/test-files/html/htmlimport4-js.js
@@ -1,0 +1,2 @@
+// This should always be loaded after htmlimport4.html
+logMessage("HTML import 4 companion JS loaded");

--- a/hummingbird-tests/test-root-context/src/main/java/com/vaadin/hummingbird/uitest/ui/DependencyView.java
+++ b/hummingbird-tests/test-root-context/src/main/java/com/vaadin/hummingbird/uitest/ui/DependencyView.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
 import com.vaadin.annotations.HtmlImport;
+import com.vaadin.annotations.JavaScript;
 import com.vaadin.annotations.Tag;
 import com.vaadin.hummingbird.html.Button;
 import com.vaadin.hummingbird.html.Div;
@@ -41,6 +42,7 @@ public class DependencyView extends AbstractDivView {
     private StreamResourceRegistration htmlMixedImport2;
 
     @Tag("div")
+    @JavaScript("/test-files/html/htmlimport4-js.js")
     @HtmlImport("/test-files/html/htmlimport4.html")
     static class HtmlComponent extends Component implements HasText {
 

--- a/hummingbird-tests/test-root-context/src/test/java/com/vaadin/hummingbird/uitest/ui/DependencyIT.java
+++ b/hummingbird-tests/test-root-context/src/test/java/com/vaadin/hummingbird/uitest/ui/DependencyIT.java
@@ -73,6 +73,8 @@ public class DependencyIT extends PhantomJSTest {
                 messages.get(0));
         Assert.assertEquals("Messagehandler initialized in HTML import 4",
                 messages.get(1));
+        Assert.assertEquals("HTML import 4 companion JS loaded",
+                messages.get(2));
 
         // Inject html
         findElementById("loadHtml").click();


### PR DESCRIPTION
Typically HTML imports do not have external dependencies but
define their dependencies inside the HTML. On the other hand,
there are situations where you want to load an extension/plugin
for an HTML import (web component) after the HTML import has been
loaded. To order is therefore changed to HTML first, JS later.

To load HTML/JS in a predefined order, use
Page.addHtmlImport/Page.addJavaScript which will load the files in
the order the methods are called.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/1038)

<!-- Reviewable:end -->
