### PR TITLE
Add docs about adding all components

### DIFF
--- a/flow-documentation/flow-components/tutorial-flow-components-setup.asciidoc
+++ b/flow-documentation/flow-components/tutorial-flow-components-setup.asciidoc
@@ -47,7 +47,8 @@ any Flow project. Besides, you can add `vaadin-platform` dependency, if you need
     </dependency>
 </dependencies>
 ----
-
+[NOTE]
+`vaadin.platform` releases regularly and you can check the version number https://github.com/vaadin/platform/releases[here]
 
 = Overview
 

--- a/flow-documentation/flow-components/tutorial-flow-components-setup.asciidoc
+++ b/flow-documentation/flow-components/tutorial-flow-components-setup.asciidoc
@@ -18,6 +18,7 @@ Currently there are the following implementations:
 - https://github.com/vaadin/vaadin-form-layout-flow[vaadin-form-layout-flow]
 - https://github.com/vaadin/vaadin-grid-flow[vaadin-grid-flow]
 - https://github.com/vaadin/vaadin-icons-flow[vaadin-icons-flow]
+- https://github.com/vaadin/vaadin-iron-list-flow[vaadin-iron-list-flow]
 - https://github.com/vaadin/vaadin-ordered-layout-flow[vaadin-ordered-layout-flow]
 - https://github.com/vaadin/vaadin-progress-bar-flow[vaadin-progress-bar-flow]
 - https://github.com/vaadin/vaadin-split-layout-flow[vaadin-split-layout-flow]
@@ -26,7 +27,7 @@ Currently there are the following implementations:
 - https://github.com/vaadin/vaadin-upload-flow[vaadin-upload-flow]
 
 These components are available as optional dependencies that can be added to
-any Flow project. Besides, you can add `vaadin-platform` dependency, if you need flow components for your project.
+any Flow project. Besides, you can add `vaadin-platform` dependency, if you need flow components for your project. It will automatically add dependencies to *ALL* available components.
 [source,xml]
 ----
 <repositories>
@@ -42,7 +43,7 @@ any Flow project. Besides, you can add `vaadin-platform` dependency, if you need
     <dependency>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin</artifactId>
-        <version>10.0.0.alpha8</version>
+        <version>${vaadin.platform.version}</version>
     </dependency>
 </dependencies>
 ----
@@ -100,7 +101,7 @@ When using Maven you can add a the button component into your `pom.xml` as this:
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-bom</artifactId>
-            <version>10.0.0.alpha8</version>
+            <version>${vaadin.platform.version}</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>

--- a/flow-documentation/flow-components/tutorial-flow-components-setup.asciidoc
+++ b/flow-documentation/flow-components/tutorial-flow-components-setup.asciidoc
@@ -26,7 +26,27 @@ Currently there are the following implementations:
 - https://github.com/vaadin/vaadin-upload-flow[vaadin-upload-flow]
 
 These components are available as optional dependencies that can be added to
-any Flow project.
+any Flow project. Besides, you can add `vaadin-platform` dependency, if you need flow components for your project.
+[source,xml]
+----
+<repositories>
+    <repository>
+    <id>vaadin-platform</id>
+    <url>https://repo.vaadin.com/nexus/content/repositories/flow</url>
+    </repository>
+</repositories>
+
+<dependencies>
+    <!-- other dependencies -->
+    <!-- component dependency -->
+    <dependency>
+        <groupId>com.vaadin</groupId>
+        <artifactId>vaadin</artifactId>
+        <version>10.0.0.alpha8</version>
+    </dependency>
+</dependencies>
+----
+
 
 = Overview
 


### PR DESCRIPTION
As a developer, i don't want to add flow components one by one, I want to add one dependency for all of them with the newest version, So that i don't need to update by myself.

people asked this before, with the platform release, our components will be released to the users, too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3086)
<!-- Reviewable:end -->
