### PR TITLE
Recognize elements attached via @Id as children (feature based)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/nodefeature/AttachExistingElementFeatureById.java
+++ b/flow-server/src/main/java/com/vaadin/flow/nodefeature/AttachExistingElementFeatureById.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.nodefeature;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import com.vaadin.flow.StateNode;
 import com.vaadin.flow.dom.Element;
@@ -83,4 +84,8 @@ public class AttachExistingElementFeatureById extends ServerSideFeature {
         node.setParent(null);
     }
 
+    @Override
+    public void forEachChild(Consumer<StateNode> action) {
+        parentNodes.keySet().stream().forEach(action::accept);
+    }
 }


### PR DESCRIPTION
An assertion error is thrown in case parent is set for the node but it's
not recognized as a child (from the features perspective).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/1692)
<!-- Reviewable:end -->
