### PR TITLE
Use null as a property value if there is no data for event expression

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/event/ComponentEventBus.java
+++ b/flow-server/src/main/java/com/vaadin/flow/event/ComponentEventBus.java
@@ -31,6 +31,7 @@ import com.vaadin.shared.Registration;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.ComponentEvent;
 
+import elemental.json.Json;
 import elemental.json.JsonValue;
 
 /**
@@ -139,7 +140,7 @@ public class ComponentEventBus implements Serializable {
         }
 
         ComponentEventBusUtil.getDomEventType(eventType)
-                .ifPresent(e -> addDomTrigger(eventType, e));
+        .ifPresent(e -> addDomTrigger(eventType, e));
     }
 
     /**
@@ -156,7 +157,7 @@ public class ComponentEventBus implements Serializable {
             String domEventType) {
         assert eventType != null;
         assert !componentEventData.containsKey(eventType)
-                || componentEventData.get(eventType).domEventRemover == null;
+        || componentEventData.get(eventType).domEventRemover == null;
 
         if (domEventType == null || domEventType.isEmpty()) {
             throw new IllegalArgumentException(
@@ -175,11 +176,11 @@ public class ComponentEventBus implements Serializable {
         // https://github.com/vaadin/flow/issues/575
         Registration remover = element.addEventListener(domEventType,
                 new DomEventListener() {
-                    @Override
-                    public void handleEvent(DomEvent e) {
-                        handleDomEvent(eventType, e);
-                    }
-                }, eventData);
+            @Override
+            public void handleEvent(DomEvent e) {
+                handleDomEvent(eventType, e);
+            }
+        }, eventData);
         componentEventData.computeIfAbsent(eventType,
                 t -> new ComponentEventData()).domEventRemover = remover;
     }
@@ -204,9 +205,7 @@ public class ComponentEventBus implements Serializable {
         expressions.forEach((expression, type) -> {
             JsonValue jsonValue = domEvent.getEventData().get(expression);
             if (jsonValue == null) {
-                throw new IllegalArgumentException(
-                        "The DOM event does not contain the expected event data: "
-                                + expression);
+                jsonValue = Json.createNull();
             }
             Object value = JsonCodec.decodeAs(jsonValue, type);
             eventDataObjects.add(value);
@@ -245,7 +244,7 @@ public class ComponentEventBus implements Serializable {
         if (listeners.isEmpty()) {
             // No more listeners for this event type
             ComponentEventBusUtil.getDomEventType(eventType)
-                    .ifPresent(e -> unregisterDomEvent(eventType, e));
+            .ifPresent(e -> unregisterDomEvent(eventType, e));
             componentEventData.remove(eventType);
         }
     }
@@ -333,7 +332,7 @@ public class ComponentEventBus implements Serializable {
             throw new IllegalArgumentException(
                     "Unable to create an event object of type "
                             + eventType.getName(),
-                    e);
+                            e);
         }
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/event/ComponentEventBusTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/event/ComponentEventBusTest.java
@@ -36,7 +36,7 @@ import elemental.json.JsonObject;
 public class ComponentEventBusTest {
 
     private static class EventTracker<T extends ComponentEvent<?>>
-            implements ComponentEventListener<T> {
+    implements ComponentEventListener<T> {
         private AtomicInteger eventHandlerCalled = new AtomicInteger(0);
         private AtomicReference<T> eventObject = new AtomicReference<>(null);
 
@@ -92,8 +92,8 @@ public class ComponentEventBusTest {
             JsonObject eventData) {
         Element e = component.getElement();
         e.getNode().getFeature(ElementListenerMap.class)
-                .fireEvent(new com.vaadin.flow.dom.DomEvent(e, domEvent,
-                        eventData));
+        .fireEvent(new com.vaadin.flow.dom.DomEvent(e, domEvent,
+                eventData));
 
     }
 
@@ -112,7 +112,7 @@ public class ComponentEventBusTest {
 
         eventTracker.reset();
         component.getEventBus()
-                .fireEvent(new MappedToDomEvent(component, true));
+        .fireEvent(new MappedToDomEvent(component, true));
 
         eventTracker.assertEventCalled(component, true);
         Assert.assertEquals(12, eventTracker.getEvent().getSomeData());
@@ -133,7 +133,7 @@ public class ComponentEventBusTest {
         });
 
         component
-                .fireEvent(new ServerEvent(component, new BigDecimal("12.22")));
+        .fireEvent(new ServerEvent(component, new BigDecimal("12.22")));
 
         Assert.assertEquals(1, eventHandlerCalled.get());
         Assert.assertEquals(new BigDecimal("12.22"), dataValueInEvent.get());
@@ -161,12 +161,15 @@ public class ComponentEventBusTest {
         fireDomEvent(c, "dom-event", Json.createObject());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void mappedDomEvent_fire_missingData() {
         TestComponent c = new TestComponent();
         EventTracker<MappedToDomEvent> eventListener = new EventTracker<>();
         c.addListener(MappedToDomEvent.class, eventListener);
         fireDomEvent(c, "dom-event", createData("event.someData", 2));
+        eventListener.assertEventCalled(c, true);
+        Assert.assertEquals(2, eventListener.getEvent().getSomeData());
+        Assert.assertNull(eventListener.getEvent().getMoreData());
     }
 
     private JsonObject createData(String key, Object value) {


### PR DESCRIPTION
Don't throw IAE when there is no data for the expression during handling
client side DOM event on the server. Just use null value for it. Some
Web Components don't send any property value in their events. So the
situation is not exceptional but rather regular.

Fixes #2077

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/2156)
<!-- Reviewable:end -->
