### PR TITLE
Look for parameter annotations on the more specific method

### DIFF
--- a/flow-server/src/main/java/com/vaadin/router/HasUrlParameter.java
+++ b/flow-server/src/main/java/com/vaadin/router/HasUrlParameter.java
@@ -132,10 +132,18 @@ public interface HasUrlParameter<T> {
             return false;
         }
         try {
-            Method setParameter = navigationTarget.getMethod(
-                    ReflectTools.getFunctionalMethod(HasUrlParameter.class)
-                            .getName(),
-                    BeforeNavigationEvent.class, Object.class);
+            String methodName = "setParameter";
+            assert methodName.equals(ReflectTools
+                    .getFunctionalMethod(HasUrlParameter.class).getName());
+
+            // Raw method has no parameter annotations if compiled by Eclipse
+            Type parameterType = GenericTypeReflector.getTypeParameter(
+                    navigationTarget,
+                    HasUrlParameter.class.getTypeParameters()[0]);
+            Class<?> parameterClass = GenericTypeReflector.erase(parameterType);
+
+            Method setParameter = navigationTarget.getMethod(methodName,
+                    BeforeNavigationEvent.class, parameterClass);
             return setParameter.getParameters()[1]
                     .isAnnotationPresent(parameterAnnotation);
         } catch (NoSuchMethodException e) {


### PR DESCRIPTION
Eclipse only puts parameter annotations on the more specific method, but
not on the method declared for the raw type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/2561)
<!-- Reviewable:end -->
