### PR TITLE
Add a context object to beforeClientResponse calls

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -32,6 +32,7 @@ import java.util.stream.Stream;
 import com.vaadin.flow.data.provider.ArrayUpdater.Update;
 import com.vaadin.flow.data.provider.DataChangeEvent.DataRefreshEvent;
 import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.internal.ExecutionContext;
 import com.vaadin.flow.internal.JsonUtils;
 import com.vaadin.flow.internal.Range;
 import com.vaadin.flow.internal.StateNode;
@@ -89,8 +90,8 @@ public class DataCommunicator<T> {
     private Registration dataProviderUpdateRegistration;
     private Set<T> updatedData = new HashSet<>();
 
-    private Runnable flushRequest;
-    private Runnable flushUpdatedDataRequest;
+    private SerializableConsumer<ExecutionContext> flushRequest;
+    private SerializableConsumer<ExecutionContext> flushUpdatedDataRequest;
 
     /**
      * Creates a new instance.
@@ -337,7 +338,7 @@ public class DataCommunicator<T> {
 
     private void requestFlush() {
         if (flushRequest == null) {
-            flushRequest = () -> {
+            flushRequest = context -> {
                 flush();
                 flushRequest = null;
             };
@@ -348,7 +349,7 @@ public class DataCommunicator<T> {
 
     private void requestFlushUpdatedData() {
         if (flushUpdatedDataRequest == null) {
-            flushUpdatedDataRequest = () -> {
+            flushUpdatedDataRequest = context -> {
                 flushUpdatedData();
                 flushUpdatedDataRequest = null;
             };

--- a/flow-data/src/main/java/com/vaadin/flow/data/renderer/BasicRenderer.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/renderer/BasicRenderer.java
@@ -82,7 +82,7 @@ public abstract class BasicRenderer<SOURCE, TARGET>
         owner.getNode()
                 .runWhenAttached(ui -> ui.getInternals().getStateTree()
                         .beforeClientResponse(owner.getNode(),
-                                () -> setupTemplateWhenAttached(owner,
+                                context -> setupTemplateWhenAttached(owner,
                                         rendering, keyMapper)));
     }
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/renderer/ComponentRenderer.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/renderer/ComponentRenderer.java
@@ -129,8 +129,9 @@ public class ComponentRenderer<COMPONENT extends Component, SOURCE>
         container.getNode()
                 .runWhenAttached(ui -> ui.getInternals().getStateTree()
                         .beforeClientResponse(container.getNode(),
-                                () -> setupTemplateWhenAttached(ui, container,
-                                        rendering, keyMapper)));
+                                context -> setupTemplateWhenAttached(
+                                        context.getUI(), container, rendering,
+                                        keyMapper)));
 
         return rendering;
     }

--- a/flow-data/src/main/java/com/vaadin/flow/data/renderer/RendererUtil.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/renderer/RendererUtil.java
@@ -75,19 +75,20 @@ public class RendererUtil {
              * the template element must have the "__dataHost" property set with
              * the column element.
              */
-            templateDataHost.getNode()
-                    .runWhenAttached(ui -> ui.getInternals().getStateTree()
-                            .beforeClientResponse(templateDataHost.getNode(),
-                                    () -> processTemplateRendererEventHandlers(
-                                            ui, templateDataHost, eventHandlers,
-                                            keyMapper)));
+            templateDataHost.getNode().runWhenAttached(
+                    ui -> ui.getInternals().getStateTree().beforeClientResponse(
+                            templateDataHost.getNode(),
+                            context -> processTemplateRendererEventHandlers(
+                                    context.getUI(), templateDataHost,
+                                    eventHandlers, keyMapper)));
 
             contentTemplate.getNode().runWhenAttached(
                     ui -> ui.getInternals().getStateTree().beforeClientResponse(
                             templateDataHost.getNode(),
-                            () -> ui.getPage().executeJavaScript(
-                                    "$0.__dataHost = $1;", contentTemplate,
-                                    templateDataHost)));
+                            context -> context.getUI().getPage()
+                                    .executeJavaScript("$0.__dataHost = $1;",
+                                            contentTemplate,
+                                            templateDataHost)));
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -750,7 +750,7 @@ public class UI extends Component
      * before the next response.
      * <p>
      * The task receives a {@link ExecutionContext} as parameter, which contains
-     * information about the component state during the server roundtrip.
+     * information about the component state before the response.
      *
      * @param component
      *            the Component relevant for the execution. Can not be

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -745,19 +745,22 @@ public class UI extends Component
      * where {@code B} produces two more tasks during execution, {@code D} and
      * {@code E}. The resulting execution would be {@code ABCDE}.
      * <p>
-     * If the {@link Component} related to the runnable is not attached to the
-     * document by the time the runnable is evaluated, the execution is
-     * postponed to before the next response.
+     * If the {@link Component} related to the task is not attached to the
+     * document by the time the task is evaluated, the execution is postponed to
+     * before the next response.
+     * <p>
+     * The task receives a {@link ExecutionContext} as parameter, which contains
+     * information about the component state during the server roundtrip.
      *
      * @param component
      *            the Component relevant for the execution. Can not be
      *            <code>null</code>
      *
      * @param execution
-     *            the Runnable to be executed. Can not be <code>null</code>
+     *            the task to be executed. Can not be <code>null</code>
      *
      * @return a registration that can be used to cancel the execution of the
