### PR TITLE
Port Change on Binder issues from framework 8.3.0.alpha1

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -193,7 +193,6 @@ public class Binder<BEAN> implements Serializable {
          * @see #setReadOnly(boolean)
          * 
          * @return {@code true} if read-only; {@code false} if not
-         * @since
          */
         public boolean isReadOnly();
 
@@ -264,7 +263,7 @@ public class Binder<BEAN> implements Serializable {
          *
          * <p>
          * <strong>Note:</strong> when a {@code null} setter is given the field
-         * will be marked as readonly by invoking {@link HasValue::setReadOnly}.
+         * will be marked as readonly by invoking {@link HasValue#setReadOnly}.
          * 
          * @param getter
          *            the function to get the value of the property to the
@@ -296,7 +295,7 @@ public class Binder<BEAN> implements Serializable {
          *
          * <p>
          * <strong>Note:</strong> when the binding is <i>read-only</i> the field
-         * will be marked as readonly by invoking {@link HasValue::setReadOnly}.
+         * will be marked as readonly by invoking {@link HasValue#setReadOnly}.
          * 
          * @param propertyName
          *            the name of the property to bind, not null

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -180,7 +180,7 @@ public class Binder<BEAN> implements Serializable {
          * @param readOnly
          *            {@code true} to set binding read-only; {@code false} to
          *            enable writes
-         * @since
+         * 
          * @throws IllegalStateException
          *             if trying to make binding read-write and the setter is
          *             {@code null}
@@ -201,7 +201,6 @@ public class Binder<BEAN> implements Serializable {
          * Gets the getter associated with this Binding.
          *
          * @return the getter
-         * @since
          */
         public ValueProvider<BEAN, TARGET> getGetter();
 
@@ -209,7 +208,6 @@ public class Binder<BEAN> implements Serializable {
          * Gets the setter associated with this Binding.
          *
          * @return the setter
-         * @since
          */
         public Setter<BEAN, TARGET> getSetter();
     }
@@ -266,8 +264,7 @@ public class Binder<BEAN> implements Serializable {
          *
          * <p>
          * <strong>Note:</strong> when a {@code null} setter is given the field
-         * will be marked as readonly by invoking
-         * ({@link HasValue::setReadOnly}.
+         * will be marked as readonly by invoking {@link HasValue::setReadOnly}.
          * 
          * @param getter
          *            the function to get the value of the property to the
@@ -299,8 +296,7 @@ public class Binder<BEAN> implements Serializable {
          *
          * <p>
          * <strong>Note:</strong> when the binding is <i>read-only</i> the field
-         * will be marked as readonly by invoking
-         * ({@link HasValue::setReadOnly}.
+         * will be marked as readonly by invoking {@link HasValue::setReadOnly}.
          * 
          * @param propertyName
          *            the name of the property to bind, not null

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -185,7 +185,7 @@ public class Binder<BEAN> implements Serializable {
          *             if trying to make binding read-write and the setter is
          *             {@code null}
          */
-        public void setReadOnly(boolean readOnly);
+        void setReadOnly(boolean readOnly);
 
         /**
          * Gets the current read-only status for this Binding.
@@ -194,21 +194,21 @@ public class Binder<BEAN> implements Serializable {
          * 
          * @return {@code true} if read-only; {@code false} if not
          */
-        public boolean isReadOnly();
+        boolean isReadOnly();
 
         /**
          * Gets the getter associated with this Binding.
          *
          * @return the getter
          */
-        public ValueProvider<BEAN, TARGET> getGetter();
+        ValueProvider<BEAN, TARGET> getGetter();
 
         /**
          * Gets the setter associated with this Binding.
          *
          * @return the setter
          */
-        public Setter<BEAN, TARGET> getSetter();
+        Setter<BEAN, TARGET> getSetter();
     }
 
     /**
@@ -921,6 +921,10 @@ public class Binder<BEAN> implements Serializable {
         @Override
         public HasValue<?, FIELDVALUE> getField() {
             return field;
+        }
+
+        private static final Logger getLogger() {
+            return LoggerFactory.getLogger(Binder.class.getName());
         }
     }
 
@@ -2341,8 +2345,7 @@ public class Binder<BEAN> implements Serializable {
      *            to set them to read-write
      */
     public void setReadOnly(boolean readOnly) {
-        getBindings().stream()
-                .filter(binding -> binding.getSetter() != null)
+        getBindings().stream().filter(binding -> binding.getSetter() != null)
                 .forEach(field -> field.setReadOnly(readOnly));
     }
 
@@ -2784,9 +2787,5 @@ public class Binder<BEAN> implements Serializable {
         Objects.requireNonNull(propertyName, "Property name may not be null");
         Optional.ofNullable(boundProperties.get(propertyName))
                 .ifPresent(Binding::unbind);
-    }
-
-    private static final Logger getLogger() {
-        return LoggerFactory.getLogger(Binder.class.getName());
     }
 }

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -34,11 +34,12 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.googlecode.gentyref.GenericTypeReflector;
+import com.vaadin.external.org.slf4j.Logger;
+import com.vaadin.external.org.slf4j.LoggerFactory;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasText;
 import com.vaadin.flow.component.HasValidation;
@@ -792,8 +793,8 @@ public class Binder<BEAN> implements Serializable {
             ValueProvider<BEAN, ?> getter = definition.getGetter();
             Setter<BEAN, ?> setter = definition.getSetter().orElse(null);
             if (setter == null) {
-                getLogger().fine(() -> propertyName
-                        + " does not have an accessible setter");
+                getLogger().info(
+                        propertyName + " does not have an accessible setter");
             }
 
             BindingBuilder<BEAN, ?> finalBinding = withConverter(
@@ -2791,6 +2792,6 @@ public class Binder<BEAN> implements Serializable {
     }
 
     private static final Logger getLogger() {
-        return Logger.getLogger(Binder.class.getName());
+        return LoggerFactory.getLogger(Binder.class.getName());
     }
 }

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BeanBinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BeanBinderTest.java
@@ -15,9 +15,6 @@
  */
 package com.vaadin.flow.data.binder;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-
 import java.io.Serializable;
 import java.time.LocalDate;
 import java.util.List;
@@ -38,6 +35,11 @@ import com.vaadin.flow.data.binder.BeanBinderTest.RequiredConstraints.SubSubCons
 import com.vaadin.flow.data.binder.testcomponents.TestTextField;
 import com.vaadin.flow.data.converter.StringToIntegerConverter;
 import com.vaadin.flow.tests.data.bean.BeanToValidate;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public class BeanBinderTest
         extends BinderTestBase<Binder<BeanToValidate>, BeanToValidate> {
@@ -291,6 +293,35 @@ public class BeanBinderTest
         nameField.setValue("Foo");
 
         assertEquals(propertyValue, item.getReadOnlyProperty());
+    }
+
+    @Test
+    public void bindReadOnlyPropertyShouldMarkFieldAsReadonly() {
+        binder.bind(nameField, "readOnlyProperty");
+
+        assertTrue("Name field should be readonly", nameField.isReadOnly());
+    }
+
+    @Test
+    public void setReadonlyShouldIgnoreBindingsForReadOnlyProperties() {
+        binder.bind(nameField, "readOnlyProperty");
+
+        binder.setReadOnly(true);
+        assertTrue("Name field should be ignored and be readonly",
+                nameField.isReadOnly());
+
+        binder.setReadOnly(false);
+        assertTrue("Name field should be ignored and be readonly",
+                nameField.isReadOnly());
+
+        nameField.setReadOnly(false);
+        binder.setReadOnly(true);
+        assertFalse("Name field should be ignored and not be readonly",
+                nameField.isReadOnly());
+
+        binder.setReadOnly(false);
+        assertFalse("Name field should be ignored and not be readonly",
+                nameField.isReadOnly());
     }
 
     @Test


### PR DESCRIPTION
Make Binder.setReadonly ignore effectively readonly bindings(vaadin/framework#10368)
Treat fields as readonly when bound with null setter(vaadin/framework#10477)
Add setReadOnly for Bindings (vaadin/framework#10482)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3670)
<!-- Reviewable:end -->
