### PR TITLE
Provide a way to fire server side event on property change

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -33,6 +33,7 @@ import com.vaadin.flow.StateNode;
 import com.vaadin.flow.dom.impl.BasicElementStateProvider;
 import com.vaadin.flow.dom.impl.BasicTextElementStateProvider;
 import com.vaadin.flow.dom.impl.CustomAttribute;
+import com.vaadin.flow.event.PropertyChangeListener;
 import com.vaadin.flow.nodefeature.ElementData;
 import com.vaadin.flow.nodefeature.OverrideElementData;
 import com.vaadin.flow.nodefeature.TemplateMap;
@@ -883,6 +884,25 @@ public class Element implements Serializable {
         return this;
     }
 
+    /**
+     * Adds a property change listener.
+     * <p>
+     * Use either two way Polymer binding or synchronize property explicitly to
+     * be able to get property change events from the client.
+     * 
+     * @see #synchronizeProperty(String, String)
+     * @param name
+     *            the property name to add the listener for
+     * @param listener
+     *            listener to get notifications about property value changes
+     * @return an event registration handle for removing the listener
+     */
+    public EventRegistrationHandle addPropertyChangeListener(String name,
+            PropertyChangeListener listener) {
+        return stateProvider.addPropertyChangeListener(getNode(), name,
+                listener);
+    }
+
     private Element setRawProperty(String name, Serializable value) {
         verifySetPropertyName(name);
 
@@ -1057,7 +1077,7 @@ public class Element implements Serializable {
      *            the property name, not null
      * @return the raw property value, or <code>null</code>
      */
-    public Object getPropertyRaw(String name) {
+    public Serializable getPropertyRaw(String name) {
         return stateProvider.getProperty(getNode(), name);
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/dom/ElementStateProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/ElementStateProvider.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.StateNode;
+import com.vaadin.flow.event.PropertyChangeListener;
 import com.vaadin.flow.nodefeature.ComponentMapping;
 import com.vaadin.server.StreamResource;
 import com.vaadin.ui.Component;
@@ -214,7 +215,7 @@ public interface ElementStateProvider extends Serializable {
      * @return the property value, or <code>null</code> if the property has not
      *         been set
      */
-    Object getProperty(StateNode node, String name);
+    Serializable getProperty(StateNode node, String name);
 
     /**
      * Sets the given property to the given value.
@@ -361,5 +362,19 @@ public interface ElementStateProvider extends Serializable {
         assert node != null;
         return node.getFeature(ComponentMapping.class).getComponent();
     }
+
+    /**
+     * Adds a property change listener.
+     * 
+     * @param node
+     *            the node containing the property
+     * @param name
+     *            the property name to add the listener for
+     * @param listener
+     *            listener to get notifications about property value changes
+     * @return an event registration handle for removing the listener
+     */
+    EventRegistrationHandle addPropertyChangeListener(StateNode node,
+            String name, PropertyChangeListener listener);
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/AbstractTextElementStateProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/AbstractTextElementStateProvider.java
@@ -27,6 +27,7 @@ import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementStateProvider;
 import com.vaadin.flow.dom.EventRegistrationHandle;
 import com.vaadin.flow.dom.Style;
+import com.vaadin.flow.event.PropertyChangeListener;
 import com.vaadin.server.StreamResource;
 
 /**
@@ -111,7 +112,7 @@ public abstract class AbstractTextElementStateProvider
     }
 
     @Override
-    public Object getProperty(StateNode node, String name) {
+    public Serializable getProperty(StateNode node, String name) {
         return null;
     }
 
@@ -162,4 +163,9 @@ public abstract class AbstractTextElementStateProvider
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public EventRegistrationHandle addPropertyChangeListener(StateNode node,
+            String name, PropertyChangeListener listener) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/BasicElementStateProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/BasicElementStateProvider.java
@@ -32,6 +32,7 @@ import com.vaadin.flow.dom.ElementStateProvider;
 import com.vaadin.flow.dom.ElementUtil;
 import com.vaadin.flow.dom.EventRegistrationHandle;
 import com.vaadin.flow.dom.Style;
+import com.vaadin.flow.event.PropertyChangeListener;
 import com.vaadin.flow.nodefeature.ClientDelegateHandlers;
 import com.vaadin.flow.nodefeature.ComponentMapping;
 import com.vaadin.flow.nodefeature.ElementAttributeMap;
@@ -292,7 +293,7 @@ public class BasicElementStateProvider implements ElementStateProvider {
     }
 
     @Override
-    public Object getProperty(StateNode node, String name) {
+    public Serializable getProperty(StateNode node, String name) {
         assert node != null;
         assert name != null;
 
@@ -375,6 +376,13 @@ public class BasicElementStateProvider implements ElementStateProvider {
         assert attribute != null;
         assert resource != null;
         getAttributeFeature(node).setResource(attribute, resource);
+    }
+
+    @Override
+    public EventRegistrationHandle addPropertyChangeListener(StateNode node,
+            String name, PropertyChangeListener listener) {
+        return getPropertyFeature(node).addPropertyChangeListener(name,
+                listener);
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/TemplateElementStateProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/TemplateElementStateProvider.java
@@ -29,6 +29,7 @@ import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementStateProvider;
 import com.vaadin.flow.dom.EventRegistrationHandle;
 import com.vaadin.flow.dom.Style;
+import com.vaadin.flow.event.PropertyChangeListener;
 import com.vaadin.flow.nodefeature.ClientDelegateHandlers;
 import com.vaadin.flow.nodefeature.ComponentMapping;
 import com.vaadin.flow.nodefeature.ElementAttributeMap;
@@ -315,9 +316,10 @@ public class TemplateElementStateProvider implements ElementStateProvider {
     }
 
     @Override
-    public Object getProperty(StateNode node, String name) {
+    public Serializable getProperty(StateNode node, String name) {
         if (templateNode.getPropertyBinding(name).isPresent()) {
-            return templateNode.getPropertyBinding(name).get().getValue(node);
+            return (Serializable) templateNode.getPropertyBinding(name).get()
+                    .getValue(node);
         } else {
             return getOverrideNode(node)
                     .map(overrideNode -> BasicElementStateProvider.get()
@@ -491,6 +493,12 @@ public class TemplateElementStateProvider implements ElementStateProvider {
                 || modelFeature == ModelList.class;
 
         return new StateNode(TemplateOverridesMap.class, modelFeature);
+    }
+
+    @Override
+    public EventRegistrationHandle addPropertyChangeListener(StateNode node,
+            String name, PropertyChangeListener listener) {
+        throw new UnsupportedOperationException();
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/event/PropertyChangeEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/event/PropertyChangeEvent.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.event;
+
+import java.io.Serializable;
+import java.util.EventObject;
+
+import com.vaadin.flow.dom.Element;
+
+/**
+ * An event fired when the value of a property changes.
+ */
+public class PropertyChangeEvent extends EventObject {
+
+    private final boolean userOriginated;
+
+    private final String propertyName;
+
+    private final Serializable oldValue;
+    private final Serializable value;
+
+    /**
+     * Creates a new {@code PropertyChangeEvent} event containing the current
+     * property value of the given element.
+     *
+     * @param element
+     *            the source element owning the property, not null
+     * @param propertyName
+     *            the property name
+     * @param oldValue
+     *            the previous value held by the source of this event
+     * @param userOriginated
+     *            {@code true} if this event originates from the client,
+     *            {@code false} otherwise.
+     */
+    public PropertyChangeEvent(Element element, String propertyName,
+            Serializable oldValue, boolean userOriginated) {
+        super(element);
+        this.propertyName = propertyName;
+        this.oldValue = oldValue;
+        this.value = element.getPropertyRaw(propertyName);
+        this.userOriginated = userOriginated;
+    }
+
+    /**
+     * Returns the value of the source before this value change event occurred.
+     * 
+     * @return the value previously held by the source of this event
+     */
+    public Serializable getOldValue() {
+        return oldValue;
+    }
+
+    /**
+     * Returns the new value that triggered this value change event.
+     *
+     * @return the new value
+     */
+    public Serializable getValue() {
+        return value;
+    }
+
+    /**
+     * Returns whether this event was triggered by user interaction, on the
+     * client side, or programmatically, on the server side.
+     *
+     * @return {@code true} if this event originates from the client,
+     *         {@code false} otherwise.
+     */
+    public boolean isUserOriginated() {
+        return userOriginated;
+    }
+
+    /**
+     * Returns the property name.
+     * 
+     * @return the property name
+     */
+    public String getPropertyName() {
+        return propertyName;
+    }
+
+    @Override
+    public Element getSource() {
+        return (Element) super.getSource();
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/event/PropertyChangeListener.java
+++ b/flow-server/src/main/java/com/vaadin/flow/event/PropertyChangeListener.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.event;
+
+import java.io.Serializable;
+
+import com.vaadin.flow.dom.EventRegistrationHandle;
+
+/**
+ * A listener for property change events.
+ *
+ * @see PropertyChangeEvent
+ * @see EventRegistrationHandle
+ */
+@FunctionalInterface
+public interface PropertyChangeListener extends Serializable {
+    /**
+     * Invoked when this listener receives a property change event from an event
+     * source to which it has been added.
+     *
+     * @param event
+     *            the received event, not null
+     */
+    public void propertyChange(PropertyChangeEvent event);
+}

--- a/flow-server/src/main/java/com/vaadin/flow/nodefeature/NodeMap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/nodefeature/NodeMap.java
@@ -94,7 +94,7 @@ public abstract class NodeMap extends NodeFeature {
             setUnChanged(key);
         }
         ensureValues();
-        Object oldValue = values.put(key, value);
+        Serializable oldValue = values.put(key, value);
 
         detatchPotentialChild(oldValue);
 
@@ -109,7 +109,7 @@ public abstract class NodeMap extends NodeFeature {
      * @return the value corresponding to the key; <code>null</code> if there is
      *         no value stored, or if <code>null</code> is stored as a value
      */
-    protected Object get(String key) {
+    protected Serializable get(String key) {
         setAccessed(key);
         if (values == null) {
             return null;
@@ -356,4 +356,5 @@ public abstract class NodeMap extends NodeFeature {
     protected boolean mayUpdateFromClient(String key, Serializable value) {
         return false;
     }
+
 }

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
@@ -102,6 +102,7 @@ public class ElementTest {
         ignore.add("addEventListener");
         ignore.add("addAttachListener");
         ignore.add("addDetachListener");
+        ignore.add("addPropertyChangeListener");
 
         // Returns index of child element
         ignore.add("indexOfChild");

--- a/flow-server/src/test/java/com/vaadin/flow/nodefeature/ElementPropertyMapTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/nodefeature/ElementPropertyMapTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.nodefeature;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.StateNode;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.EventRegistrationHandle;
+import com.vaadin.flow.dom.impl.BasicElementStateProvider;
+import com.vaadin.flow.event.PropertyChangeEvent;
+import com.vaadin.flow.event.PropertyChangeListener;
+
+public class ElementPropertyMapTest {
+
+    @Test
+    public void addPropertyChangeListener_fireServerEvent_listenerIsNotified() {
+        listenerIsNotified(false);
+    }
+
+    @Test
+    public void addPropertyChangeListener_fireClientEvent_listenerIsNotified() {
+        listenerIsNotified(true);
+    }
+
+    @Test
+    public void removePropertyChangeListener_fireEvent_listenerIsNotNotified() {
+        StateNode node = BasicElementStateProvider.createStateNode("div");
+        ElementPropertyMap map = node.getFeature(ElementPropertyMap.class);
+        PropertyChangeListener listener = ev -> {
+            Assert.fail();
+        };
+        EventRegistrationHandle registration = map
+                .addPropertyChangeListener("foo", listener);
+        registration.remove();
+
+        // listener is not called. Otherwise its assertion fails.
+        map.setProperty("foo", "bar", true);
+    }
+
+    @Test
+    public void addSeveralPropertyChangeListeners_fireEvent_listenersAreNotified() {
+        StateNode node = BasicElementStateProvider.createStateNode("div");
+        ElementPropertyMap map = node.getFeature(ElementPropertyMap.class);
+        AtomicBoolean first = new AtomicBoolean();
+        AtomicBoolean second = new AtomicBoolean();
+        PropertyChangeListener listener1 = ev -> first.set(!first.get());
+        PropertyChangeListener listener2 = ev -> second.set(!second.get());
+        map.addPropertyChangeListener("foo", listener1);
+        map.addPropertyChangeListener("foo", listener2);
+
+        map.setProperty("foo", "bar", true);
+
+        Assert.assertTrue(first.get());
+        Assert.assertTrue(second.get());
+    }
+
+    private void listenerIsNotified(boolean clientEvent) {
+        StateNode node = BasicElementStateProvider.createStateNode("div");
+        ElementPropertyMap map = node.getFeature(ElementPropertyMap.class);
+        AtomicReference<PropertyChangeEvent> event = new AtomicReference<>();
+        PropertyChangeListener listener = ev -> {
+            Assert.assertNull(event.get());
+            event.set(ev);
+        };
+        map.addPropertyChangeListener("foo", listener);
+        map.setProperty("foo", "bar", !clientEvent);
+
+        Assert.assertNull(event.get().getOldValue());
+        Assert.assertEquals("bar", event.get().getValue());
+        Assert.assertEquals("foo", event.get().getPropertyName());
+        Assert.assertEquals(Element.get(node), event.get().getSource());
+        Assert.assertEquals(clientEvent, event.get().isUserOriginated());
+
+        // listener is not called. Otherwise its assertion fails.
+        map.setProperty("bar", "foo");
+    }
+
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/PolymerPropertyChangeEventUI.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/PolymerPropertyChangeEventUI.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.template;
+
+import com.vaadin.annotations.HtmlImport;
+import com.vaadin.annotations.Tag;
+import com.vaadin.annotations.WebComponents;
+import com.vaadin.flow.event.PropertyChangeEvent;
+import com.vaadin.flow.html.Div;
+import com.vaadin.flow.template.PolymerTemplate;
+import com.vaadin.flow.template.model.TemplateModel;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.ui.UI;
+
+@WebComponents(1)
+public class PolymerPropertyChangeEventUI extends UI {
+
+    public interface Message extends TemplateModel {
+        void setText(String text);
+
+        String getText();
+    }
+
+    @Tag("property-change")
+    @HtmlImport("/com/vaadin/flow/uitest/ui/template/PolymerPropertyChange.html")
+    public static class PolymerPropertyChange extends PolymerTemplate<Message> {
+
+    }
+
+    @Override
+    protected void init(VaadinRequest request) {
+        PolymerPropertyChange template = new PolymerPropertyChange();
+        template.setId("template");
+        template.getElement().addPropertyChangeListener("text",
+                this::propertyChanged);
+        add(template);
+    }
+
+    private void propertyChanged(PropertyChangeEvent event) {
+        Div div = new Div();
+        div.setText("New property value: '" + event.getValue()
+                + "', old property value: '" + event.getOldValue() + "'");
+        div.addClassName("change-event");
+        add(div);
+    }
+}

--- a/flow-tests/test-root-context/src/main/webapp/com/vaadin/flow/uitest/ui/template/PolymerPropertyChange.html
+++ b/flow-tests/test-root-context/src/main/webapp/com/vaadin/flow/uitest/ui/template/PolymerPropertyChange.html
@@ -1,0 +1,37 @@
+<!--
+  ~ Copyright 2000-2017 Vaadin Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+<link rel="import" href="/v2/bower_components/polymer/polymer.html">
+
+<dom-module id="property-change">
+    <template>
+        <input id="input" value="{{text::input}}">
+    </template>
+    <script>
+        class MyTemplate extends Polymer.Element {
+            static get is() { return 'property-change' }
+           
+            static get properties() {
+               return {
+                    text :{
+                        type: String,
+                        notify: true
+                    }
+                };
+            }
+        }
+        customElements.define(MyTemplate.is, MyTemplate);
+    </script>
+</dom-module>

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/PolymerPropertyChangeEventIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/PolymerPropertyChangeEventIT.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.template;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+import com.vaadin.testbench.By;
+
+public class PolymerPropertyChangeEventIT extends ChromeBrowserTest {
+
+    @Test
+    public void propertyChangeEvent() {
+        open();
+
+        WebElement template = findElement(By.id("template"));
+        getInShadowRoot(template, By.id("input")).get().sendKeys("foo");
+
+        List<WebElement> changeEvents = findElements(
+                By.className("change-event"));
+        Assert.assertTrue(
+                "Expected property change event is not fired. "
+                        + "Element with expected old and new value is not found",
+                changeEvents.stream().anyMatch(
+                        event -> "New property value: 'foo', old property value: 'fo'"
+                                .equals(event.getText())));
+    }
+}


### PR DESCRIPTION
It's now possible to add property change listener in case of polymer
two-way binding to get events from the client side.

Fixes #1272

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/1484)
<!-- Reviewable:end -->
