### PR TITLE
The communicator now destroys all the data on the generators when reset

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -139,7 +139,8 @@ public class DataCommunicator<T> {
      */
     public void reset() {
         resendEntireRange = true;
-
+        dataGenerator.destroyAllData();
+        updatedData.clear();
         requestFlush();
     }
 


### PR DESCRIPTION
This fix is needed for the ComponentDataGenerator to create new components after the DataProvider/Communicator is reset.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3596)
<!-- Reviewable:end -->
