### PR TITLE
Make spring add-on depending on flow-server only.

### DIFF
--- a/flow-spring-addon/pom.xml
+++ b/flow-spring-addon/pom.xml
@@ -42,7 +42,7 @@
     <dependencies>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>flow</artifactId>
+            <artifactId>flow-server</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
No need to drag in the whole `flow` when `flow-server` is enough.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3468)
<!-- Reviewable:end -->
