### PR TITLE
Fix web jar resource handling in WebJarServer

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/webjar/WebJarServer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webjar/WebJarServer.java
@@ -94,9 +94,7 @@ public class WebJarServer implements Serializable {
      */
     public boolean tryServeWebJarResource(HttpServletRequest request,
             HttpServletResponse response) throws IOException {
-        String pathInContext = request.getServletPath() + request.getPathInfo();
-
-        String webJarPath = getWebJarPath(pathInContext);
+        String webJarPath = getWebJarPath(request.getPathInfo());
         if (webJarPath == null) {
             return false;
         }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/servlet/WebJarsServlet.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/servlet/WebJarsServlet.java
@@ -24,7 +24,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import com.vaadin.flow.server.VaadinServlet;
 
-@WebServlet("/frontend/*")
+@WebServlet("/*")
 public class WebJarsServlet extends VaadinServlet {
     @Override
     protected void service(HttpServletRequest request,

--- a/flow-tests/test-subcontext/pom.xml
+++ b/flow-tests/test-subcontext/pom.xml
@@ -25,6 +25,12 @@
             <artifactId>flow-test-resources</artifactId>
             <version>${project.version}</version>
         </dependency>
+        
+        <dependency>
+            <groupId>org.webjars.bowergithub.polymerelements</groupId>
+            <artifactId>paper-slider</artifactId>
+            <version>2.0.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/flow-tests/test-subcontext/src/main/java/com/vaadin/flow/contexttest/ui/FrontendServlet.java
+++ b/flow-tests/test-subcontext/src/main/java/com/vaadin/flow/contexttest/ui/FrontendServlet.java
@@ -17,27 +17,12 @@ package com.vaadin.flow.contexttest.ui;
 
 import javax.servlet.annotation.WebServlet;
 
-import com.vaadin.flow.dom.ElementFactory;
-import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinServlet;
 import com.vaadin.flow.server.VaadinServletConfiguration;
 
-public class RootContextUI extends DependencyUI {
-
-    /**
-     * The main servlet for the application.
-     */
-    @WebServlet(urlPatterns = {
-            "/*" }, name = "UIServlet", asyncSupported = true)
-    @VaadinServletConfiguration(ui = RootContextUI.class, productionMode = false, usingNewRouting = false)
-    public static class Servlet extends VaadinServlet {
-    }
-
-    @Override
-    protected void init(VaadinRequest request) {
-        getElement().appendChild(ElementFactory.createDiv("Root Context UI")
-                .setAttribute("id", "root"));
-        super.init(request);
-    }
+@WebServlet(urlPatterns = {
+        "/frontend-resource/*" }, name = "FrontendServlet", asyncSupported = true)
+@VaadinServletConfiguration(productionMode = false)
+public class FrontendServlet extends VaadinServlet {
 
 }

--- a/flow-tests/test-subcontext/src/main/java/com/vaadin/flow/contexttest/ui/PaperSlider.java
+++ b/flow-tests/test-subcontext/src/main/java/com/vaadin/flow/contexttest/ui/PaperSlider.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.contexttest.ui;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.DomEvent;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.HtmlImport;
+import com.vaadin.flow.router.Route;
+
+@Tag("paper-slider")
+@HtmlImport("context://frontend-resource/frontend/bower_components/paper-slider/paper-slider.html")
+@Route("slider")
+public class PaperSlider extends Component {
+    @DomEvent("value-change")
+    public static class ValueChangeEvent extends ComponentEvent<PaperSlider> {
+        public ValueChangeEvent(PaperSlider source, boolean fromClient) {
+            super(source, fromClient);
+        }
+    }
+
+    public PaperSlider() {
+        getElement().synchronizeProperty("value", "value-change");
+    }
+
+}

--- a/flow-tests/test-subcontext/src/main/java/com/vaadin/flow/contexttest/ui/SubContextUI.java
+++ b/flow-tests/test-subcontext/src/main/java/com/vaadin/flow/contexttest/ui/SubContextUI.java
@@ -14,7 +14,7 @@ public class SubContextUI extends DependencyUI {
      */
     @WebServlet(urlPatterns = {
             "/SubContext/*" }, name = "AnotherServlet", asyncSupported = true)
-    @VaadinServletConfiguration(ui = SubContextUI.class, productionMode = false)
+    @VaadinServletConfiguration(ui = SubContextUI.class, productionMode = false, usingNewRouting = false)
     public static class SubContextServlet extends VaadinServlet {
     }
 

--- a/flow-tests/test-subcontext/src/main/java/com/vaadin/flow/contexttest/ui/TemplateComponent.java
+++ b/flow-tests/test-subcontext/src/main/java/com/vaadin/flow/contexttest/ui/TemplateComponent.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.contexttest.ui;
+
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.HtmlImport;
+import com.vaadin.flow.component.polymertemplate.PolymerTemplate;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.templatemodel.TemplateModel;
+
+@Route("template")
+@HtmlImport("context://frontend-resource/frontend/frontend-template.html")
+@Tag("frontend-template")
+public class TemplateComponent extends PolymerTemplate<TemplateModel> {
+
+}

--- a/flow-tests/test-subcontext/src/main/webapp/frontend-resource/frontend/frontend-template.html
+++ b/flow-tests/test-subcontext/src/main/webapp/frontend-resource/frontend/frontend-template.html
@@ -1,0 +1,32 @@
+<!--
+  ~ Copyright 2000-2017 Vaadin Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+<!-- Using an absolute URL is a bad practice, but the nesting depth here makes it incovenient traverse up with ../.. -->
+<link rel="import" href="bower_components/polymer/polymer-element.html">
+
+<dom-module id="frontend-template">
+    <template>
+      <div id='template-element'>Template</div>
+    </template>
+
+    <script>
+        class FrontendTemplate extends Polymer.Element {
+            static get is() {
+                return 'frontend-template'
+            }
+        }
+        customElements.define(FrontendTemplate.is, FrontendTemplate);
+    </script>
+</dom-module>

--- a/flow-tests/test-subcontext/src/test/java/com/vaadin/flow/contexttest/ui/FrontendMappingIT.java
+++ b/flow-tests/test-subcontext/src/test/java/com/vaadin/flow/contexttest/ui/FrontendMappingIT.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.contexttest.ui;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class FrontendMappingIT extends ChromeBrowserTest {
+
+    @Override
+    protected String getTestPath() {
+        return "/context/frontend-resource/";
+    }
+
+    @Test
+    public void customTemplate_contextWithMapping() {
+        getDriver().get(getTestURL(getRootURL(), getTestPath() + "template",
+                new String[0]));
+
+        assertTemplate("frontend-template", "template-element");
+
+        Set<String> hrefs = getHrefs();
+        assertTrue(hrefs.contains(
+                "/context/frontend-resource/frontend/frontend-template.html"));
+        assertTrue(hrefs.contains(
+                "/context/frontend-resource/frontend/bower_components/polymer/polymer-element.html"));
+    }
+
+    @Test
+    public void webComponent_contextWithMapping() {
+        getDriver().get(getTestURL(getRootURL(), getTestPath() + "slider",
+                new String[0]));
+
+        assertTemplate("paper-slider", "sliderContainer");
+
+        Set<String> hrefs = getHrefs();
+        assertTrue(hrefs.contains(
+                "/context/frontend-resource/frontend/bower_components/paper-slider/paper-slider.html"));
+    }
+
+    private void assertTemplate(String templateTag, String nestedElementId) {
+        WebElement template = findElement(By.tagName(templateTag));
+        assertTrue(isPresentInShadowRoot(template, By.id(nestedElementId)));
+    }
+
+    private Set<String> getHrefs() {
+        return findElements(By.tagName("link")).stream()
+                .filter(link -> "import".equals(link.getAttribute("rel")))
+                .map(link -> link.getAttribute("href"))
+                .filter(href -> href.startsWith(getRootURL()))
+                .map(href -> href.substring(getRootURL().length()))
+                .collect(Collectors.toSet());
+    }
+}


### PR DESCRIPTION
This fix is related to #3301 but doesn't fix it.

With the previous code it's impossible to handle web jars by the same vaadin servlet if it has non-root mapping. One has add special additional vaadin servlet which handles web jar URLs separately.
With this patch it becomes possible to handle web jars by the same servlet. It's still possible to have a dedicated servlet for web jars in addition to the application servlet.

This PR contains changes for `WebJarsServlet` which is used in our root context test to handle web jar URLs. IT has been mapped to `/frontend/*`  and now it's mapped to `/*`. It still handles web jar URLs.

The examples how it works now are in the code below.

Servlet
```
@WebServlet(urlPatterns = {"/frontend-resource/*" })
@VaadinServletConfiguration(productionMode = false)
public class FrontendServlet extends VaadinServlet {
```
Custom template may be done in this way:
```
@HtmlImport("frontend-template.html")
@Tag("frontend-template")
public class TemplateComponent extends PolymerTemplate<TemplateModel> {
```
But in this case html import refers to the URI `context://frontend/frontend-template.html` which after the resolution will be smth like `"http://server.com/frontend/frontend-template.html"`.
And this URL cannot be handled by the `FrontendServlet`  because it's mapped to the `"http://server.com/frontend-resource"`.

But now there  is a way to have HTML import in the way:
```
@HtmlImport("context://frontend-resource/frontend/frontend-template.html")
public class TemplateComponent extends PolymerTemplate<TemplateModel> {
```
It will also require to put `frontend-template.html` into `src/main/webapp/frontend-resource/frontend/frontend-template.html` (not `src/main/webapp/resource/frontend/frontend-template.html`) .

But now `FrontendServlet` is able to handle this URI by itself without additional servlet.

The same thing with the existing web component:
```
@Tag("paper-slider")
@HtmlImport("context://frontend-resource/frontend/bower_components/paper-slider/paper-slider.html")
@Route("slider")
public class PaperSlider extends Component {
```

But we still cannot handle properly Vaadin components since they are using generated HTMLImport:
```
@HtmlImport("frontend://bower_components/vaadin-text-field/src/vaadin-text-field.html")
public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextField<R>>
```
which is never handled by the servlet itself.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3590)
<!-- Reviewable:end -->
