### PR TITLE
Sync property to server if property has no value

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/flow/nodefeature/MapProperty.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/nodefeature/MapProperty.java
@@ -265,7 +265,7 @@ public class MapProperty implements ReactiveValue {
     public void syncToServer(Object newValue) {
         Object currentValue = hasValue() ? getValue() : null;
 
-        if (hasValue() && Objects.equals(newValue, currentValue)) {
+        if (Objects.equals(newValue, currentValue)) {
             // in case we are here with the same value that has been set from
             // the server then we unlock client side updates already here via
             // unmarking the server update flag. It allows another client side
@@ -273,7 +273,9 @@ public class MapProperty implements ReactiveValue {
             // server once the server value is set successfully (e.g. mutation
             // the same property from its observer).
             isServerUpdate = false;
-        } else if (!isServerUpdate) {
+        }
+        if (!(Objects.equals(newValue, currentValue) && hasValue())
+                && !isServerUpdate) {
             StateNode node = getMap().getNode();
             StateTree tree = node.getTree();
             if (tree.isActive(node)) {

--- a/flow-client/src/main/java/com/vaadin/client/flow/nodefeature/MapProperty.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/nodefeature/MapProperty.java
@@ -265,7 +265,7 @@ public class MapProperty implements ReactiveValue {
     public void syncToServer(Object newValue) {
         Object currentValue = hasValue() ? getValue() : null;
 
-        if (Objects.equals(newValue, currentValue)) {
+        if (hasValue() && Objects.equals(newValue, currentValue)) {
             // in case we are here with the same value that has been set from
             // the server then we unlock client side updates already here via
             // unmarking the server update flag. It allows another client side

--- a/flow-client/src/test/java/com/vaadin/client/flow/nodefeature/MapPropertyTest.java
+++ b/flow-client/src/test/java/com/vaadin/client/flow/nodefeature/MapPropertyTest.java
@@ -346,4 +346,16 @@ public class MapPropertyTest {
 
         Assert.assertEquals("baz", property.getValue());
     }
+
+    @Test
+    public void syncToServer_propertyHasNoValue_propertyIsSync() {
+        TestTree tree = new TestTree();
+        StateNode node = new StateNode(11, tree);
+
+        MapProperty property = node.getMap(NodeFeatures.ELEMENT_PROPERTIES)
+                .getProperty("foo");
+
+        property.syncToServer(null);
+        Assert.assertEquals(property, tree.sentProperty);
+    }
 }

--- a/flow-tests/test-root-context/src/main/webapp/frontend/com/vaadin/flow/uitest/ui/template/BeanInListing.html
+++ b/flow-tests/test-root-context/src/main/webapp/frontend/com/vaadin/flow/uitest/ui/template/BeanInListing.html
@@ -42,7 +42,7 @@
                    },
                    activeMessage: {
                        type: String,
-                       value: '',
+                       value: null,
                        notify: true
                    }
                 };


### PR DESCRIPTION
Regardless of new value the property should be synced to the server if it has no value

This change is important because _EVERY_ model property has to have MapProperty value.
There is a code in SimpleElementBindingStrategy which checks that the property has been set (see handlePropertyChange method implementation).

So regardless of all other logic of "syncToServer" it should set the value to the property.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3503)
<!-- Reviewable:end -->
