### PR TITLE
Drop the performace test for now.

### DIFF
--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -16,7 +16,9 @@
         <module>test-resources</module>
         <module>test-root-context</module>
         <module>test-subcontext</module>
-        <module>test-performance</module>
+        <!-- Drop performance test until we can figure -->
+        <!-- out how it should work with TestBench hub -->
+        <!--<module>test-performance</module>-->
         <module>test-scalability</module>
         <module>test-memory-leaks</module>
         <module>test-expense-manager-imperative</module>


### PR DESCRIPTION
We need to drop the performance test
as it's designed to run locally and fails
on driver/server error when running on
the test grid.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/1725)
<!-- Reviewable:end -->
