### PR TITLE
Fix documentation note about frozen column reordering

### DIFF
--- a/flow-documentation/flow-components/tutorial-flow-grid.asciidoc
+++ b/flow-documentation/flow-components/tutorial-flow-grid.asciidoc
@@ -274,7 +274,7 @@ When `setResizable()` is enabled the user can resize a column by dragging its se
 === Frozen Columns
 
 You can set columns to be frozen with the `setFrozen()` method in `Column`, so that they are not scrolled off when scrolling horizontally.
-Additionally, user reordering of frozen columns is disabled.
+Additionally, user reordering of frozen columns is limited between other frozen columns.
 
 [source, java]
 ----


### PR DESCRIPTION
Frozen columns can be reordered, just not with non-frozen columns (i.e. columns can’t freeze/un-freeze as a result of reordering).

You can try the behavior here: https://cdn.vaadin.com/vaadin-valo-theme/2.0.0-alpha4/demo/grids.html#column-grouping-column-resizing-frozen-columns-and-footers (you can reorder the selection and index columns).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3027)
<!-- Reviewable:end -->