### PR TITLE
Serialize URL parameters without component instance

### DIFF
--- a/flow-server/src/main/java/com/vaadin/router/Router.java
+++ b/flow-server/src/main/java/com/vaadin/router/Router.java
@@ -17,6 +17,7 @@ package com.vaadin.router;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -31,7 +32,6 @@ import com.vaadin.server.VaadinService;
 import com.vaadin.server.startup.RouteRegistry;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.UI;
-import com.vaadin.util.ReflectTools;
 
 /**
  * The router takes care of serving content when the user navigates within a
@@ -42,6 +42,12 @@ import com.vaadin.util.ReflectTools;
  * @see Route
  */
 public class Router implements RouterInterface {
+
+    /* See https://github.com/vaadin/flow/issues/2869 */
+    private static <T> List<String> serializeUrlParameters(List<T> urlParameters) {
+        return urlParameters.stream().filter(Objects::nonNull).map(T::toString)
+                .collect(Collectors.toList());
+    }
 
     private RouteResolver routeResolver;
 
@@ -269,9 +275,7 @@ public class Router implements RouterInterface {
         String routeString = getUrlForTarget(
                 (Class<? extends Component>) navigationTarget);
 
-        List<String> serializedParameters = ReflectTools
-                .createInstance(navigationTarget)
-                .serializeUrlParameters(parameters);
+        List<String> serializedParameters = serializeUrlParameters(parameters);
         if (!parameters.isEmpty()) {
             routeString = routeString.replace(
                     "{" + parameters.get(0).getClass().getSimpleName() + "}",

--- a/flow-server/src/main/java/com/vaadin/router/RouterLink.java
+++ b/flow-server/src/main/java/com/vaadin/router/RouterLink.java
@@ -151,8 +151,8 @@ public class RouterLink extends Component
      * @param <T>
      *            url parameter type
      */
-    public <T> RouterLink(String text,
-            Class<? extends HasUrlParameter<T>> navigationTarget, T parameter) {
+    public <T, C extends Component & HasUrlParameter<T>> RouterLink(String text,
+            Class<? extends C> navigationTarget, T parameter) {
         this();
         setText(text);
         setRoute((com.vaadin.router.Router) getRouter(), navigationTarget,
@@ -192,8 +192,9 @@ public class RouterLink extends Component
      * @param <T>
      *            url parameter type
      */
-    public <T> RouterLink(com.vaadin.router.Router router, String text,
-            Class<? extends HasUrlParameter<T>> navigationTarget, T parameter) {
+    public <T, C extends Component & HasUrlParameter<T>> RouterLink(
+            com.vaadin.router.Router router, String text,
+            Class<? extends C> navigationTarget, T parameter) {
         this();
         setText(text);
         setRoute(router, navigationTarget, parameter);
@@ -226,8 +227,9 @@ public class RouterLink extends Component
      * @param <T>
      *            url parameter type
      */
-    public <T> void setRoute(com.vaadin.router.Router router,
-            Class<? extends HasUrlParameter<T>> navigationTarget, T parameter) {
+    public <T, C extends Component & HasUrlParameter<T>> void setRoute(
+            com.vaadin.router.Router router,
+            Class<? extends C> navigationTarget, T parameter) {
         validateRouteParameters(router, navigationTarget);
         String url = router.getUrl(navigationTarget, parameter);
         HREF.set(this, url);
@@ -363,9 +365,9 @@ public class RouterLink extends Component
             @Override
             public void acceptPlaceholder(String placeholderName) {
                 if (!parametersIterator.hasNext()) {
-                    throw new IllegalArgumentException(
-                            route + " has more placeholders than the number of given parameters: "
-                                    + Arrays.toString(parameters));
+                    throw new IllegalArgumentException(route
+                            + " has more placeholders than the number of given parameters: "
+                            + Arrays.toString(parameters));
                 }
                 urlSegments.add(parametersIterator.next());
             }
@@ -386,9 +388,9 @@ public class RouterLink extends Component
         });
 
         if (parametersIterator.hasNext()) {
-            throw new IllegalArgumentException(
-                    route + " has fewer placeholders than the number of given parameters: "
-                            + Arrays.toString(parameters));
+            throw new IllegalArgumentException(route
+                    + " has fewer placeholders than the number of given parameters: "
+                    + Arrays.toString(parameters));
         }
 
         return new Location(urlSegments).getPath();


### PR DESCRIPTION
Fixes #2869 avoiding component construction via reflection to get URL parameters, porting `HasUrlParameter::serializeUrlParameters` as a static method in the router itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/2992)
<!-- Reviewable:end -->
