### PR TITLE
Add API for checking if property is a sub-property of it's property set

### DIFF
--- a/flow-data/src/main/java/com/vaadin/data/BeanPropertySet.java
+++ b/flow-data/src/main/java/com/vaadin/data/BeanPropertySet.java
@@ -198,6 +198,11 @@ public class BeanPropertySet<T> implements PropertySet<T> {
             return new SerializedPropertyDefinition(getPropertySet().beanType,
                     getName());
         }
+
+        @Override
+        public boolean isSubProperty() {
+            return false;
+        }
     }
 
     /**
@@ -277,6 +282,11 @@ public class BeanPropertySet<T> implements PropertySet<T> {
          */
         public PropertyDefinition<T, ?> getParent() {
             return parent;
+        }
+
+        @Override
+        public boolean isSubProperty() {
+            return true;
         }
     }
 

--- a/flow-data/src/main/java/com/vaadin/data/PropertyDefinition.java
+++ b/flow-data/src/main/java/com/vaadin/data/PropertyDefinition.java
@@ -57,8 +57,6 @@ public interface PropertyDefinition<T, V> extends Serializable {
     /**
      * Gets the type of the class containing this property.
      *
-     * @since 8.1
-     *
      * @return the property type. not <code>null</code>
      */
     Class<?> getPropertyHolderType();
@@ -83,4 +81,13 @@ public interface PropertyDefinition<T, V> extends Serializable {
      * @return the property set, not <code>null</code>
      */
     PropertySet<T> getPropertySet();
+
+    /**
+     * Gets whether this property belongs to some other property in the property
+     * set, or directly to the property set.
+     * 
+     * @return {@code true} if this property is a sub-property of the property
+     *         set it belongs to, {@code false} otherwise
+     */
+    boolean isSubProperty();
 }

--- a/flow-data/src/test/java/com/vaadin/data/BeanPropertySetTest.java
+++ b/flow-data/src/test/java/com/vaadin/data/BeanPropertySetTest.java
@@ -220,4 +220,17 @@ public class BeanPropertySetTest {
         Assert.assertEquals(new HashSet<>(Arrays.asList("name", "born")),
                 propertyNames);
     }
+
+    @Test
+    public void isSubProperty() {
+        PropertySet<FatherAndSon> propertySet = BeanPropertySet
+                .get(FatherAndSon.class);
+
+        Assert.assertTrue(propertySet.getProperty("father.firstName").get()
+                .isSubProperty());
+        Assert.assertFalse(
+                propertySet.getProperty("father").get().isSubProperty());
+        Assert.assertTrue(propertySet.getProperty("father.son.father.son").get()
+                .isSubProperty());
+    }
 }

--- a/flow-data/src/test/java/com/vaadin/data/BeanPropertySetTest.java
+++ b/flow-data/src/test/java/com/vaadin/data/BeanPropertySetTest.java
@@ -226,11 +226,16 @@ public class BeanPropertySetTest {
         PropertySet<FatherAndSon> propertySet = BeanPropertySet
                 .get(FatherAndSon.class);
 
-        Assert.assertTrue(propertySet.getProperty("father.firstName").get()
-                .isSubProperty());
+        Assert.assertTrue(
+                "Dot-separated property chain \"father.firstName\" should refer to a sub-property",
+                propertySet.getProperty("father.firstName").get()
+                        .isSubProperty());
         Assert.assertFalse(
+                "Property name without dot-separated parent properties should not refer to a sub-property",
                 propertySet.getProperty("father").get().isSubProperty());
-        Assert.assertTrue(propertySet.getProperty("father.son.father.son").get()
-                .isSubProperty());
+        Assert.assertTrue(
+                "Dot-separated property chain \"father.son.father.son\" should refer to a sub-property",
+                propertySet.getProperty("father.son.father.son").get()
+                        .isSubProperty());
     }
 }


### PR DESCRIPTION
It's useful to know whether a property definition belongs directly to the property set or is it a sub-property of some other property in the set. This can be used for example in the implementation of BeanGrid, to add columns automatically only for the bean's direct properties. Previously there was no way of differentiating between direct properties and sub-properties.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3095)
<!-- Reviewable:end -->
