### PR TITLE
Add navigation listeners manually

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -18,9 +18,20 @@ package com.vaadin.flow.component;
 
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Future;
 
+import com.vaadin.flow.router.*;
+import com.vaadin.flow.router.internal.*;
+import com.vaadin.flow.server.Command;
+import com.vaadin.flow.server.ErrorEvent;
+import com.vaadin.flow.server.ErrorHandlingCommand;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinServlet;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.shared.Registration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,20 +46,6 @@ import com.vaadin.flow.internal.nodefeature.ElementData;
 import com.vaadin.flow.internal.nodefeature.LoadingIndicatorConfigurationMap;
 import com.vaadin.flow.internal.nodefeature.PollConfigurationMap;
 import com.vaadin.flow.internal.nodefeature.ReconnectDialogConfigurationMap;
-import com.vaadin.flow.router.EventUtil;
-import com.vaadin.flow.router.Location;
-import com.vaadin.flow.router.NavigationTrigger;
-import com.vaadin.flow.router.QueryParameters;
-import com.vaadin.flow.router.Router;
-import com.vaadin.flow.router.RouterInterface;
-import com.vaadin.flow.router.RouterLayout;
-import com.vaadin.flow.server.Command;
-import com.vaadin.flow.server.ErrorEvent;
-import com.vaadin.flow.server.ErrorHandlingCommand;
-import com.vaadin.flow.server.VaadinRequest;
-import com.vaadin.flow.server.VaadinService;
-import com.vaadin.flow.server.VaadinServlet;
-import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.communication.PushConnection;
 import com.vaadin.flow.shared.ApplicationConstants;
 
