### PR TITLE
v-uiId may be the last value

### DIFF
--- a/flow-tests/test-expense-manager-imperative/src/test/scala/com/vaadin/flow/demo/ExpenseCreation.scala
+++ b/flow-tests/test-expense-manager-imperative/src/test/scala/com/vaadin/flow/demo/ExpenseCreation.scala
@@ -27,7 +27,7 @@ class ExpenseCreation extends Simulation {
   val uidlHeaders = Map("Content-Type" -> "application/json; charset=UTF-8")
 
   val storeUiId =
-    regex(""""v-uiId":\s(\d+),""")
+    regex(""""v-uiId":\s(\d+)""")
       .saveAs("uiId")
   val storeSecurityKey =
     regex(""""Vaadin-Security-Key":\s"([^"]*)""")


### PR DESCRIPTION
Fix regex so that ti doesn't matter if
the 'v-uiId' is in between the properties
and has a comma at the end or if it's the last
property and doesn't have a comma.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/1731)
<!-- Reviewable:end -->
