### PR TITLE
Set no-store headers for error responses

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinResponse.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinResponse.java
@@ -173,6 +173,22 @@ public interface VaadinResponse {
     void setContentLength(int len);
 
     /**
+     * Sets all conceivable headers that might prevent a response from being
+     * stored in any caches.
+     *
+     * @since
+     */
+    public default void setNoCacheHeaders() {
+        // no-store to disallow storing even if cache would be revalidated
+        // must-revalidate to not use stored value even if someone asks for it
+        setHeader("Cache-Control", "no-cache, no-store, must-revalidate");
+
+        // Also set legacy values in case of old proxies in between
+        setHeader("Pragma", "no-cache");
+        setHeader("Expires", "0");
+    }
+
+    /**
      * Gets the currently processed Vaadin response. The current response is
      * automatically defined when the request is started. The current response
      * can not be used in e.g. background threads because of the way server

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinResponse.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinResponse.java
@@ -176,9 +176,8 @@ public interface VaadinResponse {
      * Sets all conceivable headers that might prevent a response from being
      * stored in any caches.
      *
-     * @since
      */
-    public default void setNoCacheHeaders() {
+    default void setNoCacheHeaders() {
         // no-store to disallow storing even if cache would be revalidated
         // must-revalidate to not use stored value even if someone asks for it
         setHeader("Cache-Control", "no-cache, no-store, must-revalidate");

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -1606,7 +1606,6 @@ public abstract class VaadinService implements Serializable {
      *            The actual response
      * @throws IOException
      *             If an error occurred while writing the response
-     * @since
      */
     public void writeUncachedStringResponse(VaadinResponse response,
             String contentType, String responseString) throws IOException {

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
@@ -15,12 +15,6 @@
  */
 package com.vaadin.flow.server;
 
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
@@ -33,6 +27,13 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.slf4j.LoggerFactory;
 
@@ -506,7 +507,7 @@ public class VaadinServlet extends HttpServlet {
                 // User has cookies disabled
                 SystemMessages systemMessages = getService().getSystemMessages(
                         ServletHelper.findLocale(null, request), request);
-                getService().writeStringResponse(response,
+                getService().writeUncachedStringResponse(response,
                         JsonConstants.JSON_CONTENT_TYPE,
                         VaadinService.createCriticalNotificationJSON(
                                 systemMessages.getCookiesDisabledCaption(),

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlRequestHandler.java
@@ -22,18 +22,19 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.StringWriter;
 import java.io.Writer;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.server.ServletHelper;
+import com.vaadin.flow.server.ServletHelper.RequestType;
 import com.vaadin.flow.server.SessionExpiredHandler;
 import com.vaadin.flow.server.SynchronizedRequestHandler;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
-import com.vaadin.flow.server.ServletHelper.RequestType;
 import com.vaadin.flow.server.communication.ServerRpcHandler.InvalidUIDLSecurityKeyException;
 import com.vaadin.flow.shared.JsonConstants;
 
@@ -140,7 +141,8 @@ public class UidlRequestHandler extends SynchronizedRequestHandler
             return false;
         }
         VaadinService service = request.getService();
-        service.writeStringResponse(response, JsonConstants.JSON_CONTENT_TYPE,
+        service.writeUncachedStringResponse(response,
+                JsonConstants.JSON_CONTENT_TYPE,
                 VaadinService.createSessionExpiredJSON());
 
         return true;


### PR DESCRIPTION
Port Change from framework.
Original commit is vaadin/framework#10628.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3672)
<!-- Reviewable:end -->
