### PR TITLE
Synchronize properties for non-public methods also.

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentMetaData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentMetaData.java
@@ -199,7 +199,7 @@ public class ComponentMetaData {
 
     private static void doCollectSynchronizedProperties(Class<?> clazz,
             Map<String, SynchronizedPropertyInfo> infos) {
-        for (Method method : clazz.getMethods()) {
+        for (Method method : clazz.getDeclaredMethods()) {
             Synchronize annotation = method.getAnnotation(Synchronize.class);
             if (annotation == null) {
                 continue;

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentMetaDataTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentMetaDataTest.java
@@ -22,9 +22,6 @@ import java.util.stream.Collectors;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.Synchronize;
-import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.internal.ComponentMetaData;
 import com.vaadin.flow.component.internal.ComponentMetaData.SynchronizedPropertyInfo;
 
@@ -68,7 +65,6 @@ public class ComponentMetaDataTest {
         public String getFoo() {
             return null;
         }
-
     }
 
     @Tag(Tag.A)
@@ -78,17 +74,40 @@ public class ComponentMetaDataTest {
         public String getFoo() {
             return null;
         }
+    }
 
+    public static class HasFooProtected extends Component {
+        @Synchronize(value = "bar", property = "baz")
+        protected String getFoo() {
+            return null;
+        }
+    }
+
+    public static class HasFooPrivate extends Component {
+        @Synchronize(value = "bar", property = "baz")
+        private String getFoo() {
+            return null;
+        }
     }
 
     @Test
     public void synchronizedProperties_methodInClass() {
-        assertFooPoperty(Sample.class);
+        assertFooProperty(Sample.class);
     }
 
     @Test
     public void synchronizedProperties_methodInInterface() {
-        assertFooPoperty(HasFooImpl.class);
+        assertFooProperty(HasFooImpl.class);
+    }
+
+    @Test
+    public void synchronizedProperties_privateMethod() {
+        assertFooProperty(HasFooProtected.class);
+    }
+
+    @Test
+    public void synchronizedProperties_protectedMethod() {
+        assertFooProperty(HasFooPrivate.class);
     }
 
     @Test
@@ -130,7 +149,7 @@ public class ComponentMetaDataTest {
         Assert.assertEquals("baz", events.get(0));
     }
 
-    private void assertFooPoperty(Class<? extends Component> clazz) {
+    private void assertFooProperty(Class<? extends Component> clazz) {
         ComponentMetaData data = new ComponentMetaData(clazz);
 
         Collection<SynchronizedPropertyInfo> props = data

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentMetaDataTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentMetaDataTest.java
@@ -83,6 +83,13 @@ public class ComponentMetaDataTest {
         }
     }
 
+    public static class HasFooPackagePrivate extends Component {
+        @Synchronize(value = "bar", property = "baz")
+        String getFoo() {
+            return null;
+        }
+    }
+
     public static class HasFooPrivate extends Component {
         @Synchronize(value = "bar", property = "baz")
         private String getFoo() {
@@ -101,12 +108,17 @@ public class ComponentMetaDataTest {
     }
 
     @Test
-    public void synchronizedProperties_privateMethod() {
+    public void synchronizedProperties_protectedMethod() {
         assertFooProperty(HasFooProtected.class);
     }
 
     @Test
-    public void synchronizedProperties_protectedMethod() {
+    public void synchronizedProperties_packagePrivateMethod() {
+        assertFooProperty(HasFooPackagePrivate.class);
+    }
+
+    @Test
+    public void synchronizedProperties_privateMethod() {
         assertFooProperty(HasFooPrivate.class);
     }
 


### PR DESCRIPTION
Due to https://github.com/vaadin/flow/issues/3422 lots of autogenerated methods became `protected` but still have `@Synchronized` annotation on them.

Fixes current synchronization approach to consider those methods also.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3469)
<!-- Reviewable:end -->
