### PR TITLE
Preserve white space inside text nodes in templates

### DIFF
--- a/hummingbird-server/src/main/java/com/vaadin/hummingbird/template/parser/DefaultTextModelBuilderFactory.java
+++ b/hummingbird-server/src/main/java/com/vaadin/hummingbird/template/parser/DefaultTextModelBuilderFactory.java
@@ -27,7 +27,6 @@ import java.util.stream.Collectors;
 
 import com.vaadin.external.jsoup.nodes.Node;
 import com.vaadin.external.jsoup.nodes.TextNode;
-
 import com.vaadin.hummingbird.template.ChildSlotBuilder;
 import com.vaadin.hummingbird.template.StaticBindingValueProvider;
 import com.vaadin.hummingbird.template.TemplateIncludeBuilder;
@@ -61,7 +60,7 @@ public class DefaultTextModelBuilderFactory
             TemplateResolver templateResolver,
             Function<Node, Optional<TemplateNodeBuilder>> builderProducer) {
         List<TemplateNodeBuilder> builders = new ArrayList<>();
-        collectBuilders(node.text(), builders, templateResolver);
+        collectBuilders(node.getWholeText(), builders, templateResolver);
         return makeCompound(builders);
     }
 

--- a/hummingbird-server/src/test/java/com/vaadin/ui/TemplateTest.java
+++ b/hummingbird-server/src/test/java/com/vaadin/ui/TemplateTest.java
@@ -194,6 +194,14 @@ public class TemplateTest {
         private TestSpan span;
     }
 
+    public static class TemplateWithPreTag extends InlineTemplate {
+        public TemplateWithPreTag() {
+            super("<div><pre>" + "Row 1\n" + "Row 2\n"
+                    + "   Indented row 3</pre></div>");
+        }
+
+    }
+
     @Test
     public void inputStreamInConstructor() {
         Template template = new TestTemplate();
@@ -372,6 +380,14 @@ public class TemplateTest {
     @Test(expected = IllegalArgumentException.class)
     public void mapWithSameIdUsedMultipleTimes() {
         new TemplateWithSameIdMultipleTimes();
+    }
+
+    @Test
+    public void preTagsPreserveWhitespace() {
+        TemplateWithPreTag template = new TemplateWithPreTag();
+        Assert.assertEquals(
+                "<pre>" + "Row 1\n" + "Row 2\n" + "   Indented row 3</pre>",
+                template.getElement().getChild(0).getOuterHTML());
     }
 
     @Before

--- a/hummingbird-tests/test-root-context/src/main/java/com/vaadin/hummingbird/uitest/ui/template/TemplateWithPreTagsView.java
+++ b/hummingbird-tests/test-root-context/src/main/java/com/vaadin/hummingbird/uitest/ui/template/TemplateWithPreTagsView.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.hummingbird.uitest.ui.template;
+
+import com.vaadin.ui.Template;
+
+public class TemplateWithPreTagsView extends Template {
+
+}

--- a/hummingbird-tests/test-root-context/src/main/resources/com/vaadin/hummingbird/uitest/ui/template/TemplateWithPreTagsView.html
+++ b/hummingbird-tests/test-root-context/src/main/resources/com/vaadin/hummingbird/uitest/ui/template/TemplateWithPreTagsView.html
@@ -1,0 +1,69 @@
+<div>
+	<pre>
+		<code class="language-java" id="code">
+import java.util.ArrayList;
+import java.util.List;
+
+import com.vaadin.annotations.EventHandler;
+import com.vaadin.hummingbird.template.model.TemplateModel;
+import com.vaadin.ui.Template;
+
+public class ForView extends Template {
+
+    public static class Item {
+        private String text;
+
+        public void setText(String text) {
+            this.text = text;
+        }
+
+        public String getText() {
+            return text;
+        }
+    }
+
+    public interface Model extends TemplateModel {
+        List<Item> getItems();
+
+        void setItems(List<Item> items);
+    }
+
+    private int itemCount = 0;
+
+    public ForView() {
+        getModel().setItems(new ArrayList<>());
+    }
+
+    @Override
+    protected Model getModel() {
+        return (Model) super.getModel();
+    }
+
+    @EventHandler
+    private void add() {
+        Item item = new Item();
+        item.setText("Item " + itemCount++);
+        getModel().getItems().add(item);
+    }
+
+    @EventHandler
+    private void remove() {
+        List<Item> items = getModel().getItems();
+        if (!items.isEmpty()) {
+            items.remove(items.size() - 1);
+        }
+    }
+
+    @EventHandler
+    private void update() {
+        List<Item> items = getModel().getItems();
+        if (!items.isEmpty()) {
+            Item item = items.get(items.size() - 1);
+            item.setText(item.getText() + " updated");
+        }
+    }
+}
+		</code>
+	</pre>
+
+</div>

--- a/hummingbird-tests/test-root-context/src/test/java/com/vaadin/hummingbird/uitest/ui/TemplateIncludeIT.java
+++ b/hummingbird-tests/test-root-context/src/test/java/com/vaadin/hummingbird/uitest/ui/TemplateIncludeIT.java
@@ -33,8 +33,8 @@ public class TemplateIncludeIT extends PhantomJSTest {
                 + "<div id=\"header\"> <span>Menu item 1</span> <span>Menu item 2</span> <span>Menu item 3</span> </div>" //
                 + "<div id=\"content\">Here goes the content</div>" //
                 + "<div id=\"footer\"> <span>Footer goes here</span> </div></div>";
-        expected = expected.replace("> <", "><");
-        outerHtml = outerHtml.replace("> <", "><");
+        expected = expected.replaceAll(">[ \n]*<", "><");
+        outerHtml = outerHtml.replaceAll(">[ \\n]*<", "><");
         Assert.assertEquals(expected, outerHtml);
     }
 }

--- a/hummingbird-tests/test-root-context/src/test/java/com/vaadin/hummingbird/uitest/ui/template/TemplateWithPreTagsIT.java
+++ b/hummingbird-tests/test-root-context/src/test/java/com/vaadin/hummingbird/uitest/ui/template/TemplateWithPreTagsIT.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.hummingbird.uitest.ui.template;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.hummingbird.testutil.PhantomJSTest;
+import com.vaadin.testbench.By;
+
+public class TemplateWithPreTagsIT extends PhantomJSTest {
+
+    @Test
+    public void ensurePreservedWhitespace() {
+        open();
+        WebElement code = findElement(By.id("code"));
+        Assert.assertTrue(code.getText()
+                .contains("{\n" + "\n" + "    public static class Item {"));
+        ;
+    }
+}


### PR DESCRIPTION
This is needed to make `<pre>` tags properly retain the whitespace

Fixes #1165

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/1168)

<!-- Reviewable:end -->
