### PR TITLE
Defer binding initially invisible element on the client side

### DIFF
--- a/flow-client/pom.xml
+++ b/flow-client/pom.xml
@@ -14,7 +14,7 @@
 	<properties>
 		<gwt.module>com.vaadin.ClientEngine</gwt.module>
 		<gwt.module.output>${project.build.outputDirectory}/META-INF/resources/VAADIN/static/</gwt.module.output>
-		<gwt.module.style>OBF</gwt.module.style>
+		<gwt.module.style>DETAILED</gwt.module.style>
 		<gwt.sdm.bindAddress>0.0.0.0</gwt.sdm.bindAddress>
 	</properties>
 

--- a/flow-client/pom.xml
+++ b/flow-client/pom.xml
@@ -14,7 +14,7 @@
 	<properties>
 		<gwt.module>com.vaadin.ClientEngine</gwt.module>
 		<gwt.module.output>${project.build.outputDirectory}/META-INF/resources/VAADIN/static/</gwt.module.output>
-		<gwt.module.style>DETAILED</gwt.module.style>
+		<gwt.module.style>OBF</gwt.module.style>
 		<gwt.sdm.bindAddress>0.0.0.0</gwt.sdm.bindAddress>
 	</properties>
 

--- a/flow-client/src/main/java/com/vaadin/client/flow/ExecuteJavaScriptProcessor.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/ExecuteJavaScriptProcessor.java
@@ -126,7 +126,7 @@ public class ExecuteJavaScriptProcessor {
         return false;
     }
 
