### PR TITLE
Introduce existing element map and its accessor on the client side

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/DefaultRegistry.java
+++ b/flow-client/src/main/java/com/vaadin/client/DefaultRegistry.java
@@ -73,6 +73,7 @@ public class DefaultRegistry extends Registry {
                 new ExecuteJavaScriptProcessor(this));
         set(TemplateRegistry.class, new TemplateRegistry());
         set(ConstantPool.class, new ConstantPool());
+        set(ExistingElementMap.class, new ExistingElementMap());
 
         // Classes with dependencies, in correct order
         set(Heartbeat.class, new Heartbeat(this));

--- a/flow-client/src/main/java/com/vaadin/client/ExistingElementMap.java
+++ b/flow-client/src/main/java/com/vaadin/client/ExistingElementMap.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.client;
+
+import com.vaadin.client.flow.collection.JsCollections;
+import com.vaadin.client.flow.collection.JsMap;
+
+import elemental.dom.Element;
+
+/**
+ * Mapping between a server side node identifier which has been requested to
+ * attach existing client side element.
+ * 
+ * @author Vaadin Ltd
+ *
+ */
+public class ExistingElementMap {
+
+    private final JsMap<Element, Integer> elementToId = JsCollections.map();
+    private final JsMap<Integer, Element> idToElement = JsCollections.map();
+
+    /**
+     * Gets the element stored via the {@link #add(int, Element)} method by the
+     * given {@code id}.
+     * 
+     * @param id
+     *            identifier associated with an element
+     * @return the element associated with the {@code id} or null if it doesn't
+     *         exist
+     */
+    public Element getElement(int id) {
+        return idToElement.get(id);
+    }
+
+    /**
+     * Gets the id stored via the {@link #add(int, Element)} method by the given
+     * {@code element}.
+     * 
+     * @param element
+     *            element associated with an identifier
+     * @return the identifier associated with the {@code element} or null if it
+     *         doesn't exist
+     */
+    public Integer getId(Element element) {
+        return elementToId.get(element);
+    }
+
+    /**
+     * Remove the identifier and the associated element from the mapping.
+     * 
+     * @param id
+     *            identifier to remove
+     */
+    public void remove(int id) {
+        Element element = idToElement.get(id);
+        if (element != null) {
+            idToElement.delete(id);
+            elementToId.delete(element);
+        }
+    }
+
+    /**
+     * Adds the {@code id} and the {@code element} to the mapping.
+     * 
+     * @param id
+     *            identifier of the server side node
+     * @param element
+     *            element associated with the identifier
+     */
+    public void add(int id, Element element) {
+        idToElement.set(id, element);
+        elementToId.set(element, id);
+    }
+}

--- a/flow-client/src/main/java/com/vaadin/client/Registry.java
+++ b/flow-client/src/main/java/com/vaadin/client/Registry.java
@@ -289,4 +289,13 @@ public class Registry {
     public ScrollPositionHandler getScrollPositionHandler() {
         return get(ScrollPositionHandler.class);
     }
+
+    /**
+     * Gets the {@link ExistingElementMap} singleton.
+     * 
+     * @return the {@link ExistingElementMap} singleton
+     */
+    public ExistingElementMap getExistingElementMap() {
+        return get(ExistingElementMap.class);
+    }
 }


### PR DESCRIPTION
To be able to identify the server side node which is going to be
attached for an exiting element it's required to track mapping between
its Id and the element on the client side. ExistingElementMap is
introduced for this purpose.

The first step for the #1524

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/1538)
<!-- Reviewable:end -->
