### PR TITLE
Use a fallback user agent so that client engine will always be loaded

### DIFF
--- a/hummingbird-client/src/main/resources/com/vaadin/ClientEngineXSI.gwt.xml
+++ b/hummingbird-client/src/main/resources/com/vaadin/ClientEngineXSI.gwt.xml
@@ -53,6 +53,9 @@
 	<!-- IE 11 should use gecko -->
 	<set-property name="user.agent" value="gecko1_8,safari" />
 
+	<!-- If no proper user agent is found, at least try some, e.g. with crawlers --> 
+	<set-property-fallback name="user.agent" value="safari" />
+
 	<replace-with
 		class="com.vaadin.client.communication.DefaultConnectionStateHandler">
 		<when-type-is class="com.vaadin.client.communication.ConnectionStateHandler" />


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/1196)

<!-- Reviewable:end -->
