### PR TITLE
Always use server side model properties for polymer elements.

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
@@ -192,17 +192,33 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
             Element element)
     /*-{
       var originalFunction = element._propertiesChanged;
-      if (!originalFunction) {
+      var readyFunction = element.ready;
+      if (!originalFunction || !readyFunction) {
         // Ignore since this isn't a polymer element
         return;
       }
       var self = this;
+      var isReady = false;
       element._propertiesChanged = function(currentProps, changedProps, oldProps) {
         originalFunction.apply(this, arguments);
-        $entry(function() {
-          self.@SimpleElementBindingStrategy::handlePropertiesChanged(*)(changedProps, node);
-        })();
-      }
+        if ( isReady ){
+            // don't send default values to the server (they are set during 
+            // the first 'ready' method call). We always set model default 
+            // values from the server side explicitly. So server always overrides 
+            // polymer default values.
+            $entry(function() {
+              self.@SimpleElementBindingStrategy::handlePropertiesChanged(*)(changedProps, node);
+            })();
+         }
+      };
+      element.ready = function(){
+          try {
+              readyFunction.apply(this);
+          }
+          finally {
+              isReady = true;
+          }
+      };
     }-*/;
 
     private void handlePropertiesChanged(

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/PolymerDefaultPropertyValueUI.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/PolymerDefaultPropertyValueUI.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.template;
+
+import com.vaadin.annotations.HtmlImport;
+import com.vaadin.annotations.Tag;
+import com.vaadin.annotations.WebComponents;
+import com.vaadin.flow.template.PolymerTemplate;
+import com.vaadin.flow.template.model.TemplateModel;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.ui.UI;
+
+@WebComponents(1)
+public class PolymerDefaultPropertyValueUI extends UI {
+
+    public interface MyModel extends TemplateModel {
+        void setText(String text);
+
+        void setName(String name);
+    }
+
+    @Tag("default-property")
+    @HtmlImport("/com/vaadin/flow/uitest/ui/template/PolymerDefaultPropertyValue.html")
+    public static class MyTemplate extends PolymerTemplate<MyModel> {
+
+        public MyTemplate() {
+            getModel().setText("foo");
+        }
+
+    }
+
+    @Override
+    protected void init(VaadinRequest request) {
+        MyTemplate template = new MyTemplate();
+        template.setId("template");
+        add(template);
+    }
+}

--- a/flow-tests/test-root-context/src/main/webapp/com/vaadin/flow/uitest/ui/template/PolymerDefaultPropertyValue.html
+++ b/flow-tests/test-root-context/src/main/webapp/com/vaadin/flow/uitest/ui/template/PolymerDefaultPropertyValue.html
@@ -1,0 +1,42 @@
+<!--
+  ~ Copyright 2000-2017 Vaadin Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+<link rel="import" href="/v2/bower_components/polymer/polymer.html">
+
+<dom-module id="default-property">
+    <template>
+        <div id="text">[[text]]</div>
+        <div id="name">[[name]]</div>
+    </template>
+    <script>
+        class MyTemplate extends Polymer.Element {
+            static get is() { return 'default-property' }
+
+            static get properties(){
+                 return {
+                    text: {
+                        type: String,
+                        value: ""
+                    },
+                    name :{
+                        type: String,
+                        value: "bar"
+                    }
+                 };
+            }
+        }
+        customElements.define(MyTemplate.is, MyTemplate);
+    </script>
+</dom-module>

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/PolymerDefaultPropertyValueIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/PolymerDefaultPropertyValueIT.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.template;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+import com.vaadin.testbench.By;
+
+public class PolymerDefaultPropertyValueIT extends ChromeBrowserTest {
+
+    @Test
+    public void initialModelValues_polymerHasDefaultValues() {
+        open();
+
+        WebElement template = findElement(By.id("template"));
+        WebElement text = getInShadowRoot(template, By.id("text")).get();
+
+        Assert.assertEquals("foo", text.getText());
+
+        WebElement name = getInShadowRoot(template, By.id("name")).get();
+        Assert.assertEquals("", name.getText());
+    }
+}


### PR DESCRIPTION
Default values for polymer properties are always overridden by server
side values: even if they are not set explicitly by the developer we
send nulls as default values for every model property. So server side
always overrides client preset values.

Fixes #1445

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/1462)
<!-- Reviewable:end -->
