### PR TITLE
Add Query::getSortingComparator to sort only if necessary

### DIFF
--- a/flow-data/src/main/java/com/vaadin/data/provider/Query.java
+++ b/flow-data/src/main/java/com/vaadin/data/provider/Query.java
@@ -151,4 +151,19 @@ public class Query<T, F> implements Serializable {
     public Comparator<T> getInMemorySorting() {
         return inMemorySorting;
     }
+
+    /**
+     * Gets the optional comparator for sorting data. The comparator is only
+     * used when fetching items, but not when counting the number of available
+     * items.
+     * <p>
+     * <strong>Note: </strong> Sort orders and comparator sorting are mutually
+     * exclusive. If the {@link DataProvider} handles one, it should ignore the
+     * other.
+     *
+     * @return optional sorting comparator
+     */
+    public Optional<Comparator<T>> getSortingComparator() {
+        return Optional.ofNullable(inMemorySorting);
+    }
 }


### PR DESCRIPTION
A first step on having a method on `Query` to return an optional `Comparator` without inferring in-memory computations. This also conforms to `getFilter`, returning an optional value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3015)
<!-- Reviewable:end -->
