### PR TITLE
Add TestBench elements for HTML components

### DIFF
--- a/flow-html-components-testbench/pom.xml
+++ b/flow-html-components-testbench/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.vaadin</groupId>
+        <artifactId>flow-project</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>flow-html-components-testbench</artifactId>
+    <name>TestBench elements for Flow HTML Components</name>
+    <packaging>jar</packaging>
+
+    <properties>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-testbench</artifactId>
+            <version>${testbench.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-test-util</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>${jetty.version}</version>
+                <configuration>
+                    <httpConnector>
+                        <port>8888</port>
+                    </httpConnector>
+                    <useTestClasspath>true</useTestClasspath>
+                    <scanIntervalSeconds>-1</scanIntervalSeconds>
+                    <stopKey>foo</stopKey>
+                    <stopPort>8889</stopPort>
+                    <stopWait>5</stopWait>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>start-jetty</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>stop-jetty</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/AnchorElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/AnchorElement.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing an <code>&lt;a&gt;</code> element.
+ */
+@Element("a")
+public class AnchorElement extends TestBenchElement {
+
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/ButtonElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/ButtonElement.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing a <code>&lt;button&gt;</code> element.
+ */
+@Element("button")
+public class ButtonElement extends TestBenchElement {
+
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/DescriptionListElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/DescriptionListElement.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing a <code>&lt;dl&gt;</code> element.
+ */
+@Element("dl")
+public class DescriptionListElement extends TestBenchElement {
+
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/DivElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/DivElement.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing a <code>&lt;div&gt;</code> element.
+ */
+@Element("div")
+public class DivElement extends TestBenchElement {
+
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/EmphasisElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/EmphasisElement.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing an <code>&lt;em&gt;</code> element.
+ */
+@Element("em")
+public class EmphasisElement extends TestBenchElement {
+
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/H1Element.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/H1Element.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing an <code>&lt;h1&gt;</code> element.
+ */
+@Element("h1")
+public class H1Element extends TestBenchElement {
+
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/H2Element.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/H2Element.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing an <code>&lt;h2&gt;</code> element.
+ */
+@Element("h2")
+public class H2Element extends TestBenchElement {
+
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/H3Element.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/H3Element.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing an <code>&lt;h3&gt;</code> element.
+ */
+@Element("h3")
+public class H3Element extends TestBenchElement {
+
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/H4Element.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/H4Element.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing an <code>&lt;h4&gt;</code> element.
+ */
+@Element("h4")
+public class H4Element extends TestBenchElement {
+
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/H5Element.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/H5Element.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing an <code>&lt;h5&gt;</code> element.
+ */
+@Element("h5")
+public class H5Element extends TestBenchElement {
+
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/H6Element.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/H6Element.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing an <code>&lt;h6&gt;</code> element.
+ */
+@Element("h6")
+public class H6Element extends TestBenchElement {
+
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/HrElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/HrElement.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing an <code>&lt;hr&gt;</code> element.
+ */
+@Element("hr")
+public class HrElement extends TestBenchElement {
+
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/ImageElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/ImageElement.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing an <code>&lt;img&gt;</code> element.
+ */
+@Element("img")
+public class ImageElement extends TestBenchElement {
+
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/InputTextElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/InputTextElement.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import org.openqa.selenium.Keys;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing an <code>&lt;input type='text'&gt;</code>
+ * element.
+ */
+@Element("input")
+public class InputTextElement extends TestBenchElement {
+
+    /**
+     * Sets the value of the text input to the given value, clearing out any old
+     * value of the input.
+     * 
+     * @param value
+     *            the value to set
+     */
+    public void setValue(String value) {
+        if ("".equals(value)) {
+            clear();
+            return;
+        }
+
+        // Remove old value
+        setProperty("value", "");
+        // Type and add a TAB to ensure a change event is sent
+        sendKeys(value + Keys.TAB);
+    }
+
+    /**
+     * Clears the input field.
+     */
+    @Override
+    public void clear() {
+        String value = getValue();
+        if ("".equals(value))
+            return;
+
+        // Type and add a TAB to ensure a change event is sent
+        setValue("a");
+        sendKeys(Keys.BACK_SPACE, Keys.TAB);
+    }
+
+    public String getValue() {
+        return getPropertyString("value");
+    }
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/LabelElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/LabelElement.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing a <code>&lt;label&gt;</code> element.
+ */
+@Element("label")
+public class LabelElement extends TestBenchElement {
+
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/ListItemElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/ListItemElement.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing a <code>&lt;li&gt;</code> element.
+ */
+@Element("li")
+public class ListItemElement extends TestBenchElement {
+
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/OrderedListElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/OrderedListElement.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing an <code>&lt;ol&gt;</code> element.
+ */
+@Element("ol")
+public class OrderedListElement extends TestBenchElement {
+
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/ParagraphElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/ParagraphElement.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing a <code>&lt;p&gt;</code> element.
+ */
+@Element("p")
+public class ParagraphElement extends TestBenchElement {
+
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/SelectElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/SelectElement.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import org.openqa.selenium.support.ui.Select;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing a <code>&lt;select&gt;</code> element.
+ */
+@Element("select")
+public class SelectElement extends TestBenchElement {
+
+    /**
+     * Selects the first option matching the given text.
+     * 
+     * @param text
+     *            the text of the option to select
+     */
+    public void selectByText(String text) {
+        // Must use the wrapped element to avoid to click() override
+        new Select(getWrappedElement()).selectByVisibleText(text);
+    }
+
+    /**
+     * Gets the text of the currently selected option.
+     *
+     * @return the text of the current option
+     */
+    public String getSelectedText() {
+        return new Select(this).getFirstSelectedOption().getText();
+    }
+
+    /**
+     * Selects the option with the given value.
+     * <p>
+     * To select based on the visible text, use {@link #selectByText(String)}.
+     * 
+     * @param value
+     *            the value to select
+     */
+    public void setValue(String value) {
+        new Select(getWrappedElement()).selectByValue(value);
+    }
+
+    /**
+     * Gets the value of the currently selected option.
+     * <p>
+     * To get the visible text, use {@link #getSelectedText()}.
+     * 
+     * @return the value of the current option
+     */
+    public String getValue() {
+        return getPropertyString("value");
+    }
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/SpanElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/SpanElement.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing a <code>&lt;span&gt;</code> element.
+ */
+@Element("span")
+public class SpanElement extends TestBenchElement {
+
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/UnorderedListElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/UnorderedListElement.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing a <code>&lt;ul&gt;</code> element.
+ */
+@Element("ul")
+public class UnorderedListElement extends TestBenchElement {
+
+}

--- a/flow-html-components-testbench/src/test/java/com/vaadin/flow/component/html/testbench/InputTextElementIT.java
+++ b/flow-html-components-testbench/src/test/java/com/vaadin/flow/component/html/testbench/InputTextElementIT.java
@@ -1,0 +1,51 @@
+package com.vaadin.flow.component.html.testbench;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class InputTextElementIT extends ChromeBrowserTest {
+
+    private InputTextElement input;
+    private DivElement log;
+
+    @Before
+    public void open() {
+        getDriver().get("http://localhost:8888/InputText");
+        input = $(InputTextElement.class).id("input");
+        log = $(DivElement.class).id("log");
+    }
+
+    @Test
+    public void getSetValue() {
+        Assert.assertEquals("", input.getValue());
+        input.setValue("foo");
+        Assert.assertEquals("foo", input.getValue());
+        Assert.assertEquals("Value is 'foo'", log.getText());
+    }
+
+    @Test
+    public void setValueEmpty() {
+        input.setValue("foo");
+        input.setValue("");
+        Assert.assertEquals("", input.getValue());
+        Assert.assertEquals("Value is ''", log.getText());
+    }
+
+    @Test
+    public void clearEmpty() {
+        input.clear();
+        Assert.assertEquals("", input.getValue());
+        Assert.assertEquals("", log.getText());
+    }
+
+    @Test
+    public void clearWithValue() {
+        input.setValue("foobar");
+        input.clear();
+        Assert.assertEquals("", input.getValue());
+        Assert.assertEquals("Value is ''", log.getText());
+    }
+}

--- a/flow-html-components-testbench/src/test/java/com/vaadin/flow/component/html/testbench/InputTextView.java
+++ b/flow-html-components-testbench/src/test/java/com/vaadin/flow/component/html/testbench/InputTextView.java
@@ -1,0 +1,21 @@
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Input;
+import com.vaadin.flow.router.Route;
+
+@Route("InputText")
+public class InputTextView extends Div {
+
+    public InputTextView() {
+        Div log = new Div();
+        log.setId("log");
+
+        Input input = new Input();
+        input.setId("input");
+        input.addChangeListener(e -> {
+            log.setText("Value is '" + input.getValue() + "'");
+        });
+        add(log, input);
+    }
+}

--- a/flow-html-components-testbench/src/test/java/com/vaadin/flow/component/html/testbench/SelectElementIT.java
+++ b/flow-html-components-testbench/src/test/java/com/vaadin/flow/component/html/testbench/SelectElementIT.java
@@ -1,0 +1,31 @@
+package com.vaadin.flow.component.html.testbench;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class SelectElementIT extends ChromeBrowserTest {
+
+    private SelectElement input;
+    private DivElement log;
+
+    @Before
+    public void open() {
+        getDriver().get("http://localhost:8888/Select");
+        input = $(SelectElement.class).id("input");
+        log = $(DivElement.class).id("log");
+    }
+
+    @Test
+    public void selectByText() {
+        input.selectByText("Visible text 5");
+        Assert.assertEquals("value5", input.getValue());
+        Assert.assertEquals("Value is 'value5'", log.getText());
+        input.selectByText("Visible text 1");
+        Assert.assertEquals("value1", input.getValue());
+        Assert.assertEquals("Value is 'value1'", log.getText());
+    }
+
+}

--- a/flow-html-components-testbench/src/test/java/com/vaadin/flow/component/html/testbench/SelectView.java
+++ b/flow-html-components-testbench/src/test/java/com/vaadin/flow/component/html/testbench/SelectView.java
@@ -1,0 +1,29 @@
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.router.Route;
+
+@Route("Select")
+public class SelectView extends Div {
+
+    public SelectView() {
+        Div log = new Div();
+        log.setId("log");
+
+        Element select = new Element("select");
+        for (int i = 1; i < 10; i++) {
+            select.appendChild(
+                    new Element("option").setAttribute("id", "id" + i)
+                            .setAttribute("value", "value" + i)
+                            .setText("Visible text " + i));
+        }
+        select.setAttribute("id", "input");
+        select.addEventListener("change", e -> {
+            log.setText("Value is '"
+                    + e.getEventData().getString("element.value") + "'");
+        }, "element.value");
+        add(log);
+        getElement().appendChild(select);
+    }
+}

--- a/flow-test-util/pom.xml
+++ b/flow-test-util/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-testbench</artifactId>
-            <version>6.0.0.alpha7</version>
+            <version>${testbench.version}</version>
         </dependency>
         <!-- override scope for junit -->
         <dependency>

--- a/flow-tests/test-root-context/pom.xml
+++ b/flow-tests/test-root-context/pom.xml
@@ -20,6 +20,11 @@
             <artifactId>flow-test-resources</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-html-components-testbench</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.webjars.bower</groupId>

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/AbstractBasicElementComponentIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/AbstractBasicElementComponentIT.java
@@ -7,19 +7,20 @@ import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.html.testbench.ButtonElement;
+import com.vaadin.flow.component.html.testbench.InputTextElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
-public abstract class AbstractBasicElementComponentIT extends ChromeBrowserTest {
+public abstract class AbstractBasicElementComponentIT
+        extends ChromeBrowserTest {
 
     @Test
     public void ensureDomUpdatesAndEventsDoSomething() {
         open();
 
         Assert.assertEquals(0, getThankYouCount());
-
-        findElement(By.tagName(Tag.INPUT)).sendKeys("abc");
-        findElement(By.tagName(Tag.BUTTON)).click();
+        $(InputTextElement.class).first().setValue("abc");
+        $(ButtonElement.class).first().click();
 
         Assert.assertEquals(1, getThankYouCount());
 

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/BasicElementIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/BasicElementIT.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.Tag;
@@ -43,7 +44,7 @@ public class BasicElementIT extends AbstractBasicElementComponentIT {
 
         Assert.assertEquals(0, getThankYouCount());
 
-        findElement(By.tagName(Tag.INPUT)).sendKeys("abc");
+        findElement(By.tagName(Tag.INPUT)).sendKeys("abc" + Keys.TAB);
         findElement(By.tagName(Tag.BUTTON)).click();
 
         Assert.assertEquals(1, getThankYouCount());

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/CompositeIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/CompositeIT.java
@@ -18,8 +18,10 @@ package com.vaadin.flow.uitest.ui;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 
+import com.vaadin.flow.component.html.testbench.InputTextElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
@@ -29,19 +31,18 @@ public class CompositeIT extends ChromeBrowserTest {
     public void changeOnClient() {
         open();
         WebElement name = findElement(By.id(CompositeNestedView.NAME_ID));
-        WebElement input = findElement(
-                By.id(CompositeNestedView.NAME_FIELD_ID));
+        InputTextElement input = $(InputTextElement.class)
+                .id(CompositeNestedView.NAME_FIELD_ID);
         Assert.assertEquals("Name on server:", name.getText());
-        input.sendKeys("123");
-        findElement(By.xpath("//body")).click(); // Make change event happen
+        input.setValue("123");
         Assert.assertEquals("Name on server: 123", name.getText());
 
-        WebElement serverValueInput = findElement(
-                By.id(CompositeView.SERVER_INPUT_ID));
+        InputTextElement serverValueInput = $(InputTextElement.class)
+                .id(CompositeView.SERVER_INPUT_ID);
         WebElement serverValueButton = findElement(
                 By.id(CompositeView.SERVER_INPUT_BUTTON_ID));
 
-        serverValueInput.sendKeys("server value");
+        serverValueInput.setValue("server value");
         serverValueButton.click();
 
         Assert.assertEquals("Name on server: server value", name.getText());

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/CompositeNestedIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/CompositeNestedIT.java
@@ -18,8 +18,10 @@ package com.vaadin.flow.uitest.ui;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 
+import com.vaadin.flow.component.html.testbench.InputTextElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
 public class CompositeNestedIT extends ChromeBrowserTest {
@@ -28,11 +30,10 @@ public class CompositeNestedIT extends ChromeBrowserTest {
     public void testBasics() {
         open();
         WebElement name = findElement(By.id(CompositeNestedView.NAME_ID));
-        WebElement input = findElement(
-                By.id(CompositeNestedView.NAME_FIELD_ID));
+        InputTextElement input = $(InputTextElement.class)
+                .id(CompositeNestedView.NAME_FIELD_ID);
         Assert.assertEquals("Name on server:", name.getText());
-        input.sendKeys("123");
-        findElement(By.xpath("//body")).click(); // Make change event happen
+        input.setValue("123");
         Assert.assertEquals("Name on server: 123", name.getText());
     }
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HistoryIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HistoryIT.java
@@ -24,8 +24,10 @@ import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 
+import com.vaadin.flow.component.html.testbench.InputTextElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
 public class HistoryIT extends ChromeBrowserTest {
@@ -36,16 +38,17 @@ public class HistoryIT extends ChromeBrowserTest {
 
         URI baseUrl = getCurrentUrl();
 
-        WebElement stateField = findElement(By.id("state"));
-        WebElement locationField = findElement(By.id("location"));
+        InputTextElement stateField = $(InputTextElement.class).id("state");
+        InputTextElement locationField = $(InputTextElement.class)
+                .id("location");
         WebElement pushButton = findElement(By.id("pushState"));
         WebElement replaceButton = findElement(By.id("replaceState"));
         WebElement backButton = findElement(By.id("back"));
         WebElement forwardButton = findElement(By.id("forward"));
         WebElement clearButton = findElement(By.id("clear"));
 
-        stateField.sendKeys("{'foo':true}");
-        locationField.sendKeys("asdf");
+        stateField.setValue("{'foo':true}");
+        locationField.setValue("asdf");
         pushButton.click();
 
         Assert.assertEquals(baseUrl.resolve("asdf"), getCurrentUrl());
@@ -62,7 +65,7 @@ public class HistoryIT extends ChromeBrowserTest {
 
         stateField.clear();
         locationField.clear();
-        locationField.sendKeys("qwerty");
+        locationField.setValue("qwerty");
         replaceButton.click();
 
         Assert.assertEquals(baseUrl.resolve("qwerty"), getCurrentUrl());

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PageIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PageIT.java
@@ -3,8 +3,10 @@ package com.vaadin.flow.uitest.ui;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 
+import com.vaadin.flow.component.html.testbench.InputTextElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
@@ -28,7 +30,7 @@ public class PageIT extends ChromeBrowserTest {
         updateTitle("Page title 1");
         verifyTitle("Page title 1");
 
-        findElement(By.id("input")).sendKeys("title 2");
+        findElement(By.id("input")).sendKeys("title 2" + Keys.TAB);
         findElement(By.id("override")).click();
 
         verifyTitle("OVERRIDDEN");
@@ -51,8 +53,7 @@ public class PageIT extends ChromeBrowserTest {
     }
 
     private void updateTitle(String title) {
-        findElement(By.id("input")).clear();
-        findElement(By.id("input")).sendKeys(title);
+        $(InputTextElement.class).id("input").setValue(title);
         findElement(By.id("button")).click();
     }
 
@@ -60,11 +61,11 @@ public class PageIT extends ChromeBrowserTest {
     public void testReload() {
         open();
 
-        TestBenchElement input = (TestBenchElement) findElement(By.id("input"));
-        input.sendKeys("foo");
+        InputTextElement input = $(InputTextElement.class).id("input");
+        input.setValue("foo");
         Assert.assertEquals("foo", input.getPropertyString("value"));
         findElement(By.id("reload")).click();
-        input = (TestBenchElement) findElement(By.id("input"));
-        Assert.assertEquals("", input.getPropertyString("value"));
+        input = $(InputTextElement.class).id("input");
+        Assert.assertEquals("", input.getValue());
     }
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TemplateComponentMappingIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/TemplateComponentMappingIT.java
@@ -48,7 +48,7 @@ public class TemplateComponentMappingIT extends ChromeBrowserTest {
         WebElement input = findElement(
                 By.id(TemplateComponentMappingView.INPUT_ID));
         input.sendKeys(Keys.BACK_SPACE, Keys.BACK_SPACE, Keys.BACK_SPACE,
-                "Hello");
+                "Hello" + Keys.TAB);
         blurInput();
         Assert.assertEquals("client: input was changed to Hello\n" //
                 + "server: input value changed to Hello", getLog());

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ViewTitleIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ViewTitleIT.java
@@ -2,8 +2,8 @@ package com.vaadin.flow.uitest.ui;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.openqa.selenium.By;
 
+import com.vaadin.flow.component.html.testbench.SelectElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
 public class ViewTitleIT extends ChromeBrowserTest {
@@ -38,8 +38,8 @@ public class ViewTitleIT extends ChromeBrowserTest {
     }
 
     private void openView(String viewName) {
-        findElement(By.tagName("select")).click();
-        findElement(By.id(viewName)).click();
+        SelectElement input = $(SelectElement.class).first();
+        input.selectByText(viewName);
     }
 
     private void verifyTitle(String title) {

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/PolymerModelPropertiesIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/PolymerModelPropertiesIT.java
@@ -19,10 +19,11 @@ import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.testutil.ChromeBrowserTest;
-import org.openqa.selenium.By;
 
 public class PolymerModelPropertiesIT extends ChromeBrowserTest {
 
@@ -37,7 +38,7 @@ public class PolymerModelPropertiesIT extends ChromeBrowserTest {
         WebElement template = findElement(By.id("template"));
         WebElement input = getInShadowRoot(template, By.id("input"));
         input.clear();
-        input.sendKeys("x");
+        input.sendKeys("x" + Keys.TAB);
 
         // property update event comes immediately
         List<WebElement> propertyUpdates = findElements(

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/TemplateInTemplateIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/TemplateInTemplateIT.java
@@ -21,6 +21,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.testutil.ChromeBrowserTest;
+import com.vaadin.testbench.TestBenchElement;
 
 public class TemplateInTemplateIT extends ChromeBrowserTest {
 
@@ -29,9 +30,11 @@ public class TemplateInTemplateIT extends ChromeBrowserTest {
         open();
 
         WebElement template = findElement(By.id("template"));
-        WebElement child = getInShadowRoot(template, By.id("child"));
+        TestBenchElement child = (TestBenchElement) getInShadowRoot(template,
+                By.id("child"));
 
-        child.click();
+        child.getPropertyElement("shadowRoot", "firstElementChild").click();
+
         Assert.assertTrue(isElementPresent(By.id("click-handler")));
 
         WebElement text = getInShadowRoot(child, By.id("text"));

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <module>flow-data</module>
         <module>flow-client</module>
         <module>flow-html-components</module>
+        <module>flow-html-components-testbench</module>
         <module>flow-theme-integrations</module>
         <module>flow-spring-addon</module>
         <module>flow-spring-boot-starter</module>
@@ -88,6 +89,7 @@
         <maven.deploy.plugin.version>2.8.2</maven.deploy.plugin.version>
         <maven.resources.plugin.version>3.0.2</maven.resources.plugin.version>
         <maven.clean.plugin.version>3.0.0</maven.clean.plugin.version>
+        <testbench.version>6.0.0.alpha8</testbench.version>
         <!-- Jetty 9.3.8/9.3.9 causes the build to fail with 'address already 
             in use' -->
         <jetty.version>9.3.7.v20160115</jetty.version>


### PR DESCRIPTION
Extra support for select and input type=text

Also updates TestBench to 6.0.0.alpha8


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3421)
<!-- Reviewable:end -->
