### PR TITLE
Fix rpc handler concurrency problem.

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/AbstractRpcInvocationHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/AbstractRpcInvocationHandler.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.server.communication.rpc;
 
+import java.util.Optional;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +37,7 @@ public abstract class AbstractRpcInvocationHandler
         implements RpcInvocationHandler {
 
     @Override
-    public Runnable handle(UI ui, JsonObject invocationJson) {
+    public Optional<Runnable> handle(UI ui, JsonObject invocationJson) {
         assert invocationJson.hasKey(JsonConstants.RPC_NODE);
         StateNode node = ui.getInternals().getStateTree()
                 .getNodeById(getNodeId(invocationJson));
@@ -64,7 +66,7 @@ public abstract class AbstractRpcInvocationHandler
                             + "is recieved from the client side for concealed node id='%s'",
                             getClass().getName(), node.getId()));
         }
-        return null;
+        return Optional.empty();
     }
 
     /**
@@ -77,7 +79,7 @@ public abstract class AbstractRpcInvocationHandler
      *            the RPC data to handle, not {@code null}
      * @return null or a Runnable for delayed execution
      */
-    protected abstract Runnable handleNode(StateNode node,
+    protected abstract Optional<Runnable> handleNode(StateNode node,
             JsonObject invocationJson);
 
     private static Logger getLogger() {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/AbstractRpcInvocationHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/AbstractRpcInvocationHandler.java
@@ -44,12 +44,12 @@ public abstract class AbstractRpcInvocationHandler
         if (node == null) {
             getLogger().warn("Got an RPC for non-existent node: {}",
                     getNodeId(invocationJson));
-            return null;
+            return Optional.empty();
         }
         if (!node.isAttached()) {
             getLogger().warn("Got an RPC for detached node: {}",
                     getNodeId(invocationJson));
-            return null;
+            return Optional.empty();
         }
 
         boolean invokeRpc = true;
@@ -62,9 +62,9 @@ public abstract class AbstractRpcInvocationHandler
             // ignore RPC requests from the client side for the nodes that are
             // invisible
             LoggerFactory.getLogger(AbstractRpcInvocationHandler.class).warn(
-                    String.format("RPC request for invocation handler '%s' "
-                            + "is recieved from the client side for concealed node id='%s'",
-                            getClass().getName(), node.getId()));
+                    "RPC request for invocation handler '{}' is recieved from "
+                            + "the client side for concealed node id='{}'",
+                    getClass().getName(), node.getId());
         }
         return Optional.empty();
     }
@@ -77,7 +77,7 @@ public abstract class AbstractRpcInvocationHandler
      *            node to handle invocation with, not {@code null}
      * @param invocationJson
      *            the RPC data to handle, not {@code null}
-     * @return null or a Runnable for delayed execution
+     * @return an optional runnable
      */
     protected abstract Optional<Runnable> handleNode(StateNode node,
             JsonObject invocationJson);

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/AttachExistingElementRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/AttachExistingElementRpcHandler.java
@@ -46,7 +46,7 @@ public class AttachExistingElementRpcHandler
     }
 
     @Override
-    protected void handleNode(StateNode node, JsonObject invocationJson) {
+    protected Runnable handleNode(StateNode node, JsonObject invocationJson) {
         assert invocationJson.hasKey(JsonConstants.RPC_ATTACH_REQUESTED_ID);
         assert invocationJson.hasKey(JsonConstants.RPC_ATTACH_ASSIGNED_ID);
         assert invocationJson.hasKey(JsonConstants.RPC_ATTACH_TAG_NAME);
@@ -82,6 +82,8 @@ public class AttachExistingElementRpcHandler
             attachElement(feature, element, index,
                     tree.getNodeById(requestedId), requestedId == assignedId);
         }
+
+        return null;
     }
 
     private void attachElement(AttachExistingElementFeature feature,

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/AttachExistingElementRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/AttachExistingElementRpcHandler.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.server.communication.rpc;
 
+import java.util.Optional;
+
 import com.vaadin.flow.dom.ChildElementConsumer;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.Node;
@@ -46,7 +48,7 @@ public class AttachExistingElementRpcHandler
     }
 
     @Override
-    protected Runnable handleNode(StateNode node, JsonObject invocationJson) {
+    protected Optional<Runnable> handleNode(StateNode node, JsonObject invocationJson) {
         assert invocationJson.hasKey(JsonConstants.RPC_ATTACH_REQUESTED_ID);
         assert invocationJson.hasKey(JsonConstants.RPC_ATTACH_ASSIGNED_ID);
         assert invocationJson.hasKey(JsonConstants.RPC_ATTACH_TAG_NAME);
@@ -83,7 +85,7 @@ public class AttachExistingElementRpcHandler
                     tree.getNodeById(requestedId), requestedId == assignedId);
         }
 
