### PR TITLE
Remove VFS webjars locator

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -109,11 +109,6 @@
             <artifactId>webjars-locator-core</artifactId>
             <version>0.32</version>
         </dependency>
-        <dependency>
-            <groupId>org.webjars</groupId>
-            <artifactId>webjars-locator-jboss-vfs</artifactId>
-            <version>0.1.0</version>
-        </dependency>
 
     </dependencies>
 


### PR DESCRIPTION
Revert this fix : https://github.com/vaadin/flow/pull/2845

Using VFS locator as a dependency leads to exception.
Reverted for now.
May be will be workarounded later on.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/2861)
<!-- Reviewable:end -->