-    private boolean isBound(StateNode node) {
+    protected boolean isBound(StateNode node) {
         boolean isNodeBound = SimpleElementBindingStrategy.isBound(node)
                 && node.getDomNode() != null;
         if (!isNodeBound || node.getParent() == null) {

--- a/flow-client/src/main/java/com/vaadin/client/flow/ExecuteJavaScriptProcessor.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/ExecuteJavaScriptProcessor.java
@@ -128,7 +128,7 @@ public class ExecuteJavaScriptProcessor {
 
     protected boolean isBound(StateNode node) {
         boolean isNodeBound = node.getDomNode() != null
-                && !SimpleElementBindingStrategy.needsBind(node);
+                && !SimpleElementBindingStrategy.needsRebind(node);
         if (!isNodeBound || node.getParent() == null) {
             return isNodeBound;
         }

--- a/flow-client/src/main/java/com/vaadin/client/flow/ExecuteJavaScriptProcessor.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/ExecuteJavaScriptProcessor.java
@@ -90,12 +90,9 @@ public class ExecuteJavaScriptProcessor {
                 if (isVirtualChildAwaitingInitialization(stateNode)
                         || !isBound(stateNode)) {
                     stateNode.addDomNodeSetListener(node -> {
-                        if (isBound(node)) {
-                            Reactive.addPostFlushListener(
-                                    () -> handleInvocation(invocation));
-                            return true;
-                        }
-                        return false;
+                        Reactive.addPostFlushListener(
+                                () -> handleInvocation(invocation));
+                        return true;
                     });
                     return;
                 }
@@ -130,7 +127,12 @@ public class ExecuteJavaScriptProcessor {
     }
 
     private boolean isBound(StateNode node) {
-        return SimpleElementBindingStrategy.isBound(node);
+        boolean isNodeBound = SimpleElementBindingStrategy.isBound(node)
+                && node.getDomNode() != null;
+        if (!isNodeBound || node.getParent() == null) {
+            return isNodeBound;
+        }
+        return isBound(node.getParent());
     }
 
     /**

--- a/flow-client/src/main/java/com/vaadin/client/flow/ExecuteJavaScriptProcessor.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/ExecuteJavaScriptProcessor.java
@@ -127,8 +127,8 @@ public class ExecuteJavaScriptProcessor {
     }
 
     protected boolean isBound(StateNode node) {
-        boolean isNodeBound = SimpleElementBindingStrategy.isBound(node)
-                && node.getDomNode() != null;
+        boolean isNodeBound = node.getDomNode() != null
+                && !SimpleElementBindingStrategy.needsBind(node);
         if (!isNodeBound || node.getParent() == null) {
             return isNodeBound;
         }

--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
@@ -237,7 +237,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
     /*-{
         this.@SimpleElementBindingStrategy::bindInitialModelProperties(*)(node, element);
         var self = this;
-
+    
         var originalFunction = element._propertiesChanged;
         if (originalFunction) {
             element._propertiesChanged = function (currentProps, changedProps, oldProps) {

--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
@@ -234,7 +234,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
     /*-{
         this.@SimpleElementBindingStrategy::bindInitialModelProperties(*)(node, element);
         var self = this;
-    
+
         var originalFunction = element._propertiesChanged;
         if (originalFunction) {
             element._propertiesChanged = function (currentProps, changedProps, oldProps) {
@@ -481,8 +481,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
 
         if (!isBound(context.node) && isVisible(context.node)) {
             remove(listeners, context, computationsCollection);
-            Reactive.addFlushListener(
-                    () -> nodeFactory.createAndBind(context.node));
+            Reactive.addFlushListener(() -> doBind(context.node, nodeFactory));
         } else if (isVisible(context.node)) {
             context.node.getMap(NodeFeatures.VISIBILITY_DATA)
                     .getProperty("bound").setValue(true);
@@ -491,6 +490,15 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
             WidgetUtil.updateAttribute(element, "hidden",
                     Boolean.TRUE.toString());
         }
+    }
+
+    private void doBind(StateNode node, BinderContext nodeFactory) {
+        Node domNode = node.getDomNode();
+        // this will fire an event which gives a chance to run logic which
+        // needs to know when the element is completely initialized
+        node.setDomNode(null);
+        node.setDomNode(domNode);
+        nodeFactory.createAndBind(node);
     }
 
     public static boolean isBound(StateNode node) {

--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
@@ -518,10 +518,18 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
      *         later on
      */
     public static boolean needsRebind(StateNode node) {
-        return node.hasFeature(NodeFeatures.VISIBILITY_DATA) && Boolean.FALSE
-                .equals(node.getMap(NodeFeatures.VISIBILITY_DATA)
-                        .getProperty(NodeProperties.VISIBILITY_BOUND_PROPERTY)
-                        .getValue());
+        if (!node.hasFeature(NodeFeatures.VISIBILITY_DATA)) {
+            // If there is no VISIBILITY_DATA feature then the node doesn't need
+            // re-bind
+            return false;
+        }
+        /*
+         * Absence of value or "true" means that the node doesn't need re-bind.
+         * So only "false" means "needs re-bind".
+         */
+        return Boolean.FALSE.equals(node.getMap(NodeFeatures.VISIBILITY_DATA)
+                .getProperty(NodeProperties.VISIBILITY_BOUND_PROPERTY)
+                .getValue());
     }
 
     private static void bindProperty(PropertyUser user, MapProperty property,

--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
@@ -138,16 +138,11 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
 
     @Override
     public Element create(StateNode node) {
-        // if (isVisible(node)) {
         String tag = getTag(node);
 
         assert tag != null : "New child must have a tag";
 
         return Browser.getDocument().createElement(tag);
-        // } else {
-        // // returns a fake element
-        // return Browser.getDocument().createScriptElement();
-        // }
     }
 
     @Override
@@ -165,10 +160,9 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
             BinderContext nodeFactory) {
         boolean isVisible = isVisible(stateNode);
 
-        assert hasSameTag(stateNode, htmlNode)
-                || !isVisible : "Element tag name is '" + htmlNode.getTagName()
-                        + "', but the required tag name is " + getTag(stateNode)
-                        + ". It's only possible when the node is invisible. But it's visible";
+        assert hasSameTag(stateNode, htmlNode) : "Element tag name is '"
+                + htmlNode.getTagName() + "', but the required tag name is "
+                + getTag(stateNode);
 
         if (BOUND.has(stateNode)) {
             return;
@@ -487,15 +481,8 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
 
         if (!isBound(context.node) && isVisible(context.node)) {
             remove(listeners, context, computationsCollection);
-            Reactive.addFlushListener(() -> {
-                // if (!isVirtualChild()) {
-                // context.node.setDomNode(null);
-                // }
-                Node newNode = nodeFactory.createAndBind(context.node);
-                // if (element.getParentElement() != null) {
-                // element.getParentElement().replaceChild(newNode, element);
-                // }
-            });
+            Reactive.addFlushListener(
+                    () -> nodeFactory.createAndBind(context.node));
         } else if (isVisible(context.node)) {
             context.node.getMap(NodeFeatures.VISIBILITY_DATA)
                     .getProperty("bound").setValue(true);
@@ -674,11 +661,6 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
                 }
             });
         });
-    }
-
-    private boolean isVirtualChild() {
-        // TODO
-        return false;
     }
 
     private void appendVirtualChild(BindingContext context, StateNode node,

--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
@@ -66,8 +66,6 @@ import jsinterop.annotations.JsFunction;
  */
 public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
 
-    private static final String VISIBILITY_BOUND_PROPERTY = "bound";
-
     private static final String ELEMENT_ATTACH_ERROR_PREFIX = "Element addressed by the ";
 
     @FunctionalInterface
@@ -449,7 +447,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
             JsArray<JsMap<String, Computation>> computationsCollection,
             BinderContext nodeFactory) {
         context.node.getMap(NodeFeatures.VISIBILITY_DATA)
-                .getProperty(VISIBILITY_BOUND_PROPERTY)
+                .getProperty(NodeProperties.VISIBILITY_BOUND_PROPERTY)
                 .setValue(isVisible(context.node));
         updateVisibility(listeners, context, computationsCollection,
                 nodeFactory);
@@ -488,7 +486,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
             Reactive.addFlushListener(() -> doBind(context.node, nodeFactory));
         } else if (isVisible(context.node)) {
             context.node.getMap(NodeFeatures.VISIBILITY_DATA)
-                    .getProperty(VISIBILITY_BOUND_PROPERTY).setValue(true);
+                    .getProperty(NodeProperties.VISIBILITY_BOUND_PROPERTY).setValue(true);
             WidgetUtil.updateAttribute(element, "hidden", null);
         } else {
             WidgetUtil.updateAttribute(element, "hidden",
@@ -508,7 +506,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
     public static boolean needsBind(StateNode node) {
         return node.hasFeature(NodeFeatures.VISIBILITY_DATA) && Boolean.FALSE
                 .equals(node.getMap(NodeFeatures.VISIBILITY_DATA)
-                        .getProperty(VISIBILITY_BOUND_PROPERTY).getValue());
+                        .getProperty(NodeProperties.VISIBILITY_BOUND_PROPERTY).getValue());
     }
 
     private static void bindProperty(PropertyUser user, MapProperty property,

--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
@@ -66,6 +66,8 @@ import jsinterop.annotations.JsFunction;
  */
 public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
 
+    private static final String VISIBILITY_BOUND_PROPERTY = "bound";
+
     private static final String ELEMENT_ATTACH_ERROR_PREFIX = "Element addressed by the ";
 
     @FunctionalInterface
@@ -209,7 +211,8 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
 
             bindPolymerModelProperties(stateNode, htmlNode);
         }
-        bindVisibility(listeners, context, computationsCollection, nodeFactory);
+        listeners.push(bindVisibility(listeners, context,
+                computationsCollection, nodeFactory));
     }
 
     private native void bindPolymerModelProperties(StateNode node,
@@ -445,7 +448,8 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
             BindingContext context,
             JsArray<JsMap<String, Computation>> computationsCollection,
             BinderContext nodeFactory) {
-        context.node.getMap(NodeFeatures.VISIBILITY_DATA).getProperty("bound")
+        context.node.getMap(NodeFeatures.VISIBILITY_DATA)
+                .getProperty(VISIBILITY_BOUND_PROPERTY)
                 .setValue(isVisible(context.node));
         updateVisibility(listeners, context, computationsCollection,
                 nodeFactory);
@@ -484,7 +488,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
             Reactive.addFlushListener(() -> doBind(context.node, nodeFactory));
         } else if (isVisible(context.node)) {
             context.node.getMap(NodeFeatures.VISIBILITY_DATA)
-                    .getProperty("bound").setValue(true);
+                    .getProperty(VISIBILITY_BOUND_PROPERTY).setValue(true);
             WidgetUtil.updateAttribute(element, "hidden", null);
         } else {
             WidgetUtil.updateAttribute(element, "hidden",
@@ -503,9 +507,9 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
 
     public static boolean isBound(StateNode node) {
         boolean isInactive = node.hasFeature(NodeFeatures.VISIBILITY_DATA)
-                && Boolean.FALSE
-                        .equals(node.getMap(NodeFeatures.VISIBILITY_DATA)
-                                .getProperty("bound").getValue());
+                && Boolean.FALSE.equals(node
+                        .getMap(NodeFeatures.VISIBILITY_DATA)
+                        .getProperty(VISIBILITY_BOUND_PROPERTY).getValue());
         return BOUND.has(node) && !isInactive;
     }
 

--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
@@ -237,7 +237,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
     /*-{
         this.@SimpleElementBindingStrategy::bindInitialModelProperties(*)(node, element);
         var self = this;
-    
+
         var originalFunction = element._propertiesChanged;
         if (originalFunction) {
             element._propertiesChanged = function (currentProps, changedProps, oldProps) {
@@ -483,7 +483,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
 
         Element element = (Element) context.htmlNode;
 
-        if (!isBound(context.node) && isVisible(context.node)) {
+        if (needsBind(context.node) && isVisible(context.node)) {
             remove(listeners, context, computationsCollection);
             Reactive.addFlushListener(() -> doBind(context.node, nodeFactory));
         } else if (isVisible(context.node)) {
@@ -505,12 +505,10 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
         nodeFactory.createAndBind(node);
     }
 
-    public static boolean isBound(StateNode node) {
-        boolean isInactive = node.hasFeature(NodeFeatures.VISIBILITY_DATA)
-                && Boolean.FALSE.equals(node
-                        .getMap(NodeFeatures.VISIBILITY_DATA)
+    public static boolean needsBind(StateNode node) {
+        return node.hasFeature(NodeFeatures.VISIBILITY_DATA) && Boolean.FALSE
+                .equals(node.getMap(NodeFeatures.VISIBILITY_DATA)
                         .getProperty(VISIBILITY_BOUND_PROPERTY).getValue());
-        return BOUND.has(node) && !isInactive;
     }
 
     private static void bindProperty(PropertyUser user, MapProperty property,

--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
@@ -235,7 +235,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
     /*-{
         this.@SimpleElementBindingStrategy::bindInitialModelProperties(*)(node, element);
         var self = this;
-
+    
         var originalFunction = element._propertiesChanged;
         if (originalFunction) {
             element._propertiesChanged = function (currentProps, changedProps, oldProps) {
@@ -481,12 +481,13 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
 
         Element element = (Element) context.htmlNode;
 
-        if (needsBind(context.node) && isVisible(context.node)) {
+        if (needsRebind(context.node) && isVisible(context.node)) {
             remove(listeners, context, computationsCollection);
             Reactive.addFlushListener(() -> doBind(context.node, nodeFactory));
         } else if (isVisible(context.node)) {
             context.node.getMap(NodeFeatures.VISIBILITY_DATA)
-                    .getProperty(NodeProperties.VISIBILITY_BOUND_PROPERTY).setValue(true);
+                    .getProperty(NodeProperties.VISIBILITY_BOUND_PROPERTY)
+                    .setValue(true);
             WidgetUtil.updateAttribute(element, "hidden", null);
         } else {
             WidgetUtil.updateAttribute(element, "hidden",
@@ -503,10 +504,24 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
         nodeFactory.createAndBind(node);
     }
 
-    public static boolean needsBind(StateNode node) {
+    /**
+     * Checks whether the {@code node} needs re-bind.
+     * <p>
+     * The node needs re-bind if it was initially invisible. As a consequence
+     * such node has not be bound. It has been bound in respect to visibility
+     * feature only (partially bound). Such node needs re-bind once it becomes
+     * visible.
+     *
+     * @param node
+     *            the node to check
+     * @return {@code true} if the node is not entirely bound and needs re-bind
+     *         later on
+     */
+    public static boolean needsRebind(StateNode node) {
         return node.hasFeature(NodeFeatures.VISIBILITY_DATA) && Boolean.FALSE
                 .equals(node.getMap(NodeFeatures.VISIBILITY_DATA)
-                        .getProperty(NodeProperties.VISIBILITY_BOUND_PROPERTY).getValue());
+                        .getProperty(NodeProperties.VISIBILITY_BOUND_PROPERTY)
+                        .getValue());
     }
 
     private static void bindProperty(PropertyUser user, MapProperty property,

--- a/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtBasicElementBinderTest.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtBasicElementBinderTest.java
@@ -1395,15 +1395,13 @@ public class GwtBasicElementBinderTest extends GwtPropertyElementBinderTest {
     }
 
     public void testSimpleElementBindingStrategy_regularElement_needsBind() {
-        setVisible(false);
+        assertFalse(SimpleElementBindingStrategy.needsBind(node));
 
-        Binder.bind(node, element);
+        node.getMap(NodeFeatures.VISIBILITY_DATA)
+                .getProperty(NodeProperties.VISIBILITY_BOUND_PROPERTY)
+                .setValue(false);
 
         assertTrue(SimpleElementBindingStrategy.needsBind(node));
-
-        setVisible(true);
-
-        assertFalse(SimpleElementBindingStrategy.needsBind(node));
     }
 
     public void testSimpleElementBindingStrategy_elementWithoutFeature_needsBind() {

--- a/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtBasicElementBinderTest.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtBasicElementBinderTest.java
@@ -1391,6 +1391,8 @@ public class GwtBasicElementBinderTest extends GwtPropertyElementBinderTest {
         Reactive.flush();
 
         // The latter visibility value has no effect on element attribute
+        // If the listener had been called then the attribute value would have
+        // been "true".
         assertNull(element.getAttribute("hidden"));
     }
 

--- a/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtBasicElementBinderTest.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtBasicElementBinderTest.java
@@ -23,6 +23,7 @@ import com.vaadin.client.ExistingElementMap;
 import com.vaadin.client.Registry;
 import com.vaadin.client.WidgetUtil;
 import com.vaadin.client.flow.binding.Binder;
+import com.vaadin.client.flow.binding.SimpleElementBindingStrategy;
 import com.vaadin.client.flow.collection.JsCollections;
 import com.vaadin.client.flow.nodefeature.MapProperty;
 import com.vaadin.client.flow.nodefeature.NodeList;
@@ -1391,6 +1392,26 @@ public class GwtBasicElementBinderTest extends GwtPropertyElementBinderTest {
 
         // The latter visibility value has no effect on element attribute
         assertNull(element.getAttribute("hidden"));
+    }
+
+    public void testSimpleElementBindingStrategy_regularElement_needsBind() {
+        setVisible(false);
+
+        Binder.bind(node, element);
+
+        assertTrue(SimpleElementBindingStrategy.needsBind(node));
+
+        setVisible(true);
+
+        assertFalse(SimpleElementBindingStrategy.needsBind(node));
+    }
+
+    public void testSimpleElementBindingStrategy_elementWithoutFeature_needsBind() {
+        StateNode emptyNode = new StateNode(45, tree);
+        // self control
+        assertFalse(emptyNode.hasFeature(NodeFeatures.VISIBILITY_DATA));
+
+        assertFalse(SimpleElementBindingStrategy.needsBind(node));
     }
 
     private void setTag() {

--- a/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtBasicElementBinderTest.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtBasicElementBinderTest.java
@@ -1330,9 +1330,17 @@ public class GwtBasicElementBinderTest extends GwtPropertyElementBinderTest {
 
         node.setDomNode(element);
 
+        List<Integer> list = Arrays.asList(0);
+        node.addDomNodeSetListener(node -> {
+            list.set(0, list.get(0) + 1);
+            return false;
+        });
+
         Binder.bind(node, element);
 
         Reactive.flush();
+
+        assertEquals(Integer.valueOf(0), list.get(0));
 
         assertEquals(0, element.getChildElementCount());
         assertNull(WidgetUtil.getJsProperty(element, "foo"));
@@ -1340,6 +1348,9 @@ public class GwtBasicElementBinderTest extends GwtPropertyElementBinderTest {
         setVisible(true);
 
         Reactive.flush();
+
+        // DOM node set listener is notified at least once
+        assertTrue(list.get(0) > 1);
 
         assertEquals(1, element.getChildren().length());
         assertTrue(element.getFirstElementChild().getTagName()

--- a/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtBasicElementBinderTest.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtBasicElementBinderTest.java
@@ -1395,13 +1395,13 @@ public class GwtBasicElementBinderTest extends GwtPropertyElementBinderTest {
     }
 
     public void testSimpleElementBindingStrategy_regularElement_needsBind() {
-        assertFalse(SimpleElementBindingStrategy.needsBind(node));
+        assertFalse(SimpleElementBindingStrategy.needsRebind(node));
 
         node.getMap(NodeFeatures.VISIBILITY_DATA)
                 .getProperty(NodeProperties.VISIBILITY_BOUND_PROPERTY)
                 .setValue(false);
 
-        assertTrue(SimpleElementBindingStrategy.needsBind(node));
+        assertTrue(SimpleElementBindingStrategy.needsRebind(node));
     }
 
     public void testSimpleElementBindingStrategy_elementWithoutFeature_needsBind() {
@@ -1409,7 +1409,7 @@ public class GwtBasicElementBinderTest extends GwtPropertyElementBinderTest {
         // self control
         assertFalse(emptyNode.hasFeature(NodeFeatures.VISIBILITY_DATA));
 
-        assertFalse(SimpleElementBindingStrategy.needsBind(node));
+        assertFalse(SimpleElementBindingStrategy.needsRebind(node));
     }
 
     private void setTag() {

--- a/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtMultipleBindingTest.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtMultipleBindingTest.java
@@ -69,7 +69,8 @@ public class GwtMultipleBindingTest extends ClientEngineTestBase {
 
         @Override
         public NodeMap getMap(int id) {
-            if (id != NodeFeatures.ELEMENT_DATA && isBound) {
+            if (id != NodeFeatures.ELEMENT_DATA
+                    && id != NodeFeatures.VISIBILITY_DATA && isBound) {
                 fail();
             }
             return super.getMap(id);

--- a/flow-client/src/test/java/com/vaadin/client/flow/ExecuteJavaScriptProcessorTest.java
+++ b/flow-client/src/test/java/com/vaadin/client/flow/ExecuteJavaScriptProcessorTest.java
@@ -392,4 +392,29 @@ public class ExecuteJavaScriptProcessorTest {
 
         Assert.assertFalse(processor.isBound(node));
     }
+
+    @Test
+    public void isBound_hasElementHasFeatureAndBoundAndUnboundParent_notBound() {
+        TestJsProcessor processor = new TestJsProcessor();
+
+        Registry registry = processor.getRegistry();
+
+        StateNode node = new StateNode(37, registry.getStateTree());
+
+        node.getMap(NodeFeatures.VISIBILITY_DATA)
+                .getProperty(NodeProperties.VISIBILITY_BOUND_PROPERTY)
+                .setValue(true);
+
+        StateNode parent = new StateNode(43, registry.getStateTree());
+
+        node.setParent(parent);
+
+        // emulate binding
+        JsElement element = new JsElement() {
+
+        };
+        node.setDomNode(element);
+
+        Assert.assertFalse(processor.isBound(node));
+    }
 }

--- a/flow-client/src/test/java/com/vaadin/client/flow/ExecuteJavaScriptProcessorTest.java
+++ b/flow-client/src/test/java/com/vaadin/client/flow/ExecuteJavaScriptProcessorTest.java
@@ -321,7 +321,8 @@ public class ExecuteJavaScriptProcessorTest {
         };
         node.setDomNode(element);
 
-        node.getMap(NodeFeatures.VISIBILITY_DATA).getProperty("bound")
+        node.getMap(NodeFeatures.VISIBILITY_DATA)
+                .getProperty(NodeProperties.VISIBILITY_BOUND_PROPERTY)
                 .setValue(true);
 
         Assert.assertTrue(processor.isBound(node));
@@ -341,7 +342,8 @@ public class ExecuteJavaScriptProcessorTest {
         };
         node.setDomNode(element);
 
-        node.getMap(NodeFeatures.VISIBILITY_DATA).getProperty("bound")
+        node.getMap(NodeFeatures.VISIBILITY_DATA)
+                .getProperty(NodeProperties.VISIBILITY_BOUND_PROPERTY)
                 .setValue(false);
 
         Assert.assertFalse(processor.isBound(node));

--- a/flow-client/src/test/java/com/vaadin/client/flow/ExecuteJavaScriptProcessorTest.java
+++ b/flow-client/src/test/java/com/vaadin/client/flow/ExecuteJavaScriptProcessorTest.java
@@ -78,6 +78,29 @@ public class ExecuteJavaScriptProcessorTest {
         protected boolean isBound(StateNode node) {
             return isBound;
         }
+
+    }
+
+    private static class TestJsProcessor extends ExecuteJavaScriptProcessor {
+
+        private final Registry registry;
+
+        private TestJsProcessor(Registry registry) {
+            super(registry);
+            this.registry = registry;
+        }
+
+        private TestJsProcessor() {
+            this(new Registry() {
+                {
+                    set(StateTree.class, new StateTree(this));
+                }
+            });
+        }
+
+        Registry getRegistry() {
+            return registry;
+        }
     }
 
     @Test
@@ -254,5 +277,117 @@ public class ExecuteJavaScriptProcessorTest {
 
         // The invocation has been executed
         Assert.assertEquals(1, processor.nodeParametersList.size());
+    }
+
+    @Test
+    public void isBound_noElement_notBound() {
+        TestJsProcessor processor = new TestJsProcessor();
+
+        Registry registry = processor.getRegistry();
+
+        StateNode node = new StateNode(37, registry.getStateTree());
+
+        Assert.assertFalse(processor.isBound(node));
+    }
+
+    @Test
+    public void isBound_hasElementHasNoFeature_bound() {
+        TestJsProcessor processor = new TestJsProcessor();
+
+        Registry registry = processor.getRegistry();
+
+        StateNode node = new StateNode(37, registry.getStateTree());
+
+        // emulate binding
+        JsElement element = new JsElement() {
+
+        };
+        node.setDomNode(element);
+
+        Assert.assertTrue(processor.isBound(node));
+    }
+
+    @Test
+    public void isBound_hasElementHasFeatureAndBound_bound() {
+        TestJsProcessor processor = new TestJsProcessor();
+
+        Registry registry = processor.getRegistry();
+
+        StateNode node = new StateNode(37, registry.getStateTree());
+
+        // emulate binding
+        JsElement element = new JsElement() {
+
+        };
+        node.setDomNode(element);
+
+        node.getMap(NodeFeatures.VISIBILITY_DATA).getProperty("bound")
+                .setValue(true);
+
+        Assert.assertTrue(processor.isBound(node));
+    }
+
+    @Test
+    public void isBound_hasElementHasFeatureAndNotBound_notBound() {
+        TestJsProcessor processor = new TestJsProcessor();
+
+        Registry registry = processor.getRegistry();
+
+        StateNode node = new StateNode(37, registry.getStateTree());
+
+        // emulate binding
+        JsElement element = new JsElement() {
+
+        };
+        node.setDomNode(element);
+
+        node.getMap(NodeFeatures.VISIBILITY_DATA).getProperty("bound")
+                .setValue(false);
+
+        Assert.assertFalse(processor.isBound(node));
+    }
+
+    @Test
+    public void isBound_hasElementHasNoFeatureAndBoundParent_bound() {
+        TestJsProcessor processor = new TestJsProcessor();
+
+        Registry registry = processor.getRegistry();
+
+        StateNode node = new StateNode(37, registry.getStateTree());
+
+        StateNode parent = new StateNode(43, registry.getStateTree());
+
+        node.setParent(parent);
+
+        // emulate binding
+        JsElement element = new JsElement() {
+
+        };
+        node.setDomNode(element);
+
+        parent.setDomNode(element);
+
+        Assert.assertTrue(processor.isBound(node));
+    }
+
+    @Test
+    public void isBound_hasElementHasNoFeatureAndUnboundParent_notBound() {
+        TestJsProcessor processor = new TestJsProcessor();
+
+        Registry registry = processor.getRegistry();
+
+        StateNode node = new StateNode(37, registry.getStateTree());
+
+        StateNode parent = new StateNode(43, registry.getStateTree());
+
+        node.setParent(parent);
+
+        // emulate binding
+        JsElement element = new JsElement() {
+
+        };
+        node.setDomNode(element);
+
+        Assert.assertFalse(processor.isBound(node));
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/NodeProperties.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/NodeProperties.java
@@ -82,6 +82,12 @@ public final class NodeProperties {
     /** Key for id property. */
     public static final String ID = "id";
 
+    /**
+     * The property value used on the client side only in addition to
+     * {@link #VISIBLE}.
+     */
+    public static final String VISIBILITY_BOUND_PROPERTY = "bound";
+
     private NodeProperties() {
     }
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/VisibilityView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/VisibilityView.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.uitest.ui;
 
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.uitest.servlet.ViewTestLayout;
@@ -30,10 +31,21 @@ public class VisibilityView extends Div {
         div.setId("visibility");
         div.setVisible(false);
 
-        NativeButton button = new NativeButton("Update visibility",
+        Label label = new Label("Nested element");
+        div.add(label);
+
+        NativeButton updateVisibility = new NativeButton("Update visibility",
                 event -> div.setVisible(!div.isVisible()));
-        button.setId("update");
-        add(div, button);
+        updateVisibility.setId("updateVisibiity");
+
+        NativeButton updateStyle = new NativeButton(
+                "Update target element property", event -> {
+                    div.setClassName("foo");
+                    label.setClassName("bar");
+                });
+        updateVisibility.setId("updateProperty");
+
+        add(div, updateVisibility, updateStyle);
     }
 
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/VisibilityView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/VisibilityView.java
@@ -32,20 +32,26 @@ public class VisibilityView extends Div {
         div.setVisible(false);
 
         Label label = new Label("Nested element");
+        label.setId("nested-label");
         div.add(label);
 
         NativeButton updateVisibility = new NativeButton("Update visibility",
                 event -> div.setVisible(!div.isVisible()));
         updateVisibility.setId("updateVisibiity");
 
+        NativeButton updateLabelVisibility = new NativeButton(
+                "Update label visibility",
+                event -> label.setVisible(!label.isVisible()));
+        updateLabelVisibility.setId("updateLabelVisibiity");
+
         NativeButton updateStyle = new NativeButton(
                 "Update target element property", event -> {
                     div.setClassName("foo");
                     label.setClassName("bar");
                 });
-        updateVisibility.setId("updateProperty");
+        updateStyle.setId("updateProperty");
 
-        add(div, updateVisibility, updateStyle);
+        add(div, updateVisibility, updateStyle, updateLabelVisibility);
     }
 
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/InvisibleDefaultPropertyValueView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/InvisibleDefaultPropertyValueView.java
@@ -20,25 +20,28 @@ import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.uitest.ui.AbstractDivView;
 
-@Route("com.vaadin.flow.uitest.ui.template.PolymerDefaultPropertyValueView")
-public class PolymerDefaultPropertyValueView extends AbstractDivView {
+@Route("com.vaadin.flow.uitest.ui.template.InvisibleDefaultPropertyValueView")
+public class InvisibleDefaultPropertyValueView extends AbstractDivView {
 
-    public PolymerDefaultPropertyValueView() {
+    public InvisibleDefaultPropertyValueView() {
         PolymerDefaultPropertyValue template = new PolymerDefaultPropertyValue();
+        template.setVisible(false);
         template.setId("template");
         add(template);
 
-        NativeButton button = new NativeButton("Show email value",
-                event -> createEmailValue(template));
-        button.setId("show-email");
-        add(button);
-    }
-
-    private void createEmailValue(PolymerDefaultPropertyValue template) {
         Div div = new Div();
-        div.setText(template.getEmail());
         div.setId("email-value");
         add(div);
+
+        NativeButton showEmail = new NativeButton("Show email value",
+                event -> div.setText(template.getEmail()));
+        showEmail.setId("show-email");
+        add(showEmail);
+
+        NativeButton setVisible = new NativeButton("Make template visible",
+                event -> template.setVisible(true));
+        setVisible.setId("set-visible");
+        add(setVisible);
     }
 
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/JsInjectedGrandChild.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/JsInjectedGrandChild.java
@@ -27,6 +27,7 @@ public class JsInjectedGrandChild extends PolymerTemplate<TemplateModel> {
 
     public JsInjectedGrandChild() {
         getElement().callFunction("greet");
+        getElement().setProperty("bar", "foo");
     }
 
     @ClientDelegate

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/JsSubTemplate.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/JsSubTemplate.java
@@ -27,4 +27,9 @@ public class JsSubTemplate extends PolymerTemplate<TemplateModel> {
 
     @Id("js-grand-child")
     private JsInjectedGrandChild component;
+
+    public JsSubTemplate() {
+        getElement().setProperty("foo", "bar");
+    }
+
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/PolymerDefaultPropertyValue.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/PolymerDefaultPropertyValue.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.template;
+
+import com.vaadin.flow.component.PropertyDescriptor;
+import com.vaadin.flow.component.PropertyDescriptors;
+import com.vaadin.flow.component.Synchronize;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.HtmlImport;
+import com.vaadin.flow.component.polymertemplate.PolymerTemplate;
+import com.vaadin.flow.templatemodel.TemplateModel;
+import com.vaadin.flow.uitest.ui.template.PolymerDefaultPropertyValue.MyModel;
+
+@Tag("default-property")
+@HtmlImport("frontend://com/vaadin/flow/uitest/ui/template/PolymerDefaultPropertyValue.html")
+public class PolymerDefaultPropertyValue extends PolymerTemplate<MyModel> {
+
+    public interface MyModel extends TemplateModel {
+        void setText(String text);
+
+        void setName(String name);
+    }
+
+    private static final PropertyDescriptor<String, String> msgDescriptor = PropertyDescriptors
+            .propertyWithDefault("message", "");
+
+    public PolymerDefaultPropertyValue() {
+        getModel().setText("foo");
+        setMessage("updated-message");
+    }
+
+    @Synchronize("email-changed")
+    public String getEmail() {
+        return getElement().getProperty("email");
+    }
+
+    @Synchronize("message-changed")
+    public String getMessage() {
+        return get(msgDescriptor);
+    }
+
+    public void setMessage(String value) {
+        set(msgDescriptor, value);
+    }
+
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/TemplatesVisibility.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/TemplatesVisibility.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.template;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.internal.StateNode;
+import com.vaadin.flow.internal.nodefeature.VirtualChildrenList;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+@Route(value = "com.vaadin.flow.uitest.ui.template.TemplatesVisibility", layout = ViewTestLayout.class)
+public class TemplatesVisibility extends Div {
+
+    public TemplatesVisibility() {
+        JsGrandParentView grandParent = new JsGrandParentView();
+        grandParent.setId("grand-parent");
+
+        grandParent.setVisible(false);
+
+        NativeButton grandParentVisibility = new NativeButton(
+                "Change grand parent visibility",
+                event -> grandParent.setVisible(!grandParent.isVisible()));
+        grandParentVisibility.setId("grand-parent-visibility");
+        add(grandParent, grandParentVisibility);
+
+        StateNode subTemplateChild = grandParent.getElement().getNode()
+                .getFeature(VirtualChildrenList.class).iterator().next();
+
+        JsSubTemplate subTemplate = (JsSubTemplate) Element
+                .get(subTemplateChild).getComponent().get();
+
+        NativeButton subTemplateVisibility = new NativeButton(
+                "Change sub template visibility",
+                event -> subTemplate.setVisible(!subTemplate.isVisible()));
+        subTemplateVisibility.setId("sub-template-visibility");
+        add(subTemplateVisibility);
+
+        StateNode grandChildNode = subTemplate.getElement().getNode()
+                .getFeature(VirtualChildrenList.class).iterator().next();
+
+        JsInjectedGrandChild grandChild = (JsInjectedGrandChild) Element
+                .get(grandChildNode).getComponent().get();
+
+        NativeButton grandChildVisibility = new NativeButton(
+                "Change grand child visibility",
+                event -> grandChild.setVisible(!grandChild.isVisible()));
+        grandChildVisibility.setId("grand-child-visibility");
+        add(grandChildVisibility);
+    }
+
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/TemplatesVisibilityView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/TemplatesVisibilityView.java
@@ -23,10 +23,10 @@ import com.vaadin.flow.internal.nodefeature.VirtualChildrenList;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 
-@Route(value = "com.vaadin.flow.uitest.ui.template.TemplatesVisibility", layout = ViewTestLayout.class)
-public class TemplatesVisibility extends Div {
+@Route(value = "com.vaadin.flow.uitest.ui.template.TemplatesVisibilityView", layout = ViewTestLayout.class)
+public class TemplatesVisibilityView extends Div {
 
-    public TemplatesVisibility() {
+    public TemplatesVisibilityView() {
         JsGrandParentView grandParent = new JsGrandParentView();
         grandParent.setId("grand-parent");
 

--- a/flow-tests/test-root-context/src/main/webapp/frontend/com/vaadin/flow/uitest/ui/template/JsInjectedGrandChild.html
+++ b/flow-tests/test-root-context/src/main/webapp/frontend/com/vaadin/flow/uitest/ui/template/JsInjectedGrandChild.html
@@ -19,14 +19,13 @@
 <dom-module id="js-injected-grand-child">
     <template>
         <label id='foo-prop'>[[foo]]</label>
-        <div id='prop'>[[bar]]</label>
+        <div id='prop'>[[bar]]</div>
     </template>
     <script>
         class JsInjectedGrandChild extends Polymer.Element {
             static get is() { return 'js-injected-grand-child' }
             
             greet() {
-                console.error('xxxxxxxxxxxx');
                 this.$server.handleClientCall("bar");
             }
         }

--- a/flow-tests/test-root-context/src/main/webapp/frontend/com/vaadin/flow/uitest/ui/template/JsInjectedGrandChild.html
+++ b/flow-tests/test-root-context/src/main/webapp/frontend/com/vaadin/flow/uitest/ui/template/JsInjectedGrandChild.html
@@ -19,12 +19,14 @@
 <dom-module id="js-injected-grand-child">
     <template>
         <label id='foo-prop'>[[foo]]</label>
+        <div id='prop'>[[bar]]</label>
     </template>
     <script>
         class JsInjectedGrandChild extends Polymer.Element {
             static get is() { return 'js-injected-grand-child' }
             
             greet() {
+                console.error('xxxxxxxxxxxx');
                 this.$server.handleClientCall("bar");
             }
         }

--- a/flow-tests/test-root-context/src/main/webapp/frontend/com/vaadin/flow/uitest/ui/template/JsSubTemplate.html
+++ b/flow-tests/test-root-context/src/main/webapp/frontend/com/vaadin/flow/uitest/ui/template/JsSubTemplate.html
@@ -18,6 +18,7 @@
 
 <dom-module id="js-sub-template">
     <template>
+      <div id="prop">[[foo]]</div>
       <js-injected-grand-child id="js-grand-child"></js-injected-grand-child>
     </template>
 

--- a/flow-tests/test-root-context/src/main/webapp/frontend/com/vaadin/flow/uitest/ui/template/PolymerDefaultPropertyValue.html
+++ b/flow-tests/test-root-context/src/main/webapp/frontend/com/vaadin/flow/uitest/ui/template/PolymerDefaultPropertyValue.html
@@ -37,7 +37,7 @@
                         type: String,
                         value: "bar"
                     },
-                    messsage :{
+                    message :{
                         type: String,
                         value: "msg",
                         notify: true

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/VisibilityIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/VisibilityIT.java
@@ -25,22 +25,76 @@ import com.vaadin.flow.testutil.ChromeBrowserTest;
 public class VisibilityIT extends ChromeBrowserTest {
 
     @Test
-    public void checkVisibility() {
+    public void checkParentVisibility() {
         open();
 
+        // The element is initially hidden. It shouldn't be bound.
+        Assert.assertFalse(isElementPresent(By.id("visibility")));
+        Assert.assertFalse(isElementPresent(By.id("nested-label")));
+
+        // make the element visible
+        WebElement visibilityButton = findElement(By.id("updateVisibiity"));
+        visibilityButton.click();
+
         WebElement div = findElement(By.id("visibility"));
-        Assert.assertEquals(Boolean.TRUE.toString(),
-                div.getAttribute("hidden"));
-
-        WebElement button = findElement(By.id("update"));
-
-        button.click();
-
         Assert.assertNull(div.getAttribute("hidden"));
 
-        button.click();
+        WebElement label = findElement(By.id("nested-label"));
+        Assert.assertNull(label.getAttribute("hidden"));
+
+        // change some properties for the element itself and it's child
+        findElement(By.id("updateProperty")).click();
+
+        Assert.assertEquals("foo", div.getAttribute("class"));
+        Assert.assertEquals("bar", label.getAttribute("class"));
+
+        // switch the visibility of the parent off and on
+        visibilityButton.click();
 
         Assert.assertEquals(Boolean.TRUE.toString(),
                 div.getAttribute("hidden"));
+
+        visibilityButton.click();
+
+        Assert.assertNull(label.getAttribute("hidden"));
+    }
+
+    @Test
+    public void checkChildVisibility() {
+        open();
+
+        WebElement visibilityButton = findElement(
+                By.id("updateLabelVisibiity"));
+        visibilityButton.click();
+
+        // The element is initially hidden. It shouldn't be bound.
+        Assert.assertFalse(isElementPresent(By.id("visibility")));
+        Assert.assertFalse(isElementPresent(By.id("nested-label")));
+
+        // make the parent visible
+        findElement(By.id("updateVisibiity")).click();
+
+        // now the child element is not bound, so it's invisible
+        Assert.assertFalse(isElementPresent(By.id("nested-label")));
+
+        // change some properties for child while it's invisible
+        findElement(By.id("updateProperty")).click();
+
+        // The element is still unbound and can't be found
+        Assert.assertFalse(isElementPresent(By.id("nested-label")));
+
+        // make it visible now
+        visibilityButton.click();
+
+        WebElement label = findElement(By.id("nested-label"));
+        Assert.assertNull(label.getAttribute("hidden"));
+
+        Assert.assertEquals("bar", label.getAttribute("class"));
+
+        // make it invisible
+        visibilityButton.click();
+
+        Assert.assertEquals(Boolean.TRUE.toString(),
+                label.getAttribute("hidden"));
     }
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/InvisibleDefaultPropertyValueIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/InvisibleDefaultPropertyValueIT.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.template;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class InvisibleDefaultPropertyValueIT extends ChromeBrowserTest {
+
+    @Test
+    public void clientDefaultPropertyValues_invisibleElement_propertiesAreNotSent() {
+        open();
+
+        // template is initially invisible
+        WebElement template = findElement(By.tagName("default-property"));
+        Assert.assertEquals(Boolean.TRUE.toString(),
+                template.getAttribute("hidden"));
+
+        // The element is not bound -> not value for "text" property
+        WebElement text = getInShadowRoot(template, By.id("text"));
+        Assert.assertEquals("", text.getText());
+
+        // "message" property has default cleint side value
+        WebElement message = getInShadowRoot(template, By.id("message"));
+        Assert.assertEquals("msg", message.getText());
+
+        // Show email value which has default property defined on the client
+        // side
+        WebElement showEmail = findElement(By.id("show-email"));
+        showEmail.click();
+
+        WebElement emailValue = findElement(By.id("email-value"));
+        // default property is not sent to the server side
+        Assert.assertEquals("", emailValue.getText());
+
+        // make the element visible
+        WebElement button = findElement(By.id("set-visible"));
+        button.click();
+
+        // properties that has server side values are updated
+        Assert.assertEquals("foo", text.getText());
+
+        WebElement name = getInShadowRoot(template, By.id("name"));
+        Assert.assertEquals("bar", name.getText());
+
+        Assert.assertEquals("updated-message", message.getText());
+
+        WebElement email = getInShadowRoot(template, By.id("email"));
+        Assert.assertEquals("foo@example.com", email.getText());
+
+        // Now check the email value on the server side
+        showEmail = findElement(By.id("show-email"));
+        showEmail.click();
+        Assert.assertEquals("foo@example.com", emailValue.getText());
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/TemplatesVisibilityIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/TemplatesVisibilityIT.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.template;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class TemplatesVisibilityIT extends ChromeBrowserTest {
+
+    @Test
+    public void grandParentVisibility_descendantsAreBound() {
+        open();
+
+        WebElement grandParent = findElement(By.tagName("js-grand-parent"));
+        WebElement subTemplate = getInShadowRoot(grandParent,
+                By.cssSelector("js-sub-template"));
+
+        // Check child and grand child property values. They shouldn't be set
+        // since the elements are not bound
+        WebElement subTemplateProp = getInShadowRoot(subTemplate,
+                By.id("prop"));
+
+        WebElement grandChild = getInShadowRoot(subTemplate,
+                By.id("js-grand-child"));
+
+        WebElement grandChildFooProp = getInShadowRoot(grandChild,
+                By.id("foo-prop"));
+
+        WebElement grandChildProp = assertInitialPropertyValues(subTemplateProp,
+                grandChild, grandChildFooProp);
+
+        // make parent visible
+        findElement(By.id("grand-parent-visibility")).click();
+
+        // now all descendants should be bound and JS is executed for the
+        // grandchild
+
+        assertBound(subTemplateProp, grandChildFooProp, grandChildProp);
+    }
+
+    @Test
+    public void subTemplateVisibility_grandChildIsBound() {
+        open();
+
+        WebElement grandParent = findElement(By.tagName("js-grand-parent"));
+        WebElement subTemplate = getInShadowRoot(grandParent,
+                By.cssSelector("js-sub-template"));
+
+        // make sub template invisible
+        findElement(By.id("sub-template-visibility")).click();
+
+        // nothing has changed: parent is not bound -> descendants are still not
+        // bound
+        WebElement subTemplateProp = getInShadowRoot(subTemplate,
+                By.id("prop"));
+        WebElement grandChild = getInShadowRoot(subTemplate,
+                By.id("js-grand-child"));
+        WebElement grandChildFooProp = getInShadowRoot(grandChild,
+                By.id("foo-prop"));
+        assertInitialPropertyValues(subTemplateProp, grandChild,
+                grandChildFooProp);
+
+        // make parent visible
+        findElement(By.id("grand-parent-visibility")).click();
+
+        // sub template is invisible now, again: all properties have no values
+
+        WebElement grandChildProp = assertInitialPropertyValues(subTemplateProp,
+                grandChild, grandChildFooProp);
+
+        // make sub template visible
+        findElement(By.id("sub-template-visibility")).click();
+
+        // now everything is bound
+        assertBound(subTemplateProp, grandChildFooProp, grandChildProp);
+    }
+
+    @Test
+    public void grandChildVisibility_grandChildIsBound() {
+        open();
+
+        WebElement grandParent = findElement(By.tagName("js-grand-parent"));
+        WebElement subTemplate = getInShadowRoot(grandParent,
+                By.cssSelector("js-sub-template"));
+
+        // make grand child template invisible
+        findElement(By.id("grand-child-visibility")).click();
+
+        // nothing has changed: parent is not bound -> descendants are still not
+        // bound
+        WebElement subTemplateProp = getInShadowRoot(subTemplate,
+                By.id("prop"));
+        WebElement grandChild = getInShadowRoot(subTemplate,
+                By.id("js-grand-child"));
+        WebElement grandChildFooProp = getInShadowRoot(grandChild,
+                By.id("foo-prop"));
+        assertInitialPropertyValues(subTemplateProp, grandChild,
+                grandChildFooProp);
+
+        // make grand parent visible
+        findElement(By.id("grand-parent-visibility")).click();
+
+        // grand child template is invisible now, again: all its properties have
+        // no values
+
+        WebElement grandChildProp = getInShadowRoot(grandChild, By.id("prop"));
+        Assert.assertNotEquals("bar", grandChildFooProp.getText());
+        Assert.assertNotEquals("foo", grandChildProp.getText());
+
+        // make grand child template visible
+        findElement(By.id("grand-child-visibility")).click();
+
+        // now everything is bound
+        assertBound(subTemplateProp, grandChildFooProp, grandChildProp);
+    }
+
+    private WebElement assertInitialPropertyValues(WebElement subTemplateProp,
+            WebElement grandChild, WebElement grandChildFooProp) {
+        WebElement grandChildProp = getInShadowRoot(grandChild, By.id("prop"));
+
+        Assert.assertNotEquals("bar", subTemplateProp.getText());
+
+        Assert.assertNotEquals("bar", grandChildFooProp.getText());
+
+        Assert.assertNotEquals("foo", grandChildProp.getText());
+        return grandChildProp;
+    }
+
+    private void assertBound(WebElement subTemplateProp,
+            WebElement grandChildFooProp, WebElement grandChildProp) {
+        waitUntil(driver -> "bar".equals(subTemplateProp.getText()));
+        // This is the result of JS execution
+        waitUntil(driver -> "bar".equals(grandChildFooProp.getText()));
+        // This is the value for the grand child received from the server side
+        Assert.assertEquals("foo", grandChildProp.getText());
+    }
+}


### PR DESCRIPTION
Initially invisible element shouldn't be bound to avoid sending data from the client side to the server side until it becomes visible.

Fix for #3148

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3212)
<!-- Reviewable:end -->
