### PR TITLE
Provide incorrect WebJar name when version does not match.

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/webjar/SemanticVersion.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webjar/SemanticVersion.java
@@ -57,6 +57,24 @@ public class SemanticVersion {
         preRelease = patchAndPreReleaseParts.length > 1 ? patchAndPreReleaseParts[1] : "";
     }
 
+    /**
+     * Gets major version number.
+     *
+     * @return major version number
+     */
+    public int getMajor() {
+        return major;
+    }
+
+    /**
+     * Gets minor version number.
+     *
+     * @return minor version number
+     */
+    public int getMinor() {
+        return minor;
+    }
+
     private String createSemanticVersioningErrorString(String versionString) {
         return String.format(
                 "Could not parse string '%s' as a semantic version string, see http://semver.org/ for details.",
@@ -86,30 +104,21 @@ public class SemanticVersion {
      * parts of the dependency are the same.
      *
      * @param version
-     *            the version to compare with
+     *            the version to compare with, not {@code null}
      * @return zero integer, if versions have the same patch part, positive
      *         integer, if current version was released later, negative integer
      *         otherwise
-     *
-     * @throws IllegalArgumentException
-     *             if other version has different major or minor version
      */
     public int comparePatchParts(SemanticVersion version) {
-        Objects.requireNonNull(version);
-        if (major != version.major || minor != version.minor) {
-            throw new IllegalArgumentException(String.format(
-                    "Received incomparable bower webJars with different bower names: '%s' and '%s'",
-                    this, version));
-        }
-        int patchComparison = Integer.compare(patch, version.patch);
+        int patchComparison = Integer.compare(patch, Objects.requireNonNull(version).patch);
         return patchComparison == 0 ? compareStringsByCharacter(preRelease, version.preRelease) : patchComparison;
     }
 
     private int compareStringsByCharacter(String first, String second) {
-        if (first.length() == 0 && second.length() != 0) {
+        if (first.isEmpty() && !second.isEmpty()) {
             return 1;
         }
-        if (first.length() != 0 && second.length() == 0) {
+        if (!first.isEmpty() && second.isEmpty()) {
             return -1;
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/webjar/WebJarBowerDependency.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webjar/WebJarBowerDependency.java
@@ -96,17 +96,21 @@ public class WebJarBowerDependency {
      *         integer otherwise
      * @throws IllegalArgumentException
      *             if dependencies have different
-     *             {@link WebJarBowerDependency#bowerName}
-     * @throws IllegalArgumentException
-     *             as a
-     *             {@link SemanticVersion#comparePatchParts(SemanticVersion)}
-     *             result
+     *             {@link WebJarBowerDependency#bowerName} or other version has
+     *             different major or minor version
      */
     public int compareVersions(WebJarBowerDependency dependency) {
         if (!Objects.equals(bowerName,
                 Objects.requireNonNull(dependency).bowerName)) {
             throw new IllegalArgumentException(String.format(
                     "Received incomparable bower webJars with different bower names: '%s' and '%s'",
+                    this, dependency));
+        }
+        if (semanticVersion.getMajor() != dependency.semanticVersion.getMajor()
+                || semanticVersion.getMinor() != dependency.semanticVersion
+                        .getMinor()) {
+            throw new IllegalArgumentException(String.format(
+                    "Received incomparable bower webJars with different major or minor version parts: '%s' and '%s'",
                     this, dependency));
         }
         return semanticVersion.comparePatchParts(dependency.semanticVersion);

--- a/flow-server/src/test/java/com/vaadin/flow/server/webjar/SemanticVersionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/webjar/SemanticVersionTest.java
@@ -16,17 +16,15 @@
 
 package com.vaadin.flow.server.webjar;
 
+import java.util.stream.Stream;
+
+import org.junit.Test;
+
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-
-import java.util.stream.Stream;
-
-import org.junit.Test;
-
-import com.vaadin.flow.server.webjar.SemanticVersion;
 
 /**
  * @author Vaadin Ltd.
@@ -79,18 +77,6 @@ public class SemanticVersionTest {
                         versionString));
             }
         }
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void versionsWithDifferentMajorVersionPartsAreIncompatible() {
-        new SemanticVersion("1.2.3")
-                .comparePatchParts(new SemanticVersion("2.2.3"));
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void versionsWithDifferentMinorVersionPartsAreIncompatible() {
-        new SemanticVersion("1.2.3")
-                .comparePatchParts(new SemanticVersion("1.1.3"));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/webjar/WebJarBowerDependencyTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/webjar/WebJarBowerDependencyTest.java
@@ -16,16 +16,14 @@
 
 package com.vaadin.flow.server.webjar;
 
+import org.junit.Test;
+
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
-
-import org.junit.Test;
-
-import com.vaadin.flow.server.webjar.WebJarBowerDependency;
 
 /**
  * @author Vaadin Ltd.
@@ -55,6 +53,20 @@ public class WebJarBowerDependencyTest {
         new WebJarBowerDependency("bowerName1", "webJarName", "1.2.3")
                 .compareVersions(new WebJarBowerDependency("bowerName2",
                         "webJarName", "1.2.3"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void versionsWithDifferentMajorVersionPartsAreIncompatible() {
+        new WebJarBowerDependency("bowerName", "webJarName", "1.2.3")
+                .compareVersions(new WebJarBowerDependency("bowerName",
+                        "webJarName", "2.2.3"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void versionsWithDifferentMinorVersionPartsAreIncompatible() {
+        new WebJarBowerDependency("bowerName", "webJarName", "1.2.3")
+                .compareVersions(new WebJarBowerDependency("bowerName",
+                        "webJarName", "1.3.3"));
     }
 
     @Test


### PR DESCRIPTION
Currently when there are different versions for the same package, we display version number only which makes it hard to understand which package is causing the trouble.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3178)
<!-- Reviewable:end -->
