### PR TITLE
Get event from arguments array instead of as a function parameter.

### DIFF
--- a/hummingbird-client/src/main/java/com/vaadin/client/hummingbird/binding/ServerEventObject.java
+++ b/hummingbird-client/src/main/java/com/vaadin/client/hummingbird/binding/ServerEventObject.java
@@ -83,8 +83,8 @@ public final class ServerEventObject extends JavaScriptObject {
      */
     public native void defineMethod(String methodName, StateNode node)
     /*-{
-        this[methodName] = $entry(function(event) {
-            event = event || $wnd.event;
+        this[methodName] = $entry(function() {
+            var event = arguments[0] || $wnd.event;
             var tree = node.@com.vaadin.client.hummingbird.StateNode::getTree()();
             var args = this.@com.vaadin.client.hummingbird.binding.ServerEventObject::getEventData(*)(event, methodName, node);
             if(args === null) {


### PR DESCRIPTION
Changing the way we get the current event fixes problem with AngularTemplate hello world demo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/1339)
<!-- Reviewable:end -->
