### PR TITLE
Handle initial value for first value change event

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/HasValue.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasValue.java
@@ -25,12 +25,11 @@ import com.vaadin.flow.shared.Registration;
  * that have a user-editable value. Emits change events whenever the value is
  * changed, either by the user or programmatically.
  *
- * @author Vaadin Ltd.
- *
  * @param <C>
  *            the component type
  * @param <V>
  *            the value type
+ * @author Vaadin Ltd.
  */
 public interface HasValue<C extends Component, V> {
 
@@ -95,13 +94,12 @@ public interface HasValue<C extends Component, V> {
      *            the component type
      * @param <V>
      *            the value type
-     *
      * @see ValueChangeEvent
      * @see Registration
      */
     @FunctionalInterface
-    interface ValueChangeListener<C extends Component, V>
-            extends ComponentEventListener<ValueChangeEvent<C, V>> {
+    interface ValueChangeListener<C extends Component, V> extends
+            ComponentEventListener<ValueChangeEvent<C, V>> {
 
         /**
          * Invoked when this listener receives a value change event from an
@@ -120,7 +118,8 @@ public interface HasValue<C extends Component, V> {
      * {@code IllegalArgumentException} if the value is not acceptable.
      * <p>
      * <i>Implementation note:</i> the implementing class should document
-     * whether null values are accepted or not.
+     * whether null values are accepted or not, and override
+     * {@link #getEmptyValue()} if the empty value is not {@code null}.
      *
      * @param value
      *            the new value
@@ -133,7 +132,8 @@ public interface HasValue<C extends Component, V> {
      * Returns the current value of this object.
      * <p>
      * <i>Implementation note:</i> the implementing class should document
-     * whether null values may be returned or not.
+     * whether null values may be returned or not, and override
+     * {@link #getEmptyValue()} if the empty value is not {@code null}.
      *
      * @return the current value
      */
@@ -162,6 +162,10 @@ public interface HasValue<C extends Component, V> {
     /**
      * Adds a value change listener. The listener is called when the value of
      * this {@code HasValue} is changed either by the user or programmatically.
+     * <p>
+     * <i>Implementation note:</i> the added listener is triggered if the value
+     * property, named by {@link #getClientValuePropertyName()}, is changed so
+     * that the new value does not match the previous value.
      *
      * @param listener
      *            the value change listener, not null
@@ -170,10 +174,30 @@ public interface HasValue<C extends Component, V> {
     default Registration addValueChangeListener(
             ValueChangeListener<C, V> listener) {
         return getComponent().getElement().addPropertyChangeListener(
-                getClientValuePropertyName(),
-                event -> listener.onComponentEvent(new ValueChangeEvent<>(
-                        getComponent(), this, (V) event.getOldValue(),
-                        event.isUserOriginated())));
+                getClientValuePropertyName(), event -> {
+                    /*
+                     * For the state tree, the default empty value of any
+                     * property is {@code null}, but for any component it might
+                     * be something else as defined by {@link #getEmptyValue()}.
+                     * (#3496)
+                     */
+                    final V oldValue;
+                    final V emptyValue = getEmptyValue();
+                    final V propertyChangeEventValue = (V) event.getOldValue();
+                    if (propertyChangeEventValue == null) {
+                        oldValue = emptyValue;
+                        if (Objects.equals(oldValue, getValue())) {
+                            // there is no value change in component API
+                            // perspective
+                            return;
+                        }
+                    } else {
+                        oldValue = propertyChangeEventValue;
+                    }
+                    listener.onComponentEvent(new ValueChangeEvent<>(getComponent(),
+                            this, oldValue, event.isUserOriginated()));
+
+                });
     }
 
     /**


### PR DESCRIPTION
Instead of forcing component developers to set the default empty value always
for each component instance, HasValue checks for empty value when value
property has changed to null.
Workarounds most common case of #3496

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3686)
<!-- Reviewable:end -->
