### PR TITLE
Remove checked exception from mock service init

### DIFF
--- a/flow-server/src/test/java/com/vaadin/router/RouterTest.java
+++ b/flow-server/src/test/java/com/vaadin/router/RouterTest.java
@@ -34,7 +34,6 @@ import com.vaadin.router.event.BeforeNavigationListener;
 import com.vaadin.server.InvalidRouteConfigurationException;
 import com.vaadin.server.MockVaadinServletService;
 import com.vaadin.server.MockVaadinSession;
-import com.vaadin.server.ServiceException;
 import com.vaadin.server.VaadinSession;
 import com.vaadin.server.startup.RouteRegistry;
 import com.vaadin.tests.util.MockUI;
@@ -169,11 +168,7 @@ public class RouterTest extends RoutingTestBase {
 
         private static VaadinSession createMockSession() {
             MockVaadinServletService service = new MockVaadinServletService();
-            try {
-                service.init();
-            } catch (ServiceException e) {
-                throw new RuntimeException(e);
-            }
+            service.init();
             return new MockVaadinSession(service);
         }
 

--- a/flow-server/src/test/java/com/vaadin/server/BootstrapHandlerDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/server/BootstrapHandlerDependenciesTest.java
@@ -223,7 +223,7 @@ public class BootstrapHandlerDependenciesTest {
     }
 
     private VaadinSession session;
-    private VaadinServletService service;
+    private MockVaadinServletService service;
 
     @Before
     public void setup() {
@@ -567,12 +567,7 @@ public class BootstrapHandlerDependenciesTest {
         ui.getInternals().setSession(session);
         VaadinRequest request = new VaadinServletRequest(createRequest(),
                 service);
-        try {
-            service.init();
-        } catch (ServiceException e) {
-            throw new RuntimeException("Error initializing the VaadinService",
-                    e);
-        }
+        service.init();
         ui.doInit(request, 0);
         return BootstrapHandler.getBootstrapPage(
                 new BootstrapContext(request, null, session, ui));

--- a/flow-server/src/test/java/com/vaadin/server/BootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/server/BootstrapHandlerTest.java
@@ -66,7 +66,7 @@ public class BootstrapHandlerTest {
     private BootstrapContext context;
     private VaadinRequest request;
     private VaadinSession session;
-    private VaadinServletService service;
+    private MockVaadinServletService service;
     private MockDeploymentConfiguration deploymentConfiguration;
     private WebBrowser browser;
 
@@ -97,12 +97,7 @@ public class BootstrapHandlerTest {
 
     private void initUI(UI ui, VaadinRequest request) {
         this.request = request;
-        try {
-            service.init();
-        } catch (ServiceException e) {
-            throw new RuntimeException("Error initializing the VaadinService",
-                    e);
-        }
+        service.init();
         ui.doInit(request, 0);
         context = new BootstrapContext(request, null, session, ui);
     }
@@ -171,8 +166,9 @@ public class BootstrapHandlerTest {
         listeners.add(evt -> evt.getDocument().head().appendElement("script")
                 .attr("src", "testing.2"));
 
-        Mockito.when(service.createInstantiator()).thenReturn(new MockInstantiator(
-                event -> listeners.forEach(event::addBootstrapListener)));
+        Mockito.when(service.createInstantiator())
+                .thenReturn(new MockInstantiator(event -> listeners
+                        .forEach(event::addBootstrapListener)));
 
         initUI(testUI);
 
@@ -219,8 +215,9 @@ public class BootstrapHandlerTest {
             return list;
         });
 
-        Mockito.when(service.createInstantiator()).thenReturn(new MockInstantiator(
-                event -> filters.forEach(event::addDependencyFilter)));
+        Mockito.when(service.createInstantiator())
+                .thenReturn(new MockInstantiator(
+                        event -> filters.forEach(event::addDependencyFilter)));
 
         initUI(testUI);
 

--- a/flow-server/src/test/java/com/vaadin/server/MockVaadinServletService.java
+++ b/flow-server/src/test/java/com/vaadin/server/MockVaadinServletService.java
@@ -50,7 +50,7 @@ public class MockVaadinServletService extends VaadinServletService {
         return Collections.emptyList();
     }
 
-    public void init(Instantiator instantiator) throws ServiceException {
+    public void init(Instantiator instantiator) {
         this.instantiator = instantiator;
 
         init();
@@ -62,6 +62,15 @@ public class MockVaadinServletService extends VaadinServletService {
             return instantiator;
         }
         return super.createInstantiator();
+    }
+
+    @Override
+    public void init() {
+        try {
+            super.init();
+        } catch (ServiceException e) {
+            throw new RuntimeException(e);
+        }
     }
 
 }


### PR DESCRIPTION
Make `MockVaadinServletService.java` slightly more convenient to use by not throwing a checked exception from the init methods.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/2484)
<!-- Reviewable:end -->
