### PR TITLE
modify the version number to jetty.version

### DIFF
--- a/flow-components-parent/flow-component-demo-helpers/pom.xml
+++ b/flow-components-parent/flow-component-demo-helpers/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>websocket-server</artifactId>
-            <version>9.3.7.v20160115</version>
+            <version>${jetty.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
change the version number for  websocket-server to ${jetty.version}

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/2846)
<!-- Reviewable:end -->
