### PR TITLE
Fix assetpath only for html-files in transpilation

### DIFF
--- a/flow-maven-plugin/src/main/resources/gulpfile.js
+++ b/flow-maven-plugin/src/main/resources/gulpfile.js
@@ -69,7 +69,7 @@ function buildConfiguration(polymerProject, redundantPathPrefix, configurationTa
                 const nonSourceUserFilesStream = gulp.src([`${es6SourceDirectory}/**/*`, `!${es6SourceDirectory}/**/*.{html,css,js}`]);
                 const buildStream = mergeStream(processedStream, nonSourceUserFilesStream)
                     .pipe(gulpRename(path => { path.dirname = path.dirname.replace(redundantPathPrefix, "") }))
-                    .pipe(gulpReplace('assetpath="'+redundantPathPrefix+'/', 'assetpath="',{ logs: { enabled: false } }))
+                    .pipe(gulpIf(/\.html$/, gulpReplace('assetpath="'+redundantPathPrefix+'/', 'assetpath="',{ logs: { enabled: false } })))
                     .pipe(gulp.dest(configurationTargetDirectory));
 
                 return new Promise((resolve, reject) => {


### PR DESCRIPTION
For some reason the gulp-replace-string task, which should match only 'assetpath="frontend/', corrupted a jpg-file in bakery. That's why a gulp-if was added to target this replace task only for html-files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3427)
<!-- Reviewable:end -->
