### PR TITLE
Remove Vaadin from menu names

### DIFF
--- a/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/ButtonView.java
+++ b/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/ButtonView.java
@@ -24,7 +24,7 @@ import com.vaadin.ui.HasClickListeners.ClickEvent;
 /**
  * View for {@link Button} demo.
  */
-@ComponentDemo(name = "Vaadin Button", href = "vaadin-button")
+@ComponentDemo(name = "Button", href = "vaadin-button")
 public class ButtonView extends DemoView {
 
     private Div message;

--- a/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/CheckboxView.java
+++ b/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/CheckboxView.java
@@ -23,7 +23,7 @@ import com.vaadin.ui.Checkbox;
 /**
  * View for {@link Checkbox} demo.
  */
-@ComponentDemo(name = "Vaadin Checkbox", href = "vaadin-checkbox")
+@ComponentDemo(name = "Checkbox", href = "vaadin-checkbox")
 public class CheckboxView extends DemoView {
 
     @Override

--- a/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/ComboBoxView.java
+++ b/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/ComboBoxView.java
@@ -27,8 +27,7 @@ import com.vaadin.ui.ComboBox;
 /**
  * View for {@link ComboBox} demo.
  */
-@ComponentDemo(name = "Vaadin ComboBox", href = "vaadin-combo-box")
-
+@ComponentDemo(name = "ComboBox", href = "vaadin-combo-box")
 public class ComboBoxView extends DemoView {
     /**
      * Example object.

--- a/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/DatePickerView.java
+++ b/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/DatePickerView.java
@@ -26,7 +26,7 @@ import com.vaadin.ui.DatePicker.DatePickerI18n;
 /**
  * View for {@link DatePicker} demo.
  */
-@ComponentDemo(name = "Vaadin Date Picker", href = "vaadin-date-picker")
+@ComponentDemo(name = "Date Picker", href = "vaadin-date-picker")
 public class DatePickerView extends DemoView {
 
     @Override

--- a/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/FormLayoutView.java
+++ b/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/FormLayoutView.java
@@ -27,7 +27,7 @@ import com.vaadin.ui.TextField;
  * 
  * @author Vaadin Ltd
  */
-@ComponentDemo(name = "Vaadin Form Layout", href = "vaadin-form-layout", subcategory = "Layouts")
+@ComponentDemo(name = "Form Layout", href = "vaadin-form-layout", subcategory = "Layouts")
 public class FormLayoutView extends DemoView {
 
     @Override

--- a/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/PasswordFieldView.java
+++ b/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/PasswordFieldView.java
@@ -24,7 +24,7 @@ import com.vaadin.ui.PasswordField;
 /**
  * View for {@link GeneratedVaadinPasswordField} demo.
  */
-@ComponentDemo(name = "Vaadin Password Field", href = "vaadin-password-field")
+@ComponentDemo(name = "Password Field", href = "vaadin-password-field")
 public class PasswordFieldView extends DemoView {
     @Override
     void initView() {

--- a/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/SplitLayoutView.java
+++ b/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/SplitLayoutView.java
@@ -25,7 +25,7 @@ import com.vaadin.ui.SplitLayout;
 /**
  * View for {@link SplitLayout} demo.
  */
-@ComponentDemo(name = "Vaadin Split Layout", href = "vaadin-split-layout", subcategory = "Layouts")
+@ComponentDemo(name = "Split Layout", href = "vaadin-split-layout", subcategory = "Layouts")
 public class SplitLayoutView extends DemoView {
 
     private static final String FIRST_CONTENT_TEXT = "First content component";

--- a/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/TextFieldView.java
+++ b/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/TextFieldView.java
@@ -23,7 +23,7 @@ import com.vaadin.ui.TextField;
 /**
  * View for {@link GeneratedVaadinTextField} demo.
  */
-@ComponentDemo(name = "Vaadin Text Field", href = "vaadin-text-field")
+@ComponentDemo(name = "Text Field", href = "vaadin-text-field")
 public class TextFieldView extends DemoView {
     @Override
     void initView() {


### PR DESCRIPTION
Name components in the menu only
'Component' instead of 'Vaadin Component'

Fixes #2257

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/2325)
<!-- Reviewable:end -->
