### PR TITLE
Use Spring's class loader when building registries

### DIFF
--- a/flow-spring-addon/src/main/java/com/vaadin/spring/VaadinServletContextInitializer.java
+++ b/flow-spring-addon/src/main/java/com/vaadin/spring/VaadinServletContextInitializer.java
@@ -224,7 +224,7 @@ public class VaadinServletContextInitializer
         } else {
             try {
                 beanClass = definition
-                        .resolveBeanClass(getClass().getClassLoader());
+                        .resolveBeanClass(appContext.getClassLoader());
             } catch (ClassNotFoundException e) {
                 throw new IllegalStateException(e);
             }


### PR DESCRIPTION
Removes the need for a custom include in spring-devtools.properties

Fixes #2819

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/2835)
<!-- Reviewable:end -->
