### PR TITLE
Revert removing flow-generated-components module from Sonar

### DIFF
--- a/.travis.script.sh
+++ b/.travis.script.sh
@@ -80,6 +80,7 @@ then
 
     # Trigger Sonar analysis
     # Verify build and build javadoc
+    echo "Running clean verify $modules -amd"
     mvn -B -e -V \
         -Pvalidation \
         -Dvaadin.testbench.developer.license=$TESTBENCH_LICENSE \
@@ -105,7 +106,7 @@ then
             -Dsonar.login=$SONAR_LOGIN \
             -Dsonar.exclusions=$SONAR_EXCLUSIONS \
             -DskipTests \
-            compile sonar:sonar -pl \!:flow-generated-components
+            compile sonar:sonar
     else
         exit 1
     fi
@@ -131,7 +132,7 @@ then
         -Dsonar.login=$SONAR_LOGIN \
         -Dsonar.exclusions=$SONAR_EXCLUSIONS \
         -DskipTests \
-        compile sonar:sonar -pl \!:flow-generated-components
+        compile sonar:sonar
 else
     # Something else than a "safe" pull request
     mvn -B -e -V \


### PR DESCRIPTION
Leaving it out caused compilation issues for the components demo module
when running sonar. The generated components are still in the ignore list
for Sonar. Since generated components' plugin dependency to code generator is now behind a
profile, the compilation of generated components should succeed for sonar target.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/1915)
<!-- Reviewable:end -->
