### PR TITLE
Omit timings in production mode

### DIFF
--- a/hummingbird-client/src/main/java/com/vaadin/client/ApplicationConnection.java
+++ b/hummingbird-client/src/main/java/com/vaadin/client/ApplicationConnection.java
@@ -128,20 +128,24 @@ public class ApplicationConnection {
         client.isActive = $entry(function() {
             return ap.@com.vaadin.client.ApplicationConnection::isActive()();
         });
-
+    
         client.getProfilingData = $entry(function() {
             var smh = ap.@com.vaadin.client.ApplicationConnection::registry.@com.vaadin.client.Registry::getMessageHandler();
             var pd = [
                 smh.@com.vaadin.client.communication.MessageHandler::lastProcessingTime,
                     smh.@com.vaadin.client.communication.MessageHandler::totalProcessingTime
                 ];
-            pd = pd.concat(smh.@com.vaadin.client.communication.MessageHandler::serverTimingInfo);
+            if (null != smh.@com.vaadin.client.communication.MessageHandler::serverTimingInfo) {
+                pd = pd.concat(smh.@com.vaadin.client.communication.MessageHandler::serverTimingInfo);
+            } else {
+                pd = pd.concat(-1, -1);
+            }
             pd[pd.length] = smh.@com.vaadin.client.communication.MessageHandler::bootstrapTime;
             return pd;
         });
-
+    
         client.initializing = false;
-
+    
         $wnd.vaadin.clients[applicationId] = client;
     }-*/;
 

--- a/hummingbird-server/src/main/java/com/vaadin/server/communication/UidlWriter.java
+++ b/hummingbird-server/src/main/java/com/vaadin/server/communication/UidlWriter.java
@@ -131,8 +131,10 @@ public class UidlWriter implements Serializable {
             response.put(JsonConstants.UIDL_KEY_EXECUTE,
                     encodeExecuteJavaScriptList(executeJavaScriptList));
         }
-
-        response.put("timings", createPerformanceData(ui));
+        if (!ui.getSession().getService().getDeploymentConfiguration()
+                .isProductionMode()) {
+            response.put("timings", createPerformanceData(ui));
+        }
         uiInternals.incrementServerId();
         return response;
     }


### PR DESCRIPTION
UIDL responses only include server side timing information when not
in production mode.

Migration of
https://github.com/vaadin/framework/commit/05003bafeb84f8251db6168746893e27bb3b0138

Fixes #1288

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/1290)
<!-- Reviewable:end -->
