### PR TITLE
Clear all current instances after test

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/I18NProviderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/I18NProviderTest.java
@@ -30,16 +30,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.i18n.I18NProvider;
-import com.vaadin.flow.server.Constants;
-import com.vaadin.flow.server.ServiceException;
-import com.vaadin.flow.server.SessionExpiredException;
-import com.vaadin.flow.server.VaadinRequest;
-import com.vaadin.flow.server.VaadinService;
-import com.vaadin.flow.server.VaadinServlet;
-import com.vaadin.flow.server.VaadinServletRequest;
-import com.vaadin.flow.server.VaadinSession;
-import com.vaadin.flow.server.WrappedHttpSession;
-import com.vaadin.flow.server.WrappedSession;
+import com.vaadin.flow.internal.CurrentInstance;
 import com.vaadin.flow.shared.ApplicationConstants;
 
 import net.jcip.annotations.NotThreadSafe;
@@ -90,8 +81,8 @@ public class I18NProviderTest {
     }
 
     @After
-    public void clearCurrentService() {
-        VaadinService.setCurrent(null);
+    public void clearCurrentInstances() {
+        CurrentInstance.clearAll();
     }
 
     private VaadinServlet initServletAndService(Properties initParams)


### PR DESCRIPTION
At least VaadinSession was left behind, causing issues depending on test
run order

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3485)
<!-- Reviewable:end -->
