### PR TITLE
Extract component creation to instantiator

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/di/DefaultInstantiator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/di/DefaultInstantiator.java
@@ -22,6 +22,7 @@ import java.util.stream.StreamSupport;
 import com.vaadin.router.event.NavigationEvent;
 import com.vaadin.server.VaadinService;
 import com.vaadin.server.VaadinServiceInitListener;
+import com.vaadin.ui.Component;
 import com.vaadin.ui.common.HasElement;
 import com.vaadin.util.ReflectTools;
 
@@ -73,5 +74,10 @@ public class DefaultInstantiator implements Instantiator {
     public <T extends HasElement> T createRouteTarget(Class<T> routeTargetType,
             NavigationEvent event) {
         return ReflectTools.createInstance(routeTargetType);
+    }
+
+    @Override
+    public <T extends Component> T createComponent(Class<T> componentClass) {
+        return ReflectTools.createInstance(componentClass);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/di/Instantiator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/di/Instantiator.java
@@ -27,6 +27,7 @@ import com.vaadin.server.VaadinService;
 import com.vaadin.server.VaadinServiceInitListener;
 import com.vaadin.server.VaadinSession;
 import com.vaadin.server.communication.UidlWriter;
+import com.vaadin.ui.Component;
 import com.vaadin.ui.UI;
 import com.vaadin.ui.common.HasElement;
 
@@ -133,6 +134,15 @@ public interface Instantiator extends Serializable {
      */
     <T extends HasElement> T createRouteTarget(Class<T> routeTargetType,
             NavigationEvent event);
+
+    /**
+     * Creates an instance of a component by its {@code componentClass}.
+     *
+     * @param componentClass
+     *            the instance type to create, not <code>null</code>
+     * @return the created instance, not <code>null</code>
+     */
+    <T extends Component> T createComponent(Class<T> componentClass);
 
     /**
      * Gets the instantiator to use for the given UI.

--- a/flow-server/src/main/java/com/vaadin/ui/ComponentUtil.java
+++ b/flow-server/src/main/java/com/vaadin/ui/ComponentUtil.java
@@ -20,9 +20,11 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementUtil;
 import com.vaadin.flow.util.ReflectionCache;
+import com.vaadin.ui.Component.MapToExistingElement;
 import com.vaadin.ui.ComponentMetaData.DependencyInfo;
 import com.vaadin.ui.ComponentMetaData.SynchronizedPropertyInfo;
 import com.vaadin.ui.common.AttachEvent;
@@ -31,8 +33,6 @@ import com.vaadin.ui.common.HtmlImport;
 import com.vaadin.ui.common.JavaScript;
 import com.vaadin.ui.common.StyleSheet;
 import com.vaadin.ui.common.Uses;
-import com.vaadin.ui.Component.MapToExistingElement;
-import com.vaadin.util.ReflectTools;
 
 /**
  * Utility methods for {@link Component}.
@@ -271,7 +271,13 @@ public class ComponentUtil {
 
         try {
             Component.elementToMapTo.set(wrapData);
-            return ReflectTools.createInstance(componentType);
+            UI ui = UI.getCurrent();
+            if (ui == null) {
+                throw new IllegalStateException("UI instance is not available. "
+                        + "It looks like you are trying to execute UI code out of UI/Servlet dispatching thread");
+            }
+            Instantiator instantiator = Instantiator.get(ui);
+            return instantiator.createComponent(componentType);
         } finally {
             // This should always be cleared, normally it's cleared in Component
             // but in case of exception it might be not cleared

--- a/flow-server/src/main/java/com/vaadin/ui/ComponentUtil.java
+++ b/flow-server/src/main/java/com/vaadin/ui/ComponentUtil.java
@@ -274,7 +274,7 @@ public class ComponentUtil {
             UI ui = UI.getCurrent();
             if (ui == null) {
                 throw new IllegalStateException("UI instance is not available. "
-                        + "It looks like you are trying to execute UI code out of UI/Servlet dispatching thread");
+                        + "It looks like you are trying to execute UI code outside the UI/Servlet dispatching thread");
             }
             Instantiator instantiator = Instantiator.get(ui);
             return instantiator.createComponent(componentType);

--- a/flow-server/src/test/java/com/vaadin/flow/router/event/EventUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/event/EventUtilTest.java
@@ -15,19 +15,28 @@
  */
 package com.vaadin.flow.router.event;
 
+import static org.mockito.Mockito.when;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
+import com.vaadin.flow.di.DefaultInstantiator;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.router.event.BeforeNavigationEvent;
 import com.vaadin.router.event.BeforeNavigationListener;
 import com.vaadin.router.event.EventUtil;
+import com.vaadin.server.VaadinService;
+import com.vaadin.server.VaadinSession;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.Tag;
+import com.vaadin.ui.UI;
 
 /**
  * Test event util functionality.
@@ -51,6 +60,27 @@ public class EventUtilTest {
         @Override
         public void beforeNavigation(BeforeNavigationEvent event) {
         }
+    }
+
+    @Before
+    public void setUp() {
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        UI ui = new UI() {
+            @Override
+            public VaadinSession getSession() {
+                return session;
+            }
+        };
+        VaadinService service = Mockito.mock(VaadinService.class);
+        when(session.getService()).thenReturn(service);
+        when(service.getInstantiator())
+                .thenReturn(new DefaultInstantiator(service));
+        UI.setCurrent(ui);
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/server/MockInstantiator.java
+++ b/flow-server/src/test/java/com/vaadin/server/MockInstantiator.java
@@ -19,6 +19,7 @@ import java.util.stream.Stream;
 
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.router.event.NavigationEvent;
+import com.vaadin.ui.Component;
 import com.vaadin.ui.common.HasElement;
 
 public class MockInstantiator implements Instantiator {
@@ -43,5 +44,10 @@ public class MockInstantiator implements Instantiator {
     public <T extends HasElement> T createRouteTarget(Class<T> routeTargetType,
             NavigationEvent event) {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T extends Component> T createComponent(Class<T> componentClass) {
+        return null;
     }
 }

--- a/flow-server/src/test/java/com/vaadin/server/startup/CustomElementRegistryInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/server/startup/CustomElementRegistryInitializerTest.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.server.startup;
 
+import static org.mockito.Mockito.when;
+
 import java.lang.reflect.Field;
 import java.util.LinkedHashSet;
 import java.util.concurrent.atomic.AtomicReference;
@@ -24,17 +26,21 @@ import java.util.stream.Stream;
 import javax.servlet.ServletException;
 
 import org.jsoup.Jsoup;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import com.vaadin.flow.di.DefaultInstantiator;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.model.TemplateModel;
 import com.vaadin.function.DeploymentConfiguration;
 import com.vaadin.server.InvalidCustomElementNameException;
 import com.vaadin.server.VaadinService;
+import com.vaadin.server.VaadinSession;
 import com.vaadin.ui.Tag;
+import com.vaadin.ui.UI;
 import com.vaadin.ui.polymertemplate.PolymerTemplate;
 import com.vaadin.ui.polymertemplate.TemplateParser;
 import com.vaadin.util.HasCurrentService;
@@ -70,6 +76,24 @@ public class CustomElementRegistryInitializerTest extends HasCurrentService {
                 new AtomicReference<>());
 
         customElementRegistryInitializer = new CustomElementRegistryInitializer();
+
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        UI ui = new UI() {
+            @Override
+            public VaadinSession getSession() {
+                return session;
+            }
+        };
+        VaadinService service = Mockito.mock(VaadinService.class);
+        when(session.getService()).thenReturn(service);
+        when(service.getInstantiator())
+                .thenReturn(new DefaultInstantiator(service));
+        UI.setCurrent(ui);
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/ui/ComponentTest.java
+++ b/flow-server/src/test/java/com/vaadin/ui/ComponentTest.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.ui;
 
+import static org.mockito.Mockito.when;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -31,10 +33,13 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
+import com.vaadin.flow.di.DefaultInstantiator;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementFactory;
 import com.vaadin.flow.dom.ElementUtil;
+import com.vaadin.server.VaadinService;
 import com.vaadin.server.VaadinSession;
 import com.vaadin.shared.Registration;
 import com.vaadin.shared.ui.Dependency;
@@ -245,6 +250,24 @@ public class ComponentTest {
         parentDivComponent.getElement().appendChild(
                 child1SpanComponent.getElement(),
                 child2InputComponent.getElement());
+
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        UI ui = new UI() {
+            @Override
+            public VaadinSession getSession() {
+                return session;
+            }
+        };
+        VaadinService service = Mockito.mock(VaadinService.class);
+        when(session.getService()).thenReturn(service);
+        when(service.getInstantiator())
+                .thenReturn(new DefaultInstantiator(service));
+        UI.setCurrent(ui);
+    }
+
+    @After
+    public void tearDown() {
+        UI.setCurrent(null);
     }
 
     @Test

--- a/flow-spring-addon/src/main/java/com/vaadin/spring/SpringInstantiator.java
+++ b/flow-spring-addon/src/main/java/com/vaadin/spring/SpringInstantiator.java
@@ -23,6 +23,7 @@ import com.vaadin.flow.di.DefaultInstantiator;
 import com.vaadin.router.event.NavigationEvent;
 import com.vaadin.server.VaadinService;
 import com.vaadin.server.VaadinServiceInitListener;
+import com.vaadin.ui.Component;
 import com.vaadin.ui.common.HasElement;
 
 /**
@@ -61,12 +62,19 @@ public class SpringInstantiator extends DefaultInstantiator {
     @Override
     public <T extends HasElement> T createRouteTarget(Class<T> routeTargetType,
             NavigationEvent event) {
-        if (context.getBeanNamesForType(routeTargetType).length == 0) {
-            return context.getAutowireCapableBeanFactory()
-                    .createBean(routeTargetType);
-        } else {
-            return context.getBean(routeTargetType);
+        return getObject(routeTargetType);
+    }
+
+    @Override
+    public <T extends Component> T createComponent(Class<T> componentClass) {
+        return getObject(componentClass);
+    }
+
+    private <T> T getObject(Class<T> type) {
+        if (context.getBeanNamesForType(type).length == 1) {
+            return context.getBean(type);
         }
+        return context.getAutowireCapableBeanFactory().createBean(type);
     }
 
 }

--- a/flow-spring-addon/src/test/java/com/vaadin/spring/service/JavaSPIInstantiator.java
+++ b/flow-spring-addon/src/test/java/com/vaadin/spring/service/JavaSPIInstantiator.java
@@ -21,6 +21,7 @@ import com.vaadin.flow.di.Instantiator;
 import com.vaadin.router.event.NavigationEvent;
 import com.vaadin.server.VaadinService;
 import com.vaadin.server.VaadinServiceInitListener;
+import com.vaadin.ui.Component;
 import com.vaadin.ui.common.HasElement;
 
 public class JavaSPIInstantiator implements Instantiator {
@@ -42,6 +43,11 @@ public class JavaSPIInstantiator implements Instantiator {
     @Override
     public <T extends HasElement> T createRouteTarget(Class<T> routeTargetType,
             NavigationEvent event) {
+        return null;
+    }
+
+    @Override
+    public <T extends Component> T createComponent(Class<T> componentClass) {
         return null;
     }
 

--- a/flow-spring-addon/src/test/java/com/vaadin/spring/service/SpringVaadinServletServiceTest.java
+++ b/flow-spring-addon/src/test/java/com/vaadin/spring/service/SpringVaadinServletServiceTest.java
@@ -76,6 +76,12 @@ public class SpringVaadinServletServiceTest {
             return null;
         }
 
+        @Override
+        public <T extends com.vaadin.ui.Component> T createComponent(
+                Class<T> componentClass) {
+            return null;
+        }
+
     }
 
     @Component

--- a/flow-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/ChildTemplate.java
+++ b/flow-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/ChildTemplate.java
@@ -15,8 +15,13 @@
  */
 package com.vaadin.flow.spring;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
 import com.vaadin.flow.model.TemplateModel;
+import com.vaadin.spring.annotation.VaadinSessionScope;
 import com.vaadin.ui.Tag;
+import com.vaadin.ui.common.AttachEvent;
 import com.vaadin.ui.common.HtmlImport;
 import com.vaadin.ui.polymertemplate.PolymerTemplate;
 
@@ -24,4 +29,25 @@ import com.vaadin.ui.polymertemplate.PolymerTemplate;
 @HtmlImport("/components/ChildTemplate.html")
 public class ChildTemplate extends PolymerTemplate<TemplateModel> {
 
+    @Component
+    @VaadinSessionScope
+    public static class BackendImpl implements Backend {
+
+        @Override
+        public String getMessage() {
+            return "foo";
+        }
+    }
+
+    public interface Backend {
+        String getMessage();
+    }
+
+    @Autowired
+    private Backend backend;
+
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        getElement().setProperty("message", backend.getMessage());
+    }
 }

--- a/flow-tests/test-spring-common/src/main/resources/META-INF/resources/components/ChildTemplate.html
+++ b/flow-tests/test-spring-common/src/main/resources/META-INF/resources/components/ChildTemplate.html
@@ -20,6 +20,7 @@
     <template>
         <div>Child Template</div>
         <label id="info">[[foo]]</label>
+        <label id="message">[[message]]</label>
     </template>
     <script>
         class ChildTemplate extends Polymer.Element {

--- a/flow-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/ParentTemplateIT.java
+++ b/flow-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/ParentTemplateIT.java
@@ -44,4 +44,16 @@ public class ParentTemplateIT extends ChromeBrowserTest {
         Assert.assertEquals("bar",
                 getInShadowRoot(child, By.id("info")).getText());
     }
+
+    @Test
+    public void injectedComponentIsSpringManaged() throws Exception {
+        open();
+
+        WebElement template = findElement(By.tagName("parent-template"));
+
+        WebElement child = getInShadowRoot(template, By.id("child"));
+
+        Assert.assertEquals("foo",
+                getInShadowRoot(child, By.id("message")).getText());
+    }
 }


### PR DESCRIPTION
Component creation via instantiator allows to use Spring mechanisms to create an instance.

Fix for #2671

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/2695)
<!-- Reviewable:end -->
