### PR TITLE
Only add '/' if base doesn't end with one.

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/BundleFilterInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/BundleFilterInitializer.java
@@ -90,7 +90,10 @@ public class BundleFilterInitializer implements VaadinServiceInitListener {
                 .getSource()).getServlet().getServletContext();
 
         String es6Base = es6ContextPathResolver.resolveVaadinUri(
-                ApplicationConstants.FRONTEND_PROTOCOL_PREFIX) + '/';
+                ApplicationConstants.FRONTEND_PROTOCOL_PREFIX);
+        if(!es6Base.endsWith("/")) {
+            es6Base += '/';
+        }
         String bundleManifestContextPath = es6Base + FLOW_BUNDLE_MANIFEST;
         try (InputStream bundleManifestStream = servletContext
                 .getResourceAsStream(bundleManifestContextPath)) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/BundleFilterInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/BundleFilterInitializerTest.java
@@ -93,7 +93,7 @@ public class BundleFilterInitializerTest {
         Mockito.doAnswer(invocation -> {
             return inputStreamProducer
                     .apply(invocation.getArgumentAt(0, String.class));
-        }).when(context).getResourceAsStream(Mockito.anyString());
+        }).when(context).getResourceAsStream("/frontend-es6/vaadin-flow-bundle-manifest.json");
         Mockito.doAnswer(invocation -> {
             return resourceProducer
                     .apply(invocation.getArgumentAt(0, String.class));


### PR DESCRIPTION
Tests now require exact match for the requested resource
and fail if it is wrong.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3567)
<!-- Reviewable:end -->
