### PR TITLE
Check for the exisiting element by id also from document

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/ElementUtils.java
+++ b/flow-client/src/main/java/com/vaadin/client/ElementUtils.java
@@ -167,7 +167,7 @@ public class ElementUtils {
             elementById = shadowRootParent.shadowRoot.getElementById(id);
         }
         if(elementById == null) {
-            elementById = $doc.getElementById("creator");
+            elementById = $doc.getElementById(id);
         }
         return elementById;
     }-*/;

--- a/flow-client/src/test-gwt/java/com/vaadin/client/GwtElementUtilsTest.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/GwtElementUtilsTest.java
@@ -215,6 +215,23 @@ public class GwtElementUtilsTest extends ClientEngineTestBase {
         assertRpcToServerArguments(99, child.getTagName(), id);
     }
 
+    // This test emulates FireFox that doesn't hide element children under shadowRoot
+    public void testAttachExistingElementById_elementOutsideShadowRoot() {
+        Browser.getDocument().getBody().appendChild(element);
+        setupShadowRoot();
+
+        String id = "identifier";
+
+        Element child = Browser.getDocument().createElement("div");
+        child.setAttribute("id", id);
+        element.appendChild(child);
+
+        ElementUtils.attachExistingElementById(node,
+                "div", requestedId, id);
+
+        assertRpcToServerArguments(requestedId, child.getTagName(), id);
+    }
+
     private Element setupShadowRoot() {
         Element shadowRoot = addShadowRoot(element);
 


### PR DESCRIPTION
Check for element by id using document.getElementById() if
shadowRoot.getElementById() returns null.
This is done because firefox doesn’t nest the elements under a shadowRoot.

Fixes flow-demo #265

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/1593)
<!-- Reviewable:end -->
