### PR TITLE
Remove the test for the actual query limit sent by the webcomponent

### DIFF
--- a/flow-components-parent/flow-components-test/src/test/java/com/vaadin/flow/tests/components/grid/GridPageSizeViewIT.java
+++ b/flow-components-parent/flow-components-test/src/test/java/com/vaadin/flow/tests/components/grid/GridPageSizeViewIT.java
@@ -30,14 +30,10 @@ public class GridPageSizeViewIT extends AbstractComponentIT {
 
         waitForElementPresent(By.tagName("vaadin-grid"));
         WebElement grid = findElement(By.tagName("vaadin-grid"));
-        WebElement info = findElement(By.id("query-info"));
 
         Object pageSize = executeScript("return arguments[0].pageSize", grid);
         Assert.assertEquals("The pageSize of the webcomponent should be 10", 10,
                 Integer.parseInt(String.valueOf(pageSize)));
-
-        // the webcomponent use 3 * the page size as the query limit
-        waitUntil(driver -> info.getText().endsWith("Query limit: 30"));
     }
 
 }


### PR DESCRIPTION
Remove the verification for the actual query limit sent by the webcomponent, since it depends on the element height and scroll position, which is unstable across CI environments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/2703)
<!-- Reviewable:end -->
