### PR TITLE
Fix html dependency parser to handle automatically frontend://

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlWriter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlWriter.java
@@ -17,7 +17,6 @@
 package com.vaadin.flow.server.communication;
 
 import javax.servlet.http.HttpServletRequest;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -64,9 +63,9 @@ import com.vaadin.flow.server.DependencyFilter;
 import com.vaadin.flow.server.DependencyFilter.FilterContext;
 import com.vaadin.flow.server.SystemMessages;
 import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinServlet;
 import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.server.VaadinSession;
-import com.vaadin.flow.server.VaadinUriResolverFactory;
 import com.vaadin.flow.shared.ApplicationConstants;
 import com.vaadin.flow.shared.JsonConstants;
 import com.vaadin.flow.shared.ui.Dependency;
@@ -230,13 +229,7 @@ public class UidlWriter implements Serializable {
 
     private static InputStream getInlineResourceStream(String url,
             HttpServletRequest currentRequest) {
-        VaadinUriResolverFactory uriResolverFactory = VaadinSession.getCurrent()
-                .getAttribute(VaadinUriResolverFactory.class);
-
-        assert uriResolverFactory != null;
-
-        String resolvedPath = uriResolverFactory
-                .toServletContextPath(VaadinService.getCurrentRequest(), url);
+        String resolvedPath = VaadinServlet.getCurrent().resolveResource(url);
         InputStream stream = currentRequest.getServletContext()
                 .getResourceAsStream(resolvedPath);
 

--- a/flow-server/src/main/java/com/vaadin/flow/shared/ui/Dependency.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/ui/Dependency.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.shared.ApplicationConstants;
+import com.vaadin.flow.shared.util.SharedUtil;
 
 import elemental.json.Json;
 import elemental.json.JsonObject;
@@ -86,24 +87,9 @@ public class Dependency implements Serializable {
         assert type != null;
 
         this.type = type;
-        this.url = prefixIfRelative(url,
+        this.url = SharedUtil.prefixIfRelative(url,
                 ApplicationConstants.FRONTEND_PROTOCOL_PREFIX);
         this.loadMode = loadMode;
-    }
-
-    private static String prefixIfRelative(String url, String prefix) {
-        // Absolute
-        if (url.startsWith("/")) {
-            return url;
-        }
-
-        // Has a protocol
-        // https://tools.ietf.org/html/rfc3986#section-3.1
-        if (url.matches("^[a-zA-Z0-9.\\-+]+:.*")) {
-            return url;
-        }
-
-        return prefix + url;
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/shared/util/SharedUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/util/SharedUtil.java
@@ -316,4 +316,28 @@ public class SharedUtil implements Serializable {
         return join(parts, "-");
     }
 
+    /**
+     * Prepend the given url with the prefix if it is not absolute and doesn't
+     * have a protocol.
+     * 
+     * @param url
+     *            url to check
+     * @param prefix
+     *            prefix to add to url
+     * @return prefixed url or url if absolute or has a protocol
+     */
+    public static String prefixIfRelative(String url, String prefix) {
+        // Absolute
+        if (url.startsWith("/")) {
+            return url;
+        }
+
+        // Has a protocol
+        // https://tools.ietf.org/html/rfc3986#section-3.1
+        if (url.matches("^[a-zA-Z0-9.\\-+]+:.*")) {
+            return url;
+        }
+
+        return prefix + url;
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/HtmlDependencyParserTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/HtmlDependencyParserTest.java
@@ -71,6 +71,12 @@ public class HtmlDependencyParserTest {
     @Test
     public void mainImportDoesntHaveContentToParse_mainInportIsReturnedAndNoExceptions() {
         String root = "foo.html";
+
+        Mockito.when(servlet.resolveResource("frontend://foo.html"))
+                .thenReturn("foo.html");
+        Mockito.when(context.getResourceAsStream("foo.html"))
+                .thenReturn(new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
+
         HtmlDependencyParser parser = new HtmlDependencyParser(root);
         Collection<String> dependencies = parser.parseDependencies();
         Assert.assertTrue(
@@ -96,6 +102,30 @@ public class HtmlDependencyParserTest {
                 importContent.getBytes(StandardCharsets.UTF_8));
         Mockito.when(context.getResourceAsStream(resolvedRoot))
                 .thenReturn(stream);
+
+
+        Mockito.when(servlet.resolveResource("frontend://baz/relative1.html"))
+                .thenReturn("baz/relative1.html");
+        Mockito.when(context.getResourceAsStream("baz/relative1.html"))
+                .thenReturn(new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
+
+
+        Mockito.when(servlet.resolveResource("frontend://relative2.html"))
+                .thenReturn("relative2.html");
+        Mockito.when(context.getResourceAsStream("relative2.html"))
+                .thenReturn(new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
+
+
+        Mockito.when(servlet.resolveResource("frontend://baz/sub/relative3.html"))
+                .thenReturn("relative3.html");
+        Mockito.when(context.getResourceAsStream("relative3.html"))
+                .thenReturn(new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
+
+
+        Mockito.when(servlet.resolveResource("/absolute.html"))
+                .thenReturn("absolute.html");
+        Mockito.when(context.getResourceAsStream("absolute.html"))
+                .thenReturn(new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
 
         Collection<String> dependencies = parser.parseDependencies();
 
@@ -128,6 +158,11 @@ public class HtmlDependencyParserTest {
                 importContent.getBytes(StandardCharsets.UTF_8));
         Mockito.when(context.getResourceAsStream(root)).thenReturn(stream);
 
+        Mockito.when(servlet.resolveResource("frontend://relative.html"))
+                .thenReturn("relative.html");
+        Mockito.when(context.getResourceAsStream("relative.html"))
+                .thenReturn(new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
+
         Collection<String> dependencies = parser.parseDependencies();
 
         Assert.assertEquals(2, dependencies.size());
@@ -156,7 +191,7 @@ public class HtmlDependencyParserTest {
         String resolvedRelative = "baz/bar/relative.html";
         Mockito.when(servlet.resolveResource("frontend://relative.html"))
                 .thenReturn(resolvedRelative);
-        Mockito.when(servlet.resolveResource("frontend://baz/bar/relative1.html"))
+        Mockito.when(servlet.resolveResource("frontend://relative1.html"))
                 .thenReturn("relative1.html");
 
         InputStream relativeContent = new ByteArrayInputStream(
@@ -195,6 +230,11 @@ public class HtmlDependencyParserTest {
                 importContent.getBytes(StandardCharsets.UTF_8));
         Mockito.when(context.getResourceAsStream(resolvedRoot))
                 .thenReturn(stream);
+
+        Mockito.when(servlet.resolveResource("frontend://relative.html"))
+                .thenReturn("relative.html");
+        Mockito.when(context.getResourceAsStream("relative.html"))
+                .thenReturn(new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
 
         HtmlDependenciesCache cache = new HtmlDependenciesCache();
         Mockito.when(session.getAttribute(HtmlDependenciesCache.class))

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/HtmlDependencyParserTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/HtmlDependencyParserTest.java
@@ -20,7 +20,6 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
-import java.util.Collections;
 
 import net.jcip.annotations.NotThreadSafe;
 import org.junit.After;
@@ -47,8 +46,6 @@ public class HtmlDependencyParserTest {
     @Before
     public void setUp() {
         service = Mockito.mock(VaadinServletService.class);
-        Mockito.when(service.getDependencyFilters())
-                .thenReturn(Collections.emptyList());
         CurrentInstance.set(VaadinService.class, service);
 
         servlet = Mockito.mock(VaadinServlet.class);
@@ -74,8 +71,8 @@ public class HtmlDependencyParserTest {
 
         Mockito.when(servlet.resolveResource("frontend://foo.html"))
                 .thenReturn("foo.html");
-        Mockito.when(context.getResourceAsStream("foo.html"))
-                .thenReturn(new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
+        Mockito.when(context.getResourceAsStream("foo.html")).thenReturn(
+                new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
 
         HtmlDependencyParser parser = new HtmlDependencyParser(root);
         Collection<String> dependencies = parser.parseDependencies();
@@ -103,29 +100,27 @@ public class HtmlDependencyParserTest {
         Mockito.when(context.getResourceAsStream(resolvedRoot))
                 .thenReturn(stream);
 
-
         Mockito.when(servlet.resolveResource("frontend://baz/relative1.html"))
                 .thenReturn("baz/relative1.html");
         Mockito.when(context.getResourceAsStream("baz/relative1.html"))
-                .thenReturn(new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
-
+                .thenReturn(new ByteArrayInputStream(
+                        "".getBytes(StandardCharsets.UTF_8)));
 
         Mockito.when(servlet.resolveResource("frontend://relative2.html"))
                 .thenReturn("relative2.html");
-        Mockito.when(context.getResourceAsStream("relative2.html"))
-                .thenReturn(new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
+        Mockito.when(context.getResourceAsStream("relative2.html")).thenReturn(
+                new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
 
-
-        Mockito.when(servlet.resolveResource("frontend://baz/sub/relative3.html"))
+        Mockito.when(
+                servlet.resolveResource("frontend://baz/sub/relative3.html"))
                 .thenReturn("relative3.html");
-        Mockito.when(context.getResourceAsStream("relative3.html"))
-                .thenReturn(new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
-
+        Mockito.when(context.getResourceAsStream("relative3.html")).thenReturn(
+                new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
 
         Mockito.when(servlet.resolveResource("/absolute.html"))
                 .thenReturn("absolute.html");
-        Mockito.when(context.getResourceAsStream("absolute.html"))
-                .thenReturn(new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
+        Mockito.when(context.getResourceAsStream("absolute.html")).thenReturn(
+                new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
 
         Collection<String> dependencies = parser.parseDependencies();
 
@@ -160,8 +155,8 @@ public class HtmlDependencyParserTest {
 
         Mockito.when(servlet.resolveResource("frontend://relative.html"))
                 .thenReturn("relative.html");
-        Mockito.when(context.getResourceAsStream("relative.html"))
-                .thenReturn(new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
+        Mockito.when(context.getResourceAsStream("relative.html")).thenReturn(
+                new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
 
         Collection<String> dependencies = parser.parseDependencies();
 
@@ -199,8 +194,8 @@ public class HtmlDependencyParserTest {
                         .getBytes(StandardCharsets.UTF_8));
         Mockito.when(context.getResourceAsStream(resolvedRelative))
                 .thenReturn(relativeContent);
-        Mockito.when(context.getResourceAsStream("relative1.html"))
-                .thenReturn(new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
+        Mockito.when(context.getResourceAsStream("relative1.html")).thenReturn(
+                new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
 
         Collection<String> dependencies = parser.parseDependencies();
 
@@ -233,8 +228,8 @@ public class HtmlDependencyParserTest {
 
         Mockito.when(servlet.resolveResource("frontend://relative.html"))
                 .thenReturn("relative.html");
-        Mockito.when(context.getResourceAsStream("relative.html"))
-                .thenReturn(new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
+        Mockito.when(context.getResourceAsStream("relative.html")).thenReturn(
+                new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
 
         HtmlDependenciesCache cache = new HtmlDependenciesCache();
         Mockito.when(session.getAttribute(HtmlDependenciesCache.class))

--- a/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerDependenciesTest.java
@@ -3,6 +3,7 @@ package com.vaadin.flow.server;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import java.io.ByteArrayInputStream;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -252,6 +253,8 @@ public class BootstrapHandlerDependenciesTest {
 
         service.setCurrentInstances(vaadinRequestMock,
                 mock(VaadinResponse.class));
+        Mockito.when(service.getDependencyFilters())
+                .thenReturn(Collections.emptyList());
 
         session = new MockVaadinSession(service);
         session.lock();

--- a/flow-test-util/src/main/java/com/vaadin/flow/testutil/ViewOrUITest.java
+++ b/flow-test-util/src/main/java/com/vaadin/flow/testutil/ViewOrUITest.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.testutil;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 
@@ -25,6 +23,8 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 
 /**
@@ -38,18 +38,19 @@ public class ViewOrUITest extends AbstractTestBenchTest {
 
     @Override
     protected String getTestPath() {
-        Class<? extends UI> uiClass = getUIClass();
+        Class<? extends Component> viewClass = getViewClass();
         try {
+            if (viewClass != null) {
+                return "/view/"
+                        + URLEncoder.encode(viewClass.getName(), UTF_8.name());
+            }
+
+            Class<? extends UI> uiClass = getUIClass();
             if (uiClass != null) {
                 return "/run/"
                         + URLEncoder.encode(uiClass.getName(), UTF_8.name());
             }
 
-            Class<? extends Component> viewClass = getViewClass();
-            if (viewClass != null) {
-                return "/view/"
-                        + URLEncoder.encode(viewClass.getName(), UTF_8.name());
-            }
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Parser now also handles any dependency filters that there
may be for instance productionMode filter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3646)
<!-- Reviewable:end -->
