### PR TITLE
Restore all current instance values after running access tasks (#1211)

### DIFF
--- a/hummingbird-server/src/main/java/com/vaadin/server/VaadinService.java
+++ b/hummingbird-server/src/main/java/com/vaadin/server/VaadinService.java
@@ -1737,8 +1737,11 @@ public abstract class VaadinService implements Serializable {
         }
 
         FutureAccess pendingAccess;
+
+        // Dump all current instances, not only the ones dumped by setCurrent
         Map<Class<?>, CurrentInstance> oldInstances = CurrentInstance
-                .setCurrent(session);
+                .getInstances();
+        CurrentInstance.setCurrent(session);
         try {
             while ((pendingAccess = session.getPendingAccessQueue()
                     .poll()) != null) {

--- a/hummingbird-server/src/test/java/com/vaadin/server/VaadinServiceTest.java
+++ b/hummingbird-server/src/test/java/com/vaadin/server/VaadinServiceTest.java
@@ -27,6 +27,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.vaadin.server.communication.StreamResourceRequestHandler;
+import com.vaadin.util.CurrentInstance;
 
 /**
  *
@@ -52,10 +53,7 @@ public class VaadinServiceTest {
 
     @Test
     public void testFireSessionDestroy() throws ServletException {
-        ServletConfig servletConfig = new MockServletConfig();
-        VaadinServlet servlet = new VaadinServlet();
-        servlet.init(servletConfig);
-        VaadinService service = servlet.getService();
+        VaadinService service = createService();
 
         TestSessionDestroyListener listener = new TestSessionDestroyListener();
 
@@ -153,5 +151,34 @@ public class VaadinServiceTest {
         Assert.assertTrue(service.createRequestHandlers().stream()
                 .filter(StreamResourceRequestHandler.class::isInstance)
                 .findAny().isPresent());
+    }
+
+    @Test
+    public void currentInstancesAfterPendingAccessTasks() {
+        VaadinService service = createService();
+
+        MockVaadinSession session = new MockVaadinSession(service);
+        session.lock();
+        service.accessSession(session, () -> {
+            CurrentInstance.set(String.class, "Set in task");
+        });
+
+        CurrentInstance.set(String.class, "Original value");
+        service.runPendingAccessTasks(session);
+        Assert.assertEquals(
+                "Original CurrentInstance should be set after the task has been run",
+                "Original value", CurrentInstance.get(String.class));
+    }
+
+    private static VaadinService createService() {
+        ServletConfig servletConfig = new MockServletConfig();
+        VaadinServlet servlet = new VaadinServlet();
+        try {
+            servlet.init(servletConfig);
+        } catch (ServletException e) {
+            throw new RuntimeException(e);
+        }
+        VaadinService service = servlet.getService();
+        return service;
     }
 }


### PR DESCRIPTION
Picked fix for clearing CurrentInstance in runPendingAccessTasks from vaadin/framework#8131

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/1225)
<!-- Reviewable:end -->
