### PR TITLE
Change the removeAll behavior to also exclude all client-side nodes

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/flow/TreeChangeProcessor.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/TreeChangeProcessor.java
@@ -123,6 +123,9 @@ public class TreeChangeProcessor {
         case JsonConstants.CHANGE_TYPE_DETACH:
             processDetachChange(node);
             break;
+        case JsonConstants.CHANGE_TYPE_CLEAR:
+            processClearChange(change, node);
+            break;
         default:
             assert false : "Unsupported change type: " + type;
         }
@@ -222,5 +225,11 @@ public class TreeChangeProcessor {
         } else {
             list.splice(index, remove);
         }
+    }
+
+    private static void processClearChange(JsonObject change, StateNode node) {
+        int nsId = (int) change.getNumber(JsonConstants.CHANGE_FEATURE);
+        NodeList list = node.getList(nsId);
+        list.clear();
     }
 }

--- a/flow-client/src/main/java/com/vaadin/client/flow/nodefeature/ListSpliceEvent.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/nodefeature/ListSpliceEvent.java
@@ -28,6 +28,7 @@ public class ListSpliceEvent extends ReactiveValueChangeEvent {
     private int index;
     private JsArray<?> remove;
     private JsArray<?> add;
+    private boolean clear;
 
     /**
      * Creates a new list splice event.
@@ -40,9 +41,13 @@ public class ListSpliceEvent extends ReactiveValueChangeEvent {
      *            the removed items, not <code>null</code>
      * @param add
      *            the added items, not <code>null</code>
+     * @param clear
+     *            <code>true</code> when this is an event triggered upon
+     *            removing all the nodes of the given list, <code>false</code>
+     *            otherwise
      */
     public ListSpliceEvent(NodeList source, int index, JsArray<?> remove,
-            JsArray<?> add) {
+            JsArray<?> add, boolean clear) {
         super(source);
 
         assert remove != null;
@@ -51,6 +56,7 @@ public class ListSpliceEvent extends ReactiveValueChangeEvent {
         this.index = index;
         this.remove = remove;
         this.add = add;
+        this.clear = clear;
     }
 
     @Override
@@ -83,5 +89,15 @@ public class ListSpliceEvent extends ReactiveValueChangeEvent {
      */
     public JsArray<?> getAdd() {
         return add;
+    }
+
+    /**
+     * Gets whether this event is a {@code clear} event.
+     * 
+     * @return <code>true</code> if the event was triggered after a full clear,
+     *         <code>false</code> otherwise.
+     */
+    public boolean isClear() {
+        return clear;
     }
 }

--- a/flow-client/src/main/java/com/vaadin/client/flow/nodefeature/NodeList.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/nodefeature/NodeList.java
@@ -136,7 +136,18 @@ public class NodeList extends NodeFeature implements ReactiveValue {
     public void splice(int index, int remove) {
         JsArray<Object> removed = values.splice(index, remove);
         eventRouter.fireEvent(new ListSpliceEvent(this, index, removed,
-                JsCollections.array()));
+                JsCollections.array(), false));
+    }
+
+    /**
+     * Removes all the nodes from the list. This causes a
+     * {@link ListSpliceEvent} to be fired, with
+     * {@link ListSpliceEvent#isClear()} as <code>true</code>.
+     */
+    public void clear() {
+        JsArray<Object> removed = values.splice(0, values.length());
+        eventRouter.fireEvent(new ListSpliceEvent(this, 0, removed,
+                JsCollections.array(), true));
     }
 
     /**
@@ -155,7 +166,8 @@ public class NodeList extends NodeFeature implements ReactiveValue {
         @SuppressWarnings("unchecked")
         JsArray<Object> addObject = (JsArray<Object>) add;
         JsArray<Object> removed = values.spliceArray(index, remove, addObject);
-        eventRouter.fireEvent(new ListSpliceEvent(this, index, removed, add));
+        eventRouter.fireEvent(
+                new ListSpliceEvent(this, index, removed, add, false));
     }
 
     @Override

--- a/flow-client/src/main/java/com/vaadin/client/flow/template/ForTemplateBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/template/ForTemplateBindingStrategy.java
@@ -124,7 +124,7 @@ public class ForTemplateBindingStrategy extends AbstractTemplateStrategy<Node> {
                     }
 
                     onSplice(new ListSpliceEvent(childList, 0,
-                            JsCollections.array(), currentChildren));
+                            JsCollections.array(), currentChildren, false));
                 });
             }
         }

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasComponents.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasComponents.java
@@ -68,7 +68,8 @@ public interface HasComponents extends HasElement {
     /**
      * Removes all contents from this component, this includes child components,
      * text content as well as child elements that have been added directly to
-     * this component using the {@link Element} API.
+     * this component using the {@link Element} API. it also removes the
+     * children that were added only at the client-side.
      */
     default void removeAll() {
         getElement().removeAllChildren();

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -661,7 +661,7 @@ public class UIInternals implements Serializable {
             Element rootElement = root.getElement();
 
             if (!uiElement.equals(rootElement.getParent())) {
-                uiElement.removeAllChildren();
+                removeServerSideChildrenFromUI(uiElement);
                 rootElement.removeFromParent();
                 uiElement.appendChild(rootElement);
             }
@@ -741,9 +741,20 @@ public class UIInternals implements Serializable {
         Element rootElement = root.getElement();
 
         if (!uiElement.equals(rootElement.getParent())) {
-            uiElement.removeAllChildren();
+            removeServerSideChildrenFromUI(uiElement);
             rootElement.removeFromParent();
             uiElement.appendChild(rootElement);
+        }
+    }
+
+    /*
+     * Removes only the server-side children of the UI. This is needed because
+     * otherwise client-side-only elements, such as the {@code noscript} element
+     * and the loading indicator would also be removed.
+     */
+    private void removeServerSideChildrenFromUI(Element ui) {
+        while (ui.getChildCount() > 0) {
+            ui.removeChild(0);
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Node.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Node.java
@@ -323,7 +323,8 @@ public abstract class Node<N extends Node<N>> implements Serializable {
     }
 
     /**
-     * Removes all child elements.
+     * Removes all child elements, including elements only present at the
+     * client-side.
      *
      * @return this element
      */

--- a/flow-server/src/main/java/com/vaadin/flow/internal/change/ListClearChange.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/change/ListClearChange.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.internal.change;
+
+import java.io.Serializable;
+
+import com.vaadin.flow.internal.ConstantPool;
+import com.vaadin.flow.internal.nodefeature.NodeList;
+import com.vaadin.flow.shared.JsonConstants;
+
+import elemental.json.JsonObject;
+
+/**
+ * Change describing a clear operation in a {@link NodeList list} node feature.
+ *
+ * @author Vaadin Ltd
+ *
+ * @param <T>
+ *            the type of the items in the node list
+ */
+public class ListClearChange<T extends Serializable>
+        extends AbstractListChange<T> {
+
+    /**
+     * Creates a new list clear change.
+     *
+     *
+     * @param list
+     *            the changed list
+     */
+    public ListClearChange(NodeList<T> list) {
+        super(list, -1);
+    }
+
+    @Override
+    public AbstractListChange<T> copy(int indx) {
+        return new ListClearChange<>(getNodeList());
+    }
+
+    @Override
+    protected void populateJson(JsonObject json, ConstantPool constantPool) {
+        json.put(JsonConstants.CHANGE_TYPE, JsonConstants.CHANGE_TYPE_CLEAR);
+        super.populateJson(json, constantPool);
+    }
+
+}

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/NodeList.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/NodeList.java
@@ -33,6 +33,7 @@ import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.internal.change.AbstractListChange;
 import com.vaadin.flow.internal.change.EmptyChange;
 import com.vaadin.flow.internal.change.ListAddChange;
+import com.vaadin.flow.internal.change.ListClearChange;
 import com.vaadin.flow.internal.change.ListRemoveChange;
 import com.vaadin.flow.internal.change.NodeChange;
 
@@ -307,8 +308,10 @@ public abstract class NodeList<T extends Serializable> extends NodeFeature {
                 // by the index
                 ((ListAddChange<T>) change).getNewItems()
                         .forEach(item -> indices.put(item, i));
+            } else if (change instanceof ListClearChange<?>) {
+                allChanges.add(change);
             } else {
-                assert false : "AbstractListChange has only two subtypes: add and remove";
+                assert false : "AbstractListChange has only three subtypes: add, remove and clear";
             }
             index++;
         }
@@ -364,12 +367,15 @@ public abstract class NodeList<T extends Serializable> extends NodeFeature {
     }
 
     /**
-     * Removes all items.
+     * Removes all nodes, including those not known by the server.
      */
     protected void clear() {
-        while (size() > 0) {
-            remove(0);
+        if (values != null) {
+            values.clear();
+            values = null;
         }
+
+        addChange(new ListClearChange<T>(this));
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/StateNodeNodeList.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/StateNodeNodeList.java
@@ -15,7 +15,9 @@
  */
 package com.vaadin.flow.internal.nodefeature;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.function.Consumer;
 
 import com.vaadin.flow.internal.StateNode;
@@ -61,6 +63,20 @@ public abstract class StateNodeNodeList extends NodeList<StateNode> {
         StateNode removed = super.remove(index);
         detatchPotentialChild(removed);
         return removed;
+    }
+
+    @Override
+    protected void clear() {
+        int size = size();
+        List<StateNode> children = null;
+        if (size > 0) {
+            children = new ArrayList<>(size);
+            forEachChild(children::add);
+        }
+        super.clear();
+        if (size > 0) {
+            children.forEach(this::detatchPotentialChild);
+        }
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/shared/JsonConstants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/JsonConstants.java
@@ -73,6 +73,11 @@ public class JsonConstants implements Serializable {
     public static final String CHANGE_TYPE_REMOVE = "remove";
 
     /**
+     * Change type for list clear changes.
+     */
+    public static final String CHANGE_TYPE_CLEAR = "clear";
+
+    /**
      * Key holding the feature of a change.
      */
     public static final String CHANGE_FEATURE = "feat";

--- a/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/NodeListAddRemoveTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/NodeListAddRemoveTest.java
@@ -4,13 +4,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
 
 import com.vaadin.flow.internal.change.ListAddChange;
+import com.vaadin.flow.internal.change.ListClearChange;
 import com.vaadin.flow.internal.change.ListRemoveChange;
 import com.vaadin.flow.internal.change.NodeChange;
-import com.vaadin.flow.internal.nodefeature.ElementClassList;
 
 public class NodeListAddRemoveTest
         extends AbstractNodeFeatureTest<ElementClassList> {
@@ -24,12 +25,12 @@ public class NodeListAddRemoveTest
 
     @Test
     public void testClear() {
-        List<String> items = resetToRemoveAfterAddCase();
+        resetToRemoveAfterAddCase();
 
         nodeList.clear();
         List<NodeChange> changes = collectChanges(nodeList);
-        Assert.assertEquals(4, changes.size());
-        verifyRemoved(changes, items, 0, 0, 0, 0);
+        Assert.assertEquals(1, changes.size());
+        verifyCleared(changes);
         Assert.assertEquals(0, nodeList.size());
     }
 
@@ -262,12 +263,21 @@ public class NodeListAddRemoveTest
         }
     }
 
+    private void verifyCleared(List<NodeChange> changes) {
+        Assert.assertEquals(1, changes.size());
+        NodeChange nodeChange = changes.get(0);
+        Assert.assertThat(nodeChange,
+                CoreMatchers.instanceOf(ListClearChange.class));
+        Assert.assertTrue(nodeChange instanceof ListClearChange);
+    }
+
     private void verifyRemoved(List<NodeChange> changes, List<String> items,
             Integer... indexes) {
         Assert.assertTrue(changes.size() > 0);
         for (int i = 0; i < indexes.length; i++) {
             NodeChange nodeChange = changes.get(i);
-            Assert.assertTrue(nodeChange instanceof ListRemoveChange);
+            Assert.assertThat(nodeChange,
+                    CoreMatchers.instanceOf(ListRemoveChange.class));
             ListRemoveChange<?> change = (ListRemoveChange<?>) nodeChange;
             Assert.assertEquals(indexes[i].intValue(), change.getIndex());
             Assert.assertEquals(items.get(i), change.getRemovedItem());
@@ -278,7 +288,8 @@ public class NodeListAddRemoveTest
             Integer... indexes) {
         for (int i = 0; i < indexes.length; i++) {
             NodeChange nodeChange = changes.get(i);
-            Assert.assertTrue(nodeChange instanceof ListAddChange);
+            Assert.assertThat(nodeChange,
+                    CoreMatchers.instanceOf(ListAddChange.class));
             ListAddChange<?> change = (ListAddChange<?>) nodeChange;
             Assert.assertEquals(indexes[i].intValue(), change.getIndex());
             Assert.assertEquals(1, change.getNewItems().size());

--- a/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/NodeListAddRemoveTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/NodeListAddRemoveTest.java
@@ -268,7 +268,6 @@ public class NodeListAddRemoveTest
         NodeChange nodeChange = changes.get(0);
         Assert.assertThat(nodeChange,
                 CoreMatchers.instanceOf(ListClearChange.class));
-        Assert.assertTrue(nodeChange instanceof ListClearChange);
     }
 
     private void verifyRemoved(List<NodeChange> changes, List<String> items,

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/ClearNodeChildrenView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/ClearNodeChildrenView.java
@@ -44,6 +44,12 @@ public class ClearNodeChildrenView extends PolymerTemplate<TemplateModel>
     @Id("containerWithSlottedChildren")
     private Div containerWithSlottedChildren;
 
+    @Id("containerWithContainer")
+    private Div containerWithContainer;
+
+    @Id("nestedContainer")
+    private Div nestedContainer;
+
     @Id("addChildToContainer1")
     private NativeButton addChildToContainer1;
 
@@ -62,6 +68,12 @@ public class ClearNodeChildrenView extends PolymerTemplate<TemplateModel>
     @Id("clearContainer3")
     private NativeButton clearContainer3;
 
+    @Id("addChildToNestedContainer")
+    private NativeButton addChildToNestedContainer;
+
+    @Id("clearContainer4")
+    private NativeButton clearContainer4;
+
     @Id("addChildToSlot")
     private NativeButton addChildToSlot;
 
@@ -79,6 +91,8 @@ public class ClearNodeChildrenView extends PolymerTemplate<TemplateModel>
                 event -> addDivTo(containerWithMixedChildren));
         addChildToContainer3.addClickListener(
                 event -> addDivTo(containerWithClientSideChildren));
+        addChildToNestedContainer
+                .addClickListener(event -> addDivTo(nestedContainer));
         addChildToSlot.addClickListener(event -> addDivTo(this));
         clearContainer1
                 .addClickListener(event -> clear(containerWithElementChildren,
@@ -89,6 +103,8 @@ public class ClearNodeChildrenView extends PolymerTemplate<TemplateModel>
         clearContainer3.addClickListener(
                 event -> clear(containerWithClientSideChildren,
                         "containerWithClientSideChildren"));
+        clearContainer4.addClickListener(event -> clear(containerWithContainer,
+                "containerWithContainer"));
         clear.addClickListener(event -> clear(this, "root"));
     }
 

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/ClearNodeChildrenView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/ClearNodeChildrenView.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.template;
+
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.HtmlImport;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.polymertemplate.Id;
+import com.vaadin.flow.component.polymertemplate.PolymerTemplate;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.templatemodel.TemplateModel;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+@Route(value = "com.vaadin.flow.uitest.ui.template.ClearNodeChildrenView", layout = ViewTestLayout.class)
+@Tag("clear-node-children")
+@HtmlImport("frontend://com/vaadin/flow/uitest/ui/template/ClearNodeChildren.html")
+public class ClearNodeChildrenView extends PolymerTemplate<TemplateModel>
+        implements HasComponents {
+
+    @Id("containerWithElementChildren")
+    private Div containerWithElementChildren;
+
+    @Id("containerWithMixedChildren")
+    private Div containerWithMixedChildren;
+
+    @Id("containerWithClientSideChildren")
+    private Div containerWithClientSideChildren;
+
+    @Id("containerWithSlottedChildren")
+    private Div containerWithSlottedChildren;
+
+    @Id("addChildToContainer1")
+    private NativeButton addChildToContainer1;
+
+    @Id("clearContainer1")
+    private NativeButton clearContainer1;
+
+    @Id("addChildToContainer2")
+    private NativeButton addChildToContainer2;
+
+    @Id("clearContainer2")
+    private NativeButton clearContainer2;
+
+    @Id("addChildToContainer3")
+    private NativeButton addChildToContainer3;
+
+    @Id("clearContainer3")
+    private NativeButton clearContainer3;
+
+    @Id("addChildToSlot")
+    private NativeButton addChildToSlot;
+
+    @Id("clear")
+    private NativeButton clear;
+
+    @Id("message")
+    private Div message;
+
+    public ClearNodeChildrenView() {
+        setId("root");
+        addChildToContainer1.addClickListener(
+                event -> addDivTo(containerWithElementChildren));
+        addChildToContainer2.addClickListener(
+                event -> addDivTo(containerWithMixedChildren));
+        addChildToContainer3.addClickListener(
+                event -> addDivTo(containerWithClientSideChildren));
+        addChildToSlot.addClickListener(event -> addDivTo(this));
+        clearContainer1
+                .addClickListener(event -> clear(containerWithElementChildren,
+                        "containerWithElementChildren"));
+        clearContainer2
+                .addClickListener(event -> clear(containerWithMixedChildren,
+                        "containerWithMixedChildren"));
+        clearContainer3.addClickListener(
+                event -> clear(containerWithClientSideChildren,
+                        "containerWithClientSideChildren"));
+        clear.addClickListener(event -> clear(this, "root"));
+    }
+
+    private void addDivTo(HasComponents container) {
+        Div div = new Div();
+        div.setText(
+                "Server div " + (container.getElement().getChildCount() + 1));
+        div.addAttachListener(evt -> message.setText(
+                message.getText() + "\nDiv '" + div.getText() + "' attached."));
+        div.addDetachListener(evt -> message.setText(
+                message.getText() + "\nDiv '" + div.getText() + "' detached."));
+        container.add(div);
+    }
+
+    private void clear(HasComponents container, String id) {
+        container.removeAll();
+        message.setText(message.getText() + "\nDiv '" + id + "' cleared.");
+    }
+
+}

--- a/flow-tests/test-root-context/src/main/webapp/frontend/com/vaadin/flow/uitest/ui/template/ClearNodeChildren.html
+++ b/flow-tests/test-root-context/src/main/webapp/frontend/com/vaadin/flow/uitest/ui/template/ClearNodeChildren.html
@@ -39,6 +39,9 @@
         </div>
         <div id="containerWithClientSideChildren" class="container">
         </div>
+        <div id="containerWithContainer" class="container">
+            <div id="nestedContainer"></div>
+        </div>
         <div id="containerWithSlottedChildren" class="container">
             <slot></slot>
         </div>
@@ -50,6 +53,8 @@
         <button id="addClientSideChild" on-click="_addClientSideChild">Add client-side child</button>
         <button id="addChildToContainer3">Add child to container 3</button>
         <button id="clearContainer3">Clear container 3</button>
+        <button id="addChildToNestedContainer">Add child to nested container</button>
+        <button id="clearContainer4">Clear container 4</button>
         <button id="addChildToSlot">Add child to slot</button>
         <button id="clear">Clear slot</button>
         <div id="message" style="white-space: pre-wrap;"></div>

--- a/flow-tests/test-root-context/src/main/webapp/frontend/com/vaadin/flow/uitest/ui/template/ClearNodeChildren.html
+++ b/flow-tests/test-root-context/src/main/webapp/frontend/com/vaadin/flow/uitest/ui/template/ClearNodeChildren.html
@@ -1,0 +1,69 @@
+<!--
+  ~ Copyright 2000-2017 Vaadin Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+<!-- Using an absolute URL is a bad practice, but the nesting depth here makes it incovenient traverse up with ../.. -->
+<link rel="import" href="/frontend/bower_components/polymer/polymer-element.html">
+
+<dom-module id="clear-node-children">
+    <template>
+        <style>
+            .container {
+                padding: 10px;
+                border: 1px solid gray;
+                margin-bottom: 10px;
+            }
+        </style>
+        
+        <div id="containerWithElementChildren" class="container">
+            <div>Client div 1</div>
+            <div>Client div 2</div>
+        </div>
+        <div id="containerWithMixedChildren" class="container">
+            Some text 1
+            <div>Client div 1</div>
+            Some text 2
+            <div>Client div 2</div>
+            Some text 3
+        </div>
+        <div id="containerWithClientSideChildren" class="container">
+        </div>
+        <div id="containerWithSlottedChildren" class="container">
+            <slot></slot>
+        </div>
+        
+        <button id="addChildToContainer1">Add child to container 1</button>
+        <button id="clearContainer1">Clear container 1</button>
+        <button id="addChildToContainer2">Add child to container 2</button>
+        <button id="clearContainer2">Clear container 2</button>
+        <button id="addClientSideChild" on-click="_addClientSideChild">Add client-side child</button>
+        <button id="addChildToContainer3">Add child to container 3</button>
+        <button id="clearContainer3">Clear container 3</button>
+        <button id="addChildToSlot">Add child to slot</button>
+        <button id="clear">Clear slot</button>
+        <div id="message" style="white-space: pre-wrap;"></div>
+    </template>
+    <script>
+        class ClearNodeChildren extends Polymer.Element {
+            static get is() { return 'clear-node-children' }
+            
+            _addClientSideChild() {
+                let element = document.createElement("div");
+                element.innerHTML = "Client child";
+                this.$.containerWithClientSideChildren.appendChild(element);
+            }
+        }
+        customElements.define(ClearNodeChildren.is, ClearNodeChildren);
+    </script>
+</dom-module>

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/ClearNodeChildrenIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/ClearNodeChildrenIT.java
@@ -201,6 +201,41 @@ public class ClearNodeChildrenIT extends ChromeBrowserTest {
         Assert.assertEquals(0, divs.size());
     }
 
+    @Test
+    public void addNodeToNestedContainer_clearParentContainer_allNodesAreRemoved() {
+        WebElement container = findInShadowRoot(root, By.id("nestedContainer"))
+                .get(0);
+
+        List<WebElement> divs = container.findElements(By.tagName("div"));
+        Assert.assertEquals(0, divs.size());
+
+        WebElement add = findInShadowRoot(root,
+                By.id("addChildToNestedContainer")).get(0);
+        String oldTtext = message.getText();
+        add.click();
+        waitForMessageToChange(oldTtext);
+        assertMessageEndsWith("Div 'Server div 1' attached.");
+
+        divs = container.findElements(By.tagName("div"));
+        Assert.assertEquals(1, divs.size());
+
+        WebElement clear = findInShadowRoot(root, By.id("clearContainer4"))
+                .get(0);
+        oldTtext = message.getText();
+        clear.click();
+        waitForMessageToChange(oldTtext);
+
+        /*
+         * Note that in this setup, the server-side components are not detached.
+         */
+        assertMessageEndsWith("Div 'containerWithContainer' cleared.");
+
+        container = findInShadowRoot(root, By.id("containerWithContainer"))
+                .get(0);
+        divs = container.findElements(By.tagName("div"));
+        Assert.assertEquals(0, divs.size());
+    }
+
     private void assertMessageEndsWith(String text) {
         Assert.assertThat(message.getText(), CoreMatchers.endsWith(text));
     }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/ClearNodeChildrenIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/ClearNodeChildrenIT.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.template;
+
+import java.util.List;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+/**
+ * Tests for validating the {@code removeAll()} feature, that should clear all
+ * the server nodes and also the client nodes that the server doesn't know
+ * about.
+ * 
+ * @author Vaadin Ltd.
+ */
+public class ClearNodeChildrenIT extends ChromeBrowserTest {
+
+    private WebElement root;
+    private WebElement message;
+
+    @Before
+    public void init() {
+        open();
+        waitForElementPresent(By.id("root"));
+        root = findElement(By.id("root"));
+        message = findInShadowRoot(root, By.id("message")).get(0);
+    }
+
+    @Test
+    public void clearContainerWithClientSideNodes_allNodesAreRemoved() {
+        WebElement container = findInShadowRoot(root,
+                By.id("containerWithElementChildren")).get(0);
+        List<WebElement> divs = container.findElements(By.tagName("div"));
+        Assert.assertEquals(2, divs.size());
+
+        WebElement clear = findInShadowRoot(root, By.id("clearContainer1"))
+                .get(0);
+        String oldTtext = message.getText();
+        clear.click();
+        waitForMessageToChange(oldTtext);
+
+        assertMessageEndsWith("Div 'containerWithElementChildren' cleared.");
+        divs = container.findElements(By.tagName("div"));
+        Assert.assertEquals(0, divs.size());
+    }
+
+    @Test
+    public void clearContainerWithClientAndServerSideNodes_allNodesAreRemoved_serverNodesAreDetached() {
+        WebElement container = findInShadowRoot(root,
+                By.id("containerWithElementChildren")).get(0);
+        List<WebElement> divs = container.findElements(By.tagName("div"));
+        Assert.assertEquals(2, divs.size());
+
+        WebElement add = findInShadowRoot(root, By.id("addChildToContainer1"))
+                .get(0);
+        String oldTtext = message.getText();
+        add.click();
+        waitForMessageToChange(oldTtext);
+        assertMessageEndsWith("Div 'Server div 1' attached.");
+
+        divs = container.findElements(By.tagName("div"));
+        Assert.assertEquals(3, divs.size());
+
+        WebElement clear = findInShadowRoot(root, By.id("clearContainer1"))
+                .get(0);
+        oldTtext = message.getText();
+        clear.click();
+        waitForMessageToChange(oldTtext);
+
+        assertMessageEndsWith(
+                "Div 'Server div 1' detached.\nDiv 'containerWithElementChildren' cleared.");
+        divs = container.findElements(By.tagName("div"));
+        Assert.assertEquals(0, divs.size());
+    }
+
+    @Test
+    public void clearContainerWithTextNodes_allNodesAreRemoved() {
+        WebElement container = findInShadowRoot(root,
+                By.id("containerWithMixedChildren")).get(0);
+
+        Assert.assertThat(container.getText(),
+                CoreMatchers.allOf(CoreMatchers.containsString("Some text 1"),
+                        CoreMatchers.containsString("Some text 2"),
+                        CoreMatchers.containsString("Some text 3")));
+
+        List<WebElement> divs = container.findElements(By.tagName("div"));
+        Assert.assertEquals(2, divs.size());
+
+        WebElement clear = findInShadowRoot(root, By.id("clearContainer2"))
+                .get(0);
+        String oldTtext = message.getText();
+        clear.click();
+        waitForMessageToChange(oldTtext);
+
+        assertMessageEndsWith("Div 'containerWithMixedChildren' cleared.");
+        divs = container.findElements(By.tagName("div"));
+        Assert.assertEquals(0, divs.size());
+        Assert.assertEquals("", container.getText());
+    }
+
+    @Test
+    public void addClientSideChildren_clearContainer_allNodesAreRemoved() {
+        WebElement container = findInShadowRoot(root,
+                By.id("containerWithClientSideChildren")).get(0);
+
+        List<WebElement> divs = container.findElements(By.tagName("div"));
+        Assert.assertEquals(0, divs.size());
+
+        WebElement add = findInShadowRoot(root, By.id("addClientSideChild"))
+                .get(0);
+        add.click();
+        divs = container.findElements(By.tagName("div"));
+        Assert.assertEquals(1, divs.size());
+
+        WebElement clear = findInShadowRoot(root, By.id("clearContainer3"))
+                .get(0);
+        String oldTtext = message.getText();
+        clear.click();
+        waitForMessageToChange(oldTtext);
+
+        assertMessageEndsWith("Div 'containerWithClientSideChildren' cleared.");
+        divs = container.findElements(By.tagName("div"));
+        Assert.assertEquals(0, divs.size());
+    }
+
+    @Test
+    public void addClienAndServertSideChildren_clearContainer_allNodesAreRemoved_serverNodesAreDetached() {
+        WebElement container = findInShadowRoot(root,
+                By.id("containerWithClientSideChildren")).get(0);
+
+        List<WebElement> divs = container.findElements(By.tagName("div"));
+        Assert.assertEquals(0, divs.size());
+
+        WebElement addClientNode = findInShadowRoot(root,
+                By.id("addClientSideChild")).get(0);
+        addClientNode.click();
+        divs = container.findElements(By.tagName("div"));
+        Assert.assertEquals(1, divs.size());
+
+        WebElement addServerNode = findInShadowRoot(root,
+                By.id("addChildToContainer3")).get(0);
+        String oldTtext = message.getText();
+        addServerNode.click();
+        waitForMessageToChange(oldTtext);
+        assertMessageEndsWith("Div 'Server div 1' attached.");
+
+        divs = container.findElements(By.tagName("div"));
+        Assert.assertEquals(2, divs.size());
+
+        WebElement clear = findInShadowRoot(root, By.id("clearContainer3"))
+                .get(0);
+        oldTtext = message.getText();
+        clear.click();
+        waitForMessageToChange(oldTtext);
+
+        assertMessageEndsWith(
+                "Div 'Server div 1' detached.\nDiv 'containerWithClientSideChildren' cleared.");
+        divs = container.findElements(By.tagName("div"));
+        Assert.assertEquals(0, divs.size());
+    }
+
+    @Test
+    public void addNodeToSlot_clearContainer_allNodesAreRemoved_serverNodesAreDetached() {
+        List<WebElement> divs = root.findElements(By.tagName("div"));
+        Assert.assertEquals(0, divs.size());
+
+        WebElement add = findInShadowRoot(root, By.id("addChildToSlot")).get(0);
+        String oldTtext = message.getText();
+        add.click();
+        waitForMessageToChange(oldTtext);
+        assertMessageEndsWith("Div 'Server div 1' attached.");
+
+        WebElement clear = findInShadowRoot(root, By.id("clear")).get(0);
+        oldTtext = message.getText();
+        clear.click();
+        waitForMessageToChange(oldTtext);
+
+        assertMessageEndsWith(
+                "Div 'Server div 1' detached.\nDiv 'root' cleared.");
+        divs = root.findElements(By.tagName("div"));
+        Assert.assertEquals(0, divs.size());
+    }
+
+    private void assertMessageEndsWith(String text) {
+        Assert.assertThat(message.getText(), CoreMatchers.endsWith(text));
+    }
+
+    private void waitForMessageToChange(String oldText) {
+        waitUntilNot(driver -> message.getText().equals(oldText));
+    }
+
+}


### PR DESCRIPTION
Now client-side only nodes are removed when a clear command is issued on the NodeList.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3737)
<!-- Reviewable:end -->
