### PR TITLE
Make the exception message clearer.

### DIFF
--- a/flow-server/src/main/java/com/vaadin/server/CustomElementRegistryInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/server/CustomElementRegistryInitializer.java
@@ -29,8 +29,8 @@ import com.vaadin.ui.Component;
 import com.vaadin.util.CustomElementNameValidator;
 
 /**
- * Servlet initializer for collecting all applicable custom element tag
- * names on startup.
+ * Servlet initializer for collecting all applicable custom element tag names on
+ * startup.
  */
 @HandlesTypes(Tag.class)
 public class CustomElementRegistryInitializer
@@ -66,7 +66,7 @@ public class CustomElementRegistryInitializer
                 } else {
                     String msg = String.format(
                             "Tag name '%s' for '%s' is not a valid custom element name.",
-                            tagName, clazz.getSimpleName());
+                            tagName, clazz.getCanonicalName());
                     throw new InvalidCustomElementNameException(msg);
                 }
             }
@@ -99,9 +99,9 @@ public class CustomElementRegistryInitializer
             customElements.put(tagName, (Class<? extends Component>) newClass);
         } else if (!componentClass.isAssignableFrom(newClass)) {
             String msg = String.format(
-                    "Incompatible tag '%s' annotation for components '%s' and '%s'",
-                    tagName, componentClass.getSimpleName(),
-                    newClass.getSimpleName());
+                    "Components '%s' and '%s' have the same @Tag('%s') annotation, but neither is a super class of the other.",
+                    componentClass.getCanonicalName(),
+                    newClass.getCanonicalName(), tagName);
             // Throw exception if neither class is a super class of the
             // other.
             throw new ClassCastException(msg);


### PR DESCRIPTION
When failing on tag name exception
make it clear that it is due to the fact
that 2 classes have the same tag name,
but neither extends the other.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/1739)
<!-- Reviewable:end -->
