### PR TITLE
Pass timezone ID from browser to server

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/WebBrowser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/WebBrowser.java
@@ -42,6 +42,7 @@ public class WebBrowser implements Serializable {
     private int rawTimezoneOffset = 0;
     private int dstSavings;
     private boolean dstInEffect;
+    private String timeZoneId;
     private boolean touchDevice;
 
     private BrowserDetails browserDetails;
@@ -333,6 +334,18 @@ public class WebBrowser implements Serializable {
     }
 
     /**
+     * Returns the TimeZone Id (like "Europe/Helsinki") provided by the browser
+     * (if the browser supports this feature).
+     *
+     * @return the TimeZone Id if provided by the browser, null otherwise.
+     * @see <a href=
+     *      "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/resolvedOptions">Intl.DateTimeFormat.prototype.resolvedOptions()</a>
+     */
+    public String getTimeZoneId() {
+        return timeZoneId;
+    }
+
+    /**
      * Returns the browser-reported TimeZone offset in milliseconds from GMT
      * ignoring possible daylight saving adjustments that may be in effect in
      * the browser.
@@ -432,7 +445,7 @@ public class WebBrowser implements Serializable {
      * @param touchDevice
      */
     void updateClientSideDetails(String sw, String sh, String tzo, String rtzo,
-            String dstSavings, String dstInEffect, String curDate,
+            String dstSavings, String dstInEffect, String tzId, String curDate,
             boolean touchDevice) {
         if (sw != null) {
             try {
@@ -469,6 +482,13 @@ public class WebBrowser implements Serializable {
         if (dstInEffect != null) {
             this.dstInEffect = Boolean.parseBoolean(dstInEffect);
         }
+
+        if (tzId == null || "undefined".equals(tzId)) {
+            this.timeZoneId = null;
+        } else {
+            this.timeZoneId = tzId;
+        }
+
         if (curDate != null) {
             try {
                 long curTime = Long.parseLong(curDate);
@@ -507,6 +527,7 @@ public class WebBrowser implements Serializable {
                     request.getParameter("v-rtzo"),
                     request.getParameter("v-dstd"),
                     request.getParameter("v-dston"),
+                    request.getParameter("v-tzid"),
                     request.getParameter("v-curdate"),
                     request.getParameter("v-td") != null);
         }


### PR DESCRIPTION
Port Change from framework 8.2.0.alpha2
original commit is vaadin/framework#10041

This is only the sever side migration about the commit, issues with this has been explained in ticket https://github.com/vaadin/flow/issues/3657

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3658)
<!-- Reviewable:end -->
