### PR TITLE
Make StateNode.runWhenAttached accept SerializableConsumer

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
@@ -34,6 +34,7 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.StateTree.BeforeClientResponseEntry;
 import com.vaadin.flow.internal.StateTree.ExecutionRegistration;
 import com.vaadin.flow.internal.change.NodeAttachChange;
@@ -636,7 +637,7 @@ public class StateNode implements Serializable {
      * @param command
      *            the command to run immediately or when the node is attached
      */
-    public void runWhenAttached(Consumer<UI> command) {
+    public void runWhenAttached(SerializableConsumer<UI> command) {
 
         if (isAttached()) {
             command.accept(getUI());


### PR DESCRIPTION
The input consumer must be serializable because it could
be captured by an attach listener when the node is not attached
Fixes #3729

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3730)
<!-- Reviewable:end -->
