### PR TITLE
Add basic html5 elements to flow

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Article.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Article.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import com.vaadin.flow.component.ClickNotifier;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HtmlContainer;
+import com.vaadin.flow.component.Tag;
+
+/**
+ * Component representing a <code>&lt;article&gt;</code> element.
+ *
+ * @author Vaadin Ltd
+ */
+@Tag(Tag.ARTICLE)
+public class Article extends HtmlContainer implements ClickNotifier {
+
+    /**
+     * Creates a new empty article.
+     */
+    public Article() {
+        super();
+    }
+
+    /**
+     * Creates a new article with the given child components.
+     *
+     * @param components
+     *            the child components
+     */
+    public Article(Component... components) {
+        super(components);
+    }
+}

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Aside.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Aside.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import com.vaadin.flow.component.ClickNotifier;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HtmlContainer;
+import com.vaadin.flow.component.Tag;
+
+/**
+ * Component representing a <code>&lt;aside&gt;</code> element.
+ *
+ * @author Vaadin Ltd
+ */
+@Tag(Tag.ASIDE)
+public class Aside extends HtmlContainer implements ClickNotifier {
+
+    /**
+     * Creates a new empty aside.
+     */
+    public Aside() {
+        super();
+    }
+
+    /**
+     * Creates a new aside with the given child components.
+     *
+     * @param components
+     *            the child components
+     */
+    public Aside(Component... components) {
+        super(components);
+    }
+}

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Footer.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Footer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import com.vaadin.flow.component.ClickNotifier;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HtmlContainer;
+import com.vaadin.flow.component.Tag;
+
+/**
+ * Component representing a <code>&lt;footer&gt;</code> element.
+ *
+ * @author Vaadin Ltd
+ */
+@Tag(Tag.FOOTER)
+public class Footer extends HtmlContainer implements ClickNotifier {
+
+    /**
+     * Creates a new empty footer.
+     */
+    public Footer() {
+        super();
+    }
+
+    /**
+     * Creates a new footer with the given child components.
+     *
+     * @param components
+     *            the child components
+     */
+    public Footer(Component... components) {
+        super(components);
+    }
+}

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Header.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Header.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import com.vaadin.flow.component.ClickNotifier;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HtmlContainer;
+import com.vaadin.flow.component.Tag;
+
+/**
+ * Component representing a <code>&lt;header&gt;</code> element.
+ *
+ * @author Vaadin Ltd
+ */
+@Tag(Tag.HEADER)
+public class Header extends HtmlContainer implements ClickNotifier {
+
+    /**
+     * Creates a new empty header.
+     */
+    public Header() {
+        super();
+    }
+
+    /**
+     * Creates a new header with the given child components.
+     *
+     * @param components
+     *            the child components
+     */
+    public Header(Component... components) {
+        super(components);
+    }
+}

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Main.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Main.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import com.vaadin.flow.component.ClickNotifier;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HtmlContainer;
+import com.vaadin.flow.component.Tag;
+
+/**
+ * Component representing a <code>&lt;main&gt;</code> element.
+ *
+ * @author Vaadin Ltd
+ */
+@Tag(Tag.MAIN)
+public class Main extends HtmlContainer implements ClickNotifier {
+
+    /**
+     * Creates a new empty main.
+     */
+    public Main() {
+        super();
+    }
+
+    /**
+     * Creates a new main with the given child components.
+     *
+     * @param components
+     *            the child components
+     */
+    public Main(Component... components) {
+        super(components);
+    }
+}

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Nav.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Nav.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import com.vaadin.flow.component.ClickNotifier;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HtmlContainer;
+import com.vaadin.flow.component.Tag;
+
+/**
+ * Component representing a <code>&lt;nav&gt;</code> element.
+ *
+ * @author Vaadin Ltd
+ */
+@Tag(Tag.NAV)
+public class Nav extends HtmlContainer implements ClickNotifier {
+
+    /**
+     * Creates a new empty nav.
+     */
+    public Nav() {
+        super();
+    }
+
+    /**
+     * Creates a new nav with the given child components.
+     *
+     * @param components
+     *            the child components
+     */
+    public Nav(Component... components) {
+        super(components);
+    }
+}

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Section.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Section.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import com.vaadin.flow.component.ClickNotifier;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HtmlContainer;
+import com.vaadin.flow.component.Tag;
+
+/**
+ * Component representing a <code>&lt;section&gt;</code> element.
+ *
+ * @author Vaadin Ltd
+ */
+@Tag(Tag.SECTION)
+public class Section extends HtmlContainer implements ClickNotifier {
+
+    /**
+     * Creates a new empty section.
+     */
+    public Section() {
+        super();
+    }
+
+    /**
+     * Creates a new section with the given child components.
+     *
+     * @param components
+     *            the child components
+     */
+    public Section(Component... components) {
+        super(components);
+    }
+}

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/ArticleTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/ArticleTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+public class ArticleTest extends ComponentTest {
+    // Actual test methods in super class
+
+    @Override
+    protected void addProperties() {
+        // Component defines no new properties
+    }
+
+}

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/AsideTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/AsideTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+public class AsideTest extends ComponentTest {
+    // Actual test methods in super class
+
+    @Override
+    protected void addProperties() {
+        // Component defines no new properties
+    }
+
+}

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/FooterTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/FooterTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+public class FooterTest extends ComponentTest {
+    // Actual test methods in super class
+
+    @Override
+    protected void addProperties() {
+        // Component defines no new properties
+    }
+
+}

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/HeaderTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/HeaderTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+public class HeaderTest extends ComponentTest {
+    // Actual test methods in super class
+
+    @Override
+    protected void addProperties() {
+        // Component defines no new properties
+    }
+
+}

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/MainTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/MainTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+public class MainTest extends ComponentTest {
+    // Actual test methods in super class
+
+    @Override
+    protected void addProperties() {
+        // Component defines no new properties
+    }
+
+}

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NavTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NavTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+public class NavTest extends ComponentTest {
+    // Actual test methods in super class
+
+    @Override
+    protected void addProperties() {
+        // Component defines no new properties
+    }
+
+}

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/SectionTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/SectionTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+public class SectionTest extends ComponentTest {
+    // Actual test methods in super class
+
+    @Override
+    protected void addProperties() {
+        // Component defines no new properties
+    }
+
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/Tag.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Tag.java
@@ -38,6 +38,14 @@ public @interface Tag {
      */
     String A = "a";
     /**
+     * Tag for an <code>&lt;article&gt;</code>.
+     */
+    String ARTICLE = "article";
+    /**
+     * Tag for an <code>&lt;aside&gt;</code>.
+     */
+    String ASIDE = "aside";
+    /**
      * Tag for an <code>&lt;br&gt;</code>.
      */
     String BR = "br";
@@ -66,6 +74,10 @@ public @interface Tag {
      */
     String EM = "em";
     /**
+     * Tag for an <code>&lt;footer&gt;</code>.
+     */
+    String FOOTER = "footer";
+    /**
      * Tag for an <code>&lt;h1&gt;</code>.
      */
     String H1 = "h1";
@@ -90,6 +102,10 @@ public @interface Tag {
      */
     String H6 = "h6";
     /**
+     * Tag for an <code>&lt;header&gt;</code>.
+     */
+    String HEADER = "header";
+    /**
      * Tag for an <code>&lt;hr&gt;</code>.
      */
     String HR = "hr";
@@ -110,6 +126,14 @@ public @interface Tag {
      */
     String LI = "li";
     /**
+     * Tag for an <code>&lt;main&gt;</code>.
+     */
+    String MAIN = "main";
+    /**
+     * Tag for an <code>&lt;nav&gt;</code>.
+     */
+    String NAV = "nav";
+    /**
      * Tag for an <code>&lt;ol&gt;</code>.
      */
     String OL = "ol";
@@ -125,6 +149,10 @@ public @interface Tag {
      * Tag for an <code>&lt;pre&gt;</code>.
      */
     String PRE = "pre";
+    /**
+     * Tag for an <code>&lt;section&gt;</code>.
+     */
+    String SECTION = "section";
     /**
      * Tag for an <code>&lt;select&gt;</code>.
      */


### PR DESCRIPTION
Adds the following html5 elements to the component collection of flow:

- article
- aside
- footer
- header
- main
- nav
- section

Discussion/Question: Do you want me to add the specific role attributes for the components as well or should this be a task for the user/developer? 

For example:

```
<nav>       should be         <nav role="navigation">
<main>      should be         <main role="main">
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3188)
<!-- Reviewable:end -->
