### PR TITLE
Enable using parameterised class as root.

### DIFF
--- a/flow-server/src/main/java/com/vaadin/router/DefaultRouteResolver.java
+++ b/flow-server/src/main/java/com/vaadin/router/DefaultRouteResolver.java
@@ -100,6 +100,9 @@ public class DefaultRouteResolver implements RouteResolver {
 
         Deque<PathDetails> paths = new ArrayDeque<>();
         StringBuilder pathBuilder = new StringBuilder(pathSegments.get(0));
+        if (!pathSegments.get(0).equals("")) {
+            paths.push(new PathDetails("", pathSegments));
+        }
         paths.push(new PathDetails(pathBuilder.toString(),
                 pathSegments.subList(1, pathSegments.size())));
         for (int i = 1; i < pathSegments.size(); i++) {

--- a/flow-server/src/main/java/com/vaadin/router/DefaultRouteResolver.java
+++ b/flow-server/src/main/java/com/vaadin/router/DefaultRouteResolver.java
@@ -100,7 +100,7 @@ public class DefaultRouteResolver implements RouteResolver {
 
         Deque<PathDetails> paths = new ArrayDeque<>();
         StringBuilder pathBuilder = new StringBuilder(pathSegments.get(0));
-        if (!pathSegments.get(0).equals("")) {
+        if (!"".equals(pathSegments.get(0))) {
             paths.push(new PathDetails("", pathSegments));
         }
         paths.push(new PathDetails(pathBuilder.toString(),


### PR DESCRIPTION
If a parameterised class parameter is `@OptionalParameter`
or `@WildcardParameter` then it should work as the
root navigatio target for route "".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/2584)
<!-- Reviewable:end -->
