### PR TITLE
Load es6-collections for all browsers

### DIFF
--- a/hummingbird-server/src/main/java/com/vaadin/server/BootstrapHandler.java
+++ b/hummingbird-server/src/main/java/com/vaadin/server/BootstrapHandler.java
@@ -370,15 +370,14 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                 + "z-index: 10000;" //
                 + "}");
 
-        if (context.getSession().getBrowser().isPhantomJS()) {
-            // Collections polyfill needed only for PhantomJS
-            head.appendChild(createJavaScriptElement(
-                    context.getUriResolver()
-                            .resolveVaadinUri("context://"
-                                    + ApplicationConstants.VAADIN_STATIC_FILES_PATH
-                                    + "server/es6-collections.js"),
-                    false));
-        }
+        // Collections polyfill needed for PhantomJS and maybe googlebot
+        head.appendChild(
+                createJavaScriptElement(
+                        context.getUriResolver()
+                                .resolveVaadinUri("context://"
+                                        + ApplicationConstants.VAADIN_STATIC_FILES_PATH
+                                        + "server/es6-collections.js"),
+                        false));
 
         head.appendChild(createWebComponentsElement(context));
 

--- a/hummingbird-server/src/test/java/com/vaadin/server/BootstrapHandlerTest.java
+++ b/hummingbird-server/src/test/java/com/vaadin/server/BootstrapHandlerTest.java
@@ -529,6 +529,10 @@ public class BootstrapHandlerTest {
         Elements jsElements = page.getElementsByTag("script");
         Elements deferElements = page.getElementsByAttribute("defer");
 
+        // Ignore polyfill that should be loaded immediately
+        jsElements.removeIf(
+                element -> element.attr("src").contains("es6-collections.js"));
+
         assertEquals(jsElements, deferElements);
         assertTrue(deferElements.stream().map(element -> element.attr("src"))
                 .anyMatch("myjavascript.js"::equals));


### PR DESCRIPTION
There are reasons to believe that googlebot might need to have the
es6-collections polyfill loaded in order to be able to index dynamic
content from Hummingbird pages. To able to easily test this hypothesis,
the polyfill is now loaded for all pages. Eventually, we should add some
carefully selected inline scripts to the page that would see what
features are available in the browser and load polyfills based on that
instead of the current situation where all WebComponents polyfills are
loaded regardless of the browser's capabilities.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/hummingbird/1410)
<!-- Reviewable:end -->
