### PR TITLE
Enable JSR-356 websockets again

### DIFF
--- a/flow-push/pom.xml
+++ b/flow-push/pom.xml
@@ -11,7 +11,7 @@
     <name>Flow Push</name>
     <packaging>jar</packaging>
     <properties>
-        <atmosphere.runtime.version>2.4.5.vaadin2</atmosphere.runtime.version>
+        <atmosphere.runtime.version>2.4.11.vaadin3</atmosphere.runtime.version>
     </properties>
 
     <dependencies>

--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -29,7 +29,7 @@ public final class Constants implements Serializable {
 
     // Keep the version number in sync with push/build.xml and other locations
     // listed in that file
-    public static final String REQUIRED_ATMOSPHERE_RUNTIME_VERSION = "2.4.5.vaadin2";
+    public static final String REQUIRED_ATMOSPHERE_RUNTIME_VERSION = "2.4.11.vaadin3";
 
     public static final String SERVLET_PARAMETER_PRODUCTION_MODE = "productionMode";
     public static final String SERVLET_PARAMETER_REQUEST_TIMING = "requestTiming";

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PushRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PushRequestHandler.java
@@ -218,10 +218,6 @@ public class PushRequestHandler
         // Disable Atmosphere's message about commercial support
         atmosphere.addInitParameter("org.atmosphere.cpr.showSupportMessage",
                 "false");
-        // Suppress JSR356 detection, see
-        // https://github.com/Atmosphere/atmosphere/issues/2104
-        atmosphere.addInitParameter(ApplicationConfig.WEBSOCKET_SUPPRESS_JSR356,
-                "true");
 
         try {
             atmosphere.init(vaadinServletConfig);


### PR DESCRIPTION
The JSR-356 standard websockets are supported by all modern servers.
Without this, the old and server specific websocket implementations are
used and these are more or less broken

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3654)
<!-- Reviewable:end -->
