### PR TITLE
Allow gathering profiling data in production mode

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/ApplicationConfiguration.java
+++ b/flow-client/src/main/java/com/vaadin/client/ApplicationConfiguration.java
@@ -37,6 +37,7 @@ public class ApplicationConfiguration {
     private int heartbeatInterval;
 
     private boolean productionMode;
+    private boolean requestTiming;
     private String servletVersion;
     private String atmosphereVersion;
     private String atmosphereJSVersion;
@@ -273,6 +274,16 @@ public class ApplicationConfiguration {
     }
 
     /**
+     * Checks if request timing info should be made available.
+     *
+     * @return {@code true} if request timing info should be made availble,
+     *         {@code false} otherwise
+     */
+    public boolean isRequestTiming() {
+        return requestTiming;
+    }
+
+    /**
      * Sets whether we are running in production mode.
      * <p>
      * With production mode disabled, a lot more information is logged to the
@@ -287,6 +298,17 @@ public class ApplicationConfiguration {
     public void setProductionMode(boolean productionMode) {
         this.productionMode = productionMode;
         Console.setProductionMode(productionMode);
+    }
+
+    /**
+     * Sets whether request timing info should be made available.
+     *
+     * @param requestTiming
+     *            {@code true} if request timing info should be made available,
+     *            {@code false} otherwise
+     */
+    public void setRequestTiming(boolean requestTiming) {
+        this.requestTiming = requestTiming;
     }
 
     /**

--- a/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
@@ -74,8 +74,9 @@ public class ApplicationConnection {
         appRootPanelName = appRootPanelName.replaceFirst("-\\d+$", "");
 
         boolean productionMode = applicationConfiguration.isProductionMode();
-        publishProductionModeJavascriptMethods(appRootPanelName,
-                productionMode);
+        boolean requestTiming = applicationConfiguration.isRequestTiming();
+        publishProductionModeJavascriptMethods(appRootPanelName, productionMode,
+                requestTiming);
         if (!productionMode) {
             String servletVersion = applicationConfiguration
                     .getServletVersion();
@@ -126,9 +127,15 @@ public class ApplicationConnection {
      *
      * @param applicationId
      *            the application id provided by the server
+     * @param productionMode
+     *            <code>true</code> if running in production mode,
+     *            <code>false</code> otherwise
+     * @param requestTiming
+     *            <code>true</code> if request timing info should be made
+     *            available, <code>false</code> otherwise
      */
     private native void publishProductionModeJavascriptMethods(
-            String applicationId, boolean productionMode)
+            String applicationId, boolean productionMode, boolean requestTiming)
     /*-{
         var ap = this;
         var client = {};
@@ -143,6 +150,22 @@ public class ApplicationConnection {
                 var poller = ap.@ApplicationConnection::registry.@com.vaadin.client.Registry::getPoller()();
                 poller.@com.vaadin.client.communication.Poller::poll()();
         });
+        if (requestTiming) {
+           client.getProfilingData = $entry(function() {
+            var smh = ap.@com.vaadin.client.ApplicationConnection::registry.@com.vaadin.client.Registry::getMessageHandler()();
+            var pd = [
+                smh.@com.vaadin.client.communication.MessageHandler::lastProcessingTime,
+                    smh.@com.vaadin.client.communication.MessageHandler::totalProcessingTime
+                ];
+            if (null != smh.@com.vaadin.client.communication.MessageHandler::serverTimingInfo) {
+                pd = pd.concat(smh.@com.vaadin.client.communication.MessageHandler::serverTimingInfo);
+            } else {
+                pd = pd.concat(-1, -1);
+            }
+            pd[pd.length] = smh.@com.vaadin.client.communication.MessageHandler::bootstrapTime;
+            return pd;
+        });
+        }
         $wnd.Vaadin.Flow.resolveUri = $entry(function(uriToResolve) {
             var ur = ap.@ApplicationConnection::registry.@com.vaadin.client.Registry::getURIResolver()();
             return ur.@com.vaadin.client.URIResolver::resolveVaadinUri(Ljava/lang/String;)(uriToResolve);
@@ -181,20 +204,6 @@ public class ApplicationConnection {
             return { "flow": servletVersion};
         });
     
-        client.getProfilingData = $entry(function() {
-            var smh = ap.@com.vaadin.client.ApplicationConnection::registry.@com.vaadin.client.Registry::getMessageHandler()();
-            var pd = [
-                smh.@com.vaadin.client.communication.MessageHandler::lastProcessingTime,
-                    smh.@com.vaadin.client.communication.MessageHandler::totalProcessingTime
-                ];
-            if (null != smh.@com.vaadin.client.communication.MessageHandler::serverTimingInfo) {
-                pd = pd.concat(smh.@com.vaadin.client.communication.MessageHandler::serverTimingInfo);
-            } else {
-                pd = pd.concat(-1, -1);
-            }
-            pd[pd.length] = smh.@com.vaadin.client.communication.MessageHandler::bootstrapTime;
-            return pd;
-        });
     }-*/;
 
     /**

--- a/flow-client/src/main/java/com/vaadin/client/bootstrap/Bootstrapper.java
+++ b/flow-client/src/main/java/com/vaadin/client/bootstrap/Bootstrapper.java
@@ -154,6 +154,9 @@ public class Bootstrapper implements EntryPoint {
 
         // Debug or production mode?
         conf.setProductionMode(!jsoConfiguration.getConfigBoolean("debug"));
+        conf.setRequestTiming(
+                jsoConfiguration.getConfigBoolean("requestTiming"));
+
     }
 
     private static void doStartApplication(final String applicationId) {

--- a/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
@@ -43,6 +43,13 @@ public interface DeploymentConfiguration extends Serializable {
     boolean isProductionMode();
 
     /**
+     * Returns whether the server provides timing info to the client.
+     *
+     * @return true if timing info is provided, false otherwise.
+     */
+    boolean isRequestTiming();
+
+    /**
      * Returns whether cross-site request forgery protection is enabled.
      *
      * @return true if XSRF protection is enabled, false otherwise.

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -642,8 +642,8 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
 
         BootstrapUtils.getViewportContent(context)
                 .ifPresent(content -> head.appendElement(META_TAG)
-                        .attr("name", VIEWPORT).attr(CONTENT_ATTRIBUTE,
-                                content));
+                        .attr("name", VIEWPORT)
+                        .attr(CONTENT_ATTRIBUTE, content));
 
         resolvePageTitle(context).ifPresent(title -> {
             if (!title.isEmpty()) {
@@ -718,8 +718,9 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
     private static Element createDependencyElement(VaadinUriResolver resolver,
             LoadMode loadMode, JsonObject dependency, Dependency.Type type) {
         boolean inlineElement = loadMode == LoadMode.INLINE;
-        String url = dependency.hasKey(Dependency.KEY_URL) ? resolver
-                .resolveVaadinUri(dependency.getString(Dependency.KEY_URL))
+        String url = dependency.hasKey(Dependency.KEY_URL)
+                ? resolver.resolveVaadinUri(
+                        dependency.getString(Dependency.KEY_URL))
                 : null;
 
         final Element dependencyElement;
@@ -851,15 +852,17 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
     private static JsonObject getApplicationParameters(VaadinRequest request,
             VaadinSession session) {
         VaadinService vaadinService = session.getService();
-        final boolean productionMode = session.getConfiguration()
+        DeploymentConfiguration deploymentConfiguration = session
+                .getConfiguration();
+        final boolean productionMode = deploymentConfiguration
                 .isProductionMode();
 
         JsonObject appConfig = Json.createObject();
 
         appConfig.put(ApplicationConstants.FRONTEND_URL_ES6,
-                session.getConfiguration().getEs6FrontendPrefix());
+                deploymentConfiguration.getEs6FrontendPrefix());
         appConfig.put(ApplicationConstants.FRONTEND_URL_ES5,
-                session.getConfiguration().getEs5FrontendPrefix());
+                deploymentConfiguration.getEs5FrontendPrefix());
 
         if (!productionMode) {
             JsonObject versionInfo = Json.createObject();
@@ -918,11 +921,15 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             appConfig.put("debug", true);
         }
 
-        appConfig.put("heartbeatInterval", vaadinService
-                .getDeploymentConfiguration().getHeartbeatInterval());
+        if (deploymentConfiguration.isRequestTiming()) {
+            appConfig.put("requestTiming", true);
+        }
 
-        boolean sendUrlsAsParameters = vaadinService
-                .getDeploymentConfiguration().isSendUrlsAsParameters();
+        appConfig.put("heartbeatInterval",
+                deploymentConfiguration.getHeartbeatInterval());
+
+        boolean sendUrlsAsParameters = deploymentConfiguration
+                .isSendUrlsAsParameters();
         if (!sendUrlsAsParameters) {
             appConfig.put("sendUrlsAsParameters", false);
         }
@@ -1163,8 +1170,8 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                 return ApplicationConstants.CLIENT_ENGINE_PATH + "/"
                         + properties.getProperty("jsFile");
             } else {
-                getLogger()
-                        .warn("No compile.properties available on initialization, "
+                getLogger().warn(
+                        "No compile.properties available on initialization, "
                                 + "could not read client engine file name.");
             }
         } catch (IOException e) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -33,6 +33,7 @@ public final class Constants implements Serializable {
             "2.4.5.vaadin2";
 
     public static final String SERVLET_PARAMETER_PRODUCTION_MODE = "productionMode";
+    public static final String SERVLET_PARAMETER_REQUEST_TIMING = "requestTiming";
     // Javadocs for VaadinService should be updated if this value is changed
     public static final String SERVLET_PARAMETER_DISABLE_XSRF_PROTECTION = "disable-xsrf-protection";
     public static final String SERVLET_PARAMETER_HEARTBEAT_INTERVAL = "heartbeatInterval";

--- a/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
@@ -97,6 +97,7 @@ public class DefaultDeploymentConfiguration
     private boolean sendUrlsAsParameters;
     private String webComponentsPolyfillBase;
     private boolean usingNewRouting;
+    private boolean requestTiming;
 
     /**
      * Create a new deployment configuration instance.
@@ -120,6 +121,7 @@ public class DefaultDeploymentConfiguration
         this.systemPropertyBaseClass = systemPropertyBaseClass;
 
         checkProductionMode();
+        checkRequestTiming();
         checkXsrfProtection();
         checkHeartbeatInterval();
         checkCloseIdleSessions();
@@ -226,6 +228,17 @@ public class DefaultDeploymentConfiguration
 
     /**
      * {@inheritDoc}
+     *
+     * The default is <code>true</code> when not in production and
+     * <code>false</code> when in production mode.
+     */
+    @Override
+    public boolean isRequestTiming() {
+        return requestTiming;
+    }
+
+    /**
+     * {@inheritDoc}
      * <p>
      * The default is true.
      */
