### PR TITLE
Added test that shows that nodeId is not

### DIFF
--- a/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtPolymerModelTest.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtPolymerModelTest.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 
+import com.vaadin.client.PolymerUtils;
 import com.vaadin.client.Registry;
 import com.vaadin.client.WidgetUtil;
 import com.vaadin.client.flow.binding.Binder;
@@ -15,6 +16,8 @@ import com.vaadin.flow.shared.NodeFeatures;
 import elemental.client.Browser;
 import elemental.dom.Element;
 import elemental.json.JsonArray;
+import elemental.json.JsonObject;
+import elemental.json.JsonValue;
 
 /**
  * @author Vaadin Ltd.
@@ -207,6 +210,23 @@ public class GwtPolymerModelTest extends GwtPropertyElementBinderTest {
                 Arrays.asList("one", "two"), this::createBasicTypeWrapper);
 
         assertUpdateListValues(nodeWithList);
+    }
+
+    public void testPolymerUtilsStoreNodeIdNotAvailableAsListItem() {
+        nextId = 98;
+        List<String> serverList = Arrays.asList("one", "two");
+        StateNode andAttachNodeWithList = createAndAttachNodeWithList(modelNode,
+                serverList);
+
+        JsonValue jsonValue = PolymerUtils.convertToJson(andAttachNodeWithList);
+
+        assertTrue("Expected instance of JsonObject from converter, but was not.",
+                jsonValue instanceof JsonObject);
+        double nodeId = ((JsonObject) jsonValue).getNumber("nodeId");
+        assertFalse(
+                "JsonValue array contained nodeId even though it shouldn't be visible",
+                jsonValue.toJson().contains(Double.toString(nodeId)));
+        assertEquals("Found nodeId didn't match the set nodeId", 98.0, nodeId);
     }
 
     @Override

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/SubPropertyModelIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/SubPropertyModelIT.java
@@ -60,7 +60,9 @@ public class SubPropertyModelIT extends ChromeBrowserTest {
         // click message
         getInShadowRoot(template, By.id("msg")).get().click();
 
-        Assert.assertEquals(findElement(By.id("statusClick")).getText(),
-                getInShadowRoot(template, By.id("msg")).get().getText());
+        Assert.assertEquals(
+                "Clicking status message did not get the same modelData as in the message box.",
+                getInShadowRoot(template, By.id("msg")).get().getText(),
+                findElement(By.id("statusClick")).getText());
     }
 }


### PR DESCRIPTION
interfering with converter value for array.

Closes #1611

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/1624)
<!-- Reviewable:end -->
