### PR TITLE
Do not crash app for using different load modes

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/shared/ui/LoadMode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/ui/LoadMode.java
@@ -37,6 +37,21 @@ import com.vaadin.flow.component.dependency.StyleSheet;
  * @author Vaadin Ltd.
  */
 public enum LoadMode {
+    /*
+     * Implementation note: the order of the enums is from "more eager" to
+     * laziest. This is due to being able to easily using the more eager load
+     * mode when duplicate dependencies are loaded with different load modes.
+     * (#3677)
+     */
+    /**
+     * Forced the dependency to be inlined in the body of the html page,
+     * removing the requirement to have additional roundtrips to fetch the
+     * script.
+     * <p>
+     * It is guaranteed that all {@link LoadMode#INLINE} dependencies are loaded
+     * before any {@link LoadMode#LAZY} dependency.
+     */
+    INLINE,
     /**
      * Forces the dependency being loaded before the initial page load. This
      * mode is suitable for situation when the application cannot start without
@@ -54,14 +69,6 @@ public enum LoadMode {
      * It is guaranteed that all {@link LoadMode#EAGER} dependencies are loaded
      * before any {@link LoadMode#LAZY} dependency.
      */
-    LAZY,
+    LAZY
 
-    /**
-     * Forced the dependency to be inlined in the body of the html page,
-     * removing the requirement to have additional roundtrips to fetch the script.
-     * <p>
-     * It is guaranteed that all {@link LoadMode#INLINE} dependencies are loaded
-     * before any {@link LoadMode#LAZY} dependency.
-     */
-    INLINE
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerDependenciesTest.java
@@ -293,10 +293,10 @@ public class BootstrapHandlerDependenciesTest {
                 new UIWithMethods_BothBothInlineAndEagerTest(),
                 new UIAnnotated_BothLazyAndInlineTest(),
                 new UIWithMethods_BothBothLazyAndInlineTest())
-                .forEach(this::checkUiWithException);
+                .forEach(this::checkUiWithNoException);
     }
 
-    private void checkUiWithException(UI ui) {
+    private void checkUiWithNoException(UI ui) {
         boolean exceptionCaught = false;
         try {
             testUis(doc -> {
@@ -304,10 +304,10 @@ public class BootstrapHandlerDependenciesTest {
         } catch (IllegalStateException expected) {
             exceptionCaught = true;
         } finally {
-            assertThat(
+            assertFalse(
                     "The exception was expected, but not thrown for ui "
                             + ui.getClass().getCanonicalName(),
-                    exceptionCaught, is(true));
+                    exceptionCaught);
         }
     }
 


### PR DESCRIPTION
It makes no sense to crash the application when developer accidentally adds the same resource with two different load modes.

Fixes #3677

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3680)
<!-- Reviewable:end -->