-     *         runnable
+     *         task
      */
     public ExecutionRegistration beforeClientResponse(Component component,
             SerializableConsumer<ExecutionContext> execution) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -28,7 +28,9 @@ import com.vaadin.flow.component.internal.UIInternals;
 import com.vaadin.flow.component.page.LoadingIndicatorConfiguration;
 import com.vaadin.flow.component.page.Page;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.CurrentInstance;
+import com.vaadin.flow.internal.ExecutionContext;
 import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.internal.StateTree.ExecutionRegistration;
 import com.vaadin.flow.internal.nodefeature.ElementData;
@@ -734,10 +736,10 @@ public class UI extends Component
     }
 
     /**
-     * Registers a {@link Runnable} to be executed before the response is sent
-     * to the client. The runnables are executed in order of registration. If
-     * runnables register more runnables, they are executed after all already
-     * registered executions for the moment.
+     * Registers a task to be executed before the response is sent to the
+     * client. The tasks are executed in order of registration. If tasks
+     * register more tasks, they are executed after all already registered tasks
+     * for the moment.
      * <p>
      * Example: three tasks are submitted, {@code A}, {@code B} and {@code C},
      * where {@code B} produces two more tasks during execution, {@code D} and
@@ -758,7 +760,7 @@ public class UI extends Component
      *         runnable
      */
     public ExecutionRegistration beforeClientResponse(Component component,
-            Runnable execution) {
+            SerializableConsumer<ExecutionContext> execution) {
 
         if (component == null) {
             throw new IllegalArgumentException(

--- a/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/PolymerTemplate.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/PolymerTemplate.java
@@ -210,7 +210,7 @@ public abstract class PolymerTemplate<M extends TemplateModel>
         // which properties needs update to the server
         getStateNode().runWhenAttached(ui -> ui.getInternals().getStateTree()
                 .beforeClientResponse(getStateNode(),
-                        () -> ui.getPage().executeJavaScript(
+                        context -> context.getUI().getPage().executeJavaScript(
                                 "this.registerUpdatableModelProperties($0, $1)",
                                 getElement(),
                                 filterUpdatableProperties(allowedProperties))));
@@ -227,7 +227,7 @@ public abstract class PolymerTemplate<M extends TemplateModel>
          */
         getStateNode().runWhenAttached(ui -> ui.getInternals().getStateTree()
                 .beforeClientResponse(getStateNode(),
-                        () -> ui.getPage().executeJavaScript(
+                        context -> context.getUI().getPage().executeJavaScript(
                                 "this.populateModelProperties($0, $1)",
                                 getElement(),
                                 filterUnsetProperties(propertyNames))));

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -1372,19 +1372,20 @@ public class Element extends Node<Element> {
 
     private void doCallFunction(UI ui, String functionName,
             Serializable... arguments) {
-        ui.getInternals().getStateTree().beforeClientResponse(getNode(), () -> {
-            // $0.method($1,$2,$3)
-            String paramPlaceholderString = IntStream
-                    .range(1, arguments.length + 1).mapToObj(i -> "$" + i)
-                    .collect(Collectors.joining(","));
-            Serializable[] jsParameters = Stream
-                    .concat(Stream.of(this), Stream.of(arguments))
-                    .toArray(Serializable[]::new);
+        ui.getInternals().getStateTree().beforeClientResponse(getNode(),
+                context -> {
+                    // $0.method($1,$2,$3)
+                    String paramPlaceholderString = IntStream
+                            .range(1, arguments.length + 1)
+                            .mapToObj(i -> "$" + i)
+                            .collect(Collectors.joining(","));
+                    Serializable[] jsParameters = Stream
+                            .concat(Stream.of(this), Stream.of(arguments))
+                            .toArray(Serializable[]::new);
 
-            ui.getPage().executeJavaScript(
-                    "$0." + functionName + "(" + paramPlaceholderString + ")",
-                    jsParameters);
-        });
+                    ui.getPage().executeJavaScript("$0." + functionName + "("
+                            + paramPlaceholderString + ")", jsParameters);
+                });
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/AbstractNodeStateProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/AbstractNodeStateProvider.java
@@ -136,7 +136,7 @@ public abstract class AbstractNodeStateProvider
                 .createStateNode(tagName);
 
         node.runWhenAttached(ui -> ui.getInternals().getStateTree()
-                .beforeClientResponse(node, () -> {
+                .beforeClientResponse(node, context -> {
                     node.getFeature(AttachExistingElementFeature.class)
                             .register(getNode(node), previousSibling,
                                     proposedNode, callback);

--- a/flow-server/src/main/java/com/vaadin/flow/internal/ExecutionContext.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/ExecutionContext.java
@@ -20,8 +20,9 @@ import java.io.Serializable;
 import com.vaadin.flow.component.UI;
 
 /**
- * Class that holds the context of a callback execution of a call to
- * {@link UI#beforeClientResponse(com.vaadin.flow.component.Component, com.vaadin.flow.function.SerializableConsumer)}.
+ * Represents the context of a callback execution when
+ * {@link UI#beforeClientResponse(com.vaadin.flow.component.Component, com.vaadin.flow.function.SerializableConsumer)}
+ * is invoked.
  * 
  * @author Vaadin Ltd.
  *
@@ -29,22 +30,22 @@ import com.vaadin.flow.component.UI;
 public class ExecutionContext implements Serializable {
 
     private final UI ui;
-    private final boolean wasAttached;
+    private final boolean wasAttachedInPreviousRoundtrip;
 
     /**
      * Creates a new, immutable context.
      * 
      * @param ui
      *            The UI associated with the execution
-     * @param wasAttached
-     *            <code>true</code> when the node associated with the execution
-     *            was attached to the tree before the request was processed,
-     *            <code>false</code> otherwise.
+     * @param wasAttachedInPreviousRoundtrip
+     *            <code>true</code> if the node was previously attached when the
+     *            roundtrip started, and <code>false</code> when the node was
+     *            attached during the current roundtrip
      */
-    public ExecutionContext(UI ui, boolean wasAttached) {
+    public ExecutionContext(UI ui, boolean wasAttachedInPreviousRoundtrip) {
         assert ui != null;
         this.ui = ui;
-        this.wasAttached = wasAttached;
+        this.wasAttachedInPreviousRoundtrip = wasAttachedInPreviousRoundtrip;
     }
 
     /**
@@ -57,15 +58,15 @@ public class ExecutionContext implements Serializable {
     }
 
     /**
-     * Gets the attached status of the node associated with the execution when
-     * the request was first received by the server.
+     * Gets whether the node associated to the execution was attached to the
+     * tree when the server roundtrip was started.
      * 
-     * @return <code>true</code> when the node associated with the execution was
-     *         attached to the tree before the request was processed,
-     *         <code>false</code> otherwise.
+     * @return <code>true</code> if the node was previously attached when the
+     *         roundtrip started, and <code>false</code> when the node was
+     *         attached during the current roundtrip
      */
-    public boolean wasAttached() {
-        return wasAttached;
+    public boolean wasAttachedInPreviousRoundtrip() {
+        return wasAttachedInPreviousRoundtrip;
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/ExecutionContext.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/ExecutionContext.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.internal;
+
+import java.io.Serializable;
+
+import com.vaadin.flow.component.UI;
+
+/**
+ * Class that holds the context of a callback execution of a call to
+ * {@link UI#beforeClientResponse(com.vaadin.flow.component.Component, com.vaadin.flow.function.SerializableConsumer)}.
+ * 
+ * @author Vaadin Ltd.
+ *
+ */
+public class ExecutionContext implements Serializable {
+
+    private final UI ui;
+    private final boolean wasAttached;
+
+    /**
+     * Creates a new, immutable context.
+     * 
+     * @param ui
+     *            The UI associated with the execution
+     * @param wasAttached
+     *            <code>true</code> when the node associated with the execution
+     *            was attached to the tree before the request was processed,
+     *            <code>false</code> otherwise.
+     */
+    public ExecutionContext(UI ui, boolean wasAttached) {
+        assert ui != null;
+        this.ui = ui;
+        this.wasAttached = wasAttached;
+    }
+
+    /**
+     * Gets the UI associated with the execution.
+     * 
+     * @return the UI, not <code>null</code>
+     */
+    public UI getUI() {
+        return ui;
+    }
+
+    /**
+     * Gets the attached status of the node associated with the execution when
+     * the request was first received by the server.
+     * 
+     * @return <code>true</code> when the node associated with the execution was
+     *         attached to the tree before the request was processed,
+     *         <code>false</code> otherwise.
+     */
+    public boolean wasAttached() {
+        return wasAttached;
+    }
+
+}

--- a/flow-server/src/main/java/com/vaadin/flow/internal/ExecutionContext.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/ExecutionContext.java
@@ -20,7 +20,7 @@ import java.io.Serializable;
 import com.vaadin.flow.component.UI;
 
 /**
- * Represents the context of a callback execution when
+ * Context of a callback execution when
  * {@link UI#beforeClientResponse(com.vaadin.flow.component.Component, com.vaadin.flow.function.SerializableConsumer)}
  * is invoked.
  * 
@@ -30,22 +30,22 @@ import com.vaadin.flow.component.UI;
 public class ExecutionContext implements Serializable {
 
     private final UI ui;
-    private final boolean wasAttachedInPreviousRoundtrip;
+    private final boolean initializingClientSide;
 
     /**
      * Creates a new, immutable context.
      * 
      * @param ui
      *            The UI associated with the execution
-     * @param wasAttachedInPreviousRoundtrip
-     *            <code>true</code> if the node was previously attached when the
-     *            roundtrip started, and <code>false</code> when the node was
-     *            attached during the current roundtrip
+     * @param initializingClientSide
+     *            <code>true</code> if the client side is being initialized as
+     *            part of the response (ie. when a node is first attached),
+     *            <code>false</code> otherwise
      */
-    public ExecutionContext(UI ui, boolean wasAttachedInPreviousRoundtrip) {
+    public ExecutionContext(UI ui, boolean initializingClientSide) {
         assert ui != null;
         this.ui = ui;
-        this.wasAttachedInPreviousRoundtrip = wasAttachedInPreviousRoundtrip;
+        this.initializingClientSide = initializingClientSide;
     }
 
     /**
@@ -58,15 +58,15 @@ public class ExecutionContext implements Serializable {
     }
 
     /**
-     * Gets whether the node associated to the execution was attached to the
-     * tree when the server roundtrip was started.
+     * Gets whether the client side is being initialized as part of the server
+     * response.
      * 
-     * @return <code>true</code> if the node was previously attached when the
-     *         roundtrip started, and <code>false</code> when the node was
-     *         attached during the current roundtrip
+     * @return <code>true</code> if the client side is being initialized as part
+     *         of the response (ie. when a node is first attached),
+     *         <code>false</code> otherwise
      */
-    public boolean wasAttachedInPreviousRoundtrip() {
-        return wasAttachedInPreviousRoundtrip;
+    public boolean isInitializingClientSide() {
+        return initializingClientSide;
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/ExecutionContext.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/ExecutionContext.java
@@ -30,22 +30,22 @@ import com.vaadin.flow.component.UI;
 public class ExecutionContext implements Serializable {
 
     private final UI ui;
-    private final boolean initializingClientSide;
+    private final boolean clientSideInitialized;
 
     /**
      * Creates a new, immutable context.
      * 
      * @param ui
      *            The UI associated with the execution
-     * @param initializingClientSide
-     *            <code>true</code> if the client side is being initialized as
-     *            part of the response (ie. when a node is first attached),
-     *            <code>false</code> otherwise
+     * @param clientSideInitialized
+     *            <code>true</code> if the client side is already initialized,
+     *            <code>false</code> if it is being initialized as part of the
+     *            current response
      */
-    public ExecutionContext(UI ui, boolean initializingClientSide) {
+    public ExecutionContext(UI ui, boolean clientSideInitialized) {
         assert ui != null;
         this.ui = ui;
-        this.initializingClientSide = initializingClientSide;
+        this.clientSideInitialized = clientSideInitialized;
     }
 
     /**
@@ -61,12 +61,12 @@ public class ExecutionContext implements Serializable {
      * Gets whether the client side is being initialized as part of the server
      * response.
      * 
-     * @return <code>true</code> if the client side is being initialized as part
-     *         of the response (ie. when a node is first attached),
-     *         <code>false</code> otherwise
+     * @return <code>true</code> if the client side is already initialized,
+     *         <code>false</code> if it is being initialized as part of the
+     *         current response
      */
-    public boolean isInitializingClientSide() {
-        return initializingClientSide;
+    public boolean isClientSideInitialized() {
+        return clientSideInitialized;
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
@@ -342,7 +342,7 @@ public class StateNode implements Serializable {
      * @return <code>true</code> if the node has a initialized client side and
      *         <code>false</code> if the client side is not initialized yet
      */
-    boolean hasInitializedClientSide() {
+    boolean isClientSideInitialized() {
         return wasAttached;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
@@ -333,6 +333,14 @@ public class StateNode implements Serializable {
         return parent != null && parent.isAttached();
     }
 
+    /*
+     * Used internally by the state tree when processing beforeClientResponse
+     * callbacks.
+     */
+    boolean wasAttached() {
+        return wasAttached;
+    }
+
     /**
      * Collects all changes made to this node since the last time
      * {@link #collectChanges(Consumer)} has been called. If the node is

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
@@ -333,11 +333,18 @@ public class StateNode implements Serializable {
         return parent != null && parent.isAttached();
     }
 
-    /*
-     * Used internally by the state tree when processing beforeClientResponse
-     * callbacks.
+    /**
+     * Gets whether this node was attached to the tree when the server roundtrip
+     * was started.
+     * <p>
+     * This is used internally by the state tree when processing
+     * beforeClientResponse callbacks.
+     * 
+     * @return <code>true</code> if the node was previously attached when the
+     *         roundtrip started, and <code>false</code> when the node was
+     *         attached during the current roundtrip
      */
-    boolean wasAttached() {
+    boolean wasAttachedInPreviousRoundtrip() {
         return wasAttached;
     }
 
@@ -737,7 +744,8 @@ public class StateNode implements Serializable {
     /**
      * Checks whether there are pending executions for this node.
      *
-     * @see StateTree#beforeClientResponse(StateNode, Runnable)
+     * @see StateTree#beforeClientResponse(StateNode,
+     *      com.vaadin.flow.function.SerializableConsumer)
      *
      * @return <code>true</code> if there are pending executions, otherwise
      *         <code>false</code>
@@ -750,7 +758,8 @@ public class StateNode implements Serializable {
      * Gets the current list of pending execution entries for this node and
      * clears the current list.
      *
-     * @see StateTree#beforeClientResponse(StateNode, Runnable)
+     * @see StateTree#beforeClientResponse(StateNode,
+     *      com.vaadin.flow.function.SerializableConsumer)
      *
      * @return the current list of entries, or and empty list if there are no
      *         entries
@@ -766,8 +775,8 @@ public class StateNode implements Serializable {
     /**
      * Adds an entry to be executed before the next client response for this
      * node. Entries should always be created through
-     * {@link StateTree#beforeClientResponse(StateNode, Runnable)} to ensure
-     * proper ordering.
+     * {@link StateTree#beforeClientResponse(StateNode, com.vaadin.flow.function.SerializableConsumer)}
+     * to ensure proper ordering.
      *
      * @param entry
      *            the entry to add, not <code>null</code>

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
@@ -334,17 +334,15 @@ public class StateNode implements Serializable {
     }
 
     /**
-     * Gets whether this node was attached to the tree when the server roundtrip
-     * was started.
+     * Gets whether the client side has been initialized for this node.
      * <p>
      * This is used internally by the state tree when processing
      * beforeClientResponse callbacks.
      * 
-     * @return <code>true</code> if the node was previously attached when the
-     *         roundtrip started, and <code>false</code> when the node was
-     *         attached during the current roundtrip
+     * @return <code>true</code> if the node has a initialized client side and
+     *         <code>false</code> if the client side is not initialized yet
      */
-    boolean wasAttachedInPreviousRoundtrip() {
+    boolean hasInitializedClientSide() {
         return wasAttached;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateTree.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateTree.java
@@ -331,7 +331,7 @@ public class StateTree implements NodeOwner {
             }
             callbacks.forEach(entry -> {
                 ExecutionContext context = new ExecutionContext(getUI(),
-                        !entry.getStateNode().hasInitializedClientSide());
+                        entry.getStateNode().isClientSideInitialized());
                 entry.getExecution().accept(context);
             });
         }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateTree.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateTree.java
@@ -278,26 +278,29 @@ public class StateTree implements NodeOwner {
     }
 
     /**
-     * Registers a {@link Runnable} to be executed before the response is sent
-     * to the client. The runnables are executed in order of registration. If
-     * runnables register more runnables, they are executed after all already
-     * registered executions for the moment.
+     * Registers a task to be executed before the response is sent to the
+     * client. The tasks are executed in order of registration. If tasks
+     * register more tasks, they are executed after all already registered tasks
+     * for the moment.
      * <p>
      * Example: three tasks are submitted, {@code A}, {@code B} and {@code C},
      * where {@code B} produces two more tasks during execution, {@code D} and
      * {@code E}. The resulting execution would be {@code ABCDE}.
      * <p>
-     * If the {@link StateNode} related to the runnable is not attached to the
-     * document by the time the runnable is evaluated, the execution is
-     * postponed to before the next response.
+     * If the {@link StateNode} related to the task is not attached to the
+     * document by the time the task is evaluated, the execution is postponed to
+     * before the next response.
+     * <p>
+     * The task receives a {@link ExecutionContext} as parameter, which contains
+     * information about the node state during the server roundtrip.
      *
      * @param context
      *            the StateNode relevant for the execution. Can not be
      *            <code>null</code>
      * @param execution
-     *            the Runnable to be executed. Can not be <code>null</code>
+     *            the task to be executed. Can not be <code>null</code>
      * @return a registration that can be used to cancel the execution of the
-     *         runnable
+     *         task
      */
     public ExecutionRegistration beforeClientResponse(StateNode context,
             SerializableConsumer<ExecutionContext> execution) {
@@ -328,7 +331,7 @@ public class StateTree implements NodeOwner {
             }
             callbacks.forEach(entry -> {
                 ExecutionContext context = new ExecutionContext(getUI(),
-                        entry.getStateNode().wasAttached());
+                        entry.getStateNode().wasAttachedInPreviousRoundtrip());
                 entry.getExecution().accept(context);
             });
         }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateTree.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateTree.java
@@ -292,7 +292,7 @@ public class StateTree implements NodeOwner {
      * before the next response.
      * <p>
      * The task receives a {@link ExecutionContext} as parameter, which contains
-     * information about the node state during the server roundtrip.
+     * information about the node state before the response.
      *
      * @param context
      *            the StateNode relevant for the execution. Can not be
@@ -331,7 +331,7 @@ public class StateTree implements NodeOwner {
             }
             callbacks.forEach(entry -> {
                 ExecutionContext context = new ExecutionContext(getUI(),
-                        entry.getStateNode().wasAttachedInPreviousRoundtrip());
+                        !entry.getStateNode().hasInitializedClientSide());
                 entry.getExecution().accept(context);
             });
         }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateTree.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateTree.java
@@ -66,14 +66,14 @@ public class StateTree implements NodeOwner {
     }
 
     /**
-     * A {@link Runnable} to be executed before the client response, together
-     * with an execution sequence number.
+     * A task to be executed before the client response, together with an
+     * execution sequence number and context object.
      * <p>
      * While of this class are stored inside individual state nodes, code
      * outside {@link StateTree} should treat the those as opaque values.
      *
-     * @see StateTree#beforeClientResponse(StateNode, Runnable) See
-     *      {@link StateTree#runExecutionsBeforeClientResponse()}
+     * @see StateTree#beforeClientResponse(StateNode, SerializableConsumer)
+     * @see StateTree#runExecutionsBeforeClientResponse()
      */
     public static final class BeforeClientResponseEntry {
         private static final Comparator<BeforeClientResponseEntry> COMPARING_INDEX = Comparator
@@ -104,13 +104,13 @@ public class StateTree implements NodeOwner {
     }
 
     /**
-     * A registration object for removing a runnable registered for execution
-     * before the client response.
+     * A registration object for removing a task registered for execution before
+     * the client response.
      */
     @FunctionalInterface
     public interface ExecutionRegistration extends Registration {
         /**
-         * Removes the associated runnable from the execution queue.
+         * Removes the associated task from the execution queue.
          */
         @Override
         void remove();
@@ -319,8 +319,8 @@ public class StateTree implements NodeOwner {
 
     /**
      * Called internally by the framework before the response is sent to the
-     * client. All runnables registered at
-     * {@link #beforeClientResponse(StateNode, SerializableConsumer) are
+     * client. All tasks registered at
+     * {@link #beforeClientResponse(StateNode, SerializableConsumer)} are
      * evaluated and executed if able.
      */
     public void runExecutionsBeforeClientResponse() {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlWriter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlWriter.java
@@ -16,6 +16,8 @@
 
 package com.vaadin.flow.server.communication;
 
+import javax.servlet.http.HttpServletRequest;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -37,8 +39,6 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import javax.servlet.http.HttpServletRequest;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -287,9 +287,9 @@ public class UidlWriter implements Serializable {
     }
 
     /**
-     * Encodes the state tree changes of the given UI. The runnables registered
+     * Encodes the state tree changes of the given UI. The executions registered
      * at
-     * {@link StateTree#beforeClientResponse(com.vaadin.flow.internal.StateNode, Runnable)}
+     * {@link StateTree#beforeClientResponse(com.vaadin.flow.internal.StateNode, com.vaadin.flow.function.SerializableConsumer)}
      * at evaluated before the changes are encoded.
      *
      * @param ui

--- a/flow-server/src/test/java/com/vaadin/flow/component/UITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/UITest.java
@@ -1,16 +1,13 @@
 package com.vaadin.flow.component;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
-
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletResponse;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -18,12 +15,6 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
-import com.vaadin.flow.component.AttachEvent;
-import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.DetachEvent;
-import com.vaadin.flow.component.Html;
-import com.vaadin.flow.component.Text;
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.page.History;
 import com.vaadin.flow.component.page.History.HistoryStateChangeEvent;
 import com.vaadin.flow.dom.Element;
@@ -42,6 +33,9 @@ import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServlet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class UITest {
 
@@ -298,9 +292,9 @@ public class UITest {
 
         List<Integer> results = new ArrayList<>();
 
-        ui.beforeClientResponse(rootComponent, () -> results.add(0));
-        ui.beforeClientResponse(rootComponent, () -> results.add(1));
-        ui.beforeClientResponse(rootComponent, () -> results.add(2));
+        ui.beforeClientResponse(rootComponent, context -> results.add(0));
+        ui.beforeClientResponse(rootComponent, context -> results.add(1));
+        ui.beforeClientResponse(rootComponent, context -> results.add(2));
 
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
         Assert.assertTrue("There should be 3 results in the list",
@@ -321,13 +315,13 @@ public class UITest {
 
         List<Integer> results = new ArrayList<>();
 
-        ui.beforeClientResponse(rootComponent, () -> results.add(0));
-        ui.beforeClientResponse(rootComponent, () -> {
+        ui.beforeClientResponse(rootComponent, context -> results.add(0));
+        ui.beforeClientResponse(rootComponent, context -> {
             results.add(1);
-            ui.beforeClientResponse(rootComponent, () -> results.add(3));
-            ui.beforeClientResponse(rootComponent, () -> results.add(4));
+            ui.beforeClientResponse(rootComponent, context2 -> results.add(3));
+            ui.beforeClientResponse(rootComponent, context2 -> results.add(4));
         });
-        ui.beforeClientResponse(rootComponent, () -> results.add(2));
+        ui.beforeClientResponse(rootComponent, context -> results.add(2));
 
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
         Assert.assertTrue("There should be 5 results in the list",
@@ -349,10 +343,10 @@ public class UITest {
 
         List<Integer> results = new ArrayList<>();
 
-        ui.beforeClientResponse(emptyComponent, () -> results.add(0));
-        ui.beforeClientResponse(rootComponent, () -> results.add(1));
-        ui.beforeClientResponse(emptyComponent, () -> results.add(2));
-        ui.beforeClientResponse(rootComponent, () -> results.add(3));
+        ui.beforeClientResponse(emptyComponent, context -> results.add(0));
+        ui.beforeClientResponse(rootComponent, context -> results.add(1));
+        ui.beforeClientResponse(emptyComponent, context -> results.add(2));
+        ui.beforeClientResponse(rootComponent, context -> results.add(3));
 
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
         Assert.assertTrue("There should be 2 results in the list",
@@ -374,16 +368,16 @@ public class UITest {
 
         List<Integer> results = new ArrayList<>();
 
-        ui.beforeClientResponse(emptyComponent1, () -> {
+        ui.beforeClientResponse(emptyComponent1, context -> {
             results.add(0);
             ui.add(emptyComponent2);
         });
-        ui.beforeClientResponse(rootComponent, () -> {
+        ui.beforeClientResponse(rootComponent, context -> {
             results.add(1);
             ui.add(emptyComponent1);
         });
-        ui.beforeClientResponse(emptyComponent2, () -> results.add(2));
-        ui.beforeClientResponse(rootComponent, () -> results.add(3));
+        ui.beforeClientResponse(emptyComponent2, context -> results.add(2));
+        ui.beforeClientResponse(rootComponent, context -> results.add(3));
 
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
         Assert.assertTrue("There should be 4 results in the list",

--- a/flow-server/src/test/java/com/vaadin/flow/component/UITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/UITest.java
@@ -407,16 +407,16 @@ public class UITest {
         AtomicInteger callCounter = new AtomicInteger();
 
         ui.beforeClientResponse(root, context -> {
-            Assert.assertTrue(
-                    "Root component should be marked as 'wasAttached'",
-                    context.wasAttachedInPreviousRoundtrip());
+            Assert.assertFalse(
+                    "Root component should NOT be marked as 'initializingClientSide'",
+                    context.isInitializingClientSide());
             callCounter.incrementAndGet();
 
         });
         ui.beforeClientResponse(leaf, context -> {
-            Assert.assertFalse(
-                    "Leaf component should not be marked as 'wasAttached'",
-                    context.wasAttachedInPreviousRoundtrip());
+            Assert.assertTrue(
+                    "Leaf component should be marked as 'initializingClientSide'",
+                    context.isInitializingClientSide());
             callCounter.incrementAndGet();
         });
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
@@ -424,9 +424,9 @@ public class UITest {
         ui.remove(root);
         ui.add(root);
         ui.beforeClientResponse(root, context -> {
-            Assert.assertTrue(
-                    "Reattached root component (in the same request) should be marked as 'wasAttached'",
-                    context.wasAttachedInPreviousRoundtrip());
+            Assert.assertFalse(
+                    "Reattached root component (in the same request) should NOT be marked as 'initializingClientSide'",
+                    context.isInitializingClientSide());
             callCounter.incrementAndGet();
         });
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
@@ -436,9 +436,9 @@ public class UITest {
         });
         ui.add(root);
         ui.beforeClientResponse(root, context -> {
-            Assert.assertFalse(
-                    "Reattached root component (in different requests) should not be marked as 'wasAttached'",
-                    context.wasAttachedInPreviousRoundtrip());
+            Assert.assertTrue(
+                    "Reattached root component (in different requests) should be marked as 'initializingClientSide'",
+                    context.isInitializingClientSide());
             callCounter.incrementAndGet();
         });
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();

--- a/flow-server/src/test/java/com/vaadin/flow/component/UITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/UITest.java
@@ -407,16 +407,16 @@ public class UITest {
         AtomicInteger callCounter = new AtomicInteger();
 
         ui.beforeClientResponse(root, context -> {
-            Assert.assertFalse(
-                    "Root component should NOT be marked as 'initializingClientSide'",
-                    context.isInitializingClientSide());
+            Assert.assertTrue(
+                    "Root component should be marked as 'clientSideInitialized'",
+                    context.isClientSideInitialized());
             callCounter.incrementAndGet();
 
         });
         ui.beforeClientResponse(leaf, context -> {
-            Assert.assertTrue(
-                    "Leaf component should be marked as 'initializingClientSide'",
-                    context.isInitializingClientSide());
+            Assert.assertFalse(
+                    "Leaf component should NOT be marked as 'clientSideInitialized'",
+                    context.isClientSideInitialized());
             callCounter.incrementAndGet();
         });
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
@@ -424,9 +424,9 @@ public class UITest {
         ui.remove(root);
         ui.add(root);
         ui.beforeClientResponse(root, context -> {
-            Assert.assertFalse(
-                    "Reattached root component (in the same request) should NOT be marked as 'initializingClientSide'",
-                    context.isInitializingClientSide());
+            Assert.assertTrue(
+                    "Reattached root component (in the same request) should be marked as 'clientSideInitialized'",
+                    context.isClientSideInitialized());
             callCounter.incrementAndGet();
         });
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
@@ -436,9 +436,9 @@ public class UITest {
         });
         ui.add(root);
         ui.beforeClientResponse(root, context -> {
-            Assert.assertTrue(
-                    "Reattached root component (in different requests) should be marked as 'initializingClientSide'",
-                    context.isInitializingClientSide());
+            Assert.assertFalse(
+                    "Reattached root component (in different requests) should NOT be marked as 'clientSideInitialized'",
+                    context.isClientSideInitialized());
             callCounter.incrementAndGet();
         });
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();

--- a/flow-server/src/test/java/com/vaadin/flow/component/UITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/UITest.java
@@ -409,14 +409,14 @@ public class UITest {
         ui.beforeClientResponse(root, context -> {
             Assert.assertTrue(
                     "Root component should be marked as 'wasAttached'",
-                    context.wasAttached());
+                    context.wasAttachedInPreviousRoundtrip());
             callCounter.incrementAndGet();
 
         });
         ui.beforeClientResponse(leaf, context -> {
             Assert.assertFalse(
                     "Leaf component should not be marked as 'wasAttached'",
-                    context.wasAttached());
+                    context.wasAttachedInPreviousRoundtrip());
             callCounter.incrementAndGet();
         });
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
@@ -426,7 +426,7 @@ public class UITest {
         ui.beforeClientResponse(root, context -> {
             Assert.assertTrue(
                     "Reattached root component (in the same request) should be marked as 'wasAttached'",
-                    context.wasAttached());
+                    context.wasAttachedInPreviousRoundtrip());
             callCounter.incrementAndGet();
         });
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
@@ -438,7 +438,7 @@ public class UITest {
         ui.beforeClientResponse(root, context -> {
             Assert.assertFalse(
                     "Reattached root component (in different requests) should not be marked as 'wasAttached'",
-                    context.wasAttached());
+                    context.wasAttachedInPreviousRoundtrip());
             callCounter.incrementAndGet();
         });
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();

--- a/flow-server/src/test/java/com/vaadin/flow/component/polymertemplate/PolymerTemplateTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/polymertemplate/PolymerTemplateTest.java
@@ -16,12 +16,6 @@
 
 package com.vaadin.flow.component.polymertemplate;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
-
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -33,6 +27,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
+import net.jcip.annotations.NotThreadSafe;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
 import org.junit.After;
@@ -61,7 +56,12 @@ import com.vaadin.flow.templatemodel.TemplateModel;
 
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
-import net.jcip.annotations.NotThreadSafe;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
 
 @NotThreadSafe
 public class PolymerTemplateTest extends HasCurrentService {

--- a/flow-server/src/test/java/com/vaadin/flow/internal/StateTreeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/StateTreeTest.java
@@ -450,11 +450,11 @@ public class StateTreeTest {
 
         StateNodeTest.setParent(node2, node1);
 
-        class CapturingRunnable
+        class CapturingConsumer
                 implements SerializableConsumer<ExecutionContext> {
             private final Object captured;
 
-            public CapturingRunnable(Object captured) {
+            public CapturingConsumer(Object captured) {
                 this.captured = captured;
             }
 
@@ -464,7 +464,7 @@ public class StateTreeTest {
             }
         }
 
-        tree.beforeClientResponse(node2, new CapturingRunnable(node2));
+        tree.beforeClientResponse(node2, new CapturingConsumer(node2));
 
         StateNodeTest.setParent(node2, null);
 

--- a/flow-server/src/test/java/com/vaadin/flow/internal/StateTreeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/StateTreeTest.java
@@ -31,6 +31,7 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.change.ListAddChange;
 import com.vaadin.flow.internal.change.ListRemoveChange;
 import com.vaadin.flow.internal.change.MapPutChange;
@@ -346,9 +347,9 @@ public class StateTreeTest {
 
         List<Integer> results = new ArrayList<>();
 
-        tree.beforeClientResponse(rootNode, () -> results.add(0));
-        tree.beforeClientResponse(rootNode, () -> results.add(1));
-        tree.beforeClientResponse(rootNode, () -> results.add(2));
+        tree.beforeClientResponse(rootNode, context -> results.add(0));
+        tree.beforeClientResponse(rootNode, context -> results.add(1));
+        tree.beforeClientResponse(rootNode, context -> results.add(2));
 
         tree.runExecutionsBeforeClientResponse();
         Assert.assertTrue("There should be 3 results in the list",
@@ -367,13 +368,13 @@ public class StateTreeTest {
 
         List<Integer> results = new ArrayList<>();
 
-        tree.beforeClientResponse(rootNode, () -> results.add(0));
-        tree.beforeClientResponse(rootNode, () -> {
+        tree.beforeClientResponse(rootNode, context -> results.add(0));
+        tree.beforeClientResponse(rootNode, context -> {
             results.add(1);
-            tree.beforeClientResponse(rootNode, () -> results.add(3));
-            tree.beforeClientResponse(rootNode, () -> results.add(4));
+            tree.beforeClientResponse(rootNode, context2 -> results.add(3));
+            tree.beforeClientResponse(rootNode, context2 -> results.add(4));
         });
-        tree.beforeClientResponse(rootNode, () -> results.add(2));
+        tree.beforeClientResponse(rootNode, context -> results.add(2));
 
         tree.runExecutionsBeforeClientResponse();
         Assert.assertTrue("There should be 5 results in the list",
@@ -393,10 +394,10 @@ public class StateTreeTest {
 
         List<Integer> results = new ArrayList<>();
 
-        tree.beforeClientResponse(emptyNode, () -> results.add(0));
-        tree.beforeClientResponse(rootNode, () -> results.add(1));
-        tree.beforeClientResponse(emptyNode, () -> results.add(2));
-        tree.beforeClientResponse(rootNode, () -> results.add(3));
+        tree.beforeClientResponse(emptyNode, context -> results.add(0));
+        tree.beforeClientResponse(rootNode, context -> results.add(1));
+        tree.beforeClientResponse(emptyNode, context -> results.add(2));
+        tree.beforeClientResponse(rootNode, context -> results.add(3));
 
         tree.runExecutionsBeforeClientResponse();
         Assert.assertTrue("There should be 2 results in the list",
@@ -416,16 +417,16 @@ public class StateTreeTest {
 
         List<Integer> results = new ArrayList<>();
 
-        tree.beforeClientResponse(emptyNode1, () -> {
+        tree.beforeClientResponse(emptyNode1, context -> {
             results.add(0);
             StateNodeTest.setParent(emptyNode2, rootNode);
         });
-        tree.beforeClientResponse(rootNode, () -> {
+        tree.beforeClientResponse(rootNode, context -> {
             results.add(1);
             StateNodeTest.setParent(emptyNode1, rootNode);
         });
-        tree.beforeClientResponse(emptyNode2, () -> results.add(2));
-        tree.beforeClientResponse(rootNode, () -> results.add(3));
+        tree.beforeClientResponse(emptyNode2, context -> results.add(2));
+        tree.beforeClientResponse(rootNode, context -> results.add(3));
 
         tree.runExecutionsBeforeClientResponse();
         Assert.assertTrue("There should be 4 results in the list",
@@ -449,7 +450,8 @@ public class StateTreeTest {
 
         StateNodeTest.setParent(node2, node1);
 
-        class CapturingRunnable implements Runnable {
+        class CapturingRunnable
+                implements SerializableConsumer<ExecutionContext> {
             private final Object captured;
 
             public CapturingRunnable(Object captured) {
@@ -457,8 +459,8 @@ public class StateTreeTest {
             }
 
             @Override
-            public void run() {
-                // nop
+            public void accept(ExecutionContext t) {
+                // no-op
             }
         }
 


### PR DESCRIPTION
The ExecutionContext contains the UI and the flag indicating whether the component/node was previously attached to the tree or not. This flag is important for components, such as Grid, that need to know whether some JS reinitialization is needed when the component is reattached.

This is needed for https://github.com/vaadin/vaadin-grid-flow/issues/89

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3617)
<!-- Reviewable:end -->
