### PR TITLE
Disallow client side updates for inactive elements

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/flow/StateTree.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/StateTree.java
@@ -24,6 +24,7 @@ import com.vaadin.client.flow.collection.JsMap;
 import com.vaadin.client.flow.nodefeature.MapProperty;
 import com.vaadin.client.flow.nodefeature.NodeMap;
 import com.vaadin.flow.internal.nodefeature.NodeFeatures;
+import com.vaadin.flow.internal.nodefeature.NodeProperties;
 
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
@@ -304,6 +305,45 @@ public class StateTree {
      */
     public Registry getRegistry() {
         return registry;
+    }
+
+    /**
+     * Returns the visibility state of the {@code node}.
+     *
+     * @param node
+     *            the node whose visibility is tested
+     * @return {@code true} is the node is visible, {@code false} otherwise
+     */
+    public boolean isVisible(StateNode node) {
+        if (!node.hasFeature(NodeFeatures.VISIBILITY_DATA)) {
+            return true;
+        }
+        NodeMap visibilityMap = node.getMap(NodeFeatures.VISIBILITY_DATA);
+        Boolean visibility = (Boolean) visibilityMap
+                .getProperty(NodeProperties.VISIBLE).getValue();
+
+        /*
+         * Absence of value or "true" means that the node should be visible. So
+         * only "false" means "hide".
+         */
+        return !Boolean.FALSE.equals(visibility);
+    }
+
+    /**
+     * Checks whether the {@code node} is active.
+     * <p>
+     * The node is active if it's visible and all its ascendant are visible.
+     *
+     * @param node
+     *            the node whose activity is tested
+     * @return {@code true} is the node is active, {@code false} otherwise
+     */
+    public boolean isActive(StateNode node) {
+        boolean isVisible = isVisible(node);
+        if (!isVisible || node.getParent() == null) {
+            return isVisible;
+        }
+        return isActive(node.getParent());
     }
 
     /**

--- a/flow-client/src/main/java/com/vaadin/client/flow/StateTree.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/StateTree.java
@@ -332,7 +332,7 @@ public class StateTree {
     /**
      * Checks whether the {@code node} is active.
      * <p>
-     * The node is active if it's visible and all its ascendant are visible.
+     * The node is active if it's visible and all its ancestors are visible.
      *
      * @param node
      *            the node whose activity is tested

--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
@@ -235,7 +235,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
     /*-{
         this.@SimpleElementBindingStrategy::bindInitialModelProperties(*)(node, element);
         var self = this;
-    
+
         var originalFunction = element._propertiesChanged;
         if (originalFunction) {
             element._propertiesChanged = function (currentProps, changedProps, oldProps) {
@@ -458,18 +458,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
     }
 
     private boolean isVisible(StateNode node) {
-        if (!node.hasFeature(NodeFeatures.VISIBILITY_DATA)) {
-            return true;
-        }
-        NodeMap visibilityMap = node.getMap(NodeFeatures.VISIBILITY_DATA);
-        Boolean visibility = (Boolean) visibilityMap
-                .getProperty(NodeProperties.VISIBLE).getValue();
-
-        /*
-         * Absence of value or "true" means that the node should be visible. So
-         * only "false" means "hide".
-         */
-        return !Boolean.FALSE.equals(visibility);
+        return node.getTree().isVisible(node);
     }
 
     private void updateVisibility(JsArray<EventRemover> listeners,

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/JsGrandParentView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/JsGrandParentView.java
@@ -18,13 +18,16 @@ package com.vaadin.flow.uitest.ui.template;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.component.polymertemplate.PolymerTemplate;
-import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.templatemodel.TemplateModel;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 
 @Tag("js-grand-parent")
 @HtmlImport("frontend://com/vaadin/flow/uitest/ui/template/JsGrandParent.html")
 @Route(value = "com.vaadin.flow.uitest.ui.template.JsGrandParentView", layout = ViewTestLayout.class)
 public class JsGrandParentView extends PolymerTemplate<TemplateModel> {
 
+    public void updateChildViaClientSide() {
+        getElement().callFunction("updateSubTempate");
+    }
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/TemplatesVisibilityView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/TemplatesVisibilityView.java
@@ -61,6 +61,12 @@ public class TemplatesVisibilityView extends Div {
                 event -> grandChild.setVisible(!grandChild.isVisible()));
         grandChildVisibility.setId("grand-child-visibility");
         add(grandChildVisibility);
+
+        NativeButton updateSubTemplateViaClientSide = new NativeButton(
+                "Update su template property via client side",
+                event -> grandParent.updateChildViaClientSide());
+        updateSubTemplateViaClientSide.setId("client-side-update-property");
+        add(updateSubTemplateViaClientSide);
     }
 
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/TemplatesVisibilityView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/TemplatesVisibilityView.java
@@ -63,7 +63,7 @@ public class TemplatesVisibilityView extends Div {
         add(grandChildVisibility);
 
         NativeButton updateSubTemplateViaClientSide = new NativeButton(
-                "Update su template property via client side",
+                "Update sub template property via client side",
                 event -> grandParent.updateChildViaClientSide());
         updateSubTemplateViaClientSide.setId("client-side-update-property");
         add(updateSubTemplateViaClientSide);

--- a/flow-tests/test-root-context/src/main/webapp/frontend/com/vaadin/flow/uitest/ui/template/JsGrandParent.html
+++ b/flow-tests/test-root-context/src/main/webapp/frontend/com/vaadin/flow/uitest/ui/template/JsGrandParent.html
@@ -18,13 +18,17 @@
 
 <dom-module id="js-grand-parent">
     <template>
-      <js-sub-template></js-sub-template>
+      <js-sub-template id='sub-template'></js-sub-template>
     </template>
 
     <script>
         class JsGrandTemplate extends Polymer.Element {
             static get is() {
                 return 'js-grand-parent'
+            }
+            
+            updateSubTempate(){
+                this.$['sub-template'].foo='baz';
             }
         }
         customElements.define(JsGrandTemplate.is, JsGrandTemplate);

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/TemplatesVisibilityIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/TemplatesVisibilityIT.java
@@ -156,14 +156,14 @@ public class TemplatesVisibilityIT extends ChromeBrowserTest {
         // The property value has not changed
         Assert.assertEquals("bar", subTemplateProp.getText());
 
-        // make template invisible
+        // make template visible
         findElement(By.id("sub-template-visibility")).click();
 
         // One more check : the property value is still the same
         Assert.assertEquals("bar", subTemplateProp.getText());
 
-        // change the sub template property via client side one more time (not
-        // the component is visible)
+        // change the sub template property via client side one more time
+        // (now the component is visible)
         findElement(By.id("client-side-update-property")).click();
 
         // Now the property value should be changed

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/TemplatesVisibilityIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/TemplatesVisibilityIT.java
@@ -131,6 +131,45 @@ public class TemplatesVisibilityIT extends ChromeBrowserTest {
         assertBound(subTemplateProp, grandChildFooProp, grandChildProp);
     }
 
+    @Test
+    public void invisibleComponent_dropClientSideChanges() {
+        open();
+
+        // make parent visible
+        findElement(By.id("grand-parent-visibility")).click();
+
+        WebElement grandParent = findElement(By.tagName("js-grand-parent"));
+        WebElement subTemplate = getInShadowRoot(grandParent,
+                By.cssSelector("js-sub-template"));
+
+        WebElement subTemplateProp = getInShadowRoot(subTemplate,
+                By.id("prop"));
+
+        Assert.assertEquals("bar", subTemplateProp.getText());
+
+        // make sub template invisible
+        findElement(By.id("sub-template-visibility")).click();
+
+        // change the sub template property via client side
+        findElement(By.id("client-side-update-property")).click();
+
+        // The property value has not changed
+        Assert.assertEquals("bar", subTemplateProp.getText());
+
+        // make template invisible
+        findElement(By.id("sub-template-visibility")).click();
+
+        // One more check : the property value is still the same
+        Assert.assertEquals("bar", subTemplateProp.getText());
+
+        // change the sub template property via client side one more time (not
+        // the component is visible)
+        findElement(By.id("client-side-update-property")).click();
+
+        // Now the property value should be changed
+        Assert.assertEquals("baz", subTemplateProp.getText());
+    }
+
     private WebElement assertInitialPropertyValues(WebElement subTemplateProp,
             WebElement grandChild, WebElement grandChildFooProp) {
         WebElement grandChildProp = getInShadowRoot(grandChild, By.id("prop"));


### PR DESCRIPTION
Reset the values back for nodes that are invisible or has invisible ascendant for client side changes.

Fix for #3150

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3222)
<!-- Reviewable:end -->
