### PR TITLE
Don't use ServletContext instead use VaadinService/Servlet

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/HtmlDependencyParser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/HtmlDependencyParser.java
@@ -115,7 +115,7 @@ public class HtmlDependencyParser {
         cache.addDependency(resolvedPath);
 
         try (InputStream content = servlet
-                .getResourceAsStream(resolvedResource)) {
+                .getResourceAsStream(resolvedPath)) {
             if (content == null) {
                 getLogger().trace(
                         "Can't find resource '{}' to parse for imports via the servlet context",

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/HtmlDependencyParser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/HtmlDependencyParser.java
@@ -108,7 +108,7 @@ public class HtmlDependencyParser {
         }
         cache.addDependency(resolvedResource);
 
-        try (InputStream content = servlet.getServletContext()
+        try (InputStream content = servlet
                 .getResourceAsStream(resolvedResource)) {
             if (content == null) {
                 getLogger().info(

--- a/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/DefaultTemplateParser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/DefaultTemplateParser.java
@@ -41,6 +41,7 @@ import com.vaadin.flow.server.DependencyFilter;
 import com.vaadin.flow.server.DependencyFilter.FilterContext;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinServletService;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.VaadinUriResolverFactory;
 import com.vaadin.flow.server.WrappedHttpSession;
@@ -80,11 +81,7 @@ public final class DefaultTemplateParser implements TemplateParser {
     public Element getTemplateContent(Class<? extends PolymerTemplate<?>> clazz,
             String tag) {
         VaadinRequest request = VaadinService.getCurrentRequest();
-        WrappedHttpSession session = (WrappedHttpSession) request
-                .getWrappedSession();
-        assert session != null;
-
-        ServletContext context = session.getHttpSession().getServletContext();
+        VaadinService service = VaadinServletService.getCurrent();
 
         boolean logEnabled = LOG_CACHE.get(clazz).compareAndSet(false, true);
 
@@ -114,7 +111,7 @@ public final class DefaultTemplateParser implements TemplateParser {
                 getLogger().debug("Html import path '{}' is resolved to '{}'",
                         url, path);
             }
-            try (InputStream content = context.getResourceAsStream(path)) {
+            try (InputStream content = service.getResourceAsStream(path)) {
                 if (content == null) {
                     throw new IllegalStateException(
                             String.format("Can't find resource '%s' "

--- a/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/DefaultTemplateParser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/DefaultTemplateParser.java
@@ -24,8 +24,6 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
-import javax.servlet.ServletContext;
-
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Comment;
 import org.jsoup.nodes.Document;
@@ -44,7 +42,6 @@ import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServletService;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.VaadinUriResolverFactory;
-import com.vaadin.flow.server.WrappedHttpSession;
 import com.vaadin.flow.shared.ui.Dependency;
 import com.vaadin.flow.shared.ui.Dependency.Type;
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -28,7 +28,6 @@ import java.io.PrintWriter;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -21,12 +21,15 @@ import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletResponse;
 import java.io.BufferedWriter;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -816,8 +819,7 @@ public abstract class VaadinService implements Serializable {
      * @throws ServiceException
      */
     private VaadinSession doFindOrCreateVaadinSession(VaadinRequest request,
-            boolean requestCanCreateSession)
-            throws SessionExpiredException {
+            boolean requestCanCreateSession) throws SessionExpiredException {
         assert ((ReentrantLock) getSessionLock(request.getWrappedSession()))
                 .isHeldByCurrentThread() : "Session has not been locked by this thread";
 
@@ -1064,7 +1066,8 @@ public abstract class VaadinService implements Serializable {
     /**
      * Sets the given Vaadin service as the current service.
      *
-     * @param service the service to set
+     * @param service
+     *            the service to set
      */
     public static void setCurrent(VaadinService service) {
         CurrentInstance.set(VaadinService.class, service);
@@ -2134,4 +2137,29 @@ public abstract class VaadinService implements Serializable {
     public RouterInterface getRouter() {
         return router;
     }
+
+    /**
+     * Returns a URL to the resource that is mapped to the given path.
+     * <p>
+     * The path must begin with a <tt>/</tt>.
+     *
+     * @param path
+     *            a <code>String</code> specifying the path to the resource
+     *
+     * @return the resource located at the named path, or <code>null</code> if
+     *         there is no resource at that path
+     */
+    public abstract URL getResource(String path);
+
+    /**
+     * Returns the resource located at the named path as an
+     * <code>InputStream</code> object.
+     *
+     * @param path
+     *            a <code>String</code> specifying the path to the resource
+     *
+     * @return the <code>InputStream</code> returned to the servlet, or
+     *         <code>null</code> if no resource exists at the specified path
+     */
+    public abstract InputStream getResourceAsStream(String path);
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
@@ -683,13 +683,7 @@ public class VaadinServlet extends HttpServlet {
     private boolean resourceIsFound(String url) {
         String resolvedUrl = resolveUrl(url);
 
-        try {
-            return inServletContext(resolvedUrl) || inWebJar(resolvedUrl);
-        } catch (IOException e) {
-            LoggerFactory.getLogger(VaadinServlet.class)
-                    .trace("Failed to parse url.", e);
-            return false;
-        }
+        return inServletContext(resolvedUrl) || inWebJar(resolvedUrl);
     }
 
     private String resolveUrl(String url) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
@@ -733,12 +733,11 @@ public class VaadinServlet extends HttpServlet {
         return resolvedUrl;
     }
 
-    private boolean inServletContext(String resolvedUrl)
-            throws MalformedURLException {
+    private boolean inServletContext(String resolvedUrl) {
         return getResource(resolvedUrl) != null;
     }
 
-    private boolean inWebJar(String resolvedUrl) throws IOException {
+    private boolean inWebJar(String resolvedUrl) {
         if (webJarServer != null) {
             Optional<String> webJarPath = webJarServer
                     .getWebJarResourcePath(resolvedUrl);

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
@@ -17,6 +17,7 @@
 package com.vaadin.flow.server;
 
 import javax.servlet.http.HttpServletRequest;
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
@@ -160,6 +161,16 @@ public class VaadinServletService extends VaadinService {
 
     private static final Logger getLogger() {
         return LoggerFactory.getLogger(VaadinServletService.class.getName());
+    }
+
+    @Override
+    public URL getResource(String path) {
+        return getServlet().getResource(path);
+    }
+
+    @Override
+    public InputStream getResourceAsStream(String path) {
+        return getServlet().getResourceAsStream(path);
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinUriResolverFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinUriResolverFactory.java
@@ -17,8 +17,6 @@ package com.vaadin.flow.server;
 
 import java.io.Serializable;
 
-import javax.servlet.ServletContext;
-
 import com.vaadin.flow.shared.VaadinUriResolver;
 
 /**
@@ -54,7 +52,7 @@ public interface VaadinUriResolverFactory extends Serializable {
 
     /**
      * Resolves the {@code path} to the path which can be used by a
-     * {@link ServletContext} to get a resource content.
+     * {@link javax.servlet.ServletContext} to get a resource content.
      * <p>
      * The factory method {@link #getUriResolver(VaadinRequest)} is used to get
      * URI resolver which resolves the {@code path}. This path works on the
@@ -62,8 +60,8 @@ public interface VaadinUriResolverFactory extends Serializable {
      * (the class {@link VaadinUriResolver} is a shared class between client and
      * server, so it cannot contain any server-side specific logic). But it
      * requires additional logic on the server side to be able to use it with
-     * the {@link ServletContext#getResource(String)} or
-     * {@link ServletContext#getResourceAsStream(String)} methods. This logic is
+     * the {@link javax.servlet.ServletContext#getResource(String)} or
+     * {@link javax.servlet.ServletContext#getResourceAsStream(String)} methods. This logic is
      * implemented in this method so it can be reused on the server-side in
      * various places.
      *

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlWriter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlWriter.java
@@ -17,7 +17,6 @@
 package com.vaadin.flow.server.communication;
 
 import javax.servlet.http.HttpServletRequest;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -215,8 +214,7 @@ public class UidlWriter implements Serializable {
                 .filter(string -> !string.isEmpty()).map(Charset::forName)
                 .orElse(StandardCharsets.UTF_8);
 
-        try (InputStream inlineResourceStream = getInlineResourceStream(url,
-                currentRequest);
+        try (InputStream inlineResourceStream = getInlineResourceStream(url);
                 BufferedReader bufferedReader = new BufferedReader(
                         new InputStreamReader(inlineResourceStream,
                                 requestCharset))) {
@@ -228,8 +226,7 @@ public class UidlWriter implements Serializable {
         }
     }
 
-    private static InputStream getInlineResourceStream(String url,
-            HttpServletRequest currentRequest) {
+    private static InputStream getInlineResourceStream(String url) {
         VaadinUriResolverFactory uriResolverFactory = VaadinSession.getCurrent()
                 .getAttribute(VaadinUriResolverFactory.class);
 
@@ -237,7 +234,7 @@ public class UidlWriter implements Serializable {
 
         String resolvedPath = uriResolverFactory
                 .toServletContextPath(VaadinService.getCurrentRequest(), url);
-        InputStream stream = currentRequest.getServletContext()
+        InputStream stream = VaadinService.getCurrent()
                 .getResourceAsStream(resolvedPath);
 
         if (stream == null) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/BundleFilterInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/BundleFilterInitializer.java
@@ -86,8 +86,8 @@ public class BundleFilterInitializer implements VaadinServiceInitListener {
 
     private Map<String, Set<String>> readBundleDependencies(
             ServiceInitEvent event, VaadinUriResolver es6ContextPathResolver) {
-        ServletContext servletContext = ((VaadinServletService) event
-                .getSource()).getServlet().getServletContext();
+        VaadinServletService servlet = ((VaadinServletService) event
+                .getSource());
 
         String es6Base = es6ContextPathResolver.resolveVaadinUri(
                 ApplicationConstants.FRONTEND_PROTOCOL_PREFIX);
@@ -95,7 +95,7 @@ public class BundleFilterInitializer implements VaadinServiceInitListener {
             es6Base += '/';
         }
         String bundleManifestContextPath = es6Base + FLOW_BUNDLE_MANIFEST;
-        try (InputStream bundleManifestStream = servletContext
+        try (InputStream bundleManifestStream = servlet
                 .getResourceAsStream(bundleManifestContextPath)) {
             if (bundleManifestStream == null) {
                 getLogger().info(
@@ -112,7 +112,7 @@ public class BundleFilterInitializer implements VaadinServiceInitListener {
                         .getArray(bundlePath);
                 for (int i = 0; i < bundledFiles.length(); i++) {
                     String bundledFile = bundledFiles.getString(i);
-                    if (servletContext.getResource(es6ContextPathResolver
+                    if (servlet.getResource(es6ContextPathResolver
                             .resolveVaadinUri(es6Base + bundlePath)) == null) {
                         throw new IllegalArgumentException(String.format(
                                 "Failed to find bundle at context path '%s', specified in manifest '%s'. "

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/BundleFilterInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/BundleFilterInitializer.java
@@ -25,8 +25,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import javax.servlet.ServletContext;
-
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/flow-server/src/main/java/com/vaadin/flow/server/webjar/WebJarServer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webjar/WebJarServer.java
@@ -27,7 +27,6 @@ import java.util.regex.Pattern;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.ResponseWriter;
 import com.vaadin.flow.server.Constants;
-import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.shared.ApplicationConstants;
 
 /**
@@ -100,7 +99,7 @@ public class WebJarServer implements Serializable {
             return false;
         }
 
-        URL resourceUrl = VaadinService.getCurrent().getResource(webJarPath);
+        URL resourceUrl = request.getServletContext().getResource(webJarPath);
         if (resourceUrl == null) {
             return false;
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/webjar/WebJarServer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webjar/WebJarServer.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.server.webjar;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.URL;
@@ -22,13 +24,10 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.ResponseWriter;
 import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.shared.ApplicationConstants;
 
 /**
@@ -101,7 +100,7 @@ public class WebJarServer implements Serializable {
             return false;
         }
 
-        URL resourceUrl = request.getServletContext().getResource(webJarPath);
+        URL resourceUrl = VaadinService.getCurrent().getResource(webJarPath);
         if (resourceUrl == null) {
             return false;
         }
@@ -109,27 +108,6 @@ public class WebJarServer implements Serializable {
         responseWriter.writeResponseContents(webJarPath, resourceUrl, request,
                 response);
         return true;
-    }
-
-    /**
-     * Check if a file is existent in a WebJar.
-     *
-     * @param filePathInContext
-     *            servlet context path for file
-     * @param servletContext
-     *            servlet context
-     * @return true if file is found else false
-     * @throws IOException
-     *             if response population fails
-     */
-    public boolean hasWebJarResource(String filePathInContext,
-            ServletContext servletContext) throws IOException {
-        Optional<String> webJarPath = getWebJarResourcePath(filePathInContext);
-        if (!webJarPath.isPresent()) {
-            return false;
-        }
-
-        return servletContext.getResource(webJarPath.get()) != null;
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/HtmlDependencyParserTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/HtmlDependencyParserTest.java
@@ -67,7 +67,7 @@ public class HtmlDependencyParserTest {
 
         Mockito.when(servlet.resolveResource("frontend://foo.html"))
                 .thenReturn("foo.html");
-        Mockito.when(context.getResourceAsStream("foo.html")).thenReturn(
+        Mockito.when(service.getResourceAsStream("foo.html")).thenReturn(
                 new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
 
         HtmlDependencyParser parser = new HtmlDependencyParser(root);
@@ -98,24 +98,24 @@ public class HtmlDependencyParserTest {
 
         Mockito.when(servlet.resolveResource("frontend://baz/relative1.html"))
                 .thenReturn("baz/relative1.html");
-        Mockito.when(context.getResourceAsStream("baz/relative1.html"))
+        Mockito.when(service.getResourceAsStream("baz/relative1.html"))
                 .thenReturn(new ByteArrayInputStream(
                         "".getBytes(StandardCharsets.UTF_8)));
 
         Mockito.when(servlet.resolveResource("frontend://relative2.html"))
                 .thenReturn("relative2.html");
-        Mockito.when(context.getResourceAsStream("relative2.html")).thenReturn(
+        Mockito.when(service.getResourceAsStream("relative2.html")).thenReturn(
                 new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
 
         Mockito.when(
                 servlet.resolveResource("frontend://baz/sub/relative3.html"))
                 .thenReturn("relative3.html");
-        Mockito.when(context.getResourceAsStream("relative3.html")).thenReturn(
+        Mockito.when(service.getResourceAsStream("relative3.html")).thenReturn(
                 new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
 
         Mockito.when(servlet.resolveResource("/absolute.html"))
                 .thenReturn("absolute.html");
-        Mockito.when(context.getResourceAsStream("absolute.html")).thenReturn(
+        Mockito.when(service.getResourceAsStream("absolute.html")).thenReturn(
                 new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
 
         Collection<String> dependencies = parser.parseDependencies();
@@ -151,7 +151,7 @@ public class HtmlDependencyParserTest {
 
         Mockito.when(servlet.resolveResource("frontend://relative.html"))
                 .thenReturn("relative.html");
-        Mockito.when(context.getResourceAsStream("relative.html")).thenReturn(
+        Mockito.when(service.getResourceAsStream("relative.html")).thenReturn(
                 new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
 
         Collection<String> dependencies = parser.parseDependencies();
@@ -190,7 +190,7 @@ public class HtmlDependencyParserTest {
                         .getBytes(StandardCharsets.UTF_8));
         Mockito.when(servlet.getResourceAsStream(resolvedRelative))
                 .thenReturn(relativeContent);
-        Mockito.when(context.getResourceAsStream("relative1.html")).thenReturn(
+        Mockito.when(service.getResourceAsStream("relative1.html")).thenReturn(
                 new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
 
         Collection<String> dependencies = parser.parseDependencies();
@@ -224,7 +224,7 @@ public class HtmlDependencyParserTest {
 
         Mockito.when(servlet.resolveResource("frontend://relative.html"))
                 .thenReturn("relative.html");
-        Mockito.when(context.getResourceAsStream("relative.html")).thenReturn(
+        Mockito.when(service.getResourceAsStream("relative.html")).thenReturn(
                 new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
 
         HtmlDependenciesCache cache = new HtmlDependenciesCache();

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/HtmlDependencyParserTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/HtmlDependencyParserTest.java
@@ -122,16 +122,22 @@ public class HtmlDependencyParserTest {
 
         Assert.assertEquals(5, dependencies.size());
 
+        Mockito.verify(servlet).getResourceAsStream(resolvedRoot);
+        Mockito.verify(servlet).getResourceAsStream("baz/relative1.html");
+        Mockito.verify(servlet).getResourceAsStream("relative2.html");
+        Mockito.verify(servlet).getResourceAsStream("relative3.html");
+        Mockito.verify(servlet).getResourceAsStream("absolute.html");
+
         Assert.assertTrue("Dependencies parser doesn't return the root URI",
                 dependencies.contains(root));
         Assert.assertTrue(
                 "Dependencies parser doesn't return the simple relative URI (same parent)",
                 dependencies.contains("baz/relative1.html"));
         Assert.assertTrue(
-                "Dependencies parser doesn't return the realtive URI which is located in the parent folder",
+                "Dependencies parser doesn't return the relative URI which is located in the parent folder",
                 dependencies.contains("relative2.html"));
         Assert.assertTrue(
-                "Dependencies parser doesn't return the realtive URI which is located sub folder",
+                "Dependencies parser doesn't return the relative URI which is located sub folder",
                 dependencies.contains("baz/sub/relative3.html"));
         Assert.assertTrue("Dependencies parser doesn't return the absolute URI",
                 dependencies.contains("/absolute.html"));
@@ -203,7 +209,7 @@ public class HtmlDependencyParserTest {
                 "Dependencies parser doesn't return the simple relative URI (same parent)",
                 dependencies.contains("relative.html"));
         Assert.assertTrue(
-                "Dependencies parser doesn't return the realtive URI which is located in the parent folder",
+                "Dependencies parser doesn't return the relative URI which is located in the parent folder",
                 dependencies.contains("relative1.html"));
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/HtmlDependencyParserTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/HtmlDependencyParserTest.java
@@ -20,8 +20,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 
-import javax.servlet.ServletContext;
-
+import net.jcip.annotations.NotThreadSafe;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -35,14 +34,11 @@ import com.vaadin.flow.server.VaadinServlet;
 import com.vaadin.flow.server.VaadinServletService;
 import com.vaadin.flow.server.VaadinSession;
 
-import net.jcip.annotations.NotThreadSafe;
-
 @NotThreadSafe
 public class HtmlDependencyParserTest {
 
     private VaadinSession session;
     private VaadinServlet servlet;
-    private ServletContext context;
     private VaadinServletService service;
 
     @Before
@@ -56,9 +52,6 @@ public class HtmlDependencyParserTest {
         session = Mockito.mock(VaadinSession.class);
         CurrentInstance.set(VaadinSession.class, session);
 
-        context = Mockito.mock(ServletContext.class);
-
-        Mockito.when(servlet.getServletContext()).thenReturn(context);
         Mockito.when(session.hasLock()).thenReturn(true);
     }
 
@@ -90,7 +83,7 @@ public class HtmlDependencyParserTest {
                 + "<link rel='import' href='/absolute.html'>";
         InputStream stream = new ByteArrayInputStream(
                 importContent.getBytes(StandardCharsets.UTF_8));
-        Mockito.when(context.getResourceAsStream(resolvedRoot))
+        Mockito.when(servlet.getResourceAsStream(resolvedRoot))
                 .thenReturn(stream);
 
         Collection<String> dependencies = parser.parseDependencies();
@@ -122,7 +115,7 @@ public class HtmlDependencyParserTest {
         String importContent = "<link rel='import' href='relative.html'>";
         InputStream stream = new ByteArrayInputStream(
                 importContent.getBytes(StandardCharsets.UTF_8));
-        Mockito.when(context.getResourceAsStream(root)).thenReturn(stream);
+        Mockito.when(servlet.getResourceAsStream(root)).thenReturn(stream);
 
         Collection<String> dependencies = parser.parseDependencies();
 
@@ -145,7 +138,7 @@ public class HtmlDependencyParserTest {
         String importContent = "<link rel='import' href='relative.html'>";
         InputStream stream = new ByteArrayInputStream(
                 importContent.getBytes(StandardCharsets.UTF_8));
-        Mockito.when(context.getResourceAsStream(resolvedRoot))
+        Mockito.when(servlet.getResourceAsStream(resolvedRoot))
                 .thenReturn(stream);
 
         String resolvedRelative = "baz/bar/relative.html";
@@ -155,7 +148,7 @@ public class HtmlDependencyParserTest {
         InputStream relativeContent = new ByteArrayInputStream(
                 "<link rel='import' href='relative1.html'>"
                         .getBytes(StandardCharsets.UTF_8));
-        Mockito.when(context.getResourceAsStream(resolvedRelative))
+        Mockito.when(servlet.getResourceAsStream(resolvedRelative))
                 .thenReturn(relativeContent);
 
         Collection<String> dependencies = parser.parseDependencies();
@@ -183,7 +176,7 @@ public class HtmlDependencyParserTest {
         String importContent = "<link rel='import' href='relative.html'>";
         InputStream stream = new ByteArrayInputStream(
                 importContent.getBytes(StandardCharsets.UTF_8));
-        Mockito.when(context.getResourceAsStream(resolvedRoot))
+        Mockito.when(servlet.getResourceAsStream(resolvedRoot))
                 .thenReturn(stream);
 
         HtmlDependenciesCache cache = new HtmlDependenciesCache();
@@ -193,7 +186,7 @@ public class HtmlDependencyParserTest {
         Collection<String> dependencies = parser.parseDependencies();
 
         Assert.assertEquals(2, dependencies.size());
-        Mockito.verify(context).getResourceAsStream(resolvedRoot);
+        Mockito.verify(servlet).getResourceAsStream(resolvedRoot);
 
         // call one more time
         dependencies = parser.parseDependencies();
@@ -201,7 +194,7 @@ public class HtmlDependencyParserTest {
         Assert.assertEquals(1, dependencies.size());
         // and there shouldn't be one more call for reading the content of the
         // import
-        Mockito.verify(context).getResourceAsStream(resolvedRoot);
+        Mockito.verify(servlet).getResourceAsStream(resolvedRoot);
     }
 
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/polymertemplate/DefaultTemplateParserTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/polymertemplate/DefaultTemplateParserTest.java
@@ -138,14 +138,14 @@ public class DefaultTemplateParserTest {
         Mockito.when(request.getWrappedSession()).thenReturn(wrappedSession);
         Mockito.when(request.getServletPath()).thenReturn("");
 
-        Mockito.when(service.getResourceAsStream("/bar.html")).thenReturn(
+        Mockito.when(servletContext.getResourceAsStream("/bar.html")).thenReturn(
                 new ByteArrayInputStream("<dom-module id='bar'></dom-module>"
                         .getBytes(StandardCharsets.UTF_8)));
-        Mockito.when(service.getResourceAsStream("/bar1.html")).thenReturn(
+        Mockito.when(servletContext.getResourceAsStream("/bar1.html")).thenReturn(
                 new ByteArrayInputStream("<dom-module id='foo'></dom-module>"
                         .getBytes(StandardCharsets.UTF_8)));
 
-        Mockito.when(service.getResourceAsStream("/bundle.html"))
+        Mockito.when(servletContext.getResourceAsStream("/bundle.html"))
                 .thenReturn(getBundle(), getBundle(), getBundle());
 
         CurrentInstance.set(VaadinRequest.class, request);
@@ -179,7 +179,7 @@ public class DefaultTemplateParserTest {
         Mockito.when(resolver.resolveVaadinUri("/bar.html"))
                 .thenReturn("/foo.html");
 
-        Mockito.when(service.getResourceAsStream("/foo.html")).thenReturn(
+        Mockito.when(servletContext.getResourceAsStream("/foo.html")).thenReturn(
                 new ByteArrayInputStream("<dom-module id='foo'></dom-module>"
                         .getBytes(StandardCharsets.UTF_8)));
 
@@ -213,11 +213,11 @@ public class DefaultTemplateParserTest {
 
         Mockito.when(request.getServletPath()).thenReturn("/run/");
 
-        Mockito.when(service.getResourceAsStream("/run/./../bar.html"))
+        Mockito.when(servletContext.getResourceAsStream("/run/./../bar.html"))
                 .thenReturn(new ByteArrayInputStream(
                         "<dom-module id='bar'></dom-module>"
                                 .getBytes(StandardCharsets.UTF_8)));
-        Mockito.when(service.getResourceAsStream("/run/./../bar1.html"))
+        Mockito.when(servletContext.getResourceAsStream("/run/./../bar1.html"))
                 .thenReturn(new ByteArrayInputStream(
                         "<dom-module id='foo'></dom-module>"
                                 .getBytes(StandardCharsets.UTF_8)));
@@ -239,11 +239,11 @@ public class DefaultTemplateParserTest {
 
         Mockito.when(request.getServletPath()).thenReturn("/run/");
 
-        Mockito.when(service.getResourceAsStream("/run/./../bar.html"))
+        Mockito.when(servletContext.getResourceAsStream("/run/./../bar.html"))
                 .thenReturn(new ByteArrayInputStream(
                         "<dom-module id='bar'></dom-module>"
                                 .getBytes(StandardCharsets.UTF_8)));
-        Mockito.when(service.getResourceAsStream("/run/./../bar1.html"))
+        Mockito.when(servletContext.getResourceAsStream("/run/./../bar1.html"))
                 .thenReturn(new ByteArrayInputStream(
                         "<dom-module id='foo'></dom-module>"
                                 .getBytes(StandardCharsets.UTF_8)));
@@ -255,13 +255,13 @@ public class DefaultTemplateParserTest {
 
         // The double slash should be ignored e.g. `/run//./..` should become
         // `/run/./..`
-        Mockito.verify(service).getResourceAsStream("/run/./../bar.html");
-        Mockito.verify(service).getResourceAsStream("/run/./../bar1.html");
+        Mockito.verify(servletContext).getResourceAsStream("/run/./../bar.html");
+        Mockito.verify(servletContext).getResourceAsStream("/run/./../bar1.html");
     }
 
     @Test
     public void defaultParser_removesComments() {
-        Mockito.when(service.getResourceAsStream("/bar.html"))
+        Mockito.when(servletContext.getResourceAsStream("/bar.html"))
                 .thenReturn(new ByteArrayInputStream(
                         "<!-- comment1 --><dom-module id='foo'><!-- comment2 --></dom-module>"
                                 .getBytes(StandardCharsets.UTF_8)));
@@ -289,7 +289,7 @@ public class DefaultTemplateParserTest {
 
     @Test(expected = IllegalStateException.class)
     public void defaultParser_templateResourceIsNotFound_throws() {
-        Mockito.when(service.getResourceAsStream("/bar1.html"))
+        Mockito.when(servletContext.getResourceAsStream("/bar1.html"))
                 .thenReturn(null);
 
         DefaultTemplateParser.getInstance()

--- a/flow-server/src/test/java/com/vaadin/flow/component/polymertemplate/DefaultTemplateParserTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/polymertemplate/DefaultTemplateParserTest.java
@@ -82,8 +82,6 @@ public class DefaultTemplateParserTest {
 
     }
 
-    private ServletContext context;
-
     private VaadinUriResolver resolver;
 
     private VaadinService service;
@@ -115,20 +113,17 @@ public class DefaultTemplateParserTest {
         Mockito.when(session.getAttribute(VaadinUriResolverFactory.class))
                 .thenReturn(factory);
 
-        context = Mockito.mock(ServletContext.class);
-        Mockito.when(httpSession.getServletContext()).thenReturn(context);
-
         Mockito.when(request.getWrappedSession()).thenReturn(wrappedSession);
         Mockito.when(request.getServletPath()).thenReturn("");
 
-        Mockito.when(context.getResourceAsStream("/bar.html")).thenReturn(
+        Mockito.when(service.getResourceAsStream("/bar.html")).thenReturn(
                 new ByteArrayInputStream("<dom-module id='bar'></dom-module>"
                         .getBytes(StandardCharsets.UTF_8)));
-        Mockito.when(context.getResourceAsStream("/bar1.html")).thenReturn(
+        Mockito.when(service.getResourceAsStream("/bar1.html")).thenReturn(
                 new ByteArrayInputStream("<dom-module id='foo'></dom-module>"
                         .getBytes(StandardCharsets.UTF_8)));
 
-        Mockito.when(context.getResourceAsStream("/bundle.html"))
+        Mockito.when(service.getResourceAsStream("/bundle.html"))
                 .thenReturn(getBundle(), getBundle(), getBundle());
 
         CurrentInstance.set(VaadinRequest.class, request);
@@ -162,7 +157,7 @@ public class DefaultTemplateParserTest {
         Mockito.when(resolver.resolveVaadinUri("/bar.html"))
                 .thenReturn("/foo.html");
 
-        Mockito.when(context.getResourceAsStream("/foo.html")).thenReturn(
+        Mockito.when(service.getResourceAsStream("/foo.html")).thenReturn(
                 new ByteArrayInputStream("<dom-module id='foo'></dom-module>"
                         .getBytes(StandardCharsets.UTF_8)));
 
@@ -196,11 +191,11 @@ public class DefaultTemplateParserTest {
 
         Mockito.when(request.getServletPath()).thenReturn("/run/");
 
-        Mockito.when(context.getResourceAsStream("/run/./../bar.html"))
+        Mockito.when(service.getResourceAsStream("/run/./../bar.html"))
                 .thenReturn(new ByteArrayInputStream(
                         "<dom-module id='bar'></dom-module>"
                                 .getBytes(StandardCharsets.UTF_8)));
-        Mockito.when(context.getResourceAsStream("/run/./../bar1.html"))
+        Mockito.when(service.getResourceAsStream("/run/./../bar1.html"))
                 .thenReturn(new ByteArrayInputStream(
                         "<dom-module id='foo'></dom-module>"
                                 .getBytes(StandardCharsets.UTF_8)));
@@ -222,11 +217,11 @@ public class DefaultTemplateParserTest {
 
         Mockito.when(request.getServletPath()).thenReturn("/run/");
 
-        Mockito.when(context.getResourceAsStream("/run/./../bar.html"))
+        Mockito.when(service.getResourceAsStream("/run/./../bar.html"))
                 .thenReturn(new ByteArrayInputStream(
                         "<dom-module id='bar'></dom-module>"
                                 .getBytes(StandardCharsets.UTF_8)));
-        Mockito.when(context.getResourceAsStream("/run/./../bar1.html"))
+        Mockito.when(service.getResourceAsStream("/run/./../bar1.html"))
                 .thenReturn(new ByteArrayInputStream(
                         "<dom-module id='foo'></dom-module>"
                                 .getBytes(StandardCharsets.UTF_8)));
@@ -238,13 +233,13 @@ public class DefaultTemplateParserTest {
 
         // The double slash should be ignored e.g. `/run//./..` should become
         // `/run/./..`
-        Mockito.verify(context).getResourceAsStream("/run/./../bar.html");
-        Mockito.verify(context).getResourceAsStream("/run/./../bar1.html");
+        Mockito.verify(service).getResourceAsStream("/run/./../bar.html");
+        Mockito.verify(service).getResourceAsStream("/run/./../bar1.html");
     }
 
     @Test
     public void defaultParser_removesComments() {
-        Mockito.when(context.getResourceAsStream("/bar.html"))
+        Mockito.when(service.getResourceAsStream("/bar.html"))
                 .thenReturn(new ByteArrayInputStream(
                         "<!-- comment1 --><dom-module id='foo'><!-- comment2 --></dom-module>"
                                 .getBytes(StandardCharsets.UTF_8)));
@@ -272,7 +267,7 @@ public class DefaultTemplateParserTest {
 
     @Test(expected = IllegalStateException.class)
     public void defaultParser_templateResourceIsNotFound_throws() {
-        Mockito.when(context.getResourceAsStream("/bar1.html"))
+        Mockito.when(service.getResourceAsStream("/bar1.html"))
                 .thenReturn(null);
 
         DefaultTemplateParser.getInstance()

--- a/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerDependenciesTest.java
@@ -236,14 +236,11 @@ public class BootstrapHandlerDependenciesTest {
         service = Mockito
                 .spy(new MockVaadinServletService(deploymentConfiguration));
 
-        ServletContext servletContextMock = mock(ServletContext.class);
-        when(servletContextMock.getResourceAsStream(anyString()))
+        when(service.getResourceAsStream(anyString()))
                 .thenAnswer(invocation -> new ByteArrayInputStream(
                         ((String) invocation.getArguments()[0]).getBytes()));
 
         HttpServletRequest servletRequestMock = mock(HttpServletRequest.class);
-        when(servletRequestMock.getServletContext())
-                .thenReturn(servletContextMock);
 
         VaadinServletRequest vaadinRequestMock = mock(
                 VaadinServletRequest.class);

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletTest.java
@@ -71,8 +71,6 @@ public class VaadinServletTest {
         context = Mockito.mock(ServletContext.class);
         factory = Mockito.mock(VaadinUriResolverFactory.class);
 
-        context = Mockito.mock(ServletContext.class);
-
         Mockito.when(session.getAttribute(VaadinUriResolverFactory.class))
                 .thenReturn(factory);
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/UidlWriterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/UidlWriterTest.java
@@ -476,14 +476,11 @@ public class UidlWriterTest {
         session.lock();
         ui.getInternals().setSession(session);
 
-        ServletContext servletContextMock = mock(ServletContext.class);
-        when(servletContextMock.getResourceAsStream(anyString()))
+        when(service.getResourceAsStream(anyString()))
                 .thenAnswer(invocation -> new ByteArrayInputStream(
                         ((String) invocation.getArguments()[0]).getBytes()));
 
         HttpServletRequest servletRequestMock = mock(HttpServletRequest.class);
-        when(servletRequestMock.getServletContext())
-                .thenReturn(servletContextMock);
 
         VaadinServletRequest vaadinRequestMock = mock(
                 VaadinServletRequest.class);

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/BundleFilterInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/BundleFilterInitializerTest.java
@@ -55,7 +55,6 @@ public class BundleFilterInitializerTest {
     }
 
     private ServiceInitEvent event;
-    private ServletContext context;
 
     private Consumer<DependencyFilter> dependencyFilterAddHandler = dependency -> {
     };
@@ -68,11 +67,9 @@ public class BundleFilterInitializerTest {
         event = Mockito.mock(ServiceInitEvent.class);
         VaadinServletService service = Mockito.mock(VaadinServletService.class);
         VaadinServlet servlet = Mockito.mock(VaadinServlet.class);
-        context = Mockito.mock(ServletContext.class);
 
         Mockito.when(event.getSource()).thenReturn(service);
         Mockito.when(service.getServlet()).thenReturn(servlet);
-        Mockito.when(servlet.getServletContext()).thenReturn(context);
 
         Mockito.when(service.getDeploymentConfiguration())
                 .thenReturn(new DefaultDeploymentConfiguration(
@@ -93,11 +90,11 @@ public class BundleFilterInitializerTest {
         Mockito.doAnswer(invocation -> {
             return inputStreamProducer
                     .apply(invocation.getArgumentAt(0, String.class));
-        }).when(context).getResourceAsStream("/frontend-es6/vaadin-flow-bundle-manifest.json");
+        }).when(service).getResourceAsStream("/frontend-es6/vaadin-flow-bundle-manifest.json");
         Mockito.doAnswer(invocation -> {
             return resourceProducer
                     .apply(invocation.getArgumentAt(0, String.class));
-        }).when(context).getResource(Mockito.anyString());
+        }).when(service).getResource(Mockito.anyString());
     }
 
     @Test(expected = UncheckedIOException.class)


### PR DESCRIPTION
This is a step in the direction so that we only use one
point for getting our resources and any fixes done
are reflected to every place using getResource[AsStream]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3656)
<!-- Reviewable:end -->
