### PR TITLE
Revert testbench version to 5.0.0

### DIFF
--- a/flow-test-util/pom.xml
+++ b/flow-test-util/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-testbench</artifactId>
-            <version>5.1.0.alpha1</version>
+            <version>5.0.0</version>
         </dependency>
         <!-- override scope for junit -->
         <dependency>


### PR DESCRIPTION
NoSuchMethod-problems in flow-demo and other projects using flow-test-util originate from a new version of Selenium that comes as a transitive dependency from vaadin-testbench 5.1.0.alpha1. Using the stable version 5.0.0 fixes the problems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/2208)
<!-- Reviewable:end -->
