### PR TITLE
Store mock references to UI and VaadinSession instances.

### DIFF
--- a/flow-spring-addon/src/test/java/com/vaadin/flow/spring/scopes/AbstractScopeTest.java
+++ b/flow-spring-addon/src/test/java/com/vaadin/flow/spring/scopes/AbstractScopeTest.java
@@ -32,9 +32,10 @@ import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.VaadinSessionState;
 import com.vaadin.flow.spring.SpringVaadinSession;
-import com.vaadin.flow.spring.scopes.AbstractScope;
 
 public abstract class AbstractScopeTest {
+
+    private VaadinSession session;
 
     public static class TestSession extends SpringVaadinSession {
 
@@ -130,6 +131,9 @@ public abstract class AbstractScopeTest {
 
         VaadinSession.setCurrent(session);
         when(session.hasLock()).thenReturn(true);
+
+        // keep a reference to the session so that it cannot be GCed.
+        this.session = session;
 
         return session;
     }

--- a/flow-spring-addon/src/test/java/com/vaadin/flow/spring/scopes/AbstractScopeTest.java
+++ b/flow-spring-addon/src/test/java/com/vaadin/flow/spring/scopes/AbstractScopeTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -43,6 +44,11 @@ public abstract class AbstractScopeTest {
             super(Mockito.mock(VaadinService.class));
         }
 
+    }
+
+    @After
+    public void clearSession() {
+        session = null;
     }
 
     @Test(expected = IllegalStateException.class)

--- a/flow-spring-addon/src/test/java/com/vaadin/flow/spring/scopes/VaadinUIScopeTest.java
+++ b/flow-spring-addon/src/test/java/com/vaadin/flow/spring/scopes/VaadinUIScopeTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -49,6 +50,12 @@ public class VaadinUIScopeTest extends AbstractScopeTest {
     public void tearDown() {
         VaadinSession.setCurrent(null);
         UI.setCurrent(null);
+        ui = null;
+    }
+
+    @After
+    public void clearUI() {
+        ui = null;
     }
 
     @Test

--- a/flow-spring-addon/src/test/java/com/vaadin/flow/spring/scopes/VaadinUIScopeTest.java
+++ b/flow-spring-addon/src/test/java/com/vaadin/flow/spring/scopes/VaadinUIScopeTest.java
@@ -43,6 +43,8 @@ import net.jcip.annotations.NotThreadSafe;
 @NotThreadSafe
 public class VaadinUIScopeTest extends AbstractScopeTest {
 
+    private UI ui;
+
     @Before
     public void tearDown() {
         VaadinSession.setCurrent(null);
@@ -194,6 +196,9 @@ public class VaadinUIScopeTest extends AbstractScopeTest {
         ui.doInit(null, 1);
 
         UI.setCurrent(ui);
+
+        // prevent UI from being GCed.
+        this.ui = ui;
         return ui;
     }
 }


### PR DESCRIPTION
Using CurrentInstance.setCurrent() assumes there is a strong reference
to the stored instance. Otherwise it may be GCed since CurrentInstance
keeps only WeakReferences.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3739)
<!-- Reviewable:end -->