-        return null;
+        return Optional.empty();
     }
 
     private void attachElement(AttachExistingElementFeature feature,

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/AttachTemplateChildRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/AttachTemplateChildRpcHandler.java
@@ -47,7 +47,7 @@ public class AttachTemplateChildRpcHandler
     }
 
     @Override
-    protected void handleNode(StateNode node, JsonObject invocationJson) {
+    protected Runnable handleNode(StateNode node, JsonObject invocationJson) {
         assert invocationJson.hasKey(JsonConstants.RPC_ATTACH_REQUESTED_ID);
         assert invocationJson.hasKey(JsonConstants.RPC_ATTACH_ASSIGNED_ID);
         assert invocationJson.hasKey(JsonConstants.RPC_ATTACH_ID);
@@ -81,7 +81,6 @@ public class AttachTemplateChildRpcHandler
                                 + "not found in the parent with id='%d'",
                         tag, id.asString(), parent.getId()));
             }
-
         } else if (requestedId != assignedId) {
             logger.error("Attach existing element has failed because "
                     + "the element has been already attached from the server side");

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/AttachTemplateChildRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/AttachTemplateChildRpcHandler.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.server.communication.rpc;
 
+import java.util.Optional;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +49,7 @@ public class AttachTemplateChildRpcHandler
     }
 
     @Override
