### PR TITLE
Support dash-separated CSS properties for Element.getStyle()

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/dom/ElementUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/ElementUtil.java
@@ -116,12 +116,6 @@ public class ElementUtil {
                     name);
         }
 
-        if (name.contains("-")) {
-            return String.format(
-                    "Invalid style property name '%s': a style property name cannot contain dashes. Use the camelCase property name",
-                    name);
-        }
-
         return null;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Style.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Style.java
@@ -40,9 +40,9 @@ public interface Style extends Serializable {
     /**
      * Sets the given style property to the given value.
      * <p>
-     * Note that the name should be in camelCase and not dash-separated, i.e.
-     * use "fontFamily" and not "font-family"
-     *
+     * Both camelCased (e.g. <code>fontFamily</code>) and dash-separated (e.g.
+     * <code>font-family</code> versions are supported.
+     * 
      * @param name
      *            the style property name as camelCase, not <code>null</code>
      * @param value
@@ -54,8 +54,8 @@ public interface Style extends Serializable {
     /**
      * Removes the given style property if it has been set.
      * <p>
-     * Note that the name should be in camelCase and not dash-separated, i.e.
-     * use "fontFamily" and not "font-family"
+     * Both camelCased (e.g. <code>fontFamily</code>) and dash-separated (e.g.
+     * <code>font-family</code> versions are supported.
      *
      * @param name
      *            the style property name as camelCase, not <code>null</code>
@@ -73,8 +73,8 @@ public interface Style extends Serializable {
     /**
      * Checks if the given style property has been set.
      * <p>
-     * Note that the name should be in camelCase and not dash-separated, i.e.
-     * use "fontFamily" and not "font-family"
+     * Both camelCased (e.g. <code>fontFamily</code>) and dash-separated (e.g.
+     * <code>font-family</code> versions are supported.
      *
      * @param name
      *            the style property name as camelCase, not <code>null</code>
@@ -86,6 +86,10 @@ public interface Style extends Serializable {
 
     /**
      * Gets the defined style property names.
+     * <p>
+     * Note that this always returns the name as camelCased, e.g.
+     * <code>fontFamily</code> even if it has been set as dash-separated
+     * (<code>font-family</code>).
      *
      * @return a stream of defined style property names
      */

--- a/flow-server/src/main/java/com/vaadin/flow/dom/StyleUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/StyleUtil.java
@@ -33,7 +33,7 @@ public class StyleUtil {
 
     /**
      * Converts the given attribute style (dash-separated) into a property style
-     * (camelCase) which is accepted by {@link Style#set(String, String)}.
+     * (camelCase).
      *
      * @param attributeStyle
      *            the attribute style

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/BasicElementStyle.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/BasicElementStyle.java
@@ -19,6 +19,7 @@ import java.util.stream.Stream;
 
 import com.vaadin.flow.dom.ElementUtil;
 import com.vaadin.flow.dom.Style;
+import com.vaadin.flow.dom.StyleUtil;
 import com.vaadin.flow.internal.nodefeature.ElementStylePropertyMap;
 
 /**
@@ -50,7 +51,7 @@ public class BasicElementStyle implements Style {
         String trimmedValue = value.trim();
         ElementUtil.validateStylePropertyValue(trimmedValue);
 
-        propertyMap.setProperty(name, trimmedValue, true);
+        propertyMap.setProperty(StyleUtil.styleAttributeToProperty(name), trimmedValue, true);
         return this;
     }
 
@@ -58,7 +59,7 @@ public class BasicElementStyle implements Style {
     public Style remove(String name) {
         ElementUtil.validateStylePropertyName(name);
 
-        propertyMap.removeProperty(name);
+        propertyMap.removeProperty(StyleUtil.styleAttributeToProperty(name));
         return this;
     }
 
@@ -72,7 +73,7 @@ public class BasicElementStyle implements Style {
     public String get(String name) {
         ElementUtil.validateStylePropertyName(name);
 
-        return (String) propertyMap.getProperty(name);
+        return (String) propertyMap.getProperty(StyleUtil.styleAttributeToProperty(name));
     }
 
     @Override
@@ -82,6 +83,6 @@ public class BasicElementStyle implements Style {
 
     @Override
     public boolean has(String name) {
-        return propertyMap.hasProperty(name);
+        return propertyMap.hasProperty(StyleUtil.styleAttributeToProperty(name));
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/BoundStyle.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/BoundStyle.java
@@ -19,6 +19,7 @@ import java.util.LinkedHashMap;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.dom.Style;
+import com.vaadin.flow.dom.StyleUtil;
 import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.template.angular.ElementTemplateNode;
 
@@ -52,7 +53,8 @@ public class BoundStyle implements Style {
 
     @Override
     public String get(String styleProperty) {
-        return staticStyles.get(styleProperty);
+        return staticStyles
+                .get(StyleUtil.styleAttributeToProperty(styleProperty));
     }
 
     @Override
@@ -67,7 +69,8 @@ public class BoundStyle implements Style {
 
     @Override
     public boolean has(String styleProperty) {
-        return staticStyles.containsKey(styleProperty);
+        return staticStyles
+                .containsKey(StyleUtil.styleAttributeToProperty(styleProperty));
     }
 
     @Override

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
@@ -1090,12 +1090,63 @@ public class ElementTest extends AbstractNodeTest {
         Assert.assertEquals(validStyle, style.get("background"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void warnAboutDashSeparated() {
+    @Test
+    public void dashSeparatedSetStyle() {
         Element element = ElementFactory.createDiv();
 
         Style style = element.getStyle();
         style.set("border-color", "blue");
+        Assert.assertEquals("blue", style.get("border-color"));
+    }
+
+    @Test
+    public void dashSeparatedGetStyle() {
+        Element element = ElementFactory.createDiv();
+
+        Style style = element.getStyle();
+        style.set("borderColor", "blue");
+        style.set("border-foo", "bar");
+        Assert.assertEquals("blue", style.get("border-color"));
+        Assert.assertEquals("bar", style.get("border-foo"));
+    }
+
+    @Test
+    public void dashSeparatedHasStyle() {
+        Element element = ElementFactory.createDiv();
+
+        Style style = element.getStyle();
+        style.set("borderColor", "blue");
+        style.set("border-foo", "bar");
+        Assert.assertTrue(style.has("border-color"));
+        Assert.assertTrue(style.has("border-foo"));
+    }
+
+    @Test
+    public void dashSeparatedRemoveStyle() {
+        Element element = ElementFactory.createDiv();
+
+        Style style = element.getStyle();
+        style.set("borderColor", "blue");
+        style.set("border-foo", "bar");
+        style.remove("border-color");
+        style.remove("border-foo");
+
+        Assert.assertFalse(style.has("border-color"));
+        Assert.assertFalse(style.has("border-foo"));
+    }
+
+    @Test
+    public void styleGetNamesDashAndCamelCase() {
+        Element element = ElementFactory.createDiv();
+
+        Style style = element.getStyle();
+        style.set("borderColor", "blue");
+        style.set("border-foo", "bar");
+
+        List<String> styles = style.getNames().collect(Collectors.toList());
+        Assert.assertEquals(2, styles.size());
+        Assert.assertTrue(styles.contains("borderColor"));
+        Assert.assertTrue(styles.contains("borderFoo"));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/flow-server/src/test/java/com/vaadin/flow/dom/TemplateElementStateProviderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/TemplateElementStateProviderTest.java
@@ -855,8 +855,7 @@ public class TemplateElementStateProviderTest {
     }
 
     private void assertClassList(ClassList classList, String... expectedNames) {
-        Set<String> expectedSet = new HashSet<>(
-                Arrays.asList(expectedNames));
+        Set<String> expectedSet = new HashSet<>(Arrays.asList(expectedNames));
 
         Assert.assertEquals(expectedNames.length, classList.size());
         Assert.assertEquals(expectedNames.length, classList.stream().count());
@@ -1045,6 +1044,24 @@ public class TemplateElementStateProviderTest {
         Assert.assertEquals("blue", element.getStyle().get("background"));
         Assert.assertArrayEquals(new Object[] { "style" },
                 element.getAttributeNames().toArray());
+    }
+
+    @Test
+    public void templateStaticStyleGetUsingDashSeparated() {
+        Element element = createElement("<div style='font-size:14px'></div>");
+
+        Assert.assertEquals("14px", element.getStyle().get("font-size"));
+        Assert.assertEquals("14px", element.getStyle().get("fontSize"));
+        Assert.assertNull(element.getStyle().get("fontsize"));
+    }
+
+    @Test
+    public void templateStaticStyleHasUsingDashSeparated() {
+        Element element = createElement("<div style='font-size:14px'></div>");
+
+        Assert.assertTrue(element.getStyle().has("font-size"));
+        Assert.assertTrue(element.getStyle().has("fontSize"));
+        Assert.assertFalse(element.getStyle().has("fontsize"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #3234

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3272)
<!-- Reviewable:end -->
