### PR TITLE
Make HtmlDependenciesCache implement Serializable

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/HtmlDependencyParser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/HtmlDependencyParser.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.internal;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
@@ -46,7 +47,7 @@ import com.vaadin.flow.shared.util.SharedUtil;
  */
 public class HtmlDependencyParser {
 
-    static class HtmlDependenciesCache {
+    static class HtmlDependenciesCache implements Serializable {
         private final Set<String> dependencies = new HashSet<>();
 
         void addDependency(String url) {


### PR DESCRIPTION
HtmlDependenciesCache is stored in VaadinSession as attribute
so it should be Serializable.
Fixes #3727

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3728)
<!-- Reviewable:end -->
