### PR TITLE
Remove reference to non-existent directory

### DIFF
--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -175,7 +175,6 @@
                                         project where the profile is triggered -->
                                     <resourceBase>${project.basedir}/src/main/webapp</resourceBase>
                                     <resourceBase>${project.basedir}/${frontend.working.directory}</resourceBase>
-                                    <resourceBase>${project.basedir}/../../flow-server/src/main/resources/META-INF/resources</resourceBase>
                                     <resourceBase>${project.basedir}/../../flow-client/target/classes/META-INF/resources</resourceBase>
                                     <resourceBase>${project.basedir}/../../flow-push/src/main/resources/META-INF/resources</resourceBase>
                                     <resourceBase>${project.basedir}/../test-resources/src/main/resources/META-INF/resources</resourceBase>


### PR DESCRIPTION
There are no longer any resources in flow-server. Starting with the
eclipse profile enabled will fail because of a missing resourceBase if
running from a clean workspace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/1993)
<!-- Reviewable:end -->
