### PR TITLE
Remove web components from pre-render HTML

### DIFF
--- a/hummingbird-server/src/main/java/com/vaadin/hummingbird/dom/Element.java
+++ b/hummingbird-server/src/main/java/com/vaadin/hummingbird/dom/Element.java
@@ -1448,7 +1448,7 @@ public class Element implements Serializable {
      * @return the outer HTML for the element
      */
     public String getOuterHTML() {
-        return ElementUtil.toJsoup(new Document(""), this, false).outerHtml();
+        return ElementUtil.toJsoup(new Document(""), this).outerHtml();
     }
 
     /**

--- a/hummingbird-server/src/main/java/com/vaadin/hummingbird/dom/ElementUtil.java
+++ b/hummingbird-server/src/main/java/com/vaadin/hummingbird/dom/ElementUtil.java
@@ -23,7 +23,6 @@ import com.vaadin.external.jsoup.nodes.Document;
 import com.vaadin.external.jsoup.nodes.Node;
 import com.vaadin.external.jsoup.nodes.TextNode;
 import com.vaadin.ui.Component;
-import com.vaadin.ui.ComponentUtil;
 import com.vaadin.ui.Composite;
 
 /**
@@ -230,12 +229,9 @@ public class ElementUtil {
      *            A JSoup document
      * @param element
      *            The element to convert
-     * @param prerender
-     *            is the html output meant for pre-rendering
      * @return A JSoup node containing the converted element
      */
-    public static Node toJsoup(Document document, Element element,
-            boolean prerender) {
+    public static Node toJsoup(Document document, Element element) {
         if (element.isTextNode()) {
             return new TextNode(element.getText(), document.baseUri());
         }
@@ -255,21 +251,36 @@ public class ElementUtil {
             }
         });
 
-        element.getChildren()//@formatter:off
-                .filter(child -> !prerender
-                        || child.isTextNode() // text nodes throw for getTag()
-                        || !"script".equalsIgnoreCase(child.getTag()))//@formatter:on
-                .map(child -> prerender ? getPrerenderElement(child)
-                        : Optional.of(child))
-                .filter(Optional::isPresent)
-                .forEach(child -> target.appendChild(
-                        toJsoup(document, child.get(), prerender)));
+        element.getChildren()
+                .forEach(child -> target.appendChild(toJsoup(document, child)));
 
         return target;
     }
 
-    private static Optional<Element> getPrerenderElement(Element element) {
-        return getComponent(element).map(ComponentUtil::getPrerenderElement)
-                .orElse(Optional.of(element));
+    /**
+     * Checks whether the given element is a custom element or not.
+     * <p>
+     * Custom elements (Web Components) are recognized by having at least one
+     * dash in the tag name.
+     *
+     * @param element
+     *            the element to check
+     * @return <code>true</code> if a custom element, <code>false</code> if not
+     */
+    public static boolean isCustomElement(Element element) {
+        return !element.isTextNode() && element.getTag().contains("-");
     }
+
+    /**
+     * Checks whether the given element is a <code>script</code> or not.
+     *
+     * @param element
+     *            the element to check
+     * @return <code>true</code> if a script, <code>false</code> if not
+     */
+    public static boolean isScript(Element element) {
+        return !element.isTextNode()
+                && "script".equalsIgnoreCase(element.getTag());
+    }
+
 }

