### PR TITLE
Ensure debug logging cannot cause application to fail

### DIFF
--- a/hummingbird-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
+++ b/hummingbird-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
@@ -348,9 +348,15 @@ public class MessageHandler {
 
                 if (!registry.getApplicationConfiguration()
                         .isProductionMode()) {
-                    JsonObject debugJson = tree.getRootNode().getDebugJson();
-                    Console.log("StateTree after applying changes:");
-                    Console.log(debugJson);
+                    try {
+                        JsonObject debugJson = tree.getRootNode()
+                                .getDebugJson();
+                        Console.log("StateTree after applying changes:");
+                        Console.log(debugJson);
+                    } catch (Exception e) {
+                        Console.error("Failed to log state tree");
+                        Console.error(e);
+                    }
                 }
             }
 

--- a/hummingbird-tests/test-root-context/src/main/java/com/vaadin/hummingbird/uitest/servlet/ViewTestServlet.java
+++ b/hummingbird-tests/test-root-context/src/main/java/com/vaadin/hummingbird/uitest/servlet/ViewTestServlet.java
@@ -30,6 +30,7 @@ import com.vaadin.hummingbird.router.RouterConfigurator;
 import com.vaadin.hummingbird.router.View;
 import com.vaadin.hummingbird.uitest.servlet.ViewTestServlet.ViewTestConfigurator;
 import com.vaadin.server.VaadinServlet;
+import com.vaadin.server.VaadinServletService;
 
 @WebServlet(asyncSupported = true, urlPatterns = { "/view/*" })
 @VaadinServletConfiguration(productionMode = false, routerConfigurator = ViewTestConfigurator.class)
@@ -48,8 +49,13 @@ public class ViewTestServlet extends VaadinServlet {
                         Class<? extends View> viewType = viewLocator
                                 .findViewClass(navigationEvent.getLocation()
                                         .getFirstSegment());
-                        return Optional.of(new TestViewRenderer(viewType,
-                                ViewTestLayout.class));
+                        if (VaadinServletService.getCurrentRequest()
+                                .getParameter("noheader") != null) {
+                            return Optional.of(new TestViewRenderer(viewType));
+                        } else {
+                            return Optional.of(new TestViewRenderer(viewType,
+                                    ViewTestLayout.class));
+                        }
                     } catch (ClassNotFoundException e) {
                         return Optional.empty();
                     }


### PR DESCRIPTION
Introduces a `?noheader` flag which can be used to make test views
render without a header, to make debugging easier

Fixes #1090

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/1098)

<!-- Reviewable:end -->
