### PR TITLE
Support setting and using custom CSS properties through Element.getStyle()

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
@@ -656,11 +656,9 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
         String name = mapProperty.getName();
         CSSStyleDeclaration styleElement = element.getStyle();
         if (mapProperty.hasValue()) {
-            WidgetUtil.setJsProperty(styleElement, name,
-                    mapProperty.getValue());
+            styleElement.setProperty(name, (String) mapProperty.getValue());
         } else {
-            // Can't delete a style property, so just clear the value
-            WidgetUtil.setJsProperty(styleElement, name, null);
+            styleElement.removeProperty(name);
         }
     }
 

--- a/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtBasicElementBinderTest.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtBasicElementBinderTest.java
@@ -646,6 +646,7 @@ public class GwtBasicElementBinderTest extends GwtPropertyElementBinderTest {
     }
 
     public void testAddStylesBeforeBind() {
+        polyfillStyleSetProperty(element);
         node.getMap(NodeFeatures.ELEMENT_STYLE_PROPERTIES).getProperty("color")
                 .setValue("green");
 
@@ -657,6 +658,7 @@ public class GwtBasicElementBinderTest extends GwtPropertyElementBinderTest {
     }
 
     public void testAddStylesAfterBind() {
+        polyfillStyleSetProperty(element);
         Binder.bind(node, element);
         node.getMap(NodeFeatures.ELEMENT_STYLE_PROPERTIES).getProperty("color")
                 .setValue("green");
@@ -666,6 +668,7 @@ public class GwtBasicElementBinderTest extends GwtPropertyElementBinderTest {
     }
 
     public void testRemoveStyles() {
+        polyfillStyleSetProperty(element);
         Binder.bind(node, element);
 
         NodeMap styleMap = node.getMap(NodeFeatures.ELEMENT_STYLE_PROPERTIES);
@@ -673,7 +676,7 @@ public class GwtBasicElementBinderTest extends GwtPropertyElementBinderTest {
         styleMap.getProperty("color").setValue("white");
 
         Reactive.flush();
-        assertEquals("background: blue; color: white;",
+        assertEquals("background: blue;color: white;",
                 element.getAttribute("style"));
 
         styleMap.getProperty("color").removeValue();
@@ -682,7 +685,19 @@ public class GwtBasicElementBinderTest extends GwtPropertyElementBinderTest {
         assertEquals("background: blue;", element.getAttribute("style"));
     }
 
+    private native void polyfillStyleSetProperty(Element element)/*-{
+         // This polyfills just enough to make the tests pass and nothing else
+         element.style.__proto__.setProperty = function(key,value) {
+             var newValue = element.getAttribute("style");
+             if (!newValue) newValue = "";
+             else if (!newValue.endsWith(";")) newValue +=";"
+
+             element.setAttribute("style", newValue + key+": "+value+";");
+         };
+         }-*/;
+
     public void testAddStylesAfterUnbind() {
+        polyfillStyleSetProperty(element);
         Binder.bind(node, element);
 
         NodeMap styleMap = node.getMap(NodeFeatures.ELEMENT_STYLE_PROPERTIES);

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/BasicElementStyle.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/BasicElementStyle.java
@@ -50,7 +50,8 @@ public class BasicElementStyle implements Style {
         String trimmedValue = value.trim();
         ElementUtil.validateStylePropertyValue(trimmedValue);
 
-        propertyMap.setProperty(StyleUtil.styleAttributeToProperty(name), trimmedValue, true);
+        propertyMap.setProperty(StyleUtil.stylePropertyToAttribute(name),
+                trimmedValue, true);
         return this;
     }
 
@@ -58,7 +59,7 @@ public class BasicElementStyle implements Style {
     public Style remove(String name) {
         ElementUtil.validateStylePropertyName(name);
 
-        propertyMap.removeProperty(StyleUtil.styleAttributeToProperty(name));
+        propertyMap.removeProperty(StyleUtil.stylePropertyToAttribute(name));
         return this;
     }
 
@@ -72,7 +73,8 @@ public class BasicElementStyle implements Style {
     public String get(String name) {
         ElementUtil.validateStylePropertyName(name);
 
-        return (String) propertyMap.getProperty(StyleUtil.styleAttributeToProperty(name));
+        return (String) propertyMap
+                .getProperty(StyleUtil.stylePropertyToAttribute(name));
     }
 
     @Override
@@ -82,6 +84,7 @@ public class BasicElementStyle implements Style {
 
     @Override
     public boolean has(String name) {
-        return propertyMap.hasProperty(StyleUtil.styleAttributeToProperty(name));
+        return propertyMap
+                .hasProperty(StyleUtil.stylePropertyToAttribute(name));
     }
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ElementStyleView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ElementStyleView.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+@Route(value = "com.vaadin.flow.uitest.ui.ElementStyleView", layout = ViewTestLayout.class)
+public class ElementStyleView extends AbstractDivView {
+
+    static final String GREEN_BORDER = "4px solid rgb(0, 255, 0)";
+    static final String RED_BORDER = "10px solid rgb(255, 0, 0)";
+
+    @Override
+    protected void onShow() {
+        Element mainElement = getElement();
+        mainElement.getStyle().set("--foo", RED_BORDER);
+
+        Div div = new Div();
+        div.setId("red-border");
+        div.getElement().getStyle().set("border", "var(--foo)");
+        div.setText("Div");
+
+        Div div2 = new Div();
+        div2.setId("green-border");
+        div2.setText("Div 2");
+        div2.getStyle().set("--foo", GREEN_BORDER);
+        div2.getElement().getStyle().set("border", "var(--foo)");
+        add(div, div2);
+
+    }
+
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ElementStyleIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ElementStyleIT.java
@@ -1,0 +1,22 @@
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.html.testbench.DivElement;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class ElementStyleIT extends ChromeBrowserTest {
+
+    @Test
+    public void customPropertiesWork() {
+        open();
+        DivElement red = $(DivElement.class).id("red-border");
+        DivElement green = $(DivElement.class).id("green-border");
+
+        Assert.assertEquals(ElementStyleView.RED_BORDER, executeScript(
+                "return getComputedStyle(arguments[0]).border", red));
+        Assert.assertEquals(ElementStyleView.GREEN_BORDER, executeScript(
+                "return getComputedStyle(arguments[0]).border", green));
+    }
+}


### PR DESCRIPTION
Changes communication to be based on the property name instead of the JS name
as the setProperty method is based on the property name

Removes the GWT unit test as setProperty() apparently does not work in HTMLUnit
even though it should according to the release notes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3563)
<!-- Reviewable:end -->
