### PR TITLE
There is a chance that the Uri resolvers adds /. to the resolvedUrl

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
@@ -648,6 +648,9 @@ public class VaadinServlet extends HttpServlet {
             // Resolve the translated url for use with servlet context path
             String resolvedUrl = uriResolverFactory.toServletContextPath(
                     VaadinRequest.getCurrent(), translatedUrl);
+            if(resolvedUrl.startsWith("/./")) {
+                resolvedUrl = resolvedUrl.substring(2);
+            }
             URL resource = getServletContext().getResource(resolvedUrl);
             if (resource != null) {
                 addUrlTranslation(theme, urlToTranslate, translatedUrl);

--- a/flow-server/src/main/java/com/vaadin/flow/server/webjar/WebJarServer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webjar/WebJarServer.java
@@ -27,6 +27,8 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.slf4j.LoggerFactory;
@@ -176,7 +178,12 @@ public class WebJarServer implements Serializable {
      */
     public boolean hasWebJarResource(String filePathInContext,
             ServletContext servletContext) throws IOException {
-        String webJarPath = getWebJarPath(filePathInContext);
+        String webJarPath = null;
+
+        Matcher matcher = Pattern.compile("([/.]?[/..]*)" + prefix).matcher(filePathInContext);
+        if(matcher.find()) {
+            webJarPath = getWebJarPath(filePathInContext.replace(matcher.group(1), ""));
+        }
         if (webJarPath == null) {
             return false;
         }

--- a/flow-server/src/test/java/com/vaadin/flow/server/webjar/WebJarServerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/webjar/WebJarServerTest.java
@@ -1,0 +1,114 @@
+package com.vaadin.flow.server.webjar;
+
+import javax.servlet.ServletContext;
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.Constants;
+
+public class WebJarServerTest {
+
+    private static final String GRID_DEPENDENCY = "/frontend/bower_components/vaadin-grid/theme/lumo/vaadin-grid-sorter.html";
+    private static final String GRID_WEBJAR = "/webjars/grid/1.0.2/theme/lumo/vaadin-grid-sorter.html";
+
+    private WebJarServer webJarServer;
+    private Map<String, WebJarBowerDependency> dependencyMap;
+
+    private ServletContext context;
+
+    private String baseUrl = "/.";
+    private String upStep = "/..";
+
+    @Before
+    public void init() throws Exception {
+        DeploymentConfiguration configuration = Mockito
+                .mock(DeploymentConfiguration.class);
+
+        Mockito.when(configuration.getDevelopmentFrontendPrefix())
+                .thenReturn(Constants.FRONTEND_URL_DEV_DEFAULT);
+
+        webJarServer = new WebJarServer(configuration);
+        Field bowerModuleToDependencyName = WebJarServer.class
+                .getDeclaredField("bowerModuleToDependencyName");
+        bowerModuleToDependencyName.setAccessible(true);
+
+        dependencyMap = (Map<String, WebJarBowerDependency>) bowerModuleToDependencyName
+                .get(webJarServer);
+
+        WebJarBowerDependency gridDependency = new WebJarBowerDependency(
+                "vaadin-grid", "grid", "1.0.2");
+
+        dependencyMap.put("vaadin-grid", gridDependency);
+
+        context = Mockito.mock(ServletContext.class);
+
+        Mockito.when(context.getResource(GRID_WEBJAR))
+                .thenReturn(new URL("http://localhost:8080" + GRID_DEPENDENCY));
+    }
+
+    @Test
+    public void test_webjar_resolves_without_any_baseurl() throws Exception {
+        String value = GRID_DEPENDENCY;
+
+        boolean foundComponent = webJarServer.hasWebJarResource(value, context);
+
+        Assert.assertTrue(
+                "Expected webJarServer to find fixed component for value: "
+                        + value,
+                foundComponent);
+    }
+
+    @Test
+    public void test_webjar_resolves_for_baseurl() throws Exception {
+        String value = GRID_DEPENDENCY;
+
+        boolean foundComponent = webJarServer.hasWebJarResource(baseUrl + value,
+                context);
+
+        Assert.assertTrue(
+                "Expected webJarServer to find fixed component for value: "
+                        + value,
+                foundComponent);
+    }
+
+    @Test
+    public void test_webjar_resolves_for_baseurl_and_up_step_combinations()
+            throws Exception {
+        String value = GRID_DEPENDENCY;
+
+        Assert.assertTrue("No match found for /.." + value,
+                webJarServer.hasWebJarResource(upStep + value, context));
+
+        Assert.assertTrue("No match found for /./.." + value, webJarServer
+                .hasWebJarResource(baseUrl + upStep + value, context));
+
+        Assert.assertTrue("No match found for /./../.." + value, webJarServer
+                .hasWebJarResource(baseUrl + upStep + upStep + value, context));
+    }
+
+    @Test
+    public void no_match_when_frontend_starts_wrong() throws Exception {
+        String value = "/wrong" + GRID_DEPENDENCY;
+
+        Assert.assertFalse("Match found for path starting with '/wrong'",
+                webJarServer.hasWebJarResource(value, context));
+
+        Assert.assertFalse("Match found for path starting with '/./wrong'",
+                webJarServer.hasWebJarResource(baseUrl + value, context));
+    }
+
+    @Test
+    public void no_match_when_start_prefix_not_at_start() throws Exception {
+        String value = "/no/match" + baseUrl + GRID_DEPENDENCY;
+
+        Assert.assertFalse("Match found for path starting with '/no/match/.'",
+                webJarServer.hasWebJarResource(value, context));
+    }
+}


### PR DESCRIPTION
This makes it so that the webJar resolver doesn't find the files.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3466)
<!-- Reviewable:end -->
