### PR TITLE
Make it possible to override custom error handlers

### DIFF
--- a/flow-server/src/main/java/com/vaadin/server/startup/ErrorNavigationTargetInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/server/startup/ErrorNavigationTargetInitializer.java
@@ -20,6 +20,7 @@ import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.HandlesTypes;
 import java.util.Set;
+import java.util.HashSet;
 import java.util.stream.Collectors;
 
 import com.vaadin.router.HasErrorParameter;
@@ -38,9 +39,7 @@ public class ErrorNavigationTargetInitializer
     public void onStartup(Set<Class<?>> classSet, ServletContext servletContext)
             throws ServletException {
         if (classSet == null) {
-            RouteRegistry.getInstance(servletContext).setErrorNavigationTargets(
-                    RouteRegistry.defaultErrorHandlers);
-            return;
+            classSet = new HashSet<>();
         }
         Set<Class<? extends Component>> routes = classSet.stream()
                 .map(clazz -> (Class<? extends Component>) clazz)

--- a/flow-server/src/main/java/com/vaadin/server/startup/ErrorNavigationTargetInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/server/startup/ErrorNavigationTargetInitializer.java
@@ -19,13 +19,10 @@ import javax.servlet.ServletContainerInitializer;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.HandlesTypes;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.vaadin.router.HasErrorParameter;
-import com.vaadin.router.InternalServerError;
-import com.vaadin.router.RouteNotFoundError;
 import com.vaadin.ui.Component;
 
 /**
@@ -41,12 +38,8 @@ public class ErrorNavigationTargetInitializer
     public void onStartup(Set<Class<?>> classSet, ServletContext servletContext)
             throws ServletException {
         if (classSet == null) {
-            Set<Class<? extends Component>> defaultErrorViews = new HashSet<>();
-            defaultErrorViews.add(RouteNotFoundError.class);
-            defaultErrorViews.add(InternalServerError.class);
-
-            RouteRegistry.getInstance(servletContext)
-                    .setErrorNavigationTargets(defaultErrorViews);
+            RouteRegistry.getInstance(servletContext).setErrorNavigationTargets(
+                    RouteRegistry.defaultErrorHandlers);
             return;
         }
         Set<Class<? extends Component>> routes = classSet.stream()

--- a/flow-server/src/main/java/com/vaadin/server/startup/RouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/server/startup/RouteRegistry.java
@@ -185,11 +185,17 @@ public class RouteRegistry implements Serializable {
         if (registered.isAssignableFrom(target)) {
             exceptionTargetsMap.put(exceptionType, target);
         } else if (!target.isAssignableFrom(registered)) {
-            String msg = String.format(
-                    "Only one target for an exception should be defined. Found '%s' and '%s' for exception '%s'",
-                    target.getName(), registered.getName(),
-                    exceptionType.getName());
-            throw new InvalidRouteLayoutConfigurationException(msg);
+            if (registered.equals(RouteNotFoundError.class)
+                    || registered.equals(InternalServerError.class)) {
+                exceptionTargetsMap.put(exceptionType, target);
+            } else if (!(target.equals(RouteNotFoundError.class)
+                    || target.equals(InternalServerError.class))) {
+                String msg = String.format(
+                        "Only one target for an exception should be defined. Found '%s' and '%s' for exception '%s'",
+                        target.getName(), registered.getName(),
+                        exceptionType.getName());
+                throw new InvalidRouteLayoutConfigurationException(msg);
+            }
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/server/startup/RouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/server/startup/RouteRegistry.java
@@ -57,7 +57,7 @@ public class RouteRegistry implements Serializable {
     private final AtomicReference<Map<Class<? extends Component>, String>> targetRoutes = new AtomicReference<>();
     private final AtomicReference<Map<Class<?>, Class<? extends Component>>> exceptionTargets = new AtomicReference<>();
 
-    final static Set<Class<? extends Component>> defaultErrorHandlers = Stream
+    static final Set<Class<? extends Component>> defaultErrorHandlers = Stream
             .of(RouteNotFoundError.class, InternalServerError.class)
             .collect(Collectors.toSet());
 


### PR DESCRIPTION
The default error handlers can now be overridden even without
specifically extending them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3113)
<!-- Reviewable:end -->
