### PR TITLE
Template/Component renderers for column headers and footers

### DIFF
--- a/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/ComboBoxView.java
+++ b/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/ComboBoxView.java
@@ -133,6 +133,7 @@ public class ComboBoxView extends DemoView {
         List<Song> listOfSongs = createListOfSongs();
 
         comboBox.setItems(listOfSongs);
+        comboBox.setValue(listOfSongs.get(1));
         comboBox.addValueChangeListener(event -> {
             Song song = comboBox.getValue();
             if (song != null) {

--- a/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/ComboBoxView.java
+++ b/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/ComboBoxView.java
@@ -133,7 +133,6 @@ public class ComboBoxView extends DemoView {
         List<Song> listOfSongs = createListOfSongs();
 
         comboBox.setItems(listOfSongs);
-        comboBox.setValue(listOfSongs.get(1));
         comboBox.addValueChangeListener(event -> {
             Song song = comboBox.getValue();
             if (song != null) {

--- a/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/GridView.java
+++ b/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/GridView.java
@@ -596,7 +596,7 @@ public class GridView extends DemoView {
         grid.addColumn(Person::getName, "name").setHeaderLabel("Name");
         grid.addColumn(Person::getAge, "age").setHeaderLabel("Age");
 
-        grid.addColumn("Address", TemplateRenderer.<Person> of(
+        grid.addColumn(TemplateRenderer.<Person> of(
                 "<div>[[item.street]], number [[item.number]]<br><small>[[item.postalCode]]</small></div>")
                 .withProperty("street",
                         person -> person.getAddress().getStreet())
@@ -604,7 +604,7 @@ public class GridView extends DemoView {
                         person -> person.getAddress().getNumber())
                 .withProperty("postalCode",
                         person -> person.getAddress().getPostalCode()),
-                "street", "number");
+                "street", "number").setHeaderLabel("Address");
 
         Checkbox multiSort = new Checkbox("Multiple column sorting enabled");
         multiSort.addValueChangeListener(
@@ -637,8 +637,10 @@ public class GridView extends DemoView {
 
         Column<Person> nameColumn = grid.addColumn(Person::getName)
                 .setHeaderLabel(TemplateRenderer.of(
-                        "<span style='color:green' title='Name'>Name</span>"));
-        Column<Person> ageColumn = grid.addColumn(Person::getAge)
+                        "<span style='color:green' title='Name'>Name</span>"))
+                .setComparator((p1, p2) -> p1.getName()
+                        .compareToIgnoreCase(p2.getName()));
+        Column<Person> ageColumn = grid.addColumn(Person::getAge, "age")
                 .setHeaderLabel(TemplateRenderer
                         .of("<span style='color:blue' title='Age'>Age</span>"));
         Column<Person> streetColumn = grid
@@ -679,8 +681,9 @@ public class GridView extends DemoView {
                     label.getStyle().set("color", "green");
                     label.setTitle("Name");
                     return label;
-                }));
-        Column<Person> ageColumn = grid.addColumn(Person::getAge)
+                })).setComparator((p1, p2) -> p1.getName()
+                        .compareToIgnoreCase(p2.getName()));
+        Column<Person> ageColumn = grid.addColumn(Person::getAge, "age")
                 .setHeaderLabel(new ComponentRenderer<>(() -> {
                     Label label = new Label("Age");
                     label.getStyle().set("color", "blue");
@@ -717,9 +720,14 @@ public class GridView extends DemoView {
         grid.mergeColumns(informationColumnGroup, addressColumnGroup);
 
         // end-source-example
+        Checkbox toggleSortable = new Checkbox("Toggle sorting for the Grid",
+                event -> grid.getColumns().forEach(
+                        column -> column.setSortable(event.getValue())));
+        toggleSortable.setValue(true);
+
         grid.setId("grid-header-with-components");
         addCard("Using components", "Column header and footer using components",
-                grid);
+                grid, new HorizontalLayout(toggleSortable));
     }
 
     private List<Person> getItems() {

--- a/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/GridView.java
+++ b/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/GridView.java
@@ -484,8 +484,8 @@ public class GridView extends DemoView {
         Grid<Person> grid = new Grid<>();
         grid.setItems(getItems());
 
-        Column<Person> idColumn = grid.addColumn(Person::getId)
-                .setHeader("ID").setFlexGrow(0).setWidth("75px");
+        Column<Person> idColumn = grid.addColumn(Person::getId).setHeader("ID")
+                .setFlexGrow(0).setWidth("75px");
         Column<Person> nameColumn = grid.addColumn(Person::getName)
                 .setHeader("Name").setResizable(true);
         grid.addColumn(Person::getAge).setHeader("Age").setResizable(true);
@@ -654,9 +654,8 @@ public class GridView extends DemoView {
                 .mergeColumns(nameColumn, ageColumn)
                 .setHeader(TemplateRenderer.of(
                         "<span style='color:orange' title='Basic Information'>Basic Information</span>"))
-                .setFooter(
-                        TemplateRenderer.of("<span style='color:red'>Total: "
-                                + getItems().size() + " people</span>"));
+                .setFooter(TemplateRenderer.of("<span style='color:red'>Total: "
+                        + getItems().size() + " people</span>"));
         ColumnGroup<Person> addressColumnGroup = grid
                 .mergeColumns(streetColumn, postalCodeColumn)
                 .setHeader(TemplateRenderer.of(
@@ -720,14 +719,9 @@ public class GridView extends DemoView {
         grid.mergeColumns(informationColumnGroup, addressColumnGroup);
 
         // end-source-example
-        Checkbox toggleSortable = new Checkbox("Toggle sorting for the Grid",
-                event -> grid.getColumns().forEach(
-                        column -> column.setSortable(event.getValue())));
-        toggleSortable.setValue(true);
-
         grid.setId("grid-header-with-components");
         addCard("Using components", "Column header and footer using components",
-                grid, new HorizontalLayout(toggleSortable));
+                grid);
     }
 
     private List<Person> getItems() {

--- a/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/GridView.java
+++ b/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/GridView.java
@@ -254,8 +254,8 @@ public class GridView extends DemoView {
         Grid<Person> grid = new Grid<>();
         grid.setItems(getItems());
 
-        grid.addColumn(Person::getName).setHeaderLabel("Name");
-        grid.addColumn(Person::getAge).setHeaderLabel("Age");
+        grid.addColumn(Person::getName).setHeader("Name");
+        grid.addColumn(Person::getAge).setHeader("Age");
 
         // end-source-example
         grid.setId("basic");
@@ -282,8 +282,8 @@ public class GridView extends DemoView {
                         .mapToObj(index -> createPerson(index, random)),
                 query -> 10000));
 
-        grid.addColumn(Person::getName).setHeaderLabel("Name");
-        grid.addColumn(Person::getAge).setHeaderLabel("Age");
+        grid.addColumn(Person::getName).setHeader("Name");
+        grid.addColumn(Person::getAge).setHeader("Age");
 
         // end-source-example
 
@@ -300,8 +300,8 @@ public class GridView extends DemoView {
         Grid<Person> grid = new Grid<>();
         grid.setItems(people);
 
-        grid.addColumn(Person::getName).setHeaderLabel("Name");
-        grid.addColumn(Person::getAge).setHeaderLabel("Age");
+        grid.addColumn(Person::getName).setHeader("Name");
+        grid.addColumn(Person::getAge).setHeader("Age");
 
         grid.asSingleSelect().addValueChangeListener(
                 event -> messageDiv.setText(String.format(
@@ -337,8 +337,8 @@ public class GridView extends DemoView {
         Grid<Person> grid = new Grid<>();
         grid.setItems(people);
 
-        grid.addColumn(Person::getName).setHeaderLabel("Name");
-        grid.addColumn(Person::getAge).setHeaderLabel("Age");
+        grid.addColumn(Person::getName).setHeader("Name");
+        grid.addColumn(Person::getAge).setHeader("Age");
 
         grid.setSelectionMode(SelectionMode.MULTI);
 
@@ -369,8 +369,8 @@ public class GridView extends DemoView {
         Grid<Person> grid = new Grid<>();
         grid.setItems(getItems());
 
-        grid.addColumn(Person::getName).setHeaderLabel("Name");
-        grid.addColumn(Person::getAge).setHeaderLabel("Age");
+        grid.addColumn(Person::getName).setHeader("Name");
+        grid.addColumn(Person::getAge).setHeader("Age");
 
         grid.setSelectionMode(SelectionMode.NONE);
         // end-source-example
@@ -385,7 +385,7 @@ public class GridView extends DemoView {
         grid.setItems(createItems());
 
         // You can use the [[index]] variable to print the row index (0 based)
-        grid.addColumn(TemplateRenderer.of("[[index]]")).setHeaderLabel("#");
+        grid.addColumn(TemplateRenderer.of("[[index]]")).setHeader("#");
 
         // You can set any property by using `withProperty`, including
         // properties not present on the original bean.
@@ -395,14 +395,14 @@ public class GridView extends DemoView {
                         person -> person.getAge() > 1
                                 ? person.getAge() + " years old"
                                 : person.getAge() + " year old"))
-                .setHeaderLabel("Person");
+                .setHeader("Person");
 
         // You can also set complex objects directly. Internal properties of the
         // bean are accessible in the template.
         grid.addColumn(TemplateRenderer.<Person> of(
                 "<div>[[item.address.street]], number [[item.address.number]]<br><small>[[item.address.postalCode]]</small></div>")
                 .withProperty("address", Person::getAddress))
-                .setHeaderLabel("Address");
+                .setHeader("Address");
 
         // You can set events handlers associated with the template. The syntax
         // follows the Polymer convention "on-event", such as "on-click".
@@ -416,7 +416,7 @@ public class GridView extends DemoView {
                             .getDataProvider();
                     dataProvider.getItems().remove(person);
                     dataProvider.refreshAll();
-                })).setHeaderLabel("Actions");
+                })).setHeader("Actions");
 
         grid.setSelectionMode(SelectionMode.NONE);
         // end-source-example
@@ -433,7 +433,7 @@ public class GridView extends DemoView {
 
         // You can use a constructor and a separate setter for the renderer
         grid.addColumn(new ComponentRenderer<>(PersonComponent::new,
-                PersonComponent::setPerson)).setHeaderLabel("Person");
+                PersonComponent::setPerson)).setHeader("Person");
 
         // Or you can use an ordinary function to get the component
         grid.addColumn(
@@ -442,7 +442,7 @@ public class GridView extends DemoView {
                             .getDataProvider();
                     dataProvider.getItems().remove(item);
                     grid.getDataCommunicator().reset();
-                }))).setHeaderLabel("Actions");
+                }))).setHeader("Actions");
 
         // Item details can also use components
         grid.setItemDetailsRenderer(new ComponentRenderer<>(PersonCard::new));
@@ -485,10 +485,10 @@ public class GridView extends DemoView {
         grid.setItems(getItems());
 
         Column<Person> idColumn = grid.addColumn(Person::getId)
-                .setHeaderLabel("ID").setFlexGrow(0).setWidth("75px");
+                .setHeader("ID").setFlexGrow(0).setWidth("75px");
         Column<Person> nameColumn = grid.addColumn(Person::getName)
-                .setHeaderLabel("Name").setResizable(true);
-        grid.addColumn(Person::getAge).setHeaderLabel("Age").setResizable(true);
+                .setHeader("Name").setResizable(true);
+        grid.addColumn(Person::getAge).setHeader("Age").setResizable(true);
 
         Button idColumnVisibility = new Button(
                 "Toggle visibility of the ID column");
@@ -506,7 +506,7 @@ public class GridView extends DemoView {
         Button merge = new Button("Merge ID and name columns");
         merge.addClickListener(event -> {
             grid.mergeColumns(idColumn, nameColumn)
-                    .setHeaderLabel("ID, Name column group");
+                    .setHeader("ID, Name column group");
             // Remove this button from the layout
             merge.getParent().ifPresent(
                     component -> ((HasComponents) component).remove(merge));
@@ -529,8 +529,8 @@ public class GridView extends DemoView {
         List<Person> people = createItems();
         grid.setItems(people);
 
-        grid.addColumn(Person::getName).setHeaderLabel("Name");
-        grid.addColumn(Person::getAge).setHeaderLabel("Age");
+        grid.addColumn(Person::getName).setHeader("Name");
+        grid.addColumn(Person::getAge).setHeader("Age");
 
         grid.setSelectionMode(SelectionMode.NONE);
         grid.setItemDetailsRenderer(TemplateRenderer
@@ -562,23 +562,23 @@ public class GridView extends DemoView {
         grid.setItems(getItems());
 
         Column<Person> nameColumn = grid.addColumn(Person::getName)
-                .setHeaderLabel("Name");
+                .setHeader("Name");
         Column<Person> ageColumn = grid.addColumn(Person::getAge)
-                .setHeaderLabel("Age");
+                .setHeader("Age");
         Column<Person> streetColumn = grid
                 .addColumn(person -> person.getAddress().getStreet())
-                .setHeaderLabel("Street");
+                .setHeader("Street");
         Column<Person> postalCodeColumn = grid
                 .addColumn(person -> person.getAddress().getPostalCode())
-                .setHeaderLabel("Postal Code");
+                .setHeader("Postal Code");
 
         ColumnGroup<Person> informationColumnGroup = grid
                 .mergeColumns(nameColumn, ageColumn)
-                .setHeaderLabel("Basic Information")
-                .setFooterLabel("Total: " + getItems().size() + " people");
+                .setHeader("Basic Information")
+                .setFooter("Total: " + getItems().size() + " people");
         ColumnGroup<Person> addressColumnGroup = grid
                 .mergeColumns(streetColumn, postalCodeColumn)
-                .setHeaderLabel("Address Information");
+                .setHeader("Address Information");
         grid.mergeColumns(informationColumnGroup, addressColumnGroup);
         // end-source-example
         grid.setId("grid-column-grouping");
@@ -593,8 +593,8 @@ public class GridView extends DemoView {
         grid.setItems(getItems());
         grid.setSelectionMode(SelectionMode.NONE);
 
-        grid.addColumn(Person::getName, "name").setHeaderLabel("Name");
-        grid.addColumn(Person::getAge, "age").setHeaderLabel("Age");
+        grid.addColumn(Person::getName, "name").setHeader("Name");
+        grid.addColumn(Person::getAge, "age").setHeader("Age");
 
         grid.addColumn(TemplateRenderer.<Person> of(
                 "<div>[[item.street]], number [[item.number]]<br><small>[[item.postalCode]]</small></div>")
@@ -604,7 +604,7 @@ public class GridView extends DemoView {
                         person -> person.getAddress().getNumber())
                 .withProperty("postalCode",
                         person -> person.getAddress().getPostalCode()),
-                "street", "number").setHeaderLabel("Address");
+                "street", "number").setHeader("Address");
 
         Checkbox multiSort = new Checkbox("Multiple column sorting enabled");
         multiSort.addValueChangeListener(
@@ -636,30 +636,30 @@ public class GridView extends DemoView {
         grid.setItems(getItems());
 
         Column<Person> nameColumn = grid.addColumn(Person::getName)
-                .setHeaderLabel(TemplateRenderer.of(
+                .setHeader(TemplateRenderer.of(
                         "<span style='color:green' title='Name'>Name</span>"))
                 .setComparator((p1, p2) -> p1.getName()
                         .compareToIgnoreCase(p2.getName()));
         Column<Person> ageColumn = grid.addColumn(Person::getAge, "age")
-                .setHeaderLabel(TemplateRenderer
+                .setHeader(TemplateRenderer
                         .of("<span style='color:blue' title='Age'>Age</span>"));
         Column<Person> streetColumn = grid
                 .addColumn(person -> person.getAddress().getStreet())
-                .setHeaderLabel("Street");
+                .setHeader("Street");
         Column<Person> postalCodeColumn = grid
                 .addColumn(person -> person.getAddress().getPostalCode())
-                .setHeaderLabel("Postal Code");
+                .setHeader("Postal Code");
 
         ColumnGroup<Person> informationColumnGroup = grid
                 .mergeColumns(nameColumn, ageColumn)
-                .setHeaderLabel(TemplateRenderer.of(
+                .setHeader(TemplateRenderer.of(
                         "<span style='color:orange' title='Basic Information'>Basic Information</span>"))
-                .setFooterLabel(
+                .setFooter(
                         TemplateRenderer.of("<span style='color:red'>Total: "
                                 + getItems().size() + " people</span>"));
         ColumnGroup<Person> addressColumnGroup = grid
                 .mergeColumns(streetColumn, postalCodeColumn)
-                .setHeaderLabel(TemplateRenderer.of(
+                .setHeader(TemplateRenderer.of(
                         "<span title='Address Information'>Address Information</span>"));
         grid.mergeColumns(informationColumnGroup, addressColumnGroup);
 
@@ -676,7 +676,7 @@ public class GridView extends DemoView {
         grid.setItems(getItems());
 
         Column<Person> nameColumn = grid.addColumn(Person::getName)
-                .setHeaderLabel(new ComponentRenderer<>(() -> {
+                .setHeader(new ComponentRenderer<>(() -> {
                     Label label = new Label("Name");
                     label.getStyle().set("color", "green");
                     label.setTitle("Name");
@@ -684,7 +684,7 @@ public class GridView extends DemoView {
                 })).setComparator((p1, p2) -> p1.getName()
                         .compareToIgnoreCase(p2.getName()));
         Column<Person> ageColumn = grid.addColumn(Person::getAge, "age")
-                .setHeaderLabel(new ComponentRenderer<>(() -> {
+                .setHeader(new ComponentRenderer<>(() -> {
                     Label label = new Label("Age");
                     label.getStyle().set("color", "blue");
                     label.setTitle("Age");
@@ -692,19 +692,19 @@ public class GridView extends DemoView {
                 }));
         Column<Person> streetColumn = grid
                 .addColumn(person -> person.getAddress().getStreet())
-                .setHeaderLabel("Street");
+                .setHeader("Street");
         Column<Person> postalCodeColumn = grid
                 .addColumn(person -> person.getAddress().getPostalCode())
-                .setHeaderLabel("Postal Code");
+                .setHeader("Postal Code");
 
         ColumnGroup<Person> informationColumnGroup = grid
                 .mergeColumns(nameColumn, ageColumn)
-                .setHeaderLabel(new ComponentRenderer<>(() -> {
+                .setHeader(new ComponentRenderer<>(() -> {
                     Label label = new Label("Basic Information");
                     label.getStyle().set("color", "orange");
                     label.setTitle("Basic Information");
                     return label;
-                })).setFooterLabel(new ComponentRenderer<>(() -> {
+                })).setFooter(new ComponentRenderer<>(() -> {
                     Label label = new Label(
                             "Total: " + getItems().size() + " people");
                     label.getStyle().set("color", "red");
@@ -712,7 +712,7 @@ public class GridView extends DemoView {
                 }));
         ColumnGroup<Person> addressColumnGroup = grid
                 .mergeColumns(streetColumn, postalCodeColumn)
-                .setHeaderLabel(new ComponentRenderer<>(() -> {
+                .setHeader(new ComponentRenderer<>(() -> {
                     Label label = new Label("Address Information");
                     label.setTitle("Address Information");
                     return label;

--- a/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/GridView.java
+++ b/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/GridView.java
@@ -241,6 +241,8 @@ public class GridView extends DemoView {
         createColumnGroup();
         createColumnComponentRenderer();
         createSorting();
+        createHeaderAndFooterUsingTemplates();
+        createHeaderAndFooterUsingComponents();
 
         addCard("Grid example model",
                 new Label("These objects are used in the examples above"));
@@ -252,8 +254,8 @@ public class GridView extends DemoView {
         Grid<Person> grid = new Grid<>();
         grid.setItems(getItems());
 
-        grid.addColumn("Name", Person::getName);
-        grid.addColumn("Age", Person::getAge);
+        grid.addColumn(Person::getName).setHeaderLabel("Name");
+        grid.addColumn(Person::getAge).setHeaderLabel("Age");
 
         // end-source-example
         grid.setId("basic");
@@ -280,8 +282,8 @@ public class GridView extends DemoView {
                         .mapToObj(index -> createPerson(index, random)),
                 query -> 10000));
 
-        grid.addColumn("Name", Person::getName);
-        grid.addColumn("Age", Person::getAge);
+        grid.addColumn(Person::getName).setHeaderLabel("Name");
+        grid.addColumn(Person::getAge).setHeaderLabel("Age");
 
         // end-source-example
 
@@ -298,8 +300,8 @@ public class GridView extends DemoView {
         Grid<Person> grid = new Grid<>();
         grid.setItems(people);
 
-        grid.addColumn("Name", Person::getName);
-        grid.addColumn("Age", Person::getAge);
+        grid.addColumn(Person::getName).setHeaderLabel("Name");
+        grid.addColumn(Person::getAge).setHeaderLabel("Age");
 
         grid.asSingleSelect().addValueChangeListener(
                 event -> messageDiv.setText(String.format(
@@ -335,8 +337,8 @@ public class GridView extends DemoView {
         Grid<Person> grid = new Grid<>();
         grid.setItems(people);
 
-        grid.addColumn("Name", Person::getName);
-        grid.addColumn("Age", Person::getAge);
+        grid.addColumn(Person::getName).setHeaderLabel("Name");
+        grid.addColumn(Person::getAge).setHeaderLabel("Age");
 
         grid.setSelectionMode(SelectionMode.MULTI);
 
@@ -367,8 +369,8 @@ public class GridView extends DemoView {
         Grid<Person> grid = new Grid<>();
         grid.setItems(getItems());
 
-        grid.addColumn("Name", Person::getName);
-        grid.addColumn("Age", Person::getAge);
+        grid.addColumn(Person::getName).setHeaderLabel("Name");
+        grid.addColumn(Person::getAge).setHeaderLabel("Age");
 
         grid.setSelectionMode(SelectionMode.NONE);
         // end-source-example
@@ -383,26 +385,28 @@ public class GridView extends DemoView {
         grid.setItems(createItems());
 
         // You can use the [[index]] variable to print the row index (0 based)
-        grid.addColumn("#", TemplateRenderer.of("[[index]]"));
+        grid.addColumn(TemplateRenderer.of("[[index]]")).setHeaderLabel("#");
 
         // You can set any property by using `withProperty`, including
         // properties not present on the original bean.
-        grid.addColumn("Person", TemplateRenderer.<Person> of(
+        grid.addColumn(TemplateRenderer.<Person> of(
                 "<div title='[[item.name]]'>[[item.name]]<br><small>[[item.yearsOld]]</small></div>")
                 .withProperty("name", Person::getName).withProperty("yearsOld",
                         person -> person.getAge() > 1
                                 ? person.getAge() + " years old"
-                                : person.getAge() + " year old"));
+                                : person.getAge() + " year old"))
+                .setHeaderLabel("Person");
 
         // You can also set complex objects directly. Internal properties of the
         // bean are accessible in the template.
-        grid.addColumn("Address", TemplateRenderer.<Person> of(
+        grid.addColumn(TemplateRenderer.<Person> of(
                 "<div>[[item.address.street]], number [[item.address.number]]<br><small>[[item.address.postalCode]]</small></div>")
-                .withProperty("address", Person::getAddress));
+                .withProperty("address", Person::getAddress))
+                .setHeaderLabel("Address");
 
         // You can set events handlers associated with the template. The syntax
         // follows the Polymer convention "on-event", such as "on-click".
-        grid.addColumn("Actions", TemplateRenderer.<Person> of(
+        grid.addColumn(TemplateRenderer.<Person> of(
                 "<button on-click='handleUpdate'>Update</button><button on-click='handleRemove'>Remove</button>")
                 .withEventHandler("handleUpdate", person -> {
                     person.setName(person.getName() + " Updated");
@@ -412,7 +416,7 @@ public class GridView extends DemoView {
                             .getDataProvider();
                     dataProvider.getItems().remove(person);
                     dataProvider.refreshAll();
-                }));
+                })).setHeaderLabel("Actions");
 
         grid.setSelectionMode(SelectionMode.NONE);
         // end-source-example
@@ -428,17 +432,17 @@ public class GridView extends DemoView {
         grid.setItems(createItems());
 
         // You can use a constructor and a separate setter for the renderer
-        grid.addColumn("Person", new ComponentRenderer<>(PersonComponent::new,
-                PersonComponent::setPerson));
+        grid.addColumn(new ComponentRenderer<>(PersonComponent::new,
+                PersonComponent::setPerson)).setHeaderLabel("Person");
 
         // Or you can use an ordinary function to get the component
-        grid.addColumn("Actions",
+        grid.addColumn(
                 new ComponentRenderer<>(item -> new Button("Remove", evt -> {
                     ListDataProvider<Person> dataProvider = (ListDataProvider<Person>) grid
                             .getDataProvider();
                     dataProvider.getItems().remove(item);
                     grid.getDataCommunicator().reset();
-                })));
+                }))).setHeaderLabel("Actions");
 
         // Item details can also use components
         grid.setItemDetailsRenderer(new ComponentRenderer<>(PersonCard::new));
@@ -480,11 +484,11 @@ public class GridView extends DemoView {
         Grid<Person> grid = new Grid<>();
         grid.setItems(getItems());
 
-        Column<Person> idColumn = grid.addColumn("ID", Person::getId)
-                .setFlexGrow(0).setWidth("75px");
-        Column<Person> nameColumn = grid.addColumn("Name", Person::getName)
-                .setResizable(true);
-        grid.addColumn("Age", Person::getAge).setResizable(true);
+        Column<Person> idColumn = grid.addColumn(Person::getId)
+                .setHeaderLabel("ID").setFlexGrow(0).setWidth("75px");
+        Column<Person> nameColumn = grid.addColumn(Person::getName)
+                .setHeaderLabel("Name").setResizable(true);
+        grid.addColumn(Person::getAge).setHeaderLabel("Age").setResizable(true);
 
         Button idColumnVisibility = new Button(
                 "Toggle visibility of the ID column");
@@ -501,7 +505,8 @@ public class GridView extends DemoView {
 
         Button merge = new Button("Merge ID and name columns");
         merge.addClickListener(event -> {
-            grid.mergeColumns("ID, Name column group", idColumn, nameColumn);
+            grid.mergeColumns(idColumn, nameColumn)
+                    .setHeaderLabel("ID, Name column group");
             // Remove this button from the layout
             merge.getParent().ifPresent(
                     component -> ((HasComponents) component).remove(merge));
@@ -524,8 +529,8 @@ public class GridView extends DemoView {
         List<Person> people = createItems();
         grid.setItems(people);
 
-        grid.addColumn("Name", Person::getName);
-        grid.addColumn("Age", Person::getAge);
+        grid.addColumn(Person::getName).setHeaderLabel("Name");
+        grid.addColumn(Person::getAge).setHeaderLabel("Age");
 
         grid.setSelectionMode(SelectionMode.NONE);
         grid.setItemDetailsRenderer(TemplateRenderer
@@ -556,19 +561,25 @@ public class GridView extends DemoView {
         Grid<Person> grid = new Grid<>();
         grid.setItems(getItems());
 
-        Column<Person> nameColumn = grid.addColumn("Name", Person::getName);
-        Column<Person> ageColumn = grid.addColumn("Age", Person::getAge);
-        Column<Person> streetColumn = grid.addColumn("Street",
-                person -> person.getAddress().getStreet());
-        Column<Person> postalCodeColumn = grid.addColumn("Postal Code",
-                person -> person.getAddress().getPostalCode());
+        Column<Person> nameColumn = grid.addColumn(Person::getName)
+                .setHeaderLabel("Name");
+        Column<Person> ageColumn = grid.addColumn(Person::getAge)
+                .setHeaderLabel("Age");
+        Column<Person> streetColumn = grid
+                .addColumn(person -> person.getAddress().getStreet())
+                .setHeaderLabel("Street");
+        Column<Person> postalCodeColumn = grid
+                .addColumn(person -> person.getAddress().getPostalCode())
+                .setHeaderLabel("Postal Code");
 
-        ColumnGroup informationColumnGroup = grid
-                .mergeColumns("Basic Information", nameColumn, ageColumn);
-        ColumnGroup addressColumnGroup = grid.mergeColumns(
-                "Address information", streetColumn, postalCodeColumn);
-        grid.mergeColumns("Person Information", informationColumnGroup,
-                addressColumnGroup);
+        ColumnGroup<Person> informationColumnGroup = grid
+                .mergeColumns(nameColumn, ageColumn)
+                .setHeaderLabel("Basic Information")
+                .setFooterLabel("Total: " + getItems().size() + " people");
+        ColumnGroup<Person> addressColumnGroup = grid
+                .mergeColumns(streetColumn, postalCodeColumn)
+                .setHeaderLabel("Address Information");
+        grid.mergeColumns(informationColumnGroup, addressColumnGroup);
         // end-source-example
         grid.setId("grid-column-grouping");
         addCard("Configuring columns", "Column grouping example", grid);
@@ -582,15 +593,17 @@ public class GridView extends DemoView {
         grid.setItems(getItems());
         grid.setSelectionMode(SelectionMode.NONE);
 
-        grid.addColumn("Name", Person::getName, "name");
-        grid.addColumn("Age", Person::getAge, "age");
+        grid.addColumn(Person::getName, "name").setHeaderLabel("Name");
+        grid.addColumn(Person::getAge, "age").setHeaderLabel("Age");
 
-        grid.addColumn("Address",
-                TemplateRenderer
-                        .<Person> of("<div>[[item.street]], number [[item.number]]<br><small>[[item.postalCode]]</small></div>")
-                        .withProperty("street", person -> person.getAddress().getStreet())
-                        .withProperty("number", person -> person.getAddress().getNumber())
-                        .withProperty("postalCode", person -> person.getAddress().getPostalCode()),
+        grid.addColumn("Address", TemplateRenderer.<Person> of(
+                "<div>[[item.street]], number [[item.number]]<br><small>[[item.postalCode]]</small></div>")
+                .withProperty("street",
+                        person -> person.getAddress().getStreet())
+                .withProperty("number",
+                        person -> person.getAddress().getNumber())
+                .withProperty("postalCode",
+                        person -> person.getAddress().getPostalCode()),
                 "street", "number");
 
         Checkbox multiSort = new Checkbox("Multiple column sorting enabled");
@@ -614,6 +627,99 @@ public class GridView extends DemoView {
         messageDiv.setId("grid-sortable-columns-message");
         addCard("Sorting", "Grid with sortable columns", grid, multiSort,
                 messageDiv);
+    }
+
+    private void createHeaderAndFooterUsingTemplates() {
+        // begin-source-example
+        // source-example-heading: Column header and footer using templates
+        Grid<Person> grid = new Grid<>();
+        grid.setItems(getItems());
+
+        Column<Person> nameColumn = grid.addColumn(Person::getName)
+                .setHeaderLabel(TemplateRenderer.of(
+                        "<span style='color:green' title='Name'>Name</span>"));
+        Column<Person> ageColumn = grid.addColumn(Person::getAge)
+                .setHeaderLabel(TemplateRenderer
+                        .of("<span style='color:blue' title='Age'>Age</span>"));
+        Column<Person> streetColumn = grid
+                .addColumn(person -> person.getAddress().getStreet())
+                .setHeaderLabel("Street");
+        Column<Person> postalCodeColumn = grid
+                .addColumn(person -> person.getAddress().getPostalCode())
+                .setHeaderLabel("Postal Code");
+
+        ColumnGroup<Person> informationColumnGroup = grid
+                .mergeColumns(nameColumn, ageColumn)
+                .setHeaderLabel(TemplateRenderer.of(
+                        "<span style='color:orange' title='Basic Information'>Basic Information</span>"))
+                .setFooterLabel(
+                        TemplateRenderer.of("<span style='color:red'>Total: "
+                                + getItems().size() + " people</span>"));
+        ColumnGroup<Person> addressColumnGroup = grid
+                .mergeColumns(streetColumn, postalCodeColumn)
+                .setHeaderLabel(TemplateRenderer.of(
+                        "<span title='Address Information'>Address Information</span>"));
+        grid.mergeColumns(informationColumnGroup, addressColumnGroup);
+
+        // end-source-example
+        grid.setId("grid-header-with-templates");
+        addCard("Using templates", "Column header and footer using templates",
+                grid);
+    }
+
+    private void createHeaderAndFooterUsingComponents() {
+        // begin-source-example
+        // source-example-heading: Column header and footer using components
+        Grid<Person> grid = new Grid<>();
+        grid.setItems(getItems());
+
+        Column<Person> nameColumn = grid.addColumn(Person::getName)
+                .setHeaderLabel(new ComponentRenderer<>(() -> {
+                    Label label = new Label("Name");
+                    label.getStyle().set("color", "green");
+                    label.setTitle("Name");
+                    return label;
+                }));
+        Column<Person> ageColumn = grid.addColumn(Person::getAge)
+                .setHeaderLabel(new ComponentRenderer<>(() -> {
+                    Label label = new Label("Age");
+                    label.getStyle().set("color", "blue");
+                    label.setTitle("Age");
+                    return label;
+                }));
+        Column<Person> streetColumn = grid
+                .addColumn(person -> person.getAddress().getStreet())
+                .setHeaderLabel("Street");
+        Column<Person> postalCodeColumn = grid
+                .addColumn(person -> person.getAddress().getPostalCode())
+                .setHeaderLabel("Postal Code");
+
+        ColumnGroup<Person> informationColumnGroup = grid
+                .mergeColumns(nameColumn, ageColumn)
+                .setHeaderLabel(new ComponentRenderer<>(() -> {
+                    Label label = new Label("Basic Information");
+                    label.getStyle().set("color", "orange");
+                    label.setTitle("Basic Information");
+                    return label;
+                })).setFooterLabel(new ComponentRenderer<>(() -> {
+                    Label label = new Label(
+                            "Total: " + getItems().size() + " people");
+                    label.getStyle().set("color", "red");
+                    return label;
+                }));
+        ColumnGroup<Person> addressColumnGroup = grid
+                .mergeColumns(streetColumn, postalCodeColumn)
+                .setHeaderLabel(new ComponentRenderer<>(() -> {
+                    Label label = new Label("Address Information");
+                    label.setTitle("Address Information");
+                    return label;
+                }));
+        grid.mergeColumns(informationColumnGroup, addressColumnGroup);
+
+        // end-source-example
+        grid.setId("grid-header-with-templates");
+        addCard("Using components", "Column header and footer using components",
+                grid);
     }
 
     private List<Person> getItems() {

--- a/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/GridView.java
+++ b/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/GridView.java
@@ -717,7 +717,7 @@ public class GridView extends DemoView {
         grid.mergeColumns(informationColumnGroup, addressColumnGroup);
 
         // end-source-example
-        grid.setId("grid-header-with-templates");
+        grid.setId("grid-header-with-components");
         addCard("Using components", "Column header and footer using components",
                 grid);
     }

--- a/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/GridView.java
+++ b/flow-components-parent/demo-flow-components/src/main/java/com/vaadin/flow/demo/views/GridView.java
@@ -572,11 +572,11 @@ public class GridView extends DemoView {
                 .addColumn(person -> person.getAddress().getPostalCode())
                 .setHeader("Postal Code");
 
-        ColumnGroup<Person> informationColumnGroup = grid
+        ColumnGroup informationColumnGroup = grid
                 .mergeColumns(nameColumn, ageColumn)
                 .setHeader("Basic Information")
                 .setFooter("Total: " + getItems().size() + " people");
-        ColumnGroup<Person> addressColumnGroup = grid
+        ColumnGroup addressColumnGroup = grid
                 .mergeColumns(streetColumn, postalCodeColumn)
                 .setHeader("Address Information");
         grid.mergeColumns(informationColumnGroup, addressColumnGroup);
@@ -650,13 +650,13 @@ public class GridView extends DemoView {
                 .addColumn(person -> person.getAddress().getPostalCode())
                 .setHeader("Postal Code");
 
-        ColumnGroup<Person> informationColumnGroup = grid
+        ColumnGroup informationColumnGroup = grid
                 .mergeColumns(nameColumn, ageColumn)
                 .setHeader(TemplateRenderer.of(
                         "<span style='color:orange' title='Basic Information'>Basic Information</span>"))
                 .setFooter(TemplateRenderer.of("<span style='color:red'>Total: "
                         + getItems().size() + " people</span>"));
-        ColumnGroup<Person> addressColumnGroup = grid
+        ColumnGroup addressColumnGroup = grid
                 .mergeColumns(streetColumn, postalCodeColumn)
                 .setHeader(TemplateRenderer.of(
                         "<span title='Address Information'>Address Information</span>"));
@@ -696,7 +696,7 @@ public class GridView extends DemoView {
                 .addColumn(person -> person.getAddress().getPostalCode())
                 .setHeader("Postal Code");
 
-        ColumnGroup<Person> informationColumnGroup = grid
+        ColumnGroup informationColumnGroup = grid
                 .mergeColumns(nameColumn, ageColumn)
                 .setHeader(new ComponentRenderer<>(() -> {
                     Label label = new Label("Basic Information");
@@ -709,7 +709,7 @@ public class GridView extends DemoView {
                     label.getStyle().set("color", "red");
                     return label;
                 }));
-        ColumnGroup<Person> addressColumnGroup = grid
+        ColumnGroup addressColumnGroup = grid
                 .mergeColumns(streetColumn, postalCodeColumn)
                 .setHeader(new ComponentRenderer<>(() -> {
                     Label label = new Label("Address Information");

--- a/flow-components-parent/demo-flow-components/src/test/java/com/vaadin/flow/demo/views/GridViewIT.java
+++ b/flow-components-parent/demo-flow-components/src/test/java/com/vaadin/flow/demo/views/GridViewIT.java
@@ -432,14 +432,14 @@ public class GridViewIT extends TabbedComponentDemoTest {
                 "There should be a cell with the renderered 'Basic Information' header",
                 topLevelColumn.getAttribute("innerHTML").contains(
                         "<span style=\"color:orange\" title=\"Basic Information\">Basic Information</span>"));
-
+        
         Assert.assertTrue("There should be a cell with the renderered footer",
                 topLevelColumn.getAttribute("innerHTML").contains(
                         "<span style=\"color:red\">Total: 499 people</span>"));
 
         List<WebElement> secondLevelColumns = topLevelColumn
                 .findElements(By.tagName("vaadin-grid-column"));
-
+        
         Assert.assertTrue(
                 "There should be a cell with the renderered 'Name' header",
                 secondLevelColumns.get(0).getAttribute("innerHTML").contains(

--- a/flow-components-parent/demo-flow-components/src/test/java/com/vaadin/flow/demo/views/GridViewIT.java
+++ b/flow-components-parent/demo-flow-components/src/test/java/com/vaadin/flow/demo/views/GridViewIT.java
@@ -418,7 +418,65 @@ public class GridViewIT extends TabbedComponentDemoTest {
                         sortOrdersString, fromClient),
                 findElement(By.id("grid-sortable-columns-message")).getText());
     }
+    
+    @Test
+    public void gridWithHeaderWithTemplateRenderer_headerAndFooterAreRenderered() {
+        openDemoPageAndCheckForErrors("using-templates");
+        WebElement grid = findElement(By.id("grid-header-with-templates"));
+        scrollToElement(grid);
 
+        WebElement topLevelColumn = grid
+                .findElement(By.tagName("vaadin-grid-column-group"));
+
+        Assert.assertTrue(
+                "There should be a cell with the renderered 'Basic Information' header",
+                topLevelColumn.getAttribute("innerHTML").contains(
+                        "<span style=\"color:orange\" title=\"Basic Information\">Basic Information</span>"));
+
+        Assert.assertTrue("There should be a cell with the renderered footer",
+                topLevelColumn.getAttribute("innerHTML").contains(
+                        "<span style=\"color:red\">Total: 499 people</span>"));
+
+        List<WebElement> secondLevelColumns = topLevelColumn
+                .findElements(By.tagName("vaadin-grid-column"));
+
+        Assert.assertTrue(
+                "There should be a cell with the renderered 'Name' header",
+                secondLevelColumns.get(0).getAttribute("innerHTML").contains(
+                        "<span style=\"color:green\" title=\"Name\">Name</span>"));
+
+        Assert.assertTrue(
+                "There should be a cell with the renderered 'Age' header",
+                secondLevelColumns.get(1).getAttribute("innerHTML").contains(
+                        "<span style=\"color:blue\" title=\"Age\">Age</span>"));
+    }
+
+    @Test
+    public void gridWithHeaderWithComponentRenderer_headerAndFooterAreRenderered() {
+        openDemoPageAndCheckForErrors("using-components");
+        WebElement grid = findElement(By.id("grid-header-with-components"));
+        scrollToElement(grid);
+
+        Assert.assertTrue(
+                "There should be a cell with the renderered 'Basic Information' header",
+                hasComponentRendereredCell(grid,
+                        "<label data-flow-renderer-item-key=\"0\" title=\"Basic Information\" style=\"color: orange;\">Basic Information</label>"));
+
+        Assert.assertTrue(
+                "There should be a cell with the renderered 'Name' header",
+                hasComponentRendereredCell(grid,
+                        "<label data-flow-renderer-item-key=\"0\" title=\"Name\" style=\"color: green;\">Name</label>"));
+
+        Assert.assertTrue(
+                "There should be a cell with the renderered 'Age' header",
+                hasComponentRendereredCell(grid,
+                        "<label data-flow-renderer-item-key=\"0\" title=\"Age\" style=\"color: blue;\">Age</label>"));
+
+        Assert.assertTrue("There should be a cell with the renderered footer",
+                hasComponentRendereredCell(grid,
+                        "<label data-flow-renderer-item-key=\"0\" style=\"color: red;\">Total: 499 people</label>"));
+    }
+    
     private static String getSelectionMessage(Object oldSelection,
             Object newSelection, boolean isFromClient) {
         return String.format(

--- a/flow-components-parent/flow-components-test/src/main/java/com/vaadin/flow/components/it/grid/GridFiltering.java
+++ b/flow-components-parent/flow-components-test/src/main/java/com/vaadin/flow/components/it/grid/GridFiltering.java
@@ -32,7 +32,7 @@ public class GridFiltering extends TestView {
 
         grid.setDataProvider(filteredDataProvider);
 
-        grid.addColumn("Data", item -> item);
+        grid.addColumn(item -> item).setHeaderLabel("Data");
 
         TextField field = new TextField();
         field.setId("filter");

--- a/flow-components-parent/flow-components-test/src/main/java/com/vaadin/flow/components/it/grid/GridFiltering.java
+++ b/flow-components-parent/flow-components-test/src/main/java/com/vaadin/flow/components/it/grid/GridFiltering.java
@@ -32,7 +32,7 @@ public class GridFiltering extends TestView {
 
         grid.setDataProvider(filteredDataProvider);
 
-        grid.addColumn(item -> item).setHeaderLabel("Data");
+        grid.addColumn(item -> item).setHeader("Data");
 
         TextField field = new TextField();
         field.setId("filter");

--- a/flow-components-parent/flow-components-test/src/main/java/com/vaadin/flow/components/it/grid/GridItemRefreshView.java
+++ b/flow-components-parent/flow-components-test/src/main/java/com/vaadin/flow/components/it/grid/GridItemRefreshView.java
@@ -56,8 +56,8 @@ public class GridItemRefreshView extends TestView {
 
     public GridItemRefreshView() {
         Grid<Bean> grid = new Grid<>();
-        grid.addColumn("First Field", Bean::getFirstField);
-        grid.addColumn("Second Field", Bean::getSecondField);
+        grid.addColumn(Bean::getFirstField).setHeaderLabel("First Field");
+        grid.addColumn(Bean::getSecondField).setHeaderLabel("Second Field");
         List<Bean> items = createItems(1000);
         grid.setItems(items);
 

--- a/flow-components-parent/flow-components-test/src/main/java/com/vaadin/flow/components/it/grid/GridItemRefreshView.java
+++ b/flow-components-parent/flow-components-test/src/main/java/com/vaadin/flow/components/it/grid/GridItemRefreshView.java
@@ -56,8 +56,8 @@ public class GridItemRefreshView extends TestView {
 
     public GridItemRefreshView() {
         Grid<Bean> grid = new Grid<>();
-        grid.addColumn(Bean::getFirstField).setHeaderLabel("First Field");
-        grid.addColumn(Bean::getSecondField).setHeaderLabel("Second Field");
+        grid.addColumn(Bean::getFirstField).setHeader("First Field");
+        grid.addColumn(Bean::getSecondField).setHeader("Second Field");
         List<Bean> items = createItems(1000);
         grid.setItems(items);
 

--- a/flow-components-parent/flow-components-test/src/main/java/com/vaadin/flow/components/it/grid/GridMultiSelectionColumnView.java
+++ b/flow-components-parent/flow-components-test/src/main/java/com/vaadin/flow/components/it/grid/GridMultiSelectionColumnView.java
@@ -60,8 +60,9 @@ public class GridMultiSelectionColumnView extends TestView {
 
     private void setUp(Grid<String> grid) {
         grid.setSelectionMode(SelectionMode.MULTI);
-        grid.addColumn("text", i -> i);
-        grid.addColumn("length", i -> String.valueOf(i.length()));
+        grid.addColumn(i -> i).setHeaderLabel("text");
+        grid.addColumn(i -> String.valueOf(i.length()))
+                .setHeaderLabel("length");
         grid.addSelectionListener(event -> message.setText(
                 "Selected item count: " + event.getAllSelectedItems().size()));
     }

--- a/flow-components-parent/flow-components-test/src/main/java/com/vaadin/flow/components/it/grid/GridMultiSelectionColumnView.java
+++ b/flow-components-parent/flow-components-test/src/main/java/com/vaadin/flow/components/it/grid/GridMultiSelectionColumnView.java
@@ -60,9 +60,9 @@ public class GridMultiSelectionColumnView extends TestView {
 
     private void setUp(Grid<String> grid) {
         grid.setSelectionMode(SelectionMode.MULTI);
-        grid.addColumn(i -> i).setHeaderLabel("text");
+        grid.addColumn(i -> i).setHeader("text");
         grid.addColumn(i -> String.valueOf(i.length()))
-                .setHeaderLabel("length");
+                .setHeader("length");
         grid.addSelectionListener(event -> message.setText(
                 "Selected item count: " + event.getAllSelectedItems().size()));
     }

--- a/flow-components-parent/flow-components-test/src/main/java/com/vaadin/flow/components/it/grid/GridPageSizeView.java
+++ b/flow-components-parent/flow-components-test/src/main/java/com/vaadin/flow/components/it/grid/GridPageSizeView.java
@@ -41,9 +41,9 @@ public class GridPageSizeView extends TestView {
         Grid<String> grid = new Grid<>(10);
 
         grid.setDataProvider(dataProvider);
-        grid.addColumn(i -> i).setHeaderLabel("text");
+        grid.addColumn(i -> i).setHeader("text");
         grid.addColumn(i -> String.valueOf(i.length()))
-                .setHeaderLabel("length");
+                .setHeader("length");
 
         info = new Label();
         info.setId("query-info");

--- a/flow-components-parent/flow-components-test/src/main/java/com/vaadin/flow/components/it/grid/GridPageSizeView.java
+++ b/flow-components-parent/flow-components-test/src/main/java/com/vaadin/flow/components/it/grid/GridPageSizeView.java
@@ -41,8 +41,9 @@ public class GridPageSizeView extends TestView {
         Grid<String> grid = new Grid<>(10);
 
         grid.setDataProvider(dataProvider);
-        grid.addColumn("text", i -> i);
-        grid.addColumn("length", i -> String.valueOf(i.length()));
+        grid.addColumn(i -> i).setHeaderLabel("text");
+        grid.addColumn(i -> String.valueOf(i.length()))
+                .setHeaderLabel("length");
 
         info = new Label();
         info.setId("query-info");

--- a/flow-components-parent/flow-components-test/src/main/java/com/vaadin/flow/components/it/grid/GridView.java
+++ b/flow-components-parent/flow-components-test/src/main/java/com/vaadin/flow/components/it/grid/GridView.java
@@ -45,9 +45,9 @@ public class GridView extends TestView {
         grid = new Grid<>();
 
         grid.setDataProvider(dataProvider1);
-        grid.addColumn(i -> i).setHeaderLabel("text");
+        grid.addColumn(i -> i).setHeader("text");
         grid.addColumn(i -> String.valueOf(i.length()))
-                .setHeaderLabel("length");
+                .setHeader("length");
 
         add(grid);
 

--- a/flow-components-parent/flow-components-test/src/main/java/com/vaadin/flow/components/it/grid/GridView.java
+++ b/flow-components-parent/flow-components-test/src/main/java/com/vaadin/flow/components/it/grid/GridView.java
@@ -45,8 +45,9 @@ public class GridView extends TestView {
         grid = new Grid<>();
 
         grid.setDataProvider(dataProvider1);
-        grid.addColumn("text", i -> i);
-        grid.addColumn("length", i -> String.valueOf(i.length()));
+        grid.addColumn(i -> i).setHeaderLabel("text");
+        grid.addColumn(i -> String.valueOf(i.length()))
+                .setHeaderLabel("length");
 
         add(grid);
 

--- a/flow-components-parent/flow-components-test/src/test/java/com/vaadin/flow/tests/components/MixinTest.java
+++ b/flow-components-parent/flow-components-test/src/test/java/com/vaadin/flow/tests/components/MixinTest.java
@@ -30,6 +30,7 @@ import com.vaadin.ui.common.HasSize;
 import com.vaadin.ui.common.HasStyle;
 import com.vaadin.ui.dialog.Dialog;
 import com.vaadin.ui.formlayout.FormLayout.FormItem;
+import com.vaadin.ui.grid.AbstractColumn;
 import com.vaadin.ui.grid.ColumnGroup;
 import com.vaadin.ui.grid.Grid;
 import com.vaadin.ui.grid.GridSelectionColumn;
@@ -46,15 +47,13 @@ public class MixinTest {
     private static final Set<Class<?>> REQUIRED_INTERFACES = new HashSet<>();
 
     static {
-        PACKAGE_WHITELIST.addAll(
-                Arrays.asList("com.vaadin.ui.common", "com.vaadin.ui.html",
-                        "com.vaadin.ui.polymertemplate"));
-        CLASS_WHITELIST
-                .addAll(Arrays.asList(Icon.class, FormItem.class,
-                        GridSelectionColumn.class, Dialog.class,
-                        Grid.Column.class, ColumnGroup.class));
-        REQUIRED_INTERFACES.addAll(
-                Arrays.asList(HasSize.class, HasStyle.class));
+        PACKAGE_WHITELIST.addAll(Arrays.asList("com.vaadin.ui.common",
+                "com.vaadin.ui.html", "com.vaadin.ui.polymertemplate"));
+        CLASS_WHITELIST.addAll(Arrays.asList(Icon.class, FormItem.class,
+                GridSelectionColumn.class, Dialog.class, Grid.Column.class,
+                ColumnGroup.class, AbstractColumn.class));
+        REQUIRED_INTERFACES
+                .addAll(Arrays.asList(HasSize.class, HasStyle.class));
     }
 
     @Test

--- a/flow-components-parent/flow-components-test/src/test/java/com/vaadin/flow/tests/components/grid/GridSortingTest.java
+++ b/flow-components-parent/flow-components-test/src/test/java/com/vaadin/flow/tests/components/grid/GridSortingTest.java
@@ -161,8 +161,8 @@ public class GridSortingTest {
         grid.addSortListener(testSortListener);
 
         nameColumn = grid.addColumn(Person::getName, "name")
-                .setHeaderLabel("Name");
-        ageColumn = grid.addColumn(Person::getAge, "age").setHeaderLabel("Age");
+                .setHeader("Name");
+        ageColumn = grid.addColumn(Person::getAge, "age").setHeader("Age");
 
         templateColumn = grid.addColumn(TemplateRenderer.<Person> of(
                 "<div>[[item.street]], number [[item.number]]<br><small>[[item.postalCode]]</small></div>")
@@ -170,7 +170,7 @@ public class GridSortingTest {
                         person -> person.getAddress().getStreet())
                 .withProperty("number",
                         person -> person.getAddress().getNumber()),
-                "street", "number").setHeaderLabel("Address");
+                "street", "number").setHeader("Address");
     }
 
     @Test
@@ -225,7 +225,7 @@ public class GridSortingTest {
         Column<Person> column = grid
                 .addColumn(TemplateRenderer.<Person> of("")
                         .withProperty("address", Person::getAddress), "address")
-                .setHeaderLabel("");
+                .setHeader("");
         JsonArray sortersArray = Json.createArray();
         sortersArray.set(0, createSortObject(column.getColumnId(), "asc"));
         callSortersChanged(sortersArray);

--- a/flow-components-parent/flow-components-test/src/test/java/com/vaadin/flow/tests/components/grid/GridSortingTest.java
+++ b/flow-components-parent/flow-components-test/src/test/java/com/vaadin/flow/tests/components/grid/GridSortingTest.java
@@ -160,18 +160,17 @@ public class GridSortingTest {
         grid.setItems(new ArrayList<>());
         grid.addSortListener(testSortListener);
 
-        nameColumn = grid.addColumn("Name", Person::getName, "name");
-        ageColumn = grid.addColumn("Age", Person::getAge, "age");
+        nameColumn = grid.addColumn(Person::getName, "name")
+                .setHeaderLabel("Name");
+        ageColumn = grid.addColumn(Person::getAge, "age").setHeaderLabel("Age");
 
-        templateColumn = grid.addColumn("Address",
-                TemplateRenderer
-                        .<Person> of(
-                                "<div>[[item.street]], number [[item.number]]<br><small>[[item.postalCode]]</small></div>")
-                        .withProperty("street",
-                                person -> person.getAddress().getStreet())
-                        .withProperty("number",
-                                person -> person.getAddress().getNumber()),
-                "street", "number");
+        templateColumn = grid.addColumn(TemplateRenderer.<Person> of(
+                "<div>[[item.street]], number [[item.number]]<br><small>[[item.postalCode]]</small></div>")
+                .withProperty("street",
+                        person -> person.getAddress().getStreet())
+                .withProperty("number",
+                        person -> person.getAddress().getNumber()),
+                "street", "number").setHeaderLabel("Address");
     }
 
     @Test
@@ -223,9 +222,10 @@ public class GridSortingTest {
 
     @Test
     public void template_renderer_non_comparable_property() {
-        Column<Person> column = grid.addColumn("", TemplateRenderer
-                .<Person> of("").withProperty("address", Person::getAddress),
-                "address");
+        Column<Person> column = grid
+                .addColumn(TemplateRenderer.<Person> of("")
+                        .withProperty("address", Person::getAddress), "address")
+                .setHeaderLabel("");
         JsonArray sortersArray = Json.createArray();
         sortersArray.set(0, createSortObject(column.getColumnId(), "asc"));
         callSortersChanged(sortersArray);
@@ -266,7 +266,8 @@ public class GridSortingTest {
         return json;
     }
 
-    private <T, V extends SortOrder<T>> void assertSortOrdersEquals(List<V> o1, List<V> o2) {
+    private <T, V extends SortOrder<T>> void assertSortOrdersEquals(List<V> o1,
+            List<V> o2) {
         Assert.assertEquals(o1.size(), o2.size());
         for (int i = 0; i < o1.size(); ++i) {
             Assert.assertEquals(o1.get(i).getDirection(),

--- a/flow-components-parent/flow-components-test/src/test/java/com/vaadin/flow/tests/components/grid/GridSortingTest.java
+++ b/flow-components-parent/flow-components-test/src/test/java/com/vaadin/flow/tests/components/grid/GridSortingTest.java
@@ -224,8 +224,7 @@ public class GridSortingTest {
     public void template_renderer_non_comparable_property() {
         Column<Person> column = grid
                 .addColumn(TemplateRenderer.<Person> of("")
-                        .withProperty("address", Person::getAddress), "address")
-                .setHeader("");
+                        .withProperty("address", Person::getAddress), "address");
         JsonArray sortersArray = Json.createArray();
         sortersArray.set(0, createSortObject(column.getColumnId(), "asc"));
         callSortersChanged(sortersArray);

--- a/flow-components-parent/flow-components-test/src/test/java/com/vaadin/flow/tests/components/grid/SortOrderBuildersTest.java
+++ b/flow-components-parent/flow-components-test/src/test/java/com/vaadin/flow/tests/components/grid/SortOrderBuildersTest.java
@@ -34,11 +34,11 @@ public class SortOrderBuildersTest {
     public void gridSortOrderBuilder() {
         Grid<String> grid = new Grid<>();
         Column<String> col1 = grid.addColumn(string -> string)
-                .setHeaderLabel("");
+                .setHeader("");
         Column<String> col2 = grid.addColumn(string -> string)
-                .setHeaderLabel("");
+                .setHeader("");
         Column<String> col3 = grid.addColumn(string -> string)
-                .setHeaderLabel("");
+                .setHeader("");
 
         // construct with asc
         verifySortOrders(

--- a/flow-components-parent/flow-components-test/src/test/java/com/vaadin/flow/tests/components/grid/SortOrderBuildersTest.java
+++ b/flow-components-parent/flow-components-test/src/test/java/com/vaadin/flow/tests/components/grid/SortOrderBuildersTest.java
@@ -33,12 +33,10 @@ public class SortOrderBuildersTest {
     @Test
     public void gridSortOrderBuilder() {
         Grid<String> grid = new Grid<>();
-        Column<String> col1 = grid.addColumn(string -> string)
-                .setHeader("");
-        Column<String> col2 = grid.addColumn(string -> string)
-                .setHeader("");
-        Column<String> col3 = grid.addColumn(string -> string)
-                .setHeader("");
+        Column<String> col1 = grid.addColumn(string -> string);
+        Column<String> col2 = grid.addColumn(string -> string);
+        Column<String> col3 = grid.addColumn(string -> string);
+                
 
         // construct with asc
         verifySortOrders(

--- a/flow-components-parent/flow-components-test/src/test/java/com/vaadin/flow/tests/components/grid/SortOrderBuildersTest.java
+++ b/flow-components-parent/flow-components-test/src/test/java/com/vaadin/flow/tests/components/grid/SortOrderBuildersTest.java
@@ -33,9 +33,12 @@ public class SortOrderBuildersTest {
     @Test
     public void gridSortOrderBuilder() {
         Grid<String> grid = new Grid<>();
-        Column<String> col1 = grid.addColumn("", string -> string);
-        Column<String> col2 = grid.addColumn("", string -> string);
-        Column<String> col3 = grid.addColumn("", string -> string);
+        Column<String> col1 = grid.addColumn(string -> string)
+                .setHeaderLabel("");
+        Column<String> col2 = grid.addColumn(string -> string)
+                .setHeaderLabel("");
+        Column<String> col3 = grid.addColumn(string -> string)
+                .setHeaderLabel("");
 
         // construct with asc
         verifySortOrders(

--- a/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/grid/AbstractColumn.java
+++ b/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/grid/AbstractColumn.java
@@ -48,7 +48,7 @@ public class AbstractColumn<T extends AbstractColumn<T>> extends Component
     }
 
     /**
-     * Gets the owner of this column
+     * Gets the owner of this column.
      * 
      * @return the grid which owns this column
      */
@@ -88,15 +88,19 @@ public class AbstractColumn<T extends AbstractColumn<T>> extends Component
         }
 
         headerOrFooter.setProperty("innerHTML",
-                getRendererTemplate(header, renderer));
+                header ? getHeaderRendererTemplate(renderer)
+                        : getFooterRendererTemplate(renderer));
         GridTemplateRendererUtil.setupTemplateRenderer(
                 (TemplateRenderer) renderer, headerOrFooter, getElement(),
                 getGrid().getDataGenerator(), () -> (DataKeyMapper) getGrid()
                         .getDataCommunicator().getKeyMapper());
     }
 
-    protected String getRendererTemplate(boolean header,
-            TemplateRenderer<?> renderer) {
+    protected String getHeaderRendererTemplate(TemplateRenderer<?> renderer) {
+        return renderer.getTemplate();
+    }
+
+    protected String getFooterRendererTemplate(TemplateRenderer<?> renderer) {
         return renderer.getTemplate();
     }
 

--- a/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/grid/AbstractColumn.java
+++ b/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/grid/AbstractColumn.java
@@ -18,6 +18,7 @@ package com.vaadin.ui.grid;
 import com.vaadin.data.provider.DataKeyMapper;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.ui.Component;
+import com.vaadin.ui.common.HasStyle;
 import com.vaadin.ui.renderers.ComponentRenderer;
 import com.vaadin.ui.renderers.TemplateRenderer;
 
@@ -30,7 +31,7 @@ import com.vaadin.ui.renderers.TemplateRenderer;
  *            the subclass type
  */
 public class AbstractColumn<T extends AbstractColumn<T>> extends Component
-        implements ColumnBase<T> {
+        implements ColumnBase<T>, HasStyle {
 
     protected Grid<?> grid;
     protected Element headerTemplate;

--- a/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/grid/AbstractColumn.java
+++ b/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/grid/AbstractColumn.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.ui.grid;
+
+import com.vaadin.data.provider.DataKeyMapper;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.ui.Component;
+import com.vaadin.ui.renderers.ComponentRenderer;
+import com.vaadin.ui.renderers.TemplateRenderer;
+
+/**
+ * Base class with common implementation for different types of columns used
+ * inside a {@link Grid}.
+ * 
+ * @author Vaadin Ltd.
+ * @param <T>
+ *            the subclass type
+ */
+public class AbstractColumn<T extends AbstractColumn<T>> extends Component
+        implements ColumnBase<T> {
+
+    protected Grid<?> grid;
+    protected Element headerTemplate;
+    protected Element footerTemplate;
+
+    /**
+     * Base constructor with the destination Grid.
+     * 
+     * @param grid
+     *            the grid that is the owner of this column
+     */
+    public AbstractColumn(Grid<?> grid) {
+        this.grid = grid;
+    }
+
+    /**
+     * Gets the owner of this column
+     * 
+     * @return the grid which owns this column
+     */
+    public Grid<?> getGrid() {
+        return grid;
+    }
+
+    @Override
+    public T setHeaderLabel(TemplateRenderer<?> renderer) {
+        if (headerTemplate == null) {
+            headerTemplate = new Element("template").setAttribute("class",
+                    "header");
+            getElement().appendChild(headerTemplate);
+        }
+
+        setupHeaderOrFooter(true, renderer, headerTemplate);
+        return (T) this;
+    }
+
+    @Override
+    public T setFooterLabel(TemplateRenderer<?> renderer) {
+        if (footerTemplate == null) {
+            footerTemplate = new Element("template").setAttribute("class",
+                    "footer");
+            getElement().appendChild(footerTemplate);
+        }
+
+        setupHeaderOrFooter(false, renderer, footerTemplate);
+        return (T) this;
+    }
+
+    private void setupHeaderOrFooter(boolean header,
+            TemplateRenderer<?> renderer, Element headerOrFooter) {
+        if (renderer instanceof ComponentRenderer) {
+            GridTemplateRendererUtil.setupHeaderOrFooterComponentRenderer(this,
+                    (ComponentRenderer) renderer);
+        }
+
+        headerOrFooter.setProperty("innerHTML",
+                getRendererTemplate(header, renderer));
+        GridTemplateRendererUtil.setupTemplateRenderer(
+                (TemplateRenderer) renderer, headerOrFooter, getElement(),
+                getGrid().getDataGenerator(), () -> (DataKeyMapper) getGrid()
+                        .getDataCommunicator().getKeyMapper());
+    }
+
+    protected String getRendererTemplate(boolean header,
+            TemplateRenderer<?> renderer) {
+        return renderer.getTemplate();
+    }
+
+}

--- a/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/grid/AbstractColumn.java
+++ b/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/grid/AbstractColumn.java
@@ -56,7 +56,7 @@ public class AbstractColumn<T extends AbstractColumn<T>> extends Component
     }
 
     @Override
-    public T setHeaderLabel(TemplateRenderer<?> renderer) {
+    public T setHeader(TemplateRenderer<?> renderer) {
         if (headerTemplate == null) {
             headerTemplate = new Element("template").setAttribute("class",
                     "header");
@@ -68,7 +68,7 @@ public class AbstractColumn<T extends AbstractColumn<T>> extends Component
     }
 
     @Override
-    public T setFooterLabel(TemplateRenderer<?> renderer) {
+    public T setFooter(TemplateRenderer<?> renderer) {
         if (footerTemplate == null) {
             footerTemplate = new Element("template").setAttribute("class",
                     "footer");

--- a/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/grid/ColumnBase.java
+++ b/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/grid/ColumnBase.java
@@ -16,8 +16,10 @@
 package com.vaadin.ui.grid;
 
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.util.HtmlUtils;
 import com.vaadin.ui.common.HasElement;
 import com.vaadin.ui.event.Synchronize;
+import com.vaadin.ui.renderers.TemplateRenderer;
 
 /**
  * Mixin interface for {@link Grid} columns.
@@ -27,9 +29,7 @@ import com.vaadin.ui.event.Synchronize;
  *
  * @author Vaadin Ltd.
  */
-@FunctionalInterface
-public interface ColumnBase<T extends ColumnBase<T>>
-        extends HasElement {
+public interface ColumnBase<T extends ColumnBase<T>> extends HasElement {
 
     /**
      * When set to {@code true}, the column is user-resizable. By default this
@@ -102,6 +102,50 @@ public interface ColumnBase<T extends ColumnBase<T>>
     default boolean isFrozen() {
         return getElement().getProperty("frozen", false);
     }
+
+    /**
+     * Sets a header text to the column.
+     * 
+     * @param labelText
+     *            the text to be shown at the column header
+     * @return this column, for method chaining
+     */
+    default T setHeaderLabel(String labelText) {
+        setHeaderLabel(TemplateRenderer.of(HtmlUtils.escape(labelText)));
+        return (T) this;
+    }
+
+    /**
+     * Sets a header template to the column.
+     * 
+     * @param renderer
+     *            the template renderer to be used to render the header of the
+     *            column
+     * @return this column, for method chaining
+     */
+    T setHeaderLabel(TemplateRenderer<?> renderer);
+
+    /**
+     * Sets a footer text to the column.
+     * 
+     * @param labelText
+     *            the text to be shown at the column footer
+     * @return this column, for method chaining
+     */
+    default T setFooterLabel(String labelText) {
+        setFooterLabel(TemplateRenderer.of(HtmlUtils.escape(labelText)));
+        return (T) this;
+    }
+
+    /**
+     * Sets a footer template to the column.
+     * 
+     * @param renderer
+     *            the template renderer to be used to render the footer of the
+     *            column
+     * @return this column, for method chaining
+     */
+    T setFooterLabel(TemplateRenderer<?> renderer);
 
     /**
      * Gets the underlying column element.

--- a/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/grid/ColumnBase.java
+++ b/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/grid/ColumnBase.java
@@ -110,8 +110,8 @@ public interface ColumnBase<T extends ColumnBase<T>> extends HasElement {
      *            the text to be shown at the column header
      * @return this column, for method chaining
      */
-    default T setHeaderLabel(String labelText) {
-        setHeaderLabel(TemplateRenderer.of(HtmlUtils.escape(labelText)));
+    default T setHeader(String labelText) {
+        setHeader(TemplateRenderer.of(HtmlUtils.escape(labelText)));
         return (T) this;
     }
 
@@ -123,7 +123,7 @@ public interface ColumnBase<T extends ColumnBase<T>> extends HasElement {
      *            column
      * @return this column, for method chaining
      */
-    T setHeaderLabel(TemplateRenderer<?> renderer);
+    T setHeader(TemplateRenderer<?> renderer);
 
     /**
      * Sets a footer text to the column.
@@ -132,8 +132,8 @@ public interface ColumnBase<T extends ColumnBase<T>> extends HasElement {
      *            the text to be shown at the column footer
      * @return this column, for method chaining
      */
-    default T setFooterLabel(String labelText) {
-        setFooterLabel(TemplateRenderer.of(HtmlUtils.escape(labelText)));
+    default T setFooter(String labelText) {
+        setFooter(TemplateRenderer.of(HtmlUtils.escape(labelText)));
         return (T) this;
     }
 
@@ -145,7 +145,7 @@ public interface ColumnBase<T extends ColumnBase<T>> extends HasElement {
      *            column
      * @return this column, for method chaining
      */
-    T setFooterLabel(TemplateRenderer<?> renderer);
+    T setFooter(TemplateRenderer<?> renderer);
 
     /**
      * Gets the underlying column element.

--- a/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/grid/ColumnGroup.java
+++ b/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/grid/ColumnGroup.java
@@ -27,14 +27,11 @@ import com.vaadin.ui.common.HtmlImport;
 /**
  * Server-side component for the {@code <vaadin-grid-column-group>} element.
  * 
- * @param <T>
- *            type of the underlying grid this column group is compatible with
- * 
  * @author Vaadin Ltd.
  */
 @HtmlImport("frontend://bower_components/vaadin-grid/vaadin-grid-column-group.html")
 @Tag("vaadin-grid-column-group")
-public class ColumnGroup<T> extends AbstractColumn<ColumnGroup<T>> {
+public class ColumnGroup extends AbstractColumn<ColumnGroup> {
 
     private final Collection<ColumnBase<?>> childColumns;
 

--- a/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/grid/ColumnGroup.java
+++ b/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/grid/ColumnGroup.java
@@ -26,7 +26,10 @@ import com.vaadin.ui.common.HtmlImport;
 
 /**
  * Server-side component for the {@code <vaadin-grid-column-group>} element.
- *
+ * 
+ * @param <T>
+ *            type of the underlying grid this column group is compatible with
+ * 
  * @author Vaadin Ltd.
  */
 @HtmlImport("frontend://bower_components/vaadin-grid/vaadin-grid-column-group.html")

--- a/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/grid/ColumnGroup.java
+++ b/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/grid/ColumnGroup.java
@@ -21,8 +21,6 @@ import java.util.Collection;
 import java.util.List;
 
 import com.vaadin.flow.dom.Element;
-import com.vaadin.flow.util.HtmlUtils;
-import com.vaadin.ui.Component;
 import com.vaadin.ui.Tag;
 import com.vaadin.ui.common.HtmlImport;
 
@@ -33,8 +31,7 @@ import com.vaadin.ui.common.HtmlImport;
  */
 @HtmlImport("frontend://bower_components/vaadin-grid/vaadin-grid-column-group.html")
 @Tag("vaadin-grid-column-group")
-public class ColumnGroup extends Component
-        implements ColumnBase<ColumnGroup> {
+public class ColumnGroup<T> extends AbstractColumn<ColumnGroup<T>> {
 
     private final Collection<ColumnBase<?>> childColumns;
 
@@ -42,30 +39,27 @@ public class ColumnGroup extends Component
      * Constructs a new column group with the given header and grouping the
      * given columns.
      *
-     * @param header
-     *            the header text of this column group
+     * @param grid
+     *            the owner of this column group
      * @param columns
      *            the columns to group
      */
-    public ColumnGroup(String header, ColumnBase<?>... columns) {
-        this(header, Arrays.asList(columns));
+    public ColumnGroup(Grid<?> grid, ColumnBase<?>... columns) {
+        this(grid, Arrays.asList(columns));
     }
 
     /**
      * Constructs a new column group with the given header and grouping the
      * given columns.
      *
-     * @param header
-     *            the header text of this column group
+     * @param grid
+     *            the owner of this column group
      * @param columns
      *            the columns to group
      */
-    public ColumnGroup(String header, Collection<ColumnBase<?>> columns) {
+    public ColumnGroup(Grid<?> grid, Collection<ColumnBase<?>> columns) {
+        super(grid);
         childColumns = columns;
-        Element headerTemplate = new Element("template")
-                .setAttribute("class", "header")
-                .setProperty("innerHTML", HtmlUtils.escape(header));
-        getElement().appendChild(headerTemplate);
         columns.forEach(
                 column -> getElement().appendChild(column.getElement()));
     }

--- a/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/grid/Grid.java
+++ b/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/grid/Grid.java
@@ -517,14 +517,12 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
         }
 
         @Override
-        protected String getRendererTemplate(boolean header,
+        protected String getHeaderRendererTemplate(
                 TemplateRenderer<?> renderer) {
-            String template = super.getRendererTemplate(header, renderer);
-            if (header) {
-                rawHeaderTemplate = template;
-                if (isSortable()) {
-                    template = addGridSorter(template);
-                }
+            String template = super.getHeaderRendererTemplate(renderer);
+            rawHeaderTemplate = template;
+            if (isSortable()) {
+                template = addGridSorter(template);
             }
             return template;
         }

--- a/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/grid/Grid.java
+++ b/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/grid/Grid.java
@@ -323,6 +323,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
          * @see #setWidth(String)
          *
          * @param flexGrow
+         *            the flex grow ratio
          * @return this column, for method chaining
          */
         public Column<T> setFlexGrow(int flexGrow) {
@@ -1211,8 +1212,6 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
     /**
      * Merges two or more columns into a {@link ColumnGroup}.
      *
-     * @param header
-     *            the header text of the resulting column group
      * @param firstColumn
      *            the first column to merge
      * @param secondColumn
@@ -1233,8 +1232,6 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
     /**
      * Merges two or more columns into a {@link ColumnGroup}.
      *
-     * @param header
-     *            the header text of the resulting column group
      * @param columnsToMerge
      *            the columns to merge, not {@code null} and size must be
      *            greater than 1

--- a/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/grid/Grid.java
+++ b/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/grid/Grid.java
@@ -497,7 +497,6 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
                                         : rawHeaderTemplate);
                 getElement().appendChild(headerTemplate);
             }
-
             return this;
         }
 
@@ -858,17 +857,15 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
      * sorting property does not extend Comparable, no in-memory sorting is
      * configured for it.
      *
-     * @param header
-     *            the column header name
      * @param renderer
      *            the renderer used to create the grid cell structure
      * @param sortingProperties
      *            the sorting properties to use for this column
      * @return the created column
      */
-    public Column<T> addColumn(String header, TemplateRenderer<T> renderer,
+    public Column<T> addColumn(TemplateRenderer<T> renderer,
             String... sortingProperties) {
-        Column<T> column = addColumn(header, renderer);
+        Column<T> column = addColumn(renderer);
 
         Map<String, ValueProvider<T, ?>> valueProviders = renderer
                 .getValueProviders();

--- a/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/grid/Grid.java
+++ b/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/grid/Grid.java
@@ -1216,7 +1216,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
      *            optional additional columns to merge
      * @return the column group that contains the merged columns
      */
-    public ColumnGroup<T> mergeColumns(ColumnBase<?> firstColumn,
+    public ColumnGroup mergeColumns(ColumnBase<?> firstColumn,
             ColumnBase<?> secondColumn, ColumnBase<?>... additionalColumns) {
         List<ColumnBase<?>> toMerge = new ArrayList<>();
         toMerge.add(firstColumn);
@@ -1233,8 +1233,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
      *            greater than 1
      * @return the column group that contains the merged columns
      */
-    public ColumnGroup<T> mergeColumns(
-            Collection<ColumnBase<?>> columnsToMerge) {
+    public ColumnGroup mergeColumns(Collection<ColumnBase<?>> columnsToMerge) {
         Objects.requireNonNull(columnsToMerge,
                 "Columns to merge cannot be null");
         if (columnsToMerge.size() < 2) {
@@ -1255,7 +1254,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
             parentColumns.remove(column);
         });
 
-        ColumnGroup<T> columnGroup = new ColumnGroup<>(this, columnsToMerge);
+        ColumnGroup columnGroup = new ColumnGroup(this, columnsToMerge);
 
         getElement().insertChild(insertIndex, columnGroup.getElement());
         parentColumns.add(insertIndex, columnGroup);
@@ -1356,7 +1355,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
         return getElement().getProperty("multiSort", false);
     }
 
-    private List<Column<T>> fetchChildColumns(ColumnGroup<?> columnGroup) {
+    private List<Column<T>> fetchChildColumns(ColumnGroup columnGroup) {
         List<Column<T>> ret = new ArrayList<>();
         columnGroup.getChildColumns()
                 .forEach(column -> appendChildColumns(ret, column));

--- a/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/grid/Grid.java
+++ b/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/grid/Grid.java
@@ -383,7 +383,10 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
          * column as sortable with {@link #setSortable(boolean)}.
          *
          * @param keyExtractor
-         * @return
+         *            the value provider used to extract the {@link Comparable}
+         *            sort key
+         * @return this column
+         * @see Comparator#comparing(java.util.function.Function)
          */
         public <V extends Comparable<? super V>> Column<T> setComparator(
                 ValueProvider<T, V> keyExtractor) {
@@ -507,7 +510,7 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
         /**
          * Gets the generated unique identifier of this column.
          *
-         * @return
+         * @return the unique id of the column, not <code>null</code>
          */
         public String getColumnId() {
             return columnId;
@@ -804,8 +807,6 @@ public class Grid<T> extends Component implements HasDataProvider<T>, HasStyle,
      * @see Column#setComparator(ValueProvider)
      * @see Column#setSortProperty(String...)
      *
-     * @param header
-     *            the column header name
      * @param valueProvider
      *            the value provider
      * @param sortingProperties

--- a/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/grid/GridTemplateRendererUtil.java
+++ b/flow-components-parent/flow-components/src/main/java/com/vaadin/ui/grid/GridTemplateRendererUtil.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.ui.grid;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.vaadin.data.provider.DataKeyMapper;
+import com.vaadin.flow.dom.DomEvent;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.function.SerializableConsumer;
+import com.vaadin.ui.Component;
+import com.vaadin.ui.UI;
+import com.vaadin.ui.grid.Grid.GridDataGenerator;
+import com.vaadin.ui.renderers.ComponentRenderer;
+import com.vaadin.ui.renderers.ComponentRendererUtil;
+import com.vaadin.ui.renderers.TemplateRenderer;
+import com.vaadin.util.JsonSerializer;
+
+/**
+ * Helper class with utility methods used internally by {@link Grid} to support
+ * {@link TemplateRenderer}s inside cells, headers, footers and detail rows.
+ * <p>
+ * This class is not meant to be used outside the scope of the Grid.
+ * 
+ * @author Vaadin Ltd.
+ */
+class GridTemplateRendererUtil {
+
+    /**
+     * Internal object to hold {@link ComponentRenderer}s and their generated
+     * {@link Component}s together.
+     * 
+     * @param <T>
+     *            the model item attached to the component
+     */
+    static final class RendereredComponent<T> implements Serializable {
+        private Component component;
+        private ComponentRenderer<? extends Component, T> componentRenderer;
+
+        /**
+         * Default constructor.
+         * 
+         * @param component
+         *            the generated component
+         * @param componentRenderer
+         *            the renderer that generated the component
+         */
+        public RendereredComponent(Component component,
+                ComponentRenderer<? extends Component, T> componentRenderer) {
+            this.component = component;
+            this.componentRenderer = componentRenderer;
+        }
+
+        /**
+         * Gets the current generated component.
+         * 
+         * @return the generated component by the renderer
+         */
+        public Component getComponent() {
+            return component;
+        }
+
+        /**
+         * Recreates the component by calling
+         * {@link ComponentRenderer#createComponent(Object)}, and sets the
+         * internal component returned by {@link #getComponent()}.
+         * 
+         * @param item
+         *            the model item to be attached to the component instance
+         * @return the new generated component returned by the renderer
+         */
+        public Component recreateComponent(T item) {
+            component = componentRenderer.createComponent(item);
+            return component;
+        }
+    }
+
+    private GridTemplateRendererUtil() {
+    }
+
+    static <T> void setupTemplateRenderer(TemplateRenderer<T> renderer,
+            Element contentTemplate, Element templateDataHost,
+            GridDataGenerator<T> dataGenerator,
+            Supplier<DataKeyMapper<T>> keyMapperSupplier) {
+
+        renderer.getValueProviders()
+                .forEach((key, provider) -> dataGenerator.addDataGenerator(
+                        (item, jsonObject) -> jsonObject.put(key,
+                                JsonSerializer.toJson(provider.apply(item)))));
+
+        Map<String, SerializableConsumer<T>> eventConsumers = renderer
+                .getEventHandlers();
+
+        if (!eventConsumers.isEmpty()) {
+            /*
+             * This code allows the template to use Polymer specific syntax for
+             * events, such as on-click (instead of the native onclick). The
+             * principle is: we set a new function inside the column, and the
+             * function is called by the rendered template. For that to work,
+             * the template element must have the "__dataHost" property set with
+             * the column element.
+             */
+            templateDataHost.getNode().runWhenAttached(
+                    ui -> processTemplateRendererEventConsumers(ui,
+                            templateDataHost, eventConsumers,
+                            keyMapperSupplier));
+
+            contentTemplate.getNode()
+                    .runWhenAttached(ui -> ui.getPage().executeJavaScript(
+                            "$0.__dataHost = $1;", contentTemplate,
+                            templateDataHost));
+        }
+    }
+
+    private static <T> void processTemplateRendererEventConsumers(UI ui,
+            Element colElement,
+            Map<String, SerializableConsumer<T>> eventConsumers,
+            Supplier<DataKeyMapper<T>> keyMapperSupplier) {
+        eventConsumers.forEach(
+                (handlerName, consumer) -> setupTemplateRendererEventHandler(ui,
+                        colElement, handlerName, consumer, keyMapperSupplier));
+    }
+
+    private static <T> void setupTemplateRendererEventHandler(UI ui,
+            Element eventOrigin, String handlerName, Consumer<T> consumer,
+            Supplier<DataKeyMapper<T>> keyMapperSupplier) {
+
+        // vaadin.sendEventMessage is an exported function at the client
+        // side
+        ui.getPage().executeJavaScript(String.format(
+                "$0.%s = function(e) {vaadin.sendEventMessage(%d, '%s', {key: e.model.__data.item.key})}",
+                handlerName, eventOrigin.getNode().getId(), handlerName),
+                eventOrigin);
+
+        eventOrigin.addEventListener(handlerName,
+                event -> processEventFromTemplateRenderer(event, handlerName,
+                        consumer, keyMapperSupplier));
+    }
+
+    private static <T> void processEventFromTemplateRenderer(DomEvent event,
+            String handlerName, Consumer<T> consumer,
+            Supplier<DataKeyMapper<T>> keyMapperSupplier) {
+        if (event.getEventData() != null) {
+            String itemKey = event.getEventData().getString("key");
+            T item = keyMapperSupplier.get().get(itemKey);
+
+            if (item != null) {
+                consumer.accept(item);
+            } else {
+                Logger.getLogger(GridTemplateRendererUtil.class.getName())
+                        .log(Level.INFO, () -> String.format(
+                                "Received an event for the handler '%s' with item key '%s', but the item is not present in the KeyMapper. Ignoring event.",
+                                handlerName, itemKey));
+            }
+        } else {
+            Logger.getLogger(GridTemplateRendererUtil.class.getName()).log(Level.INFO,
+                    () -> String.format(
+                            "Received an event for the handler '%s' without any data. Ignoring event.",
+                            handlerName));
+        }
+    }
+
+    static <T> void setupHeaderOrFooterComponentRenderer(Component owner,
+            ComponentRenderer<? extends Component, T> componentRenderer) {
+        Element container = ComponentRendererUtil
+                .createContainerForRenderers(owner);
+
+        componentRenderer.setTemplateAttribute("key", "0");
+        componentRenderer.setTemplateAttribute("keyname",
+                "data-flow-renderer-item-key");
+        componentRenderer.setTemplateAttribute("containerid",
+                container.getAttribute("id"));
+
+        Component renderedComponent = componentRenderer.createComponent(null);
+        GridTemplateRendererUtil.registerRenderedComponent(componentRenderer, null,
+                container, "0", renderedComponent);
+    }
+
+    static <T> void registerRenderedComponent(
+            ComponentRenderer<? extends Component, T> componentRenderer,
+            Map<String, RendereredComponent<T>> renderedComponents,
+            Element container, String key, Component component) {
+        component.getElement().setAttribute("data-flow-renderer-item-key", key);
+        container.appendChild(component.getElement());
+
+        if (renderedComponents != null) {
+            renderedComponents.put(key,
+                    new RendereredComponent<>(component, componentRenderer));
+        }
+    }
+
+}

--- a/flow-components-parent/flow-components/src/test/java/com/vaadin/ui/grid/GridColumnGroupingTest.java
+++ b/flow-components-parent/flow-components/src/test/java/com/vaadin/ui/grid/GridColumnGroupingTest.java
@@ -33,9 +33,9 @@ public class GridColumnGroupingTest {
     @Before
     public void init() {
         grid = new Grid<>();
-        firstColumn = grid.addColumn("", str -> str);
-        secondColumn = grid.addColumn("", str -> str);
-        thirdColumn = grid.addColumn("", str -> str);
+        firstColumn = grid.addColumn(str -> str);
+        secondColumn = grid.addColumn(str -> str);
+        thirdColumn = grid.addColumn(str -> str);
     }
 
     @Test
@@ -43,10 +43,12 @@ public class GridColumnGroupingTest {
         Assert.assertEquals(
                 Arrays.asList(firstColumn, secondColumn, thirdColumn),
                 grid.getParentColumns());
-        ColumnGroup merged = grid.mergeColumns("", firstColumn, thirdColumn);
+        ColumnGroup<String> merged = grid.mergeColumns(firstColumn,
+                thirdColumn);
         Assert.assertEquals(Arrays.asList(merged, secondColumn),
                 grid.getParentColumns());
-        ColumnGroup secondMerge = grid.mergeColumns("", merged, secondColumn);
+        ColumnGroup<String> secondMerge = grid.mergeColumns(merged,
+                secondColumn);
         Assert.assertEquals(Arrays.asList(secondMerge),
                 grid.getParentColumns());
         Assert.assertEquals(
@@ -56,14 +58,13 @@ public class GridColumnGroupingTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void cant_merge_columns_not_in_grid() {
-        Column<String> otherColumn = new Grid<String>().addColumn("",
-                str -> str);
-        grid.mergeColumns("", firstColumn, otherColumn);
+        Column<String> otherColumn = new Grid<String>().addColumn(str -> str);
+        grid.mergeColumns(firstColumn, otherColumn);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void cant_merge_already_merged_columns() {
-        grid.mergeColumns("", firstColumn, secondColumn);
-        grid.mergeColumns("", firstColumn, thirdColumn);
+        grid.mergeColumns(firstColumn, secondColumn);
+        grid.mergeColumns(firstColumn, thirdColumn);
     }
 }

--- a/flow-components-parent/flow-components/src/test/java/com/vaadin/ui/grid/GridColumnGroupingTest.java
+++ b/flow-components-parent/flow-components/src/test/java/com/vaadin/ui/grid/GridColumnGroupingTest.java
@@ -43,12 +43,10 @@ public class GridColumnGroupingTest {
         Assert.assertEquals(
                 Arrays.asList(firstColumn, secondColumn, thirdColumn),
                 grid.getParentColumns());
-        ColumnGroup<String> merged = grid.mergeColumns(firstColumn,
-                thirdColumn);
+        ColumnGroup merged = grid.mergeColumns(firstColumn, thirdColumn);
         Assert.assertEquals(Arrays.asList(merged, secondColumn),
                 grid.getParentColumns());
-        ColumnGroup<String> secondMerge = grid.mergeColumns(merged,
-                secondColumn);
+        ColumnGroup secondMerge = grid.mergeColumns(merged, secondColumn);
         Assert.assertEquals(Arrays.asList(secondMerge),
                 grid.getParentColumns());
         Assert.assertEquals(

--- a/flow-documentation/data-provider/tutorial-flow-data-provider.asciidoc
+++ b/flow-documentation/data-provider/tutorial-flow-data-provider.asciidoc
@@ -22,9 +22,9 @@ In the following example, a `Grid` is configured with one column from the person
 [source, java]
 ----
 Grid<Person> grid = new Grid<>();
-grid.addColumn(Person::getName).setHeaderLabel("Name");
+grid.addColumn(Person::getName).setHeader("Name");
 grid.addColumn(person -> Integer.toString(person.getYearOfBirth()))
-    .setHeaderLabel("Year of birth");
+    .setHeader("Year of birth");
 ----
 
 After we have told the component how the data should be shown, we only need to give it some data to actually show. The easiest way of doing that is to directly pass the values to show to `setItems`.
@@ -254,7 +254,7 @@ ConfigurableFilterDataProvider<Person, Void, String> wrapper =
 
 Grid<Person> grid = new Grid<>();
 grid.setDataProvider(personProvider);
-grid.addColumn(Person::getName).setHeaderLabel("Name");
+grid.addColumn(Person::getName).setHeader("Name");
 
 searchField.addValueChangeListener(event -> {
   String filter = event.getValue();
@@ -468,7 +468,7 @@ DataProvider<Person, String> allPersonsWithId = new CallbackDataProvider<>(
 
 Grid<Person> persons = new Grid<>();
 persons.setDataProvider(allPersonsWithId);
-persons.addColumn(Person::getName).setHeaderLabel("Name");
+persons.addColumn(Person::getName).setHeader("Name");
 
 Button modifyPersonButton = new Button("Modify person", clickEvent -> {
     Person personToChange = allPersonsWithId.fetch(

--- a/flow-documentation/data-provider/tutorial-flow-data-provider.asciidoc
+++ b/flow-documentation/data-provider/tutorial-flow-data-provider.asciidoc
@@ -22,9 +22,9 @@ In the following example, a `Grid` is configured with one column from the person
 [source, java]
 ----
 Grid<Person> grid = new Grid<>();
-grid.addColumn("Name", Person::getName);
-grid.addColumn("Year of birth",
-                person -> Integer.toString(person.getYearOfBirth()));
+grid.addColumn(Person::getName).setHeaderLabel("Name");
+grid.addColumn(person -> Integer.toString(person.getYearOfBirth()))
+    .setHeaderLabel("Year of birth");
 ----
 
 After we have told the component how the data should be shown, we only need to give it some data to actually show. The easiest way of doing that is to directly pass the values to show to `setItems`.
@@ -254,7 +254,7 @@ ConfigurableFilterDataProvider<Person, Void, String> wrapper =
 
 Grid<Person> grid = new Grid<>();
 grid.setDataProvider(personProvider);
-grid.addColumn("Name",Person::getName);
+grid.addColumn(Person::getName).setHeaderLabel("Name");
 
 searchField.addValueChangeListener(event -> {
   String filter = event.getValue();
@@ -468,7 +468,7 @@ DataProvider<Person, String> allPersonsWithId = new CallbackDataProvider<>(
 
 Grid<Person> persons = new Grid<>();
 persons.setDataProvider(allPersonsWithId);
-persons.addColumn("Name", Person::getName);
+persons.addColumn(Person::getName).setHeaderLabel("Name");
 
 Button modifyPersonButton = new Button("Modify person", clickEvent -> {
     Person personToChange = allPersonsWithId.fetch(

--- a/flow-documentation/flow-components/tutorial-flow-grid.asciidoc
+++ b/flow-documentation/flow-components/tutorial-flow-grid.asciidoc
@@ -41,9 +41,9 @@ List<Person> people = Arrays.asList(
 // Create a grid bound to the list
 Grid<Person> grid = new Grid<>();
 grid.setItems(people);
-grid.addColumn("Name", Person::getName);
-grid.addColumn("Year of birth",
-        person -> Integer.toString(person.getYearOfBirth()));
+grid.addColumn(Person::getName).setHeaderLabel("Name");
+grid.addColumn(person -> Integer.toString(person.getYearOfBirth()))
+    .setHeaderLabel("Year of birth");
 
 layout.add(grid);
 ----
@@ -190,7 +190,8 @@ The setter methods in `Column` have _fluent API_, so you can easily chain the co
 
 [source, java]
 ----
-Column<Person> nameColumn = grid.addColumn("Name", Person::getName)
+Column<Person> nameColumn = grid.addColumn(Person::getName)
+    .setHeaderLabel("Name")
     .setFlexGrow(0)
     .setWidth("100px")
     .setResizable(false);
@@ -241,26 +242,24 @@ you can call `addColumn()`.
 
 ////
 
-////
-NOT IMPLEMENTED YET
+[[components.grid.columns.header]]
+=== Column Header and Footer
 
-=== Column Captions
-
-Column captions are displayed in the grid header. You can set the header caption
-explicitly through the column object with `setCaption()`.
+Column labels are displayed in the grid header. You can set the header label
+explicitly through the column object with `setHeaderLabel()`.
 
 [source, java]
 ----
-Column<Date> bornColumn = grid.addColumn(Person::getBirthDate);
-bornColumn.setCaption("Born date");
+Column<Person> bornColumn = grid.addColumn(Person::getYearOfBirth);
+bornColumn.setHeaderLabel("Born date");
 ----
 
-This is equivalent to setting it with `setText()` for the header
-cell; the `HeaderCell` also allows setting the caption in HTML or as
-a component, as well as styling it, as described later in
-<<components.grid.headerfooter>>.
-////
+You can set the footer for a column in the same way:
 
+[source, java]
+----
+bornColumn.setFooterLabel("Summary");
+----
 
 [[components.grid.columns.width]]
 === Column Widths

--- a/flow-documentation/flow-components/tutorial-flow-grid.asciidoc
+++ b/flow-documentation/flow-components/tutorial-flow-grid.asciidoc
@@ -41,9 +41,9 @@ List<Person> people = Arrays.asList(
 // Create a grid bound to the list
 Grid<Person> grid = new Grid<>();
 grid.setItems(people);
-grid.addColumn(Person::getName).setHeaderLabel("Name");
+grid.addColumn(Person::getName).setHeader("Name");
 grid.addColumn(person -> Integer.toString(person.getYearOfBirth()))
-    .setHeaderLabel("Year of birth");
+    .setHeader("Year of birth");
 
 layout.add(grid);
 ----
@@ -191,7 +191,7 @@ The setter methods in `Column` have _fluent API_, so you can easily chain the co
 [source, java]
 ----
 Column<Person> nameColumn = grid.addColumn(Person::getName)
-    .setHeaderLabel("Name")
+    .setHeader("Name")
     .setFlexGrow(0)
     .setWidth("100px")
     .setResizable(false);
@@ -246,19 +246,19 @@ you can call `addColumn()`.
 === Column Header and Footer
 
 Column labels are displayed in the grid header. You can set the header label
-explicitly through the column object with `setHeaderLabel()`.
+explicitly through the column object with `setHeader()`.
 
 [source, java]
 ----
 Column<Person> bornColumn = grid.addColumn(Person::getYearOfBirth);
-bornColumn.setHeaderLabel("Born date");
+bornColumn.setHeader("Born date");
 ----
 
 You can set the footer for a column in the same way:
 
 [source, java]
 ----
-bornColumn.setFooterLabel("Summary");
+bornColumn.setFooter("Summary");
 ----
 
 [[components.grid.columns.width]]
@@ -291,9 +291,8 @@ The following example simply bolds the names of the persons.
 Grid<Person> grid = new Grid<>();
 grid.setItems(people);
 
-grid.addColumn("Name",
-        TemplateRenderer.<Person> of("<b>[[item.name]]</b>")
-                .withProperty("name", Person::getName));
+grid.addColumn(TemplateRenderer.<Person> of("<b>[[item.name]]</b>")
+                .withProperty("name", Person::getName)).setHeader("Name");
 ----
 
 As you can see, the template-string is passed for the static `TemplateRenderer.of()` method,
@@ -314,10 +313,11 @@ add a new column to display that.
 
 [source, java]
 ----
-grid.addColumn("Age",
-        TemplateRenderer.<Person> of("[[item.age]] years old")
-                .withProperty("age", person -> Year.now().getValue()
-                        - person.getYearOfBirth()));
+grid.addColumn(TemplateRenderer.<Person> of("[[item.age]] years old")
+                .withProperty("age",
+                        person -> Year.now().getValue()
+                                - person.getYearOfBirth()))
+                .setHeader("Age");
 ----
 
 === Binding Beans
@@ -331,9 +331,10 @@ properties in your template with only one `withProperty()` call, as you can see 
 
 [source, java]
 ----
-grid.addColumn("Address", TemplateRenderer.<Person> of(
+grid.addColumn(TemplateRenderer.<Person> of(
         "<div>[[item.address.street]], number [[item.address.number]]<br><small>[[item.address.postalCode]]</small></div>")
-        .withProperty("address", Person::getAddress));
+        .withProperty("address", Person::getAddress))
+        .setHeader("Address");
 ----
 
 === Handling Events
@@ -348,17 +349,17 @@ is used to map those method-names to server-side code.
 
 [source, java]
 ----
-grid.addColumn("Actions", TemplateRenderer.<Person> of(
-        "<button on-click='handleUpdate'>Update</button><button on-click='handleRemove'>Remove</button>")
-        .withEventHandler("handleUpdate", person -> {
-            person.setName(person.getName() + " Updated");
-            grid.getDataProvider().refreshItem(person);
-        }).withEventHandler("handleRemove", person -> {
-            ListDataProvider<Person> dataProvider = (ListDataProvider<Person>) grid
-                    .getDataProvider();
-            dataProvider.getItems().remove(person);
-            dataProvider.refreshAll();
-        }));
+grid.addColumn(TemplateRenderer.<Person> of(
+                "<button on-click='handleUpdate'>Update</button><button on-click='handleRemove'>Remove</button>")
+                .withEventHandler("handleUpdate", person -> {
+                    person.setName(person.getName() + " Updated");
+                    grid.getDataProvider().refreshItem(person);
+                }).withEventHandler("handleRemove", person -> {
+                    ListDataProvider<Person> dataProvider = (ListDataProvider<Person>) grid
+                            .getDataProvider();
+                    dataProvider.getItems().remove(person);
+                    dataProvider.refreshAll();
+                })).setHeader("Actions");
 ----
 
 After editing the server-side data used by the grid, you need to refresh the grid's `DataProvider` to make

--- a/flow-documentation/src/main/java/com/vaadin/flow/tutorial/component/GridBasic.java
+++ b/flow-documentation/src/main/java/com/vaadin/flow/tutorial/component/GridBasic.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.tutorial.component;
 
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
@@ -29,6 +30,7 @@ import com.vaadin.ui.grid.GridMultiSelectionModel;
 import com.vaadin.ui.grid.GridSingleSelectionModel;
 import com.vaadin.ui.html.Label;
 import com.vaadin.ui.layout.HorizontalLayout;
+import com.vaadin.ui.renderers.TemplateRenderer;
 
 @CodeFor("flow-components/tutorial-flow-grid.asciidoc")
 public class GridBasic {
@@ -129,14 +131,19 @@ public class GridBasic {
         nameColumn.setFrozen(true);
     }
     
+    public void gridHeaderAndFooter() {
+        Grid<Person> grid = new Grid<>();
+        
+        Column<Person> bornColumn = grid.addColumn(Person::getYearOfBirth);
+        bornColumn.setHeaderLabel("Born date");
+        
+        bornColumn.setFooterLabel("Summary");
+    }
+    
     /* code of commented lines
 
      grid.setColumnOrder(firstnameColumn, lastnameColumn,
                     bornColumn, birthplaceColumn,
                     diedColumn);
-     
-     Column<Date> bornColumn = grid.addColumn(Person::getBirthDate);
-     bornColumn.setCaption("Born date");
-     
      */
 }

--- a/flow-documentation/src/main/java/com/vaadin/flow/tutorial/component/GridBasic.java
+++ b/flow-documentation/src/main/java/com/vaadin/flow/tutorial/component/GridBasic.java
@@ -45,9 +45,9 @@ public class GridBasic {
         // Create a grid bound to the list
         Grid<Person> grid = new Grid<>();
         grid.setItems(people);
-        grid.addColumn("Name", Person::getName);
-        grid.addColumn("Year of birth",
-                person -> Integer.toString(person.getYearOfBirth()));
+        grid.addColumn(Person::getName).setHeaderLabel("Name");
+        grid.addColumn(person -> Integer.toString(person.getYearOfBirth()))
+                .setHeaderLabel("Year of birth");
 
         layout.add(grid);
     }
@@ -118,7 +118,8 @@ public class GridBasic {
     public void gridConfiguringColumns() {
         Grid<Person> grid = new Grid<>();
         
-        Column<Person> nameColumn = grid.addColumn("Name", Person::getName)
+        Column<Person> nameColumn = grid.addColumn(Person::getName)
+            .setHeaderLabel("Name")
             .setFlexGrow(0)
             .setWidth("100px")
             .setResizable(false);

--- a/flow-documentation/src/main/java/com/vaadin/flow/tutorial/component/GridBasic.java
+++ b/flow-documentation/src/main/java/com/vaadin/flow/tutorial/component/GridBasic.java
@@ -47,9 +47,9 @@ public class GridBasic {
         // Create a grid bound to the list
         Grid<Person> grid = new Grid<>();
         grid.setItems(people);
-        grid.addColumn(Person::getName).setHeaderLabel("Name");
+        grid.addColumn(Person::getName).setHeader("Name");
         grid.addColumn(person -> Integer.toString(person.getYearOfBirth()))
-                .setHeaderLabel("Year of birth");
+                .setHeader("Year of birth");
 
         layout.add(grid);
     }
@@ -121,7 +121,7 @@ public class GridBasic {
         Grid<Person> grid = new Grid<>();
         
         Column<Person> nameColumn = grid.addColumn(Person::getName)
-            .setHeaderLabel("Name")
+            .setHeader("Name")
             .setFlexGrow(0)
             .setWidth("100px")
             .setResizable(false);
@@ -135,9 +135,9 @@ public class GridBasic {
         Grid<Person> grid = new Grid<>();
         
         Column<Person> bornColumn = grid.addColumn(Person::getYearOfBirth);
-        bornColumn.setHeaderLabel("Born date");
+        bornColumn.setHeader("Born date");
         
-        bornColumn.setFooterLabel("Summary");
+        bornColumn.setFooter("Summary");
     }
     
     /* code of commented lines

--- a/flow-documentation/src/main/java/com/vaadin/flow/tutorial/component/GridTemplateRenderer.java
+++ b/flow-documentation/src/main/java/com/vaadin/flow/tutorial/component/GridTemplateRenderer.java
@@ -33,32 +33,33 @@ public class GridTemplateRenderer {
         Grid<Person> grid = new Grid<>();
         grid.setItems(people);
 
-        grid.addColumn("Name",
-                TemplateRenderer.<Person> of("<b>[[item.name]]</b>")
-                        .withProperty("name", Person::getName));
+        grid.addColumn(TemplateRenderer.<Person> of("<b>[[item.name]]</b>")
+                .withProperty("name", Person::getName)).setHeaderLabel("Name");
     }
 
     public void customProperties() {
         Grid<Person> grid = new Grid<>();
 
-        grid.addColumn("Age",
-                TemplateRenderer.<Person> of("[[item.age]] years old")
-                        .withProperty("age", person -> Year.now().getValue()
-                                - person.getYearOfBirth()));
+        grid.addColumn(TemplateRenderer.<Person> of("[[item.age]] years old")
+                .withProperty("age",
+                        person -> Year.now().getValue()
+                                - person.getYearOfBirth()))
+                .setHeaderLabel("Age");
     }
 
     public void bindingBeans() {
         Grid<Person> grid = new Grid<>();
 
-        grid.addColumn("Address", TemplateRenderer.<Person> of(
+        grid.addColumn(TemplateRenderer.<Person> of(
                 "<div>[[item.address.street]], number [[item.address.number]]<br><small>[[item.address.postalCode]]</small></div>")
-                .withProperty("address", Person::getAddress));
+                .withProperty("address", Person::getAddress))
+                .setHeaderLabel("Address");
     }
 
     public void handlingEvents() {
         Grid<Person> grid = new Grid<>();
 
-        grid.addColumn("Actions", TemplateRenderer.<Person> of(
+        grid.addColumn(TemplateRenderer.<Person> of(
                 "<button on-click='handleUpdate'>Update</button><button on-click='handleRemove'>Remove</button>")
                 .withEventHandler("handleUpdate", person -> {
                     person.setName(person.getName() + " Updated");
@@ -68,7 +69,7 @@ public class GridTemplateRenderer {
                             .getDataProvider();
                     dataProvider.getItems().remove(person);
                     dataProvider.refreshAll();
-                }));
+                })).setHeaderLabel("Actions");
     }
 
     public static class Person {

--- a/flow-documentation/src/main/java/com/vaadin/flow/tutorial/component/GridTemplateRenderer.java
+++ b/flow-documentation/src/main/java/com/vaadin/flow/tutorial/component/GridTemplateRenderer.java
@@ -34,7 +34,7 @@ public class GridTemplateRenderer {
         grid.setItems(people);
 
         grid.addColumn(TemplateRenderer.<Person> of("<b>[[item.name]]</b>")
-                .withProperty("name", Person::getName)).setHeaderLabel("Name");
+                .withProperty("name", Person::getName)).setHeader("Name");
     }
 
     public void customProperties() {
@@ -44,7 +44,7 @@ public class GridTemplateRenderer {
                 .withProperty("age",
                         person -> Year.now().getValue()
                                 - person.getYearOfBirth()))
-                .setHeaderLabel("Age");
+                .setHeader("Age");
     }
 
     public void bindingBeans() {
@@ -53,7 +53,7 @@ public class GridTemplateRenderer {
         grid.addColumn(TemplateRenderer.<Person> of(
                 "<div>[[item.address.street]], number [[item.address.number]]<br><small>[[item.address.postalCode]]</small></div>")
                 .withProperty("address", Person::getAddress))
-                .setHeaderLabel("Address");
+                .setHeader("Address");
     }
 
     public void handlingEvents() {
@@ -69,7 +69,7 @@ public class GridTemplateRenderer {
                             .getDataProvider();
                     dataProvider.getItems().remove(person);
                     dataProvider.refreshAll();
-                })).setHeaderLabel("Actions");
+                })).setHeader("Actions");
     }
 
     public static class Person {

--- a/flow-documentation/src/main/java/com/vaadin/flow/tutorial/dataproviders/DataProviders.java
+++ b/flow-documentation/src/main/java/com/vaadin/flow/tutorial/dataproviders/DataProviders.java
@@ -124,9 +124,9 @@ public class DataProviders {
 
     public void grid() {
         Grid<Person> grid = new Grid<>();
-        grid.addColumn(Person::getName).setHeaderLabel("Name");
+        grid.addColumn(Person::getName).setHeader("Name");
         grid.addColumn(person -> Integer.toString(person.getYearOfBirth()))
-                .setHeaderLabel("Year of birth");
+                .setHeader("Year of birth");
     }
 
     public void setItems() {
@@ -276,7 +276,7 @@ public class DataProviders {
 
         Grid<Person> grid = new Grid<>();
         grid.setDataProvider(personProvider);
-        grid.addColumn(Person::getName).setHeaderLabel("Name");
+        grid.addColumn(Person::getName).setHeader("Name");
 
         searchField.addValueChangeListener(event -> {
           String filter = event.getValue();
@@ -378,7 +378,7 @@ public class DataProviders {
 
         Grid<Person> persons = new Grid<>();
         persons.setDataProvider(allPersonsWithId);
-        persons.addColumn(Person::getName).setHeaderLabel("Name");
+        persons.addColumn(Person::getName).setHeader("Name");
 
         Button modifyPersonButton = new Button("Modify person", clickEvent -> {
             Person personToChange = allPersonsWithId.fetch(

--- a/flow-documentation/src/main/java/com/vaadin/flow/tutorial/dataproviders/DataProviders.java
+++ b/flow-documentation/src/main/java/com/vaadin/flow/tutorial/dataproviders/DataProviders.java
@@ -124,9 +124,9 @@ public class DataProviders {
 
     public void grid() {
         Grid<Person> grid = new Grid<>();
-        grid.addColumn("Name", Person::getName);
-        grid.addColumn("Year of birth",
-                person -> Integer.toString(person.getYearOfBirth()));
+        grid.addColumn(Person::getName).setHeaderLabel("Name");
+        grid.addColumn(person -> Integer.toString(person.getYearOfBirth()))
+                .setHeaderLabel("Year of birth");
     }
 
     public void setItems() {
@@ -276,7 +276,7 @@ public class DataProviders {
 
         Grid<Person> grid = new Grid<>();
         grid.setDataProvider(personProvider);
-        grid.addColumn("Name",Person::getName);
+        grid.addColumn(Person::getName).setHeaderLabel("Name");
 
         searchField.addValueChangeListener(event -> {
           String filter = event.getValue();
@@ -378,7 +378,7 @@ public class DataProviders {
 
         Grid<Person> persons = new Grid<>();
         persons.setDataProvider(allPersonsWithId);
-        persons.addColumn("Name", Person::getName);
+        persons.addColumn(Person::getName).setHeaderLabel("Name");
 
         Button modifyPersonButton = new Button("Modify person", clickEvent -> {
             Person personToChange = allPersonsWithId.fetch(

--- a/flow-server/src/main/java/com/vaadin/ui/renderers/ComponentRendererUtil.java
+++ b/flow-server/src/main/java/com/vaadin/ui/renderers/ComponentRendererUtil.java
@@ -53,6 +53,7 @@ public class ComponentRendererUtil {
     public static Element createContainerForRenderers(Component owner) {
         Element container = new Element(Tag.DIV, false);
         container.getStyle().set("display", "none");
+        container.setAttribute("hidden", true);
 
         String containerId = UUID.randomUUID().toString();
         container.setAttribute("id", containerId);


### PR DESCRIPTION
This PR also refactors the `addColumn` API to not support a String parameter for the header anymore.

ComponentRenderer specific logic was moved from Grid to make it easier to be reused in the future, and to reduce the complexity of the Grid itself.

Introduces a new super class for the Columns: AbstractColumn, with common logic for rendering templates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/2933)
<!-- Reviewable:end -->
