### PR TITLE
Make HasValue not have to be a Component

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/HasValue.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasValue.java
@@ -32,7 +32,7 @@ import com.vaadin.flow.shared.Registration;
  * @param <V>
  *            the value type
  */
-public interface HasValue<C extends Component, V> extends HasElement {
+public interface HasValue<C extends Component, V> {
 
     /**
      * An event fired when the value of a {@code HasValue} changes.
@@ -42,8 +42,7 @@ public interface HasValue<C extends Component, V> extends HasElement {
      * @param <V>
      *            the value type
      */
-    class ValueChangeEvent<C extends Component, V>
-    extends ComponentEvent<C> {
+    class ValueChangeEvent<C extends Component, V> extends ComponentEvent<C> {
 
         private final V oldValue;
         private final V value;
@@ -101,8 +100,8 @@ public interface HasValue<C extends Component, V> extends HasElement {
      * @see Registration
      */
     @FunctionalInterface
-    interface ValueChangeListener<C extends Component, V> extends
-            ComponentEventListener<ValueChangeEvent<C, V>> {
+    interface ValueChangeListener<C extends Component, V>
+            extends ComponentEventListener<ValueChangeEvent<C, V>> {
 
         /**
          * Invoked when this listener receives a value change event from an
@@ -141,6 +140,26 @@ public interface HasValue<C extends Component, V> extends HasElement {
     V getValue();
 
     /**
+     * Returns the component instance this {@code HasValue} is bound to.
+     * <p>
+     * The default implementation expects the {@code HasValue} to also extend
+     * {@link Component}. If that is not the case, this method should be
+     * overridden to return the correct {@link Component} instance.
+     * 
+     * @return the component instance, never {@code null}
+     */
+    default C getComponent() {
+        try {
+            return (C) this;
+        } catch (ClassCastException cce) {
+            throw new ClassCastException(String.format(
+                    "The class %1$s implementing %2$s does not extend %3$s. It should override the getComponent() method to return the component instance the %1$s is bound to. Original message: %4$s",
+                    getClass().getName(), HasValue.class.getName(),
+                    Component.class.getName(), cce.getMessage()));
+        }
+    }
+
+    /**
      * Adds a value change listener. The listener is called when the value of
      * this {@code HasValue} is changed either by the user or programmatically.
      *
@@ -150,11 +169,10 @@ public interface HasValue<C extends Component, V> extends HasElement {
      */
     default Registration addValueChangeListener(
             ValueChangeListener<C, V> listener) {
-        return getElement().addPropertyChangeListener(
+        return getComponent().getElement().addPropertyChangeListener(
                 getClientValuePropertyName(),
-                event -> listener
-                        .onComponentEvent(new ValueChangeEvent<>((C) this,
-                        this, (V) event.getOldValue(),
+                event -> listener.onComponentEvent(new ValueChangeEvent<>(
+                        getComponent(), this, (V) event.getOldValue(),
                         event.isUserOriginated())));
     }
 
@@ -241,7 +259,7 @@ public interface HasValue<C extends Component, V> extends HasElement {
      *            read-only mode or not
      */
     default void setReadOnly(boolean readOnly) {
-        getElement().setProperty("readonly", readOnly);
+        getComponent().getElement().setProperty("readonly", readOnly);
     }
 
     /**
@@ -251,7 +269,7 @@ public interface HasValue<C extends Component, V> extends HasElement {
      *         not.
      */
     default boolean isReadOnly() {
-        return getElement().getProperty("readonly", false);
+        return getComponent().getElement().getProperty("readonly", false);
     }
 
     /**
@@ -264,7 +282,7 @@ public interface HasValue<C extends Component, V> extends HasElement {
      *            <code>false</code> if not
      */
     default void setRequiredIndicatorVisible(boolean requiredIndicatorVisible) {
-        getElement().setProperty("required",
+        getComponent().getElement().setProperty("required",
                 requiredIndicatorVisible);
     }
 
@@ -274,6 +292,6 @@ public interface HasValue<C extends Component, V> extends HasElement {
      * @return <code>true</code> if visible, <code>false</code> if not
      */
     default boolean isRequiredIndicatorVisible() {
-        return getElement().getProperty("required", false);
+        return getComponent().getElement().getProperty("required", false);
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasValueTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasValueTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.component;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.router.RouterLink;
+
+public class HasValueTest {
+
+    public static class HasValueComponent extends RouterLink implements HasValue<RouterLink, String> {
+
+        @Override
+        public void setValue(String value) {
+
+        }
+
+        @Override
+        public String getValue() {
+            return null;
+        }
+    }
+
+    public static class HasValueNotComponent implements HasValue<RouterLink, String> {
+
+        @Override
+        public void setValue(String value) {
+
+        }
+
+        @Override
+        public String getValue() {
+            return null;
+        }
+    }
+
+    @Test
+    public void testGetComponent_hasValueIsComponent_defaultWorks() {
+        HasValueComponent hasValueComponent = new HasValueComponent();
+        Assert.assertEquals("invalid component type", hasValueComponent, hasValueComponent.getComponent());
+    }
+
+    @Test(expected = ClassCastException.class)
+    public void testGetComponent_notComponent_throwsAnException() {
+        new HasValueNotComponent().getComponent();
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasValueTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasValueTest.java
@@ -14,10 +14,11 @@
 
 package com.vaadin.flow.component;
 
-import org.junit.Assert;
-import org.junit.Test;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.vaadin.flow.router.RouterLink;
+import org.junit.Assert;
+import org.junit.Test;
 
 public class HasValueTest {
 
@@ -25,7 +26,7 @@ public class HasValueTest {
 
         @Override
         public void setValue(String value) {
-
+            getComponent().getElement().setProperty(getClientValuePropertyName(), value);
         }
 
         @Override
@@ -56,5 +57,16 @@ public class HasValueTest {
     @Test(expected = ClassCastException.class)
     public void testGetComponent_notComponent_throwsAnException() {
         new HasValueNotComponent().getComponent();
+    }
+
+    @Test
+    public void testAddValueChangeListener_defaultImplementation_usesGetComponentAsSource() {
+        HasValueComponent component = new HasValueComponent();
+        AtomicReference<Component> sourceReference = new AtomicReference<>();
+
+        component.addValueChangeListener(event -> sourceReference.set(event.getSource()));
+        component.setValue("foobar");
+
+        Assert.assertEquals("Incorrect event source",component, sourceReference.get());
     }
 }


### PR DESCRIPTION
HasValue should not have to be a component, but it should have an
reference to it instead. Now it by default presumes so, but users can
override the method for cases where the HasValue is not actually a
component, like with Grid's selection models.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3703)
<!-- Reviewable:end -->
