### PR TITLE
simplify Instantiator to have only one method getOrCreate(Class<T> type)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/di/DefaultInstantiator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/di/DefaultInstantiator.java
@@ -62,6 +62,11 @@ public class DefaultInstantiator implements Instantiator {
         return getServiceLoaderListeners(service.getClassLoader());
     }
 
+    @Override
+    public <T> T getOrCreate(Class<T> type) {
+        return ReflectTools.createInstance(type);
+    }
+
     /**
      * Helper for finding service init listeners using {@link ServiceLoader}.
      *
@@ -74,17 +79,6 @@ public class DefaultInstantiator implements Instantiator {
         ServiceLoader<VaadinServiceInitListener> loader = ServiceLoader
                 .load(VaadinServiceInitListener.class, classloader);
         return StreamSupport.stream(loader.spliterator(), false);
-    }
-
-    @Override
-    public <T extends HasElement> T createRouteTarget(Class<T> routeTargetType,
-            NavigationEvent event) {
-        return ReflectTools.createInstance(routeTargetType);
-    }
-
-    @Override
-    public <T extends Component> T createComponent(Class<T> componentClass) {
-        return ReflectTools.createInstance(componentClass);
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/di/Instantiator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/di/Instantiator.java
@@ -122,6 +122,18 @@ public interface Instantiator extends Serializable {
     }
 
     /**
+     * Provides an instance of any given type, this is an abstraction
+     * that allows to make use of DI-frameworks from add-ons.
+     *
+     * How the object is created an whether it is being cached or not
+     * is up to the implementation.
+     * @param type
+     *            the instance type to create, not <code>null</code>
+     * @return an instance of the given type
+     */
+    <T> T getOrCreate(Class<T> type);
+
+    /**
      * Creates an instance of a navigation target or router layout. This method
      * is not called in cases when a component instance is reused when
      * navigating.
@@ -133,8 +145,10 @@ public interface Instantiator extends Serializable {
      *            <code>null</code>
      * @return the created instance, not <code>null</code>
      */
-    <T extends HasElement> T createRouteTarget(Class<T> routeTargetType,
-            NavigationEvent event);
+    default <T extends HasElement> T createRouteTarget(Class<T> routeTargetType,
+            NavigationEvent event){
+        return getOrCreate(routeTargetType);
+    }
 
     /**
      * Creates an instance of a component by its {@code componentClass}.
@@ -143,7 +157,9 @@ public interface Instantiator extends Serializable {
      *            the instance type to create, not <code>null</code>
      * @return the created instance, not <code>null</code>
      */
-    <T extends Component> T createComponent(Class<T> componentClass);
+    default <T extends Component> T createComponent(Class<T> componentClass){
+        return getOrCreate(componentClass);
+    }
 
     /**
      * Gets the instantiator to use for the given UI.
@@ -163,9 +179,11 @@ public interface Instantiator extends Serializable {
     }
 
     /**
-     * Get the I18NProvider if on has been defined.
+     * Get the I18NProvider if one has been defined.
      *
      * @return I18NProvier instance
      */
