### PR TITLE
Include non-transpiled web component resources to production build

### DIFF
--- a/flow-documentation/web-components/tutorial-flow-maven-plugin.asciidoc
+++ b/flow-documentation/web-components/tutorial-flow-maven-plugin.asciidoc
@@ -67,7 +67,7 @@ The goal parameters are:
 * copyOutputDirectory `default: ${project.build.directory}/frontend/`
     The directory to copy files to. 
     
-* excludes `default: **/LICENSE*,**/demo/**,**/docs/**,**/test*/**,**/.*,**/*.md`
+* excludes `default: \*\*/LICENSE,\*\*/LICENCE,\*\*/demo/\*\*,\*\*/docs/\*\*,\*\*/test\*/\*\*,\*\*/.\*,\*\*/\*.md`
     File globs to specify files that should not be copied to copyOutputDirectory, set in regular Maven fashion: single string, comma-separated values.
     
 * frontendWorkingDirectory `default: ${project.basedir}/src/main/webapp/frontend/`
@@ -138,9 +138,9 @@ The goal parameters are:
 After the goal is complete, the files from `transpileEs6SourceDirectory` are processed. 
 It results in:
 * `transpileOutputDirectory/es6OutputDirectoryName` with all files from `transpileEs6SourceDirectory` copied into it 
-and with all `*.css`, `*.js` and `*.html` additionally optimized for production usage.
+and with all `\*.css`, `\*.js` and `\*.html` additionally optimized for production usage.
 * If not configured to be skipped, `transpileOutputDirectory/es5OutputDirectoryName` with all files from `transpileEs6SourceDirectory` copied into it 
-and with all `*.css`, `*.js` and `*.html` additionally optimized for production usage AND transpiled into ES5 so that old browsers are able to use the application still
+and with all `\*.css`, `\*.js` and `\*.html` additionally optimized for production usage AND transpiled into ES5 so that old browsers are able to use the application still
 * `transpileWorkingDirectory` with all frontend tools and additional files created for the tools, can be ignored after the process
 
 ## Bundle Configuration

--- a/flow-documentation/web-components/tutorial-flow-maven-plugin.asciidoc
+++ b/flow-documentation/web-components/tutorial-flow-maven-plugin.asciidoc
@@ -67,7 +67,7 @@ The goal parameters are:
 * copyOutputDirectory `default: ${project.build.directory}/frontend/`
     The directory to copy files to. 
     
-* excludes `default: \*\*/LICENSE,\*\*/LICENCE,\*\*/demo/\*\*,\*\*/docs/\*\*,\*\*/test\*/\*\*,\*\*/.\*,\*\*/\*.md`
+* excludes `default: $$**/LICENSE,**/LICENCE,**/demo/**,**/docs/**,**/test*/**,**/.*,**/*.md$$`
     File globs to specify files that should not be copied to copyOutputDirectory, set in regular Maven fashion: single string, comma-separated values.
     
 * frontendWorkingDirectory `default: ${project.basedir}/src/main/webapp/frontend/`
@@ -138,9 +138,9 @@ The goal parameters are:
 After the goal is complete, the files from `transpileEs6SourceDirectory` are processed. 
 It results in:
 * `transpileOutputDirectory/es6OutputDirectoryName` with all files from `transpileEs6SourceDirectory` copied into it 
-and with all `\*.css`, `\*.js` and `\*.html` additionally optimized for production usage.
+and with all `$$*.css$$`, `$$*.js$$` and `$$*.html$$` additionally optimized for production usage.
 * If not configured to be skipped, `transpileOutputDirectory/es5OutputDirectoryName` with all files from `transpileEs6SourceDirectory` copied into it 
-and with all `\*.css`, `\*.js` and `\*.html` additionally optimized for production usage AND transpiled into ES5 so that old browsers are able to use the application still
+and with all `$$*.css$$`, `$$*.js$$` and `$$*.html$$` additionally optimized for production usage AND transpiled into ES5 so that old browsers are able to use the application still
 * `transpileWorkingDirectory` with all frontend tools and additional files created for the tools, can be ignored after the process
 
 ## Bundle Configuration

--- a/flow-documentation/web-components/tutorial-flow-maven-plugin.asciidoc
+++ b/flow-documentation/web-components/tutorial-flow-maven-plugin.asciidoc
@@ -67,7 +67,7 @@ The goal parameters are:
 * copyOutputDirectory `default: ${project.build.directory}/frontend/`
     The directory to copy files to. 
     
