### PR TITLE
Fix Analyzer for moved Vaadin Elements

### DIFF
--- a/flow-components-parent/flow-code-generator-api/src/main/java/com/vaadin/generator/ComponentGenerator.java
+++ b/flow-components-parent/flow-code-generator-api/src/main/java/com/vaadin/generator/ComponentGenerator.java
@@ -15,8 +15,7 @@
  */
 package com.vaadin.generator;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
+import javax.annotation.Generated;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -32,18 +31,6 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.TreeSet;
-
-import javax.annotation.Generated;
-
-import org.apache.commons.lang3.ClassUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.jboss.forge.roaster.Roaster;
-import org.jboss.forge.roaster.model.Visibility;
-import org.jboss.forge.roaster.model.source.JavaClassSource;
-import org.jboss.forge.roaster.model.source.JavaDocSource;
-import org.jboss.forge.roaster.model.source.MethodSource;
-import org.jboss.forge.roaster.model.source.ParameterSource;
-import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
@@ -77,8 +64,18 @@ import com.vaadin.generator.metadata.ComponentType;
 import com.vaadin.generator.registry.BehaviorRegistry;
 import com.vaadin.generator.registry.ExclusionRegistry;
 import com.vaadin.generator.registry.PropertyNameRemapRegistry;
-
 import elemental.json.JsonObject;