--- a/hummingbird-server/src/main/java/com/vaadin/hummingbird/dom/Prerenderer.java
+++ b/hummingbird-server/src/main/java/com/vaadin/hummingbird/dom/Prerenderer.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2000-2016 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.hummingbird.dom;
+
+import java.util.Optional;
+
+import com.vaadin.external.jsoup.nodes.Node;
+import com.vaadin.external.jsoup.nodes.TextNode;
+import com.vaadin.external.jsoup.parser.Tag;
+import com.vaadin.ui.Component;
+import com.vaadin.ui.ComponentUtil;
+
+/**
+ * A class with helper methods related to pre-rendering elements.
+ *
+ * @author Vaadin Ltd
+ */
+public class Prerenderer {
+
+    private static final String BASE_URI = "";
+
+    private Prerenderer() {
+        // Utility class
+    }
+
+    /**
+     * Converts the given element to a JSoup node, which can be used for
+     * pre-rendering.
+     * <p>
+     * <b>Does NOT include children</b>, use
+     * {@link #prerenderElementTree(Element, boolean, boolean)} creating a JSoup
+     * node with children.
+     *
+     * @param element
+     *            the element to convert
+     * @return the JSoup representation of the given element
+     */
+    public static Node toJsoup(Element element) {
+        if (element.isTextNode()) {
+            return new TextNode(element.getText(), BASE_URI);
+        }
+
+        com.vaadin.external.jsoup.nodes.Element target = new com.vaadin.external.jsoup.nodes.Element(
+                Tag.valueOf(element.getTag()), BASE_URI);
+        if (element.hasProperty("innerHTML")) {
+            target.html((String) element.getPropertyRaw("innerHTML"));
+        }
+
+        element.getAttributeNames().forEach(name -> {
+            String attributeValue = element.getAttribute(name);
+            if ("".equals(attributeValue)) {
+                target.attr(name, true);
+            } else {
+                target.attr(name, attributeValue);
+            }
+        });
+        return target;
+    }
+
+    /**
+     * Returns an optional pre-rendered version of the given element and its
+     * children, or an empty optional if this element should not be included in
+     * the pre-render HTML.
+     * <p>
+     * {@link ElementUtil#isCustomElement(Element) Web components} and scripts
+     * are ignored.
+     * <p>
+     * This method is a short-hand for
+     * {@link #prerenderElementTree(Element, boolean, boolean)}.
+     *
+     * @param element
+     *            the element to pre-render
+     * @return the node to pre-render, or an empty optional if the given element
+     *         should not be pre-rendered
+     * @see #prerenderElementTree(Element, boolean, boolean)
+     */
+    public static Optional<Node> prerenderElementTree(Element element) {
+        return prerenderElementTree(element, true, true);
+    }
+
+    /**
+     * Returns an optional pre-rendered version of the given element and its
+     * children, or an empty optional if this element should not be included in
+     * the pre-render HTML.
+     *
+     * @param element
+     *            the element to pre-render
+     * @param filterScripts
+     *            should scripts be included or not
+     * @param filterCustomElements
+     *            should custom elements be included or not
+     * @return the node to pre-render, or an empty optional if the given element
+     *         should not be pre-rendered
+     */
+    public static Optional<Node> prerenderElementTree(Element element,
+            boolean filterScripts, boolean filterCustomElements) {
+        if (filterCustomElements && ElementUtil.isCustomElement(element)
+                || filterScripts && ElementUtil.isScript(element)) {
+            return Optional.empty();
+        }
+
+        Node target = toJsoup(element);
+        if (target instanceof com.vaadin.external.jsoup.nodes.Element) {
+            com.vaadin.external.jsoup.nodes.Element targetElement = (com.vaadin.external.jsoup.nodes.Element) target;
+            element.getChildren().forEach(child -> {
+                Optional<Component> component = ElementUtil.getComponent(child);
+                // if there is a component mapping, let it handle the
+                // pre-rendering, if not, just recurse with this method, which
+                // is the same what component implementation does by default
+                Optional<Node> childNode = component.isPresent()
+                        ? ComponentUtil.prerender(component.get())
+                        : prerenderElementTree(child, filterScripts,
+                                filterCustomElements);
+                childNode.ifPresent(targetElement::appendChild);
+            });
+        }
+        return Optional.of(target);
+    }
+}

