### PR TITLE
Add constructor to Icon with collection/name arguments

### DIFF
--- a/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/icon/Icon.java
+++ b/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/icon/Icon.java
@@ -45,15 +45,27 @@ public class Icon extends Component implements HasStyle {
     /**
      * Creates an Icon component that displays the given icon from
      * {@link VaadinIcons}.
-     * 
+     *
      * @param icon
      *            the icon to display
      */
     public Icon(VaadinIcons icon) {
+        this(ICON_COLLECTION_NAME, icon.name().toLowerCase().replace('_', '-'));
+    }
+
+    /**
+     * Creates an Icon component that displays the given {@code icon} from the
+     * given {@code collection}.
+     *
+     * @param collection
+     *            the icon collection
+     * @param icon
+     *            the icon name
+     */
+    public Icon(String collection, String icon) {
         // iron-icon's icon-attribute uses the format "collection:name",
         // eg. icon="vaadin:arrow-down"
-        getElement().setAttribute(ICON_ATTRIBUTE_NAME, ICON_COLLECTION_NAME
-                + ":" + icon.name().toLowerCase().replace('_', '-'));
+        getElement().setAttribute(ICON_ATTRIBUTE_NAME, collection + ':' + icon);
     }
 
     /**
@@ -102,4 +114,5 @@ public class Icon extends Component implements HasStyle {
     public String getColor() {
         return getStyle().get(ElementConstants.STYLE_COLOR);
     }
+
 }

--- a/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/icon/Icon.java
+++ b/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/icon/Icon.java
@@ -114,5 +114,4 @@ public class Icon extends Component implements HasStyle {
     public String getColor() {
         return getStyle().get(ElementConstants.STYLE_COLOR);
     }
-
 }

--- a/flow-documentation/flow-components/tutorial-flow-icon.asciidoc
+++ b/flow-documentation/flow-components/tutorial-flow-icon.asciidoc
@@ -20,7 +20,7 @@ icons from https://github.com/vaadin/vaadin-icons[vaadin-icons], e.g.
 [source, java]
 ----
 Icon icon = VaadinIcons.VAADIN_H.create();
-Button button = new Button("Vaadin", icon);
+new Button("Vaadin", icon);
 ----
 
 You can also create an `Icon` from other collections, e.g.
@@ -28,4 +28,5 @@ You can also create an `Icon` from other collections, e.g.
 [source, java]
 ----
 Icon icon = new Icon("valo", "clock");
+new Button("Clock", icon);
 ----

--- a/flow-documentation/flow-components/tutorial-flow-icon.asciidoc
+++ b/flow-documentation/flow-components/tutorial-flow-icon.asciidoc
@@ -1,0 +1,31 @@
+---
+title: Icon
+order: 3
+layout: page
+---
+
+= Icon
+
+== Overview
+
+`Icon` is for displaying an icon from https://github.com/vaadin/vaadin-icons[vaadin-icons]
+or another icon collection (see
+    https://www.webcomponents.org/element/PolymerElements/iron-iconset-svg[iron-iconset-svg]).
+
+== Using Icon
+
+`Icon` is normally used with the default `VaadinIcons` enumeration which maps all the
+icons from https://github.com/vaadin/vaadin-icons[vaadin-icons], e.g.
+
+[source, java]
+----
+Icon icon = VaadinIcons.VAADIN_H.create();
+Button button = new Button("Vaadin", icon);
+----
+
+You can also create an `Icon` from other collections, e.g.
+
+[source, java]
+----
+Icon icon = new Icon("valo", "clock");
+----

--- a/flow-documentation/src/main/java/com/vaadin/flow/tutorial/component/IconBasic.java
+++ b/flow-documentation/src/main/java/com/vaadin/flow/tutorial/component/IconBasic.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.tutorial.component;
+
+import com.vaadin.flow.tutorial.annotations.CodeFor;
+import com.vaadin.ui.button.Button;
+import com.vaadin.ui.icon.Icon;
+import com.vaadin.ui.icon.VaadinIcons;
+
+@CodeFor("flow-components/tutorial-flow-icon.asciidoc")
+public class IconBasic {
+
+    public void basics() {
+        Icon icon = VaadinIcons.VAADIN_H.create();
+        new Button("Vaadin", icon);
+    }
+    
+    public void customCollection() {
+        Icon icon = new Icon("valo", "clock");
+        new Button("Clock", icon);
+    }
+}


### PR DESCRIPTION
At first I wanted also to make collection and icon name editable, but on a second thought the resulting API for an icon would be overly complicated. If the user want to change those, the component could simply be replaced with a new one.

Fixes #2527.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/2726)
<!-- Reviewable:end -->