@@ -308,6 +321,14 @@ public class DefaultDeploymentConfiguration
         if (!productionMode) {
             getLogger().warn(NOT_PRODUCTION_MODE_INFO);
         }
+    }
+
+    /**
+     * Checks if request timing data should be provided to the client.
+     */
+    private void checkRequestTiming() {
+        requestTiming = getBooleanProperty(
+                Constants.SERVLET_PARAMETER_REQUEST_TIMING, !productionMode);
     }
 
     /**
@@ -435,10 +456,10 @@ public class DefaultDeploymentConfiguration
         String scanBase = uriResolver.resolveVaadinUri(
                 ApplicationConstants.FRONTEND_PROTOCOL_PREFIX);
         if (!scanBase.startsWith(CONTEXT_ROOT_PATH)) {
-            String message = formatDefaultPolyfillMessage( String
-                .format( "Cannot automatically find the %s polyfill because the property "
-                        + "'%s' value is not absolute (doesn't start with '/')",
-                    WEB_COMPONENTS_LOADER_JS_NAME, Constants.FRONTEND_URL_ES6 ) );
+            String message = formatDefaultPolyfillMessage(String.format(
+                    "Cannot automatically find the %s polyfill because the property "
+                            + "'%s' value is not absolute (doesn't start with '/')",
+                    WEB_COMPONENTS_LOADER_JS_NAME, Constants.FRONTEND_URL_ES6));
             getLogger().warn(message);
             return Optional.empty();
         }
@@ -478,7 +499,8 @@ public class DefaultDeploymentConfiguration
         String fileName = polyfills.iterator().next();
         String dirName = fileName.substring(0, fileName.lastIndexOf('/'));
 
-        getLogger().info("Will use {} polyfill discovered in {}", WEB_COMPONENTS_LOADER_JS_NAME, dirName);
+        getLogger().info("Will use {} polyfill discovered in {}",
+                WEB_COMPONENTS_LOADER_JS_NAME, dirName);
         return Optional.of(prefix + dirName + '/');
     }
 
@@ -488,4 +510,5 @@ public class DefaultDeploymentConfiguration
                 + "Configure %2$s with an explicit value to use that location instead of scanning for an implementation.",
                 baseMessage, Constants.SERVLET_PARAMETER_POLYFILL_BASE);
     }
+
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlWriter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlWriter.java
@@ -158,8 +158,8 @@ public class UidlWriter implements Serializable {
             response.put(JsonConstants.UIDL_KEY_EXECUTE,
                     encodeExecuteJavaScriptList(executeJavaScriptList));
         }
-        if (!ui.getSession().getService().getDeploymentConfiguration()
-                .isProductionMode()) {
+        if (ui.getSession().getService().getDeploymentConfiguration()
+                .isRequestTiming()) {
             response.put("timings", createPerformanceData(ui));
         }
         uiInternals.incrementServerId();

--- a/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
@@ -76,6 +76,11 @@ public class AbstractDeploymentConfigurationTest {
         }
 
         @Override
+        public boolean isRequestTiming() {
+            return !isProductionMode();
+        }
+
+        @Override
         public boolean isXsrfProtectionEnabled() {
             return false;
         }
@@ -106,8 +111,8 @@ public class AbstractDeploymentConfigurationTest {
         }
 
         @Override
-        public <T> T getApplicationOrSystemProperty(String propertyName, T defaultValue,
-                                                    Function<String, T> converter) {
+        public <T> T getApplicationOrSystemProperty(String propertyName,
+                T defaultValue, Function<String, T> converter) {
             return Optional.ofNullable(properties.getProperty(propertyName))
                     .map(converter).orElse(defaultValue);
         }

--- a/flow-server/src/test/java/com/vaadin/tests/util/MockDeploymentConfiguration.java
+++ b/flow-server/src/test/java/com/vaadin/tests/util/MockDeploymentConfiguration.java
@@ -37,6 +37,12 @@ public class MockDeploymentConfiguration
         return productionMode;
     }
 
+    @Override
+    public boolean isRequestTiming() {
+        return !productionMode;
+    }
+
+
     public void setProductionMode(boolean productionMode) {
         this.productionMode = productionMode;
     }
@@ -122,4 +128,5 @@ public class MockDeploymentConfiguration
     public boolean isUsingNewRouting() {
         return true;
     }
+
 }

--- a/flow-test-util/src/main/java/com/vaadin/flow/testutil/AbstractTestBenchTest.java
+++ b/flow-test-util/src/main/java/com/vaadin/flow/testutil/AbstractTestBenchTest.java
@@ -101,6 +101,10 @@ public abstract class AbstractTestBenchTest extends TestBenchHelpers {
         openUrl("view-production", parameters);
     }
 
+    protected void openProductionWithTiming(String... parameters) {
+        openUrl("view-production-timing", parameters);
+    }
+
     protected void openForEs6Url(String... parameters) {
         openUrl("view-es6-url", parameters);
     }
@@ -233,11 +237,13 @@ public abstract class AbstractTestBenchTest extends TestBenchHelpers {
     }
 
     /**
-     * Returns host address that can be targeted from the outside, like from a test hub.
+     * Returns host address that can be targeted from the outside, like from a
+     * test hub.
      *
      * @return host address
-     * @throws RuntimeException if host name could not be determined or {@link SocketException} was caught during
-     * the determination.
+     * @throws RuntimeException
+     *             if host name could not be determined or
+     *             {@link SocketException} was caught during the determination.
      */
     protected String getCurrentHostAddress() {
         try {
@@ -316,7 +322,8 @@ public abstract class AbstractTestBenchTest extends TestBenchHelpers {
                 .filter(LocalExecution::active);
     }
 
-    private static Optional<String> getHostAddress(NetworkInterface nwInterface) {
+    private static Optional<String> getHostAddress(
+            NetworkInterface nwInterface) {
         Enumeration<InetAddress> addresses = nwInterface.getInetAddresses();
         while (addresses.hasMoreElements()) {
             InetAddress address = addresses.nextElement();

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/servlet/ProductionModeTimingDataViewTestServlet.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/servlet/ProductionModeTimingDataViewTestServlet.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.servlet;
+
+import javax.servlet.annotation.WebInitParam;
+import javax.servlet.annotation.WebServlet;
+
+import com.vaadin.flow.server.VaadinServletConfiguration;
+
+@WebServlet(asyncSupported = true, urlPatterns = {
+        "/view-production-timing/*" }, initParams = @WebInitParam(name = "requestTiming", value = "true"))
+@VaadinServletConfiguration(productionMode = true)
+public class ProductionModeTimingDataViewTestServlet extends ViewTestServlet {
+
+}


### PR DESCRIPTION
Development mode does a lot of things which makes it slower than production
mode but easier to debug. Performance should always be measured when using bundling
and other optimizations to get realistic results but to avoid leaking server info,
the timing info is not made available by default.

This change makes it possible to set 'requestTiming' to 'true' to get timing data
when in production mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3638)
<!-- Reviewable:end -->
