### PR TITLE
Only reset scroll position for router links

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/PopStateHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/PopStateHandler.java
@@ -59,22 +59,10 @@ public class PopStateHandler {
     public void bind() {
         // track the location after the latest response from server
         registry.getRequestResponseTracker().addResponseHandlingEndedHandler(
-                event -> updateCurrentPathAndScroll());
+                event -> pathAfterPreviousResponse = Browser.getWindow()                
+                .getLocation().getPathname());                
 
         Browser.getWindow().setOnpopstate(this::onPopStateEvent);
-    }
-
-    private void updateCurrentPathAndScroll() {
-        String oldPath = pathAfterPreviousResponse;
-        pathAfterPreviousResponse = Browser.getWindow().getLocation()
-                .getPathname();
-
-        // move to page top only if there is no fragment so scroll position
-        // doesn't bounce around
-        if (!pathAfterPreviousResponse.equals(oldPath)
-                && !pathAfterPreviousResponse.contains("#")) {
-            Browser.getWindow().scrollTo(0, 0);
-        }
     }
 
     private void onPopStateEvent(Event e) {

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/scroll/PushStateScrollView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/scroll/PushStateScrollView.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.scroll;
+
+import java.util.function.BiConsumer;
+
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.ElementFactory;
+import com.vaadin.flow.uitest.ui.AbstractDivView;
+import com.vaadin.ui.History;
+import com.vaadin.ui.UI;
+
+import elemental.json.JsonValue;
+
+public class PushStateScrollView extends AbstractDivView {
+    public PushStateScrollView() {
+        Element filler = ElementFactory.createDiv(
+                "Pushing or replacing history state should not affect the scroll position. Scroll down for buttons to click.");
+        filler.getStyle().set("height", "150vh");
+
+        History history = UI.getCurrent().getPage().getHistory();
+
+        getElement().appendChild(filler,
+                createButton("push", history::pushState),
+                createButton("replace", history::replaceState));
+    }
+
+    private static Element createButton(String name,
+            BiConsumer<JsonValue, String> action) {
+        String location = PushStateScrollView.class.getName() + "/" + name;
+
+        Element button = ElementFactory.createButton(name);
+
+        button.setAttribute("id", name);
+        button.addEventListener("click", e -> action.accept(null, location));
+
+        return button;
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/scroll/PushStateScrollIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/scroll/PushStateScrollIT.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.scroll;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class PushStateScrollIT extends ChromeBrowserTest {
+    @Test
+    public void pushNoScroll() {
+        testNoScrolling("push");
+    }
+
+    @Test
+    public void replaceNoScroll() {
+        testNoScrolling("replace");
+    }
+
+    private void testNoScrolling(String buttonId) {
+        open();
+
+        WebElement button = findElement(By.id(buttonId));
+
+        scrollIntoView(button);
+
+        int scrollBeforeClick = getScrollY();
+
+        // Sanity check
+        Assert.assertNotEquals("Should be scrolled down before clicking", 0,
+                scrollBeforeClick);
+
+        button.click();
+
+        Assert.assertEquals("Scroll position should not have changed",
+                scrollBeforeClick, getScrollY());
+    }
+
+    private void scrollIntoView(WebElement element) {
+        new Actions(getCommandExecutor().getWrappedDriver())
+                .moveToElement(element).perform();
+    }
+}


### PR DESCRIPTION
Partially reverts #1844 to avoid reseting scroll position regardless of
what caused the URL to change. Instead, the scroll reset is triggered
from the previous location, but deferred until after the next response
has been handled.

Fixes #1985

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/1996)
<!-- Reviewable:end -->
