### PR TITLE
DependencyParser should add prefix if needed.

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentMetaData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentMetaData.java
@@ -78,10 +78,7 @@ public class ComponentMetaData {
 
         private HtmlImportDependency(Collection<String> uris,
                 LoadMode loadMode) {
-            List<String> uriList = new ArrayList<>();
-            uris.forEach(uri -> uriList.add(SharedUtil.prefixIfRelative(uri,
-                    ApplicationConstants.FRONTEND_PROTOCOL_PREFIX)));
-            this.uris = Collections.unmodifiableCollection(uriList);
+            this.uris = Collections.unmodifiableCollection(uris);
             this.loadMode = loadMode;
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentMetaData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentMetaData.java
@@ -35,9 +35,7 @@ import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.dependency.Uses;
 import com.vaadin.flow.internal.AnnotationReader;
 import com.vaadin.flow.internal.ReflectTools;
-import com.vaadin.flow.shared.ApplicationConstants;
 import com.vaadin.flow.shared.ui.LoadMode;
-import com.vaadin.flow.shared.util.SharedUtil;
 
 /**
  * Immutable meta data related to a component class.

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentMetaData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentMetaData.java
@@ -35,7 +35,9 @@ import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.dependency.Uses;
 import com.vaadin.flow.internal.AnnotationReader;
 import com.vaadin.flow.internal.ReflectTools;
+import com.vaadin.flow.shared.ApplicationConstants;
 import com.vaadin.flow.shared.ui.LoadMode;
+import com.vaadin.flow.shared.util.SharedUtil;
 
 /**
  * Immutable meta data related to a component class.
@@ -76,7 +78,10 @@ public class ComponentMetaData {
 
         private HtmlImportDependency(Collection<String> uris,
                 LoadMode loadMode) {
-            this.uris = Collections.unmodifiableCollection(uris);
+            List<String> uriList = new ArrayList<>();
+            uris.forEach(uri -> uriList.add(SharedUtil.prefixIfRelative(uri,
+                    ApplicationConstants.FRONTEND_PROTOCOL_PREFIX)));
+            this.uris = Collections.unmodifiableCollection(uriList);
             this.loadMode = loadMode;
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/HtmlDependencyParser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/HtmlDependencyParser.java
@@ -79,13 +79,10 @@ public class HtmlDependencyParser {
     }
 
     private void parseDependencies(String path, Set<String> dependencies) {
-        String url = SharedUtil.prefixIfRelative(path,
-                ApplicationConstants.FRONTEND_PROTOCOL_PREFIX);
-
-        if (dependencies.contains(url)) {
+        if (dependencies.contains(path)) {
             return;
         }
-        dependencies.add(url);
+        dependencies.add(path);
 
         VaadinSession session = VaadinSession.getCurrent();
         VaadinServlet servlet = VaadinServlet.getCurrent();
@@ -106,17 +103,17 @@ public class HtmlDependencyParser {
             session.setAttribute(HtmlDependenciesCache.class, cache);
         }
 
+        String url = SharedUtil.prefixIfRelative(path,
+                ApplicationConstants.FRONTEND_PROTOCOL_PREFIX);
 
-        String resolvedPath = servlet
-                .resolveResource(url);
+        String resolvedPath = servlet.resolveResource(url);
 
         if (cache.hasDependency(resolvedPath)) {
             return;
         }
         cache.addDependency(resolvedPath);
 
-        try (InputStream content = servlet
-                .getResourceAsStream(resolvedPath)) {
+        try (InputStream content = servlet.getResourceAsStream(resolvedPath)) {
             if (content == null) {
                 getLogger().trace(
                         "Can't find resource '{}' to parse for imports via the servlet context",

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/HtmlDependencyParser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/HtmlDependencyParser.java
@@ -72,8 +72,9 @@ public class HtmlDependencyParser {
 
     Collection<String> parseDependencies() {
         Set<String> dependencies = new HashSet<>();
-
-        parseDependencies(root, dependencies);
+        String rooUri = SharedUtil.prefixIfRelative(root,
+                ApplicationConstants.FRONTEND_PROTOCOL_PREFIX);
+        parseDependencies(rooUri, dependencies);
 
         return dependencies;
     }
@@ -103,10 +104,8 @@ public class HtmlDependencyParser {
             session.setAttribute(HtmlDependenciesCache.class, cache);
         }
 
-        String url = SharedUtil.prefixIfRelative(path,
-                ApplicationConstants.FRONTEND_PROTOCOL_PREFIX);
 
-        String resolvedPath = servlet.resolveResource(url);
+        String resolvedPath = servlet.resolveResource(path);
 
         if (cache.hasDependency(resolvedPath)) {
             return;

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/HtmlDependencyParser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/HtmlDependencyParser.java
@@ -79,10 +79,13 @@ public class HtmlDependencyParser {
     }
 
     private void parseDependencies(String path, Set<String> dependencies) {
-        if (dependencies.contains(path)) {
+        String url = SharedUtil.prefixIfRelative(path,
+                ApplicationConstants.FRONTEND_PROTOCOL_PREFIX);
+
+        if (dependencies.contains(url)) {
             return;
         }
-        dependencies.add(path);
+        dependencies.add(url);
 
         VaadinSession session = VaadinSession.getCurrent();
         VaadinServlet servlet = VaadinServlet.getCurrent();
@@ -103,8 +106,6 @@ public class HtmlDependencyParser {
             session.setAttribute(HtmlDependenciesCache.class, cache);
         }
 
-        String url = SharedUtil.prefixIfRelative(path,
-                ApplicationConstants.FRONTEND_PROTOCOL_PREFIX);
 
         String resolvedPath = servlet
                 .resolveResource(url);

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/HtmlDependencyParserTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/HtmlDependencyParserTest.java
@@ -74,7 +74,7 @@ public class HtmlDependencyParserTest {
         Assert.assertTrue(
                 "Dependencies parser doesn't return the root URI but '"
                         + dependencies + "'",
-                dependencies.contains("frontend://" + root));
+                dependencies.contains(root));
     }
 
     @Test
@@ -128,16 +128,16 @@ public class HtmlDependencyParserTest {
         Mockito.verify(servlet).getResourceAsStream("absolute.html");
 
         Assert.assertTrue("Dependencies parser doesn't return the root URI",
-                dependencies.contains("frontend://" + root));
+                dependencies.contains(root));
         Assert.assertTrue(
                 "Dependencies parser doesn't return the simple relative URI (same parent)",
-                dependencies.contains("frontend://baz/relative1.html"));
+                dependencies.contains("baz/relative1.html"));
         Assert.assertTrue(
-                "Dependencies parser doesn't return the realtive URI which is located in the parent folder",
-                dependencies.contains("frontend://relative2.html"));
+                "Dependencies parser doesn't return the relative URI which is located in the parent folder",
+                dependencies.contains("relative2.html"));
         Assert.assertTrue(
-                "Dependencies parser doesn't return the realtive URI which is located sub folder",
-                dependencies.contains("frontend://baz/sub/relative3.html"));
+                "Dependencies parser doesn't return the relative URI which is located sub folder",
+                dependencies.contains("baz/sub/relative3.html"));
         Assert.assertTrue("Dependencies parser doesn't return the absolute URI",
                 dependencies.contains("/absolute.html"));
     }
@@ -203,13 +203,13 @@ public class HtmlDependencyParserTest {
         Assert.assertEquals(3, dependencies.size());
 
         Assert.assertTrue("Dependencies parser doesn't return the root URI",
-                dependencies.contains("frontend://" + root));
+                dependencies.contains(root));
         Assert.assertTrue(
                 "Dependencies parser doesn't return the simple relative URI (same parent)",
-                dependencies.contains("frontend://relative.html"));
+                dependencies.contains("relative.html"));
         Assert.assertTrue(
-                "Dependencies parser doesn't return the realtive URI which is located in the parent folder",
-                dependencies.contains("frontend://relative1.html"));
+                "Dependencies parser doesn't return the relative URI which is located in the parent folder",
+                dependencies.contains("relative1.html"));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/HtmlDependencyParserTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/HtmlDependencyParserTest.java
@@ -74,7 +74,7 @@ public class HtmlDependencyParserTest {
         Assert.assertTrue(
                 "Dependencies parser doesn't return the root URI but '"
                         + dependencies + "'",
-                dependencies.contains(root));
+                dependencies.contains("frontend://" + root));
     }
 
     @Test
@@ -97,24 +97,24 @@ public class HtmlDependencyParserTest {
 
         Mockito.when(servlet.resolveResource("frontend://baz/relative1.html"))
                 .thenReturn("baz/relative1.html");
-        Mockito.when(service.getResourceAsStream("baz/relative1.html"))
+        Mockito.when(servlet.getResourceAsStream("baz/relative1.html"))
                 .thenReturn(new ByteArrayInputStream(
                         "".getBytes(StandardCharsets.UTF_8)));
 
-        Mockito.when(servlet.resolveResource("frontend://relative2.html"))
+        Mockito.when(servlet.resolveResource("frontend://baz/../relative2.html"))
                 .thenReturn("relative2.html");
-        Mockito.when(service.getResourceAsStream("relative2.html")).thenReturn(
+        Mockito.when(servlet.getResourceAsStream("relative2.html")).thenReturn(
                 new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
 
         Mockito.when(
                 servlet.resolveResource("frontend://baz/sub/relative3.html"))
                 .thenReturn("relative3.html");
-        Mockito.when(service.getResourceAsStream("relative3.html")).thenReturn(
+        Mockito.when(servlet.getResourceAsStream("relative3.html")).thenReturn(
                 new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
 
         Mockito.when(servlet.resolveResource("/absolute.html"))
                 .thenReturn("absolute.html");
-        Mockito.when(service.getResourceAsStream("absolute.html")).thenReturn(
+        Mockito.when(servlet.getResourceAsStream("absolute.html")).thenReturn(
                 new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
 
         Collection<String> dependencies = parser.parseDependencies();
@@ -128,16 +128,16 @@ public class HtmlDependencyParserTest {
         Mockito.verify(servlet).getResourceAsStream("absolute.html");
 
         Assert.assertTrue("Dependencies parser doesn't return the root URI",
-                dependencies.contains(root));
+                dependencies.contains("frontend://" + root));
         Assert.assertTrue(
                 "Dependencies parser doesn't return the simple relative URI (same parent)",
-                dependencies.contains("baz/relative1.html"));
+                dependencies.contains("frontend://baz/relative1.html"));
         Assert.assertTrue(
                 "Dependencies parser doesn't return the relative URI which is located in the parent folder",
-                dependencies.contains("relative2.html"));
+                dependencies.contains("frontend://baz/../relative2.html"));
         Assert.assertTrue(
                 "Dependencies parser doesn't return the relative URI which is located sub folder",
-                dependencies.contains("baz/sub/relative3.html"));
+                dependencies.contains("frontend://baz/sub/relative3.html"));
         Assert.assertTrue("Dependencies parser doesn't return the absolute URI",
                 dependencies.contains("/absolute.html"));
     }
@@ -203,13 +203,13 @@ public class HtmlDependencyParserTest {
         Assert.assertEquals(3, dependencies.size());
 
         Assert.assertTrue("Dependencies parser doesn't return the root URI",
-                dependencies.contains(root));
+                dependencies.contains("frontend://" + root));
         Assert.assertTrue(
                 "Dependencies parser doesn't return the simple relative URI (same parent)",
-                dependencies.contains("relative.html"));
+                dependencies.contains("frontend://relative.html"));
         Assert.assertTrue(
                 "Dependencies parser doesn't return the relative URI which is located in the parent folder",
-                dependencies.contains("relative1.html"));
+                dependencies.contains("frontend://relative1.html"));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/HtmlDependencyParserTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/HtmlDependencyParserTest.java
@@ -79,7 +79,7 @@ public class HtmlDependencyParserTest {
         Assert.assertTrue(
                 "Dependencies parser doesn't return the root URI but '"
                         + dependencies + "'",
-                dependencies.contains(root));
+                dependencies.contains("frontend://" + root));
     }
 
     @Test
@@ -127,16 +127,16 @@ public class HtmlDependencyParserTest {
         Assert.assertEquals(5, dependencies.size());
 
         Assert.assertTrue("Dependencies parser doesn't return the root URI",
-                dependencies.contains(root));
+                dependencies.contains("frontend://" + root));
         Assert.assertTrue(
                 "Dependencies parser doesn't return the simple relative URI (same parent)",
-                dependencies.contains("baz/relative1.html"));
+                dependencies.contains("frontend://baz/relative1.html"));
         Assert.assertTrue(
                 "Dependencies parser doesn't return the realtive URI which is located in the parent folder",
-                dependencies.contains("relative2.html"));
+                dependencies.contains("frontend://relative2.html"));
         Assert.assertTrue(
                 "Dependencies parser doesn't return the realtive URI which is located sub folder",
-                dependencies.contains("baz/sub/relative3.html"));
+                dependencies.contains("frontend://baz/sub/relative3.html"));
         Assert.assertTrue("Dependencies parser doesn't return the absolute URI",
                 dependencies.contains("/absolute.html"));
     }
@@ -202,13 +202,13 @@ public class HtmlDependencyParserTest {
         Assert.assertEquals(3, dependencies.size());
 
         Assert.assertTrue("Dependencies parser doesn't return the root URI",
-                dependencies.contains(root));
+                dependencies.contains("frontend://" + root));
         Assert.assertTrue(
                 "Dependencies parser doesn't return the simple relative URI (same parent)",
-                dependencies.contains("relative.html"));
+                dependencies.contains("frontend://relative.html"));
         Assert.assertTrue(
                 "Dependencies parser doesn't return the realtive URI which is located in the parent folder",
-                dependencies.contains("relative1.html"));
+                dependencies.contains("frontend://relative1.html"));
     }
 
     @Test

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/theme/HtmlParserThemeTemplateView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/theme/HtmlParserThemeTemplateView.java
@@ -23,7 +23,7 @@ import com.vaadin.flow.templatemodel.TemplateModel;
 import com.vaadin.flow.theme.Theme;
 
 @Tag("parser-template")
-@HtmlImport("frontend://com/vaadin/flow/uitest/ui/custom-theme/HtmlParserThemeTemplate.html")
+@HtmlImport("com/vaadin/flow/uitest/ui/custom-theme/HtmlParserThemeTemplate.html")
 @Route(value = "com.vaadin.flow.uitest.ui.theme.HtmlParserThemeTemplateView")
 @Theme(MyTheme.class)
 public class HtmlParserThemeTemplateView

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/theme/HtmlParserThemeTemplateView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/theme/HtmlParserThemeTemplateView.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.theme;
+
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.HtmlImport;
+import com.vaadin.flow.component.polymertemplate.PolymerTemplate;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.templatemodel.TemplateModel;
+import com.vaadin.flow.theme.Theme;
+
+@Tag("parser-template")
+@HtmlImport("frontend://com/vaadin/flow/uitest/ui/custom-theme/HtmlParserThemeTemplate.html")
+@Route(value = "com.vaadin.flow.uitest.ui.theme.HtmlParserThemeTemplateView")
+@Theme(MyTheme.class)
+public class HtmlParserThemeTemplateView
+        extends PolymerTemplate<TemplateModel> {
+}

--- a/flow-tests/test-root-context/src/main/webapp/frontend/bower_components/my-component/theme/myTheme/my-component.html
+++ b/flow-tests/test-root-context/src/main/webapp/frontend/bower_components/my-component/theme/myTheme/my-component.html
@@ -1,13 +1,13 @@
 <link rel="import" href="../../../../bower_components/polymer/polymer-element.html">
+<link rel="import" href="../../src/my-component.html">
 
 <dom-module id="my-component">
-    <template>
-        <div id="theme-component">My themed component</div>
-    </template>
     <script>
-        class MyComponent extends Polymer.Element {
-            static get is() { return 'my-component' }
-        }
-        customElements.define(MyComponent.is, MyComponent);
+        customElements.whenDefined('my-component').then(() => {
+            let element = document.createElement("div");
+            element.setAttribute("id", "theme-component");
+            element.innerHTML = "My themed component";
+            document.body.appendChild(element);
+        });
     </script>
 </dom-module>

--- a/flow-tests/test-root-context/src/main/webapp/frontend/com/vaadin/flow/uitest/ui/custom-theme/HtmlParserThemeTemplate.html
+++ b/flow-tests/test-root-context/src/main/webapp/frontend/com/vaadin/flow/uitest/ui/custom-theme/HtmlParserThemeTemplate.html
@@ -1,0 +1,14 @@
+<link rel="import" href="/frontend/bower_components/polymer/polymer-element.html">
+<link rel="import" href="../../../../../../bower_components/my-component/src/my-component.html">
+
+<dom-module id="parser-template">
+    <template>
+        <my-component></my-component>
+    </template>
+    <script>
+        class HtmlParserThemeTemplate extends Polymer.Element {
+            static get is() { return 'parser-template' }
+        }
+        customElements.define(HtmlParserThemeTemplate.is, HtmlParserThemeTemplate);
+    </script>
+</dom-module>

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/theme/HtmlParserThemeTemplateIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/theme/HtmlParserThemeTemplateIT.java
@@ -22,22 +22,12 @@ import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
-public class MyThemeIT extends ChromeBrowserTest {
+public class HtmlParserThemeTemplateIT extends ChromeBrowserTest {
 
     @Test
-    public void loadBaseComponent() {
+    public void themeComponentShouldLoadForTemplate() {
         getDriver().get(getRootURL()
-                + "/view/com.vaadin.flow.uitest.ui.theme.MyComponentView");
-
-        WebElement element = findElement(By.tagName("my-component"));
-        Assert.assertFalse(
-                findInShadowRoot(element, By.id("component")).isEmpty());
-    }
-
-    @Test
-    public void loadThemeComponent() {
-        getDriver().get(getRootURL()
-                + "/view/com.vaadin.flow.uitest.ui.theme.MyThemeComponentView");
+                + "/view/com.vaadin.flow.uitest.ui.theme.HtmlParserThemeTemplateView");
 
         Assert.assertTrue(
                 findElement(By.id("theme-component")).isDisplayed());


### PR DESCRIPTION
The HtmlDependencyParser should store the dependency with
the frontend protocol prefix if relative, else we will load wrong.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3693)
<!-- Reviewable:end -->
