### PR TITLE
Removed ES6 method call from class that should be executable in older ES5 browsers.

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
@@ -227,7 +227,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
       if ( @com.vaadin.client.PolymerUtils::isPolymerElement(*)(element) ){
           handlePropertiesFunction(this, false);
       }
-      else if ($wnd.customElements && element.localName.includes('-')){
+      else if ($wnd.customElements && element.localName.indexOf('-') > -1){
           var self = this;
           var callback = function (){
               handlePropertiesFunction(self, true);


### PR DESCRIPTION
Fix #1666

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/1667)
<!-- Reviewable:end -->
