### PR TITLE
Add highlight capabilities to RouterLink

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/HighlightAction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/HighlightAction.java
@@ -15,7 +15,7 @@
  */
 package com.vaadin.flow.router;
 
-import com.vaadin.flow.function.SerializableBiConsumer;
+import java.io.Serializable;
 
 /**
  * An action to be performed to set the highlight state of the target.
@@ -24,7 +24,7 @@ import com.vaadin.flow.function.SerializableBiConsumer;
  *            the target type of the highlight action
  */
 @FunctionalInterface
-public interface HighlightAction<T> extends SerializableBiConsumer<T, Boolean> {
+public interface HighlightAction<T> extends Serializable {
 
     /**
      * Performs the highlight action on the target.
@@ -32,8 +32,8 @@ public interface HighlightAction<T> extends SerializableBiConsumer<T, Boolean> {
      * @param t
      *            the target of the highlight action
      * @param highlight
-     *            true if the target should be highlighted
+     *            true if the target should be highlighted, false to clear the
+     *            highlight state previously set by this action
      */
-    @Override
-    void accept(T t, Boolean highlight);
+    void highlight(T t, boolean highlight);
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/HighlightAction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/HighlightAction.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.router;
+
+import com.vaadin.flow.function.SerializableBiConsumer;
+
+/**
+ * An action to be performed to set the highlight state of the target.
+ *
+ * @param <T>
+ *            the target type of the highlight action
+ */
+@FunctionalInterface
+public interface HighlightAction<T> extends SerializableBiConsumer<T, Boolean> {
+
+    /**
+     * Performs the highlight action on the target.
+     *
+     * @param t
+     *            the target of the highlight action
+     * @param highlight
+     *            true if the target should be highlighted
+     */
+    @Override
+    void accept(T t, Boolean highlight);
+}

--- a/flow-server/src/main/java/com/vaadin/flow/router/HighlightActions.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/HighlightActions.java
@@ -23,6 +23,9 @@ import com.vaadin.flow.component.HasStyle;
  */
 public final class HighlightActions {
 
+    private HighlightActions() {
+    }
+
     /**
      * An action which toggles {@code className} class on the target based on
      * its highlight state.
@@ -84,8 +87,5 @@ public final class HighlightActions {
         return (link, highligh) -> {
             // Do nothing.
         };
-    }
-
-    private HighlightActions() {
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/HighlightActions.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/HighlightActions.java
@@ -36,13 +36,8 @@ public final class HighlightActions {
      */
     public static <C extends HasStyle> HighlightAction<C> toggleClassName(
             String className) {
-        return (link, highligh) -> {
-            if (highligh) {
-                link.addClassName(className);
-            } else {
-                link.removeClassName(className);
-            }
-        };
+        return (component, highlight) -> component.getClassNames()
+                .set(className, highlight);
     }
 
     /**
@@ -55,13 +50,8 @@ public final class HighlightActions {
      */
     public static <C extends HasElement> HighlightAction<C> toggleTheme(
             String theme) {
-        return (link, highligh) -> {
-            if (highligh) {
-                link.getElement().getThemeList().add(theme);
-            } else {
-                link.getElement().getThemeList().remove(theme);
-            }
-        };
+        return (component, highlight) -> component.getElement().getThemeList()
+                .set(theme, highlight);
     }
 
     /**
@@ -74,8 +64,8 @@ public final class HighlightActions {
      */
     public static <C extends HasElement> HighlightAction<C> toggleAttribute(
             String attribute) {
-        return (link, highlight) -> link.getElement().setAttribute(attribute,
-                highlight);
+        return (component, highlight) -> component.getElement()
+                .setAttribute(attribute, highlight);
     }
 
     /**
@@ -84,7 +74,7 @@ public final class HighlightActions {
      * @return the highlight action
      */
     public static <C extends HasElement> HighlightAction<C> none() {
-        return (link, highligh) -> {
+        return (component, highlight) -> {
             // Do nothing.
         };
     }

--- a/flow-server/src/main/java/com/vaadin/flow/router/HighlightActions.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/HighlightActions.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.router;
+
+import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.component.HasStyle;
+
+/**
+ * A set of predefined {@link HighlightAction}s.
+ */
+public final class HighlightActions {
+
+    /**
+     * An action which toggles {@code className} class on the target based on
+     * its highlight state.
+     *
+     * @param className
+     *            the class name to toggle
+     * @return the highlight action
+     */
+    public static <C extends HasStyle> HighlightAction<C> toggleClassName(
+            String className) {
+        return (link, highligh) -> {
+            if (highligh) {
+                link.addClassName(className);
+            } else {
+                link.removeClassName(className);
+            }
+        };
+    }
+
+    /**
+     * An action which toggles {@code theme} on the target based on its
+     * highlight state.
+     *
+     * @param theme
+     *            the theme to toggle
+     * @return the highlight action
+     */
+    public static <C extends HasElement> HighlightAction<C> toggleTheme(
+            String theme) {
+        return (link, highligh) -> {
+            if (highligh) {
+                link.getElement().getThemeList().add(theme);
+            } else {
+                link.getElement().getThemeList().remove(theme);
+            }
+        };
+    }
+
+    /**
+     * An action which toggles the target's {@code attribute} based on its
+     * highlight state.
+     *
+     * @param attribute
+     *            the attribute to toggle
+     * @return the highlight action
+     */
+    public static <C extends HasElement> HighlightAction<C> toggleAttribute(
+            String attribute) {
+        return (link, highlight) -> link.getElement().setAttribute(attribute,
+                highlight);
+    }
+
+    /**
+     * An action which does nothing, regardless of the highlight state.
+     *
+     * @return the highlight action
+     */
+    public static <C extends HasElement> HighlightAction<C> none() {
+        return (link, highligh) -> {
+            // Do nothing.
+        };
+    }
+
+    private HighlightActions() {
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/router/HighlightCondition.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/HighlightCondition.java
@@ -15,7 +15,7 @@
  */
 package com.vaadin.flow.router;
 
-import com.vaadin.flow.function.SerializableBiPredicate;
+import java.io.Serializable;
 
 /**
  * A condition to meet to determine the highlight state of the target.
@@ -24,8 +24,7 @@ import com.vaadin.flow.function.SerializableBiPredicate;
  *            the target type of the highlight condition
  */
 @FunctionalInterface
-public interface HighlightCondition<T>
-        extends SerializableBiPredicate<T, AfterNavigationEvent> {
+public interface HighlightCondition<T> extends Serializable {
 
     /**
      * Tests if the target should be highlighted based on the navigation
@@ -36,6 +35,5 @@ public interface HighlightCondition<T>
      * @param event
      *            the navigation event
      */
-    @Override
     boolean test(T t, AfterNavigationEvent event);
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/HighlightCondition.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/HighlightCondition.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.router;
+
+import com.vaadin.flow.function.SerializableBiPredicate;
+
+@FunctionalInterface
+public interface HighlightCondition<T>
+        extends SerializableBiPredicate<T, AfterNavigationEvent> {
+}

--- a/flow-server/src/main/java/com/vaadin/flow/router/HighlightCondition.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/HighlightCondition.java
@@ -34,6 +34,7 @@ public interface HighlightCondition<T> extends Serializable {
      *            the target of the highlight condition
      * @param event
      *            the navigation event
+     * @return true if the condition is met, false otherwise
      */
-    boolean test(T t, AfterNavigationEvent event);
+    boolean shouldHighlight(T t, AfterNavigationEvent event);
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/HighlightCondition.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/HighlightCondition.java
@@ -17,7 +17,25 @@ package com.vaadin.flow.router;
 
 import com.vaadin.flow.function.SerializableBiPredicate;
 
+/**
+ * A condition to meet to determine the highlight state of the target.
+ *
+ * @param <T>
+ *            the target type of the highlight condition
+ */
 @FunctionalInterface
 public interface HighlightCondition<T>
         extends SerializableBiPredicate<T, AfterNavigationEvent> {
+
+    /**
+     * Tests if the target should be highlighted based on the navigation
+     * {@code event}.
+     *
+     * @param t
+     *            the target of the highlight condition
+     * @param event
+     *            the navigation event
+     */
+    @Override
+    boolean test(T t, AfterNavigationEvent event);
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/HighlightConditions.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/HighlightConditions.java
@@ -26,7 +26,7 @@ public final class HighlightConditions {
     }
 
     /**
-     * Highlight if the navigation path is the same of the target
+     * Highlight if the navigation path is the same as the target
      * {@link RouterLink}.
      *
      * @return the highlight condition

--- a/flow-server/src/main/java/com/vaadin/flow/router/HighlightConditions.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/HighlightConditions.java
@@ -22,6 +22,9 @@ import com.vaadin.flow.component.HasElement;
  */
 public final class HighlightConditions {
 
+    private HighlightConditions() {
+    }
+
     /**
      * Highlight if the navigation path is the same of the target
      * {@link RouterLink}.
@@ -47,6 +50,8 @@ public final class HighlightConditions {
     /**
      * Highlight if the navigation path starts with {@code prefix}.
      *
+     * @param prefix
+     *            the prefix to match on the location path
      * @return the highlight condition
      */
     public static <C extends HasElement> HighlightCondition<C> locationPrefix(
@@ -71,8 +76,5 @@ public final class HighlightConditions {
      */
     public static <C extends HasElement> HighlightCondition<C> never() {
         return (link, event) -> false;
-    }
-
-    private HighlightConditions() {
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/HighlightConditions.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/HighlightConditions.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.router;
+
+import com.vaadin.flow.component.HasElement;
+
+/**
+ * A set of predefined {@link HighlightCondition}s.
+ */
+public final class HighlightConditions {
+
+    /**
+     * Highlight if the navigation path is the same of the target
+     * {@link RouterLink}.
+     *
+     * @return the highlight condition
+     */
+    public static HighlightCondition<RouterLink> sameLocation() {
+        return (link, event) -> event.getLocation().getPath()
+                .equals(link.getHref());
+    }
+
+    /**
+     * Highlight if the navigation path starts with the target
+     * {@link RouterLink} path.
+     *
+     * @return the highlight condition
+     */
+    public static HighlightCondition<RouterLink> locationPrefix() {
+        return (link, event) -> event.getLocation().getPath()
+                .startsWith(link.getHref());
+    }
+
+    /**
+     * Highlight if the navigation path starts with {@code prefix}.
+     *
+     * @return the highlight condition
+     */
+    public static <C extends HasElement> HighlightCondition<C> locationPrefix(
+            String prefix) {
+        return (link, event) -> event.getLocation().getPath()
+                .startsWith(prefix);
+    }
+
+    /**
+     * Always highlight.
+     *
+     * @return an always true highlight condition
+     */
+    public static <C extends HasElement> HighlightCondition<C> always() {
+        return (link, event) -> true;
+    }
+
+    /**
+     * Never highlight.
+     *
+     * @return an always false highlight condition
+     */
+    public static <C extends HasElement> HighlightCondition<C> never() {
+        return (link, event) -> false;
+    }
+
+    private HighlightConditions() {
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/router/HighlightConditions.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/HighlightConditions.java
@@ -56,7 +56,7 @@ public final class HighlightConditions {
      */
     public static <C extends HasElement> HighlightCondition<C> locationPrefix(
             String prefix) {
-        return (link, event) -> event.getLocation().getPath()
+        return (component, event) -> event.getLocation().getPath()
                 .startsWith(prefix);
     }
 
@@ -66,7 +66,7 @@ public final class HighlightConditions {
      * @return an always true highlight condition
      */
     public static <C extends HasElement> HighlightCondition<C> always() {
-        return (link, event) -> true;
+        return (component, event) -> true;
     }
 
     /**
@@ -75,6 +75,6 @@ public final class HighlightConditions {
      * @return an always false highlight condition
      */
     public static <C extends HasElement> HighlightCondition<C> never() {
-        return (link, event) -> false;
+        return (component, event) -> false;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouterLink.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouterLink.java
@@ -48,10 +48,16 @@ import com.vaadin.flow.shared.ApplicationConstants;
  */
 @Tag(Tag.A)
 public class RouterLink extends Component
-        implements HasText, HasComponents, HasStyle {
+        implements HasText, HasComponents, HasStyle, AfterNavigationObserver {
 
     private static final PropertyDescriptor<String, String> HREF = PropertyDescriptors
             .attributeWithDefault("href", "", false);
+
+    private HighlightCondition<RouterLink> highlightCondition = HighlightConditions
+            .locationPrefix();
+
+    private HighlightAction<RouterLink> highlightAction = HighlightActions
+            .toggleAttribute("highlight");
 
     /**
      * Creates a new empty router link.
@@ -420,5 +426,51 @@ public class RouterLink extends Component
                             + "Use overloaded method with explicit router parameter.");
         }
         return router.get();
+    }
+
+    /**
+     * Gets the {@link HighlightCondition} of this component.
+     *
+     * @return the highlight condition
+     */
+    public HighlightCondition<RouterLink> getHighlightCondition() {
+        return highlightCondition;
+    }
+
+    /**
+     * Sets the {@link HighlightCondition} of this component.
+     *
+     * @param highlightCondition
+     *            the highlight condition
+     */
+    public void setHighlightCondition(
+            HighlightCondition<RouterLink> highlightCondition) {
+        this.highlightCondition = highlightCondition;
+    }
+
+    /**
+     * Gets the {@link HighlightAction} of this component.
+     *
+     * @return the highlight action
+     */
+    public HighlightAction<RouterLink> getHighlightAction() {
+        return highlightAction;
+    }
+
+    /**
+     * Sets the {@link HighlightAction} of this component.
+     *
+     * @param highlightAction
+     *            the highlight action
+     */
+    public void setHighlightAction(
+            HighlightAction<RouterLink> highlightAction) {
+        this.highlightAction = highlightAction;
+    }
+
+    @Override
+    public void afterNavigation(AfterNavigationEvent event) {
+        getHighlightAction().accept(this,
+                getHighlightCondition().test(this, event));
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouterLink.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouterLink.java
@@ -430,7 +430,7 @@ public class RouterLink extends Component
 
     /**
      * Gets the {@link HighlightCondition} of this link.
-     *
+     * <p>
      * The default condition is to checked whether the current location starts
      * with this link's {@link #getHref()} value, as defined in
      * {@link HighlightConditions#locationPrefix()}.
@@ -446,11 +446,12 @@ public class RouterLink extends Component
     /**
      * Sets the {@link HighlightCondition} of this link, which determines if the
      * link should be highlighted when a {@link AfterNavigationEvent} occurs.
-     *
+     * <p>
      * The evaluation of this condition will be processed by this link's
      * {@link HighlightAction}.
      *
      * @see #setHighlightAction(HighlightAction)
+     * @see HighlightConditions
      *
      * @param highlightCondition
      *            the highlight condition, not {@code null}
@@ -464,7 +465,7 @@ public class RouterLink extends Component
 
     /**
      * Gets the {@link HighlightAction} of this link.
-     *
+     * <p>
      * The default action is to toggle the {@code highlight} attribute of the
      * element, as defined in {@link HighlightActions#toggleAttribute(String)}.
      *
@@ -479,12 +480,13 @@ public class RouterLink extends Component
     /**
      * Sets the {@link HighlightAction} of this link, which will be performed
      * with the evaluation of this link's {@link HighlightCondition}.
-     *
+     * <p>
      * The old action will be executed passing {@code false} to
      * {@link HighlightAction#highlight(Object, boolean)} to clear any previous
      * highlight state.
      *
      * @see #setHighlightCondition(HighlightCondition)
+     * @see HighlightActions
      *
      * @param highlightAction
      *            the highlight action, not {@code null}
@@ -500,6 +502,6 @@ public class RouterLink extends Component
     @Override
     public void afterNavigation(AfterNavigationEvent event) {
         getHighlightAction().highlight(this,
-                getHighlightCondition().test(this, event));
+                getHighlightCondition().shouldHighlight(this, event));
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouterLink.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouterLink.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import com.vaadin.flow.component.Component;
@@ -458,7 +459,8 @@ public class RouterLink extends Component
      */
     public void setHighlightCondition(
             HighlightCondition<RouterLink> highlightCondition) {
-        assert highlightCondition != null;
+        Objects.requireNonNull(highlightCondition,
+                "HighlightCondition may not be null");
 
         this.highlightCondition = highlightCondition;
     }
@@ -493,7 +495,8 @@ public class RouterLink extends Component
      */
     public void setHighlightAction(
             HighlightAction<RouterLink> highlightAction) {
-        assert highlightAction != null;
+        Objects.requireNonNull(highlightCondition,
+                "HighlightAction may not be null");
 
         this.highlightAction.highlight(this, false);
         this.highlightAction = highlightAction;

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouterLink.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouterLink.java
@@ -429,48 +429,77 @@ public class RouterLink extends Component
     }
 
     /**
-     * Gets the {@link HighlightCondition} of this component.
+     * Gets the {@link HighlightCondition} of this link.
      *
-     * @return the highlight condition
+     * The default condition is to checked whether the current location starts
+     * with this link's {@link #getHref()} value, as defined in
+     * {@link HighlightConditions#locationPrefix()}.
+     *
+     * @see #setHighlightCondition(HighlightCondition)
+     *
+     * @return the highlight condition, never {@code null}
      */
     public HighlightCondition<RouterLink> getHighlightCondition() {
         return highlightCondition;
     }
 
     /**
-     * Sets the {@link HighlightCondition} of this component.
+     * Sets the {@link HighlightCondition} of this link, which determines if the
+     * link should be highlighted when a {@link AfterNavigationEvent} occurs.
+     *
+     * The evaluation of this condition will be processed by this link's
+     * {@link HighlightAction}.
+     *
+     * @see #setHighlightAction(HighlightAction)
      *
      * @param highlightCondition
-     *            the highlight condition
+     *            the highlight condition, not {@code null}
      */
     public void setHighlightCondition(
             HighlightCondition<RouterLink> highlightCondition) {
+        assert highlightCondition != null;
+
         this.highlightCondition = highlightCondition;
     }
 
     /**
-     * Gets the {@link HighlightAction} of this component.
+     * Gets the {@link HighlightAction} of this link.
      *
-     * @return the highlight action
+     * The default action is to toggle the {@code highlight} attribute of the
+     * element, as defined in {@link HighlightActions#toggleAttribute(String)}.
+     *
+     * @see #setHighlightAction(HighlightAction)
+     *
+     * @return the highlight action, never {@code null}
      */
     public HighlightAction<RouterLink> getHighlightAction() {
         return highlightAction;
     }
 
     /**
-     * Sets the {@link HighlightAction} of this component.
+     * Sets the {@link HighlightAction} of this link, which will be performed
+     * with the evaluation of this link's {@link HighlightCondition}.
+     *
+     * The old action will be executed passing {@code false} to
+     * {@link HighlightAction#highlight(Object, boolean)} to clear any previous
+     * highlight state.
+     *
+     * @see #setHighlightCondition(HighlightCondition)
      *
      * @param highlightAction
-     *            the highlight action
+     *            the highlight action, not {@code null}
      */
     public void setHighlightAction(
             HighlightAction<RouterLink> highlightAction) {
+        assert highlightAction != null;
+
+        this.highlightAction.highlight(this, false);
         this.highlightAction = highlightAction;
     }
 
     @Override
     public void afterNavigation(AfterNavigationEvent event) {
-        getHighlightAction().accept(this,
+        getHighlightAction().highlight(this,
                 getHighlightCondition().test(this, event));
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterLinkTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterLinkTest.java
@@ -417,6 +417,26 @@ public class RouterLinkTest extends HasCurrentService {
     }
 
     @Test
+    public void testRouterLinkClearOldHighlightAction()
+            throws InvalidRouteConfigurationException {
+
+        registry.setNavigationTargets(Stream.of(FooNavigationTarget.class)
+                .collect(Collectors.toSet()));
+
+        com.vaadin.flow.router.Router router = new com.vaadin.flow.router.Router(
+                registry);
+
+        RouterLink link = new RouterLink(router, "Foo",
+                FooNavigationTarget.class);
+        triggerNavigationEvent(router, link, "foo/bar");
+
+        link.setHighlightAction(HighlightActions.toggleClassName("highlight"));
+        triggerNavigationEvent(router, link, "foo/bar/baz");
+
+        Assert.assertFalse(link.getElement().hasAttribute("highlight"));
+    }
+
+    @Test
     public void testRouterLinkClassNameHightlightAction()
             throws InvalidRouteConfigurationException {
 
@@ -434,7 +454,7 @@ public class RouterLinkTest extends HasCurrentService {
         Assert.assertTrue(link.hasClassName("highlight"));
 
         triggerNavigationEvent(router, link, "bar");
-        Assert.assertFalse(link.getElement().hasAttribute("highlight"));
+        Assert.assertFalse(link.hasClassName("highlight"));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterLinkTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterLinkTest.java
@@ -306,6 +306,15 @@ public class RouterLinkTest extends HasCurrentService {
         return ui;
     }
 
+    private void triggerNavigationEvent(com.vaadin.flow.router.Router router,
+            RouterLink link, String location) {
+        AfterNavigationEvent event = new AfterNavigationEvent(
+                new LocationChangeEvent(router, this.createUI(),
+                        NavigationTrigger.ROUTER_LINK, new Location(location),
+                        Collections.emptyList()));
+        link.afterNavigation(event);
+    }
+
     @Override
     protected VaadinService createService() {
         return Mockito.mock(VaadinService.class);
@@ -354,17 +363,10 @@ public class RouterLinkTest extends HasCurrentService {
         RouterLink link = new RouterLink(router, "Foo",
                 FooNavigationTarget.class);
 
-        AfterNavigationEvent event = new AfterNavigationEvent(
-                new LocationChangeEvent(router, this.createUI(),
-                        NavigationTrigger.ROUTER_LINK, new Location("foo/bar"),
-                        Collections.emptyList()));
-        link.afterNavigation(event);
+        triggerNavigationEvent(router, link, "foo/bar");
         Assert.assertTrue(link.getElement().hasAttribute("highlight"));
 
-        event = new AfterNavigationEvent(new LocationChangeEvent(router,
-                this.createUI(), NavigationTrigger.ROUTER_LINK,
-                new Location("baz"), Collections.emptyList()));
-        link.afterNavigation(event);
+        triggerNavigationEvent(router, link, "baz");
         Assert.assertFalse(link.getElement().hasAttribute("highlight"));
     }
 
@@ -382,17 +384,10 @@ public class RouterLinkTest extends HasCurrentService {
                 FooNavigationTarget.class);
         link.setHighlightCondition(HighlightConditions.sameLocation());
 
-        AfterNavigationEvent event = new AfterNavigationEvent(
-                new LocationChangeEvent(router, this.createUI(),
-                        NavigationTrigger.ROUTER_LINK, new Location("foo/bar"),
-                        Collections.emptyList()));
-        link.afterNavigation(event);
+        triggerNavigationEvent(router, link, "foo/bar");
         Assert.assertFalse(link.getElement().hasAttribute("highlight"));
 
-        event = new AfterNavigationEvent(new LocationChangeEvent(router,
-                this.createUI(), NavigationTrigger.ROUTER_LINK,
-                new Location("foo"), Collections.emptyList()));
-        link.afterNavigation(event);
+        triggerNavigationEvent(router, link, "foo");
         Assert.assertTrue(link.getElement().hasAttribute("highlight"));
     }
 
@@ -411,24 +406,13 @@ public class RouterLinkTest extends HasCurrentService {
         link.setHighlightCondition(
                 HighlightConditions.locationPrefix("foo/ba"));
 
-        AfterNavigationEvent event = new AfterNavigationEvent(
-                new LocationChangeEvent(router, this.createUI(),
-                        NavigationTrigger.ROUTER_LINK, new Location("foo/bar"),
-                        Collections.emptyList()));
-
-        link.afterNavigation(event);
+        triggerNavigationEvent(router, link, "foo/bar");
         Assert.assertTrue(link.getElement().hasAttribute("highlight"));
 
-        event = new AfterNavigationEvent(new LocationChangeEvent(router,
-                this.createUI(), NavigationTrigger.ROUTER_LINK,
-                new Location("foo/baz"), Collections.emptyList()));
-        link.afterNavigation(event);
+        triggerNavigationEvent(router, link, "foo/baz");
         Assert.assertTrue(link.getElement().hasAttribute("highlight"));
 
-        event = new AfterNavigationEvent(new LocationChangeEvent(router,
-                this.createUI(), NavigationTrigger.ROUTER_LINK,
-                new Location("foo/qux"), Collections.emptyList()));
-        link.afterNavigation(event);
+        triggerNavigationEvent(router, link, "foo/qux");
         Assert.assertFalse(link.getElement().hasAttribute("highlight"));
     }
 
@@ -446,17 +430,10 @@ public class RouterLinkTest extends HasCurrentService {
                 FooNavigationTarget.class);
         link.setHighlightAction(HighlightActions.toggleClassName("highlight"));
 
-        AfterNavigationEvent event = new AfterNavigationEvent(
-                new LocationChangeEvent(router, this.createUI(),
-                        NavigationTrigger.ROUTER_LINK, new Location("foo/bar"),
-                        Collections.emptyList()));
-        link.afterNavigation(event);
+        triggerNavigationEvent(router, link, "foo/bar");
         Assert.assertTrue(link.hasClassName("highlight"));
 
-        event = new AfterNavigationEvent(new LocationChangeEvent(router,
-                this.createUI(), NavigationTrigger.ROUTER_LINK,
-                new Location("bar"), Collections.emptyList()));
-        link.afterNavigation(event);
+        triggerNavigationEvent(router, link, "bar");
         Assert.assertFalse(link.getElement().hasAttribute("highlight"));
     }
 
@@ -474,18 +451,11 @@ public class RouterLinkTest extends HasCurrentService {
                 FooNavigationTarget.class);
         link.setHighlightAction(HighlightActions.toggleTheme("highlight"));
 
-        AfterNavigationEvent event = new AfterNavigationEvent(
-                new LocationChangeEvent(router, this.createUI(),
-                        NavigationTrigger.ROUTER_LINK, new Location("foo/bar"),
-                        Collections.emptyList()));
-        link.afterNavigation(event);
+        triggerNavigationEvent(router, link, "foo/bar");
         Assert.assertTrue(
                 link.getElement().getThemeList().contains("highlight"));
 
-        event = new AfterNavigationEvent(new LocationChangeEvent(router,
-                this.createUI(), NavigationTrigger.ROUTER_LINK,
-                new Location("bar"), Collections.emptyList()));
-        link.afterNavigation(event);
+        triggerNavigationEvent(router, link, "bar");
         Assert.assertFalse(
                 link.getElement().getThemeList().contains("highlight"));
     }

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterLinkTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterLinkTest.java
@@ -16,6 +16,8 @@
 package com.vaadin.flow.router;
 
 import javax.servlet.ServletException;
+
+import java.util.Collections;
 import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -337,6 +339,155 @@ public class RouterLinkTest extends HasCurrentService {
         RouterLink link = new RouterLink(router, "Greeting",
                 GreetingNavigationTarget.class, "hello");
         Assert.assertEquals("greeting/hello", link.getHref());
+    }
+
+    @Test
+    public void testRouterLinkDefaultHighlightCondition()
+            throws InvalidRouteConfigurationException {
+
+        registry.setNavigationTargets(Stream.of(FooNavigationTarget.class)
+                .collect(Collectors.toSet()));
+
+        com.vaadin.flow.router.Router router = new com.vaadin.flow.router.Router(
+                registry);
+
+        RouterLink link = new RouterLink(router, "Foo",
+                FooNavigationTarget.class);
+
+        AfterNavigationEvent event = new AfterNavigationEvent(
+                new LocationChangeEvent(router, this.createUI(),
+                        NavigationTrigger.ROUTER_LINK, new Location("foo/bar"),
+                        Collections.emptyList()));
+        link.afterNavigation(event);
+        Assert.assertTrue(link.getElement().hasAttribute("highlight"));
+
+        event = new AfterNavigationEvent(new LocationChangeEvent(router,
+                this.createUI(), NavigationTrigger.ROUTER_LINK,
+                new Location("baz"), Collections.emptyList()));
+        link.afterNavigation(event);
+        Assert.assertFalse(link.getElement().hasAttribute("highlight"));
+    }
+
+    @Test
+    public void testRouterLinkSameLocationHighlightCondition()
+            throws InvalidRouteConfigurationException {
+
+        registry.setNavigationTargets(Stream.of(FooNavigationTarget.class)
+                .collect(Collectors.toSet()));
+
+        com.vaadin.flow.router.Router router = new com.vaadin.flow.router.Router(
+                registry);
+
+        RouterLink link = new RouterLink(router, "Foo",
+                FooNavigationTarget.class);
+        link.setHighlightCondition(HighlightConditions.sameLocation());
+
+        AfterNavigationEvent event = new AfterNavigationEvent(
+                new LocationChangeEvent(router, this.createUI(),
+                        NavigationTrigger.ROUTER_LINK, new Location("foo/bar"),
+                        Collections.emptyList()));
+        link.afterNavigation(event);
+        Assert.assertFalse(link.getElement().hasAttribute("highlight"));
+
+        event = new AfterNavigationEvent(new LocationChangeEvent(router,
+                this.createUI(), NavigationTrigger.ROUTER_LINK,
+                new Location("foo"), Collections.emptyList()));
+        link.afterNavigation(event);
+        Assert.assertTrue(link.getElement().hasAttribute("highlight"));
+    }
+
+    @Test
+    public void testRouterLinkLocationPrefixHighlightCondition()
+            throws InvalidRouteConfigurationException {
+
+        registry.setNavigationTargets(Stream.of(FooNavigationTarget.class)
+                .collect(Collectors.toSet()));
+
+        com.vaadin.flow.router.Router router = new com.vaadin.flow.router.Router(
+                registry);
+
+        RouterLink link = new RouterLink(router, "Foo",
+                FooNavigationTarget.class);
+        link.setHighlightCondition(
+                HighlightConditions.locationPrefix("foo/ba"));
+
+        AfterNavigationEvent event = new AfterNavigationEvent(
+                new LocationChangeEvent(router, this.createUI(),
+                        NavigationTrigger.ROUTER_LINK, new Location("foo/bar"),
+                        Collections.emptyList()));
+
+        link.afterNavigation(event);
+        Assert.assertTrue(link.getElement().hasAttribute("highlight"));
+
+        event = new AfterNavigationEvent(new LocationChangeEvent(router,
+                this.createUI(), NavigationTrigger.ROUTER_LINK,
+                new Location("foo/baz"), Collections.emptyList()));
+        link.afterNavigation(event);
+        Assert.assertTrue(link.getElement().hasAttribute("highlight"));
+
+        event = new AfterNavigationEvent(new LocationChangeEvent(router,
+                this.createUI(), NavigationTrigger.ROUTER_LINK,
+                new Location("foo/qux"), Collections.emptyList()));
+        link.afterNavigation(event);
+        Assert.assertFalse(link.getElement().hasAttribute("highlight"));
+    }
+
+    @Test
+    public void testRouterLinkClassNameHightlightAction()
+            throws InvalidRouteConfigurationException {
+
+        registry.setNavigationTargets(Stream.of(FooNavigationTarget.class)
+                .collect(Collectors.toSet()));
+
+        com.vaadin.flow.router.Router router = new com.vaadin.flow.router.Router(
+                registry);
+
+        RouterLink link = new RouterLink(router, "Foo",
+                FooNavigationTarget.class);
+        link.setHighlightAction(HighlightActions.toggleClassName("highlight"));
+
+        AfterNavigationEvent event = new AfterNavigationEvent(
+                new LocationChangeEvent(router, this.createUI(),
+                        NavigationTrigger.ROUTER_LINK, new Location("foo/bar"),
+                        Collections.emptyList()));
+        link.afterNavigation(event);
+        Assert.assertTrue(link.hasClassName("highlight"));
+
+        event = new AfterNavigationEvent(new LocationChangeEvent(router,
+                this.createUI(), NavigationTrigger.ROUTER_LINK,
+                new Location("bar"), Collections.emptyList()));
+        link.afterNavigation(event);
+        Assert.assertFalse(link.getElement().hasAttribute("highlight"));
+    }
+
+    @Test
+    public void testRouterLinkThemeHightlightAction()
+            throws InvalidRouteConfigurationException {
+
+        registry.setNavigationTargets(Stream.of(FooNavigationTarget.class)
+                .collect(Collectors.toSet()));
+
+        com.vaadin.flow.router.Router router = new com.vaadin.flow.router.Router(
+                registry);
+
+        RouterLink link = new RouterLink(router, "Foo",
+                FooNavigationTarget.class);
+        link.setHighlightAction(HighlightActions.toggleTheme("highlight"));
+
+        AfterNavigationEvent event = new AfterNavigationEvent(
+                new LocationChangeEvent(router, this.createUI(),
+                        NavigationTrigger.ROUTER_LINK, new Location("foo/bar"),
+                        Collections.emptyList()));
+        link.afterNavigation(event);
+        Assert.assertTrue(
+                link.getElement().getThemeList().contains("highlight"));
+
+        event = new AfterNavigationEvent(new LocationChangeEvent(router,
+                this.createUI(), NavigationTrigger.ROUTER_LINK,
+                new Location("bar"), Collections.emptyList()));
+        link.afterNavigation(event);
+        Assert.assertFalse(
+                link.getElement().getThemeList().contains("highlight"));
     }
 
     @Rule


### PR DESCRIPTION
Fixes #482 while tempting to leave an open door to support highlighting on other components, e.g. `Tab`.

Introduces two interfaces:

- `HighlightCondition<T> extends SerializableBiPredicate<T, AfterNavigationEvent>`
- `HighlightAction<T> extends SerializableBiConsumer<T, Boolean>`

with some predefined logic in `HighlightConditions` and `HighlightActions`.

Then enables `RouterLink` implementing `AfterNavigationObserver` with getter/setters for both (with reasonable defaults).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3526)
<!-- Reviewable:end -->
