### PR TITLE
Improve reporting related to syncid mismatches

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -176,6 +176,8 @@ public class UIInternals implements Serializable {
     private static final Pattern componentSource = Pattern
             .compile(".*/src/vaadin-([\\w\\-]*).html");
 
+    private byte[] lastProcessedMessageHash = null;
+
     /**
      * Creates a new instance for the given UI.
      *
@@ -198,7 +200,7 @@ public class UIInternals implements Serializable {
 
     /**
      * Gets the last processed server message id.
-     *
+     * <p>
      * Used internally for communication tracking.
      *
      * @return lastProcessedServerMessageId the id of the last processed server
@@ -209,16 +211,35 @@ public class UIInternals implements Serializable {
     }
 
     /**
-     * Sets the last processed server message id.
+     * Gets the hash of the last processed message from the client.
+     * <p>
+     * The hash is set through
+     * {@link #setLastProcessedClientToServerId(int, byte[])}.
+     * <p>
+     * Used internally for communication tracking.
      *
+     * @return the hash as a byte array, or <code>null</code> if no hash has
+     *         been set
+     */
+    public byte[] getLastProcessedMessageHash() {
+        return lastProcessedMessageHash;
+    }
+
+    /**
+     * Sets the last processed server message id.
+     * <p>
      * Used internally for communication tracking.
      *
      * @param lastProcessedClientToServerId
      *            the id of the last processed server message
+     * @param lastProcessedMessageHash
+     *            the hash of the message
      */
     public void setLastProcessedClientToServerId(
-            int lastProcessedClientToServerId) {
+            int lastProcessedClientToServerId,
+            byte[] lastProcessedMessageHash) {
         this.lastProcessedClientToServerId = lastProcessedClientToServerId;
+        this.lastProcessedMessageHash = lastProcessedMessageHash;
     }
 
     /**


### PR DESCRIPTION
* Show sync ids in the exception message instead of logging separately
with various logging levels
* Include the beginning of the actual message in the exception message
* Separately report the case of receiving identical messages in
succession.

Related to #2210

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3726)
<!-- Reviewable:end -->
