### PR TITLE
Client side in memory virtual children elements

### DIFF
--- a/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtBasicElementBinderTest.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtBasicElementBinderTest.java
@@ -262,6 +262,29 @@ public class GwtBasicElementBinderTest extends GwtPropertyElementBinderTest {
         assertEquals("child", childElement.getId());
     }
 
+    public void testVirtualChild() {
+        Binder.bind(node, element);
+
+        StateNode childNode = createChildNode("child");
+
+        NodeMap elementData = childNode.getMap(NodeFeatures.ELEMENT_DATA);
+        JsonObject object = Json.createObject();
+        object.put(NodeProperties.TYPE, NodeProperties.IN_MEMORY_CHILD);
+        elementData.getProperty(NodeProperties.PAYLOAD).setValue(object);
+
+        NodeList virtialChildren = node
+                .getList(NodeFeatures.NEW_VIRTUAL_CHILDREN);
+        virtialChildren.add(0, childNode);
+
+        Reactive.flush();
+
+        assertEquals(element.getChildElementCount(), 0);
+
+        Element childElement = (Element) childNode.getDomNode();
+        assertEquals("SPAN", childElement.getTagName());
+        assertEquals("child", childElement.getId());
+    }
+
     public void testInsertChild() {
         Binder.bind(node, element);
 

--- a/flow-server/src/main/java/com/vaadin/flow/dom/ElementStateProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/ElementStateProvider.java
@@ -368,7 +368,7 @@ public interface ElementStateProvider extends Serializable {
 
     /**
      * Adds a property change listener.
-     * 
+     *
      * @param node
      *            the node containing the property
      * @param name
@@ -382,7 +382,7 @@ public interface ElementStateProvider extends Serializable {
 
     /**
      * Gets shadow root for the {@code node} if it has been attached.
-     * 
+     *
      * @param node
      *            the node having a shadow root, not {@code null}
      * @return the shadow root of the {@code node}, may be null
@@ -391,7 +391,7 @@ public interface ElementStateProvider extends Serializable {
 
     /**
      * Attaches the shadow root for the {@code node}.
-     * 
+     *
      * @param node
      *            the node to attach the shadow root
      * @return the shadow root of the {@code node}
@@ -405,7 +405,7 @@ public interface ElementStateProvider extends Serializable {
      * The {@code previousSibling} parameter value can be {@code null} which
      * means that the very first child with the given {@code tagName} will be
      * used to attach (if any).
-     * 
+     *
      * @param node
      *            the parent node
      * @param tagName
@@ -418,5 +418,15 @@ public interface ElementStateProvider extends Serializable {
      */
     void attachExistingElement(StateNode node, String tagName,
             Element previousSibling, ChildElementConsumer callback);
+
+    /**
+     * Append the given element as a virtual child.
+     *
+     * @param node
+     *            the node containing the data
+     * @param child
+     *            the child element to add
+     */
+    void appendVirtualChild(StateNode node, Element child);
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/ElementStateProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/ElementStateProvider.java
@@ -426,7 +426,12 @@ public interface ElementStateProvider extends Serializable {
      *            the node containing the data
      * @param child
      *            the child element to add
+     * @param type
+     *            the type of additional payload data
+     * @param payload
+     *            the additional payload data
      */
-    void appendVirtualChild(StateNode node, Element child);
+    void appendVirtualChild(StateNode node, Element child, String type,
+            String payload);
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Node.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Node.java
@@ -21,6 +21,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.StateNode;
+import com.vaadin.flow.nodefeature.NodeProperties;
 
 /**
  * A class representing a node in the DOM.
@@ -139,27 +140,33 @@ public abstract class Node<N extends Node<N>> implements Serializable {
         return getSelf();
     }
 
-    public N appendVirtualChild(Element... children) {
-        if (children == null) {
+    /**
+     * Appends the given child as the virtual child of the element.
+     * <p>
+     * The virtual child is not really a child of the DOM element. The
+     * client-side counterpart is created in the memory but it's not attached to
+     * the DOM tree. The resulting element can be retrieved via calling
+     * client-side JS function providing the node id as an argument (the result
+     * of <code>getNode().getId()</code> on the child element).
+     *
+     * @param child
+     *            the element to add
+     * @return this element
+     */
+    public N appendVirtualChild(Element child) {
+        if (child == null) {
             throw new IllegalArgumentException(
-                    THE_CHILDREN_ARRAY_CANNOT_BE_NULL);
+                    "Element to insert must not be null");
         }
-
-        for (int i = 0; i < children.length; i++) {
-            Element child = children[i];
-            if (child == null) {
-                throw new IllegalArgumentException(
-                        "Element to insert must not be null");
-            }
-            Node<?> parentNode = child.getParentNode();
-            if (parentNode != null) {
-                throw new IllegalArgumentException(
-                        "Element to insert already has a parent and can't "
-                                + "be added as a virtual child");
-            }
-            getStateProvider().appendVirtualChild(node, child);
-            ensureChildHasParent(child, true);
+        Node<?> parentNode = child.getParentNode();
+        if (parentNode != null) {
+            throw new IllegalArgumentException(
+                    "Element to insert already has a parent and can't "
+                            + "be added as a virtual child");
         }
+        getStateProvider().appendVirtualChild(getNode(), child,
+                NodeProperties.IN_MEMORY_CHILD, null);
+        ensureChildHasParent(child, true);
 
         return getSelf();
     }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Node.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Node.java
@@ -141,31 +141,39 @@ public abstract class Node<N extends Node<N>> implements Serializable {
     }
 
     /**
-     * Appends the given child as the virtual child of the element.
+     * Appends the given children as the virtual children of the element.
      * <p>
      * The virtual child is not really a child of the DOM element. The
      * client-side counterpart is created in the memory but it's not attached to
      * the DOM tree. The resulting element is referenced via the server side
      * {@link Element} in JS function call as usual.
      *
-     * @param child
-     *            the element to add
+     * @param children
+     *            the element(s) to add
      * @return this element
      */
-    public N appendVirtualChild(Element child) {
-        if (child == null) {
+    public N appendVirtualChild(Element... children) {
+        if (children == null) {
             throw new IllegalArgumentException(
-                    "Element to insert must not be null");
+                    THE_CHILDREN_ARRAY_CANNOT_BE_NULL);
         }
-        Node<?> parentNode = child.getParentNode();
-        if (parentNode != null) {
-            throw new IllegalArgumentException(
-                    "Element to insert already has a parent and can't "
-                            + "be added as a virtual child");
+
+        for (int i = 0; i < children.length; i++) {
+            Element child = children[i];
+            if (child == null) {
+                throw new IllegalArgumentException(
+                        "Element to insert must not be null");
+            }
+            Node<?> parentNode = child.getParentNode();
+            if (parentNode != null) {
+                throw new IllegalArgumentException(
+                        "Element to insert already has a parent and can't "
+                                + "be added as a virtual child");
+            }
+            getStateProvider().appendVirtualChild(getNode(), child,
+                    NodeProperties.IN_MEMORY_CHILD, null);
+            ensureChildHasParent(child, true);
         }
-        getStateProvider().appendVirtualChild(getNode(), child,
-                NodeProperties.IN_MEMORY_CHILD, null);
-        ensureChildHasParent(child, true);
 
         return getSelf();
     }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Node.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Node.java
@@ -145,9 +145,8 @@ public abstract class Node<N extends Node<N>> implements Serializable {
      * <p>
      * The virtual child is not really a child of the DOM element. The
      * client-side counterpart is created in the memory but it's not attached to
-     * the DOM tree. The resulting element can be retrieved via calling
-     * client-side JS function providing the node id as an argument (the result
-     * of <code>getNode().getId()</code> on the child element).
+     * the DOM tree. The resulting element is referenced via the server side
+     * {@link Element} in JS function call as usual.
      *
      * @param child
      *            the element to add

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Node.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Node.java
@@ -26,7 +26,7 @@ import com.vaadin.flow.StateNode;
  * A class representing a node in the DOM.
  * <p>
  * Contains methods for updating and querying hierarchical structure.
- * 
+ *
  * @author Vaadin Ltd
  *
  * @param <N>
@@ -88,7 +88,7 @@ public abstract class Node<N extends Node<N>> implements Serializable {
 
     /**
      * Gets the number of child elements.
-     * 
+     *
      * @return the number of child elements
      */
     public int getChildCount() {
@@ -97,7 +97,7 @@ public abstract class Node<N extends Node<N>> implements Serializable {
 
     /**
      * Returns the child element at the given position.
-     * 
+     *
      * @param index
      *            the index of the child element to return
      * @return the child element
@@ -135,6 +135,31 @@ public abstract class Node<N extends Node<N>> implements Serializable {
         }
 
         insertChild(getChildCount(), children);
+
+        return getSelf();
+    }
+
+    public N appendVirtualChild(Element... children) {
+        if (children == null) {
+            throw new IllegalArgumentException(
+                    THE_CHILDREN_ARRAY_CANNOT_BE_NULL);
+        }
+
+        for (int i = 0; i < children.length; i++) {
+            Element child = children[i];
+            if (child == null) {
+                throw new IllegalArgumentException(
+                        "Element to insert must not be null");
+            }
+            Node<?> parentNode = child.getParentNode();
+            if (parentNode != null) {
+                throw new IllegalArgumentException(
+                        "Element to insert already has a parent and can't "
+                                + "be added as a virtual child");
+            }
+            getStateProvider().appendVirtualChild(node, child);
+            ensureChildHasParent(child, true);
+        }
 
         return getSelf();
     }
@@ -297,7 +322,7 @@ public abstract class Node<N extends Node<N>> implements Serializable {
 
     /**
      * Gets the parent node.
-     * 
+     *
      * @return the parent node or null if this element does not have a parent
      */
     @SuppressWarnings("rawtypes")
@@ -307,7 +332,7 @@ public abstract class Node<N extends Node<N>> implements Serializable {
 
     /**
      * Gets the narrow typed reference to this object.
-     * 
+     *
      * @return this object casted to its type
      */
     protected abstract N getSelf();
@@ -341,7 +366,7 @@ public abstract class Node<N extends Node<N>> implements Serializable {
      * <p>
      * Default implementation doesn't do anything. Subclasses may override the
      * method to implement their own behavior.
-     * 
+     *
      * @param child
      *            the element to check for its parent
      * @param internalCheck
@@ -377,7 +402,7 @@ public abstract class Node<N extends Node<N>> implements Serializable {
      * doesn't exist.
      * <p>
      * This API is experimental and disabled for public usage.
-     * 
+     *
      * @param tagName
      *            the tag name of the element to attach, not {@code null}
      * @param previousSibling

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/AbstractNodeStateProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/AbstractNodeStateProvider.java
@@ -23,13 +23,14 @@ import com.vaadin.flow.dom.Node;
 import com.vaadin.flow.dom.ShadowRoot;
 import com.vaadin.flow.nodefeature.AttachExistingElementFeature;
 import com.vaadin.flow.nodefeature.ElementChildrenList;
+import com.vaadin.flow.nodefeature.NewVirtualChildrenList;
 import com.vaadin.flow.nodefeature.NodeFeature;
 import com.vaadin.flow.nodefeature.ShadowRootHost;
 
 /**
  * Abstract implementation of the {@link ElementStateProvider} related to the
  * composition essence of the provider.
- * 
+ *
  * @author Vaadin Ltd
  *
  */
@@ -49,7 +50,7 @@ public abstract class AbstractNodeStateProvider
 
     /**
      * Returns the features supported by the provider.
-     * 
+     *
      * @return features supported by the provider
      */
     protected abstract Class<? extends NodeFeature>[] getProviderFeatures();
@@ -143,10 +144,21 @@ public abstract class AbstractNodeStateProvider
         });
     }
 
+    @Override
+    public void appendVirtualChild(StateNode node, Element child, String type,
+            String payload) {
+        if (node.hasFeature(NewVirtualChildrenList.class)) {
+            node.getFeature(NewVirtualChildrenList.class)
+                    .append(child.getNode(), type, payload);
+        } else {
+            throw new UnsupportedOperationException();
+        }
+    }
+
     /**
      * Gets the flyweight instance for the {@code node} supported by the
      * provider.
-     * 
+     *
      * @see #supports(StateNode)
      * @param node
      *            the node to wrap into flyweight

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/AbstractTextElementStateProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/AbstractTextElementStateProvider.java
@@ -184,4 +184,9 @@ public abstract class AbstractTextElementStateProvider
             Element previousSibling, ChildElementConsumer callback) {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public void appendVirtualChild(StateNode node, Element child) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/AbstractTextElementStateProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/AbstractTextElementStateProvider.java
@@ -186,7 +186,8 @@ public abstract class AbstractTextElementStateProvider
     }
 
     @Override
-    public void appendVirtualChild(StateNode node, Element child) {
+    public void appendVirtualChild(StateNode node, Element child, String type,
+            String payload) {
         throw new UnsupportedOperationException();
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/BasicElementStateProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/BasicElementStateProvider.java
@@ -42,6 +42,7 @@ import com.vaadin.flow.nodefeature.ElementData;
 import com.vaadin.flow.nodefeature.ElementListenerMap;
 import com.vaadin.flow.nodefeature.ElementPropertyMap;
 import com.vaadin.flow.nodefeature.ElementStylePropertyMap;
+import com.vaadin.flow.nodefeature.NewVirtualChildrenList;
 import com.vaadin.flow.nodefeature.NodeFeature;
 import com.vaadin.flow.nodefeature.ParentGeneratorHolder;
 import com.vaadin.flow.nodefeature.PolymerEventListenerMap;
@@ -80,7 +81,7 @@ public class BasicElementStateProvider extends AbstractNodeStateProvider {
             ParentGeneratorHolder.class, PolymerServerEventHandlers.class,
             ClientDelegateHandlers.class, PolymerEventListenerMap.class,
             ShadowRootData.class, AttachExistingElementFeature.class,
-            AttachTemplateChildFeature.class };
+            AttachTemplateChildFeature.class, NewVirtualChildrenList.class };
 
     private BasicElementStateProvider() {
         // Not meant to be sub classed and only once instance should ever exist
@@ -337,12 +338,6 @@ public class BasicElementStateProvider extends AbstractNodeStateProvider {
     public StateNode attachShadow(StateNode node) {
         assert getShadowRoot(node) == null;
         return ShadowRootStateProvider.get().createShadowRootNode(node);
-    }
-
-    @Override
-    public void appendVirtualChild(StateNode node, Element child) {
-        // TODO Auto-generated method stub
-
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/BasicElementStateProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/BasicElementStateProvider.java
@@ -329,11 +329,6 @@ public class BasicElementStateProvider extends AbstractNodeStateProvider {
     }
 
     @Override
-    protected Class<? extends NodeFeature>[] getProviderFeatures() {
-        return features;
-    }
-
-    @Override
     public StateNode getShadowRoot(StateNode node) {
         return node.getFeature(ShadowRootData.class).getShadowRoot();
     }
@@ -345,8 +340,19 @@ public class BasicElementStateProvider extends AbstractNodeStateProvider {
     }
 
     @Override
+    public void appendVirtualChild(StateNode node, Element child) {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
     protected Node<?> getNode(StateNode node) {
         assert supports(node);
         return Element.get(node);
+    }
+
+    @Override
+    protected Class<? extends NodeFeature>[] getProviderFeatures() {
+        return features;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/BasicTextElementStateProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/BasicTextElementStateProvider.java
@@ -85,7 +85,7 @@ public class BasicTextElementStateProvider
     }
 
     @Override
-    public Node getParent(StateNode node) {
+    public Node<?> getParent(StateNode node) {
         return BasicElementStateProvider.get().getParent(node);
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/ShadowRootStateProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/ShadowRootStateProvider.java
@@ -28,6 +28,7 @@ import com.vaadin.flow.dom.ShadowRoot;
 import com.vaadin.flow.dom.Style;
 import com.vaadin.flow.nodefeature.AttachExistingElementFeature;
 import com.vaadin.flow.nodefeature.ElementChildrenList;
+import com.vaadin.flow.nodefeature.NewVirtualChildrenList;
 import com.vaadin.flow.nodefeature.NodeFeature;
 import com.vaadin.flow.nodefeature.ShadowRootData;
 import com.vaadin.flow.nodefeature.ShadowRootHost;
@@ -55,7 +56,8 @@ public class ShadowRootStateProvider extends AbstractNodeStateProvider {
     @SuppressWarnings("unchecked")
     private static final Class<? extends NodeFeature>[] FEATURES = new Class[] {
             ElementChildrenList.class, ShadowRootHost.class,
-            AttachExistingElementFeature.class, VirtualChildrenList.class };
+            AttachExistingElementFeature.class, VirtualChildrenList.class,
+            NewVirtualChildrenList.class };
 
     /**
      * Gets the one and only instance.
@@ -221,9 +223,4 @@ public class ShadowRootStateProvider extends AbstractNodeStateProvider {
         node.getFeature(VirtualChildrenList.class).append(child.getNode());
     }
 
-    @Override
-    public void appendVirtualChild(StateNode node, Element child) {
-        // TODO Auto-generated method stub
-
-    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/ShadowRootStateProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/ShadowRootStateProvider.java
@@ -44,7 +44,7 @@ import com.vaadin.ui.event.PropertyChangeListener;
  * <p>
  * The data is stored directly in the state node but this should be considered
  * an implementation detail which can change.
- * 
+ *
  * @author Vaadin Ltd
  *
  */
@@ -68,7 +68,7 @@ public class ShadowRootStateProvider extends AbstractNodeStateProvider {
 
     /**
      * Create a new shadow root node for the given element {@code node}.
-     * 
+     *
      * @param node
      *            the node to create the shadow root for
      * @return the shadow root node
@@ -211,7 +211,7 @@ public class ShadowRootStateProvider extends AbstractNodeStateProvider {
 
     /**
      * Insert the given virtual child at the given position.
-     * 
+     *
      * @param node
      *            node containing data
      * @param child
@@ -219,5 +219,11 @@ public class ShadowRootStateProvider extends AbstractNodeStateProvider {
      */
     public void insertVirtualChild(StateNode node, Element child) {
         node.getFeature(VirtualChildrenList.class).append(child.getNode());
+    }
+
+    @Override
+    public void appendVirtualChild(StateNode node, Element child) {
+        // TODO Auto-generated method stub
+
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/TemplateElementStateProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/TemplateElementStateProvider.java
@@ -573,4 +573,9 @@ public class TemplateElementStateProvider implements ElementStateProvider {
             Element previousSibling, ChildElementConsumer callback) {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public void appendVirtualChild(StateNode node, Element child) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/TemplateElementStateProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/TemplateElementStateProvider.java
@@ -575,7 +575,8 @@ public class TemplateElementStateProvider implements ElementStateProvider {
     }
 
     @Override
-    public void appendVirtualChild(StateNode node, Element child) {
+    public void appendVirtualChild(StateNode node, Element child, String type,
+            String payload) {
         throw new UnsupportedOperationException();
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/nodefeature/ElementData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/nodefeature/ElementData.java
@@ -61,7 +61,7 @@ public class ElementData extends NodeValue<Serializable[]> {
     public void setTag(String tag) {
         Serializable[] value = new Serializable[2];
         value[0] = tag;
-        value[1] = getPyload();
+        value[1] = getPayload();
         setValue(value);
     }
 
@@ -91,7 +91,7 @@ public class ElementData extends NodeValue<Serializable[]> {
      * Gets the payload data of the element.
      *
      */
-    public JsonValue getPyload() {
+    public JsonValue getPayload() {
         Serializable[] value = getValue();
         return value == null ? null : (JsonValue) value[1];
     }
@@ -115,9 +115,9 @@ public class ElementData extends NodeValue<Serializable[]> {
             if (!Objects.equals(previousValue[0], getTag())) {
                 collector.accept(new MapPutChange(this, getKey(), getTag()));
             }
-            if (!Objects.equals(previousValue[1], getPyload())) {
+            if (!Objects.equals(previousValue[1], getPayload())) {
                 collector.accept(new MapPutChange(this, NodeProperties.PAYLOAD,
-                        getPyload()));
+                        getPayload()));
             }
         } else if (change instanceof EmptyChange) {
             collector.accept(change);

--- a/flow-server/src/main/java/com/vaadin/flow/nodefeature/ElementData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/nodefeature/ElementData.java
@@ -16,14 +16,25 @@
 
 package com.vaadin.flow.nodefeature;
 
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+
 import com.vaadin.flow.StateNode;
+import com.vaadin.flow.change.EmptyChange;
+import com.vaadin.flow.change.MapPutChange;
+import com.vaadin.flow.change.NodeChange;
+
+import elemental.json.JsonValue;
 
 /**
  * Map of basic element information.
  *
  * @author Vaadin Ltd
  */
-public class ElementData extends NodeValue<String> {
+public class ElementData extends NodeValue<Serializable[]> {
 
     /**
      * Creates a new element data map for the given node.
@@ -48,7 +59,10 @@ public class ElementData extends NodeValue<String> {
      *            the tag name
      */
     public void setTag(String tag) {
-        setValue(tag);
+        Serializable[] value = new Serializable[2];
+        value[0] = tag;
+        value[1] = getPyload();
+        setValue(value);
     }
 
     /**
@@ -57,7 +71,56 @@ public class ElementData extends NodeValue<String> {
      * @return the tag name
      */
     public String getTag() {
-        return getValue();
+        return getValue() == null ? null : (String) getValue()[0];
     }
 
+    /**
+     * Sets the payload data of the element.
+     *
+     * @param payload
+     *            the payload data
+     */
+    public void setPyload(JsonValue payload) {
+        Serializable[] value = new Serializable[2];
+        value[0] = getTag();
+        value[1] = payload;
+        setValue(value);
+    }
+
+    /**
+     * Gets the payload data of the element.
+     *
+     */
+    public JsonValue getPyload() {
+        Serializable[] value = getValue();
+        return value == null ? null : (JsonValue) value[1];
+    }
+
+    @Override
+    public void collectChanges(Consumer<NodeChange> collector) {
+        List<NodeChange> changes = new ArrayList<>(1);
+        super.collectChanges(changes::add);
+
+        Serializable[] previousValue;
+        Serializable tracker = getNode().getChangeTracker(this, () -> null);
+
+        if (tracker instanceof Serializable[]) {
+            previousValue = (Serializable[]) tracker;
+        } else {
+            previousValue = new Serializable[2];
+        }
+
+        NodeChange change = changes.get(0);
+        if (change instanceof MapPutChange) {
+            if (!Objects.equals(previousValue[0], getTag())) {
+                collector.accept(new MapPutChange(this, getKey(), getTag()));
+            }
+            if (!Objects.equals(previousValue[1], getPyload())) {
+                collector.accept(new MapPutChange(this, NodeProperties.PAYLOAD,
+                        getPyload()));
+            }
+        } else if (change instanceof EmptyChange) {
+            collector.accept(change);
+        }
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/nodefeature/NewVirtualChildrenList.java
+++ b/flow-server/src/main/java/com/vaadin/flow/nodefeature/NewVirtualChildrenList.java
@@ -42,6 +42,20 @@ public class NewVirtualChildrenList extends StateNodeNodeList {
         super(node);
     }
 
+    /**
+     * Inserts an item supplied with payload data at the given index of the
+     * list.
+     *
+     *
+     * @param index
+     *            index to insert at
+     * @param node
+     *            the item to append
+     * @param type
+     *            the payload type
+     * @param payload
+     *            the payload data
+     */
     public void add(int index, StateNode node, String type, String payload) {
         assert node != null;
 
@@ -55,12 +69,23 @@ public class NewVirtualChildrenList extends StateNodeNodeList {
         super.add(index, node);
     }
 
+    /**
+     * Inserts an item supplied with payload type at the given index of the
+     * list.
+     *
+     * @param index
+     *            index to insert at
+     * @param node
+     *            the item to append
+     * @param type
+     *            the payload type
+     */
     public void add(int index, StateNode node, String type) {
         add(index, node, type, null);
     }
 
     /**
-     * Appends an item as last in the list.
+     * Appends an item supplied with payload data as last in the list.
      *
      * @param node
      *            the item to append
@@ -70,7 +95,7 @@ public class NewVirtualChildrenList extends StateNodeNodeList {
     }
 
     /**
-     * Appends an item as last in the list.
+     * Appends an item supplied with payload type as last in the list.
      *
      * @param node
      *            the item to append

--- a/flow-server/src/main/java/com/vaadin/flow/nodefeature/NewVirtualChildrenList.java
+++ b/flow-server/src/main/java/com/vaadin/flow/nodefeature/NewVirtualChildrenList.java
@@ -91,6 +91,10 @@ public class NewVirtualChildrenList extends StateNodeNodeList {
      *
      * @param node
      *            the item to append
+     * @param type
+     *            the payload type
+     * @param payload
+     *            the payload data
      */
     public void append(StateNode node, String type, String payload) {
         add(size(), node, type, payload);
@@ -101,6 +105,8 @@ public class NewVirtualChildrenList extends StateNodeNodeList {
      *
      * @param node
      *            the item to append
+     * @param type
+     *            the payload type
      */
     public void append(StateNode node, String type) {
         append(node, type, null);

--- a/flow-server/src/main/java/com/vaadin/flow/nodefeature/NewVirtualChildrenList.java
+++ b/flow-server/src/main/java/com/vaadin/flow/nodefeature/NewVirtualChildrenList.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.nodefeature;
 
-import java.io.Serializable;
-
 import com.vaadin.flow.StateNode;
 
 import elemental.json.Json;
@@ -44,11 +42,15 @@ public class NewVirtualChildrenList extends StateNodeNodeList {
         super(node);
     }
 
-    public void add(int index, StateNode node, String type,
-            Serializable payload) {
+    public void add(int index, StateNode node, String type, String payload) {
         assert node != null;
 
         JsonObject object = Json.createObject();
+        object.put(NodeProperties.TYPE, type);
+        if (payload != null) {
+            object.put(NodeProperties.PAYLOAD, payload);
+        }
+
         node.getFeature(ElementData.class).setPyload(object);
         super.add(index, node);
     }
@@ -63,7 +65,7 @@ public class NewVirtualChildrenList extends StateNodeNodeList {
      * @param node
      *            the item to append
      */
-    public void append(StateNode node, String type, Serializable payload) {
+    public void append(StateNode node, String type, String payload) {
         add(size(), node, type, payload);
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/nodefeature/NewVirtualChildrenList.java
+++ b/flow-server/src/main/java/com/vaadin/flow/nodefeature/NewVirtualChildrenList.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.nodefeature;
+
+import com.vaadin.flow.StateNode;
+
+import elemental.json.Json;
+import elemental.json.JsonObject;
+
+/**
+ * List of nodes describing the virtually connected child elements of an
+ * element.
+ * <p>
+ * TODO: this is temporary class. It will replace {@link VirtualChildrenList}
+ * (and will be renamed) along with rewriting {@code @Id} functionality.
+ *
+ * @author Vaadin Ltd
+ *
+ */
+public class NewVirtualChildrenList extends StateNodeNodeList {
+
+    /**
+     * Creates a new element virtual children list for the given node.
+     *
+     * @param node
+     *            the node that the list belongs to
+     */
+    public NewVirtualChildrenList(StateNode node) {
+        super(node);
+    }
+
+    public void add(int index, StateNode node, String type, String payload) {
+        assert node != null;
+
+        JsonObject object = Json.createObject();
+        object.put(NodeProperties.TYPE, type);
+        if (payload != null) {
+            object.put(NodeProperties.PAYLOAD, payload);
+        }
+
+        node.getFeature(ElementData.class).setPyload(object);
+        super.add(index, node);
+    }
+
+    public void add(int index, StateNode node, String type) {
+        add(index, node, type, null);
+    }
+
+    /**
+     * Appends an item as last in the list.
+     *
+     * @param node
+     *            the item to append
+     */
+    public void append(StateNode node, String type, String payload) {
+        add(size(), node, type, payload);
+    }
+
+    /**
+     * Appends an item as last in the list.
+     *
+     * @param node
+     *            the item to append
+     */
+    public void append(StateNode node, String type) {
+        append(node, type, null);
+    }
+
+    @Override
+    protected StateNode remove(int index) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected void clear() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int size() {
+        return super.size();
+    }
+
+}

--- a/flow-server/src/main/java/com/vaadin/flow/nodefeature/NewVirtualChildrenList.java
+++ b/flow-server/src/main/java/com/vaadin/flow/nodefeature/NewVirtualChildrenList.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.nodefeature;
 
+import java.util.Iterator;
+
 import com.vaadin.flow.StateNode;
 
 import elemental.json.Json;
@@ -102,6 +104,16 @@ public class NewVirtualChildrenList extends StateNodeNodeList {
      */
     public void append(StateNode node, String type) {
         append(node, type, null);
+    }
+
+    @Override
+    public StateNode get(int index) {
+        return super.get(index);
+    }
+
+    @Override
+    public Iterator<StateNode> iterator() {
+        return super.iterator();
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/nodefeature/NewVirtualChildrenList.java
+++ b/flow-server/src/main/java/com/vaadin/flow/nodefeature/NewVirtualChildrenList.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.nodefeature;
 
+import java.io.Serializable;
+
 import com.vaadin.flow.StateNode;
 
 import elemental.json.Json;
@@ -42,15 +44,11 @@ public class NewVirtualChildrenList extends StateNodeNodeList {
         super(node);
     }
 
-    public void add(int index, StateNode node, String type, String payload) {
+    public void add(int index, StateNode node, String type,
+            Serializable payload) {
         assert node != null;
 
         JsonObject object = Json.createObject();
-        object.put(NodeProperties.TYPE, type);
-        if (payload != null) {
-            object.put(NodeProperties.PAYLOAD, payload);
-        }
-
         node.getFeature(ElementData.class).setPyload(object);
         super.add(index, node);
     }
@@ -65,7 +63,7 @@ public class NewVirtualChildrenList extends StateNodeNodeList {
      * @param node
      *            the item to append
      */
-    public void append(StateNode node, String type, String payload) {
+    public void append(StateNode node, String type, Serializable payload) {
         add(size(), node, type, payload);
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/nodefeature/NodeFeatureRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/nodefeature/NodeFeatureRegistry.java
@@ -91,6 +91,8 @@ public class NodeFeatureRegistry {
                 AttachTemplateChildFeature::new);
         registerFeature(VirtualChildrenList.class, VirtualChildrenList::new);
         registerFeature(BasicTypeValue.class, BasicTypeValue::new);
+        registerFeature(NewVirtualChildrenList.class,
+                NewVirtualChildrenList::new);
     }
 
     private NodeFeatureRegistry() {

--- a/flow-server/src/main/java/com/vaadin/flow/nodefeature/NodeFeatures.java
+++ b/flow-server/src/main/java/com/vaadin/flow/nodefeature/NodeFeatures.java
@@ -15,36 +15,7 @@
  */
 package com.vaadin.flow.nodefeature;
 
-import com.vaadin.flow.nodefeature.AttachExistingElementFeature;
-import com.vaadin.flow.nodefeature.AttachTemplateChildFeature;
-import com.vaadin.flow.nodefeature.BasicTypeValue;
-import com.vaadin.flow.nodefeature.ClientDelegateHandlers;
-import com.vaadin.flow.nodefeature.ComponentMapping;
-import com.vaadin.flow.nodefeature.ElementAttributeMap;
-import com.vaadin.flow.nodefeature.ElementChildrenList;
-import com.vaadin.flow.nodefeature.ElementClassList;
-import com.vaadin.flow.nodefeature.ElementData;
-import com.vaadin.flow.nodefeature.ElementListenerMap;
-import com.vaadin.flow.nodefeature.ElementPropertyMap;
-import com.vaadin.flow.nodefeature.ElementStylePropertyMap;
-import com.vaadin.flow.nodefeature.ModelList;
-import com.vaadin.flow.nodefeature.ModelMap;
-import com.vaadin.flow.nodefeature.OverrideElementData;
-import com.vaadin.flow.nodefeature.ParentGeneratorHolder;
-import com.vaadin.flow.nodefeature.PollConfigurationMap;
-import com.vaadin.flow.nodefeature.PolymerEventListenerMap;
-import com.vaadin.flow.nodefeature.PolymerServerEventHandlers;
-import com.vaadin.flow.nodefeature.PushConfigurationMap;
 import com.vaadin.flow.nodefeature.PushConfigurationMap.PushConfigurationParametersMap;
-import com.vaadin.flow.nodefeature.ReconnectDialogConfigurationMap;
-import com.vaadin.flow.nodefeature.ShadowRootData;
-import com.vaadin.flow.nodefeature.ShadowRootHost;
-import com.vaadin.flow.nodefeature.SynchronizedPropertiesList;
-import com.vaadin.flow.nodefeature.SynchronizedPropertyEventsList;
-import com.vaadin.flow.nodefeature.TemplateMap;
-import com.vaadin.flow.nodefeature.TemplateOverridesMap;
-import com.vaadin.flow.nodefeature.TextNodeMap;
-import com.vaadin.flow.nodefeature.VirtualChildrenList;
 
 /**
  * Registry of node feature id numbers and map keys shared between server and
@@ -187,9 +158,14 @@ public final class NodeFeatures {
     public static final int VIRTUAL_CHILD_ELEMENTS = 29;
 
     /**
-     * Id for {@link BasicTypeValue}.
+     * {@link NewVirtualChildrenList} Id for {@link BasicTypeValue}.
      */
     public static final int BASIC_TYPE_VALUE = 30;
+
+    /**
+     * Id for {@link NewVirtualChildrenList}.
+     */
+    public static final int NEW_VIRTUAL_CHILDREN = 31;
 
     private NodeFeatures() {
         // Only static

--- a/flow-server/src/main/java/com/vaadin/flow/nodefeature/NodeProperties.java
+++ b/flow-server/src/main/java/com/vaadin/flow/nodefeature/NodeProperties.java
@@ -58,6 +58,11 @@ public final class NodeProperties {
      */
     public static final String TYPE = "type";
 
+    /**
+     * JsonObject type value for {@link NewVirtualChildrenList}.
+     */
+    public static final String IN_MEMORY_CHILD = "inMemory";
+
     /** Key for id property. */
     public static final String ID = "id";
 

--- a/flow-server/src/main/java/com/vaadin/flow/nodefeature/NodeProperties.java
+++ b/flow-server/src/main/java/com/vaadin/flow/nodefeature/NodeProperties.java
@@ -15,12 +15,6 @@
  */
 package com.vaadin.flow.nodefeature;
 
-import com.vaadin.flow.nodefeature.BasicTypeValue;
-import com.vaadin.flow.nodefeature.ElementData;
-import com.vaadin.flow.nodefeature.ShadowRootData;
-import com.vaadin.flow.nodefeature.TemplateMap;
-import com.vaadin.flow.nodefeature.TextNodeMap;
-
 /**
  * Various node properties' ids.
  *
@@ -32,6 +26,12 @@ public final class NodeProperties {
      * Key for {@link ElementData#getTag()}.
      */
     public static final String TAG = "tag";
+
+    /**
+     * Key for {@link ElementData#getPayload()}.
+     */
+    public static final String PAYLOAD = "payload";
+
     /**
      * Key for {@link TextNodeMap#getText()}.
      */
@@ -52,6 +52,11 @@ public final class NodeProperties {
      * Key for {@link BasicTypeValue#getValue()}.
      */
     public static final String VALUE = "value";
+
+    /**
+     * JsonObject type key for {@link NewVirtualChildrenList}.
+     */
+    public static final String TYPE = "type";
 
     /** Key for id property. */
     public static final String ID = "id";

--- a/flow-server/src/test/java/com/vaadin/flow/nodefeature/ElementDataTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/nodefeature/ElementDataTest.java
@@ -16,18 +16,95 @@
 
 package com.vaadin.flow.nodefeature;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.vaadin.flow.StateNode;
+import com.vaadin.flow.change.MapPutChange;
+import com.vaadin.flow.change.NodeChange;
+
+import elemental.json.Json;
+import elemental.json.JsonObject;
+
 public class ElementDataTest extends AbstractNodeFeatureTest<ElementData> {
-    private final ElementData elementData = createFeature();
+    private final ElementData elementData = new StateNode(
+            Collections.singletonList(ElementData.class))
+                    .getFeature(ElementData.class);
 
     @Test
-    public void testSetGetTag() {
+    public void setGetTag() {
         Assert.assertNull("Tag should initially be null", elementData.getTag());
 
         elementData.setTag("myTag");
 
         Assert.assertEquals("myTag", elementData.getTag());
+    }
+
+    @Test
+    public void setGetPayload() {
+        Assert.assertNull("Tag should initially be null",
+                elementData.getPayload());
+
+        JsonObject object = Json.createObject();
+        elementData.setPyload(object);
+
+        Assert.assertEquals(object, elementData.getPayload());
+    }
+
+    @Test
+    public void collectChanges_setTagOnly_onlyOneChange() {
+        elementData.setTag("foo");
+        List<NodeChange> changes = new ArrayList<>();
+        elementData.collectChanges(changes::add);
+
+        Assert.assertEquals(1, changes.size());
+        Assert.assertTrue(changes.get(0) instanceof MapPutChange);
+        MapPutChange change = (MapPutChange) changes.get(0);
+        Assert.assertEquals(NodeProperties.TAG, change.getKey());
+        Assert.assertEquals(elementData.getNode(), change.getNode());
+        Assert.assertEquals("foo", change.getValue());
+    }
+
+    @Test
+    public void collectChanges_setPayloadOnly_onlyOneChange() {
+        JsonObject object = Json.createObject();
+        elementData.setPyload(object);
+        List<NodeChange> changes = new ArrayList<>();
+        elementData.collectChanges(changes::add);
+
+        Assert.assertEquals(1, changes.size());
+        Assert.assertTrue(changes.get(0) instanceof MapPutChange);
+        MapPutChange change = (MapPutChange) changes.get(0);
+        Assert.assertEquals(NodeProperties.PAYLOAD, change.getKey());
+        Assert.assertEquals(elementData.getNode(), change.getNode());
+        Assert.assertEquals(object, change.getValue());
+    }
+
+    @Test
+    public void collectChanges_setBothTagAndPayload_twoChanges() {
+        JsonObject object = Json.createObject();
+        elementData.setPyload(object);
+        elementData.setTag("foo");
+
+        List<NodeChange> changes = new ArrayList<>();
+        elementData.collectChanges(changes::add);
+
+        Assert.assertEquals(2, changes.size());
+        Assert.assertTrue(changes.get(0) instanceof MapPutChange);
+        Assert.assertTrue(changes.get(1) instanceof MapPutChange);
+
+        MapPutChange change = (MapPutChange) changes.get(0);
+        Assert.assertEquals(NodeProperties.TAG, change.getKey());
+        Assert.assertEquals(elementData.getNode(), change.getNode());
+        Assert.assertEquals("foo", change.getValue());
+
+        change = (MapPutChange) changes.get(1);
+        Assert.assertEquals(NodeProperties.PAYLOAD, change.getKey());
+        Assert.assertEquals(elementData.getNode(), change.getNode());
+        Assert.assertEquals(object, change.getValue());
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/nodefeature/NewVirtualChildrenListTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/nodefeature/NewVirtualChildrenListTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.nodefeature;
+
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.StateNode;
+
+import elemental.json.JsonObject;
+
+public class NewVirtualChildrenListTest {
+
+    private StateNode node = new StateNode(NewVirtualChildrenList.class);
+    private NewVirtualChildrenList list = node
+            .getFeature(NewVirtualChildrenList.class);
+
+    private StateNode child = new StateNode(ElementData.class);
+
+    @Test
+    public void insert_atIndexWithType_payloadIsSetAndElementIsInserted() {
+        list.add(0, child, "foo", null);
+
+        Assert.assertEquals(child, list.get(0));
+
+        JsonObject payload = (JsonObject) child.getFeature(ElementData.class)
+                .getPayload();
+        Assert.assertNotNull(payload);
+
+        Assert.assertEquals("foo", payload.get(NodeProperties.TYPE).asString());
+
+        StateNode anotherChild = new StateNode(ElementData.class);
+        list.add(0, anotherChild, "bar", null);
+
+        Assert.assertEquals(anotherChild, list.get(0));
+
+        payload = (JsonObject) anotherChild.getFeature(ElementData.class)
+                .getPayload();
+        Assert.assertNotNull(payload);
+
+        Assert.assertEquals("bar", payload.get(NodeProperties.TYPE).asString());
+    }
+
+    @Test
+    public void insert_atIndexWithPayload_payloadIsSetAndElementIsInserted() {
+        list.add(0, child, "foo", "bar");
+
+        Assert.assertEquals(child, list.get(0));
+
+        JsonObject payload = (JsonObject) child.getFeature(ElementData.class)
+                .getPayload();
+        Assert.assertNotNull(payload);
+
+        Assert.assertEquals("foo", payload.get(NodeProperties.TYPE).asString());
+        Assert.assertEquals("bar",
+                payload.get(NodeProperties.PAYLOAD).asString());
+    }
+
+    @Test
+    public void iteratorAndSize_addTwoItems_methodsReturnCorrectValues() {
+        list.append(child, "foo");
+        StateNode anotherChild = new StateNode(ElementData.class);
+        list.append(anotherChild, "bar");
+
+        Assert.assertEquals(2, list.size());
+
+        Set<StateNode> set = StreamSupport
+                .stream(Spliterators.spliteratorUnknownSize(list.iterator(),
+                        Spliterator.ORDERED), false)
+                .collect(Collectors.toSet());
+        Assert.assertEquals(2, set.size());
+
+        set.remove(child);
+        set.remove(anotherChild);
+
+        Assert.assertEquals(0, set.size());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void remove_throw() {
+        list.append(child, "foo");
+        list.remove(0);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void clear_throw() {
+        list.append(child, "foo");
+        list.clear();
+    }
+
+}

--- a/flow-server/src/test/java/com/vaadin/flow/nodefeature/NodeFeatureTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/nodefeature/NodeFeatureTest.java
@@ -103,6 +103,8 @@ public class NodeFeatureTest {
         expectedIds.put(VirtualChildrenList.class,
                 NodeFeatures.VIRTUAL_CHILD_ELEMENTS);
         expectedIds.put(BasicTypeValue.class, NodeFeatures.BASIC_TYPE_VALUE);
+        expectedIds.put(NewVirtualChildrenList.class,
+                NodeFeatures.NEW_VIRTUAL_CHILDREN);
 
         return expectedIds;
     }

--- a/flow-server/src/test/java/com/vaadin/flow/nodefeature/NodeValueEmptyRequiredFeatureTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/nodefeature/NodeValueEmptyRequiredFeatureTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.nodefeature;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -33,17 +34,17 @@ public class NodeValueEmptyRequiredFeatureTest {
 
     private StateNode node;
 
-    private NodeValue<String> nodeValue;
+    private NodeValue<Serializable> nodeValue;
 
     @Before
     public void setUp() {
-        node = new StateNode(Arrays.asList(ElementData.class)) {
+        node = new StateNode(Arrays.asList(BasicTypeValue.class)) {
             @Override
             public boolean isAttached() {
                 return true;
             }
         };
-        nodeValue = node.getFeature(ElementData.class);
+        nodeValue = node.getFeature(BasicTypeValue.class);
     }
 
     @Test

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/InMemoryChildren.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/InMemoryChildren.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+import com.vaadin.router.Route;
+import com.vaadin.ui.common.JavaScript;
+import com.vaadin.ui.html.Div;
+import com.vaadin.ui.html.Label;
+import com.vaadin.ui.html.NativeButton;
+
+@JavaScript("frontend://in-memory-connector.js")
+@Route(value = "com.vaadin.flow.uitest.ui.InMemoryChildren", layout = ViewTestLayout.class)
+public class InMemoryChildren extends AbstractDivView {
+
+    @Override
+    protected void onShow() {
+        Label label = new Label();
+        label.setId("in-memory");
+        label.setText("In memory element");
+        getElement().appendVirtualChild(label.getElement());
+        getElement().getNode()
+                .runWhenAttached(ui -> ui.getPage().executeJavaScript(
+                        "window.inMemoryConnector.init($0, $1)", getElement(),
+                        label));
+        Div target = new Div();
+        target.setId("target");
+        add(target);
+        NativeButton button = new NativeButton(
+                "Add copy of in-memory element to the target",
+                event -> getElement().callFunction("useInMemoryElement",
+                        target));
+        button.setId("copy");
+        add(button);
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/InMemoryChildrenView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/InMemoryChildrenView.java
@@ -23,8 +23,8 @@ import com.vaadin.ui.html.Label;
 import com.vaadin.ui.html.NativeButton;
 
 @JavaScript("frontend://in-memory-connector.js")
-@Route(value = "com.vaadin.flow.uitest.ui.InMemoryChildren", layout = ViewTestLayout.class)
-public class InMemoryChildren extends AbstractDivView {
+@Route(value = "com.vaadin.flow.uitest.ui.InMemoryChildrenView", layout = ViewTestLayout.class)
+public class InMemoryChildrenView extends AbstractDivView {
 
     @Override
     protected void onShow() {

--- a/flow-tests/test-root-context/src/main/webapp/frontend/in-memory-connector.js
+++ b/flow-tests/test-root-context/src/main/webapp/frontend/in-memory-connector.js
@@ -1,0 +1,11 @@
+window.inMemoryConnector = {
+        
+        init: function( component, inMemoryElement ){
+            component.$dataContainer = inMemoryElement;
+            
+            component.useInMemoryElement = function(parent){
+                var copy = component.$dataContainer.cloneNode(true);
+                parent.appendChild(copy);
+            }
+        }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/InMemoryChildrenIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/InMemoryChildrenIT.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class InMemoryChildrenIT extends ChromeBrowserTest {
+
+    @Test
+    public void inMemoryElementInJs() {
+        open();
+
+        Assert.assertFalse(isElementPresent(By.id("in-memory")));
+
+        findElement(By.id("copy")).click();
+
+        Assert.assertTrue(isElementPresent(By.id("in-memory")));
+    }
+}


### PR DESCRIPTION
Make it possible to create an element on the client side which is not attached to the DOM tree.
The element is addressed from the server side via Element API.

Fix for #2826.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3070)
<!-- Reviewable:end -->
