### PR TITLE
Don't fail on javadocs error on generated components

### DIFF
--- a/flow-components-parent/flow-generated-components/pom.xml
+++ b/flow-components-parent/flow-generated-components/pom.xml
@@ -20,11 +20,24 @@
     </dependencies>
 
     <properties>
-        <!-- Skip javadoc for generated components to avoid formatting errors on the build -->
+        <!-- Skip javadoc for generated components -->
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <!-- Skip Sonar for generated components for now -->
         <sonar.exclusions>**/*.java</sonar.exclusions>
     </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <!-- When javadocs are created, let's not fail since we cannot guarantee perfect syntax for now -->
+                    <failOnError>false</failOnError>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <profiles>
         <profile>


### PR DESCRIPTION
Since the snapshot build explicitly doesn't skip javadocs,
need to specify generated components module to not fail on errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/1917)
<!-- Reviewable:end -->
