### PR TITLE
Check message for dom nodes and throw exception if one is found.

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/WidgetUtil.java
+++ b/flow-client/src/main/java/com/vaadin/client/WidgetUtil.java
@@ -285,4 +285,22 @@ public class WidgetUtil {
     /*-{
       return Object.keys(value);
     }-*/;
+
+    /**
+     * We drop the keys '__shady', 'host' and 'parent' for the JsonObject as
+     * these come when we run with polyfills and may create cyclic dependencies.
+     *
+     * @param payload
+     *            JsonObject to stringify
+     * @return json string of given object
+     */
+    public static native String stringify(JsonObject payload) /*-{
+        return JSON.stringify(payload, function(key, value) {
+            if(value instanceof Node){
+                throw "Message JsonObject contained a dom node reference which " +
+                "should not be sent to the server and can cause a cyclic dependecy.";
+            }
+            return value;
+        });
+    }-*/;
 }

--- a/flow-client/src/main/java/com/vaadin/client/WidgetUtil.java
+++ b/flow-client/src/main/java/com/vaadin/client/WidgetUtil.java
@@ -18,7 +18,6 @@ package com.vaadin.client;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
-
 import com.vaadin.client.flow.dom.DomApi;
 
 import elemental.client.Browser;
@@ -287,8 +286,9 @@ public class WidgetUtil {
     }-*/;
 
     /**
-     * We drop the keys '__shady', 'host' and 'parent' for the JsonObject as
-     * these come when we run with polyfills and may create cyclic dependencies.
+     * When serializing the JsonObject we check the values for dom nodes and
+     * throw and exception if one is found as they should not be synced and may
+     * create cyclic dependencies.
      *
      * @param payload
      *            JsonObject to stringify

--- a/flow-client/src/main/java/com/vaadin/client/communication/AtmospherePushConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/AtmospherePushConnection.java
@@ -25,6 +25,7 @@ import com.vaadin.client.ResourceLoader;
 import com.vaadin.client.ResourceLoader.ResourceLoadEvent;
 import com.vaadin.client.ResourceLoader.ResourceLoadListener;
 import com.vaadin.client.ValueMap;
+import com.vaadin.client.WidgetUtil;
 import com.vaadin.flow.shared.ApplicationConstants;
 import com.vaadin.flow.shared.communication.PushConstants;
 import com.vaadin.flow.shared.util.SharedUtil;
@@ -264,17 +265,18 @@ public class AtmospherePushConnection implements PushConnection {
                     "This server to client push connection should not be used to send client to server messages");
         }
         if (state == State.CONNECTED) {
+            String messageJson = WidgetUtil.stringify(message);
             Console.log("Sending push (" + transport + ") message to server: "
-                    + message.toJson());
+                    + messageJson);
 
             if (transport.equals("websocket")) {
                 FragmentedMessage fragmented = new FragmentedMessage(
-                        message.toJson());
+                        messageJson);
                 while (fragmented.hasNextFragment()) {
                     doPush(socket, fragmented.getNextFragment());
                 }
             } else {
-                doPush(socket, message.toJson());
+                doPush(socket, messageJson);
             }
             return;
         }

--- a/flow-client/src/main/java/com/vaadin/client/communication/XhrConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/XhrConnection.java
@@ -22,6 +22,7 @@ import com.vaadin.client.Console;
 import com.vaadin.client.Profiler;
 import com.vaadin.client.Registry;
 import com.vaadin.client.ValueMap;
+import com.vaadin.client.WidgetUtil;
 import com.vaadin.client.gwt.elemental.js.util.Xhr;
 import com.vaadin.flow.shared.ApplicationConstants;
 import com.vaadin.flow.shared.JsonConstants;
@@ -156,10 +157,11 @@ public class XhrConnection {
         responseHandler.setPayload(payload);
         responseHandler.setRequestStartTime(Profiler.getRelativeTimeMillis());
 
-        XMLHttpRequest xhr = Xhr.post(getUri(), payload.toJson(),
+        String payloadJson = WidgetUtil.stringify(payload);
+        XMLHttpRequest xhr = Xhr.post(getUri(), payloadJson,
                 JsonConstants.JSON_CONTENT_TYPE, responseHandler);
 
-        Console.log("Sending xhr message to server: " + payload.toJson());
+        Console.log("Sending xhr message to server: " + payloadJson);
 
         if (webkitMaybeIgnoringRequests && BrowserInfo.get().isWebkit()) {
             final int retryTimeout = 250;

--- a/flow-client/src/main/java/com/vaadin/client/flow/TreeChangeProcessor.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/TreeChangeProcessor.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.client.flow;
 
+import com.vaadin.client.WidgetUtil;
 import com.vaadin.client.flow.collection.JsArray;
 import com.vaadin.client.flow.collection.JsCollections;
 import com.vaadin.client.flow.collection.JsSet;
@@ -162,7 +163,7 @@ public class TreeChangeProcessor {
             property.setValue(child);
         } else {
             assert false : "Change should have either value or nodeValue property: "
-                    + change.toJson();
+                    + WidgetUtil.stringify(change);
         }
     }
 


### PR DESCRIPTION
This may make it easier to catch problems with components
that for some reason tries to sync dom nodes to the server.
This happened for instance with Tabs where it tried to serialize the
items that contained Tab nodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3560)
<!-- Reviewable:end -->
