### PR TITLE
Require a component class for creating a component around an element

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -1499,7 +1499,7 @@ public class Element implements Serializable {
      *            the component type
      * @return the component instance connected to the given element
      */
-    public <T> T as(Class<T> componentType) {
+    public <T extends Component> T as(Class<T> componentType) {
         return ComponentUtil.componentFromElement(this, componentType, false);
     }
 

--- a/flow-server/src/main/java/com/vaadin/ui/ComponentUtil.java
+++ b/flow-server/src/main/java/com/vaadin/ui/ComponentUtil.java
@@ -254,7 +254,7 @@ public class ComponentUtil {
      *            <code>false</code> to only map the component to the element
      * @return a new component instance of the given type
      */
-    public static <T> T componentFromElement(Element element,
+    public static <T extends Component> T componentFromElement(Element element,
             Class<T> componentType, boolean mapComponent) {
         if (element == null) {
             throw new IllegalArgumentException("Element to use cannot be null");


### PR DESCRIPTION
Fixes inconsistency between Component.from and Element.as

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/1464)
<!-- Reviewable:end -->
