### PR TITLE
Enable reusing template elements for rendering

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/renderer/BasicRenderer.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/renderer/BasicRenderer.java
@@ -68,10 +68,10 @@ public abstract class BasicRenderer<SOURCE, TARGET>
 
     @Override
     public Rendering<SOURCE> render(Element container,
-            DataKeyMapper<SOURCE> keyMapper) {
-        removeTemplates(container);
+            DataKeyMapper<SOURCE> keyMapper, Element contentTemplate) {
         SimpleValueRendering rendering = new SimpleValueRendering(
                 keyMapper == null ? null : keyMapper::key);
+        rendering.setTemplateElement(contentTemplate);
         setupTemplate(container, rendering, keyMapper);
 
         return rendering;
@@ -79,10 +79,6 @@ public abstract class BasicRenderer<SOURCE, TARGET>
 
     private void setupTemplate(Element owner, SimpleValueRendering rendering,
             DataKeyMapper<SOURCE> keyMapper) {
-
-        Element templateElement = new Element("template", false);
-        rendering.setTemplateElement(templateElement);
-
         owner.getNode()
                 .runWhenAttached(ui -> ui.getInternals().getStateTree()
                         .beforeClientResponse(owner.getNode(),
@@ -93,7 +89,7 @@ public abstract class BasicRenderer<SOURCE, TARGET>
     private void setupTemplateWhenAttached(Element owner,
             SimpleValueRendering rendering, DataKeyMapper<SOURCE> keyMapper) {
 
-        Element templateElement = rendering.getTemplateElement().get();
+        Element templateElement = rendering.getTemplateElement();
         owner.appendChild(templateElement);
 
         if (keyMapper != null) {
@@ -129,11 +125,11 @@ public abstract class BasicRenderer<SOURCE, TARGET>
      */
     protected String getTemplatePropertyName(Rendering<SOURCE> context) {
         Objects.requireNonNull(context, "The context should not be null");
-        if (!context.getTemplateElement().isPresent()) {
+        Element templateElement = context.getTemplateElement();
+        if (templateElement == null) {
             throw new IllegalArgumentException(
                     "The provided rendering doesn't contain a template element");
         }
-        Element templateElement = context.getTemplateElement().get();
         return "_" + getClass().getSimpleName() + "_"
                 + templateElement.getNode().getId();
     }
@@ -203,8 +199,8 @@ public abstract class BasicRenderer<SOURCE, TARGET>
         }
 
         @Override
-        public Optional<Element> getTemplateElement() {
-            return Optional.ofNullable(templateElement);
+        public Element getTemplateElement() {
+            return templateElement;
         }
 
         @Override

--- a/flow-data/src/main/java/com/vaadin/flow/data/renderer/BasicRenderer.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/renderer/BasicRenderer.java
@@ -114,8 +114,8 @@ public abstract class BasicRenderer<SOURCE, TARGET>
      * template. By default, it generates a unique name by using the class name
      * of the renderer and the node id of the template element.
      * <p>
-     * This method is only called when {@link #render(Element, DataKeyMapper,
-     * Element))} is invoked.
+     * This method is only called when
+     * {@link #render(Element, DataKeyMapper, Element)} is invoked.
      * 
      * @param context
      *            the rendering context
@@ -137,8 +137,8 @@ public abstract class BasicRenderer<SOURCE, TARGET>
     /**
      * Gets the template String for a given property.
      * <p>
-     * This method is only called when {@link #render(Element, DataKeyMapper,
-     * Element))} is invoked.
+     * This method is only called when
+     * {@link #render(Element, DataKeyMapper, Element)} is invoked.
      * 
      * @param property
      *            the property to be used inside the template

--- a/flow-data/src/main/java/com/vaadin/flow/data/renderer/BasicRenderer.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/renderer/BasicRenderer.java
@@ -114,8 +114,8 @@ public abstract class BasicRenderer<SOURCE, TARGET>
      * template. By default, it generates a unique name by using the class name
      * of the renderer and the node id of the template element.
      * <p>
-     * This method is only called when {@link #render(Element, DataKeyMapper)}
-     * is invoked.
+     * This method is only called when {@link #render(Element, DataKeyMapper,
+     * Element))} is invoked.
      * 
      * @param context
      *            the rendering context
@@ -137,8 +137,8 @@ public abstract class BasicRenderer<SOURCE, TARGET>
     /**
      * Gets the template String for a given property.
      * <p>
-     * This method is only called when {@link #render(Element, DataKeyMapper)}
-     * is invoked.
+     * This method is only called when {@link #render(Element, DataKeyMapper,
+     * Element))} is invoked.
      * 
      * @param property
      *            the property to be used inside the template

--- a/flow-data/src/main/java/com/vaadin/flow/data/renderer/ComponentRenderer.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/renderer/ComponentRenderer.java
@@ -120,13 +120,11 @@ public class ComponentRenderer<COMPONENT extends Component, SOURCE>
 
     @Override
     public Rendering<SOURCE> render(Element container,
-            DataKeyMapper<SOURCE> keyMapper) {
-
-        removeTemplates(container);
+            DataKeyMapper<SOURCE> keyMapper, Element contentTemplate) {
 
         ComponentRendering rendering = new ComponentRendering(
                 keyMapper == null ? null : keyMapper::key);
-        rendering.setTemplateElement(new Element("template", false));
+        rendering.setTemplateElement(contentTemplate);
 
         container.getNode()
                 .runWhenAttached(ui -> ui.getInternals().getStateTree()
@@ -155,7 +153,7 @@ public class ComponentRenderer<COMPONENT extends Component, SOURCE>
     private void setupTemplateWhenAttached(UI ui, Element owner,
             ComponentRendering rendering, DataKeyMapper<SOURCE> keyMapper) {
         String appId = ui.getInternals().getAppId();
-        Element templateElement = rendering.getTemplateElement().get();
+        Element templateElement = rendering.getTemplateElement();
         owner.appendChild(templateElement);
 
         Element container = new Element("div", false);
@@ -223,8 +221,8 @@ public class ComponentRenderer<COMPONENT extends Component, SOURCE>
         }
 
         @Override
-        public Optional<Element> getTemplateElement() {
-            return Optional.ofNullable(templateElement);
+        public Element getTemplateElement() {
+            return templateElement;
         }
 
         @Override

--- a/flow-data/src/main/java/com/vaadin/flow/data/renderer/Renderer.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/renderer/Renderer.java
@@ -162,11 +162,8 @@ public class Renderer<SOURCE> implements Serializable {
     }
 
     /**
-     * Effectively creates the {@code <template>} used for rendering the model
-     * objects.
-     * <p>
-     * Subclasses of Renderer usually override this method to provide additional
-     * features.
+     * Handles the rendering of the model objects by creating a new
+     * {@code <template>} element in the given container.
      * 
      * @param container
      *            the element in which the template will be attached to
@@ -179,15 +176,39 @@ public class Renderer<SOURCE> implements Serializable {
      */
     public Rendering<SOURCE> render(Element container,
             DataKeyMapper<SOURCE> keyMapper) {
+        return render(container, keyMapper, new Element("template", false));
+    }
+
+    /**
+     * Handles the rendering of the model objects by using the given
+     * {@code <template>} element in the given container.
+     * <p>
+     * Subclasses of Renderer usually override this method to provide additional
+     * features.
+     * 
+     * @param container
+     *            the element in which the template will be attached to, not
+     *            {@code null}
+     * @param keyMapper
+     *            mapper used internally to fetch items by key and to provide
+     *            keys for given items. It is required when either event
+     *            handlers or {@link DataGenerator} are supported
+     * @param contentTemplate
+     *            the {@code <template>} element to be used for rendering in the
+     *            container, not {@code null}
+     * @return the context of the rendering, that can be used by the components
+     *         to provide extra customization
+     */
+    public Rendering<SOURCE> render(Element container,
+            DataKeyMapper<SOURCE> keyMapper, Element contentTemplate) {
         Objects.requireNonNull(template,
                 "The template string is null. Either build the Renderer by using the 'Renderer(String)' constructor or override the 'render' method to provide custom behavior");
 
-        removeTemplates(container);
+        contentTemplate.setProperty("innerHTML", template);
 
-        Element contentTemplate = new Element("template", false)
-                .setProperty("innerHTML", template);
-
-        container.appendChild(contentTemplate);
+        if (contentTemplate.getParent() != container) {
+            container.appendChild(contentTemplate);
+        }
 
         if (keyMapper != null) {
             RendererUtil.registerEventHandlers(this, contentTemplate, container,
@@ -241,23 +262,10 @@ public class Renderer<SOURCE> implements Serializable {
         }
 
         @Override
-        public Optional<Element> getTemplateElement() {
-            return Optional.of(templateElement);
+        public Element getTemplateElement() {
+            return templateElement;
         }
 
-    }
-
-    /**
-     * Removes any {@code <template>} elements inside the given element.
-     * 
-     * @param parent
-     *            the element whose template-children to remove, not
-     *            {@code null}
-     */
-    protected void removeTemplates(Element parent) {
-        parent.removeChild(parent.getChildren()
-                .filter(child -> "template".equals(child.getTag()))
-                .toArray(Element[]::new));
     }
 
 }

--- a/flow-data/src/main/java/com/vaadin/flow/data/renderer/Rendering.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/renderer/Rendering.java
@@ -49,8 +49,8 @@ public interface Rendering<SOURCE> extends Serializable {
      * can be used to set specific attributes to the template, or change its
      * contents before it is stamped on the client-side.
      * 
-     * @return the associated template element, if any
+     * @return the associated template element
      */
-    Optional<Element> getTemplateElement();
+    Element getTemplateElement();
 
 }

--- a/flow-data/src/main/java/com/vaadin/flow/data/renderer/Rendering.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/renderer/Rendering.java
@@ -49,7 +49,8 @@ public interface Rendering<SOURCE> extends Serializable {
      * can be used to set specific attributes to the template, or change its
      * contents before it is stamped on the client-side.
      * 
-     * @return the associated template element
+     * @return the associated template element, or {@code null} if no template
+     *         element is associated with the rendering
      */
     Element getTemplateElement();
 


### PR DESCRIPTION
 - Add a new overload for `render()` that takes an existing `<template>` element to be used for rendering instead of creating a new element
 - Don't remove existing template-elements because they can now be reused, and because that caused problems with grid columns since they contain multiple templates
 - Return `Element` instead of `Optional<Element>` from `Rendering::getTemplateElement` because it's usually guaranteed to exist

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3555)
<!-- Reviewable:end -->
