### PR TITLE
Fix getting template path.

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/template/DefaultTemplateParser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/template/DefaultTemplateParser.java
@@ -115,6 +115,8 @@ public class DefaultTemplateParser implements TemplateParser {
             assert servletPath != null;
             if (!servletPath.endsWith("/") && !uri.startsWith("/")) {
                 servletPath += "/";
+            } else if(servletPath.endsWith("/") && uri.startsWith("/")) {
+                servletPath = servletPath.substring(0, servletPath.length()-1);
             }
             // "Revert" the `../` from uri resolver so that we point to the
             // context root.


### PR DESCRIPTION
As we work on the server we should always only
target context root and not take note of pathInfo
when searching for templates on the server.

Fixes #1856

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/1871)
<!-- Reviewable:end -->
