### PR TITLE
Fix getting topParentLayout for classes with only @ParentLayout

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -569,17 +569,18 @@ public class UIInternals implements Serializable {
      * @param viewLocation
      *            the location of the route target relative to the servlet
      *            serving the UI, not <code>null</code>
+     *            @param path the resolved route path so we can determine what the rendered target is for
      * @param target
      *            the component to show, not <code>null</code>
      * @param layouts
      *            the parent layouts
      */
-    public void showRouteTarget(Location viewLocation, Component target,
+    public void showRouteTarget(Location viewLocation, String path, Component target,
             List<RouterLayout> layouts) {
         assert target != null;
         assert viewLocation != null;
 
-        updateTheme(target);
+        updateTheme(target, path);
 
         this.viewLocation = viewLocation;
 
@@ -637,9 +638,9 @@ public class UIInternals implements Serializable {
         }
     }
 
-    private void updateTheme(Component target) {
+    private void updateTheme(Component target, String path) {
         Class<? extends RouterLayout> topParentLayout = RouterUtil
-                .getTopParentLayout(target.getClass());
+                .getTopParentLayout(target.getClass(), path);
         Theme themeAnnotation;
         if (topParentLayout != null) {
             themeAnnotation = topParentLayout.getAnnotation(Theme.class);

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/ErrorStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/ErrorStateRenderer.java
@@ -125,7 +125,7 @@ public class ErrorStateRenderer implements NavigationHandler {
         List<RouterLayout> routerLayouts = (List<RouterLayout>) (List<?>) chain
                 .subList(1, chain.size());
 
-        ui.getInternals().showRouteTarget(event.getLocation(),
+        ui.getInternals().showRouteTarget(event.getLocation(), null,
                 componentInstance, routerLayouts);
 
         RouterUtil.updatePageTitle(event, componentInstance);

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/NavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/NavigationStateRenderer.java
@@ -27,10 +27,10 @@ import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.Element;
-import com.vaadin.flow.router.BeforeEvent;
 import com.vaadin.flow.router.AfterNavigationEvent;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.BeforeEnterObserver;
+import com.vaadin.flow.router.BeforeEvent;
 import com.vaadin.flow.router.BeforeLeaveEvent;
 import com.vaadin.flow.router.BeforeLeaveObserver;
 import com.vaadin.flow.router.ErrorNavigationEvent;
@@ -167,7 +167,8 @@ public class NavigationStateRenderer implements NavigationHandler {
                 .subList(1, chain.size());
 
         ui.getInternals().showRouteTarget(event.getLocation(),
-                componentInstance, routerLayouts);
+                navigationState.getResolvedPath(), componentInstance,
+                routerLayouts);
 
         RouterUtil.updatePageTitle(event, componentInstance);
 
@@ -289,8 +290,7 @@ public class NavigationStateRenderer implements NavigationHandler {
         return TransitionOutcome.FINISHED;
     }
 
-    private int reroute(NavigationEvent event,
-            BeforeEvent beforeNavigation) {
+    private int reroute(NavigationEvent event, BeforeEvent beforeNavigation) {
         NavigationHandler handler = beforeNavigation.getRerouteTarget();
 
         NavigationEvent newNavigationEvent = getNavigationEvent(event,

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/RouterUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/RouterUtil.java
@@ -223,30 +223,6 @@ public final class RouterUtil {
     }
 
     /**
-     * Get the top most parent layout for navigation target {@link Route}
-     * annotation or a non route target with {@link ParentLayout}.
-     *
-     * @param component
-     *            navigation target to get top most parent for
-     * @return top parent layout for target or null if none found
-     */
-    public static Class<? extends RouterLayout> getTopParentLayout(
-            Class<?> component) {
-        Optional<Route> route = AnnotationReader.getAnnotationFor(component,
-                Route.class);
-        if (route.isPresent() && !route.get().layout().equals(UI.class)) {
-            return recuseToTopLayout(route.get().layout());
-        } else {
-            Optional<ParentLayout> parentLayout = AnnotationReader
-                    .getAnnotationFor(component, ParentLayout.class);
-            if (parentLayout.isPresent()) {
-                return recuseToTopLayout(parentLayout.get().value());
-            }
-        }
-        return null;
-    }
-
-    /**
      * Get the top most parent layout for navigation target according to the
      * {@link Route} or {@link RouteAlias} annotation. Also handles non route
      * targets with {@link ParentLayout}.
@@ -260,6 +236,16 @@ public final class RouterUtil {
      */
     public static Class<? extends RouterLayout> getTopParentLayout(
             final Class<?> component, final String path) {
+        if (path == null) {
+            Optional<ParentLayout> parentLayout = AnnotationReader
+                    .getAnnotationFor(component, ParentLayout.class);
+            if (parentLayout.isPresent()) {
+                return recuseToTopLayout(parentLayout.get().value());
+            }
+            // No need to check for Route or RouteAlias as the path is null
+            return null;
+        }
+
         Optional<Route> route = AnnotationReader.getAnnotationFor(component,
                 Route.class);
         List<RouteAlias> routeAliases = AnnotationReader
@@ -268,12 +254,6 @@ public final class RouterUtil {
                 && path.equals(getRoutePath(component, route.get()))
                 && !route.get().layout().equals(UI.class)) {
             return recuseToTopLayout(route.get().layout());
-        } else if (path == null) {
-            Optional<ParentLayout> parentLayout = AnnotationReader
-                    .getAnnotationFor(component, ParentLayout.class);
-            if (parentLayout.isPresent()) {
-                return recuseToTopLayout(parentLayout.get().value());
-            }
         } else {
             Optional<RouteAlias> matchingRoute = getMatchingRouteAlias(
                     component, path, routeAliases);

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/RouterUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/RouterUtil.java
@@ -61,7 +61,7 @@ public final class RouterUtil {
         if (route.isPresent() && !route.get().layout().equals(UI.class)) {
             return collectRouteParentLayouts(route.get().layout());
         }
-        return new ArrayList<>(0);
+        return Collections.emptyList();
     }
 
     /**
@@ -236,6 +236,12 @@ public final class RouterUtil {
                 Route.class);
         if (route.isPresent() && !route.get().layout().equals(UI.class)) {
             return recuseToTopLayout(route.get().layout());
+        } else {
+            Optional<ParentLayout> parentLayout = AnnotationReader
+                    .getAnnotationFor(component, ParentLayout.class);
+            if (parentLayout.isPresent()) {
+                return recuseToTopLayout(parentLayout.get().value());
+            }
         }
         return null;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/RouterUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/RouterUtil.java
@@ -254,7 +254,7 @@ public final class RouterUtil {
      *            navigation target to get top most parent for
      * @param path
      *            path used to get navigation target so we know which annotation
-     *            to handle
+     *            to handle or null for error views.
      * @return top parent layout for target or null if none found
      */
     public static Class<? extends RouterLayout> getTopParentLayout(
@@ -267,6 +267,12 @@ public final class RouterUtil {
                 && path.equals(getRoutePath(component, route.get()))
                 && !route.get().layout().equals(UI.class)) {
             return recuseToTopLayout(route.get().layout());
+        } else if (path == null) {
+            Optional<ParentLayout> parentLayout = AnnotationReader
+                    .getAnnotationFor(component, ParentLayout.class);
+            if (parentLayout.isPresent()) {
+                return recuseToTopLayout(parentLayout.get().value());
+            }
         } else {
             Optional<RouteAlias> matchingRoute = getMatchingRouteAlias(
                     component, path, routeAliases);

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/RouterUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/RouterUtil.java
@@ -224,7 +224,7 @@ public final class RouterUtil {
 
     /**
      * Get the top most parent layout for navigation target {@link Route}
-     * annotation.
+     * annotation or a non route target with {@link ParentLayout}.
      *
      * @param component
      *            navigation target to get top most parent for
@@ -248,7 +248,8 @@ public final class RouterUtil {
 
     /**
      * Get the top most parent layout for navigation target according to the
-     * {@link Route} or {@link RouteAlias} annotation.
+     * {@link Route} or {@link RouteAlias} annotation. Also handles non route
+     * targets with {@link ParentLayout}.
      *
      * @param component
      *            navigation target to get top most parent for

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractRouteRegistryInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractRouteRegistryInitializer.java
@@ -115,19 +115,21 @@ public abstract class AbstractRouteRegistryInitializer {
     /* Route validator methods for bootstrap implementations */
     private void validateRouteImplementation(Class<?> route,
             Class<?> implementation) {
-        if (!UI.class.equals(route.getAnnotation(Route.class).layout())) {
+        Route annotation = route.getAnnotation(Route.class);
+        if (!UI.class.equals(annotation.layout())) {
             if (implementation.isAssignableFrom(route)) {
                 throw new InvalidRouteLayoutConfigurationException(String
                         .format("%s needs to be the top parent layout '%s' not '%s'",
                                 implementation.getSimpleName(),
-                                RouterUtil.getTopParentLayout(route).getName(),
+                                RouterUtil.getTopParentLayout(route,
+                                        annotation.value()).getName(),
                                 route.getName()));
             }
 
             List<Class<? extends RouterLayout>> parentLayouts = RouterUtil
-                    .getParentLayouts(route);
+                    .getParentLayouts(route, annotation.value());
             Class<? extends RouterLayout> topParentLayout = RouterUtil
-                    .getTopParentLayout(route);
+                    .getTopParentLayout(route, annotation.value());
 
             validateParentImplementation(parentLayouts, topParentLayout,
                     implementation);
@@ -183,19 +185,21 @@ public abstract class AbstractRouteRegistryInitializer {
     /* Route validator methods for bootstrap annotations */
     private void validateRouteAnnotation(Class<?> route,
             Class<? extends Annotation> annotation) {
-        if (!UI.class.equals(route.getAnnotation(Route.class).layout())) {
+        Route routeAnnotation = route.getAnnotation(Route.class);
+        if (!UI.class.equals(routeAnnotation.layout())) {
             if (route.isAnnotationPresent(annotation)) {
                 throw new InvalidRouteLayoutConfigurationException(String
                         .format("%s annotation needs to be on the top parent layout '%s' not on '%s'",
                                 annotation.getSimpleName(),
-                                RouterUtil.getTopParentLayout(route).getName(),
+                                RouterUtil.getTopParentLayout(route,
+                                        routeAnnotation.value()).getName(),
                                 route.getName()));
             }
 
             List<Class<? extends RouterLayout>> parentLayouts = RouterUtil
-                    .getParentLayouts(route);
+                    .getParentLayouts(route, routeAnnotation.value());
             Class<? extends RouterLayout> topParentLayout = RouterUtil
-                    .getTopParentLayout(route);
+                    .getTopParentLayout(route, routeAnnotation.value());
 
             validateParentAnnotation(parentLayouts, topParentLayout,
                     annotation);

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/RouterUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/RouterUtilTest.java
@@ -99,7 +99,8 @@ public class RouterUtilTest {
 
     @Tag(Tag.DIV)
     @ParentLayout(Parent.class)
-    public static class NonRouteTargetWithParents extends Component {}
+    public static class NonRouteTargetWithParents extends Component {
+    }
 
     @Test
     public void route_path_should_contain_parent_prefix() {
@@ -365,4 +366,12 @@ public class RouterUtilTest {
 
     }
 
+    @Test
+    public void also_non_routes_can_be_used_to_get_top_parent_layout() {
+        Class<? extends RouterLayout> topParentLayout = RouterUtil
+                .getTopParentLayout(MiddleParent.class);
+        Assert.assertEquals(
+                "Middle parent should have gotten Parent as top parent layout",
+                Parent.class, topParentLayout);
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/RouterUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/RouterUtilTest.java
@@ -369,7 +369,7 @@ public class RouterUtilTest {
     @Test
     public void also_non_routes_can_be_used_to_get_top_parent_layout() {
         Class<? extends RouterLayout> topParentLayout = RouterUtil
-                .getTopParentLayout(MiddleParent.class);
+                .getTopParentLayout(MiddleParent.class, null);
         Assert.assertEquals(
                 "Middle parent should have gotten Parent as top parent layout",
                 Parent.class, topParentLayout);


### PR DESCRIPTION
The old getTopParentLayout only handled classes
that had @Route in them, but there are cases (e.g. error layouts)
that might only have @ParentLayout.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3335)
<!-- Reviewable:end -->
