### PR TITLE
StateNode should check if detached on setParent.

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/NodeOwner.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/NodeOwner.java
@@ -53,4 +53,13 @@ public interface NodeOwner extends Serializable {
      *            the node to be marked as dirty
      */
     void markAsDirty(StateNode node);
+
+    /**
+     * Check if given node is registered to this node owner.
+     * 
+     * @param node
+     *            node to check registration status for
+     * @return true if node is registered
+     */
+    boolean hasNode(StateNode node);
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/NullOwner.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/NullOwner.java
@@ -57,4 +57,10 @@ public class NullOwner implements NodeOwner {
     public void markAsDirty(StateNode node) {
         assert node.getOwner() == this;
     }
+
+    @Override
+    public boolean hasNode(StateNode node) {
+        assert node.getOwner() == this;
+        return true;
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
@@ -144,6 +144,9 @@ public class StateNode implements Serializable {
      *            is not attached to another node
      */
     public void setParent(StateNode parent) {
+        if(hasDetached()) {
+            return;
+        }
         boolean attachedBefore = isAttached();
         boolean attachedAfter = false;
 
@@ -174,6 +177,10 @@ public class StateNode implements Serializable {
         } else {
             this.parent = parent;
         }
+    }
+
+    private boolean hasDetached() {
+        return isAttached() && !owner.hasNode(this);
     }
 
     private boolean isAncestorOf(StateNode node) {

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateTree.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateTree.java
@@ -189,6 +189,12 @@ public class StateTree implements NodeOwner {
         }
     }
 
+    @Override
+    public boolean hasNode(StateNode node) {
+        assert node.getOwner() == this;
+        return idToNode.containsKey(node.getId());
+    }
+
     /**
      * Finds a node with the given id.
      *


### PR DESCRIPTION
If we have detached and unregistered the node already and
a listener fires a new setParent(null) we should see that we
are already detached and ignore any concurrent detaches during
this setParent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3235)
<!-- Reviewable:end -->
