### PR TITLE
Lock WebJars BOM to Polymer to 2.3.1

### DIFF
--- a/webjars-bom/pom.xml
+++ b/webjars-bom/pom.xml
@@ -112,17 +112,17 @@
             <dependency>
                 <groupId>org.webjars.bower</groupId>
                 <artifactId>polymer</artifactId>
-                <version>2.4.0</version>
+                <version>2.3.1</version>
             </dependency>
             <dependency>
                 <groupId>org.webjars.bower</groupId>
                 <artifactId>github-com-polymer-polymer</artifactId>
-                <version>2.4.0</version>
+                <version>2.3.1</version>
             </dependency>
             <dependency>
                 <groupId>org.webjars.bower</groupId>
                 <artifactId>github-com-Polymer-polymer</artifactId>
-                <version>2.4.0</version>
+                <version>2.3.1</version>
             </dependency>
             <dependency>
                 <groupId>org.webjars.bower</groupId>


### PR DESCRIPTION
There is lots of issues with Polymer 2.4.0 and Vaadin Elements, waiting for new element releases and Polymer 2.4.1.