### PR TITLE
Add support for @Id without value

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/Id.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/Id.java
@@ -31,9 +31,10 @@ import java.lang.annotation.Target;
 @Documented
 public @interface Id {
     /**
-     * The id of the element to map to.
+     * The id of the element to map to. When empty, the name of the field is
+     * used instead.
      *
      * @return the id of the element to map to
      */
-    String value();
+    String value() default "";
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/TemplateDataAnalyzer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/TemplateDataAnalyzer.java
@@ -212,13 +212,17 @@ class TemplateDataAnalyzer {
             return;
         }
         String id = idAnnotation.get().value();
+        boolean emptyValue = id.isEmpty();
+        if (emptyValue) {
+            id = field.getName();
+        }
         if (notInjectableElementIds.contains(id)) {
             throw new IllegalStateException(String.format(
-                    "Class '%s' whose template URI is '%s' contains field '%s' annotated with @Id('%s'). "
+                    "Class '%s' whose template URI is '%s' contains field '%s' annotated with @Id%s. "
                             + "Corresponding element was found in a sub template, "
                             + "for which injection is not supported.",
                     templateClass.getName(), htmlImportUri, field.getName(),
-                    id));
+                    emptyValue ? "" : "(\"" + id + "\")"));
         }
 
         if (!addTagName(id, field).isPresent()) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/TemplateDataAnalyzer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/TemplateDataAnalyzer.java
@@ -222,7 +222,9 @@ class TemplateDataAnalyzer {
                             + "Corresponding element was found in a sub template, "
                             + "for which injection is not supported.",
                     templateClass.getName(), htmlImportUri, field.getName(),
-                    emptyValue ? "" : "(\"" + id + "\")"));
+                    emptyValue
+                            ? " without value (so the name of the field should match the id of an element in the template)"
+                            : "(\"" + id + "\")"));
         }
 
         if (!addTagName(id, field).isPresent()) {


### PR DESCRIPTION
When `@Id` is used without value, the name of the field will be used to map the element on the template to the field on the Java class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3758)
<!-- Reviewable:end -->