@@ -790,5 +787,34 @@ public class UI extends Component
     @Override
     public Optional<UI> getUI() {
         return Optional.of(this);
+    }
+
+    /**
+     * Adds a listener that gets notified before the navigation state changes.
+     *
+     * @see BeforeEnterListener
+     *
+     * @param beforeEnterListener
+     *            the before enter listener
+     * @return a handle that can be used for removing the Handler
+     */
+    public Registration addBeforeEnterListener(BeforeEnterListener beforeEnterListener){
+        Objects.requireNonNull(beforeEnterListener);
+
+        return internals.addBeforeEnterListener(beforeEnterListener);
+    }
+
+    /**
+     * Adds a listener that gets notified after the navigation state changed.
+     *
+     * @see BeforeLeaveHandler
+     *
+     * @param beforeLeaveListener
+     *            the before leave listener
+     * @return a handle that can be used for removing the Handler
+     */
+    public Registration addBeforeLeaveListener(BeforeLeaveListener beforeLeaveListener){
+        Objects.requireNonNull(beforeLeaveListener);
+        return internals.addBeforeLeaveListener(beforeLeaveListener);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -16,17 +16,13 @@
 package com.vaadin.flow.component.internal;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.vaadin.flow.router.*;
+import com.vaadin.flow.router.internal.*;
+import com.vaadin.flow.shared.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,10 +47,6 @@ import com.vaadin.flow.internal.nodefeature.NodeFeature;
 import com.vaadin.flow.internal.nodefeature.PollConfigurationMap;
 import com.vaadin.flow.internal.nodefeature.PushConfigurationMap;
 import com.vaadin.flow.internal.nodefeature.ReconnectDialogConfigurationMap;
-import com.vaadin.flow.router.Location;
-import com.vaadin.flow.router.RouterLayout;
-import com.vaadin.flow.router.internal.ContinueNavigationAction;
-import com.vaadin.flow.router.internal.RouterUtil;
 import com.vaadin.flow.router.legacy.HasChildView;
 import com.vaadin.flow.router.legacy.View;
 import com.vaadin.flow.server.VaadinRequest;
@@ -75,6 +67,59 @@ import com.vaadin.flow.theme.Theme;
  * @author Vaadin Ltd
  */
 public class UIInternals implements Serializable {
+
+    private final ArrayList<BeforeEnterListener> beforeEnterListeners = new ArrayList<>();
+
+    private final ArrayList<BeforeLeaveListener> beforeLeaveListeners = new ArrayList<>();
+
+    /**
+     * A {@link Collection} of {@link BeforeEnterHandler}s for this UI.
+     * This collection is not modifiable.
+     * @return the Collection, not <code>null</code>
+     */
+    public Collection<BeforeEnterHandler> getBeforeEnterListeners(){
+        return Collections.unmodifiableCollection(beforeEnterListeners);
+    }
+
+    /**
+     * A {@link Collection} of {@link BeforeLeaveHandler}s for this UI.
+     * This collection is not modifiable.
+     * @return the Collection, not <code>null</code>
+     */
+    public Collection<BeforeLeaveHandler> getBeforeLeaveListeners(){
+        return Collections.unmodifiableCollection(beforeLeaveListeners);
+    }
+
+    /**
+     * Adds a listener that gets notified before the navigation state changes.
+     *
+     * @see BeforeEnterListener
+     *
+     * @param beforeEnterListener
+     *            the before enter listener
+     * @return a handle that can be used for removing the Handler
+     */
+    public Registration addBeforeEnterListener(BeforeEnterListener beforeEnterListener) {
+
+        beforeEnterListeners.add(beforeEnterListener);
+
+        return () -> beforeEnterListeners.remove(beforeEnterListener);
+    }
+
+    /**
+     * Adds a listener that gets notified after the navigation state changed.
+     *
+     * @see BeforeLeaveHandler
+     *
+     * @param beforeLeaveListener
+     *            the before leave listener
+     * @return a handle that can be used for removing the Handler
+     */
+    public Registration addBeforeLeaveListener(BeforeLeaveListener beforeLeaveListener) {
+        beforeLeaveListeners.add(beforeLeaveListener);
+
+        return () -> beforeLeaveListeners.remove(beforeLeaveListener);
+    }
 
     /**
      * A {@link Page#executeJavaScript(String, Serializable...)} invocation that

--- a/flow-server/src/main/java/com/vaadin/flow/router/BeforeEnterListener.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/BeforeEnterListener.java
@@ -15,25 +15,18 @@
  */
 package com.vaadin.flow.router;
 
+import com.vaadin.flow.component.*;
 import com.vaadin.flow.router.internal.*;
 
 /**
- * Any {@code com.vaadin.ui.Component} implementing this interface will be
- * informed when they are being detached from the UI.
+ * A Listener that can be attached to any {@link UI} via {@link UI#addBeforeEnterListener(BeforeEnterListener)}.
  * <p>
  * During this phase there is the possibility to reroute to another navigation
- * target or to postpone the navigation (to for instance get user input).
+ * target.
  *
  * @author Vaadin Ltd
  */
 @FunctionalInterface
-public interface BeforeLeaveObserver extends BeforeLeaveHandler {
-
-    /**
-     * Method called before navigation to detaching Component chain is made.
-     * 
-     * @param event
-     *            before navigation event with event details
-     */
-    void beforeLeave(BeforeLeaveEvent event);
+public interface BeforeEnterListener extends BeforeEnterHandler {
+    void beforeEnter(BeforeEnterEvent event);
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/BeforeEnterObserver.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/BeforeEnterObserver.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.router;
 
+import com.vaadin.flow.router.internal.*;
+
 /**
  * Any {@code com.vaadin.ui.Component} implementing this interface will be
  * informed when they are being attached to the UI.
@@ -25,13 +27,6 @@ package com.vaadin.flow.router;
  * @author Vaadin Ltd
  */
 @FunctionalInterface
-public interface BeforeEnterObserver {
-
-    /**
-     * Method called before navigation to attaching Component chain is made.
-     * 
-     * @param event
-     *            before navigation event with event details
-     */
+public interface BeforeEnterObserver extends BeforeEnterHandler{
     void beforeEnter(BeforeEnterEvent event);
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/BeforeLeaveListener.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/BeforeLeaveListener.java
@@ -27,10 +27,10 @@ import com.vaadin.flow.router.internal.*;
  * @author Vaadin Ltd
  */
 @FunctionalInterface
-public interface BeforeLeaveObserver extends BeforeLeaveHandler {
+public interface BeforeLeaveListener extends BeforeLeaveHandler {
 
     /**
-     * Method called before navigation to detaching Component chain is made.
+     * Method called before navigation.
      * 
      * @param event
      *            before navigation event with event details

--- a/flow-server/src/main/java/com/vaadin/flow/router/EventUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/EventUtil.java
@@ -74,37 +74,36 @@ public final class EventUtil {
     }
 
     /**
-     * Collect all Components implementing {@link BeforeEnterObserver} connected
+     * A stream of all Components implementing {@link BeforeEnterObserver} connected
      * to the tree of all given Components in list.
      *
      * @param components
      *            components to search
      * @return navigation listeners
      */
-    public static List<BeforeEnterObserver> collectBeforeEnterObservers(
+    public static Stream<BeforeEnterObserver> collectBeforeEnterObservers(
             List<HasElement> components) {
         Stream<Element> elements = components.stream().flatMap(
                 component -> flattenDescendants(component.getElement()));
 
-        return getImplementingComponents(elements, BeforeEnterObserver.class)
-                .collect(Collectors.toList());
+        return getImplementingComponents(elements, BeforeEnterObserver.class);
     }
 
     /**
-     * Collect all Components implementing {@link AfterNavigationObserver} that
+     * A stream of all Components implementing {@link AfterNavigationObserver} that
      * are found in the trees of given Components.
      *
      * @param components
      *            components to search
      * @return after navigation listeners
      */
-    public static List<AfterNavigationObserver> collectAfterNavigationObservers(
+    public static Stream<AfterNavigationObserver> collectAfterNavigationObservers(
             List<HasElement> components) {
         Stream<Element> elements = components.stream().flatMap(
                 component -> flattenDescendants(component.getElement()));
 
         return getImplementingComponents(elements,
-                AfterNavigationObserver.class).collect(Collectors.toList());
+                AfterNavigationObserver.class);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/BeforeEnterHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/BeforeEnterHandler.java
@@ -1,0 +1,20 @@
+package com.vaadin.flow.router.internal;
+
+import com.vaadin.flow.router.*;
+
+/**
+ * base-interface for all interfaces handling the {@link BeforeEnterEvent}.
+ *
+ * @author Vaadin Ltd
+ */
+@FunctionalInterface
+public interface BeforeEnterHandler {
+
+    /**
+     * Method called before navigation.
+     *
+     * @param event
+     *            before navigation event with event details
+     */
+    void beforeEnter(BeforeEnterEvent event);
+}

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/BeforeLeaveHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/BeforeLeaveHandler.java
@@ -1,0 +1,13 @@
+package com.vaadin.flow.router.internal;
+
+import com.vaadin.flow.router.*;
+
+/**
+ * base-interface for all interfaces handling the {@link BeforeLeaveEvent}.
+ *
+ * @author Vaadin Ltd
+ */
+@FunctionalInterface
+public interface BeforeLeaveHandler {
+    void beforeLeave(BeforeLeaveEvent event);
+}

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/Postpone.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/Postpone.java
@@ -19,63 +19,60 @@ import java.io.Serializable;
 import java.util.ArrayDeque;
 import java.util.Deque;
 
-import com.vaadin.flow.router.BeforeEnterObserver;
-import com.vaadin.flow.router.BeforeLeaveObserver;
-
 /**
  * Container class for containing left over listeners on postponed navigation.
  */
 public class Postpone implements Serializable {
-    private final ArrayDeque<BeforeLeaveObserver> remainingLeaveListeners;
-    private final ArrayDeque<BeforeEnterObserver> remainingNavigationListeners;
+    private final ArrayDeque<BeforeLeaveHandler> remainingLeaveListeners;
+    private final ArrayDeque<BeforeEnterHandler> remainingNavigationListeners;
 
-    private Postpone(Deque<BeforeLeaveObserver> beforeLeave,
-            Deque<BeforeEnterObserver> beforeNavigation) {
+    private Postpone(Deque<BeforeLeaveHandler> beforeLeave,
+            Deque<BeforeEnterHandler> beforeNavigation) {
         remainingLeaveListeners = new ArrayDeque<>(beforeLeave);
         remainingNavigationListeners = new ArrayDeque<>(beforeNavigation);
     }
 
     /**
-     * Set any remaining {@link BeforeLeaveObserver}s to be continued from.
+     * Set any remaining {@link BeforeLeaveHandler}s to be continued from.
      * 
      * @param beforeLeave
      *            listeners to continue calling
      * @return uncalled listeners to continue from
      */
-    public static Postpone withLeaveObservers(
-            Deque<BeforeLeaveObserver> beforeLeave) {
+    public static Postpone withLeaveHandlers(
+            Deque<BeforeLeaveHandler> beforeLeave) {
         return new Postpone(beforeLeave, new ArrayDeque<>());
     }
 
     /**
-     * Set any remaining {@link BeforeEnterObserver}s to be continued from.
+     * Set any remaining {@link BeforeEnterHandler}s to be continued from.
      *
      * @param beforeNavigation
      *            listeners to continue calling
      * @return uncalled listeners to continue from
      */
-    public static Postpone withNavigationObservers(
-            Deque<BeforeEnterObserver> beforeNavigation) {
+    public static Postpone withNavigationHandlers(
+            Deque<BeforeEnterHandler> beforeNavigation) {
         return new Postpone(new ArrayDeque<>(), beforeNavigation);
     }
 
     /**
-     * Get {@link BeforeLeaveObserver}s that have been left over from a
+     * Get {@link BeforeEnterHandler}s that have been left over from a
      * postpone.
      * 
-     * @return remaining BeforeLeaveObservers or empty ArrayDeque
+     * @return remaining BeforeLeaveHandlers or empty ArrayDeque
      */
-    public Deque<BeforeLeaveObserver> getLeaveObservers() {
+    public Deque<BeforeLeaveHandler> getLeaveHandlers() {
         return remainingLeaveListeners;
     }
 
     /**
-     * Get {@link BeforeEnterObserver}s that have been left over from a
+     * Get {@link BeforeEnterHandler}s that have been left over from a
      * postpone.
      * 
-     * @return remaining BeforeNavigationObservers or empty ArrayDeque
+     * @return remaining BeforeNavigationHandlers or empty ArrayDeque
      */
-    public Deque<BeforeEnterObserver> getNavigationObservers() {
+    public Deque<BeforeEnterHandler> getNavigationHandlers() {
         return remainingNavigationListeners;
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/router/EventUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/EventUtilTest.java
@@ -156,7 +156,7 @@ public class EventUtilTest {
         bar.getElement().appendChild(new Foo().getElement(), nested);
 
         List<BeforeEnterObserver> beforeNavigationObservers = EventUtil
-                .collectBeforeEnterObservers(Arrays.asList(foo, bar));
+                .collectBeforeEnterObservers(Arrays.asList(foo, bar)).collect(Collectors.toList());
 
         Assert.assertEquals("Wrong amount of listener instances found", 2,
                 beforeNavigationObservers.size());
@@ -178,7 +178,7 @@ public class EventUtilTest {
         bar.getElement().appendChild(new Foo().getElement(), nested);
 
         List<BeforeEnterObserver> beforeNavigationObservers = EventUtil
-                .collectBeforeEnterObservers(Arrays.asList(foo, bar));
+                .collectBeforeEnterObservers(Arrays.asList(foo, bar)).collect(Collectors.toList());
 
         Assert.assertEquals("Wrong amount of listener instances found", 2,
                 beforeNavigationObservers.size());


### PR DESCRIPTION
This PR consists of two Commits. The first commit adds support for UIListeners in the VaadinService, that get called every time a new UI is being created. The second commit adds support for manually added BeforeEnterObservers and BeforeLeaveObservers. 

The use-case for this PR is [here](https://github.com/berndhopp/vaadin-security/blob/v10/src/main/java/org/ilay/Ilay.java)

fixes [2754](https://github.com/vaadin/flow/issues/2754)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3499)
<!-- Reviewable:end -->
