### PR TITLE
Give test a bit more leeway in position

### DIFF
--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/scroll/ScrollIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/scroll/ScrollIT.java
@@ -9,8 +9,8 @@ import com.vaadin.testbench.By;
 
 public class ScrollIT extends ChromeBrowserTest {
 
-    // Scroll position may differ a little locally and in Travis
-    private static final int allowedScrollVariance = 15;
+    // Scroll position may differ a little locally and in Travis and Test grid
+    private static final int allowedScrollVariance = 20;
 
     @Test
     public void testScrollRestoration_basicBackForward() {


### PR DESCRIPTION
Due to many different environments we
give a bit more leeway for scroll position
variance for test grid, travis and local execution.

Closes #1702

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/1709)
<!-- Reviewable:end -->
