### PR TITLE
Exclude a property from generated ListBox

### DIFF
--- a/flow-components-parent/flow-code-generator-api/src/main/java/com/vaadin/generator/registry/ExclusionRegistry.java
+++ b/flow-components-parent/flow-code-generator-api/src/main/java/com/vaadin/generator/registry/ExclusionRegistry.java
@@ -47,6 +47,7 @@ public class ExclusionRegistry {
         excludeProperty("vaadin-text-area", "hasValue");
         excludeProperty("vaadin-dialog", "noCloseOnEsc");
         excludeProperty("vaadin-dialog", "noCloseOnOutsideClick");
+        excludeProperty("vaadin-list-box", "selected");
         excludeEvent("vaadin-combo-box", "selected-item-changed");
         excludeEvent("vaadin-combo-box", "change");
 

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/listbox/GeneratedVaadinListBox.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/listbox/GeneratedVaadinListBox.java
@@ -21,8 +21,8 @@ import com.vaadin.flow.component.ComponentSupplier;
 import javax.annotation.Generated;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.HtmlImport;
-import com.vaadin.flow.component.Synchronize;
 import elemental.json.JsonArray;
+import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.component.EventData;
 import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.ComponentEvent;
@@ -69,145 +69,82 @@ import com.vaadin.flow.component.HasComponents;
  * how to apply styles for shadow parts</a>
  * </p>
  */
-@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.0-SNAPSHOT",
-        "WebComponent: Vaadin.ListBoxElement#1.0.0-alpha7",
-        "Flow#1.0-SNAPSHOT" })
+@Generated({"Generator: com.vaadin.generator.ComponentGenerator#1.0-SNAPSHOT",
+		"WebComponent: Vaadin.ListBoxElement#1.0.0-alpha7", "Flow#1.0-SNAPSHOT"})
 @Tag("vaadin-list-box")
 @HtmlImport("frontend://bower_components/vaadin-list-box/src/vaadin-list-box.html")
