### PR TITLE
Skip expense manager performance tests if not explicitly enabled 

### DIFF
--- a/hummingbird-tests/test-expense-manager-imperative/pom.xml
+++ b/hummingbird-tests/test-expense-manager-imperative/pom.xml
@@ -16,6 +16,8 @@
         <!-- Skip scalability tests by default, explicitly enabled on build server -->
         <gatling.skip>true</gatling.skip>
         <gatling.version>2.2.1</gatling.version>
+        <!-- Skip tests by default, explicitly enabled on build server -->
+        <maven.test.skip>true</maven.test.skip>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Performance tests are only needed on the build server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/1333)
<!-- Reviewable:end -->
