### PR TITLE
Provide default implementations for ModelConverter methods

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/template/model/ModelConverter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/template/model/ModelConverter.java
@@ -16,7 +16,9 @@
 package com.vaadin.flow.template.model;
 
 import java.io.Serializable;
+import java.lang.reflect.Type;
 
+import com.googlecode.gentyref.GenericTypeReflector;
 import com.vaadin.annotations.Convert;
 
 /**
@@ -41,14 +43,36 @@ public interface ModelConverter<A, M extends Serializable>
      * 
      * @return the application type
      */
-    Class<A> getApplicationType();
+    @SuppressWarnings("unchecked")
+    default Class<A> getApplicationType() {
+        Type type = GenericTypeReflector.getTypeParameter(this.getClass(),
+                ModelConverter.class.getTypeParameters()[0]);
+        if (type instanceof Class<?>) {
+            return (Class<A>) GenericTypeReflector.erase(type);
+        }
+        throw new InvalidTemplateModelException(String.format(
+                "Could not detect the application type of ModelConverter '%s'. "
+                        + "The method getApplicationType needs to be overridden manually.",
+                this.getClass().getName()));
+    }
 
     /**
      * Get the model type of this converter.
      * 
      * @return the model type
      */
-    Class<M> getModelType();
+    @SuppressWarnings("unchecked")
+    default Class<M> getModelType() {
+        Type type = GenericTypeReflector.getTypeParameter(this.getClass(),
+                ModelConverter.class.getTypeParameters()[1]);
+        if (type instanceof Class<?>) {
+            return (Class<M>) GenericTypeReflector.erase(type);
+        }
+        throw new InvalidTemplateModelException(String.format(
+                "Could not detect the model type of ModelConverter '%s'. "
+                        + "The method getModelType needs to be overridden manually.",
+                this.getClass().getName()));
+    }
 
     /**
      * Converts the given value from application type to the model type.

--- a/flow-server/src/test/java/com/vaadin/flow/template/model/TemplateModelWithConvertersTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/template/model/TemplateModelWithConvertersTest.java
@@ -182,17 +182,10 @@ public class TemplateModelWithConvertersTest {
 
     public static class LongToStringConverter
             implements ModelConverter<Long, String> {
-        public LongToStringConverter() {
-        }
 
         @Override
         public Class<Long> getApplicationType() {
             return long.class;
-        }
-
-        @Override
-        public Class<String> getModelType() {
-            return String.class;
         }
 
         @Override
@@ -210,16 +203,6 @@ public class TemplateModelWithConvertersTest {
             implements ModelConverter<Date, String> {
 
         @Override
-        public Class<Date> getApplicationType() {
-            return Date.class;
-        }
-
-        @Override
-        public Class<String> getModelType() {
-            return String.class;
-        }
-
-        @Override
         public String toModel(Date applicationValue) {
             return Long.toString(applicationValue.getTime());
         }
@@ -232,16 +215,6 @@ public class TemplateModelWithConvertersTest {
 
     public static class StringToBeanWithStringConverter
             implements ModelConverter<String, BeanWithString> {
-
-        @Override
-        public Class<String> getApplicationType() {
-            return String.class;
-        }
-
-        @Override
-        public Class<BeanWithString> getModelType() {
-            return BeanWithString.class;
-        }
 
         @Override
         public BeanWithString toModel(String applicationValue) {
@@ -263,11 +236,6 @@ public class TemplateModelWithConvertersTest {
         }
 
         @Override
-        public Class<BeanWithLong> getModelType() {
-            return BeanWithLong.class;
-        }
-
-        @Override
         public BeanWithLong toModel(Long applicationValue) {
             return new BeanWithLong(applicationValue);
         }
@@ -280,16 +248,6 @@ public class TemplateModelWithConvertersTest {
 
     public static class DateToBeanWithStringConverter
             implements ModelConverter<Date, BeanWithString> {
-
-        @Override
-        public Class<Date> getApplicationType() {
-            return Date.class;
-        }
-
-        @Override
-        public Class<BeanWithString> getModelType() {
-            return BeanWithString.class;
-        }
 
         @Override
         public BeanWithString toModel(Date applicationValue) {
@@ -305,11 +263,6 @@ public class TemplateModelWithConvertersTest {
 
     public static class UnsupportedModelConverter
             implements ModelConverter<String, Long> {
-
-        @Override
-        public Class<String> getApplicationType() {
-            return String.class;
-        }
 
         @Override
         public Class<Long> getModelType() {
@@ -329,16 +282,6 @@ public class TemplateModelWithConvertersTest {
 
     public static class DateToDateBeanConverter
             implements ModelConverter<Date, DateBean> {
-
-        @Override
-        public Class<Date> getApplicationType() {
-            return Date.class;
-        }
-
-        @Override
-        public Class<DateBean> getModelType() {
-            return DateBean.class;
-        }
 
         @Override
         public DateBean toModel(Date applicationValue) {


### PR DESCRIPTION
This commit adds default implementations for
ModelConverter#getApplicationType and ModelConverter#getModelType

Closes #2033

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/2040)
<!-- Reviewable:end -->
