### PR TITLE
ComponentGenerator to not allow null for String values

### DIFF
--- a/flow-components-parent/flow-code-generator-api/src/main/java/com/vaadin/generator/ComponentGenerator.java
+++ b/flow-components-parent/flow-code-generator-api/src/main/java/com/vaadin/generator/ComponentGenerator.java
@@ -809,9 +809,7 @@ public class ComponentGenerator {
                             .generateElementApiValueGetterForType(
                             basicType, property.getName()));
 
-                    if (String.class.getName().equals(javaType.getTypeName())) {
-                        addGetEmptyStringValue(javaClass);
-                    }
+                    addGetEmptyValueIfString(javaClass, javaType);
                 } else {
                     method.setBody(ComponentGeneratorUtils
                             .generateElementApiGetterForType(basicType,
@@ -821,12 +819,15 @@ public class ComponentGenerator {
         }
     }
 
-    private void addGetEmptyStringValue(JavaClassSource javaClass) {
-        MethodSource<JavaClassSource> method = javaClass.addMethod().setPublic()
-                .setReturnType(String.class.getSimpleName());
-        method.setName("getEmptyValue");
-        method.setBody("return \"\";");
-        method.addAnnotation(Override.class);
+    private void addGetEmptyValueIfString(JavaClassSource javaClass,
+            Class<?> javaType) {
+        if (javaType == String.class) {
+            MethodSource<JavaClassSource> method = javaClass.addMethod()
+                    .setPublic().setReturnType(String.class.getSimpleName());
+            method.setName("getEmptyValue");
+            method.setBody("return \"\";");
+            method.addAnnotation(Override.class);
+        }
     }
 
     /**
@@ -1022,7 +1023,8 @@ public class ComponentGenerator {
                         setterType, parameterName);
 
                 boolean nullable = !"value".equals(propertyJavaName)
-                        || !shouldImplementHasValue(metadata) || !String.class.getName().equals(setterType.getTypeName());
+                        || !shouldImplementHasValue(metadata)
+                        || String.class != setterType;
 
                 method.setBody(
                         ComponentGeneratorUtils.generateElementApiSetterForType(
@@ -1049,8 +1051,7 @@ public class ComponentGenerator {
                     if (setterType.isPrimitive()) {
                         implementHasValueSetterWithPimitiveType(javaClass,
                                 property, method, setterType, parameterName);
-                    }
-                    else if (!nullable) {
+                    } else if (!nullable) {
                         method.setBody(String.format(
                                 "Objects.requireNonNull(%s, \"%s cannot be null\");",
                                 parameterName, parameterName)

--- a/flow-components-parent/flow-code-generator-api/src/main/java/com/vaadin/generator/ComponentGeneratorUtils.java
+++ b/flow-components-parent/flow-code-generator-api/src/main/java/com/vaadin/generator/ComponentGeneratorUtils.java
@@ -362,16 +362,11 @@ public final class ComponentGeneratorUtils {
             return String.format("getElement().setPropertyJson(\"%s\", %s);",
                     propertyName, parameterName);
         case STRING:
-            if (nullable) {
-                // Don't insert null as property value. Insert empty String
-                // instead.
-                return String.format(
-                        "getElement().setProperty(\"%s\", %s == null ? \"\" : %s);",
-                        propertyName, parameterName, parameterName);
-            }
-            return String.format(
-                    "getElement().setProperty(\"%s\", %s);", propertyName,
-                    parameterName);
+            // Don't insert null as property value. Insert empty String instead.
+            return String.format(nullable
+                    ? "getElement().setProperty(\"%s\", %s == null ? \"\" : %s);"
+                    : "getElement().setProperty(\"%s\", %s);", propertyName,
+                    parameterName, parameterName);
         default:
             return String.format("getElement().setProperty(\"%s\", %s);",
                     propertyName, parameterName);

--- a/flow-components-parent/flow-code-generator-api/src/main/java/com/vaadin/generator/ComponentGeneratorUtils.java
+++ b/flow-components-parent/flow-code-generator-api/src/main/java/com/vaadin/generator/ComponentGeneratorUtils.java
@@ -348,11 +348,13 @@ public final class ComponentGeneratorUtils {
      *            The name of the property in the javascript model.
      * @param parameterName
      *            The name of the parameter in the Java source code.
+     * @param nullable
+     *            whether the value can be null or not
      * @return the code snippet ready to be added in a Java source code.
      */
     public static String generateElementApiSetterForType(
             ComponentBasicType basicType, String propertyName,
-            String parameterName) {
+            String parameterName, boolean nullable) {
         switch (basicType) {
         case ARRAY:
         case UNDEFINED:
@@ -360,10 +362,16 @@ public final class ComponentGeneratorUtils {
             return String.format("getElement().setPropertyJson(\"%s\", %s);",
                     propertyName, parameterName);
         case STRING:
-            // Don't insert null as property value. Insert empty String instead.
+            if (nullable) {
+                // Don't insert null as property value. Insert empty String
+                // instead.
+                return String.format(
+                        "getElement().setProperty(\"%s\", %s == null ? \"\" : %s);",
+                        propertyName, parameterName, parameterName);
+            }
             return String.format(
-                    "getElement().setProperty(\"%s\", %s == null ? \"\" : %s);",
-                    propertyName, parameterName, parameterName);
+                    "getElement().setProperty(\"%s\", %s);", propertyName,
+                    parameterName);
         default:
             return String.format("getElement().setProperty(\"%s\", %s);",
                     propertyName, parameterName);

--- a/flow-components-parent/flow-code-generator-api/src/main/java/com/vaadin/generator/FunctionParameterVariantCombinator.java
+++ b/flow-components-parent/flow-code-generator-api/src/main/java/com/vaadin/generator/FunctionParameterVariantCombinator.java
@@ -92,6 +92,7 @@ public class FunctionParameterVariantCombinator {
         if (paramData.getType() != null) {
             paramData.getType().forEach(typeVariants::add);
         }
+        typeVariants.sort(Comparator.comparing(ComponentType::toString));
         return typeVariants;
     }
 }

--- a/flow-components-parent/flow-code-generator-api/src/test/java/com/vaadin/generator/ComponentGeneratorTest.java
+++ b/flow-components-parent/flow-code-generator-api/src/test/java/com/vaadin/generator/ComponentGeneratorTest.java
@@ -922,7 +922,11 @@ public class ComponentGeneratorTest {
                 .removeIndentation(generatedClass);
 
         Assert.assertTrue(generatedClass.contains(
-                "@Override public void setValue(String value) { if (!Objects.equals(value, getValue())) {"));
+                "@Override public void setValue(String value) {"
+                        + " Objects.requireNonNull(value, \"value cannot be null\");"
+                        + " if (!Objects.equals(value, getValue())) {"));
+        Assert.assertTrue(generatedClass.contains(
+                "@Override public String getEmptyValue() { return \"\"; }"));
     }
 
     @Test

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/ui/combobox/GeneratedVaadinComboBoxDropdownWrapper.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/ui/combobox/GeneratedVaadinComboBoxDropdownWrapper.java
@@ -340,7 +340,7 @@ public class GeneratedVaadinComboBoxDropdownWrapper<R extends GeneratedVaadinCom
      * @param path
      *            Target path to unlink.
      */
-    protected void unlinkPaths(JsonObject path) {
+    public void unlinkPaths(String path) {
         getElement().callFunction("unlinkPaths", path);
     }
 
@@ -359,7 +359,7 @@ public class GeneratedVaadinComboBoxDropdownWrapper<R extends GeneratedVaadinCom
      * @param path
      *            Target path to unlink.
      */
-    public void unlinkPaths(String path) {
+    protected void unlinkPaths(JsonObject path) {
         getElement().callFunction("unlinkPaths", path);
     }
 
@@ -615,7 +615,7 @@ public class GeneratedVaadinComboBoxDropdownWrapper<R extends GeneratedVaadinCom
      *            Path to array.
      */
     @NotSupported
-    protected void pop(JsonObject path) {
+    protected void pop(String path) {
     }
 
     /**
@@ -642,7 +642,7 @@ public class GeneratedVaadinComboBoxDropdownWrapper<R extends GeneratedVaadinCom
      *            Path to array.
      */
     @NotSupported
-    protected void pop(String path) {
+    protected void pop(JsonObject path) {
     }
 
     /**
@@ -739,7 +739,7 @@ public class GeneratedVaadinComboBoxDropdownWrapper<R extends GeneratedVaadinCom
      *            Path to array.
      */
     @NotSupported
-    protected void shift(JsonObject path) {
+    protected void shift(String path) {
     }
 
     /**
@@ -766,7 +766,7 @@ public class GeneratedVaadinComboBoxDropdownWrapper<R extends GeneratedVaadinCom
      *            Path to array.
      */
     @NotSupported
-    protected void shift(String path) {
+    protected void shift(JsonObject path) {
     }
 
     /**

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/ui/combobox/GeneratedVaadinComboBoxLight.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/ui/combobox/GeneratedVaadinComboBoxLight.java
@@ -322,6 +322,11 @@ public class GeneratedVaadinComboBoxLight<R extends GeneratedVaadinComboBoxLight
         return value == null ? getEmptyValue() : value;
     }
 
+    @Override
+    public String getEmptyValue() {
+        return "";
+    }
+
     /**
      * <p>
      * Description copied from corresponding location in WebComponent:
@@ -343,8 +348,9 @@ public class GeneratedVaadinComboBoxLight<R extends GeneratedVaadinComboBoxLight
      */
     @Override
     public void setValue(String value) {
+        Objects.requireNonNull(value, "value cannot be null");
         if (!Objects.equals(value, getValue())) {
-            getElement().setProperty("value", value == null ? "" : value);
+            getElement().setProperty("value", value);
         }
     }
 

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/ui/combobox/GeneratedVaadinComboBoxLight.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/ui/combobox/GeneratedVaadinComboBoxLight.java
@@ -880,11 +880,11 @@ public class GeneratedVaadinComboBoxLight<R extends GeneratedVaadinComboBoxLight
     public static class SelectedItemChangeEvent<R extends GeneratedVaadinComboBoxLight<R>>
             extends ComponentEvent<R> {
         private final JsonObject detail;
-        private final JsonObject detailValue;
+        private final String detailValue;
 
         public SelectedItemChangeEvent(R source, boolean fromClient,
                 @EventData("event.detail") JsonObject detail,
-                @EventData("event.detail.value") JsonObject detailValue) {
+                @EventData("event.detail.value") String detailValue) {
             super(source, fromClient);
             this.detail = detail;
             this.detailValue = detailValue;
@@ -894,7 +894,7 @@ public class GeneratedVaadinComboBoxLight<R extends GeneratedVaadinComboBoxLight
             return detail;
         }
 
-        public JsonObject getDetailValue() {
+        public String getDetailValue() {
             return detailValue;
         }
     }

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/ui/datepicker/GeneratedVaadinDatePickerLight.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/ui/datepicker/GeneratedVaadinDatePickerLight.java
@@ -100,6 +100,11 @@ public class GeneratedVaadinDatePickerLight<R extends GeneratedVaadinDatePickerL
         return value == null ? getEmptyValue() : value;
     }
 
+    @Override
+    public String getEmptyValue() {
+        return "";
+    }
+
     /**
      * <p>
      * Description copied from corresponding location in WebComponent:
@@ -121,8 +126,9 @@ public class GeneratedVaadinDatePickerLight<R extends GeneratedVaadinDatePickerL
      */
     @Override
     public void setValue(String value) {
+        Objects.requireNonNull(value, "value cannot be null");
         if (!Objects.equals(value, getValue())) {
-            getElement().setProperty("value", value == null ? "" : value);
+            getElement().setProperty("value", value);
         }
     }
 

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/ui/datepicker/GeneratedVaadinInfiniteScroller.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/ui/datepicker/GeneratedVaadinInfiniteScroller.java
@@ -271,7 +271,7 @@ public class GeneratedVaadinInfiniteScroller<R extends GeneratedVaadinInfiniteSc
      * @param path
      *            Target path to unlink.
      */
-    protected void unlinkPaths(JsonObject path) {
+    public void unlinkPaths(String path) {
         getElement().callFunction("unlinkPaths", path);
     }
 
@@ -290,7 +290,7 @@ public class GeneratedVaadinInfiniteScroller<R extends GeneratedVaadinInfiniteSc
      * @param path
      *            Target path to unlink.
      */
-    public void unlinkPaths(String path) {
+    protected void unlinkPaths(JsonObject path) {
         getElement().callFunction("unlinkPaths", path);
     }
 
@@ -546,7 +546,7 @@ public class GeneratedVaadinInfiniteScroller<R extends GeneratedVaadinInfiniteSc
      *            Path to array.
      */
     @NotSupported
-    protected void pop(JsonObject path) {
+    protected void pop(String path) {
     }
 
     /**
@@ -573,7 +573,7 @@ public class GeneratedVaadinInfiniteScroller<R extends GeneratedVaadinInfiniteSc
      *            Path to array.
      */
     @NotSupported
-    protected void pop(String path) {
+    protected void pop(JsonObject path) {
     }
 
     /**
@@ -670,7 +670,7 @@ public class GeneratedVaadinInfiniteScroller<R extends GeneratedVaadinInfiniteSc
      *            Path to array.
      */
     @NotSupported
-    protected void shift(JsonObject path) {
+    protected void shift(String path) {
     }
 
     /**
@@ -697,7 +697,7 @@ public class GeneratedVaadinInfiniteScroller<R extends GeneratedVaadinInfiniteSc
      *            Path to array.
      */
     @NotSupported
-    protected void shift(String path) {
+    protected void shift(JsonObject path) {
     }
 
     /**

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/ui/paper/input/GeneratedPaperInput.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/ui/paper/input/GeneratedPaperInput.java
@@ -244,6 +244,11 @@ public class GeneratedPaperInput<R extends GeneratedPaperInput<R>>
         return value == null ? getEmptyValue() : value;
     }
 
+    @Override
+    public String getEmptyValue() {
+        return "";
+    }
+
     /**
      * <p>
      * Description copied from corresponding location in WebComponent:
@@ -257,8 +262,9 @@ public class GeneratedPaperInput<R extends GeneratedPaperInput<R>>
      */
     @Override
     public void setValue(String value) {
+        Objects.requireNonNull(value, "value cannot be null");
         if (!Objects.equals(value, getValue())) {
-            getElement().setProperty("value", value == null ? "" : value);
+            getElement().setProperty("value", value);
         }
     }
 

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/ui/paper/input/GeneratedPaperTextarea.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/ui/paper/input/GeneratedPaperTextarea.java
@@ -243,6 +243,11 @@ public class GeneratedPaperTextarea<R extends GeneratedPaperTextarea<R>>
         return value == null ? getEmptyValue() : value;
     }
 
+    @Override
+    public String getEmptyValue() {
+        return "";
+    }
+
     /**
      * <p>
      * Description copied from corresponding location in WebComponent:
@@ -256,8 +261,9 @@ public class GeneratedPaperTextarea<R extends GeneratedPaperTextarea<R>>
      */
     @Override
     public void setValue(String value) {
+        Objects.requireNonNull(value, "value cannot be null");
         if (!Objects.equals(value, getValue())) {
-            getElement().setProperty("value", value == null ? "" : value);
+            getElement().setProperty("value", value);
         }
     }
 

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/ui/paper/tabs/GeneratedPaperTabs.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/ui/paper/tabs/GeneratedPaperTabs.java
@@ -1026,7 +1026,7 @@ public class GeneratedPaperTabs<R extends GeneratedPaperTabs<R>> extends
      * @param value
      *            the value to select.
      */
-    public void select(double value) {
+    public void select(String value) {
         getElement().callFunction("select", value);
     }
 
@@ -1043,7 +1043,7 @@ public class GeneratedPaperTabs<R extends GeneratedPaperTabs<R>> extends
      * @param value
      *            the value to select.
      */
-    public void select(String value) {
+    public void select(double value) {
         getElement().callFunction("select", value);
     }
 

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/ui/textfield/GeneratedVaadinTextArea.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/ui/textfield/GeneratedVaadinTextArea.java
@@ -519,6 +519,11 @@ public class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<R>>
         return value == null ? getEmptyValue() : value;
     }
 
+    @Override
+    public String getEmptyValue() {
+        return "";
+    }
+
     /**
      * <p>
      * Description copied from corresponding location in WebComponent:
@@ -533,8 +538,9 @@ public class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<R>>
      */
     @Override
     public void setValue(String value) {
+        Objects.requireNonNull(value, "value cannot be null");
         if (!Objects.equals(value, getValue())) {
-            getElement().setProperty("value", value == null ? "" : value);
+            getElement().setProperty("value", value);
         }
     }
 

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/ui/textfield/GeneratedVaadinTextField.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/ui/textfield/GeneratedVaadinTextField.java
@@ -519,6 +519,11 @@ public class GeneratedVaadinTextField<R extends GeneratedVaadinTextField<R>>
         return value == null ? getEmptyValue() : value;
     }
 
+    @Override
+    public String getEmptyValue() {
+        return "";
+    }
+
     /**
      * <p>
      * Description copied from corresponding location in WebComponent:
@@ -533,8 +538,9 @@ public class GeneratedVaadinTextField<R extends GeneratedVaadinTextField<R>>
      */
     @Override
     public void setValue(String value) {
+        Objects.requireNonNull(value, "value cannot be null");
         if (!Objects.equals(value, getValue())) {
-            getElement().setProperty("value", value == null ? "" : value);
+            getElement().setProperty("value", value);
         }
     }
 


### PR DESCRIPTION
Please see https://github.com/vaadin/vaadin-text-field-flow/pull/37

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3114)
<!-- Reviewable:end -->
