### PR TITLE
Skip Sonar for generated components

### DIFF
--- a/.travis.script.sh
+++ b/.travis.script.sh
@@ -5,9 +5,6 @@
 # TRAVIS_SECURE_ENV_VARS == true if encrypted variables, e.g. SONAR_HOST is available
 # TRAVIS_REPO_SLUG == the repository, e.g. vaadin/vaadin
 
-# Exclude the bower_components, node_modules and generated components from Sonar analysis
-SONAR_EXCLUSIONS=**/bower_components/**,**/node_modules/**,**/node/**,**/flow-generated-components/**
-
 # Get all changes to branch (no-merges)
 actualCommits=`git log --no-merges --pretty=oneline master^..HEAD`
 
@@ -104,7 +101,6 @@ then
             -Dsonar.analysis.mode=issues \
             -Dsonar.host.url=$SONAR_HOST \
             -Dsonar.login=$SONAR_LOGIN \
-            -Dsonar.exclusions=$SONAR_EXCLUSIONS \
             -DskipTests \
             compile sonar:sonar
     else
@@ -130,7 +126,6 @@ then
         -Dsonar.analysis.mode=publish \
         -Dsonar.host.url=$SONAR_HOST \
         -Dsonar.login=$SONAR_LOGIN \
-        -Dsonar.exclusions=$SONAR_EXCLUSIONS \
         -DskipTests \
         compile sonar:sonar
 else

--- a/flow-components-parent/flow-generated-components/pom.xml
+++ b/flow-components-parent/flow-generated-components/pom.xml
@@ -22,6 +22,8 @@
     <properties>
         <!-- Skip javadoc for generated components to avoid formatting errors on the build -->
         <maven.javadoc.skip>true</maven.javadoc.skip>
+        <!-- Skip Sonar for generated components for now -->
+        <sonar.exclusions>**/*.java</sonar.exclusions>
     </properties>
 
     <profiles>


### PR DESCRIPTION
The path needs to be relative to the submodule, so declaring it as a property in module pom.xml instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/1916)
<!-- Reviewable:end -->
