### PR TITLE
Generate components only when necessary

### DIFF
--- a/.travis.script.sh
+++ b/.travis.script.sh
@@ -25,7 +25,6 @@ change=`diff <(git show --name-only $actualCommits) <(git show --summary $actual
 
 # Collect changed modules to build and build also modules that depend on the
 # selected modules (see the flag '-amd')
-
 modules=
 if [[ $change == *"flow-push/"* ]]
 then
@@ -48,8 +47,9 @@ else
 
     if [[ $change == *"flow-components-parent/"* ]]
     then
+      ## only trigger the analyzer & generator for validation builds on PRs that touched component generation
       echo "Setting components flag to true"
-      modules="$modules -pl flow-components-parent"
+      modules="$modules -pl flow-components-parent -P generator"
     fi
 
     if [[ $change == *"flow-client/"* ]]
@@ -105,7 +105,7 @@ then
             -Dsonar.login=$SONAR_LOGIN \
             -Dsonar.exclusions=$SONAR_EXCLUSIONS \
             -DskipTests \
-            compile sonar:sonar
+            compile sonar:sonar -pl \!:flow-generated-components
     else
         exit 1
     fi
@@ -131,7 +131,7 @@ then
         -Dsonar.login=$SONAR_LOGIN \
         -Dsonar.exclusions=$SONAR_EXCLUSIONS \
         -DskipTests \
-        compile sonar:sonar
+        compile sonar:sonar -pl \!:flow-generated-components
 else
     # Something else than a "safe" pull request
     mvn -B -e -V \

--- a/flow-components-parent/flow-generated-components/pom.xml
+++ b/flow-components-parent/flow-generated-components/pom.xml
@@ -24,40 +24,44 @@
         <maven.javadoc.skip>true</maven.javadoc.skip>
     </properties>
 
-    <build>
-        <plugins>
-            <!-- Clears the source folder so it can be generated again -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-clean-plugin</artifactId>
-                <version>3.0.0</version>
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>src/main/java</directory>
-                        </fileset>
-                    </filesets>
-                </configuration>
-            </plugin>
-
-            <!-- Code generator configuration -->
-            <plugin>
-                <groupId>com.vaadin</groupId>
-                <artifactId>flow-code-generator</artifactId>
-                <version>${flow.version}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>generate</goal>
-                        </goals>
+    <profiles>
+        <profile>
+            <id>generator</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-clean-plugin</artifactId>
+                        <version>3.0.0</version>
                         <configuration>
-                            <basePackage>com.vaadin.components</basePackage>
-                            <licenseFile>license_header</licenseFile>
+                            <filesets>
+                                <fileset>
+                                    <directory>src/main/java</directory>
+                                </fileset>
+                            </filesets>
                         </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+                    </plugin>
+
+                    <!-- Code generator configuration -->
+                    <plugin>
+                        <groupId>com.vaadin</groupId>
+                        <artifactId>flow-code-generator</artifactId>
+                        <version>${flow.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>generate</goal>
+                                </goals>
+                                <configuration>
+                                    <basePackage>com.vaadin.components</basePackage>
+                                    <licenseFile>license_header</licenseFile>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/flow-components-parent/flow-webcomponent-api-analyzer/pom.xml
+++ b/flow-components-parent/flow-webcomponent-api-analyzer/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <!-- Inheriting parent so we can get configuration properties and organization, 
         license etc. information from it. Drawback is some not needed dependencies. -->
@@ -10,90 +10,99 @@
     </parent>
     <artifactId>flow-webcomponent-api-analyzer</artifactId>
     <name>Flow WebComponent API Analyzer</name>
-    <description>Reads WebComponent APIs with Polymer Analyzer and Transform them to Json for Component Generator</description>
+    <description>Reads WebComponent APIs with Polymer Analyzer and Transform them to Json for Component Generator
+    </description>
     <!-- Versioning doesn't follow Flow Core. -->
     <version>0.0.1-SNAPSHOT</version>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>com.github.eirslett</groupId>
-                <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.4</version>
-                <configuration>
-                    <nodeVersion>${node.version}</nodeVersion>
-                    <npmVersion>${npm.version}</npmVersion>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>install node, npm and api reader</id>
-                        <goals>
-                            <goal>install-node-and-npm</goal>
-                            <goal>npm</goal>
-                        </goals>
-                        <phase>initialize</phase>
-                    </execution>
-                    <execution>
-                        <id>install bower</id>
-                        <goals>
-                            <goal>npm</goal>
-                        </goals>
-                        <configuration><arguments>install --save bower</arguments></configuration>
-                        <phase>initialize</phase>
-                    </execution>
-                    <execution>
-                        <id>bower install</id>
-                        <goals>
-                            <goal>bower</goal>
-                        </goals>
-                        <phase>initialize</phase>
-                    </execution>
-                    <execution>
-                        <id>read polymer api</id>
-                        <goals>
-                            <goal>npm</goal>
-                        </goals>
-                        <phase>generate-sources</phase>
+    <profiles>
+        <profile>
+            <id>generator</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.eirslett</groupId>
+                        <artifactId>frontend-maven-plugin</artifactId>
+                        <version>1.4</version>
                         <configuration>
-                            <!-- TODO #1805 need to figure out how to pass command line parameters
-                             from maven calls to this, such as what packages to create
-                             and what should be the output folder. flow-webcomponent-api-analyzer.jsr.js
-                             for current defaults. -->
-                            <!-- This argument matches to the "scripts" defined
-                             in package.json file. -->
-                            <arguments>run-script
-                                flow-components</arguments>
+                            <nodeVersion>${node.version}</nodeVersion>
+                            <npmVersion>${npm.version}</npmVersion>
                         </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-clean-plugin</artifactId>
-                <!-- Clean up generated sources and downloaded webcomponents -->
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>generated-json</directory>
-                        </fileset>
-                        <fileset>
-                            <directory>dependencies</directory>
-                        </fileset>
-                        <fileset>
-                            <directory>node_modules</directory>
-                        </fileset>
-                        <fileset>
-                            <directory>bower_components</directory>
-                        </fileset>
-                        
-                        <!-- Since this module is responsible for generating the json_metadata 
-                            directory, it is also responsible for cleaning it out -->
-                        <fileset>
-                            <directory>../flow-generated-components/json_metadata</directory>
-                        </fileset>
-                    </filesets>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+                        <executions>
+                            <execution>
+                                <id>install node, npm and api reader</id>
+                                <goals>
+                                    <goal>install-node-and-npm</goal>
+                                    <goal>npm</goal>
+                                </goals>
+                                <phase>initialize</phase>
+                            </execution>
+                            <execution>
+                                <id>install bower</id>
+                                <goals>
+                                    <goal>npm</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>install --save bower</arguments>
+                                </configuration>
+                                <phase>initialize</phase>
+                            </execution>
+                            <execution>
+                                <id>bower install</id>
+                                <goals>
+                                    <goal>bower</goal>
+                                </goals>
+                                <phase>initialize</phase>
+                            </execution>
+                            <execution>
+                                <id>read polymer api</id>
+                                <goals>
+                                    <goal>npm</goal>
+                                </goals>
+                                <phase>generate-sources</phase>
+                                <configuration>
+                                    <!-- TODO #1805 need to figure out how to pass command line parameters
+                                     from maven calls to this, such as what packages to create
+                                     and what should be the output folder. flow-webcomponent-api-analyzer.jsr.js
+                                     for current defaults. -->
+                                    <!-- This argument matches to the "scripts" defined
+                                     in package.json file. -->
+                                    <arguments>run-script
+                                        flow-components
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-clean-plugin</artifactId>
+                        <!-- Clean up generated sources and downloaded webcomponents -->
+                        <configuration>
+                            <filesets>
+                                <fileset>
+                                    <directory>generated-json</directory>
+                                </fileset>
+                                <fileset>
+                                    <directory>dependencies</directory>
+                                </fileset>
+                                <fileset>
+                                    <directory>node_modules</directory>
+                                </fileset>
+                                <fileset>
+                                    <directory>bower_components</directory>
+                                </fileset>
+
+                                <!-- Since this module is responsible for generating the json_metadata
+                                    directory, it is also responsible for cleaning it out -->
+                                <fileset>
+                                    <directory>../flow-generated-components/json_metadata</directory>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Do not run analyzer or generator when not required.
Don't clean generated content when not necessary.
Skip generated components module completely when running sonar,
since it would require that the generator maven plugin is installed,
which is not done always.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/1914)
<!-- Reviewable:end -->