-public class GeneratedVaadinListBox<R extends GeneratedVaadinListBox<R>> extends
-        Component implements HasStyle, ComponentSupplier<R>, HasComponents {
+public class GeneratedVaadinListBox<R extends GeneratedVaadinListBox<R>>
+		extends
+			Component implements HasStyle, ComponentSupplier<R>, HasComponents {
 
-    /**
-     * <p>
-     * Description copied from corresponding location in WebComponent:
-     * </p>
-     * <p>
-     * The index of the item selected in the items array
-     * <p>
-     * This property is synchronized automatically from client side when a
-     * 'selected-changed' event happens.
-     * </p>
-     * 
-     * @return the {@code selected} property from the webcomponent
-     */
-    @Synchronize(property = "selected", value = "selected-changed")
-    public double getSelected() {
-        return getElement().getProperty("selected", 0.0);
-    }
+	/**
+	 * <p>
+	 * Description copied from corresponding location in WebComponent:
+	 * </p>
+	 * <p>
+	 * The array of list items
+	 * <p>
+	 * This property is synchronized automatically from client side when a
+	 * 'items-changed' event happens.
+	 * </p>
+	 * 
+	 * @return the {@code items} property from the webcomponent
+	 */
+	@Synchronize(property = "items", value = "items-changed")
+	protected JsonArray protectedGetItems() {
+		return (JsonArray) getElement().getPropertyRaw("items");
+	}
 
-    /**
-     * <p>
-     * Description copied from corresponding location in WebComponent:
-     * </p>
-     * <p>
-     * The index of the item selected in the items array
-     * </p>
-     * 
-     * @param selected
-     *            the double value to set
-     */
-    public void setSelected(double selected) {
-        getElement().setProperty("selected", selected);
-    }
+	public void focus() {
+		getElement().callFunction("focus");
+	}
 
-    /**
-     * <p>
-     * Description copied from corresponding location in WebComponent:
-     * </p>
-     * <p>
-     * The array of list items
-     * <p>
-     * This property is synchronized automatically from client side when a
-     * 'items-changed' event happens.
-     * </p>
-     * 
-     * @return the {@code items} property from the webcomponent
-     */
-    @Synchronize(property = "items", value = "items-changed")
-    protected JsonArray protectedGetItems() {
-        return (JsonArray) getElement().getPropertyRaw("items");
-    }
+	@DomEvent("items-changed")
+	public static class ItemsChangeEvent<R extends GeneratedVaadinListBox<R>>
+			extends
+				ComponentEvent<R> {
+		private final JsonArray items;
 
-    public void focus() {
-        getElement().callFunction("focus");
-    }
+		public ItemsChangeEvent(R source, boolean fromClient,
+				@EventData("event.items") JsonArray items) {
+			super(source, fromClient);
+			this.items = items;
+		}
 
-    @DomEvent("selected-changed")
-    public static class SelectedChangeEvent<R extends GeneratedVaadinListBox<R>>
-            extends ComponentEvent<R> {
-        private final double selected;
+		public JsonArray getItems() {
+			return items;
+		}
+	}
 
-        public SelectedChangeEvent(R source, boolean fromClient,
-                @EventData("event.selected") double selected) {
-            super(source, fromClient);
-            this.selected = selected;
-        }
+	/**
+	 * Adds a listener for {@code items-changed} events fired by the
+	 * webcomponent.
+	 * 
+	 * @param listener
+	 *            the listener
+	 * @return a {@link Registration} for removing the event listener
+	 */
+	@SuppressWarnings({"rawtypes", "unchecked"})
+	public Registration addItemsChangeListener(
+			ComponentEventListener<ItemsChangeEvent<R>> listener) {
+		return addListener(ItemsChangeEvent.class,
+				(ComponentEventListener) listener);
+	}
 
-        public double getSelected() {
-            return selected;
-        }
-    }
+	/**
+	 * Adds the given components as children of this component.
+	 * 
+	 * @param components
+	 *            the components to add
+	 * @see HasComponents#add(Component...)
+	 */
+	public GeneratedVaadinListBox(Component... components) {
+		add(components);
+	}
 
-    /**
-     * Adds a listener for {@code selected-changed} events fired by the
-     * webcomponent.
-     * 
-     * @param listener
-     *            the listener
-     * @return a {@link Registration} for removing the event listener
-     */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    public Registration addSelectedChangeListener(
-            ComponentEventListener<SelectedChangeEvent<R>> listener) {
-        return addListener(SelectedChangeEvent.class,
-                (ComponentEventListener) listener);
-    }
-
-    @DomEvent("items-changed")
-    public static class ItemsChangeEvent<R extends GeneratedVaadinListBox<R>>
-            extends ComponentEvent<R> {
-        private final JsonArray items;
-
-        public ItemsChangeEvent(R source, boolean fromClient,
-                @EventData("event.items") JsonArray items) {
-            super(source, fromClient);
-            this.items = items;
-        }
-
-        public JsonArray getItems() {
-            return items;
-        }
-    }
-
-    /**
-     * Adds a listener for {@code items-changed} events fired by the
-     * webcomponent.
-     * 
-     * @param listener
-     *            the listener
-     * @return a {@link Registration} for removing the event listener
-     */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    public Registration addItemsChangeListener(
-            ComponentEventListener<ItemsChangeEvent<R>> listener) {
-        return addListener(ItemsChangeEvent.class,
-                (ComponentEventListener) listener);
-    }
-
-    /**
-     * Adds the given components as children of this component.
-     * 
-     * @param components
-     *            the components to add
-     * @see HasComponents#add(Component...)
-     */
-    public GeneratedVaadinListBox(Component... components) {
-        add(components);
-    }
-
-    /**
-     * Default constructor.
-     */
-    public GeneratedVaadinListBox() {
-    }
+	/**
+	 * Default constructor.
+	 */
+	public GeneratedVaadinListBox() {
+	}
 }

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/listbox/GeneratedVaadinListBox.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/listbox/GeneratedVaadinListBox.java
@@ -15,20 +15,22 @@
  */
 package com.vaadin.flow.component.listbox;
 
-import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.HasStyle;
-import com.vaadin.flow.component.ComponentSupplier;
 import javax.annotation.Generated;
-import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.dependency.HtmlImport;
-import elemental.json.JsonArray;
-import com.vaadin.flow.component.Synchronize;
-import com.vaadin.flow.component.EventData;
-import com.vaadin.flow.component.DomEvent;
+
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.shared.Registration;
+import com.vaadin.flow.component.ComponentSupplier;
+import com.vaadin.flow.component.DomEvent;
+import com.vaadin.flow.component.EventData;
 import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.HasStyle;
+import com.vaadin.flow.component.Synchronize;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.HtmlImport;
+import com.vaadin.flow.shared.Registration;
+
+import elemental.json.JsonArray;
 
 /**
  * <p>
@@ -64,87 +66,86 @@ import com.vaadin.flow.component.HasComponents;
  * </tbody>
  * </table>
  * <p>
- * See <a
- * href="https://github.com/vaadin/vaadin-themable-mixin/wiki">ThemableMixin –
- * how to apply styles for shadow parts</a>
+ * See
+ * <a href="https://github.com/vaadin/vaadin-themable-mixin/wiki">ThemableMixin
+ * – how to apply styles for shadow parts</a>
  * </p>
  */
-@Generated({"Generator: com.vaadin.generator.ComponentGenerator#1.0-SNAPSHOT",
-		"WebComponent: Vaadin.ListBoxElement#1.0.0-alpha7", "Flow#1.0-SNAPSHOT"})
+@Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.0-SNAPSHOT",
+        "WebComponent: Vaadin.ListBoxElement#1.0.0-alpha7",
+        "Flow#1.0-SNAPSHOT" })
 @Tag("vaadin-list-box")
 @HtmlImport("frontend://bower_components/vaadin-list-box/src/vaadin-list-box.html")
