### PR TITLE
Get rid of split packages

### DIFF
--- a/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/combobox/ComboBox.java
+++ b/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/combobox/ComboBox.java
@@ -31,10 +31,10 @@ import com.vaadin.data.provider.KeyMapper;
 import com.vaadin.data.provider.Query;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.shared.Registration;
-import com.vaadin.ui.ItemLabelGenerator;
 import com.vaadin.ui.common.HasSize;
 import com.vaadin.ui.common.HasValidation;
 import com.vaadin.ui.common.HasValue;
+import com.vaadin.ui.common.ItemLabelGenerator;
 
 import elemental.json.Json;
 import elemental.json.JsonArray;

--- a/flow-server/src/main/java/com/vaadin/ui/common/ItemLabelGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/ui/common/ItemLabelGenerator.java
@@ -13,16 +13,14 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.ui;
+package com.vaadin.ui.common;
 
 import com.vaadin.function.SerializableFunction;
-import com.vaadin.ui.combobox.ComboBox;
 
 /**
  * {@link ItemLabelGenerator} can be used to customize the string shown to the
  * user for an item.
  *
- * @see ComboBox#setItemLabelGenerator(ItemLabelGenerator)
  * @param <T>
  *            item type
  * @author Vaadin Ltd

--- a/flow-server/src/test/java/com/vaadin/packaging/SplitPackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/packaging/SplitPackagesTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.packaging;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SplitPackagesTest {
+    /*
+     * Modules that contain known split packages that we don't care about
+     */
+    private static final Set<String> ignoredModules = new HashSet<>(
+            Arrays.asList("demo-flow-components", "flow-tests",
+                    "flow-code-generator", "flow-generated-components"));
+
+    /*
+     * Scans through all Maven modules to collect for which Java packages that
+     * module declares at least one Java class. The test fails if any Java
+     * package contains classes from multiple modules.
+     */
+    @Test
+    public void findSplitPackages() throws IOException {
+        Collection<File> modules = findModules();
+        Map<String, Set<File>> packageToModules = mapPackagesToModules(modules);
+        String errors = collectErrors(packageToModules);
+
+        if (!errors.isEmpty()) {
+            Assert.fail(errors.toString());
+        }
+    }
+
+    private String collectErrors(Map<String, Set<File>> packages) {
+        return packages.entrySet().stream()
+                .flatMap(entry -> getErrors(entry.getKey(), entry.getValue()))
+                .collect(Collectors.joining("\n"));
+    }
+
+    private Stream<? extends String> getErrors(String pck, Set<File> modules) {
+        if (modules.size() != 1) {
+            return Stream.of(pck + " contains classes from multiple modules: "
+                    + modules);
+        } else {
+            return Stream.empty();
+        }
+    }
+
+    private Map<String, Set<File>> mapPackagesToModules(
+            Collection<File> modules) {
+        Map<String, Set<File>> packageToModules = new HashMap<>();
+
+        for (File module : modules) {
+            File srcDir = new File(module, "src/main/java");
+
+            if (!srcDir.exists()) {
+                continue;
+            }
+
+            HashSet<String> packages = new HashSet<>();
+
+            collectPackages("", srcDir, packages);
+
+            for (String pck : packages) {
+                packageToModules.computeIfAbsent(pck, key -> new HashSet<>())
+                        .add(module);
+            }
+        }
+        return packageToModules;
+    }
+
+    private void collectPackages(String packageName, File dir,
+            HashSet<String> packages) {
+        boolean containsJavaFile = false;
+
+        for (File child : dir.listFiles()) {
+            if (child.isDirectory()) {
+                String childPackageName = packageName + "." + child.getName();
+
+                collectPackages(childPackageName, child, packages);
+            } else {
+                containsJavaFile |= child.getName().endsWith(".java");
+            }
+        }
+
+        if (containsJavaFile) {
+            if (!packageName.isEmpty()) {
+                // Remove leading .
+                packageName = packageName.substring(1);
+            }
+
+            packages.add(packageName);
+        }
+    }
+
+    private Collection<File> findModules() throws IOException {
+        Collection<File> modules = new ArrayList<>();
+
+        collectModules(new File(".."), modules);
+
+        return modules;
+    }
+
+    private void collectModules(File dir, Collection<File> modules) {
+        if (ignoredModules.contains(dir.getName())) {
+            return;
+        }
+
+        if (new File(dir, "pom.xml").exists()) {
+            modules.add(dir);
+
+            for (File child : dir.listFiles()) {
+                if (child.isDirectory()) {
+                    collectModules(child, modules);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
* Adds an automatic test that verifies that there are no split packages
* Moves the only current offender to a more generic location

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/2847)
<!-- Reviewable:end -->
