### PR TITLE
Include 'style' in getAttributeNames when used in a template

### DIFF
--- a/hummingbird-server/src/main/java/com/vaadin/hummingbird/dom/impl/BoundStyle.java
+++ b/hummingbird-server/src/main/java/com/vaadin/hummingbird/dom/impl/BoundStyle.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.hummingbird.dom.impl;
+
+import java.util.LinkedHashMap;
+import java.util.stream.Stream;
+
+import com.vaadin.hummingbird.StateNode;
+import com.vaadin.hummingbird.dom.Style;
+import com.vaadin.hummingbird.template.ElementTemplateNode;
+
+/**
+ * Handles inline styles for a template element.
+ *
+ * @author Vaadin Ltd
+ */
+public class BoundStyle implements Style {
+
+    private final LinkedHashMap<String, String> staticStyles;
+
+    /**
+     * Creates a new style holder for the given template node using data from
+     * the given state node.
+     *
+     * @param templateNode
+     *            the template node
+     * @param node
+     *            the state node
+     */
+    public BoundStyle(ElementTemplateNode templateNode, StateNode node) {
+        String styleAttribute = templateNode.getAttributeBinding("style")
+                .map(binding -> binding.getValue(node, "")).orElse("");
+        if (!styleAttribute.isEmpty()) {
+            staticStyles = StyleAttributeHandler.parseStyles(styleAttribute);
+        } else {
+            staticStyles = new LinkedHashMap<>();
+        }
+    }
+
+    @Override
+    public String get(String styleProperty) {
+        return staticStyles.get(styleProperty);
+    }
+
+    @Override
+    public Style set(String styleProperty, String value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Style remove(String styleProperty) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean has(String styleProperty) {
+        return staticStyles.containsKey(styleProperty);
+    }
+
+    @Override
+    public Stream<String> getNames() {
+        return staticStyles.keySet().stream();
+    }
+
+    @Override
+    public Style clear() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/hummingbird-server/src/main/java/com/vaadin/hummingbird/dom/impl/StyleAttributeHandler.java
+++ b/hummingbird-server/src/main/java/com/vaadin/hummingbird/dom/impl/StyleAttributeHandler.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.hummingbird.dom.impl;
 
+import java.util.LinkedHashMap;
 import java.util.stream.Collectors;
 
 import com.helger.css.ECSSVersion;
@@ -55,28 +56,44 @@ public class StyleAttributeHandler extends CustomAttribute {
     @Override
     public void setAttribute(Element element, String attributeValue) {
         Style style = element.getStyle();
+        style.clear();
+        parseStyles(attributeValue).forEach(style::set);
+    }
+
+    /**
+     * Parses the given style string and populates the given style object with
+     * the found styles.
+     *
+     * @param styleString
+     *            the string to parse
+     * @return a map containing the found style rules
+     */
+    public static LinkedHashMap<String, String> parseStyles(
+            String styleString) {
         CollectingCSSParseErrorHandler errorCollector = new CollectingCSSParseErrorHandler();
         CSSDeclarationList parsed = CSSReaderDeclarationList.readFromString(
-                attributeValue, ECSSVersion.LATEST, errorCollector);
+                styleString, ECSSVersion.LATEST, errorCollector);
         if (errorCollector.hasParseErrors()) {
             throw new IllegalArgumentException(String
-                    .format(ERROR_PARSING_STYLE, attributeValue, errorCollector
+                    .format(ERROR_PARSING_STYLE, styleString, errorCollector
                             .getAllParseErrors().get(0).getErrorMessage()));
         }
         if (parsed == null) {
             // Did not find any styles
             throw new IllegalArgumentException(String.format(
-                    ERROR_PARSING_STYLE, attributeValue, "No styles found"));
+                    ERROR_PARSING_STYLE, styleString, "No styles found"));
         }
 
-        style.clear();
+        LinkedHashMap<String, String> parsedStyles = new LinkedHashMap<>();
         for (CSSDeclaration declaration : parsed.getAllDeclarations()) {
             String key = declaration.getProperty();
             String value = declaration.getExpression()
                     .getAsCSSString(new CSSWriterSettings(ECSSVersion.LATEST)
                             .setOptimizedOutput(true), 0);
-            style.set(StyleUtil.styleAttributeToProperty(key), value);
+            parsedStyles.put(StyleUtil.styleAttributeToProperty(key), value);
         }
+
+        return parsedStyles;
     }
 
     @Override

--- a/hummingbird-server/src/main/java/com/vaadin/hummingbird/dom/impl/TemplateElementStateProvider.java
+++ b/hummingbird-server/src/main/java/com/vaadin/hummingbird/dom/impl/TemplateElementStateProvider.java
@@ -380,8 +380,7 @@ public class TemplateElementStateProvider implements ElementStateProvider {
 
     @Override
     public Style getStyle(StateNode node) {
-        // Should eventually be based on [style.foo]=bar in the template
-        return new ImmutableEmptyStyle();
+        return new BoundStyle(templateNode, node);
     }
 
     @Override

--- a/hummingbird-server/src/test/java/com/vaadin/hummingbird/dom/TemplateElementStateProviderTest.java
+++ b/hummingbird-server/src/test/java/com/vaadin/hummingbird/dom/TemplateElementStateProviderTest.java
@@ -443,18 +443,12 @@ public class TemplateElementStateProviderTest {
     public void testHardcodedStyleAttribute() {
         Element element = createElement("<div style='display:none'></div>");
 
-        /*
-         * Currently empty since getStyle() is implemented to always be empty.
-         *
-         * Should be updated to make sure getAttributeNames() still doesn't
-         * throw after actual style support has been implemented.
-         */
-        Assert.assertEquals(0, element.getAttributeNames().count());
+        Assert.assertEquals(1, element.getAttributeNames().count());
 
         // Test the same after attributes have been migrated to an override node
         element.setProperty("foo", "bar");
 
-        Assert.assertEquals(0, element.getAttributeNames().count());
+        Assert.assertEquals(1, element.getAttributeNames().count());
     }
 
     @Test
@@ -1036,7 +1030,16 @@ public class TemplateElementStateProviderTest {
         Assert.assertNull(element.getProperty("boundproperty"));
         Assert.assertArrayEquals(new Object[] { "boundProperty" },
                 element.getPropertyNames().toArray());
+    }
 
+    @Test
+    public void templateStaticStyleAttribute() {
+        Element element = createElement("<div style='background:blue'></div>");
+
+        Assert.assertEquals("background:blue", element.getAttribute("style"));
+        Assert.assertEquals("blue", element.getStyle().get("background"));
+        Assert.assertArrayEquals(new Object[] { "style" },
+                element.getAttributeNames().toArray());
     }
 
 }

--- a/hummingbird-server/src/test/java/com/vaadin/hummingbird/template/TemplateParserTest.java
+++ b/hummingbird-server/src/test/java/com/vaadin/hummingbird/template/TemplateParserTest.java
@@ -308,6 +308,23 @@ public class TemplateParserTest {
                 .getAttributeBinding("sometag");
         Assert.assertTrue(binding.isPresent());
         Assert.assertEquals("value", binding.get().getValue(null));
+
+    }
+
+    @Test
+    public void parseStyle() {
+        ElementTemplateNode node = (ElementTemplateNode) parse(
+                "<button style='background-color:red'>");
+
+        Assert.assertEquals(1, node.getAttributeNames().count());
+        Assert.assertEquals(0, node.getPropertyNames().count());
+        Assert.assertEquals(0, node.getClassNames().count());
+
+        Optional<BindingValueProvider> binding = node
+                .getAttributeBinding("style");
+        Assert.assertTrue(binding.isPresent());
+        Assert.assertEquals("background-color:red",
+                binding.get().getValue(null));
     }
 
 }


### PR DESCRIPTION
A 'style' attribute has currently no special meaning in a template.
This is bound to change when style binding is implemented.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/1063)

<!-- Reviewable:end -->
