### PR TITLE
Add mixin interface HasItemsAndComponents

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/HasItemsAndComponents.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/HasItemsAndComponents.java
@@ -21,7 +21,6 @@ import java.util.stream.IntStream;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasElement;
-import com.vaadin.flow.data.binder.HasItemsAndComponents.ItemComponent;
 
 /**
  * Mixin interface for components that display a collection of items and can
@@ -36,11 +35,8 @@ import com.vaadin.flow.data.binder.HasItemsAndComponents.ItemComponent;
  * 
  * @param <T>
  *            the type of the displayed items
- * @param <C>
- *            the type of the components that display the items
  */
-public interface HasItemsAndComponents<T, C extends ItemComponent<T>>
-        extends HasComponents, HasItems<T> {
+public interface HasItemsAndComponents<T> extends HasComponents, HasItems<T> {
 
     /**
      * Interface for components that are used inside an
@@ -52,7 +48,7 @@ public interface HasItemsAndComponents<T, C extends ItemComponent<T>>
      *            the type of the displayed item
      */
     public interface ItemComponent<T> extends HasElement {
-        public T getItem();
+        T getItem();
     }
 
     /**

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/HasItemsAndComponents.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/HasItemsAndComponents.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.data.binder;
+
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.data.binder.HasItemsAndComponents.ItemComponent;
+
+/**
+ * Mixin interface for components that display a collection of items and can
+ * have additional components between the items.
+ * <p>
+ * The items should be represented by components that implement
+ * {@link ItemComponent}. Additionally any type of components can be added at
+ * any position with {@link #addComponents(Object, Component...)} or
+ * {@link #prependComponents(Object, Component...)}.
+ * 
+ * @author Vaadin Ltd.
+ * 
+ * @param <T>
+ *            the type of the displayed items
+ * @param <C>
+ *            the type of the components that display the items
+ */
+public interface HasItemsAndComponents<T, C extends ItemComponent<T>>
+        extends HasComponents, HasItems<T> {
+
+    /**
+     * Interface for components that are used inside an
+     * {@link HasItemsAndComponents} for representing a single item.
+     * 
+     * @author Vaadin Ltd.
+     * 
+     * @param <T>
+     *            the type of the displayed item
+     */
+    public interface ItemComponent<T> extends HasElement {
+        public T getItem();
+    }
+
+    /**
+     * Adds the components after the given item.
+     *
+     * @param afterItem
+     *            item to add components after
+     * @param components
+     *            components to add after item
+     * @throws IllegalArgumentException
+     *             if this component doesn't contain the item
+     */
+    default void addComponents(T afterItem, Component... components) {
+        int insertPosition = getItemPosition(afterItem);
+        if (insertPosition == -1) {
+            throw new IllegalArgumentException(
+                    "Could not locate the item after which to insert components.");
+        }
+        for (Component component : components) {
+            insertPosition++;
+            getElement().insertChild(insertPosition, component.getElement());
+        }
+    }
+
+    /**
+     * Adds the components before the given item.
+     *
+     * @param beforeItem
+     *            item to add components in front of
+     * @param components
+     *            components to add before item
+     * @throws IllegalArgumentException
+     *             if this component doesn't contain the item
+     */
+    default void prependComponents(T beforeItem, Component... components) {
+        int insertPosition = getItemPosition(beforeItem);
+        if (insertPosition == -1) {
+            throw new IllegalArgumentException(
+                    "Could not locate the item before which to insert components.");
+        }
+        for (Component component : components) {
+            getElement().insertChild(insertPosition, component.getElement());
+            insertPosition++;
+        }
+    }
+
+    /**
+     * Gets the index of the child element that represents the given item.
+     * 
+     * @param item
+     *            the item to look for
+     * @return the index of the child element that represents the item, or -1 if
+     *         the item is not found
+     */
+    default int getItemPosition(T item) {
+        if (item == null) {
+            return -1;
+        }
+        return IntStream.range(0, getElement().getChildCount()).filter(i -> {
+            Optional<Component> c = getElement().getChild(i).getComponent();
+            return c.isPresent() && c.get() instanceof ItemComponent
+                    && item.equals(((ItemComponent<?>) c.get()).getItem());
+        }).findFirst().orElse(-1);
+    }
+}


### PR DESCRIPTION
This interface contains logic for inserting arbitrary components anywhere between the items of a component that implements HasItems. This logic is extracted from RadioButtonGroup to avoid duplicating it for ListBox.
ItemComponent interface is for the components that represent the items. For example, when RadioButtonGroup implements HasItemsAndComponents, RadioButton would implement ItemComponent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3290)
<!-- Reviewable:end -->