-public class GeneratedVaadinListBox<R extends GeneratedVaadinListBox<R>>
-		extends
-			Component implements HasStyle, ComponentSupplier<R>, HasComponents {
+public class GeneratedVaadinListBox<R extends GeneratedVaadinListBox<R>> extends
+        Component implements HasStyle, ComponentSupplier<R>, HasComponents {
 
-	/**
-	 * <p>
-	 * Description copied from corresponding location in WebComponent:
-	 * </p>
-	 * <p>
-	 * The array of list items
-	 * <p>
-	 * This property is synchronized automatically from client side when a
-	 * 'items-changed' event happens.
-	 * </p>
-	 * 
-	 * @return the {@code items} property from the webcomponent
-	 */
-	@Synchronize(property = "items", value = "items-changed")
-	protected JsonArray protectedGetItems() {
-		return (JsonArray) getElement().getPropertyRaw("items");
-	}
+    /**
+     * <p>
+     * Description copied from corresponding location in WebComponent:
+     * </p>
+     * <p>
+     * The array of list items
+     * <p>
+     * This property is synchronized automatically from client side when a
+     * 'items-changed' event happens.
+     * </p>
+     * 
+     * @return the {@code items} property from the webcomponent
+     */
+    @Synchronize(property = "items", value = "items-changed")
+    protected JsonArray protectedGetItems() {
+        return (JsonArray) getElement().getPropertyRaw("items");
+    }
 
-	public void focus() {
-		getElement().callFunction("focus");
-	}
+    public void focus() {
+        getElement().callFunction("focus");
+    }
 
-	@DomEvent("items-changed")
-	public static class ItemsChangeEvent<R extends GeneratedVaadinListBox<R>>
-			extends
-				ComponentEvent<R> {
-		private final JsonArray items;
+    @DomEvent("items-changed")
+    public static class ItemsChangeEvent<R extends GeneratedVaadinListBox<R>>
+            extends ComponentEvent<R> {
+        private final JsonArray items;
 
-		public ItemsChangeEvent(R source, boolean fromClient,
-				@EventData("event.items") JsonArray items) {
-			super(source, fromClient);
-			this.items = items;
-		}
+        public ItemsChangeEvent(R source, boolean fromClient,
+                @EventData("event.items") JsonArray items) {
+            super(source, fromClient);
+            this.items = items;
+        }
 
-		public JsonArray getItems() {
-			return items;
-		}
-	}
+        public JsonArray getItems() {
+            return items;
+        }
+    }
 
-	/**
-	 * Adds a listener for {@code items-changed} events fired by the
-	 * webcomponent.
-	 * 
-	 * @param listener
-	 *            the listener
-	 * @return a {@link Registration} for removing the event listener
-	 */
-	@SuppressWarnings({"rawtypes", "unchecked"})
-	public Registration addItemsChangeListener(
-			ComponentEventListener<ItemsChangeEvent<R>> listener) {
-		return addListener(ItemsChangeEvent.class,
-				(ComponentEventListener) listener);
-	}
+    /**
+     * Adds a listener for {@code items-changed} events fired by the
+     * webcomponent.
+     * 
+     * @param listener
+     *            the listener
+     * @return a {@link Registration} for removing the event listener
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public Registration addItemsChangeListener(
+            ComponentEventListener<ItemsChangeEvent<R>> listener) {
+        return addListener(ItemsChangeEvent.class,
+                (ComponentEventListener) listener);
+    }
 
-	/**
-	 * Adds the given components as children of this component.
-	 * 
-	 * @param components
-	 *            the components to add
-	 * @see HasComponents#add(Component...)
-	 */
-	public GeneratedVaadinListBox(Component... components) {
-		add(components);
-	}
+    /**
+     * Adds the given components as children of this component.
+     * 
+     * @param components
+     *            the components to add
+     * @see HasComponents#add(Component...)
+     */
+    public GeneratedVaadinListBox(Component... components) {
+        add(components);
+    }
 
-	/**
-	 * Default constructor.
-	 */
-	public GeneratedVaadinListBox() {
-	}
+    /**
+     * Default constructor.
+     */
+    public GeneratedVaadinListBox() {
+    }
 }


### PR DESCRIPTION
`<vaadin-list-box>` has a property `selected`, which is a number indicating the index of the selected item. It makes no sense to provide the generated API for the users: `setSelected(double)` and `double getSelected()`. That's why the property is excluded and the API regenerated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3292)
<!-- Reviewable:end -->
