### PR TITLE
Add VFS support to locate Webjars

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -109,6 +109,11 @@
             <artifactId>webjars-locator-core</artifactId>
             <version>0.32</version>
         </dependency>
+        <dependency>
+            <groupId>org.webjars</groupId>
+            <artifactId>webjars-locator-jboss-vfs</artifactId>
+            <version>0.1.0</version>
+        </dependency>
 
     </dependencies>
 


### PR DESCRIPTION
The default Webjar locator do not support the VFS protocol used e.g. by WildFly. This PR adds the VFS locator as a dependency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/2845)
<!-- Reviewable:end -->
