### PR TITLE
correct a typo in documentation

### DIFF
--- a/flow-documentation/application-structure/tutorial-bootstrap.asciidoc
+++ b/flow-documentation/application-structure/tutorial-bootstrap.asciidoc
@@ -145,7 +145,7 @@ public static class BodySizeAnnotatedRoute extends Div {
 }
 ----
 
-You can define height and with or just one of them as wanted.
+You can define height and width or just one of them as wanted.
 
 With the `PageConfigurator` you can just addInlineContent like:
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3285)
<!-- Reviewable:end -->
