### PR TITLE
RouterLink exception now more descriptive.

### DIFF
--- a/flow-server/src/main/java/com/vaadin/router/RouterLink.java
+++ b/flow-server/src/main/java/com/vaadin/router/RouterLink.java
@@ -124,8 +124,15 @@ public class RouterLink extends Component
         this();
         setText(text);
         if (View.class.isAssignableFrom(navigationTarget)) {
-            setRoute((com.vaadin.flow.router.Router) getRouter(),
-                    (Class<? extends View>) navigationTarget);
+            try {
+                setRoute((com.vaadin.flow.router.Router) getRouter(),
+                        (Class<? extends View>) navigationTarget);
+            } catch (ClassCastException cce) {
+                String message = String.format(
+                        "Only navigation targets for old Router should implement 'View'. Remove 'implements View' from '%s'",
+                        navigationTarget.getName());
+                throw new IllegalArgumentException(message, cce);
+            }
         } else {
             setRoute((com.vaadin.router.Router) getRouter(), navigationTarget);
         }


### PR DESCRIPTION
Having new router navigation target
implement `View` will fail on the `RouterLink(name,target)`
constructor. Now it will give a better exception on what failed
instead of ClassCastException.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/2495)
<!-- Reviewable:end -->
