### PR TITLE
Use PropertyChangeListener in generated components

### DIFF
--- a/flow-components-parent/flow-code-generator-api/src/main/java/com/vaadin/generator/ComponentGenerator.java
+++ b/flow-components-parent/flow-code-generator-api/src/main/java/com/vaadin/generator/ComponentGenerator.java
@@ -1423,34 +1423,8 @@ public class ComponentGenerator {
         eventConstructor.addParameter("boolean", "fromClient");
 
         if (isPropertyChange) {
-            // Save the property value to the event and add a getter if
-            // corresponding getter is found from the component.
-
-            MethodSource<JavaClassSource> getterInComponent = propertyToGetterMap
-                    .get(propertyNameCamelCase);
-
-            if (getterInComponent != null) {
-                eventConstructor.setBody(eventConstructor.getBody() + String
-                        .format("this.%s = source.%s();", propertyNameCamelCase,
-                                getterInComponent.getName()));
-                eventClass.addField().setPrivate().setFinal(true)
-                        .setType(getterInComponent.getReturnType().getName())
-                        .setName(propertyNameCamelCase);
-
-                // Remove the trailing type name from the getter name.
-                // Eg. isOpenedBoolean -> isOpened
-                String getterNameInEvent = getterInComponent.getName()
-                        .substring(0,
-                                getterInComponent.getName()
-                                        .lastIndexOf(StringUtils.capitalize(
-                                                propertyNameCamelCase))
-                                        + propertyNameCamelCase.length());
-
-                eventClass.addMethod().setPublic()
-                        .setReturnType(getterInComponent.getReturnType())
-                        .setName(getterNameInEvent).setBody(String
-                                .format("return %s;", propertyNameCamelCase));
-            }
+            addFieldAndGetterToPropertyChangeEvent(propertyNameCamelCase,
+                    propertyToGetterMap, eventClass, eventConstructor);
         } else {
             addEventDataParameters(javaClass, event, eventClassName, eventClass,
                     eventConstructor);
@@ -1462,6 +1436,40 @@ public class ComponentGenerator {
         javaClass.addImport(ComponentEventListener.class);
 
         return eventClass;
+    }
+
+    private void addFieldAndGetterToPropertyChangeEvent(
+            String propertyNameCamelCase,
+            Map<String, MethodSource<JavaClassSource>> propertyToGetterMap,
+            JavaClassSource eventClass,
+            MethodSource<JavaClassSource> eventConstructor) {
+
+        // Save the property value to the event and add a getter if
+        // corresponding getter is found from the component.
+
+        MethodSource<JavaClassSource> getterInComponent = propertyToGetterMap
+                .get(propertyNameCamelCase);
+
+        if (getterInComponent != null) {
+            eventConstructor.setBody(eventConstructor.getBody() + String.format(
+                    "this.%s = source.%s();", propertyNameCamelCase,
+                    getterInComponent.getName()));
+            eventClass.addField().setPrivate().setFinal(true)
+                    .setType(getterInComponent.getReturnType().getName())
+                    .setName(propertyNameCamelCase);
+
+            // Remove the trailing type name from the getter name.
+            // Eg. isOpenedBoolean -> isOpened
+            String getterNameInEvent = getterInComponent.getName().substring(0,
+                    getterInComponent.getName().lastIndexOf(
+                            StringUtils.capitalize(propertyNameCamelCase))
+                            + propertyNameCamelCase.length());
+
+            eventClass.addMethod().setPublic()
+                    .setReturnType(getterInComponent.getReturnType())
+                    .setName(getterNameInEvent).setBody(
+                            String.format("return %s;", propertyNameCamelCase));
+        }
     }
 
     private void addEventDataParameters(JavaClassSource javaClass,

--- a/flow-components-parent/flow-code-generator-api/src/main/java/com/vaadin/generator/ComponentGenerator.java
+++ b/flow-components-parent/flow-code-generator-api/src/main/java/com/vaadin/generator/ComponentGenerator.java
@@ -1340,16 +1340,16 @@ public class ComponentGenerator {
         eventJavaApiName = ComponentGeneratorUtils
                 .formatStringToValidJavaIdentifier(eventJavaApiName);
 
-        // will be null if this is not a property-change event
         String propertyNameCamelCase = null;
-
-        if (eventJavaApiName.endsWith("Changed")) {
+        boolean isPropertyChange = eventJavaApiName.endsWith("Changed");
+        if (isPropertyChange) {
             // removes the "d" in the end, to create addSomethingChangeListener
             // and SomethingChangeEvent
             eventJavaApiName = eventJavaApiName.substring(0,
                     eventJavaApiName.length() - 1);
 
-            propertyNameCamelCase = eventJavaApiName.replace("Change", "");
+            propertyNameCamelCase = eventJavaApiName.substring(0,
+                    eventJavaApiName.length() - "Change".length());
         }
 
         JavaClassSource eventClass = createEventListenerEventClass(javaClass,
@@ -1374,7 +1374,7 @@ public class ComponentGenerator {
                 .addTagValue(JAVADOC_RETURN,
                         "a {@link Registration} for removing the event listener");
 
-        if (propertyNameCamelCase != null) {
+        if (isPropertyChange) {
             String propertyNameBeforeRenaming = ComponentGeneratorUtils
                     .formatStringToValidJavaIdentifier(event.getName()
                             .replace(PROPERTY_CHANGE_EVENT_POSTFIX, ""));

--- a/flow-components-parent/flow-code-generator-api/src/main/java/com/vaadin/generator/ComponentGenerator.java
+++ b/flow-components-parent/flow-code-generator-api/src/main/java/com/vaadin/generator/ComponentGenerator.java
@@ -1373,10 +1373,13 @@ public class ComponentGenerator {
                         "a {@link Registration} for removing the event listener");
 
         if (propertyNameCamelCase != null) {
+            String propertyNameBeforeRenaming = ComponentGeneratorUtils
+                    .formatStringToValidJavaIdentifier(event.getName()
+                            .replace(PROPERTY_CHANGE_EVENT_POSTFIX, ""));
             method.setBody(String.format(
                     "return getElement().addPropertyChangeListener(\"%s\", "
                             + "event -> listener.onComponentEvent(new %s<%s>(get(), event.isUserOriginated())));",
-                    propertyNameCamelCase, eventClass.getName(),
+                    propertyNameBeforeRenaming, eventClass.getName(),
                     eventClass.getTypeVariables().get(0).getName()));
         } else {
             method.setBody(String.format(
@@ -1447,7 +1450,7 @@ public class ComponentGenerator {
             }
         }
 
-        if (!isPropertyChange) {
+        else {
             for (ComponentPropertyBaseData property : event.getProperties()) {
                 // Add new parameter to constructor
                 final String propertyName = property.getName();

--- a/flow-components-parent/flow-code-generator-api/src/test/java/com/vaadin/generator/ComponentGeneratorTest.java
+++ b/flow-components-parent/flow-code-generator-api/src/test/java/com/vaadin/generator/ComponentGeneratorTest.java
@@ -47,6 +47,8 @@ import com.vaadin.generator.metadata.ComponentObjectType.ComponentObjectTypeInne
 import com.vaadin.generator.metadata.ComponentPropertyBaseData;
 import com.vaadin.generator.metadata.ComponentPropertyData;
 
+import static org.hamcrest.CoreMatchers.containsString;
+
 /**
  * Unit tests for the component generator
  */
@@ -359,8 +361,8 @@ public class ComponentGeneratorTest {
         generatedClass = ComponentGeneratorTestUtils
                 .removeIndentation(generatedClass);
 
-        Assert.assertTrue("Custom event class was not found.",
-                generatedClass.contains(
+        Assert.assertThat("Custom event class was not found.", generatedClass,
+                containsString(
                         "public static class SomethingChangeEvent<R extends MyComponent<R>> extends ComponentEvent<R> {"));
 
         Assert.assertFalse("DomEvent should not be used for property changes",
@@ -373,18 +375,19 @@ public class ComponentGeneratorTest {
         Assert.assertTrue("Couldn't find correct listener for event.",
                 matcher.find());
 
-        Assert.assertTrue(
+        Assert.assertThat(
                 "Event should be propagated to a property change listener",
-                StringUtils.deleteWhitespace(generatedClass).contains(
+                StringUtils.deleteWhitespace(generatedClass), containsString(
                         "getElement().addPropertyChangeListener(\"something\","));
 
         Assert.assertFalse("DomEvent imported even without dom-events",
                 generatedClass
                         .contains("import " + DomEvent.class.getName() + ";"));
-        Assert.assertTrue("Missing ComponentEvent import", generatedClass
-                .contains("import " + ComponentEvent.class.getName() + ";"));
-        Assert.assertTrue("Missing ComponentEventListener import",
-                generatedClass.contains("import "
+        Assert.assertThat("Missing ComponentEvent import", generatedClass,
+                containsString(
+                        "import " + ComponentEvent.class.getName() + ";"));
+        Assert.assertThat("Missing ComponentEventListener import",
+                generatedClass, containsString("import "
                         + ComponentEventListener.class.getName() + ";"));
         Assert.assertFalse("EventData imported even without events",
                 generatedClass
@@ -609,13 +612,13 @@ public class ComponentGeneratorTest {
         generatedClass = ComponentGeneratorTestUtils
                 .removeIndentation(generatedClass);
 
-        Assert.assertTrue(
+        Assert.assertThat(
                 "Event should save the property value from the source component",
-                generatedClass
-                        .contains("someproperty = source.getSomeproperty();"));
+                generatedClass,
+                containsString("someproperty = source.getSomeproperty();"));
 
-        Assert.assertTrue("Event should have getter for the property",
-                generatedClass.contains(
+        Assert.assertThat("Event should have getter for the property",
+                generatedClass, containsString(
                         "public String getSomeproperty() { return someproperty; }"));
     }
 

--- a/flow-components-parent/flow-code-generator-api/src/test/java/com/vaadin/generator/registry/PropertyNameRemapRegistryTest.java
+++ b/flow-components-parent/flow-code-generator-api/src/test/java/com/vaadin/generator/registry/PropertyNameRemapRegistryTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -102,8 +103,7 @@ public class PropertyNameRemapRegistryTest {
                         "return getElement().getProperty(\"original-property-name\");"));
 
         Assert.assertTrue("Setter for renamed property should be present",
-                generatedSource
-                        .contains("setRenamed(String renamed)"));
+                generatedSource.contains("setRenamed(String renamed)"));
         Assert.assertTrue(
                 "Setter should use the original property name for setting the value through the element API",
                 generatedSource.contains(
@@ -117,9 +117,9 @@ public class PropertyNameRemapRegistryTest {
                 generatedSource
                         .contains("public static class RenamedChangeEvent"));
         Assert.assertTrue(
-                "Renamed change event class should still be bound to the original property name",
-                generatedSource.contains(
-                        "@DomEvent(\"original-property-name-changed\")"));
+                "Renamed property change listener should internally use the original property name",
+                StringUtils.deleteWhitespace(generatedSource).contains(
+                        "addPropertyChangeListener(\"originalPropertyName\","));
     }
 
     @Test

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/checkbox/GeneratedVaadinCheckbox.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/checkbox/GeneratedVaadinCheckbox.java
@@ -23,7 +23,6 @@ import javax.annotation.Generated;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.component.Synchronize;
-import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.shared.Registration;
@@ -299,11 +298,17 @@ public abstract class GeneratedVaadinCheckbox<R extends GeneratedVaadinCheckbox<
         getElement().setProperty("value", postValue == null ? "" : postValue);
     }
 
-    @DomEvent("checked-changed")
     public static class CheckedChangeEvent<R extends GeneratedVaadinCheckbox<R>>
             extends ComponentEvent<R> {
+        private final boolean checked;
+
         public CheckedChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
+            this.checked = source.isCheckedBoolean();
+        }
+
+        public boolean isChecked() {
+            return checked;
         }
     }
 
@@ -315,18 +320,26 @@ public abstract class GeneratedVaadinCheckbox<R extends GeneratedVaadinCheckbox<
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addCheckedChangeListener(
             ComponentEventListener<CheckedChangeEvent<R>> listener) {
-        return addListener(CheckedChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("checked",
+                        event -> listener.onComponentEvent(
+                                new CheckedChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 
-    @DomEvent("indeterminate-changed")
     public static class IndeterminateChangeEvent<R extends GeneratedVaadinCheckbox<R>>
             extends ComponentEvent<R> {
+        private final boolean indeterminate;
+
         public IndeterminateChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
+            this.indeterminate = source.isIndeterminateBoolean();
+        }
+
+        public boolean isIndeterminate() {
+            return indeterminate;
         }
     }
 
@@ -338,10 +351,11 @@ public abstract class GeneratedVaadinCheckbox<R extends GeneratedVaadinCheckbox<
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addIndeterminateChangeListener(
             ComponentEventListener<IndeterminateChangeEvent<R>> listener) {
-        return addListener(IndeterminateChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement().addPropertyChangeListener("indeterminate",
+                event -> listener
+                        .onComponentEvent(new IndeterminateChangeEvent<R>(get(),
+                                event.isUserOriginated())));
     }
 }

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/combobox/GeneratedVaadinComboBox.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/combobox/GeneratedVaadinComboBox.java
@@ -15,23 +15,21 @@
  */
 package com.vaadin.flow.component.combobox;
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.ComponentEvent;
-import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.component.DomEvent;
-import com.vaadin.flow.component.EventData;
-import com.vaadin.flow.component.Focusable;
 import com.vaadin.flow.component.HasStyle;
-import com.vaadin.flow.component.NotSupported;
-import com.vaadin.flow.component.Synchronize;
+import com.vaadin.flow.component.Focusable;
+import javax.annotation.Generated;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.HtmlImport;
-import com.vaadin.flow.dom.Element;
-import com.vaadin.flow.shared.Registration;
-
+import com.vaadin.flow.component.Synchronize;
 import elemental.json.JsonArray;
+import com.vaadin.flow.component.NotSupported;
+import com.vaadin.flow.component.EventData;
+import com.vaadin.flow.component.DomEvent;
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.shared.Registration;
+import com.vaadin.flow.dom.Element;
 
 /**
  * <p>
@@ -40,9 +38,8 @@ import elemental.json.JsonArray;
  * <p>
  * {@code <vaadin-combo-box>} is a combo box element combining a dropdown list
  * with an input field for filtering the list of items. If you want to replace
- * the default input field with a custom implementation, you should use the
- * <a href=
- * "#/elements/vaadin-combo-box-light">{@code <vaadin-combo-box-light>}</a>
+ * the default input field with a custom implementation, you should use the <a
+ * href="#/elements/vaadin-combo-box-light">{@code <vaadin-combo-box-light>}</a>
  * element.
  * </p>
  * <p>
@@ -217,9 +214,9 @@ import elemental.json.JsonArray;
  * </tbody>
  * </table>
  * <p>
- * See
- * <a href="https://github.com/vaadin/vaadin-themable-mixin/wiki">ThemableMixin
- * – how to apply styles for shadow parts</a>
+ * See <a
+ * href="https://github.com/vaadin/vaadin-themable-mixin/wiki">ThemableMixin –
+ * how to apply styles for shadow parts</a>
  * </p>
  */
 @Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.0-SNAPSHOT",
@@ -988,11 +985,11 @@ public abstract class GeneratedVaadinComboBox<R extends GeneratedVaadinComboBox<
      * 
      * @param components
      *            The components to add.
-     * @see <a href=
-     *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot">MDN
+     * @see <a
+     *      href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot">MDN
      *      page about slots</a>
-     * @see <a href=
-     *      "https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
+     * @see <a
+     *      href="https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
      *      website about slots</a>
      * @return this instance, for method chaining
      */

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/combobox/GeneratedVaadinComboBox.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/combobox/GeneratedVaadinComboBox.java
@@ -15,22 +15,23 @@
  */
 package com.vaadin.flow.component.combobox;
 
-import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.HasStyle;
-import com.vaadin.flow.component.Focusable;
 import javax.annotation.Generated;
-import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.dependency.HtmlImport;
-import com.vaadin.flow.component.Synchronize;
-import elemental.json.JsonArray;
-import com.vaadin.flow.component.NotSupported;
-import com.vaadin.flow.component.EventData;
-import com.vaadin.flow.component.DomEvent;
+
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.shared.Registration;
-import elemental.json.JsonObject;
+import com.vaadin.flow.component.DomEvent;
+import com.vaadin.flow.component.EventData;
+import com.vaadin.flow.component.Focusable;
+import com.vaadin.flow.component.HasStyle;
+import com.vaadin.flow.component.NotSupported;
+import com.vaadin.flow.component.Synchronize;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.shared.Registration;
+
+import elemental.json.JsonArray;
 
 /**
  * <p>
@@ -39,8 +40,9 @@ import com.vaadin.flow.dom.Element;
  * <p>
  * {@code <vaadin-combo-box>} is a combo box element combining a dropdown list
  * with an input field for filtering the list of items. If you want to replace
- * the default input field with a custom implementation, you should use the <a
- * href="#/elements/vaadin-combo-box-light">{@code <vaadin-combo-box-light>}</a>
+ * the default input field with a custom implementation, you should use the
+ * <a href=
+ * "#/elements/vaadin-combo-box-light">{@code <vaadin-combo-box-light>}</a>
  * element.
  * </p>
  * <p>
@@ -215,9 +217,9 @@ import com.vaadin.flow.dom.Element;
  * </tbody>
  * </table>
  * <p>
- * See <a
- * href="https://github.com/vaadin/vaadin-themable-mixin/wiki">ThemableMixin –
- * how to apply styles for shadow parts</a>
+ * See
+ * <a href="https://github.com/vaadin/vaadin-themable-mixin/wiki">ThemableMixin
+ * – how to apply styles for shadow parts</a>
  * </p>
  */
 @Generated({ "Generator: com.vaadin.generator.ComponentGenerator#1.0-SNAPSHOT",
@@ -863,26 +865,10 @@ public abstract class GeneratedVaadinComboBox<R extends GeneratedVaadinComboBox<
                 (ComponentEventListener) listener);
     }
 
-    @DomEvent("value-changed")
     public static class ValueChangeEvent<R extends GeneratedVaadinComboBox<R>>
             extends ComponentEvent<R> {
-        private final JsonObject detail;
-        private final String detailValue;
-
-        public ValueChangeEvent(R source, boolean fromClient,
-                @EventData("event.detail") JsonObject detail,
-                @EventData("event.detail.value") String detailValue) {
+        public ValueChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
-            this.detail = detail;
-            this.detailValue = detailValue;
-        }
-
-        public JsonObject getDetail() {
-            return detail;
-        }
-
-        public String getDetailValue() {
-            return detailValue;
         }
     }
 
@@ -894,22 +880,22 @@ public abstract class GeneratedVaadinComboBox<R extends GeneratedVaadinComboBox<
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addValueChangeListener(
             ComponentEventListener<ValueChangeEvent<R>> listener) {
-        return addListener(ValueChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("value",
+                        event -> listener
+                                .onComponentEvent(new ValueChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 
-    @DomEvent("opened-changed")
     public static class OpenedChangeEvent<R extends GeneratedVaadinComboBox<R>>
             extends ComponentEvent<R> {
         private final boolean opened;
 
-        public OpenedChangeEvent(R source, boolean fromClient,
-                @EventData("event.opened") boolean opened) {
+        public OpenedChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
-            this.opened = opened;
+            this.opened = source.isOpenedBoolean();
         }
 
         public boolean isOpened() {
@@ -925,22 +911,22 @@ public abstract class GeneratedVaadinComboBox<R extends GeneratedVaadinComboBox<
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addOpenedChangeListener(
             ComponentEventListener<OpenedChangeEvent<R>> listener) {
-        return addListener(OpenedChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("opened",
+                        event -> listener.onComponentEvent(
+                                new OpenedChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 
-    @DomEvent("filter-changed")
     public static class FilterChangeEvent<R extends GeneratedVaadinComboBox<R>>
             extends ComponentEvent<R> {
         private final String filter;
 
-        public FilterChangeEvent(R source, boolean fromClient,
-                @EventData("event.filter") String filter) {
+        public FilterChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
-            this.filter = filter;
+            this.filter = source.getFilterString();
         }
 
         public String getFilter() {
@@ -956,22 +942,22 @@ public abstract class GeneratedVaadinComboBox<R extends GeneratedVaadinComboBox<
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addFilterChangeListener(
             ComponentEventListener<FilterChangeEvent<R>> listener) {
-        return addListener(FilterChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("filter",
+                        event -> listener.onComponentEvent(
+                                new FilterChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 
-    @DomEvent("invalid-changed")
     public static class InvalidChangeEvent<R extends GeneratedVaadinComboBox<R>>
             extends ComponentEvent<R> {
         private final boolean invalid;
 
-        public InvalidChangeEvent(R source, boolean fromClient,
-                @EventData("event.invalid") boolean invalid) {
+        public InvalidChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
-            this.invalid = invalid;
+            this.invalid = source.isInvalidBoolean();
         }
 
         public boolean isInvalid() {
@@ -987,11 +973,13 @@ public abstract class GeneratedVaadinComboBox<R extends GeneratedVaadinComboBox<
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addInvalidChangeListener(
             ComponentEventListener<InvalidChangeEvent<R>> listener) {
-        return addListener(InvalidChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("invalid",
+                        event -> listener.onComponentEvent(
+                                new InvalidChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 
     /**
@@ -1000,11 +988,11 @@ public abstract class GeneratedVaadinComboBox<R extends GeneratedVaadinComboBox<
      * 
      * @param components
      *            The components to add.
-     * @see <a
-     *      href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot">MDN
+     * @see <a href=
+     *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/slot">MDN
      *      page about slots</a>
-     * @see <a
-     *      href="https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
+     * @see <a href=
+     *      "https://html.spec.whatwg.org/multipage/scripting.html#the-slot-element">Spec
      *      website about slots</a>
      * @return this instance, for method chaining
      */

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/combobox/GeneratedVaadinComboBoxDropdown.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/combobox/GeneratedVaadinComboBoxDropdown.java
@@ -228,11 +228,17 @@ public abstract class GeneratedVaadinComboBoxDropdown<R extends GeneratedVaadinC
                 (ComponentEventListener) listener);
     }
 
-    @DomEvent("opened-changed")
     public static class OpenedChangeEvent<R extends GeneratedVaadinComboBoxDropdown<R>>
             extends ComponentEvent<R> {
+        private final boolean opened;
+
         public OpenedChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
+            this.opened = source.isOpenedBoolean();
+        }
+
+        public boolean isOpened() {
+            return opened;
         }
     }
 
@@ -244,18 +250,26 @@ public abstract class GeneratedVaadinComboBoxDropdown<R extends GeneratedVaadinC
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addOpenedChangeListener(
             ComponentEventListener<OpenedChangeEvent<R>> listener) {
-        return addListener(OpenedChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("opened",
+                        event -> listener.onComponentEvent(
+                                new OpenedChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 
-    @DomEvent("template-changed")
     public static class TemplateChangeEvent<R extends GeneratedVaadinComboBoxDropdown<R>>
             extends ComponentEvent<R> {
+        private final JsonObject template;
+
         public TemplateChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
+            this.template = source.getTemplateJsonObject();
+        }
+
+        public JsonObject getTemplate() {
+            return template;
         }
     }
 
@@ -267,10 +281,12 @@ public abstract class GeneratedVaadinComboBoxDropdown<R extends GeneratedVaadinC
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addTemplateChangeListener(
             ComponentEventListener<TemplateChangeEvent<R>> listener) {
-        return addListener(TemplateChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("template",
+                        event -> listener.onComponentEvent(
+                                new TemplateChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 }

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/combobox/GeneratedVaadinComboBoxItem.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/combobox/GeneratedVaadinComboBoxItem.java
@@ -113,23 +113,6 @@ public abstract class GeneratedVaadinComboBoxItem<R extends GeneratedVaadinCombo
      * 
      * @return the {@code item} property from the webcomponent
      */
-    protected String getItemStringString() {
-        return getElement().getProperty("item");
-    }
-
-    /**
-     * <p>
-     * Description copied from corresponding location in WebComponent:
-     * </p>
-     * <p>
-     * The item to render
-     * <p>
-     * This property is not synchronized automatically from the client side, so
-     * the returned value may not be the same as in client side.
-     * </p>
-     * 
-     * @return the {@code item} property from the webcomponent
-     */
     protected JsonObject getItemObjectJsonObject() {
         return (JsonObject) getElement().getPropertyRaw("item");
     }

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/combobox/GeneratedVaadinComboBoxLight.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/combobox/GeneratedVaadinComboBoxLight.java
@@ -15,23 +15,21 @@
  */
 package com.vaadin.flow.component.combobox;
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.ComponentEvent;
-import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.component.ComponentSupplier;
-import com.vaadin.flow.component.DomEvent;
-import com.vaadin.flow.component.EventData;
 import com.vaadin.flow.component.HasStyle;
-import com.vaadin.flow.component.NotSupported;
-import com.vaadin.flow.component.Synchronize;
+import com.vaadin.flow.component.ComponentSupplier;
+import javax.annotation.Generated;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.HtmlImport;
-import com.vaadin.flow.shared.Registration;
-
+import com.vaadin.flow.component.Synchronize;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
+import com.vaadin.flow.component.NotSupported;
+import com.vaadin.flow.component.DomEvent;
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.shared.Registration;
+import com.vaadin.flow.component.EventData;
 
 /**
  * <p>
@@ -774,26 +772,17 @@ public abstract class GeneratedVaadinComboBoxLight<R extends GeneratedVaadinComb
                 (ComponentEventListener) listener);
     }
 
-    @DomEvent("selected-item-changed")
     public static class SelectedItemChangeEvent<R extends GeneratedVaadinComboBoxLight<R>>
             extends ComponentEvent<R> {
-        private final JsonObject detail;
-        private final JsonObject detailValue;
+        private final JsonObject selectedItem;
 
-        public SelectedItemChangeEvent(R source, boolean fromClient,
-                @EventData("event.detail") JsonObject detail,
-                @EventData("event.detail.value") JsonObject detailValue) {
+        public SelectedItemChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
-            this.detail = detail;
-            this.detailValue = detailValue;
+            this.selectedItem = source.getSelectedItemJsonObject();
         }
 
-        public JsonObject getDetail() {
-            return detail;
-        }
-
-        public JsonObject getDetailValue() {
-            return detailValue;
+        public JsonObject getSelectedItem() {
+            return selectedItem;
         }
     }
 
@@ -805,33 +794,25 @@ public abstract class GeneratedVaadinComboBoxLight<R extends GeneratedVaadinComb
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addSelectedItemChangeListener(
             ComponentEventListener<SelectedItemChangeEvent<R>> listener) {
-        return addListener(SelectedItemChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement().addPropertyChangeListener("selectedItem",
+                event -> listener
+                        .onComponentEvent(new SelectedItemChangeEvent<R>(get(),
+                                event.isUserOriginated())));
     }
 
-    @DomEvent("value-changed")
     public static class ValueChangeEvent<R extends GeneratedVaadinComboBoxLight<R>>
             extends ComponentEvent<R> {
-        private final JsonObject detail;
-        private final String detailValue;
+        private final String value;
 
-        public ValueChangeEvent(R source, boolean fromClient,
-                @EventData("event.detail") JsonObject detail,
-                @EventData("event.detail.value") String detailValue) {
+        public ValueChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
-            this.detail = detail;
-            this.detailValue = detailValue;
+            this.value = source.getValueString();
         }
 
-        public JsonObject getDetail() {
-            return detail;
-        }
-
-        public String getDetailValue() {
-            return detailValue;
+        public String getValue() {
+            return value;
         }
     }
 
@@ -843,22 +824,22 @@ public abstract class GeneratedVaadinComboBoxLight<R extends GeneratedVaadinComb
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addValueChangeListener(
             ComponentEventListener<ValueChangeEvent<R>> listener) {
-        return addListener(ValueChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("value",
+                        event -> listener
+                                .onComponentEvent(new ValueChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 
-    @DomEvent("opened-changed")
     public static class OpenedChangeEvent<R extends GeneratedVaadinComboBoxLight<R>>
             extends ComponentEvent<R> {
         private final boolean opened;
 
-        public OpenedChangeEvent(R source, boolean fromClient,
-                @EventData("event.opened") boolean opened) {
+        public OpenedChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
-            this.opened = opened;
+            this.opened = source.isOpenedBoolean();
         }
 
         public boolean isOpened() {
@@ -874,22 +855,22 @@ public abstract class GeneratedVaadinComboBoxLight<R extends GeneratedVaadinComb
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addOpenedChangeListener(
             ComponentEventListener<OpenedChangeEvent<R>> listener) {
-        return addListener(OpenedChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("opened",
+                        event -> listener.onComponentEvent(
+                                new OpenedChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 
-    @DomEvent("filter-changed")
     public static class FilterChangeEvent<R extends GeneratedVaadinComboBoxLight<R>>
             extends ComponentEvent<R> {
         private final String filter;
 
-        public FilterChangeEvent(R source, boolean fromClient,
-                @EventData("event.filter") String filter) {
+        public FilterChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
-            this.filter = filter;
+            this.filter = source.getFilterString();
         }
 
         public String getFilter() {
@@ -905,22 +886,22 @@ public abstract class GeneratedVaadinComboBoxLight<R extends GeneratedVaadinComb
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addFilterChangeListener(
             ComponentEventListener<FilterChangeEvent<R>> listener) {
-        return addListener(FilterChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("filter",
+                        event -> listener.onComponentEvent(
+                                new FilterChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 
-    @DomEvent("invalid-changed")
     public static class InvalidChangeEvent<R extends GeneratedVaadinComboBoxLight<R>>
             extends ComponentEvent<R> {
         private final boolean invalid;
 
-        public InvalidChangeEvent(R source, boolean fromClient,
-                @EventData("event.invalid") boolean invalid) {
+        public InvalidChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
-            this.invalid = invalid;
+            this.invalid = source.isInvalidBoolean();
         }
 
         public boolean isInvalid() {
@@ -936,10 +917,12 @@ public abstract class GeneratedVaadinComboBoxLight<R extends GeneratedVaadinComb
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addInvalidChangeListener(
             ComponentEventListener<InvalidChangeEvent<R>> listener) {
-        return addListener(InvalidChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("invalid",
+                        event -> listener.onComponentEvent(
+                                new InvalidChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 }

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/combobox/GeneratedVaadinComboBoxOverlay.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/combobox/GeneratedVaadinComboBoxOverlay.java
@@ -299,11 +299,17 @@ public abstract class GeneratedVaadinComboBoxOverlay<R extends GeneratedVaadinCo
                 (ComponentEventListener) listener);
     }
 
-    @DomEvent("opened-changed")
     public static class OpenedChangeEvent<R extends GeneratedVaadinComboBoxOverlay<R>>
             extends ComponentEvent<R> {
+        private final boolean opened;
+
         public OpenedChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
+            this.opened = source.isOpenedBoolean();
+        }
+
+        public boolean isOpened() {
+            return opened;
         }
     }
 
@@ -315,18 +321,26 @@ public abstract class GeneratedVaadinComboBoxOverlay<R extends GeneratedVaadinCo
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addOpenedChangeListener(
             ComponentEventListener<OpenedChangeEvent<R>> listener) {
-        return addListener(OpenedChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("opened",
+                        event -> listener.onComponentEvent(
+                                new OpenedChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 
-    @DomEvent("template-changed")
     public static class TemplateChangeEvent<R extends GeneratedVaadinComboBoxOverlay<R>>
             extends ComponentEvent<R> {
+        private final JsonObject template;
+
         public TemplateChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
+            this.template = source.getTemplateJsonObject();
+        }
+
+        public JsonObject getTemplate() {
+            return template;
         }
     }
 
@@ -338,18 +352,26 @@ public abstract class GeneratedVaadinComboBoxOverlay<R extends GeneratedVaadinCo
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addTemplateChangeListener(
             ComponentEventListener<TemplateChangeEvent<R>> listener) {
-        return addListener(TemplateChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("template",
+                        event -> listener.onComponentEvent(
+                                new TemplateChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 
-    @DomEvent("content-changed")
     public static class ContentChangeEvent<R extends GeneratedVaadinComboBoxOverlay<R>>
             extends ComponentEvent<R> {
+        private final JsonObject content;
+
         public ContentChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
+            this.content = source.getContentJsonObject();
+        }
+
+        public JsonObject getContent() {
+            return content;
         }
     }
 
@@ -361,10 +383,12 @@ public abstract class GeneratedVaadinComboBoxOverlay<R extends GeneratedVaadinCo
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addContentChangeListener(
             ComponentEventListener<ContentChangeEvent<R>> listener) {
-        return addListener(ContentChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("content",
+                        event -> listener.onComponentEvent(
+                                new ContentChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 }

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePicker.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePicker.java
@@ -24,11 +24,9 @@ import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.component.Synchronize;
 import elemental.json.JsonObject;
 import com.vaadin.flow.component.NotSupported;
-import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.shared.Registration;
-import com.vaadin.flow.component.EventData;
 import com.vaadin.flow.dom.Element;
 
 /**
@@ -1036,11 +1034,17 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
     protected void checkValidity(String value) {
     }
 
-    @DomEvent("invalid-changed")
     public static class InvalidChangeEvent<R extends GeneratedVaadinDatePicker<R>>
             extends ComponentEvent<R> {
+        private final boolean invalid;
+
         public InvalidChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
+            this.invalid = source.isInvalidBoolean();
+        }
+
+        public boolean isInvalid() {
+            return invalid;
         }
     }
 
@@ -1052,26 +1056,26 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addInvalidChangeListener(
             ComponentEventListener<InvalidChangeEvent<R>> listener) {
-        return addListener(InvalidChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("invalid",
+                        event -> listener.onComponentEvent(
+                                new InvalidChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 
-    @DomEvent("value-changed")
     public static class ValueAsStringChangeEvent<R extends GeneratedVaadinDatePicker<R>>
             extends ComponentEvent<R> {
-        private final String value;
+        private final String valueAsString;
 
-        public ValueAsStringChangeEvent(R source, boolean fromClient,
-                @EventData("event.value") String value) {
+        public ValueAsStringChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
-            this.value = value;
+            this.valueAsString = source.getValueAsStringString();
         }
 
-        public String getValue() {
-            return value;
+        public String getValueAsString() {
+            return valueAsString;
         }
     }
 
@@ -1083,22 +1087,21 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addValueAsStringChangeListener(
             ComponentEventListener<ValueAsStringChangeEvent<R>> listener) {
-        return addListener(ValueAsStringChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement().addPropertyChangeListener("valueAsString",
+                event -> listener
+                        .onComponentEvent(new ValueAsStringChangeEvent<R>(get(),
+                                event.isUserOriginated())));
     }
 
-    @DomEvent("opened-changed")
     public static class OpenedChangeEvent<R extends GeneratedVaadinDatePicker<R>>
             extends ComponentEvent<R> {
         private final boolean opened;
 
-        public OpenedChangeEvent(R source, boolean fromClient,
-                @EventData("event.opened") boolean opened) {
+        public OpenedChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
-            this.opened = opened;
+            this.opened = source.isOpenedBoolean();
         }
 
         public boolean isOpened() {
@@ -1114,11 +1117,13 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addOpenedChangeListener(
             ComponentEventListener<OpenedChangeEvent<R>> listener) {
-        return addListener(OpenedChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("opened",
+                        event -> listener.onComponentEvent(
+                                new OpenedChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 
     /**

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePicker.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePicker.java
@@ -1089,7 +1089,7 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      */
     protected Registration addValueAsStringChangeListener(
             ComponentEventListener<ValueAsStringChangeEvent<R>> listener) {
-        return getElement().addPropertyChangeListener("valueAsString",
+        return getElement().addPropertyChangeListener("value",
                 event -> listener
                         .onComponentEvent(new ValueAsStringChangeEvent<R>(get(),
                                 event.isUserOriginated())));

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePickerLight.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePickerLight.java
@@ -24,8 +24,6 @@ import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.component.Synchronize;
 import elemental.json.JsonObject;
 import com.vaadin.flow.component.NotSupported;
-import com.vaadin.flow.component.EventData;
-import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.shared.Registration;
@@ -723,15 +721,13 @@ public abstract class GeneratedVaadinDatePickerLight<R extends GeneratedVaadinDa
     protected void checkValidity(String value) {
     }
 
-    @DomEvent("value-changed")
     public static class ValueChangeEvent<R extends GeneratedVaadinDatePickerLight<R>>
             extends ComponentEvent<R> {
         private final String value;
 
-        public ValueChangeEvent(R source, boolean fromClient,
-                @EventData("event.value") String value) {
+        public ValueChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
-            this.value = value;
+            this.value = source.getValueString();
         }
 
         public String getValue() {
@@ -747,22 +743,22 @@ public abstract class GeneratedVaadinDatePickerLight<R extends GeneratedVaadinDa
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addValueChangeListener(
             ComponentEventListener<ValueChangeEvent<R>> listener) {
-        return addListener(ValueChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("value",
+                        event -> listener
+                                .onComponentEvent(new ValueChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 
-    @DomEvent("opened-changed")
     public static class OpenedChangeEvent<R extends GeneratedVaadinDatePickerLight<R>>
             extends ComponentEvent<R> {
         private final boolean opened;
 
-        public OpenedChangeEvent(R source, boolean fromClient,
-                @EventData("event.opened") boolean opened) {
+        public OpenedChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
-            this.opened = opened;
+            this.opened = source.isOpenedBoolean();
         }
 
         public boolean isOpened() {
@@ -778,10 +774,12 @@ public abstract class GeneratedVaadinDatePickerLight<R extends GeneratedVaadinDa
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addOpenedChangeListener(
             ComponentEventListener<OpenedChangeEvent<R>> listener) {
-        return addListener(OpenedChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("opened",
+                        event -> listener.onComponentEvent(
+                                new OpenedChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 }

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePickerOverlay.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePickerOverlay.java
@@ -299,11 +299,17 @@ public abstract class GeneratedVaadinDatePickerOverlay<R extends GeneratedVaadin
                 (ComponentEventListener) listener);
     }
 
-    @DomEvent("opened-changed")
     public static class OpenedChangeEvent<R extends GeneratedVaadinDatePickerOverlay<R>>
             extends ComponentEvent<R> {
+        private final boolean opened;
+
         public OpenedChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
+            this.opened = source.isOpenedBoolean();
+        }
+
+        public boolean isOpened() {
+            return opened;
         }
     }
 
@@ -315,18 +321,26 @@ public abstract class GeneratedVaadinDatePickerOverlay<R extends GeneratedVaadin
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addOpenedChangeListener(
             ComponentEventListener<OpenedChangeEvent<R>> listener) {
-        return addListener(OpenedChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("opened",
+                        event -> listener.onComponentEvent(
+                                new OpenedChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 
-    @DomEvent("template-changed")
     public static class TemplateChangeEvent<R extends GeneratedVaadinDatePickerOverlay<R>>
             extends ComponentEvent<R> {
+        private final JsonObject template;
+
         public TemplateChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
+            this.template = source.getTemplateJsonObject();
+        }
+
+        public JsonObject getTemplate() {
+            return template;
         }
     }
 
@@ -338,18 +352,26 @@ public abstract class GeneratedVaadinDatePickerOverlay<R extends GeneratedVaadin
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addTemplateChangeListener(
             ComponentEventListener<TemplateChangeEvent<R>> listener) {
-        return addListener(TemplateChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("template",
+                        event -> listener.onComponentEvent(
+                                new TemplateChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 
-    @DomEvent("content-changed")
     public static class ContentChangeEvent<R extends GeneratedVaadinDatePickerOverlay<R>>
             extends ComponentEvent<R> {
+        private final JsonObject content;
+
         public ContentChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
+            this.content = source.getContentJsonObject();
+        }
+
+        public JsonObject getContent() {
+            return content;
         }
     }
 
@@ -361,10 +383,12 @@ public abstract class GeneratedVaadinDatePickerOverlay<R extends GeneratedVaadin
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addContentChangeListener(
             ComponentEventListener<ContentChangeEvent<R>> listener) {
-        return addListener(ContentChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("content",
+                        event -> listener.onComponentEvent(
+                                new ContentChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 }

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePickerOverlayContent.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePickerOverlayContent.java
@@ -352,11 +352,17 @@ public abstract class GeneratedVaadinDatePickerOverlayContent<R extends Generate
                 (ComponentEventListener) listener);
     }
 
-    @DomEvent("selected-date-changed")
     public static class SelectedDateChangeEvent<R extends GeneratedVaadinDatePickerOverlayContent<R>>
             extends ComponentEvent<R> {
+        private final JsonObject selectedDate;
+
         public SelectedDateChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
+            this.selectedDate = source.getSelectedDateJsonObject();
+        }
+
+        public JsonObject getSelectedDate() {
+            return selectedDate;
         }
     }
 
@@ -368,18 +374,25 @@ public abstract class GeneratedVaadinDatePickerOverlayContent<R extends Generate
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addSelectedDateChangeListener(
             ComponentEventListener<SelectedDateChangeEvent<R>> listener) {
-        return addListener(SelectedDateChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement().addPropertyChangeListener("selectedDate",
+                event -> listener
+                        .onComponentEvent(new SelectedDateChangeEvent<R>(get(),
+                                event.isUserOriginated())));
     }
 
-    @DomEvent("focused-date-changed")
     public static class FocusedDateChangeEvent<R extends GeneratedVaadinDatePickerOverlayContent<R>>
             extends ComponentEvent<R> {
+        private final JsonObject focusedDate;
+
         public FocusedDateChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
+            this.focusedDate = source.getFocusedDateJsonObject();
+        }
+
+        public JsonObject getFocusedDate() {
+            return focusedDate;
         }
     }
 
@@ -391,10 +404,11 @@ public abstract class GeneratedVaadinDatePickerOverlayContent<R extends Generate
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addFocusedDateChangeListener(
             ComponentEventListener<FocusedDateChangeEvent<R>> listener) {
-        return addListener(FocusedDateChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement().addPropertyChangeListener("focusedDate",
+                event -> listener
+                        .onComponentEvent(new FocusedDateChangeEvent<R>(get(),
+                                event.isUserOriginated())));
     }
 }

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinInfiniteScroller.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinInfiniteScroller.java
@@ -297,7 +297,7 @@ public abstract class GeneratedVaadinInfiniteScroller<R extends GeneratedVaadinI
      *            Target path to unlink.
      */
     @NotSupported
-    protected void unlinkPaths(String path) {
+    protected void unlinkPaths(JsonObject path) {
     }
 
     /**
@@ -320,7 +320,7 @@ public abstract class GeneratedVaadinInfiniteScroller<R extends GeneratedVaadinI
      *            Target path to unlink.
      */
     @NotSupported
-    protected void unlinkPaths(JsonObject path) {
+    protected void unlinkPaths(String path) {
     }
 
     /**
@@ -587,7 +587,7 @@ public abstract class GeneratedVaadinInfiniteScroller<R extends GeneratedVaadinI
      *            Path to array.
      */
     @NotSupported
-    protected void pop(String path) {
+    protected void pop(JsonObject path) {
     }
 
     /**
@@ -614,7 +614,7 @@ public abstract class GeneratedVaadinInfiniteScroller<R extends GeneratedVaadinI
      *            Path to array.
      */
     @NotSupported
-    protected void pop(JsonObject path) {
+    protected void pop(String path) {
     }
 
     /**
@@ -711,7 +711,7 @@ public abstract class GeneratedVaadinInfiniteScroller<R extends GeneratedVaadinI
      *            Path to array.
      */
     @NotSupported
-    protected void shift(String path) {
+    protected void shift(JsonObject path) {
     }
 
     /**
@@ -738,7 +738,7 @@ public abstract class GeneratedVaadinInfiniteScroller<R extends GeneratedVaadinI
      *            Path to array.
      */
     @NotSupported
-    protected void shift(JsonObject path) {
+    protected void shift(String path) {
     }
 
     /**

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinMonthCalendar.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinMonthCalendar.java
@@ -22,7 +22,6 @@ import javax.annotation.Generated;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.HtmlImport;
 import elemental.json.JsonObject;
-import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.shared.Registration;
@@ -277,11 +276,17 @@ public abstract class GeneratedVaadinMonthCalendar<R extends GeneratedVaadinMont
         return getElement().getProperty("disabled", false);
     }
 
-    @DomEvent("selected-date-changed")
     public static class SelectedDateChangeEvent<R extends GeneratedVaadinMonthCalendar<R>>
             extends ComponentEvent<R> {
+        private final JsonObject selectedDate;
+
         public SelectedDateChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
+            this.selectedDate = source.getSelectedDateJsonObject();
+        }
+
+        public JsonObject getSelectedDate() {
+            return selectedDate;
         }
     }
 
@@ -293,10 +298,11 @@ public abstract class GeneratedVaadinMonthCalendar<R extends GeneratedVaadinMont
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addSelectedDateChangeListener(
             ComponentEventListener<SelectedDateChangeEvent<R>> listener) {
-        return addListener(SelectedDateChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement().addPropertyChangeListener("selectedDate",
+                event -> listener
+                        .onComponentEvent(new SelectedDateChangeEvent<R>(get(),
+                                event.isUserOriginated())));
     }
 }

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/dialog/GeneratedVaadinDialog.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/dialog/GeneratedVaadinDialog.java
@@ -22,7 +22,6 @@ import javax.annotation.Generated;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.component.Synchronize;
-import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.shared.Registration;
@@ -91,11 +90,17 @@ public abstract class GeneratedVaadinDialog<R extends GeneratedVaadinDialog<R>>
         getElement().setProperty("opened", opened);
     }
 
-    @DomEvent("opened-changed")
     public static class OpenedChangeEvent<R extends GeneratedVaadinDialog<R>>
             extends ComponentEvent<R> {
+        private final boolean opened;
+
         public OpenedChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
+            this.opened = source.isOpenedBoolean();
+        }
+
+        public boolean isOpened() {
+            return opened;
         }
     }
 
@@ -107,10 +112,12 @@ public abstract class GeneratedVaadinDialog<R extends GeneratedVaadinDialog<R>>
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addOpenedChangeListener(
             ComponentEventListener<OpenedChangeEvent<R>> listener) {
-        return addListener(OpenedChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("opened",
+                        event -> listener.onComponentEvent(
+                                new OpenedChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 }

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/dialog/GeneratedVaadinDialogOverlay.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/dialog/GeneratedVaadinDialogOverlay.java
@@ -294,11 +294,17 @@ public abstract class GeneratedVaadinDialogOverlay<R extends GeneratedVaadinDial
                 (ComponentEventListener) listener);
     }
 
-    @DomEvent("opened-changed")
     public static class OpenedChangeEvent<R extends GeneratedVaadinDialogOverlay<R>>
             extends ComponentEvent<R> {
+        private final boolean opened;
+
         public OpenedChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
+            this.opened = source.isOpenedBoolean();
+        }
+
+        public boolean isOpened() {
+            return opened;
         }
     }
 
@@ -310,18 +316,26 @@ public abstract class GeneratedVaadinDialogOverlay<R extends GeneratedVaadinDial
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addOpenedChangeListener(
             ComponentEventListener<OpenedChangeEvent<R>> listener) {
-        return addListener(OpenedChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("opened",
+                        event -> listener.onComponentEvent(
+                                new OpenedChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 
-    @DomEvent("template-changed")
     public static class TemplateChangeEvent<R extends GeneratedVaadinDialogOverlay<R>>
             extends ComponentEvent<R> {
+        private final JsonObject template;
+
         public TemplateChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
+            this.template = source.getTemplateJsonObject();
+        }
+
+        public JsonObject getTemplate() {
+            return template;
         }
     }
 
@@ -333,18 +347,26 @@ public abstract class GeneratedVaadinDialogOverlay<R extends GeneratedVaadinDial
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addTemplateChangeListener(
             ComponentEventListener<TemplateChangeEvent<R>> listener) {
-        return addListener(TemplateChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("template",
+                        event -> listener.onComponentEvent(
+                                new TemplateChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 
-    @DomEvent("content-changed")
     public static class ContentChangeEvent<R extends GeneratedVaadinDialogOverlay<R>>
             extends ComponentEvent<R> {
+        private final JsonObject content;
+
         public ContentChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
+            this.content = source.getContentJsonObject();
+        }
+
+        public JsonObject getContent() {
+            return content;
         }
     }
 
@@ -356,10 +378,12 @@ public abstract class GeneratedVaadinDialogOverlay<R extends GeneratedVaadinDial
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addContentChangeListener(
             ComponentEventListener<ContentChangeEvent<R>> listener) {
-        return addListener(ContentChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("content",
+                        event -> listener.onComponentEvent(
+                                new ContentChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 }

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/listbox/GeneratedVaadinListBox.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/listbox/GeneratedVaadinListBox.java
@@ -23,8 +23,6 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.HtmlImport;
 import elemental.json.JsonArray;
 import com.vaadin.flow.component.Synchronize;
-import com.vaadin.flow.component.EventData;
-import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.shared.Registration;
@@ -98,15 +96,13 @@ public abstract class GeneratedVaadinListBox<R extends GeneratedVaadinListBox<R>
         getElement().callFunction("focus");
     }
 
-    @DomEvent("items-changed")
     public static class ItemsChangeEvent<R extends GeneratedVaadinListBox<R>>
             extends ComponentEvent<R> {
         private final JsonArray items;
 
-        public ItemsChangeEvent(R source, boolean fromClient,
-                @EventData("event.items") JsonArray items) {
+        public ItemsChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
-            this.items = items;
+            this.items = source.getItemsJsonArray();
         }
 
         public JsonArray getItems() {
@@ -122,10 +118,12 @@ public abstract class GeneratedVaadinListBox<R extends GeneratedVaadinListBox<R>
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addItemsChangeListener(
             ComponentEventListener<ItemsChangeEvent<R>> listener) {
-        return addListener(ItemsChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("items",
+                        event -> listener
+                                .onComponentEvent(new ItemsChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 }

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/notification/GeneratedVaadinNotification.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/notification/GeneratedVaadinNotification.java
@@ -22,7 +22,6 @@ import javax.annotation.Generated;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.component.Synchronize;
-import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.shared.Registration;
@@ -177,11 +176,17 @@ public abstract class GeneratedVaadinNotification<R extends GeneratedVaadinNotif
         getElement().callFunction("close");
     }
 
-    @DomEvent("opened-changed")
     public static class OpenedChangeEvent<R extends GeneratedVaadinNotification<R>>
             extends ComponentEvent<R> {
+        private final boolean opened;
+
         public OpenedChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
+            this.opened = source.isOpenedBoolean();
+        }
+
+        public boolean isOpened() {
+            return opened;
         }
     }
 
@@ -193,10 +198,12 @@ public abstract class GeneratedVaadinNotification<R extends GeneratedVaadinNotif
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addOpenedChangeListener(
             ComponentEventListener<OpenedChangeEvent<R>> listener) {
-        return addListener(OpenedChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("opened",
+                        event -> listener.onComponentEvent(
+                                new OpenedChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 }

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/radiobutton/GeneratedVaadinRadioButton.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/radiobutton/GeneratedVaadinRadioButton.java
@@ -23,7 +23,6 @@ import javax.annotation.Generated;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.component.Synchronize;
-import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.shared.Registration;
@@ -255,11 +254,17 @@ public abstract class GeneratedVaadinRadioButton<R extends GeneratedVaadinRadioB
         getElement().setProperty("value", value == null ? "" : value);
     }
 
-    @DomEvent("checked-changed")
     public static class CheckedChangeEvent<R extends GeneratedVaadinRadioButton<R>>
             extends ComponentEvent<R> {
+        private final boolean checked;
+
         public CheckedChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
+            this.checked = source.isCheckedBoolean();
+        }
+
+        public boolean isChecked() {
+            return checked;
         }
     }
 
@@ -271,10 +276,12 @@ public abstract class GeneratedVaadinRadioButton<R extends GeneratedVaadinRadioB
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addCheckedChangeListener(
             ComponentEventListener<CheckedChangeEvent<R>> listener) {
-        return addListener(CheckedChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("checked",
+                        event -> listener.onComponentEvent(
+                                new CheckedChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 }

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/radiobutton/GeneratedVaadinRadioGroup.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/radiobutton/GeneratedVaadinRadioGroup.java
@@ -21,7 +21,6 @@ import com.vaadin.flow.component.ComponentSupplier;
 import javax.annotation.Generated;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.HtmlImport;
-import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.shared.Registration;
@@ -110,7 +109,6 @@ public abstract class GeneratedVaadinRadioGroup<R extends GeneratedVaadinRadioGr
         getElement().setProperty("disabled", disabled);
     }
 
-    @DomEvent("value-changed")
     public static class ValueChangeEvent<R extends GeneratedVaadinRadioGroup<R>>
             extends ComponentEvent<R> {
         public ValueChangeEvent(R source, boolean fromClient) {
@@ -126,10 +124,12 @@ public abstract class GeneratedVaadinRadioGroup<R extends GeneratedVaadinRadioGr
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addValueChangeListener(
             ComponentEventListener<ValueChangeEvent<R>> listener) {
-        return addListener(ValueChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("value",
+                        event -> listener
+                                .onComponentEvent(new ValueChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 }

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/tabs/GeneratedVaadinTab.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/tabs/GeneratedVaadinTab.java
@@ -15,11 +15,10 @@
  */
 package com.vaadin.flow.component.tabs;
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.ComponentSupplier;
 import com.vaadin.flow.component.HasStyle;
+import com.vaadin.flow.component.ComponentSupplier;
+import javax.annotation.Generated;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.HtmlImport;
 

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/tabs/GeneratedVaadinTabs.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/tabs/GeneratedVaadinTabs.java
@@ -15,11 +15,10 @@
  */
 package com.vaadin.flow.component.tabs;
 
-import javax.annotation.Generated;
-
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.ComponentSupplier;
 import com.vaadin.flow.component.HasStyle;
+import com.vaadin.flow.component.ComponentSupplier;
+import javax.annotation.Generated;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.HtmlImport;
 

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextArea.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextArea.java
@@ -27,7 +27,6 @@ import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.shared.Registration;
-import com.vaadin.flow.component.EventData;
 import com.vaadin.flow.dom.Element;
 
 /**
@@ -738,15 +737,13 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
                 (ComponentEventListener) listener);
     }
 
-    @DomEvent("value-changed")
     public static class ValueChangeEvent<R extends GeneratedVaadinTextArea<R>>
             extends ComponentEvent<R> {
         private final String value;
 
-        public ValueChangeEvent(R source, boolean fromClient,
-                @EventData("event.value") String value) {
+        public ValueChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
-            this.value = value;
+            this.value = source.getValueString();
         }
 
         public String getValue() {
@@ -762,22 +759,22 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addValueChangeListener(
             ComponentEventListener<ValueChangeEvent<R>> listener) {
-        return addListener(ValueChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("value",
+                        event -> listener
+                                .onComponentEvent(new ValueChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 
-    @DomEvent("invalid-changed")
     public static class InvalidChangeEvent<R extends GeneratedVaadinTextArea<R>>
             extends ComponentEvent<R> {
         private final boolean invalid;
 
-        public InvalidChangeEvent(R source, boolean fromClient,
-                @EventData("event.invalid") boolean invalid) {
+        public InvalidChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
-            this.invalid = invalid;
+            this.invalid = source.isInvalidBoolean();
         }
 
         public boolean isInvalid() {
@@ -793,11 +790,13 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addInvalidChangeListener(
             ComponentEventListener<InvalidChangeEvent<R>> listener) {
-        return addListener(InvalidChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("invalid",
+                        event -> listener.onComponentEvent(
+                                new InvalidChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 
     /**

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextField.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextField.java
@@ -27,7 +27,6 @@ import com.vaadin.flow.component.DomEvent;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.shared.Registration;
-import com.vaadin.flow.component.EventData;
 import com.vaadin.flow.dom.Element;
 
 /**
@@ -856,15 +855,13 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
                 (ComponentEventListener) listener);
     }
 
-    @DomEvent("value-changed")
     public static class ValueChangeEvent<R extends GeneratedVaadinTextField<R>>
             extends ComponentEvent<R> {
         private final String value;
 
-        public ValueChangeEvent(R source, boolean fromClient,
-                @EventData("event.value") String value) {
+        public ValueChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
-            this.value = value;
+            this.value = source.getValueString();
         }
 
         public String getValue() {
@@ -880,22 +877,22 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addValueChangeListener(
             ComponentEventListener<ValueChangeEvent<R>> listener) {
-        return addListener(ValueChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("value",
+                        event -> listener
+                                .onComponentEvent(new ValueChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 
-    @DomEvent("invalid-changed")
     public static class InvalidChangeEvent<R extends GeneratedVaadinTextField<R>>
             extends ComponentEvent<R> {
         private final boolean invalid;
 
-        public InvalidChangeEvent(R source, boolean fromClient,
-                @EventData("event.invalid") boolean invalid) {
+        public InvalidChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
-            this.invalid = invalid;
+            this.invalid = source.isInvalidBoolean();
         }
 
         public boolean isInvalid() {
@@ -911,11 +908,13 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addInvalidChangeListener(
             ComponentEventListener<InvalidChangeEvent<R>> listener) {
-        return addListener(InvalidChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("invalid",
+                        event -> listener.onComponentEvent(
+                                new InvalidChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 
     /**

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/upload/GeneratedVaadinUpload.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/upload/GeneratedVaadinUpload.java
@@ -1224,11 +1224,17 @@ public abstract class GeneratedVaadinUpload<R extends GeneratedVaadinUpload<R>>
                 (ComponentEventListener) listener);
     }
 
-    @DomEvent("files-changed")
     public static class FilesChangeEvent<R extends GeneratedVaadinUpload<R>>
             extends ComponentEvent<R> {
+        private final JsonArray files;
+
         public FilesChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
+            this.files = source.getFilesJsonArray();
+        }
+
+        public JsonArray getFiles() {
+            return files;
         }
     }
 
@@ -1240,18 +1246,26 @@ public abstract class GeneratedVaadinUpload<R extends GeneratedVaadinUpload<R>>
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addFilesChangeListener(
             ComponentEventListener<FilesChangeEvent<R>> listener) {
-        return addListener(FilesChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement()
+                .addPropertyChangeListener("files",
+                        event -> listener
+                                .onComponentEvent(new FilesChangeEvent<R>(get(),
+                                        event.isUserOriginated())));
     }
 
-    @DomEvent("max-files-reached-changed")
     public static class MaxFilesReachedChangeEvent<R extends GeneratedVaadinUpload<R>>
             extends ComponentEvent<R> {
+        private final boolean maxFilesReached;
+
         public MaxFilesReachedChangeEvent(R source, boolean fromClient) {
             super(source, fromClient);
+            this.maxFilesReached = source.isMaxFilesReachedBoolean();
+        }
+
+        public boolean isMaxFilesReached() {
+            return maxFilesReached;
         }
     }
 
@@ -1263,11 +1277,12 @@ public abstract class GeneratedVaadinUpload<R extends GeneratedVaadinUpload<R>>
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Registration addMaxFilesReachedChangeListener(
             ComponentEventListener<MaxFilesReachedChangeEvent<R>> listener) {
-        return addListener(MaxFilesReachedChangeEvent.class,
-                (ComponentEventListener) listener);
+        return getElement().addPropertyChangeListener("maxFilesReached",
+                event -> listener.onComponentEvent(
+                        new MaxFilesReachedChangeEvent<R>(get(),
+                                event.isUserOriginated())));
     }
 
     /**


### PR DESCRIPTION
In case of property changes, generated listeners don't just wait for the asynchronous dom-events to occur but instead use `PropertyChangeListeners` which take care of firing the events immediately when the property is changed from server-side. This is how `HasValue::addValueChangeListener` works already.

Also, the property change events now always contain a getter for the changed property.

Because of these changes the property change events no longer contain `EventData` from the client-side.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3620)
<!-- Reviewable:end -->