-    protected Runnable handleNode(StateNode node, JsonObject invocationJson) {
+    protected Optional<Runnable> handleNode(StateNode node, JsonObject invocationJson) {
         assert invocationJson.hasKey(JsonConstants.RPC_ATTACH_REQUESTED_ID);
         assert invocationJson.hasKey(JsonConstants.RPC_ATTACH_ASSIGNED_ID);
         assert invocationJson.hasKey(JsonConstants.RPC_ATTACH_ID);

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/EventRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/EventRpcHandler.java
@@ -39,7 +39,7 @@ public class EventRpcHandler extends AbstractRpcInvocationHandler {
     }
 
     @Override
-    public void handleNode(StateNode node, JsonObject invocationJson) {
+    public Runnable handleNode(StateNode node, JsonObject invocationJson) {
         assert invocationJson.hasKey(JsonConstants.RPC_EVENT_TYPE);
 
         String eventType = invocationJson
@@ -54,6 +54,8 @@ public class EventRpcHandler extends AbstractRpcInvocationHandler {
         DomEvent event = new DomEvent(Element.get(node), eventType, eventData);
 
         node.getFeature(ElementListenerMap.class).fireEvent(event);
+
+        return null;
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/EventRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/EventRpcHandler.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.server.communication.rpc;
 
+import java.util.Optional;
+
 import com.vaadin.flow.dom.DomEvent;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.StateNode;
@@ -39,7 +41,7 @@ public class EventRpcHandler extends AbstractRpcInvocationHandler {
     }
 
     @Override
-    public Runnable handleNode(StateNode node, JsonObject invocationJson) {
+    public Optional<Runnable> handleNode(StateNode node, JsonObject invocationJson) {
         assert invocationJson.hasKey(JsonConstants.RPC_EVENT_TYPE);
 
         String eventType = invocationJson
@@ -55,7 +57,7 @@ public class EventRpcHandler extends AbstractRpcInvocationHandler {
 
         node.getFeature(ElementListenerMap.class).fireEvent(event);
 
-        return null;
+        return Optional.empty();
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/MapSyncRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/MapSyncRpcHandler.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.server.communication.rpc;
 
 import java.io.Serializable;
+import java.util.Optional;
 
 import com.vaadin.flow.internal.JsonCodec;
 import com.vaadin.flow.internal.StateNode;
@@ -45,7 +46,7 @@ public class MapSyncRpcHandler extends AbstractRpcInvocationHandler {
     }
 
     @Override
-    protected Runnable handleNode(StateNode node, JsonObject invocationJson) {
+    protected Optional<Runnable> handleNode(StateNode node, JsonObject invocationJson) {
         assert invocationJson.hasKey(JsonConstants.RPC_FEATURE);
         assert invocationJson.hasKey(JsonConstants.RPC_PROPERTY);
         assert invocationJson.hasKey(JsonConstants.RPC_PROPERTY_VALUE);
@@ -64,7 +65,7 @@ public class MapSyncRpcHandler extends AbstractRpcInvocationHandler {
 
         ElementPropertyMap elementPropertyMap = (ElementPropertyMap) node
                 .getFeature(feature);
-        return elementPropertyMap.deferredUpdateFromClient(property, value);
+        return Optional.of(elementPropertyMap.deferredUpdateFromClient(property, value));
     }
 
     private Serializable tryConvert(Serializable value, StateNode context) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/MapSyncRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/MapSyncRpcHandler.java
@@ -16,8 +16,6 @@
 package com.vaadin.flow.server.communication.rpc;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
 
 import com.vaadin.flow.internal.JsonCodec;
 import com.vaadin.flow.internal.StateNode;
@@ -41,15 +39,13 @@ import elemental.json.JsonObject;
  */
 public class MapSyncRpcHandler extends AbstractRpcInvocationHandler {
 
-    private List<Runnable> pendingChangeEvents = new ArrayList<>();
-
     @Override
     public String getRpcType() {
         return JsonConstants.RPC_TYPE_MAP_SYNC;
     }
 
     @Override
-    protected void handleNode(StateNode node, JsonObject invocationJson) {
+    protected Runnable handleNode(StateNode node, JsonObject invocationJson) {
         assert invocationJson.hasKey(JsonConstants.RPC_FEATURE);
         assert invocationJson.hasKey(JsonConstants.RPC_PROPERTY);
         assert invocationJson.hasKey(JsonConstants.RPC_PROPERTY_VALUE);
@@ -68,18 +64,7 @@ public class MapSyncRpcHandler extends AbstractRpcInvocationHandler {
 
         ElementPropertyMap elementPropertyMap = (ElementPropertyMap) node
                 .getFeature(feature);
-        Runnable changeEventRunnable = elementPropertyMap
-                .deferredUpdateFromClient(property, value);
-        pendingChangeEvents.add(changeEventRunnable);
-    }
-
-    /**
-     * Triggers and clears all pending property change events that have been
-     * accumulated during the handling of nodes.
-     */
-    public void flushPendingChangeEvents() {
-        pendingChangeEvents.forEach(Runnable::run);
-        pendingChangeEvents.clear();
+        return elementPropertyMap.deferredUpdateFromClient(property, value);
     }
 
     private Serializable tryConvert(Serializable value, StateNode context) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/NavigationRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/NavigationRpcHandler.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.server.communication.rpc;
 
+import java.util.Optional;
+
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.page.History;
 import com.vaadin.flow.component.page.History.HistoryStateChangeEvent;
@@ -41,7 +43,7 @@ public class NavigationRpcHandler implements RpcInvocationHandler {
     }
 
     @Override
-    public Runnable handle(UI ui, JsonObject invocationJson) {
+    public Optional<Runnable> handle(UI ui, JsonObject invocationJson) {
         History history = ui.getPage().getHistory();
 
         HistoryStateChangeHandler historyStateChangeHandler = history
@@ -63,7 +65,7 @@ public class NavigationRpcHandler implements RpcInvocationHandler {
             historyStateChangeHandler.onHistoryStateChange(event);
         }
 
-        return null;
+        return Optional.empty();
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/NavigationRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/NavigationRpcHandler.java
@@ -41,7 +41,7 @@ public class NavigationRpcHandler implements RpcInvocationHandler {
     }
 
     @Override
-    public void handle(UI ui, JsonObject invocationJson) {
+    public Runnable handle(UI ui, JsonObject invocationJson) {
         History history = ui.getPage().getHistory();
 
         HistoryStateChangeHandler historyStateChangeHandler = history
@@ -62,6 +62,8 @@ public class NavigationRpcHandler implements RpcInvocationHandler {
                     state, new Location(location), trigger);
             historyStateChangeHandler.onHistoryStateChange(event);
         }
+
+        return null;
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/PublishedServerEventHandlerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/PublishedServerEventHandlerRpcHandler.java
@@ -63,7 +63,7 @@ public class PublishedServerEventHandlerRpcHandler
     }
 
     @Override
-    public Runnable handleNode(StateNode node, JsonObject invocationJson) {
+    public Optional<Runnable> handleNode(StateNode node, JsonObject invocationJson) {
         assert invocationJson
                 .hasKey(JsonConstants.RPC_TEMPLATE_EVENT_METHOD_NAME);
         String methodName = invocationJson
@@ -93,7 +93,7 @@ public class PublishedServerEventHandlerRpcHandler
         invokeMethod(component.get(), component.get().getClass(), methodName,
                 (JsonArray) args);
 
-        return null;
+        return Optional.empty();
     }
 
     static void invokeMethod(Component instance, Class<?> clazz,

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/PublishedServerEventHandlerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/PublishedServerEventHandlerRpcHandler.java
@@ -63,7 +63,7 @@ public class PublishedServerEventHandlerRpcHandler
     }
 
     @Override
-    public void handleNode(StateNode node, JsonObject invocationJson) {
+    public Runnable handleNode(StateNode node, JsonObject invocationJson) {
         assert invocationJson
                 .hasKey(JsonConstants.RPC_TEMPLATE_EVENT_METHOD_NAME);
         String methodName = invocationJson
@@ -93,6 +93,7 @@ public class PublishedServerEventHandlerRpcHandler
         invokeMethod(component.get(), component.get().getClass(), methodName,
                 (JsonArray) args);
 
+        return null;
     }
 
     static void invokeMethod(Component instance, Class<?> clazz,

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/RpcInvocationHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/RpcInvocationHandler.java
@@ -45,7 +45,8 @@ public interface RpcInvocationHandler {
      *            the UI to handle against, not {@code null}
      * @param invocationJson
      *            the RPC data to handle, not {@code null}
+     * @return null or a Runnable for delayed execution
      */
-    void handle(UI ui, JsonObject invocationJson);
+    Runnable handle(UI ui, JsonObject invocationJson);
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/RpcInvocationHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/RpcInvocationHandler.java
@@ -47,7 +47,7 @@ public interface RpcInvocationHandler {
      *            the UI to handle against, not {@code null}
      * @param invocationJson
      *            the RPC data to handle, not {@code null}
-     * @return null or a Runnable for delayed execution
+     * @return an optional runnable
      */
     Optional<Runnable> handle(UI ui, JsonObject invocationJson);
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/RpcInvocationHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/RpcInvocationHandler.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.server.communication.rpc;
 
+import java.util.Optional;
+
 import com.vaadin.flow.component.UI;
 
 import elemental.json.JsonObject;
@@ -47,6 +49,6 @@ public interface RpcInvocationHandler {
      *            the RPC data to handle, not {@code null}
      * @return null or a Runnable for delayed execution
      */
-    Runnable handle(UI ui, JsonObject invocationJson);
+    Optional<Runnable> handle(UI ui, JsonObject invocationJson);
 
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/AbstractRpcInvocationHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/AbstractRpcInvocationHandlerTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.server.communication.rpc;
 
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import org.junit.Assert;
@@ -42,9 +43,9 @@ public class AbstractRpcInvocationHandlerTest {
         }
 
         @Override
-        protected Runnable handleNode(StateNode node, JsonObject invocationJson) {
+        protected Optional<Runnable> handleNode(StateNode node, JsonObject invocationJson) {
             this.node = node;
-            return null;
+            return Optional.empty();
         }
     };
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/AbstractRpcInvocationHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/AbstractRpcInvocationHandlerTest.java
@@ -42,8 +42,9 @@ public class AbstractRpcInvocationHandlerTest {
         }
 
         @Override
-        protected void handleNode(StateNode node, JsonObject invocationJson) {
+        protected Runnable handleNode(StateNode node, JsonObject invocationJson) {
             this.node = node;
+            return null;
         }
     };
 

--- a/flow-tests/test-root-ui-context/src/main/java/com/vaadin/flow/uitest/servlet/RpcLoggerServlet.java
+++ b/flow-tests/test-root-ui-context/src/main/java/com/vaadin/flow/uitest/servlet/RpcLoggerServlet.java
@@ -114,13 +114,13 @@ public class RpcLoggerServlet extends VaadinServlet {
         }
 
         @Override
-        public void handle(UI ui, JsonObject invocationJson) {
-            delegate.handle(ui, invocationJson);
+        public Runnable handle(UI ui, JsonObject invocationJson) {
+            Runnable runnable = delegate.handle(ui, invocationJson);
             StateNode node = ui.getInternals().getStateTree()
                     .getNodeById(getNodeId(invocationJson));
             Div container = new Div();
             container.addClassName("log");
-            Label nodeLabel = new Label();
+            Label nodeLabel;
             if (node == null) {
                 nodeLabel = new Label("Node is null");
             } else {
@@ -136,6 +136,8 @@ public class RpcLoggerServlet extends VaadinServlet {
             json.addClassName("json");
             container.add(json);
             ui.add(container);
+
+            return runnable;
         }
 
         private static int getNodeId(JsonObject invocationJson) {

--- a/flow-tests/test-root-ui-context/src/main/java/com/vaadin/flow/uitest/servlet/RpcLoggerServlet.java
+++ b/flow-tests/test-root-ui-context/src/main/java/com/vaadin/flow/uitest/servlet/RpcLoggerServlet.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.uitest.servlet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.servlet.annotation.WebServlet;
 
@@ -114,8 +115,8 @@ public class RpcLoggerServlet extends VaadinServlet {
         }
 
         @Override
-        public Runnable handle(UI ui, JsonObject invocationJson) {
-            Runnable runnable = delegate.handle(ui, invocationJson);
+        public Optional<Runnable> handle(UI ui, JsonObject invocationJson) {
+            Optional<Runnable> runnable = delegate.handle(ui, invocationJson);
             StateNode node = ui.getInternals().getStateTree()
                     .getNodeById(getNodeId(invocationJson));
             Div container = new Div();


### PR DESCRIPTION
The rpc handlers are static and initialized only once.
This means that they themselves can not collect pending
events or other, but these should be delegated to the actual
ServerRPCHandler that is always handled for each session
within a session lock.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3339)
<!-- Reviewable:end -->