--- a/hummingbird-server/src/main/java/com/vaadin/server/BootstrapHandler.java
+++ b/hummingbird-server/src/main/java/com/vaadin/server/BootstrapHandler.java
@@ -40,7 +40,6 @@ import com.vaadin.external.jsoup.nodes.DocumentType;
 import com.vaadin.external.jsoup.nodes.Element;
 import com.vaadin.external.jsoup.nodes.Node;
 import com.vaadin.external.jsoup.parser.Tag;
-import com.vaadin.hummingbird.dom.ElementUtil;
 import com.vaadin.server.communication.AtmospherePushConnection;
 import com.vaadin.server.communication.UidlWriter;
 import com.vaadin.shared.ApplicationConstants;
@@ -445,12 +444,10 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             document.head().after("<body></body>");
             body = document.body();
         } else {
-            Optional<com.vaadin.hummingbird.dom.Element> uiElement = ComponentUtil
-                    .getPrerenderElement(context.getUI());
+            Optional<Node> uiElement = ComponentUtil.prerender(context.getUI());
 
             if (uiElement.isPresent()) {
-                Node prerenderedUIElement = ElementUtil.toJsoup(document,
-                        uiElement.get(), true);
+                Node prerenderedUIElement = uiElement.get();
                 assert prerenderedUIElement instanceof Element;
                 assert "body"
                         .equals(((Element) prerenderedUIElement).tagName());

--- a/hummingbird-server/src/main/java/com/vaadin/ui/Component.java
+++ b/hummingbird-server/src/main/java/com/vaadin/ui/Component.java
@@ -22,9 +22,11 @@ import java.util.stream.Stream.Builder;
 
 import com.vaadin.annotations.AnnotationReader;
 import com.vaadin.annotations.Tag;
+import com.vaadin.external.jsoup.nodes.Node;
 import com.vaadin.hummingbird.dom.Element;
 import com.vaadin.hummingbird.dom.ElementUtil;
 import com.vaadin.hummingbird.dom.EventRegistrationHandle;
+import com.vaadin.hummingbird.dom.Prerenderer;
 import com.vaadin.hummingbird.event.ComponentEventBus;
 import com.vaadin.hummingbird.event.ComponentEventListener;
 
@@ -176,15 +178,22 @@ public abstract class Component implements HasElement, Serializable,
      * A component should override this method to pre-render something else than
      * the default, which is the element returned by {@link #getElement()}.
      * <p>
+     * By default <b>Web Components are and scripts are not included</b> in the
+     * pre-render HTML.
+     * <p>
      * Each component which supports pre-rendering should output the HTML tree
-     * for itself, call {@link #getPrerenderElement()} for its children and
-     * ensure they are attached to the pre-rendered element tree.
+     * for itself, handle pre-rendering for its children and ensure they are
+     * attached to the pre-rendered element tree.
+     * <p>
+     * The {@link Prerenderer} class provides some helper methods related to
+     * pre-rendering.
      *
-     * @return an element with the pre-rendered DOM structure of the component
-     *         and its children
+     * @return an JSoup node with the pre-rendered DOM structure of the
+     *         component and its children
+     * @see Prerenderer for useful methods
      */
-    protected Optional<Element> getPrerenderElement() {
-        return Optional.of(getElement());
+    protected Optional<Node> prerender() {
+        return Prerenderer.prerenderElementTree(getElement());
     }
 
     /**

--- a/hummingbird-server/src/main/java/com/vaadin/ui/ComponentUtil.java
+++ b/hummingbird-server/src/main/java/com/vaadin/ui/ComponentUtil.java
@@ -24,6 +24,7 @@ import com.vaadin.annotations.HtmlImport;
 import com.vaadin.annotations.JavaScript;
 import com.vaadin.annotations.StyleSheet;
 import com.vaadin.annotations.Uses;
+import com.vaadin.external.jsoup.nodes.Node;
 import com.vaadin.hummingbird.dom.Element;
 import com.vaadin.hummingbird.dom.ElementUtil;
 import com.vaadin.hummingbird.util.ReflectionCache;
@@ -324,14 +325,14 @@ public class ComponentUtil {
      * Gets the pre-render element for the given component.
      * <p>
      * This is a framework internal method used for accessing the protected
-     * {@link Component#getPrerenderElement()} method.
+     * {@link Component#prerender()} method.
      *
      * @param component
      *            the component to get pre-render element for
      * @return the pre-render element
-     * @see Component#getPrerenderElement()
+     * @see Component#prerender()
      */
-    public static Optional<Element> getPrerenderElement(Component component) {
-        return component.getPrerenderElement();
+    public static Optional<Node> prerender(Component component) {
+        return component.prerender();
     }
 }

--- a/hummingbird-server/src/main/java/com/vaadin/ui/Composite.java
+++ b/hummingbird-server/src/main/java/com/vaadin/ui/Composite.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Type;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import com.vaadin.external.jsoup.nodes.Node;
 import com.vaadin.hummingbird.dom.Element;
 import com.vaadin.hummingbird.dom.ElementUtil;
 import com.vaadin.util.ReflectTools;
@@ -175,8 +176,8 @@ public abstract class Composite<T extends Component> extends Component {
     }
 
     @Override
-    protected Optional<Element> getPrerenderElement() {
-        return getContent().getPrerenderElement();
+    protected Optional<Node> prerender() {
+        return getContent().prerender();
     }
 
     /**

--- a/hummingbird-server/src/main/java/com/vaadin/ui/UI.java
+++ b/hummingbird-server/src/main/java/com/vaadin/ui/UI.java
@@ -24,8 +24,10 @@ import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import com.vaadin.external.jsoup.nodes.Node;
 import com.vaadin.hummingbird.StateNode;
 import com.vaadin.hummingbird.dom.Element;
+import com.vaadin.hummingbird.dom.Prerenderer;
 import com.vaadin.hummingbird.nodefeature.ElementData;
 import com.vaadin.hummingbird.nodefeature.LoadingIndicatorConfigurationMap;
 import com.vaadin.hummingbird.nodefeature.PollConfigurationMap;
@@ -622,12 +624,13 @@ public class UI extends Component
      *
      * @return an element with the pre-rendered DOM structure of the UI and its
      *         children
-     * @see Component#getPrerenderElement()
+     * @see Component#prerender()
+     * @see Prerenderer#prerenderElementTree(Element)
      */
     @Override
-    protected Optional<Element> getPrerenderElement() {
+    protected Optional<Node> prerender() {
         // overridden because of additional javadocs
-        return super.getPrerenderElement();
+        return super.prerender();
     }
 
     /**

--- a/hummingbird-server/src/test/java/com/vaadin/hummingbird/dom/ElementUtilTest.java
+++ b/hummingbird-server/src/test/java/com/vaadin/hummingbird/dom/ElementUtilTest.java
@@ -92,19 +92,13 @@ public class ElementUtilTest {
         InlineTemplate template = new InlineTemplate(
                 "<div><script>window.alert('shazbot');</script></div>");
         Node jsoupNode = ElementUtil.toJsoup(new Document(""),
-                template.getElement(), false);
+                template.getElement());
 
         Assert.assertEquals(1, jsoupNode.childNodeSize());
 
         Node child = jsoupNode.childNode(0);
         Assert.assertEquals("<script>window.alert('shazbot');</script>",
                 child.outerHtml());
-
-        // pre-render==true won't contain script
-        jsoupNode = ElementUtil.toJsoup(new Document(""), template.getElement(),
-                true);
-
-        Assert.assertEquals(0, jsoupNode.childNodeSize());
     }
 
 }


### PR DESCRIPTION
All custom elements are filtered out from pre-render HTML.
For now it is not possible to add web components to pre-render.

Closes #1167

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/1186)

<!-- Reviewable:end -->
