### PR TITLE
Remove excessive logging about excessive imports

### DIFF
--- a/flow-server/src/main/java/com/vaadin/ui/DependencyList.java
+++ b/flow-server/src/main/java/com/vaadin/ui/DependencyList.java
@@ -82,10 +82,6 @@ public class DependencyList implements Serializable {
         String dependencyUrl = dependency.getUrl();
 
         if (urlCache.contains(dependencyUrl)) {
-            getLogger().log(Level.WARNING,
-                    () -> String.format(
-                            "Dependency with url %s was imported numerous times, it's advised to remove excessive imports",
-                            dependencyUrl));
             Optional.ofNullable(urlToLoadedDependency.get(dependencyUrl))
                     .ifPresent(currentDependency -> checkDuplicateDependency(
                             dependency, currentDependency));


### PR DESCRIPTION
With the previous implementation, messages were logged every time a user
returns to a view that contains anything that defines dependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/1657)
<!-- Reviewable:end -->
