### PR TITLE
Revert "Update to official GWT 2.8.0-rc2 (#1159)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,8 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<gwt.version>2.8.0-rc2</gwt.version>
-		<jsinterop.version>1.0.0</jsinterop.version>
+		<gwt.version>2.8.0.snapshot20160630</gwt.version>
+		<jsinterop.version>1.0.0.snapshot20160419</jsinterop.version>
 		<sonar.java.source>8</sonar.java.source>
 		<sonar.analysis.mode>preview</sonar.analysis.mode>
 		<sonar.issuesReport.console.enable>true</sonar.issuesReport.console.enable>


### PR DESCRIPTION
The update caused problems with running GWT unit tests

This reverts commit 736ce1b271d5c6b749e3a3c84422c72a77f63e02.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/1182)

<!-- Reviewable:end -->
