### PR TITLE
Clear old templates before rendering

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/renderer/BasicRenderer.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/renderer/BasicRenderer.java
@@ -69,7 +69,7 @@ public abstract class BasicRenderer<SOURCE, TARGET>
     @Override
     public Rendering<SOURCE> render(Element container,
             KeyMapper<SOURCE> keyMapper) {
-
+        removeTemplates(container);
         SimpleValueRendering rendering = new SimpleValueRendering(
                 keyMapper == null ? null : keyMapper::key);
         setupTemplate(container, rendering, keyMapper);

--- a/flow-data/src/main/java/com/vaadin/flow/data/renderer/ComponentRenderer.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/renderer/ComponentRenderer.java
@@ -122,6 +122,8 @@ public class ComponentRenderer<COMPONENT extends Component, SOURCE>
     public Rendering<SOURCE> render(Element container,
             KeyMapper<SOURCE> keyMapper) {
 
+        removeTemplates(container);
+
         ComponentRendering rendering = new ComponentRendering(
                 keyMapper == null ? null : keyMapper::key);
         rendering.setTemplateElement(new Element("template", false));
@@ -152,6 +154,7 @@ public class ComponentRenderer<COMPONENT extends Component, SOURCE>
 
     private void setupTemplateWhenAttached(UI ui, Element owner,
             ComponentRendering rendering, KeyMapper<SOURCE> keyMapper) {
+
         String appId = ui.getInternals().getAppId();
         Element templateElement = rendering.getTemplateElement().get();
         owner.appendChild(templateElement);

--- a/flow-data/src/main/java/com/vaadin/flow/data/renderer/Renderer.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/renderer/Renderer.java
@@ -181,6 +181,9 @@ public class Renderer<SOURCE> implements Serializable {
             KeyMapper<SOURCE> keyMapper) {
         Objects.requireNonNull(template,
                 "The template string is null. Either build the Renderer by using the 'Renderer(String)' constructor or override the 'render' method to provide custom behavior");
+
+        removeTemplates(container);
+
         Element contentTemplate = new Element("template", false)
                 .setProperty("innerHTML", template);
 
@@ -242,6 +245,19 @@ public class Renderer<SOURCE> implements Serializable {
             return Optional.of(templateElement);
         }
 
+    }
+
+    /**
+     * Removes any {@code <template>} elements inside the given element.
+     * 
+     * @param parent
+     *            the element whose template-children to remove, not
+     *            {@code null}
+     */
+    protected void removeTemplates(Element parent) {
+        parent.removeChild(parent.getChildren()
+                .filter(child -> "template".equals(child.getTag()))
+                .toArray(Element[]::new));
     }
 
 }


### PR DESCRIPTION
This prevents from having multiple `<template>` elements in components that use renderers and thus fixes changing the renderer after one has been already set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3551)
<!-- Reviewable:end -->
