### PR TITLE
Take care about several property change executions

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
@@ -141,20 +141,20 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
     }
 
     private static class InitialPropertyUpdate {
-        private Runnable command;
+        private JsArray<Runnable> commands = JsCollections.array();
         private final StateNode node;
 
         private InitialPropertyUpdate(StateNode node) {
             this.node = node;
         }
 
-        private void setCommand(Runnable command) {
-            this.command = command;
+        private void addCommand(Runnable command) {
+            commands.set(commands.length(), command);
         }
 
         private void execute() {
-            if (command != null) {
-                command.run();
+            if (commands != null) {
+                commands.forEach(Runnable::run);
             }
             node.clearNodeData(this);
         }
@@ -310,7 +310,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
         if (initialUpdate == null) {
             runnable.run();
         } else {
-            initialUpdate.setCommand(runnable);
+            initialUpdate.addCommand(runnable);
         }
     }
 

--- a/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtPolymerModelTest.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtPolymerModelTest.java
@@ -411,7 +411,7 @@ public class GwtPolymerModelTest extends GwtPropertyElementBinderTest {
         element._propertiesChanged = function() {
             element.propertiesChangedCallCount += 1;
         };
-    
+
         element.callbackCallCount = 0;
         $wnd.customElements = {
             whenDefined: function() {

--- a/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtPolymerModelTest.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtPolymerModelTest.java
@@ -300,6 +300,51 @@ public class GwtPolymerModelTest extends GwtPropertyElementBinderTest {
                         PROPERTY_PREFIX + propertyName));
     }
 
+    public void testInitialUpdateSeveralModelPropertiesAtOnce_propertiesAreUpdatable_propertiesAreSynced() {
+        addMockMethods(element);
+        String propertyName1 = "black";
+        String propertyValue1 = "coffee";
+        setModelProperty(node, propertyName1, propertyValue1);
+
+        String propertyName2 = "baz";
+        String propertyValue2 = "foo";
+        setModelProperty(node, propertyName2, propertyValue2);
+
+        node.setNodeData(new UpdatableModelProperties(
+                JsCollections.array(propertyName1, propertyName2)));
+
+        Binder.bind(node, element);
+        Reactive.flush();
+        assertEquals(
+                "Expected to have property with name " + propertyName1
+                        + " defined after initial binding",
+                propertyValue1, WidgetUtil.getJsProperty(element,
+                        PROPERTY_PREFIX + propertyName1));
+        assertEquals(
+                "Expected to have property with name " + propertyName2
+                        + " defined after initial binding",
+                propertyValue2, WidgetUtil.getJsProperty(element,
+                        PROPERTY_PREFIX + propertyName2));
+
+        String newPropertyValue1 = "bubblegum";
+        emulatePolymerPropertyChange(element, propertyName1, newPropertyValue1);
+
+        String newPropertyValue2 = "bar";
+        emulatePolymerPropertyChange(element, propertyName2, newPropertyValue2);
+
+        Reactive.flush();
+        assertEquals(
+                "Expected to have property with name " + propertyName1
+                        + " updated from client side",
+                newPropertyValue1, WidgetUtil.getJsProperty(element,
+                        PROPERTY_PREFIX + propertyName1));
+        assertEquals(
+                "Expected to have property with name " + propertyName2
+                        + " updated from client side",
+                newPropertyValue2, WidgetUtil.getJsProperty(element,
+                        PROPERTY_PREFIX + propertyName2));
+    }
+
     public void testInitialUpdateModelProperty_propertyIsUpdatableAndSchedulerIsNotExecuted_propertyIsNotSync() {
         addMockMethods(element);
         String propertyName = "black";


### PR DESCRIPTION
On the client side there may be several property handling calls which should be deferred because of waiting of JS execution (which sets updatable properties).
All of them should be executed. Not only one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3521)
<!-- Reviewable:end -->
