### PR TITLE
Read push settings from the same place as viewport settings

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -96,8 +96,6 @@ public class UI extends Component
 
     private final Page page = new Page(this);
 
-    private RouterInterface router;
-
     /**
      * Creates a new empty UI.
      */
@@ -189,11 +187,8 @@ public class UI extends Component
         init(request);
 
         // Use router if it's active
-        RouterInterface serviceRouter = getSession().getService().getRouter();
-        if (serviceRouter.getConfiguration().isConfigured()) {
-            router = serviceRouter;
-            router.initializeUI(this, request);
-        }
+        getRouterInterface()
+                .ifPresent(router -> router.initializeUI(this, request));
     }
 
     /**
@@ -709,6 +704,7 @@ public class UI extends Component
      *         implementation
      */
     public Optional<Router> getRouter() {
+        RouterInterface router = internals.getRouter();
         if (router instanceof Router) {
             return Optional.of((Router) router);
         } else {
@@ -730,7 +726,7 @@ public class UI extends Component
     public Optional<RouterInterface> getRouterInterface() {
         // XXX When removing this, also remove mention of the old router from
         // the javadoc for getRouter()
-        return Optional.ofNullable(router);
+        return Optional.ofNullable(internals.getRouter());
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -53,6 +53,7 @@ import com.vaadin.flow.internal.nodefeature.PollConfigurationMap;
 import com.vaadin.flow.internal.nodefeature.PushConfigurationMap;
 import com.vaadin.flow.internal.nodefeature.ReconnectDialogConfigurationMap;
 import com.vaadin.flow.router.Location;
+import com.vaadin.flow.router.RouterInterface;
 import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.router.internal.ContinueNavigationAction;
 import com.vaadin.flow.router.internal.RouterUtil;
@@ -169,6 +170,9 @@ public class UIInternals implements Serializable {
     private final ConstantPool constantPool = new ConstantPool();
 
     private AbstractTheme theme = null;
+
+    private RouterInterface router;
+
     private static final Pattern componentSource = Pattern
             .compile(".*/src/vaadin-([\\w\\-]*).html");
 
@@ -347,6 +351,16 @@ public class UIInternals implements Serializable {
         }
 
         if (session != null) {
+            VaadinService service = getSession().getService();
+            if (service != null) {
+                // Allow null service to simplify testing mocks
+                RouterInterface serviceRouter = service.getRouter();
+                if (serviceRouter != null
+                        && serviceRouter.getConfiguration().isConfigured()) {
+                    router = serviceRouter;
+                }
+            }
+
             ComponentUtil.onComponentAttach(ui, true);
         }
     }
@@ -837,7 +851,7 @@ public class UIInternals implements Serializable {
      *            last location navigated to
      */
     public void setLastHandledNavigation(Location location) {
-        this.lastHandledNavigation = location;
+        lastHandledNavigation = location;
     }
 
     /**
@@ -878,5 +892,16 @@ public class UIInternals implements Serializable {
                 VaadinRequest.getCurrent());
         appId = appId.substring(0, appId.indexOf('-'));
         return appId;
+    }
+
+    /**
+     * Gets the router used for navigating in this UI, if the router was active
+     * when this UI was initialized.
+     *
+     * @return the router used for this UI, or <code>null</code> if there is no
+     *         router
+     */
+    public RouterInterface getRouter() {
+        return router;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Push.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Push.java
@@ -14,13 +14,14 @@
  * the License.
  */
 
-package com.vaadin.flow.component;
+package com.vaadin.flow.component.page;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.shared.communication.PushMode;
 import com.vaadin.flow.shared.ui.Transport;
 

--- a/flow-server/src/main/java/com/vaadin/flow/internal/AnnotationReader.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/AnnotationReader.java
@@ -23,15 +23,11 @@ import java.util.List;
 import java.util.Optional;
 
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.Push;
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.legacy.View;
-import com.vaadin.flow.shared.communication.PushMode;
-import com.vaadin.flow.shared.ui.Transport;
 
 /**
  * Helper class for reading annotation data.
@@ -55,32 +51,6 @@ public class AnnotationReader {
             Class<? extends View> viewWithTitle) {
         return getAnnotationFor(viewWithTitle, PageTitle.class)
                 .map(PageTitle::value);
-    }
-
-    /**
-     * Finds the {@link PushMode} to use for a specific UI, if defined with a
-     * {@link Push @Push} annotation.
-     *
-     * @param uiClass
-     *            the UI to search for the Push annotation.
-     * @return the push mode to use, or an empty optional if no annotation
-     *         present
-     */
-    public static Optional<PushMode> getPushMode(Class<? extends UI> uiClass) {
-        return getAnnotationFor(uiClass, Push.class).map(Push::value);
-    }
-
-    /**
-     * Finds the {@link Transport} to use for a specific UI, if defined with a
-     * {@link Push @Push} annotation.
-     *
-     * @param uiClass
-     *            the UI to search for the Push annotation
-     * @return the transport type to use, or an empty optional if no annotation
-     *         present
-     */
-    public static Optional<Transport> getPushTransport(Class<?> uiClass) {
-        return getAnnotationFor(uiClass, Push.class).map(Push::transport);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractRouteRegistryInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractRouteRegistryInitializer.java
@@ -22,11 +22,10 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javax.servlet.annotation.HandlesTypes;
+
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
-import com.vaadin.flow.component.page.BodySize;
-import com.vaadin.flow.component.page.Inline;
-import com.vaadin.flow.component.page.Viewport;
 import com.vaadin.flow.router.HasDynamicTitle;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
@@ -35,7 +34,6 @@ import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.router.internal.RouterUtil;
 import com.vaadin.flow.server.InvalidRouteLayoutConfigurationException;
 import com.vaadin.flow.server.PageConfigurator;
-import com.vaadin.flow.theme.Theme;
 
 /**
  * Common validation methods for route registry initializer.
@@ -87,8 +85,11 @@ public abstract class AbstractRouteRegistryInitializer {
         }
 
         /* Validate annotation usage */
-        Stream.of(Viewport.class, BodySize.class, Inline.class, Theme.class)
-                .forEach(annotation -> {
+        Stream.of(AnnotationValidator.class.getAnnotation(HandlesTypes.class)
+                .value()).forEach(type -> {
+                    Class<? extends Annotation> annotation = type
+                            .asSubclass(Annotation.class);
+
                     validateRouteAnnotation(route, annotation);
 
                     for (RouteAlias alias : route

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/AnnotationValidator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/AnnotationValidator.java
@@ -26,6 +26,7 @@ import javax.servlet.annotation.HandlesTypes;
 
 import com.vaadin.flow.component.page.BodySize;
 import com.vaadin.flow.component.page.Inline;
+import com.vaadin.flow.component.page.Push;
 import com.vaadin.flow.component.page.Viewport;
 import com.vaadin.flow.theme.Theme;
 
@@ -33,7 +34,8 @@ import com.vaadin.flow.theme.Theme;
  * Validation class that is run during servlet container initialization which
  * checks that specific annotations are not configured wrong.
  */
-@HandlesTypes({ Viewport.class, BodySize.class, Inline.class, Theme.class })
+@HandlesTypes({ Viewport.class, BodySize.class, Inline.class, Theme.class,
+        Push.class })
 public class AnnotationValidator extends AbstractAnnotationValidator
         implements ServletContainerInitializer {
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/AnnotationValidatorTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/AnnotationValidatorTest.java
@@ -1,9 +1,16 @@
 package com.vaadin.flow.server.startup;
 
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
+import static com.vaadin.flow.server.startup.AbstractAnnotationValidator.ERROR_MESSAGE_BEGINNING;
+import static com.vaadin.flow.server.startup.AbstractAnnotationValidator.MIDDLE_ROUTER_LAYOUT;
+import static com.vaadin.flow.server.startup.AbstractAnnotationValidator.NON_PARENT;
+import static com.vaadin.flow.server.startup.AbstractAnnotationValidator.NON_PARENT_ALIAS;
+import static com.vaadin.flow.server.startup.AbstractAnnotationValidator.NON_ROUTER_LAYOUT;
+
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -16,20 +23,15 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.page.BodySize;
 import com.vaadin.flow.component.page.Inline;
+import com.vaadin.flow.component.page.Push;
 import com.vaadin.flow.component.page.Viewport;
 import com.vaadin.flow.router.ParentLayout;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteAlias;
 import com.vaadin.flow.router.RouterLayout;
-import com.vaadin.flow.theme.AbstractTheme;
 import com.vaadin.flow.server.InvalidApplicationConfigurationException;
+import com.vaadin.flow.theme.AbstractTheme;
 import com.vaadin.flow.theme.Theme;
-
-import static com.vaadin.flow.server.startup.AnnotationValidator.ERROR_MESSAGE_BEGINNING;
-import static com.vaadin.flow.server.startup.AnnotationValidator.MIDDLE_ROUTER_LAYOUT;
-import static com.vaadin.flow.server.startup.AnnotationValidator.NON_PARENT;
-import static com.vaadin.flow.server.startup.AnnotationValidator.NON_PARENT_ALIAS;
-import static com.vaadin.flow.server.startup.AnnotationValidator.NON_ROUTER_LAYOUT;
 
 public class AnnotationValidatorTest {
 
@@ -89,6 +91,11 @@ public class AnnotationValidatorTest {
     @Tag(Tag.DIV)
     @Theme(MyTheme.class)
     public static class NonRoute extends Component {
+    }
+
+    @Tag(Tag.DIV)
+    @Push
+    public static class NonRoutePush extends Component {
     }
 
     @Route("root")
@@ -204,6 +211,18 @@ public class AnnotationValidatorTest {
 
         annotationValidator.onStartup(
                 Stream.of(NonRoute.class).collect(Collectors.toSet()),
+                servletContext);
+    }
+
+    @Test
+    public void onStartUp_non_linked_push_throws() throws ServletException {
+        expectedEx.expect(InvalidApplicationConfigurationException.class);
+        expectedEx.expectMessage(ERROR_MESSAGE_BEGINNING
+                + String.format(NON_ROUTER_LAYOUT, NonRoutePush.class.getName(),
+                        Push.class.getSimpleName()));
+
+        annotationValidator.onStartup(
+                Stream.of(NonRoutePush.class).collect(Collectors.toSet()),
                 servletContext);
     }
 

--- a/flow-spring-addon/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/flow-spring-addon/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -29,6 +29,7 @@ import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 import javax.servlet.ServletException;
+import javax.servlet.annotation.HandlesTypes;
 
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
@@ -41,9 +42,6 @@ import org.springframework.core.type.filter.AssignableTypeFilter;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.page.BodySize;
-import com.vaadin.flow.component.page.Inline;
-import com.vaadin.flow.component.page.Viewport;
 import com.vaadin.flow.router.HasErrorParameter;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteAlias;
@@ -51,10 +49,10 @@ import com.vaadin.flow.server.InvalidRouteConfigurationException;
 import com.vaadin.flow.server.startup.AbstractAnnotationValidator;
 import com.vaadin.flow.server.startup.AbstractCustomElementRegistryInitializer;
 import com.vaadin.flow.server.startup.AbstractRouteRegistryInitializer;
+import com.vaadin.flow.server.startup.AnnotationValidator;
 import com.vaadin.flow.server.startup.CustomElementRegistry;
 import com.vaadin.flow.server.startup.RouteRegistry;
 import com.vaadin.flow.server.startup.ServletVerifier;
-import com.vaadin.flow.theme.Theme;
 
 /**
  * Servlet context initializer for Spring Boot Application.
@@ -178,8 +176,8 @@ public class VaadinServletContextInitializer
 
         @Override
         protected List<Class<?>> getAnnotations() {
-            return Arrays.asList(Viewport.class, BodySize.class, Inline.class,
-                    Theme.class);
+            return Arrays.asList(AnnotationValidator.class
+                    .getAnnotation(HandlesTypes.class).value());
         }
 
     }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PushSettingsView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PushSettingsView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2017 Vaadin Ltd.
+ * Copyright 2000-2018 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -13,30 +13,19 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.flow.router;
+package com.vaadin.flow.uitest.ui;
 
-import com.vaadin.flow.server.startup.RouteRegistry;
+import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.page.Push;
+import com.vaadin.flow.router.Route;
 
-/**
- * Route registry with a public constructor for testing purposes.
- *
- * @author Vaadin Ltd
- */
-public class TestRouteRegistry extends RouteRegistry {
-    /**
-     * Creates a new test route registry.
-     */
-    public TestRouteRegistry() {
-        super();
-    }
-
+@Push
+@Route("com.vaadin.flow.uitest.ui.PushSettingsView")
+public class PushSettingsView extends AbstractDivView {
     @Override
-    public boolean hasRoutes() {
-        /*
-         * Always pretend there are routes even though they might actually be
-         * injected later on.
-         */
-        return true;
+    protected void onAttach(AttachEvent attachEvent) {
+        setId("pushMode");
+        setText("Push mode: "
+                + attachEvent.getUI().getPushConfiguration().getPushMode());
     }
-
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PushSettingsIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PushSettingsIT.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class PushSettingsIT extends ChromeBrowserTest {
+    @Test
+    public void pushSetting() {
+        open();
+
+        String modeText = findElement(By.id("pushMode")).getText();
+
+        Assert.assertEquals("Push mode: AUTOMATIC", modeText);
+    }
+
+}

--- a/flow-tests/test-root-ui-context/src/main/java/com/vaadin/flow/uitest/ui/push/BasicPushLongPollingUI.java
+++ b/flow-tests/test-root-ui-context/src/main/java/com/vaadin/flow/uitest/ui/push/BasicPushLongPollingUI.java
@@ -1,10 +1,14 @@
 package com.vaadin.flow.uitest.ui.push;
 
-import com.vaadin.flow.component.Push;
+import com.vaadin.flow.component.page.Push;
 import com.vaadin.flow.internal.nodefeature.PushConfigurationMap;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.shared.ui.Transport;
 
+/*
+ * Note that @Push is generally not supported in this location, but instead
+ * explicitly picked up by logic in the BasicPushUI constructor.
+ */
 @Push(transport = Transport.LONG_POLLING)
 public class BasicPushLongPollingUI extends BasicPushUI {
 

--- a/flow-tests/test-root-ui-context/src/main/java/com/vaadin/flow/uitest/ui/push/BasicPushUI.java
+++ b/flow-tests/test-root-ui-context/src/main/java/com/vaadin/flow/uitest/ui/push/BasicPushUI.java
@@ -15,9 +15,26 @@
  */
 package com.vaadin.flow.uitest.ui.push;
 
-import com.vaadin.flow.component.Push;
+import com.vaadin.flow.component.page.Push;
+import com.vaadin.flow.server.VaadinRequest;
 
+/*
+ * Note that @Push is generally not supported in this location, but instead
+ * explicitly picked up by logic in the BasicPushUI constructor.
+ */
 @Push
 public class BasicPushUI extends ClientServerCounterUI {
+    @Override
+    protected void init(VaadinRequest request) {
+        /*
+         * Read push settings from the UI instead of the the navigation target /
+         * router layout to preserve the structure of these legacy testing UIs
+         */
+        Push push = getClass().getAnnotation(Push.class);
 
+        getPushConfiguration().setPushMode(push.value());
+        getPushConfiguration().setTransport(push.transport());
+
+        super.init(request);
+    }
 }

--- a/flow-tests/test-root-ui-context/src/main/java/com/vaadin/flow/uitest/ui/push/BasicPushWebsocketUI.java
+++ b/flow-tests/test-root-ui-context/src/main/java/com/vaadin/flow/uitest/ui/push/BasicPushWebsocketUI.java
@@ -1,10 +1,14 @@
 package com.vaadin.flow.uitest.ui.push;
 
-import com.vaadin.flow.component.Push;
+import com.vaadin.flow.component.page.Push;
 import com.vaadin.flow.internal.nodefeature.PushConfigurationMap;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.shared.ui.Transport;
 
+/*
+ * Note that @Push is generally not supported in this location, but instead
+ * explicitly picked up by logic in the BasicPushUI constructor.
+ */
 @Push(transport = Transport.WEBSOCKET)
 public class BasicPushWebsocketUI extends BasicPushUI {
 

--- a/flow-tests/test-root-ui-context/src/main/java/com/vaadin/flow/uitest/ui/push/BasicPushWebsocketXhrUI.java
+++ b/flow-tests/test-root-ui-context/src/main/java/com/vaadin/flow/uitest/ui/push/BasicPushWebsocketXhrUI.java
@@ -1,10 +1,14 @@
 package com.vaadin.flow.uitest.ui.push;
 
-import com.vaadin.flow.component.Push;
+import com.vaadin.flow.component.page.Push;
 import com.vaadin.flow.internal.nodefeature.PushConfigurationMap;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.shared.ui.Transport;
 
+/*
+ * Note that @Push is generally not supported in this location, but instead
+ * explicitly picked up by logic in the BasicPushUI constructor.
+ */
 @Push(transport = Transport.WEBSOCKET_XHR)
 public class BasicPushWebsocketXhrUI extends BasicPushUI {
 


### PR DESCRIPTION
Read push settings from the same place as viewport settings

* Simplify finding of page configuration annotations 
* Set the router immediately when the session is available to be able to
apply push settings before UI.init.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3484)
<!-- Reviewable:end -->
