### PR TITLE
Remove track message size interceptor and other streaming related code

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/communication/AtmospherePushConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/AtmospherePushConnection.java
@@ -662,7 +662,7 @@ public class AtmospherePushConnection implements PushConnection {
             reconnectInterval: 5000,
             timeout: -1,
             maxReconnectOnClose: 10000000,
-            trackMessageLength: true,
+            trackMessageLength: false,
             enableProtocol: true,
             handleOnlineOffline: false,
             messageDelimiter: String.fromCharCode(@com.vaadin.flow.shared.communication.PushConstants::MESSAGE_DELIMITER)

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PushHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PushHandler.java
@@ -77,15 +77,6 @@ public class PushHandler {
         resource.getResponse().setContentType("text/plain; charset=UTF-8");
 
         VaadinSession session = ui.getSession();
-        if (resource.transport() == TRANSPORT.STREAMING) {
-            // Must ensure that the streaming response contains
-            // "Connection: close", otherwise iOS 6 will wait for the
-            // response to this request before sending another request to
-            // the same server (as it will apparently try to reuse the same
-            // connection)
-            resource.getResponse().addHeader("Connection", "close");
-        }
-
         String requestToken = resource.getRequest()
                 .getParameter(ApplicationConstants.PUSH_ID_PARAMETER);
         if (!isPushIdValid(session, requestToken)) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PushRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PushRequestHandler.java
@@ -18,28 +18,26 @@ package com.vaadin.flow.server.communication;
 
 import java.io.IOException;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 
 import org.atmosphere.cache.UUIDBroadcasterCache;
-import org.atmosphere.client.TrackMessageSizeInterceptor;
 import org.atmosphere.cpr.ApplicationConfig;
 import org.atmosphere.cpr.AtmosphereFramework;
 import org.atmosphere.cpr.AtmosphereFramework.AtmosphereHandlerWrapper;
 import org.atmosphere.cpr.AtmosphereHandler;
-import org.atmosphere.cpr.AtmosphereInterceptor;
 import org.atmosphere.cpr.AtmosphereRequestImpl;
 import org.atmosphere.cpr.AtmosphereResponseImpl;
 import org.atmosphere.interceptor.HeartbeatInterceptor;
 import org.atmosphere.util.VoidAnnotationProcessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.RequestHandler;
 import com.vaadin.flow.server.ServiceException;
 import com.vaadin.flow.server.ServletHelper;
+import com.vaadin.flow.server.ServletHelper.RequestType;
 import com.vaadin.flow.server.SessionExpiredHandler;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
@@ -47,7 +45,6 @@ import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.server.VaadinServletResponse;
 import com.vaadin.flow.server.VaadinServletService;
 import com.vaadin.flow.server.VaadinSession;
-import com.vaadin.flow.server.ServletHelper.RequestType;
 import com.vaadin.flow.shared.communication.PushConstants;
 
 /**
@@ -221,12 +218,6 @@ public class PushRequestHandler
 
         try {
             atmosphere.init(vaadinServletConfig);
-
-            // Ensure the client-side knows how to split the message stream
-            // into individual messages when using certain transports
-            AtmosphereInterceptor trackMessageSize = new TrackMessageSizeInterceptor();
-            trackMessageSize.configure(atmosphere.getAtmosphereConfig());
-            atmosphere.interceptor(trackMessageSize);
         } catch (ServletException e) {
             throw new RuntimeException("Atmosphere init failed", e);
         }


### PR DESCRIPTION
Size tracker was needed when using streaming to avoid mixing messages but
should not be needed with long polling nor websockets, as both transports
send one message in one response/frame

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3661)
<!-- Reviewable:end -->
