### PR TITLE
Run ES5 and ES6 in different gulp tasks.

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/common/FrontendToolsManager.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/common/FrontendToolsManager.java
@@ -156,7 +156,6 @@ public class FrontendToolsManager {
         }
 
         ImmutableMap.Builder<String, String> gulpFileParameters = new ImmutableMap.Builder<String, String>()
-                .put("{skip_es5}", Boolean.toString(skipEs5))
                 .put("{es6_source_directory}", es6SourceDirectory.getAbsolutePath())
                 .put("{target_directory}", outputDirectory.getAbsolutePath())
                 .put("{es5_configuration_name}", es5OutputDirectoryName)
@@ -166,17 +165,19 @@ public class FrontendToolsManager {
                 .put("{fragment_files}", combineFilePathsIntoString(frontendDataProvider.createFragmentFiles(workingDirectory)));
         createFileFromTemplateResource("gulpfile.js", gulpFileParameters.build());
 
+        Map<String, File> transpilationResults = new HashMap<>();
         try {
-            factory.getGulpRunner().execute("build", Collections.emptyMap());
+            factory.getGulpRunner().execute("build_es6", Collections.emptyMap());
+            addTranspilationResult(transpilationResults, outputDirectory, es6OutputDirectoryName);
+
+            if (!skipEs5) {
+                factory.getGulpRunner().execute("build_es5", Collections.emptyMap());
+                addTranspilationResult(transpilationResults, outputDirectory, es5OutputDirectoryName);
+            }
         } catch (TaskRunnerException e) {
             throw new IllegalStateException("Transpilation with gulp has failed", e);
         }
 
-        Map<String, File> transpilationResults = new HashMap<>();
-        addTranspilationResult(transpilationResults, outputDirectory, es6OutputDirectoryName);
-        if (!skipEs5) {
-            addTranspilationResult(transpilationResults, outputDirectory, es5OutputDirectoryName);
-        }
         return transpilationResults;
     }
 

--- a/flow-maven-plugin/src/main/resources/gulpfile.js
+++ b/flow-maven-plugin/src/main/resources/gulpfile.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const skipEs5 = {skip_es5};
 const bundle = {bundle};
 const shellFile = "{shell_file}";
 const fragmentFiles = [{fragment_files}];
@@ -26,11 +25,11 @@ const parse5 = require('parse5');
 const cssSlam = require('css-slam');
 const htmlMinifier = require('html-minifier');
 const babelCore = require('babel-core');
-const babelTransform = function(contents, options) {
+const babelTransform = function (contents, options) {
     return babelCore.transform(contents, options).code;
 };
 
-function build() {
+function build(transpileJs, configurationName) {
     const workingDirectory = __dirname;
     const polymerProperties = {
         root: workingDirectory,
@@ -43,12 +42,7 @@ function build() {
     }
     const polymerProject = new polymerBuild.PolymerProject(polymerProperties);
 
-    if (!skipEs5) {
-        buildConfiguration(polymerProject, path.relative(workingDirectory, es6SourceDirectory), path.join(targetDirectory, es5ConfigurationName), true, bundle);
-    } else {
-        console.log('Skipping es5 transpilation');
-    }
-    buildConfiguration(polymerProject, path.relative(workingDirectory, es6SourceDirectory), path.join(targetDirectory, es6ConfigurationName), false, bundle);
+    buildConfiguration(polymerProject, path.relative(workingDirectory, es6SourceDirectory), path.join(targetDirectory, configurationName), transpileJs, bundle);
 }
 
 function buildConfiguration(polymerProject, redundantPathPrefix, configurationTargetDirectory, transpileJs, bundle) {
@@ -165,7 +159,16 @@ class FlowBuildBundler extends polymerBuild.BuildBundler {
     }
 }
 
-gulp.task('build', build);
+gulp.task('build_es6', function () {
+    build(false, es6ConfigurationName)
+});
+
+gulp.task('build_es5', function () {
+    console.log('Starting ES5 transpilation.');
+    build(true, es5ConfigurationName)
+    console.log('ES5 transpilation completed.');
+});
+
 process.on('unhandledRejection', (error, p) => {
     console.error('Failed to process frontend files.');
     console.error(`error: ${error.stack}`);


### PR DESCRIPTION
Running both ES5 transpilation and ES6 bundling
at the same time corrupts the ES6 files with ES5 
contents.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3377)
<!-- Reviewable:end -->
