### PR TITLE
Fix DatePicker and CheckBox generated classes

### DIFF
--- a/flow-components-parent/flow-code-generator-api/src/main/java/com/vaadin/generator/ComponentGenerator.java
+++ b/flow-components-parent/flow-code-generator-api/src/main/java/com/vaadin/generator/ComponentGenerator.java
@@ -519,11 +519,17 @@ public class ComponentGenerator {
         classBehaviorsAndMixins.add(metadata.getTag());
 
         if (metadata.getBehaviors() != null) {
-            classBehaviorsAndMixins.addAll(metadata.getBehaviors());
+            metadata.getBehaviors().stream()
+                    .filter(behavior -> !ExclusionRegistry
+                            .isBehaviorOrMixinExcluded(metadata.getTag(), behavior))
+                    .forEach(classBehaviorsAndMixins::add);
         }
 
         if (metadata.getMixins() != null) {
-            classBehaviorsAndMixins.addAll(metadata.getMixins());
+            metadata.getMixins().stream()
+                    .filter(mixin -> !ExclusionRegistry
+                            .isBehaviorOrMixinExcluded(metadata.getTag(), mixin))
+                    .forEach(classBehaviorsAndMixins::add);
         }
 
         Set<Class<?>> interfaces = BehaviorRegistry

--- a/flow-components-parent/flow-code-generator-api/src/main/java/com/vaadin/generator/registry/ExclusionRegistry.java
+++ b/flow-components-parent/flow-code-generator-api/src/main/java/com/vaadin/generator/registry/ExclusionRegistry.java
@@ -34,6 +34,7 @@ public class ExclusionRegistry {
     private static final Map<String, Set<String>> PROPERTY_EXCLUSION_REGISTRY = new HashMap<>();
     private static final Map<String, Set<String>> EVENT_EXCLUSION_REGISTRY = new HashMap<>();
     private static final Map<String, Set<String>> METHOD_EXCLUSION_REGISTRY = new HashMap<>();
+    private static final Map<String, Set<String>> BEHAVIOR_EXCLUSION_REGISTRY = new HashMap<>();
 
     static {
         excludeProperty("vaadin-combo-box", "value");
@@ -50,6 +51,8 @@ public class ExclusionRegistry {
         excludeProperty("vaadin-list-box", "selected");
         excludeEvent("vaadin-combo-box", "selected-item-changed");
         excludeEvent("vaadin-combo-box", "change");
+        excludeBehaviorOrMixin("vaadin-date-picker",
+                "Polymer.GestureEventListeners");
 
         // Polymer lifecycle callbacks
         excludeMethod(null, "connectedCallback");
@@ -114,6 +117,22 @@ public class ExclusionRegistry {
         put(elementTag, methodName, METHOD_EXCLUSION_REGISTRY);
     }
 
+    /**
+     * Excludes a behavior or mixin from being evaluated for a specific element
+     * denoted by its tag.
+     * 
+     * @param elementTag
+     *            the tag of the element which the behavior should be excluded
+     *            from generation. Setting <code>null</code> makes the exclusion
+     *            apply to all elements
+     * @param behaviorName
+     *            the name of the behavior or mixin to be excluded
+     */
+    public static void excludeBehaviorOrMixin(String elementTag,
+            String behaviorName) {
+        put(elementTag, behaviorName, BEHAVIOR_EXCLUSION_REGISTRY);
+    }
+
     private static boolean isExcluded(String elementTag, String name,
             Map<String, Set<String>> map) {
         if (map.getOrDefault(null, Collections.emptySet()).contains(name)) {
@@ -166,5 +185,22 @@ public class ExclusionRegistry {
     public static boolean isMethodExcluded(String elementTag,
             String methodName) {
         return isExcluded(elementTag, methodName, METHOD_EXCLUSION_REGISTRY);
+    }
+
+    /**
+     * Gets whether a behavior or mixin should be excluded or not from the
+     * generation.
+     * 
+     * @param elementTag
+     *            the tag of the element
+     * @param behaviorName
+     *            the name of the behavior or mixin
+     * @return <code>true</code> if the behavior should be excluded,
+     *         <code>false</code> otherwise
+     */
+    public static boolean isBehaviorOrMixinExcluded(String elementTag,
+            String behaviorName) {
+        return isExcluded(elementTag, behaviorName,
+                BEHAVIOR_EXCLUSION_REGISTRY);
     }
 }

--- a/flow-components-parent/flow-code-generator-api/src/main/java/com/vaadin/generator/registry/PropertyNameRemapRegistry.java
+++ b/flow-components-parent/flow-code-generator-api/src/main/java/com/vaadin/generator/registry/PropertyNameRemapRegistry.java
@@ -31,7 +31,6 @@ public final class PropertyNameRemapRegistry {
     private static final Map<String, Map<String, String>> REGISTRY = new HashMap<>();
     static {
         put("vaadin-checkbox", "value", "postValue");
-        put("vaadin-checkbox", "checked", "value");
         put("vaadin-date-picker", "value", "valueAsString");
         put("vaadin-date-picker", "min", "minAsString");
         put("vaadin-date-picker", "max", "maxAsString");

--- a/flow-components-parent/flow-code-generator-api/src/test/java/com/vaadin/generator/registry/ExclusionRegistryTest.java
+++ b/flow-components-parent/flow-code-generator-api/src/test/java/com/vaadin/generator/registry/ExclusionRegistryTest.java
@@ -29,6 +29,10 @@ public class ExclusionRegistryTest {
                 ExclusionRegistry.isMethodExcluded("some-tag", "someEvent"));
         Assert.assertFalse(ExclusionRegistry.isMethodExcluded("some-tag",
                 "someOtherEvent"));
+        Assert.assertFalse(ExclusionRegistry
+                .isBehaviorOrMixinExcluded("some-tag", "someEvent"));
+        Assert.assertFalse(ExclusionRegistry
+                .isBehaviorOrMixinExcluded("some-tag", "someOtherEvent"));
     }
 
     @Test
@@ -51,6 +55,10 @@ public class ExclusionRegistryTest {
                 ExclusionRegistry.isMethodExcluded("some-tag", "someProperty"));
         Assert.assertFalse(ExclusionRegistry.isMethodExcluded("some-tag",
                 "someOtherProperty"));
+        Assert.assertFalse(ExclusionRegistry
+                .isBehaviorOrMixinExcluded("some-tag", "someProperty"));
+        Assert.assertFalse(ExclusionRegistry
+                .isBehaviorOrMixinExcluded("some-tag", "someOtherProperty"));
     }
 
     @Test
@@ -67,12 +75,43 @@ public class ExclusionRegistryTest {
 
         Assert.assertFalse(
                 ExclusionRegistry.isEventExcluded("some-tag", "someMethod"));
+        Assert.assertFalse(ExclusionRegistry.isEventExcluded("some-tag",
+                "someOtherMethod"));
         Assert.assertFalse(
-                ExclusionRegistry.isEventExcluded("some-tag", "someMethod"));
+                ExclusionRegistry.isPropertyExcluded("some-tag", "someMethod"));
         Assert.assertFalse(ExclusionRegistry.isPropertyExcluded("some-tag",
                 "someOtherMethod"));
+        Assert.assertFalse(ExclusionRegistry
+                .isBehaviorOrMixinExcluded("some-tag", "someMethod"));
+        Assert.assertFalse(ExclusionRegistry
+                .isBehaviorOrMixinExcluded("some-tag", "someOtherMethod"));
+    }
+
+    @Test
+    public void excludeBehaviors() {
+        ExclusionRegistry.excludeBehaviorOrMixin("some-tag", "someBehavior");
+        ExclusionRegistry.excludeBehaviorOrMixin(null, "someOtherBehavior");
+
+        Assert.assertTrue(ExclusionRegistry
+                .isBehaviorOrMixinExcluded("some-tag", "someBehavior"));
+        Assert.assertTrue(ExclusionRegistry
+                .isBehaviorOrMixinExcluded("some-tag", "someOtherBehavior"));
+        Assert.assertTrue(ExclusionRegistry.isBehaviorOrMixinExcluded(
+                "some-other-tag", "someOtherBehavior"));
+
+        Assert.assertFalse(
+                ExclusionRegistry.isEventExcluded("some-tag", "someBehavior"));
+        Assert.assertFalse(ExclusionRegistry.isEventExcluded("some-tag",
+                "someOtherBehavior"));
+        Assert.assertFalse(
+                ExclusionRegistry.isMethodExcluded("some-tag", "someBehavior"));
+        Assert.assertFalse(ExclusionRegistry.isMethodExcluded("some-tag",
+                "someOtherBehavior"));
         Assert.assertFalse(ExclusionRegistry.isPropertyExcluded("some-tag",
-                "someOtherMethod"));
+                "someBehavior"));
+        Assert.assertFalse(ExclusionRegistry.isPropertyExcluded("some-tag",
+                "someOtherBehavior"));
+
     }
 
 }

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/checkbox/GeneratedVaadinCheckbox.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/checkbox/GeneratedVaadinCheckbox.java
@@ -207,7 +207,7 @@ public abstract class GeneratedVaadinCheckbox<R extends GeneratedVaadinCheckbox<
      * @return the {@code checked} property from the webcomponent
      */
     @Synchronize(property = "checked", value = "checked-changed")
-    protected boolean isValueBoolean() {
+    protected boolean isCheckedBoolean() {
         return getElement().getProperty("checked", false);
     }
 
@@ -219,11 +219,11 @@ public abstract class GeneratedVaadinCheckbox<R extends GeneratedVaadinCheckbox<
      * True if the checkbox is checked.
      * </p>
      * 
-     * @param value
+     * @param checked
      *            the boolean value to set
      */
-    protected void setValue(boolean value) {
-        getElement().setProperty("checked", value);
+    protected void setChecked(boolean checked) {
+        getElement().setProperty("checked", checked);
     }
 
     /**
@@ -300,9 +300,9 @@ public abstract class GeneratedVaadinCheckbox<R extends GeneratedVaadinCheckbox<
     }
 
     @DomEvent("checked-changed")
-    public static class ValueChangeEvent<R extends GeneratedVaadinCheckbox<R>>
+    public static class CheckedChangeEvent<R extends GeneratedVaadinCheckbox<R>>
             extends ComponentEvent<R> {
-        public ValueChangeEvent(R source, boolean fromClient) {
+        public CheckedChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
         }
     }
@@ -316,9 +316,9 @@ public abstract class GeneratedVaadinCheckbox<R extends GeneratedVaadinCheckbox<
      * @return a {@link Registration} for removing the event listener
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    protected Registration addValueChangeListener(
-            ComponentEventListener<ValueChangeEvent<R>> listener) {
-        return addListener(ValueChangeEvent.class,
+    protected Registration addCheckedChangeListener(
+            ComponentEventListener<CheckedChangeEvent<R>> listener) {
+        return addListener(CheckedChangeEvent.class,
                 (ComponentEventListener) listener);
     }
 

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePicker.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePicker.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.component.datepicker;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.Focusable;
-import com.vaadin.flow.component.HasClickListeners;
 import javax.annotation.Generated;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.HtmlImport;
@@ -242,8 +241,7 @@ import com.vaadin.flow.dom.Element;
 @Tag("vaadin-date-picker")
 @HtmlImport("frontend://bower_components/vaadin-date-picker/src/vaadin-date-picker.html")
 public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePicker<R>>
-        extends Component
-        implements HasStyle, Focusable<R>, HasClickListeners<R> {
+        extends Component implements HasStyle, Focusable<R> {
 
     /**
      * <p>


### PR DESCRIPTION
Adds a new feature on the generator - to be able to exclude Behaviors and Mixins from being evaluated for code generation. That fixes the DatePicker generated class (it shouldn't have click listeners). In the same patch there's a change to make the CheckBox more extensible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3463)
<!-- Reviewable:end -->