-* excludes `default: $$**/LICENSE,**/LICENCE,**/demo/**,**/docs/**,**/test*/**,**/.*,**/*.md$$`
+* excludes `default: $$**/LICENSE*,**/LICENCE*,**/demo/**,**/docs/**,**/test*/**,**/.*,**/*.md,**/bower.json,**/package.json,**/package-lock.json$$`
     File globs to specify files that should not be copied to copyOutputDirectory, set in regular Maven fashion: single string, comma-separated values.
     
 * frontendWorkingDirectory `default: ${project.basedir}/src/main/webapp/frontend/`

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/CopyProductionFilesMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/CopyProductionFilesMojo.java
@@ -42,7 +42,7 @@ public class CopyProductionFilesMojo extends AbstractMojo {
     @Parameter(name = "copyOutputDirectory", defaultValue = "${project.build.directory}/frontend/", required = true)
     private File copyOutputDirectory;
 
-    @Parameter(name = "excludes", defaultValue = "**/LICENSE,**/LICENCE,**/demo/**,**/docs/**,**/test*/**,**/.*,**/*.md", required = true)
+    @Parameter(name = "excludes", defaultValue = "**/LICENSE*,**/LICENCE*,**/demo/**,**/docs/**,**/test*/**,**/.*,**/*.md,**/bower.json,**/package.json,**/package-lock.json", required = true)
     private String excludes;
 
     @Parameter(name = "frontendWorkingDirectory", property = "frontend.working.directory", defaultValue = "${project.basedir}/src/main/webapp/frontend/", required = true)

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/CopyProductionFilesMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/CopyProductionFilesMojo.java
@@ -42,7 +42,7 @@ public class CopyProductionFilesMojo extends AbstractMojo {
     @Parameter(name = "copyOutputDirectory", defaultValue = "${project.build.directory}/frontend/", required = true)
     private File copyOutputDirectory;
 
-    @Parameter(name = "excludes", defaultValue = "**/LICENSE*,**/demo/**,**/docs/**,**/test*/**,**/.*,**/*.md", required = true)
+    @Parameter(name = "excludes", defaultValue = "**/LICENSE,**/LICENCE,**/demo/**,**/docs/**,**/test*/**,**/.*,**/*.md", required = true)
     private String excludes;
 
     @Parameter(name = "frontendWorkingDirectory", property = "frontend.working.directory", defaultValue = "${project.basedir}/src/main/webapp/frontend/", required = true)

--- a/flow-maven-plugin/src/main/resources/gulpfile.js
+++ b/flow-maven-plugin/src/main/resources/gulpfile.js
@@ -65,7 +65,7 @@ function buildConfiguration(polymerProject, redundantPathPrefix, configurationTa
                     .pipe(htmlSplitter.rejoin())
                     .pipe(bundle ? buildBundler : gulpIgnore.exclude(file => { return file.path === shellFile } ));
 
-                const nonSourceUserFilesStream = gulp.src([`${es6SourceDirectory}/**/*`, `!${es6SourceDirectory}/bower_components/**/*`, `!${es6SourceDirectory}/**/*.{html,css,js}`]);
+                const nonSourceUserFilesStream = gulp.src([`${es6SourceDirectory}/**/*`, `!${es6SourceDirectory}/**/*.{html,css,js}`]);
                 const buildStream = mergeStream(processedStream, nonSourceUserFilesStream)
                     .pipe(gulpRename(path => { path.dirname = path.dirname.replace(redundantPathPrefix, "") }))
                     .pipe(gulp.dest(configurationTargetDirectory));


### PR DESCRIPTION
Transpilation step of the Maven-plugin used to exclude all the non-transpiled files inside bower_components from the final war. This would cause for example missing images that originate from the webjars.
Exclusions should be handled with the maven-plugin parameter, which I also improved to not include LICENCE files by default (there are two naming conventions: LICENCE and LICENSE). Also updated the tutorial about this and escaped all the asterisks.

This is a partly solution for https://github.com/vaadin/flow/issues/3322 but doesn't fully fix it as the urls for images computed at the client-side still have one unnecessary "/frontend/" part when using bundling (this fixes already the case of using transpilation without bundling).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3388)
<!-- Reviewable:end -->
