### PR TITLE
Remove getTestPath

### DIFF
--- a/flow-components-parent/flow-component-demo-helpers/src/main/java/com/vaadin/flow/demo/ComponentDemoTest.java
+++ b/flow-components-parent/flow-component-demo-helpers/src/main/java/com/vaadin/flow/demo/ComponentDemoTest.java
@@ -33,11 +33,6 @@ public abstract class ComponentDemoTest extends ChromeBrowserTest {
         return 9998;
     }
 
-    @Override
-    protected String getTestPath() {
-        return ("/");
-    }
-
     /**
      * Method run before each test.
      */


### PR DESCRIPTION
As every component has its own router title, this method is not in use any more

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3060)
<!-- Reviewable:end -->
