### PR TITLE
Hotfix for component renderers when the datacommunicator is reset.

### DIFF
--- a/flow-server/src/main/resources/META-INF/resources/frontend/flow-component-renderer.html
+++ b/flow-server/src/main/resources/META-INF/resources/frontend/flow-component-renderer.html
@@ -43,15 +43,16 @@
         } else if (this.firstElementChild !== renderedComponent){
           this.replaceChild(renderedComponent, this.firstElementChild);
           this.hidden = false;
-          this._notifyResize();
+          this.onComponentRendered();
         } else {
           this.hidden = false;
+          this.onComponentRendered();
         }
       } else {
         if (renderedComponent) {
           this.appendChild(renderedComponent);
           this.hidden = false;
-          this._notifyResize();
+          this.onComponentRendered();
         } else {
           this._asyncAttachRenderedComponentIfAble();
         }
@@ -64,7 +65,7 @@
       }
     }
 
-    _notifyResize(){
+    onComponentRendered(){
       // subclasses can override this method to execute custom logic on resize
     }
     


### PR DESCRIPTION
Add a resize call when the internal component is re-rendered (without
re-attach). Change the resize call to not be public, and use a more
meaningful name.

A bigger update for the `vaadin-grid-flow` will follow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3157)
<!-- Reviewable:end -->
