### PR TITLE
Add API for getting the full property chain of a sub-property

### DIFF
--- a/flow-data/src/main/java/com/vaadin/data/BeanPropertySet.java
+++ b/flow-data/src/main/java/com/vaadin/data/BeanPropertySet.java
@@ -104,7 +104,7 @@ public class BeanPropertySet<T> implements PropertySet<T> {
     }
 
     private abstract static class AbstractBeanPropertyDefinition<T, V>
-    implements PropertyDefinition<T, V> {
+            implements PropertyDefinition<T, V> {
         private final PropertyDescriptor descriptor;
         private final BeanPropertySet<T> propertySet;
         private final Class<?> propertyHolderType;
@@ -156,7 +156,7 @@ public class BeanPropertySet<T> implements PropertySet<T> {
     }
 
     private static class BeanPropertyDefinition<T, V>
-    extends AbstractBeanPropertyDefinition<T, V> {
+            extends AbstractBeanPropertyDefinition<T, V> {
 
         public BeanPropertyDefinition(BeanPropertySet<T> propertySet,
                 Class<T> propertyHolderType, PropertyDescriptor descriptor) {
@@ -200,8 +200,8 @@ public class BeanPropertySet<T> implements PropertySet<T> {
         }
 
         @Override
-        public boolean isSubProperty() {
-            return false;
+        public PropertyDefinition<T, ?> getParent() {
+            return null;
         }
     }
 
@@ -216,7 +216,7 @@ public class BeanPropertySet<T> implements PropertySet<T> {
      *            the value type returned by the getter and set by the setter
      */
     public static class NestedBeanPropertyDefinition<T, V>
-    extends AbstractBeanPropertyDefinition<T, V> {
+            extends AbstractBeanPropertyDefinition<T, V> {
 
         private final PropertyDefinition<T, ?> parent;
 
@@ -275,18 +275,9 @@ public class BeanPropertySet<T> implements PropertySet<T> {
                     parent.getName() + "." + getName());
         }
 
-        /**
-         * Gets the parent property definition.
-         *
-         * @return the property definition for the parent
-         */
+        @Override
         public PropertyDefinition<T, ?> getParent() {
             return parent;
-        }
-
-        @Override
-        public boolean isSubProperty() {
-            return true;
         }
     }
 

--- a/flow-data/src/main/java/com/vaadin/data/PropertyDefinition.java
+++ b/flow-data/src/main/java/com/vaadin/data/PropertyDefinition.java
@@ -83,11 +83,37 @@ public interface PropertyDefinition<T, V> extends Serializable {
     PropertySet<T> getPropertySet();
 
     /**
+     * Gets the parent property of this property if this is a sub-property of
+     * the property set. If this property belongs directly to the property set,
+     * it doesn't have a parent and this method returns {@code null}.
+     * 
+     * @return the parent property, may be {@code null}
+     */
+    PropertyDefinition<T, ?> getParent();
+
+    /**
      * Gets whether this property belongs to some other property in the property
      * set, or directly to the property set.
      * 
      * @return {@code true} if this property is a sub-property of the property
      *         set it belongs to, {@code false} otherwise
      */
-    boolean isSubProperty();
+    default boolean isSubProperty() {
+        return getParent() != null;
+    }
+
+    /**
+     * Gets the full name of this property. For sub-properties this means the
+     * full path from the property set to this property, with dot-separated
+     * parent properties, eg. "property.subProperty".
+     * 
+     * @return the full property name, not {@code null}
+     */
+    default String getFullName() {
+        if (getParent() != null) {
+            return getParent().getFullName() + '.' + getName();
+        } else {
+            return getName();
+        }
+    }
 }

--- a/flow-data/src/test/java/com/vaadin/data/BeanPropertySetTest.java
+++ b/flow-data/src/test/java/com/vaadin/data/BeanPropertySetTest.java
@@ -238,4 +238,38 @@ public class BeanPropertySetTest {
                 propertySet.getProperty("father.son.father.son").get()
                         .isSubProperty());
     }
+
+    @Test
+    public void getFullName_returnsFullPropertyChain() {
+        PropertySet<FatherAndSon> propertySet = BeanPropertySet
+                .get(FatherAndSon.class);
+        String subPropertyFullName = "father.son.father.son.firstName";
+        PropertyDefinition<FatherAndSon, ?> subProperty = propertySet
+                .getProperty(subPropertyFullName).get();
+        Assert.assertEquals(
+                "Name of a sub-property should be the simple name of the property",
+                "firstName", subProperty.getName());
+        Assert.assertEquals(
+                "Full name of a sub-property should be the full property chain with parent properties",
+                subPropertyFullName, subProperty.getFullName());
+    }
+
+    @Test
+    public void getParentForDirectProperty_returnsNull() {
+        PropertySet<FatherAndSon> propertySet = BeanPropertySet
+                .get(FatherAndSon.class);
+        Assert.assertNull(
+                "Direct property of a property set should not have a parent",
+                propertySet.getProperty("father").get().getParent());
+    }
+
+    @Test
+    public void getParentForSubProperty_returnsParent() {
+        PropertySet<FatherAndSon> propertySet = BeanPropertySet
+                .get(FatherAndSon.class);
+        Assert.assertEquals(
+                "Parent property of \"father.son.father\" should be \"father.son\"",
+                "father.son", propertySet.getProperty("father.son.father").get()
+                        .getParent().getFullName());
+    }
 }


### PR DESCRIPTION
PropertyDefinition has now a method getFullName() that returns the full property chain from the root of the property set. For non-sub-properties it just calls getName(). This is needed at least for BeanGrid, so it can automatically set unique column-keys. There's also another new public method, getParent() that was added to PropertyDefinition interface to allow default-implementations for other methods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3097)
<!-- Reviewable:end -->