-    I18NProvider getI18NProvider();
+    default I18NProvider getI18NProvider(){
+        return getOrCreate(I18NProvider.class);
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/MockInstantiator.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/MockInstantiator.java
@@ -17,14 +17,8 @@ package com.vaadin.flow.server;
 
 import java.util.stream.Stream;
 
-import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.di.Instantiator;
-import com.vaadin.flow.i18n.I18NProvider;
 import com.vaadin.flow.internal.ReflectTools;
-import com.vaadin.flow.router.NavigationEvent;
-import com.vaadin.flow.server.VaadinService;
-import com.vaadin.flow.server.VaadinServiceInitListener;
 
 public class MockInstantiator implements Instantiator {
 
@@ -45,19 +39,7 @@ public class MockInstantiator implements Instantiator {
     }
 
     @Override
-    public <T extends HasElement> T createRouteTarget(Class<T> routeTargetType,
-            NavigationEvent event) {
-        return ReflectTools.createInstance(routeTargetType);
+    public <T> T getOrCreate(Class<T> type) {
+        return ReflectTools.createInstance(type);
     }
-
-    @Override
-    public <T extends Component> T createComponent(Class<T> componentClass) {
-        return null;
-    }
-
-    @Override
-    public I18NProvider getI18NProvider() {
-        return null;
-    }
-
 }

--- a/flow-spring-addon/src/main/java/com/vaadin/flow/spring/SpringInstantiator.java
+++ b/flow-spring-addon/src/main/java/com/vaadin/flow/spring/SpringInstantiator.java
@@ -20,11 +20,8 @@ import java.util.stream.Stream;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 
-import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.di.DefaultInstantiator;
 import com.vaadin.flow.i18n.I18NProvider;
-import com.vaadin.flow.router.NavigationEvent;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServiceInitListener;
 
@@ -62,17 +59,6 @@ public class SpringInstantiator extends DefaultInstantiator {
     }
 
     @Override
-    public <T extends HasElement> T createRouteTarget(Class<T> routeTargetType,
-            NavigationEvent event) {
-        return getObject(routeTargetType);
-    }
-
-    @Override
-    public <T extends Component> T createComponent(Class<T> componentClass) {
-        return getObject(componentClass);
-    }
-
-    @Override
     public I18NProvider getI18NProvider() {
         int beansCount = context.getBeanNamesForType(I18NProvider.class).length;
         if (beansCount == 1) {
@@ -86,11 +72,12 @@ public class SpringInstantiator extends DefaultInstantiator {
         }
     }
 
-    private <T> T getObject(Class<T> type) {
+    @Override
+    public <T> T getOrCreate(Class<T> type) {
         if (context.getBeanNamesForType(type).length == 1) {
             return context.getBean(type);
         }
+
         return context.getAutowireCapableBeanFactory().createBean(type);
     }
-
 }

--- a/flow-spring-addon/src/test/java/com/vaadin/flow/spring/service/JavaSPIInstantiator.java
+++ b/flow-spring-addon/src/test/java/com/vaadin/flow/spring/service/JavaSPIInstantiator.java
@@ -17,11 +17,7 @@ package com.vaadin.flow.spring.service;
 
 import java.util.stream.Stream;
 
-import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.di.Instantiator;
-import com.vaadin.flow.i18n.I18NProvider;
-import com.vaadin.flow.router.NavigationEvent;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServiceInitListener;
 
@@ -42,19 +38,7 @@ public class JavaSPIInstantiator implements Instantiator {
     }
 
     @Override
-    public <T extends HasElement> T createRouteTarget(Class<T> routeTargetType,
-            NavigationEvent event) {
+    public <T> T getOrCreate(Class<T> type) {
         return null;
     }
-
-    @Override
-    public <T extends Component> T createComponent(Class<T> componentClass) {
-        return null;
-    }
-
-    @Override
-    public I18NProvider getI18NProvider() {
-        return null;
-    }
-
 }

--- a/flow-spring-addon/src/test/java/com/vaadin/flow/spring/service/SpringVaadinServletServiceTest.java
+++ b/flow-spring-addon/src/test/java/com/vaadin/flow/spring/service/SpringVaadinServletServiceTest.java
@@ -31,10 +31,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Component;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.di.Instantiator;
-import com.vaadin.flow.i18n.I18NProvider;
-import com.vaadin.flow.router.NavigationEvent;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServiceInitListener;
 import com.vaadin.flow.spring.instantiator.SpringInstantiatorTest;
@@ -72,22 +69,9 @@ public class SpringVaadinServletServiceTest {
         }
 
         @Override
-        public <T extends HasElement> T createRouteTarget(
-                Class<T> routeTargetType, NavigationEvent event) {
+        public <T> T getOrCreate(Class<T> type) {
             return null;
         }
-
-        @Override
-        public <T extends com.vaadin.flow.component.Component> T createComponent(
-                Class<T> componentClass) {
-            return null;
-        }
-
-        @Override
-        public I18NProvider getI18NProvider() {
-            return null;
-        }
-
     }
 
     @Component


### PR DESCRIPTION
Instantiator needs only one method, the special cases for I18Provider, Component, HasValue are not needed. 
This also enables better integration for addons, since now addons can more simply use Instantiator as a generic object creator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3409)
<!-- Reviewable:end -->
