### PR TITLE
Html dependencies should not be loaded in async mode due to issues with Chrome loading.

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/DependencyLoader.java
+++ b/flow-client/src/main/java/com/vaadin/client/DependencyLoader.java
@@ -192,7 +192,7 @@ public class DependencyLoader {
             return resourceLoader::loadStylesheet;
         case DependencyList.TYPE_HTML_IMPORT:
             return (scriptUrl, resourceLoadListener) -> resourceLoader
-                    .loadHtml(scriptUrl, resourceLoadListener, true);
+                    .loadHtml(scriptUrl, resourceLoadListener, false);
         case DependencyList.TYPE_JAVASCRIPT:
             return (scriptUrl, resourceLoadListener) -> resourceLoader
                     .loadScript(scriptUrl, resourceLoadListener, false, true);

--- a/flow-client/src/main/java/com/vaadin/client/ResourceLoader.java
+++ b/flow-client/src/main/java/com/vaadin/client/ResourceLoader.java
@@ -287,7 +287,9 @@ public class ResourceLoader {
             LinkElement linkTag = getDocument().createLinkElement();
             linkTag.setAttribute("rel", "import");
             linkTag.setAttribute("href", url);
-            linkTag.setAttribute("async", Boolean.toString(async));
+            if (async) {
+                linkTag.setAttribute("async", "true");
+            }
 
             class LoadAndReadyListener
                     implements ResourceLoadListener, Runnable {

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/dependencies/DependenciesLoadingAnnotationsIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/dependencies/DependenciesLoadingAnnotationsIT.java
@@ -89,18 +89,5 @@ public class DependenciesLoadingAnnotationsIT extends PhantomJSTest {
                                     javaScriptImport.getAttribute("src")),
                             javaScriptImport.getAttribute("async"));
                 });
-
-        findElements(By.tagName("link")).stream()
-                .filter(element -> element.getAttribute("href")
-                        .endsWith(".html"))
-                .forEach(
-                        htmlImport -> Assert
-                                .assertEquals(
-                                        String.format(
-                                                "All html dependencies should be loaded with 'async' attribute. Dependency with url %s does not have this attribute",
-                                                htmlImport
-                                                        .getAttribute("href")),
-                                        "true",
-                                        htmlImport.getAttribute("async")));
     }
 }


### PR DESCRIPTION
Since we've discovered that async html loading may lead to issues with loading dependencies, we need to remove it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/1588)
<!-- Reviewable:end -->
