### PR TITLE
Port changes from Fw 8.1.x

### DIFF
--- a/flow-data/src/main/java/com/vaadin/data/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/data/Binder.java
@@ -38,14 +38,14 @@ import java.util.stream.Stream;
 import com.googlecode.gentyref.GenericTypeReflector;
 
 import com.vaadin.data.converter.StringToIntegerConverter;
-import com.vaadin.data.validator.BeanValidator;
 import com.vaadin.data.event.EventRouter;
+import com.vaadin.data.validator.BeanValidator;
 import com.vaadin.function.SerializableFunction;
 import com.vaadin.function.SerializablePredicate;
 import com.vaadin.function.ValueProvider;
 import com.vaadin.shared.Registration;
-import com.vaadin.ui.UI;
 import com.vaadin.ui.Component;
+import com.vaadin.ui.UI;
 import com.vaadin.ui.common.HasText;
 import com.vaadin.ui.common.HasValidation;
 import com.vaadin.ui.common.HasValue;
@@ -1595,6 +1595,12 @@ public class Binder<BEAN> implements Serializable {
      * level validators if a bean is currently set with
      * {@link #setBean(Object)}, and returns whether any of the validators
      * failed.
+     * <p>
+     * <b>Note:</b> Calling this method will not trigger status change events,
+     * unlike {@link #validate()} and will not modify the UI. To also update
+     * error indicators on fields, use {@code validate().isOk()}.
+     *
+     * @see #validate()
      *
      * @return whether this binder is in a valid state
      * @throws IllegalStateException
@@ -2089,7 +2095,7 @@ public class Binder<BEAN> implements Serializable {
      *
      * MyForm myForm = new MyForm();
      * ...
-     * binder.bindMemberFields(myForm);
+     * binder.bindInstanceFields(myForm);
      * </pre>
      *
      * This binds the firstName TextField to a "firstName" property in the item,

--- a/flow-data/src/main/java/com/vaadin/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/data/provider/DataCommunicator.java
@@ -210,7 +210,7 @@ public class DataCommunicator<T> {
 
         this.dataProvider = dataProvider;
 
-        keyMapper.setIdentifierGetter(dataProvider::getId);
+        getKeyMapper().setIdentifierGetter(dataProvider::getId);
 
         handleAttach();
 

--- a/flow-server/src/main/java/com/vaadin/shared/util/SharedUtil.java
+++ b/flow-server/src/main/java/com/vaadin/shared/util/SharedUtil.java
@@ -134,7 +134,7 @@ public class SharedUtil implements Serializable {
         }
 
         if (string.length() <= 1) {
-            return string.toUpperCase();
+            return string.toUpperCase(Locale.ENGLISH);
         }
 
         return string.substring(0, 1).toUpperCase(Locale.ENGLISH)

--- a/flow-server/src/test/java/com/vaadin/shared/util/SharedUtilTests.java
+++ b/flow-server/src/test/java/com/vaadin/shared/util/SharedUtilTests.java
@@ -133,6 +133,7 @@ public class SharedUtilTests {
         try {
             Locale.setDefault(new Locale("tr", "TR"));
             Assert.assertEquals("Integer", SharedUtil.capitalize("integer"));
+            Assert.assertEquals("I", SharedUtil.capitalize("i"));
         } finally {
             Locale.setDefault(defaultLocale);
         }


### PR DESCRIPTION
Port the following minor changes:
* Use getter instead of field for keyMapper
  https://github.com/vaadin/framework/pull/9831
* Fix capitalization of single character strings
  https://github.com/vaadin/framework/pull/9880
* Fix Binder bindInstanceFields code example in JavaDoc
  https://github.com/vaadin/framework/pull/9929
* Update Binder isValid() javadoc
  https://github.com/vaadin/framework/pull/9930

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/2982)
<!-- Reviewable:end -->
