### PR TITLE
Do less info logging when multiple similar WebJars found.

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/webjar/WebJarServer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webjar/WebJarServer.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.server.webjar;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -24,12 +26,9 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
-import org.slf4j.LoggerFactory;
 import java.util.stream.Collectors;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
+import org.slf4j.LoggerFactory;
 import org.webjars.WebJarAssetLocator;
 
 import com.vaadin.flow.function.DeploymentConfiguration;
@@ -103,7 +102,7 @@ public class WebJarServer implements Serializable {
         int comparison = oldDependency.compareVersions(newDependency);
         if (comparison == 0) {
             LoggerFactory.getLogger(getClass().getName())
-                    .info("Have found multiple webJars with name and version: '{}'", oldDependency);
+                    .trace("Have found multiple webJars with name and version: '{}'", oldDependency);
             return oldDependency;
         } else if (comparison > 0) {
             return oldDependency;


### PR DESCRIPTION
Turns out that having multiple similar WebJars is rather common situation.
For example, https://travis-ci.com/vaadin/patient-portal-demo-flow outputs the following:

<img width="1679" alt="screen shot 2018-01-16 at 13 57 21" src="https://user-images.githubusercontent.com/2690773/34987870-564ae192-fac5-11e7-8f8f-62da394b6958.png">

There is almost nothing the user can do about the situation and Flow handles it fine.
This makes no sense to log it with INFO level hence the level is decreased.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3329)
<!-- Reviewable:end -->