+import org.apache.commons.lang3.ClassUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.jboss.forge.roaster.Roaster;
+import org.jboss.forge.roaster.model.Visibility;
+import org.jboss.forge.roaster.model.source.JavaClassSource;
+import org.jboss.forge.roaster.model.source.JavaDocSource;
+import org.jboss.forge.roaster.model.source.MethodSource;
+import org.jboss.forge.roaster.model.source.ParameterSource;
+import org.slf4j.LoggerFactory;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Base class of the component generation process. It takes a
@@ -325,9 +322,15 @@ public class ComponentGenerator {
     private JavaClassSource generateClassSource(ComponentMetadata metadata,
             String basePackage) {
         String targetPackage = basePackage;
-        if (StringUtils.isNotBlank(metadata.getBaseUrl())) {
+        String baseUrl = metadata.getBaseUrl();
+        if (StringUtils.isNotBlank(baseUrl)) {
+            // all analyzed Vaadin Elements are inside <element-name>/src/ folder,
+            // this is a fugly way to remove that
+            if (baseUrl.contains("/src/")) {
+                baseUrl = baseUrl.replace("/src/","/");
+            }
             String subPackage = ComponentGeneratorUtils
-                    .convertFilePathToPackage(metadata.getBaseUrl());
+                    .convertFilePathToPackage(baseUrl);
             if (StringUtils.isNotBlank(subPackage)) {
 
                 int firstDot = subPackage.indexOf('.');

--- a/flow-components-parent/flow-generated-components/json_metadata/vaadin-notification-card.json
+++ b/flow-components-parent/flow-generated-components/json_metadata/vaadin-notification-card.json
@@ -1,7 +1,7 @@
 {
   "name": "Vaadin.VaadinNotificationCard",
   "tag": "vaadin-notification-card",
-  "baseUrl": "vaadin-notification/vaadin-notification.html",
+  "baseUrl": "vaadin-notification/src/vaadin-notification.html",
   "version": "UNKNOWN",
   "properties": [],
   "methods": [],
@@ -13,5 +13,5 @@
   "mixins": [
     "Vaadin.ThemableMixin"
   ],
-  "description": "The container element for the notification\n\n### Styling\n\n[Generic styling/theming documentation](https://cdn.vaadin.com/vaadin-valo-theme/0.3.1/demo/customization.html)"
+  "description": "The container element for the notification\n\n### Styling\nThe following shadow DOM parts are available for styling:\n\nPart name | Description\n----------------|----------------\n`overlay` | The notification container\n`content` | The content of the notification\n\n[Generic styling/theming documentation](https://cdn.vaadin.com/vaadin-valo-theme/0.3.1/demo/customization.html)"
 }

--- a/flow-components-parent/flow-generated-components/json_metadata/vaadin-notification-overlay.json
+++ b/flow-components-parent/flow-generated-components/json_metadata/vaadin-notification-overlay.json
@@ -1,7 +1,7 @@
 {
   "name": "Vaadin.VaadinNotificationOverlay",
   "tag": "vaadin-notification-overlay",
-  "baseUrl": "vaadin-notification/vaadin-notification.html",
+  "baseUrl": "vaadin-notification/src/vaadin-notification.html",
   "version": "UNKNOWN",
   "properties": [
     {
@@ -10,120 +10,23 @@
         "BOOLEAN"
       ],
       "objectType": [],
-      "description": "",
-      "notify": true
-    },
-    {
-      "name": "template",
-      "type": [
-        "OBJECT"
-      ],
-      "objectType": [],
-      "description": "",
-      "notify": true
-    },
-    {
-      "name": "content",
-      "type": [
-        "OBJECT"
-      ],
-      "objectType": [],
-      "description": "",
-      "notify": true
-    },
-    {
-      "name": "withBackdrop",
-      "type": [
-        "BOOLEAN"
-      ],
-      "objectType": [],
-      "description": ""
-    },
-    {
-      "name": "modeless",
-      "type": [
-        "BOOLEAN"
-      ],
-      "objectType": [],
-      "description": "When true the overlay won't disable the main content, showing\nit doesn’t change the functionality of the user interface.\n           "
-    },
-    {
-      "name": "focusTrap",
-      "type": [
-        "BOOLEAN"
-      ],
-      "objectType": [],
-      "description": "When true move focus to the first focusable element in the overlay,\nor to the overlay if there are no focusable elements.\n           "
+      "description": "True when the overlay is opened\n             "
     }
   ],
-  "methods": [
-    {
-      "name": "close",
-      "description": "",
-      "parameters": [
-        {
-          "name": "sourceEvent",
-          "type": [
-            "OBJECT"
-          ],
-          "objectType": [],
-          "description": "Missing documentation!"
-        }
-      ],
-      "returns": "UNDEFINED"
-    },
-    {
-      "name": "connectedCallback",
-      "description": "",
-      "parameters": [],
-      "returns": "UNDEFINED"
-    },
-    {
-      "name": "disconnectedCallback",
-      "description": "",
-      "parameters": [],
-      "returns": "UNDEFINED"
-    }
+  "methods": [],
+  "events": [],
+  "slots": [
+    "top-stretch",
+    "top-start",
+    "top-center",
+    "top-end",
+    "middle",
+    "bottom-start",
+    "bottom-center",
+    "bottom-end",
+    "bottom-stretch"
   ],
-  "events": [
-    {
-      "name": "vaadin-overlay-close",
-      "description": "vaadin-overlay-close\nfired before the `vaadin-overlay` will be closed. If canceled the closing of the overlay is canceled as well.",
-      "properties": []
-    },
-    {
-      "name": "vaadin-overlay-escape-press",
-      "description": "vaadin-overlay-escape-press\nfired before the `vaadin-overlay` will be closed on ESC button press. If canceled the closing of the overlay is canceled as well.",
-      "properties": []
-    },
-    {
-      "name": "vaadin-overlay-open",
-      "description": "vaadin-overlay-open\nfired after the `vaadin-overlay` is opened.",
-      "properties": []
-    },
-    {
-      "name": "vaadin-overlay-outside-click",
-      "description": "vaadin-overlay-outside-click\nfired before the `vaadin-overlay` will be closed on outside click. If canceled the closing of the overlay is canceled as well.",
-      "properties": []
-    },
-    {
-      "name": "opened-changed",
-      "description": "Fired when the `opened` property changes.",
-      "properties": []
-    },
-    {
-      "name": "template-changed",
-      "description": "Fired when the `template` property changes.",
-      "properties": []
-    },
-    {
-      "name": "content-changed",
-      "description": "Fired when the `content` property changes.",
-      "properties": []
-    }
-  ],
-  "slots": [],
   "behaviors": [],
   "mixins": [],
-  "description": "The overlay element.\n\n### Styling\n\n[Generic styling/theming documentation](https://cdn.vaadin.com/vaadin-valo-theme/0.3.1/demo/customization.html)\n\nSee [`<vaadin-overlay>` documentation](https://github.com/vaadin/vaadin-overlay/blob/master/vaadin-overlay.html)\nfor `<vaadin-notification-overlay>` parts."
+  "description": "The notification overlay element."
 }

--- a/flow-components-parent/flow-generated-components/json_metadata/vaadin-notification.json
+++ b/flow-components-parent/flow-generated-components/json_metadata/vaadin-notification.json
@@ -1,8 +1,8 @@
 {
   "name": "Vaadin.NotificationElement",
   "tag": "vaadin-notification",
-  "baseUrl": "vaadin-notification/vaadin-notification.html",
-  "version": "1.0.0-alpha3",
+  "baseUrl": "vaadin-notification/src/vaadin-notification.html",
+  "version": "1.0.0-alpha4",
   "properties": [
     {
       "name": "duration",
@@ -22,20 +22,12 @@
       "notify": true
     },
     {
-      "name": "verticalAlign",
+      "name": "position",
       "type": [
         "STRING"
       ],
       "objectType": [],
-      "description": "Vertical alignment of the notification in the viewport\nValid values are `top-stretch|top|middle|bottom|bottom-stretch`\n             "
-    },
-    {
-      "name": "horizontalAlign",
-      "type": [
-        "STRING"
-      ],
-      "objectType": [],
-      "description": "Horizontal alignment of the notification in the viewport\nOnly applies for notifications in `top` or `bottom` containers.\nValid values are `start|center|end`\nHorizontal alignment is skipped in case verticalAlign is set to `top-stretch|middle|bottom-stretch`\n             "
+      "description": "Alignment of the notification in the viewport\nValid values are `top-stretch|top-start|top-center|top-end|middle|bottom-start|bottom-center|bottom-end|bottom-stretch`\n             "
     }
   ],
   "methods": [
@@ -62,5 +54,5 @@
   "slots": [],
   "behaviors": [],
   "mixins": [],
-  "description": "`<vaadin-notification>` is a Polymer 2 element providing accessible and customizable notifications (toasts).\n\n```\n<vaadin-notification>\n  <template>\n    Your work has been saved\n  </template>\n</vaadin-notification>\n```\n\n### Styling\n\n[Generic styling/theming documentation](https://cdn.vaadin.com/vaadin-valo-theme/0.3.1/demo/customization.html)\n\nThe following Shadow DOM parts are available for styling:\n\nPart name  | Description | Theme for Element\n-----------|-------------|------------------\n`content`  | The container of all regions | vaadin-notification-overlay\n`top-stretch` | top-stretch container | vaadin-notification-overlay\n`top` | top container | vaadin-notification-overlay\n`top-start` | top-start container, child of top | vaadin-notification-overlay\n`top-center` | top-center container, child of top | vaadin-notification-overlay\n`top-end` | top-end container, child of top | vaadin-notification-overlay\n`middle` | middle container | vaadin-notification-overlay\n`bottom` | bottom container | vaadin-notification-overlay\n`bottom-start` | bottom-start container, child of bottom | vaadin-notification-overlay\n`bottom-center` | bottom-center container, child of bottom | vaadin-notification-overlay\n`bottom-end` | bottom-end container, child of bottom | vaadin-notification-overlay\n`bottom-stretch` | bottom-stretch container, child of bottom | vaadin-notification-overlay"
+  "description": "`<vaadin-notification>` is a Polymer 2 element providing accessible and customizable notifications (toasts).\n\n```\n<vaadin-notification>\n  <template>\n    Your work has been saved\n  </template>\n</vaadin-notification>\n```"
 }

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/notification/GeneratedVaadinNotification.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/notification/GeneratedVaadinNotification.java
@@ -15,17 +15,16 @@
  */
 package com.vaadin.flow.component.notification;
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.ComponentEvent;
-import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.component.ComponentSupplier;
-import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.HasStyle;
-import com.vaadin.flow.component.Synchronize;
+import com.vaadin.flow.component.ComponentSupplier;
+import javax.annotation.Generated;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.HtmlImport;
+import com.vaadin.flow.component.Synchronize;
+import com.vaadin.flow.component.DomEvent;
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.shared.Registration;
 
 /**
@@ -44,91 +43,12 @@ Your work has been saved
 </template>
 </vaadin-notification>}
  * </p>
- * <h3>Styling</h3>
- * <p>
- * <a href=
- * "https://cdn.vaadin.com/vaadin-valo-theme/0.3.1/demo/customization.html"
- * >Generic styling/theming documentation</a>
- * </p>
- * <p>
- * The following Shadow DOM parts are available for styling:
- * </p>
- * <table>
- * <thead>
- * <tr>
- * <th>Part name</th>
- * <th>Description</th>
- * <th>Theme for Element</th>
- * </tr>
- * </thead> <tbody>
- * <tr>
- * <td>{@code content}</td>
- * <td>The container of all regions</td>
- * <td>vaadin-notification-overlay</td>
- * </tr>
- * <tr>
- * <td>{@code top-stretch}</td>
- * <td>top-stretch container</td>
- * <td>vaadin-notification-overlay</td>
- * </tr>
- * <tr>
- * <td>{@code top}</td>
- * <td>top container</td>
- * <td>vaadin-notification-overlay</td>
- * </tr>
- * <tr>
- * <td>{@code top-start}</td>
- * <td>top-start container, child of top</td>
- * <td>vaadin-notification-overlay</td>
- * </tr>
- * <tr>
- * <td>{@code top-center}</td>
- * <td>top-center container, child of top</td>
- * <td>vaadin-notification-overlay</td>
- * </tr>
- * <tr>
- * <td>{@code top-end}</td>
- * <td>top-end container, child of top</td>
- * <td>vaadin-notification-overlay</td>
- * </tr>
- * <tr>
- * <td>{@code middle}</td>
- * <td>middle container</td>
- * <td>vaadin-notification-overlay</td>
- * </tr>
- * <tr>
- * <td>{@code bottom}</td>
- * <td>bottom container</td>
- * <td>vaadin-notification-overlay</td>
- * </tr>
- * <tr>
- * <td>{@code bottom-start}</td>
- * <td>bottom-start container, child of bottom</td>
- * <td>vaadin-notification-overlay</td>
- * </tr>
- * <tr>
- * <td>{@code bottom-center}</td>
- * <td>bottom-center container, child of bottom</td>
- * <td>vaadin-notification-overlay</td>
- * </tr>
- * <tr>
- * <td>{@code bottom-end}</td>
- * <td>bottom-end container, child of bottom</td>
- * <td>vaadin-notification-overlay</td>
- * </tr>
- * <tr>
- * <td>{@code bottom-stretch}</td>
- * <td>bottom-stretch container, child of bottom</td>
- * <td>vaadin-notification-overlay</td>
- * </tr>
- * </tbody>
- * </table>
  */
 @Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.0-SNAPSHOT",
-        "WebComponent: Vaadin.NotificationElement#1.0.0-alpha3",
+        "WebComponent: Vaadin.NotificationElement#1.0.0-alpha4",
         "Flow#1.0-SNAPSHOT" })
 @Tag("vaadin-notification")
-@HtmlImport("frontend://bower_components/vaadin-notification/vaadin-notification.html")
+@HtmlImport("frontend://bower_components/vaadin-notification/src/vaadin-notification.html")
 public class GeneratedVaadinNotification<R extends GeneratedVaadinNotification<R>>
         extends Component implements HasStyle, ComponentSupplier<R> {
 
@@ -204,17 +124,17 @@ public class GeneratedVaadinNotification<R extends GeneratedVaadinNotification<R
      * Description copied from corresponding location in WebComponent:
      * </p>
      * <p>
-     * Vertical alignment of the notification in the viewport Valid values are
-     * {@code top-stretch|top|middle|bottom|bottom-stretch}
+     * Alignment of the notification in the viewport Valid values are
+     * {@code top-stretch|top-start|top-center|top-end|middle|bottom-start|bottom-center|bottom-end|bottom-stretch}
      * <p>
      * This property is not synchronized automatically from the client side, so
      * the returned value may not be the same as in client side.
      * </p>
      * 
-     * @return the {@code verticalAlign} property from the webcomponent
+     * @return the {@code position} property from the webcomponent
      */
-    public String getVerticalAlign() {
-        return getElement().getProperty("verticalAlign");
+    public String getPosition() {
+        return getElement().getProperty("position");
     }
 
     /**
@@ -222,55 +142,15 @@ public class GeneratedVaadinNotification<R extends GeneratedVaadinNotification<R
      * Description copied from corresponding location in WebComponent:
      * </p>
      * <p>
-     * Vertical alignment of the notification in the viewport Valid values are
-     * {@code top-stretch|top|middle|bottom|bottom-stretch}
+     * Alignment of the notification in the viewport Valid values are
+     * {@code top-stretch|top-start|top-center|top-end|middle|bottom-start|bottom-center|bottom-end|bottom-stretch}
      * </p>
      * 
-     * @param verticalAlign
+     * @param position
      *            the String value to set
      */
-    public void setVerticalAlign(String verticalAlign) {
-        getElement().setProperty("verticalAlign",
-                verticalAlign == null ? "" : verticalAlign);
-    }
-
-    /**
-     * <p>
-     * Description copied from corresponding location in WebComponent:
-     * </p>
-     * <p>
-     * Horizontal alignment of the notification in the viewport Only applies for
-     * notifications in {@code top} or {@code bottom} containers. Valid values
-     * are {@code start|center|end} Horizontal alignment is skipped in case
-     * verticalAlign is set to {@code top-stretch|middle|bottom-stretch}
-     * <p>
-     * This property is not synchronized automatically from the client side, so
-     * the returned value may not be the same as in client side.
-     * </p>
-     * 
-     * @return the {@code horizontalAlign} property from the webcomponent
-     */
-    public String getHorizontalAlign() {
-        return getElement().getProperty("horizontalAlign");
-    }
-
-    /**
-     * <p>
-     * Description copied from corresponding location in WebComponent:
-     * </p>
-     * <p>
-     * Horizontal alignment of the notification in the viewport Only applies for
-     * notifications in {@code top} or {@code bottom} containers. Valid values
-     * are {@code start|center|end} Horizontal alignment is skipped in case
-     * verticalAlign is set to {@code top-stretch|middle|bottom-stretch}
-     * </p>
-     * 
-     * @param horizontalAlign
-     *            the String value to set
-     */
-    public void setHorizontalAlign(String horizontalAlign) {
-        getElement().setProperty("horizontalAlign",
-                horizontalAlign == null ? "" : horizontalAlign);
+    public void setPosition(String position) {
+        getElement().setProperty("position", position == null ? "" : position);
     }
 
     /**

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/notification/GeneratedVaadinNotificationCard.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/notification/GeneratedVaadinNotificationCard.java
@@ -15,14 +15,13 @@
  */
 package com.vaadin.flow.component.notification;
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.ComponentSupplier;
-import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasStyle;
+import com.vaadin.flow.component.ComponentSupplier;
+import javax.annotation.Generated;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.HtmlImport;
+import com.vaadin.flow.component.HasComponents;
 
 /**
  * <p>
@@ -33,6 +32,26 @@ import com.vaadin.flow.component.dependency.HtmlImport;
  * </p>
  * <h3>Styling</h3>
  * <p>
+ * The following shadow DOM parts are available for styling:
+ * </p>
+ * <table>
+ * <thead>
+ * <tr>
+ * <th>Part name</th>
+ * <th>Description</th>
+ * </tr>
+ * </thead> <tbody>
+ * <tr>
+ * <td>{@code overlay}</td>
+ * <td>The notification container</td>
+ * </tr>
+ * <tr>
+ * <td>{@code content}</td>
+ * <td>The content of the notification</td>
+ * </tr>
+ * </tbody>
+ * </table>
+ * <p>
  * <a href=
  * "https://cdn.vaadin.com/vaadin-valo-theme/0.3.1/demo/customization.html"
  * >Generic styling/theming documentation</a>
@@ -42,7 +61,7 @@ import com.vaadin.flow.component.dependency.HtmlImport;
         "WebComponent: Vaadin.VaadinNotificationCard#UNKNOWN",
         "Flow#1.0-SNAPSHOT" })
 @Tag("vaadin-notification-card")
-@HtmlImport("frontend://bower_components/vaadin-notification/vaadin-notification.html")
+@HtmlImport("frontend://bower_components/vaadin-notification/src/vaadin-notification.html")
 public class GeneratedVaadinNotificationCard<R extends GeneratedVaadinNotificationCard<R>>
         extends Component
         implements HasStyle, ComponentSupplier<R>, HasComponents {

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/notification/GeneratedVaadinNotificationOverlay.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/notification/GeneratedVaadinNotificationOverlay.java
@@ -15,61 +15,55 @@
  */
 package com.vaadin.flow.component.notification;
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.ComponentEvent;
-import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.component.ComponentSupplier;
-import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.HasStyle;
-import com.vaadin.flow.component.Synchronize;
+import com.vaadin.flow.component.ComponentSupplier;
+import javax.annotation.Generated;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.HtmlImport;
-import com.vaadin.flow.shared.Registration;
-
-import elemental.json.JsonObject;
+import com.vaadin.flow.dom.Element;
 
 /**
  * <p>
  * Description copied from corresponding location in WebComponent:
  * </p>
  * <p>
- * The overlay element.
- * </p>
- * <h3>Styling</h3>
- * <p>
- * <a href=
- * "https://cdn.vaadin.com/vaadin-valo-theme/0.3.1/demo/customization.html"
- * >Generic styling/theming documentation</a>
- * </p>
- * <p>
- * See <a href=
- * "https://github.com/vaadin/vaadin-overlay/blob/master/vaadin-overlay.html">
- * {@code <vaadin-overlay>} documentation</a> for
- * {@code <vaadin-notification-overlay>} parts.
+ * The notification overlay element.
  * </p>
  */
 @Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.0-SNAPSHOT",
         "WebComponent: Vaadin.VaadinNotificationOverlay#UNKNOWN",
         "Flow#1.0-SNAPSHOT" })
 @Tag("vaadin-notification-overlay")
-@HtmlImport("frontend://bower_components/vaadin-notification/vaadin-notification.html")
+@HtmlImport("frontend://bower_components/vaadin-notification/src/vaadin-notification.html")
 public class GeneratedVaadinNotificationOverlay<R extends GeneratedVaadinNotificationOverlay<R>>
         extends Component implements HasStyle, ComponentSupplier<R> {
 
     /**
-     * This property is synchronized automatically from client side when a
-     * 'opened-changed' event happens.
+     * <p>
+     * Description copied from corresponding location in WebComponent:
+     * </p>
+     * <p>
+     * True when the overlay is opened
+     * <p>
+     * This property is not synchronized automatically from the client side, so
+     * the returned value may not be the same as in client side.
+     * </p>
      * 
      * @return the {@code opened} property from the webcomponent
      */
-    @Synchronize(property = "opened", value = "opened-changed")
     public boolean isOpened() {
         return getElement().getProperty("opened", false);
     }
 
     /**
+     * <p>
+     * Description copied from corresponding location in WebComponent:
+     * </p>
+     * <p>
+     * True when the overlay is opened
+     * </p>
+     * 
      * @param opened
      *            the boolean value to set
      */
@@ -78,295 +72,231 @@ public class GeneratedVaadinNotificationOverlay<R extends GeneratedVaadinNotific
     }
 
     /**
-     * This property is synchronized automatically from client side when a
-     * 'template-changed' event happens.
+     * Adds the given components as children of this component at the slot
+     * 'top-stretch'.
      * 
-     * @return the {@code template} property from the webcomponent
+     * @param components
+     *            The components to add.
+     * @see <a
+     *      href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot">MDN
+     *      page about slots</a>
+     * @see <a
+     *      href="https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
+     *      website about slots</a>
+     * @return this instance, for method chaining
      */
-    @Synchronize(property = "template", value = "template-changed")
-    protected JsonObject protectedGetTemplate() {
-        return (JsonObject) getElement().getPropertyRaw("template");
+    public R addToTopStretch(Component... components) {
+        for (Component component : components) {
+            component.getElement().setAttribute("slot", "top-stretch");
+            getElement().appendChild(component.getElement());
+        }
+        return get();
     }
 
     /**
-     * @param template
-     *            the JsonObject value to set
-     */
-    protected void setTemplate(JsonObject template) {
-        getElement().setPropertyJson("template", template);
-    }
-
-    /**
-     * This property is synchronized automatically from client side when a
-     * 'content-changed' event happens.
+     * Adds the given components as children of this component at the slot
+     * 'top-start'.
      * 
-     * @return the {@code content} property from the webcomponent
+     * @param components
+     *            The components to add.
+     * @see <a
+     *      href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot">MDN
+     *      page about slots</a>
+     * @see <a
+     *      href="https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
+     *      website about slots</a>
+     * @return this instance, for method chaining
      */
-    @Synchronize(property = "content", value = "content-changed")
-    protected JsonObject protectedGetContent() {
-        return (JsonObject) getElement().getPropertyRaw("content");
+    public R addToTopStart(Component... components) {
+        for (Component component : components) {
+            component.getElement().setAttribute("slot", "top-start");
+            getElement().appendChild(component.getElement());
+        }
+        return get();
     }
 
     /**
-     * @param content
-     *            the JsonObject value to set
-     */
-    protected void setContent(JsonObject content) {
-        getElement().setPropertyJson("content", content);
-    }
-
-    /**
-     * This property is not synchronized automatically from the client side, so
-     * the returned value may not be the same as in client side.
+     * Adds the given components as children of this component at the slot
+     * 'top-center'.
      * 
-     * @return the {@code withBackdrop} property from the webcomponent
+     * @param components
+     *            The components to add.
+     * @see <a
+     *      href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot">MDN
+     *      page about slots</a>
+     * @see <a
+     *      href="https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
+     *      website about slots</a>
+     * @return this instance, for method chaining
      */
-    public boolean isWithBackdrop() {
-        return getElement().getProperty("withBackdrop", false);
+    public R addToTopCenter(Component... components) {
+        for (Component component : components) {
+            component.getElement().setAttribute("slot", "top-center");
+            getElement().appendChild(component.getElement());
+        }
+        return get();
     }
 
     /**
-     * @param withBackdrop
-     *            the boolean value to set
-     */
-    public void setWithBackdrop(boolean withBackdrop) {
-        getElement().setProperty("withBackdrop", withBackdrop);
-    }
-
-    /**
-     * <p>
-     * Description copied from corresponding location in WebComponent:
-     * </p>
-     * <p>
-     * When true the overlay won't disable the main content, showing it doesn’t
-     * change the functionality of the user interface.
-     * <p>
-     * This property is not synchronized automatically from the client side, so
-     * the returned value may not be the same as in client side.
-     * </p>
+     * Adds the given components as children of this component at the slot
+     * 'top-end'.
      * 
-     * @return the {@code modeless} property from the webcomponent
+     * @param components
+     *            The components to add.
+     * @see <a
+     *      href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot">MDN
+     *      page about slots</a>
+     * @see <a
+     *      href="https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
+     *      website about slots</a>
+     * @return this instance, for method chaining
      */
-    public boolean isModeless() {
-        return getElement().getProperty("modeless", false);
+    public R addToTopEnd(Component... components) {
+        for (Component component : components) {
+            component.getElement().setAttribute("slot", "top-end");
+            getElement().appendChild(component.getElement());
+        }
+        return get();
     }
 
     /**
-     * <p>
-     * Description copied from corresponding location in WebComponent:
-     * </p>
-     * <p>
-     * When true the overlay won't disable the main content, showing it doesn’t
-     * change the functionality of the user interface.
-     * </p>
+     * Adds the given components as children of this component at the slot
+     * 'middle'.
      * 
-     * @param modeless
-     *            the boolean value to set
+     * @param components
+     *            The components to add.
+     * @see <a
+     *      href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot">MDN
+     *      page about slots</a>
+     * @see <a
+     *      href="https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
+     *      website about slots</a>
+     * @return this instance, for method chaining
      */
-    public void setModeless(boolean modeless) {
-        getElement().setProperty("modeless", modeless);
+    public R addToMiddle(Component... components) {
+        for (Component component : components) {
+            component.getElement().setAttribute("slot", "middle");
+            getElement().appendChild(component.getElement());
+        }
+        return get();
     }
 
     /**
-     * <p>
-     * Description copied from corresponding location in WebComponent:
-     * </p>
-     * <p>
-     * When true move focus to the first focusable element in the overlay, or to
-     * the overlay if there are no focusable elements.
-     * <p>
-     * This property is not synchronized automatically from the client side, so
-     * the returned value may not be the same as in client side.
-     * </p>
+     * Adds the given components as children of this component at the slot
+     * 'bottom-start'.
      * 
-     * @return the {@code focusTrap} property from the webcomponent
+     * @param components
+     *            The components to add.
+     * @see <a
+     *      href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot">MDN
+     *      page about slots</a>
+     * @see <a
+     *      href="https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
+     *      website about slots</a>
+     * @return this instance, for method chaining
      */
-    public boolean isFocusTrap() {
-        return getElement().getProperty("focusTrap", false);
+    public R addToBottomStart(Component... components) {
+        for (Component component : components) {
+            component.getElement().setAttribute("slot", "bottom-start");
+            getElement().appendChild(component.getElement());
+        }
+        return get();
     }
 
     /**
-     * <p>
-     * Description copied from corresponding location in WebComponent:
-     * </p>
-     * <p>
-     * When true move focus to the first focusable element in the overlay, or to
-     * the overlay if there are no focusable elements.
-     * </p>
+     * Adds the given components as children of this component at the slot
+     * 'bottom-center'.
      * 
-     * @param focusTrap
-     *            the boolean value to set
+     * @param components
+     *            The components to add.
+     * @see <a
+     *      href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot">MDN
+     *      page about slots</a>
+     * @see <a
+     *      href="https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
+     *      website about slots</a>
+     * @return this instance, for method chaining
      */
-    public void setFocusTrap(boolean focusTrap) {
-        getElement().setProperty("focusTrap", focusTrap);
+    public R addToBottomCenter(Component... components) {
+        for (Component component : components) {
+            component.getElement().setAttribute("slot", "bottom-center");
+            getElement().appendChild(component.getElement());
+        }
+        return get();
     }
 
     /**
-     * @param sourceEvent
-     *            Missing documentation!
+     * Adds the given components as children of this component at the slot
+     * 'bottom-end'.
+     * 
+     * @param components
+     *            The components to add.
+     * @see <a
+     *      href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot">MDN
+     *      page about slots</a>
+     * @see <a
+     *      href="https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
+     *      website about slots</a>
+     * @return this instance, for method chaining
      */
-    protected void close(JsonObject sourceEvent) {
-        getElement().callFunction("close", sourceEvent);
+    public R addToBottomEnd(Component... components) {
+        for (Component component : components) {
+            component.getElement().setAttribute("slot", "bottom-end");
+            getElement().appendChild(component.getElement());
+        }
+        return get();
     }
 
-    @DomEvent("vaadin-overlay-close")
-    public static class VaadinOverlayCloseEvent<R extends GeneratedVaadinNotificationOverlay<R>>
-            extends ComponentEvent<R> {
-        public VaadinOverlayCloseEvent(R source, boolean fromClient) {
-            super(source, fromClient);
+    /**
+     * Adds the given components as children of this component at the slot
+     * 'bottom-stretch'.
+     * 
+     * @param components
+     *            The components to add.
+     * @see <a
+     *      href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot">MDN
+     *      page about slots</a>
+     * @see <a
+     *      href="https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
+     *      website about slots</a>
+     * @return this instance, for method chaining
+     */
+    public R addToBottomStretch(Component... components) {
+        for (Component component : components) {
+            component.getElement().setAttribute("slot", "bottom-stretch");
+            getElement().appendChild(component.getElement());
+        }
+        return get();
+    }
+
+    /**
+     * Removes the given child components from this component.
+     * 
+     * @param components
+     *            The components to remove.
+     * @throws IllegalArgumentException
+     *             if any of the components is not a child of this component.
+     */
+    public void remove(Component... components) {
+        for (Component component : components) {
+            if (getElement().equals(component.getElement().getParent())) {
+                component.getElement().removeAttribute("slot");
+                getElement().removeChild(component.getElement());
+            } else {
+                throw new IllegalArgumentException("The given component ("
+                        + component + ") is not a child of this component");
+            }
         }
     }
 
     /**
-     * Adds a listener for {@code vaadin-overlay-close} events fired by the
-     * webcomponent.
-     * 
-     * @param listener
-     *            the listener
-     * @return a {@link Registration} for removing the event listener
+     * Removes all contents from this component, this includes child components,
+     * text content as well as child elements that have been added directly to
+     * this component using the {@link Element} API.
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    public Registration addVaadinOverlayCloseListener(
-            ComponentEventListener<VaadinOverlayCloseEvent<R>> listener) {
-        return addListener(VaadinOverlayCloseEvent.class,
-                (ComponentEventListener) listener);
-    }
-
-    @DomEvent("vaadin-overlay-escape-press")
-    public static class VaadinOverlayEscapePressEvent<R extends GeneratedVaadinNotificationOverlay<R>>
-            extends ComponentEvent<R> {
-        public VaadinOverlayEscapePressEvent(R source, boolean fromClient) {
-            super(source, fromClient);
-        }
-    }
-
-    /**
-     * Adds a listener for {@code vaadin-overlay-escape-press} events fired by
-     * the webcomponent.
-     * 
-     * @param listener
-     *            the listener
-     * @return a {@link Registration} for removing the event listener
-     */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    public Registration addVaadinOverlayEscapePressListener(
-            ComponentEventListener<VaadinOverlayEscapePressEvent<R>> listener) {
-        return addListener(VaadinOverlayEscapePressEvent.class,
-                (ComponentEventListener) listener);
-    }
-
-    @DomEvent("vaadin-overlay-open")
-    public static class VaadinOverlayOpenEvent<R extends GeneratedVaadinNotificationOverlay<R>>
-            extends ComponentEvent<R> {
-        public VaadinOverlayOpenEvent(R source, boolean fromClient) {
-            super(source, fromClient);
-        }
-    }
-
-    /**
-     * Adds a listener for {@code vaadin-overlay-open} events fired by the
-     * webcomponent.
-     * 
-     * @param listener
-     *            the listener
-     * @return a {@link Registration} for removing the event listener
-     */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    public Registration addVaadinOverlayOpenListener(
-            ComponentEventListener<VaadinOverlayOpenEvent<R>> listener) {
-        return addListener(VaadinOverlayOpenEvent.class,
-                (ComponentEventListener) listener);
-    }
-
-    @DomEvent("vaadin-overlay-outside-click")
-    public static class VaadinOverlayOutsideClickEvent<R extends GeneratedVaadinNotificationOverlay<R>>
-            extends ComponentEvent<R> {
-        public VaadinOverlayOutsideClickEvent(R source, boolean fromClient) {
-            super(source, fromClient);
-        }
-    }
-
-    /**
-     * Adds a listener for {@code vaadin-overlay-outside-click} events fired by
-     * the webcomponent.
-     * 
-     * @param listener
-     *            the listener
-     * @return a {@link Registration} for removing the event listener
-     */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    public Registration addVaadinOverlayOutsideClickListener(
-            ComponentEventListener<VaadinOverlayOutsideClickEvent<R>> listener) {
-        return addListener(VaadinOverlayOutsideClickEvent.class,
-                (ComponentEventListener) listener);
-    }
-
-    @DomEvent("opened-changed")
-    public static class OpenedChangeEvent<R extends GeneratedVaadinNotificationOverlay<R>>
-            extends ComponentEvent<R> {
-        public OpenedChangeEvent(R source, boolean fromClient) {
-            super(source, fromClient);
-        }
-    }
-
-    /**
-     * Adds a listener for {@code opened-changed} events fired by the
-     * webcomponent.
-     * 
-     * @param listener
-     *            the listener
-     * @return a {@link Registration} for removing the event listener
-     */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    public Registration addOpenedChangeListener(
-            ComponentEventListener<OpenedChangeEvent<R>> listener) {
-        return addListener(OpenedChangeEvent.class,
-                (ComponentEventListener) listener);
-    }
-
-    @DomEvent("template-changed")
-    public static class TemplateChangeEvent<R extends GeneratedVaadinNotificationOverlay<R>>
-            extends ComponentEvent<R> {
-        public TemplateChangeEvent(R source, boolean fromClient) {
-            super(source, fromClient);
-        }
-    }
-
-    /**
-     * Adds a listener for {@code template-changed} events fired by the
-     * webcomponent.
-     * 
-     * @param listener
-     *            the listener
-     * @return a {@link Registration} for removing the event listener
-     */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    public Registration addTemplateChangeListener(
-            ComponentEventListener<TemplateChangeEvent<R>> listener) {
-        return addListener(TemplateChangeEvent.class,
-                (ComponentEventListener) listener);
-    }
-
-    @DomEvent("content-changed")
-    public static class ContentChangeEvent<R extends GeneratedVaadinNotificationOverlay<R>>
-            extends ComponentEvent<R> {
-        public ContentChangeEvent(R source, boolean fromClient) {
-            super(source, fromClient);
-        }
-    }
-
-    /**
-     * Adds a listener for {@code content-changed} events fired by the
-     * webcomponent.
-     * 
-     * @param listener
-     *            the listener
-     * @return a {@link Registration} for removing the event listener
-     */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    public Registration addContentChangeListener(
-            ComponentEventListener<ContentChangeEvent<R>> listener) {
-        return addListener(ContentChangeEvent.class,
-                (ComponentEventListener) listener);
+    public void removeAll() {
+        getElement().getChildren()
+                .forEach(child -> child.removeAttribute("slot"));
+        getElement().removeAllChildren();
     }
 }

--- a/flow-components-parent/flow-webcomponent-api-analyzer/bower.json
+++ b/flow-components-parent/flow-webcomponent-api-analyzer/bower.json
@@ -51,6 +51,6 @@
     "vaadin-progress-bar": "1.0.0-alpha6",
     "vaadin-tabs": "1.0.0-beta1",
     "vaadin-radio-button": "1.0.0-alpha8",
-    "vaadin-notification": "1.0.0-alpha3"
+    "vaadin-notification": "1.0.0-alpha4"
   }
 }

--- a/flow-components-parent/flow-webcomponent-api-analyzer/lib/js/element-filter.js
+++ b/flow-components-parent/flow-webcomponent-api-analyzer/lib/js/element-filter.js
@@ -56,6 +56,7 @@ module.exports = class ElementFilter {
     return this.acceptPath(file.path);
   }
 
+
   /**
    * Evaluates whether a given file should be accepted for the analysis.
    *
@@ -63,7 +64,13 @@ module.exports = class ElementFilter {
    * @returns true if the file should be analyzed, false otherwise
    */
   acceptPath(filePath) {
-    const folderName = path.dirname(filePath).split(path.sep).pop();
+    const folders = path.dirname(filePath).split(path.sep);
+    // we'll only analyze files the root or inside /src
+    var folderName = folders.pop();
+    if (folderName.indexOf('src') === 0) {
+      folderName = folders.pop();
+    }
     return this._dependencies.indexOf(folderName) >= 0;
   }
+
 };


### PR DESCRIPTION
Updates vaadin-notification to 1.0.0.alpha4 which has been moved to /src/.
Changes the element filter to include elements inside /src/.
Changes how the package name is created in the generator, to discard /src/.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3217)
<!-- Reviewable:end -->
