### PR TITLE
Make template interpret attributes as lower case again

### DIFF
--- a/hummingbird-server/src/main/java/com/vaadin/hummingbird/template/ElementTemplateBuilder.java
+++ b/hummingbird-server/src/main/java/com/vaadin/hummingbird/template/ElementTemplateBuilder.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -88,7 +89,9 @@ public class ElementTemplateBuilder implements TemplateNodeBuilder {
      * Adds an attribute binding to this builder.
      *
      * @param name
-     *            the name of the attribute, not <code>null</code>
+     *            the name of the attribute, not <code>null</code>. Will be
+     *            automatically converted to lower case to make attributes case
+     *            insensitive.
      * @param binding
      *            the binding that will provide the attribute value, not
      *            <code>null</code>
@@ -101,7 +104,7 @@ public class ElementTemplateBuilder implements TemplateNodeBuilder {
         assert !attributes.containsKey(
                 name) : "There is already an attribute named " + name;
 
-        attributes.put(name, binding);
+        attributes.put(name.toLowerCase(Locale.ENGLISH), binding);
         return this;
     }
 

--- a/hummingbird-server/src/test/java/com/vaadin/hummingbird/dom/TemplateElementStateProviderTest.java
+++ b/hummingbird-server/src/test/java/com/vaadin/hummingbird/dom/TemplateElementStateProviderTest.java
@@ -1013,4 +1013,30 @@ public class TemplateElementStateProviderTest {
         Assert.assertEquals("John", element.getProperty("prop"));
     }
 
+    @Test
+    public void templateMixedCaseAttributeProperty() {
+        Element element = createElement(
+                "<div [boundProperty]='modelParam' unboundAttribute='value' [attr.boundAttribute]='modelParam'></div>");
+
+        ModelMap.get(element.getNode()).setValue("modelParam", "modelValue");
+
+        // Attribute names are case insensitive
+        Assert.assertEquals("value", element.getAttribute("unboundattribute"));
+        Assert.assertEquals("value", element.getAttribute("UNBOUNDattribute"));
+        Assert.assertEquals("modelValue",
+                element.getAttribute("boundattribute"));
+        Assert.assertEquals("modelValue",
+                element.getAttribute("BOUNDattribute"));
+        Assert.assertArrayEquals(
+                new Object[] { "unboundattribute", "boundattribute" },
+                element.getAttributeNames().toArray());
+
+        // Property names are case sensitive
+        Assert.assertEquals("modelValue", element.getProperty("boundProperty"));
+        Assert.assertNull(element.getProperty("boundproperty"));
+        Assert.assertArrayEquals(new Object[] { "boundProperty" },
+                element.getPropertyNames().toArray());
+
+    }
+
 }

--- a/hummingbird-server/src/test/java/com/vaadin/hummingbird/template/TemplateParserTest.java
+++ b/hummingbird-server/src/test/java/com/vaadin/hummingbird/template/TemplateParserTest.java
@@ -294,4 +294,20 @@ public class TemplateParserTest {
         parse("<button (click='handle($event)'>");
     }
 
+    @Test
+    public void parseMixedCaseAttributeStyle() {
+        ElementTemplateNode node = (ElementTemplateNode) parse(
+                "<button someTag='value'>");
+        Assert.assertEquals(1, node.getAttributeNames().count());
+        Assert.assertEquals("sometag",
+                node.getAttributeNames().findFirst().get());
+        Assert.assertEquals(0, node.getPropertyNames().count());
+        Assert.assertEquals(0, node.getClassNames().count());
+
+        Optional<BindingValueProvider> binding = node
+                .getAttributeBinding("sometag");
+        Assert.assertTrue(binding.isPresent());
+        Assert.assertEquals("value", binding.get().getValue(null));
+    }
+
 }


### PR DESCRIPTION
This was broken by the update to a case sensitive jsoup.
Now attributes are case insensitive while properties are
case sensitive.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/1064)

<!-- Reviewable:end -->
