### PR TITLE
Fix syntax highlight in docs

### DIFF
--- a/flow-documentation/spring/tutorial-spring-routing.asciidoc
+++ b/flow-documentation/spring/tutorial-spring-routing.asciidoc
@@ -25,12 +25,12 @@ In the same way you may define any other router path. See
 <<../routing/tutorial-routing-annotation#,Defining Routes with @Route>> 
 tutorial and other router tutorials for more details about using router.
 
-The only thing that is new here for Spring is the possibility to use DI in the
+The only thing that is new here for Spring is the possibility to use dependency injection in the
 components annotated with `@Route`. Such a component is instantiated by Spring
 and becomes a Spring initialized bean. In particular it means that you may autowire
 other Spring managed beans. Here is an example:
 
- [source,java]
+[source,java]
 ----
 @Route("")
 public class RootComponent extends Div {


### PR DESCRIPTION
There was a space before `[source,java]` that broke the code syntax highlight.
Also, changed from "DI" to full term because someone might not know the abbreviation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3126)
<!-- Reviewable:end -->
