### PR TITLE
Change the order of how nodes are attached to the client

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
@@ -986,8 +986,9 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
 
         Node beforeRef;
         if (index == 0) {
-            // Insert at the first position
-            beforeRef = DomApi.wrap(context.htmlNode).getFirstChild();
+            // Insert at the first position after the client-side-only nodes
+            beforeRef = getFirstNodeMappedAsStateNode(nodeChildren,
+                    context.htmlNode);
         } else if (index <= nodeChildren.length() && index > 0) {
             StateNode previousSibling = getPreviousSibling(index, context);
             // Insert before the next sibling of the current node
@@ -1019,6 +1020,25 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
 
             beforeRef = DomApi.wrap(childNode).getNextSibling();
         }
+    }
+
+    private static Node getFirstNodeMappedAsStateNode(
+            NodeList mappedNodeChildren, Node htmlNode) {
+
+        JsArray<Node> clientList = DomApi.wrap(htmlNode).getChildNodes();
+        for (int c = 0; c < clientList.length(); c++) {
+            Node clientNode = clientList.get(c);
+            for (int i = 0; i < mappedNodeChildren.length(); i++) {
+                Object object = mappedNodeChildren.get(i);
+                if (object instanceof StateNode) {
+                    StateNode stateNode = (StateNode) object;
+                    if (clientNode.equals(stateNode.getDomNode())) {
+                        return clientNode;
+                    }
+                }
+            }
+        }
+        return null;
     }
 
     private StateNode getPreviousSibling(int index, BindingContext context) {

--- a/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtBasicElementBinderTest.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtBasicElementBinderTest.java
@@ -294,28 +294,35 @@ public class GwtBasicElementBinderTest extends GwtPropertyElementBinderTest {
 
         StateNode childNode = createChildNode("first");
 
-        // One client side element, insert at the very beginning
+        // With one client side element, insert at 0 will translate to index 1
         children.add(0, childNode);
 
+        // <div/><span>first</span>
         Reactive.flush();
 
         assertEquals(2, element.getChildElementCount());
 
         Element childElement = (Element) element.getChildren().at(0);
+        assertEquals("DIV", childElement.getTagName());
 
+        childElement = (Element) element.getChildren().at(1);
         assertEquals("SPAN", childElement.getTagName());
         assertEquals("first", childElement.getId());
 
         childNode = createChildNode("second", "a");
-        // Insert before the bound node and pure client side node at the very
-        // beginning
+        // Insert at the first position (which will be translated to after the
+        // client-side nodes)
         children.add(0, childNode);
+
+        // <div/><a>second</a><span>first</span>
         Reactive.flush();
 
         assertEquals(3, element.getChildElementCount());
 
         childElement = (Element) element.getChildren().at(0);
+        assertEquals("DIV", childElement.getTagName());
 
+        childElement = (Element) element.getChildren().at(1);
         assertEquals("A", childElement.getTagName());
         assertEquals("second", childElement.getId());
 
@@ -324,25 +331,31 @@ public class GwtBasicElementBinderTest extends GwtPropertyElementBinderTest {
                 (Element) element.getChildren().at(1));
 
         childNode = createChildNode("third", "h1");
-        // Insert at the first position.
+        // Insert at the second position.
         children.add(1, childNode);
+
+        // <div/><div/><a>second</a><h1>third</h1><span>first</span>
         Reactive.flush();
 
         assertEquals(element.getChildElementCount(), 5);
 
         childElement = (Element) element.getChildren().at(1);
+        assertEquals("DIV", childElement.getTagName());
 
+        childElement = (Element) element.getChildren().at(3);
         assertEquals("H1", childElement.getTagName());
         assertEquals("third", childElement.getId());
 
         childNode = createChildNode("fourth", "br");
         // Insert after the last bound node
         children.add(3, childNode);
+
+        // <div/><div/><a>second</a><h1>third</h1><span>first</span><br>fourth</br>
         Reactive.flush();
 
         assertEquals(6, element.getChildElementCount());
 
-        childElement = (Element) element.getChildren().at(4);
+        childElement = (Element) element.getChildren().at(5);
 
         // Element should be before the client side element and after the bound
         // node
@@ -379,12 +392,15 @@ public class GwtBasicElementBinderTest extends GwtPropertyElementBinderTest {
 
         // check that order is the correct one
         Element childElement = (Element) children.at(0);
-        assertEquals("third", childElement.getId());
+        assertEquals("DIV", childElement.getTagName());
 
         childElement = (Element) children.at(1);
-        assertEquals("first", childElement.getId());
+        assertEquals("third", childElement.getId());
 
         childElement = (Element) children.at(2);
+        assertEquals("first", childElement.getId());
+
+        childElement = (Element) children.at(3);
         assertEquals("second", childElement.getId());
     }
 
@@ -686,15 +702,15 @@ public class GwtBasicElementBinderTest extends GwtPropertyElementBinderTest {
     }
 
     private native void polyfillStyleSetProperty(Element element)/*-{
-         // This polyfills just enough to make the tests pass and nothing else
-         element.style.__proto__.setProperty = function(key,value) {
-             var newValue = element.getAttribute("style");
-             if (!newValue) newValue = "";
-             else if (!newValue.endsWith(";")) newValue +=";"
-
-             element.setAttribute("style", newValue + key+": "+value+";");
-         };
-         }-*/;
+                                                                 // This polyfills just enough to make the tests pass and nothing else
+                                                                 element.style.__proto__.setProperty = function(key,value) {
+                                                                 var newValue = element.getAttribute("style");
+                                                                 if (!newValue) newValue = "";
+                                                                 else if (!newValue.endsWith(";")) newValue +=";"
+                                                                 
+                                                                 element.setAttribute("style", newValue + key+": "+value+";");
+                                                                 };
+                                                                 }-*/;
 
     public void testAddStylesAfterUnbind() {
         polyfillStyleSetProperty(element);

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/ChildOrderView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/ChildOrderView.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.template;
+
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.HtmlImport;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.polymertemplate.Id;
+import com.vaadin.flow.component.polymertemplate.PolymerTemplate;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.templatemodel.TemplateModel;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+@Route(value = "com.vaadin.flow.uitest.ui.template.ChildOrderView", layout = ViewTestLayout.class)
+@Tag("child-order-template")
+@HtmlImport("frontend://com/vaadin/flow/uitest/ui/template/ChildOrderTemplate.html")
+public class ChildOrderView extends PolymerTemplate<TemplateModel> {
+
+    @Id
+    private Div containerWithElement;
+
+    @Id
+    private Div containerWithText;
+
+    @Id
+    private NativeButton addChildToContainer1;
+
+    @Id
+    private NativeButton prependChildToContainer1;
+
+    @Id
+    private NativeButton removeChildFromContainer1;
+
+    @Id
+    private NativeButton addChildToContainer2;
+
+    @Id
+    private NativeButton prependChildToContainer2;
+
+    @Id
+    private NativeButton removeChildFromContainer2;
+
+    public ChildOrderView() {
+        setId("root");
+        addChildToContainer1.addClickListener(event -> {
+            Div div = new Div();
+            div.setText("Server child "
+                    + (containerWithElement.getElement().getChildCount() + 1));
+            containerWithElement.add(div);
+        });
+
+        prependChildToContainer1.addClickListener(event -> {
+            Div div = new Div();
+            div.setText("Server child "
+                    + (containerWithElement.getElement().getChildCount() + 1));
+            containerWithElement.getElement().insertChild(0, div.getElement());
+        });
+
+        removeChildFromContainer1.addClickListener(event -> {
+            if (containerWithElement.getElement().getChildCount() > 0) {
+                containerWithElement.getElement().removeChild(
+                        containerWithElement.getElement().getChildCount() - 1);
+            }
+        });
+
+        addChildToContainer2.addClickListener(event -> {
+            Element text = Element.createText("\nServer text "
+                    + (containerWithText.getElement().getChildCount() + 1));
+            containerWithText.getElement().appendChild(text);
+        });
+
+        prependChildToContainer2.addClickListener(event -> {
+            Element text = Element.createText("\nServer text "
+                    + (containerWithText.getElement().getChildCount() + 1));
+            containerWithText.getElement().insertChild(0, text);
+        });
+
+        removeChildFromContainer2.addClickListener(event -> {
+            if (containerWithText.getElement().getChildCount() > 0) {
+                containerWithText.getElement().removeChild(
+                        containerWithText.getElement().getChildCount() - 1);
+            }
+        });
+    }
+}

--- a/flow-tests/test-root-context/src/main/webapp/frontend/com/vaadin/flow/uitest/ui/template/ChildOrderTemplate.html
+++ b/flow-tests/test-root-context/src/main/webapp/frontend/com/vaadin/flow/uitest/ui/template/ChildOrderTemplate.html
@@ -1,0 +1,58 @@
+<!--
+  ~ Copyright 2000-2017 Vaadin Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+<!-- Using an absolute URL is a bad practice, but the nesting depth here makes it incovenient traverse up with ../.. -->
+<link rel="import" href="/frontend/bower_components/polymer/polymer-element.html">
+
+<dom-module id="child-order-template">
+    <template>
+        <div id="containerWithElement">
+            <div>Client child</div>
+        </div>
+        <div>
+            <button id="addClientSideChildToContainer1" on-click="_addClientSideChildToContainer1">Add client-side child to container 1</button>
+            <button id="addChildToContainer1">Add child to container 1</button>
+            <button id="prependChildToContainer1">Prepend child to container 1</button>
+            <button id="removeChildFromContainer1">Remove last child of container 1</button>
+        </div>
+        
+        <div id="containerWithText">
+            Client text
+        </div>
+        <div>
+            <button id="addClientSideChildToContainer2" on-click="_addClientSideChildToContainer2">Add client-side child to container 2</button>
+            <button id="addChildToContainer2">Add child to container 2</button>
+            <button id="prependChildToContainer2">Prepend child to container 2</button>
+            <button id="removeChildFromContainer2">Remove last child of container 2</button>
+        </div>
+    </template>
+    <script>
+        class ChildOrderTemplate extends Polymer.Element {
+            static get is() { return 'child-order-template' }
+           
+            _addClientSideChildToContainer1() {
+                let element = document.createElement("div");
+                element.innerHTML = "Client child";
+                this.$.containerWithElement.appendChild(element);
+            }
+            
+            _addClientSideChildToContainer2() {
+                let text = document.createTextNode("\nClient text");
+                this.$.containerWithText.appendChild(text);
+            }
+        }
+        customElements.define(ChildOrderTemplate.is, ChildOrderTemplate);
+    </script>
+</dom-module>

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ExceptionStacktraceIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ExceptionStacktraceIT.java
@@ -29,7 +29,9 @@ public class ExceptionStacktraceIT extends ChromeBrowserTest {
     public void loggerAbsenceWarningAndStacktrace() {
         open();
 
-        WebElement main = findElement(By.cssSelector("body > div"));
+        WebElement main = findElements(By.cssSelector("body > div")).stream()
+                .filter(element -> element.getAttribute("class").isEmpty())
+                .findFirst().get();
 
         Assert.assertFalse(
                 "There should be no warning about SLF4J absence because the test project should have slf4j bindings",

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/ChildOrderIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/ChildOrderIT.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.template;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+/**
+ * Tests to validate the ordering of server-side nodes when added alongside
+ * client-side nodes.
+ * 
+ * @author Vaadin Ltd.
+ */
+public class ChildOrderIT extends ChromeBrowserTest {
+
+    private WebElement root;
+
+    @Before
+    public void init() {
+        open();
+        waitForElementPresent(By.id("root"));
+        root = findElement(By.id("root"));
+    }
+
+    @Test
+    public void appendElementsFromServer_elementsAreAddedAfterExistingOnes() {
+        WebElement container = findInShadowRoot(root,
+                By.id("containerWithElement")).get(0);
+
+        assertNodeOrder(container, "Client child");
+
+        clickAndWaitForContainerToChange(container, "addChildToContainer1");
+        assertNodeOrder(container, "Client child", "Server child 1");
+
+        clickAndWaitForContainerToChange(container, "addChildToContainer1");
+        assertNodeOrder(container, "Client child", "Server child 1",
+                "Server child 2");
+
+        clickAndWaitForContainerToChange(container,
+                "addClientSideChildToContainer1");
+        assertNodeOrder(container, "Client child", "Server child 1",
+                "Server child 2", "Client child");
+
+        /*
+         * Client side nodes added after the server side ones are not considered
+         * in the counting, so they are left behind
+         */
+        clickAndWaitForContainerToChange(container, "addChildToContainer1");
+        assertNodeOrder(container, "Client child", "Server child 1",
+                "Server child 2", "Server child 3", "Client child");
+
+        clickAndWaitForContainerToChange(container,
+                "removeChildFromContainer1");
+        assertNodeOrder(container, "Client child", "Server child 1",
+                "Server child 2", "Client child");
+
+        clickAndWaitForContainerToChange(container,
+                "removeChildFromContainer1");
+        assertNodeOrder(container, "Client child", "Server child 1",
+                "Client child");
+    }
+
+    @Test
+    public void prependElementsFromServer_elementsAreAddedBeforeExistingOnes() {
+        WebElement container = findInShadowRoot(root,
+                By.id("containerWithElement")).get(0);
+
+        assertNodeOrder(container, "Client child");
+
+        clickAndWaitForContainerToChange(container, "prependChildToContainer1");
+        assertNodeOrder(container, "Client child", "Server child 1");
+
+        clickAndWaitForContainerToChange(container, "prependChildToContainer1");
+        assertNodeOrder(container, "Client child", "Server child 2",
+                "Server child 1");
+
+        clickAndWaitForContainerToChange(container,
+                "addClientSideChildToContainer1");
+        assertNodeOrder(container, "Client child", "Server child 2",
+                "Server child 1", "Client child");
+
+        clickAndWaitForContainerToChange(container, "prependChildToContainer1");
+        assertNodeOrder(container, "Client child", "Server child 3",
+                "Server child 2", "Server child 1", "Client child");
+
+        clickAndWaitForContainerToChange(container,
+                "removeChildFromContainer1");
+        assertNodeOrder(container, "Client child", "Server child 3",
+                "Server child 2", "Client child");
+
+        clickAndWaitForContainerToChange(container,
+                "removeChildFromContainer1");
+        assertNodeOrder(container, "Client child", "Server child 3",
+                "Client child");
+    }
+
+    @Test
+    public void appendTextsFromServer_textsAreAddedAfterExistingOnes() {
+        WebElement container = findInShadowRoot(root,
+                By.id("containerWithText")).get(0);
+
+        assertNodeOrder(container, "Client text");
+
+        clickAndWaitForContainerToChange(container, "addChildToContainer2");
+        assertNodeOrder(container, "Client text", "Server text 1");
+
+        clickAndWaitForContainerToChange(container, "addChildToContainer2");
+        assertNodeOrder(container, "Client text", "Server text 1",
+                "Server text 2");
+
+        clickAndWaitForContainerToChange(container,
+                "addClientSideChildToContainer2");
+        assertNodeOrder(container, "Client text", "Server text 1",
+                "Server text 2", "Client text");
+
+        /*
+         * Client side nodes added after the server side ones are not considered
+         * in the counting, so they are left behind
+         */
+        clickAndWaitForContainerToChange(container, "addChildToContainer2");
+        assertNodeOrder(container, "Client text", "Server text 1",
+                "Server text 2", "Server text 3", "Client text");
+
+        clickAndWaitForContainerToChange(container,
+                "removeChildFromContainer2");
+        assertNodeOrder(container, "Client text", "Server text 1",
+                "Server text 2", "Client text");
+
+        clickAndWaitForContainerToChange(container,
+                "removeChildFromContainer2");
+        assertNodeOrder(container, "Client text", "Server text 1",
+                "Client text");
+    }
+
+    @Test
+    public void prependTextsFromServer_textsAreAddedBeforeExistingOnes() {
+        WebElement container = findInShadowRoot(root,
+                By.id("containerWithText")).get(0);
+
+        assertNodeOrder(container, "Client text");
+
+        clickAndWaitForContainerToChange(container, "prependChildToContainer2");
+        assertNodeOrder(container, "Client text", "Server text 1");
+
+        clickAndWaitForContainerToChange(container, "prependChildToContainer2");
+        assertNodeOrder(container, "Client text", "Server text 2",
+                "Server text 1");
+
+        clickAndWaitForContainerToChange(container,
+                "addClientSideChildToContainer2");
+        assertNodeOrder(container, "Client text", "Server text 2",
+                "Server text 1", "Client text");
+
+        clickAndWaitForContainerToChange(container, "prependChildToContainer2");
+        assertNodeOrder(container, "Client text", "Server text 3",
+                "Server text 2", "Server text 1", "Client text");
+
+        clickAndWaitForContainerToChange(container,
+                "removeChildFromContainer2");
+        assertNodeOrder(container, "Client text", "Server text 3",
+                "Server text 2", "Client text");
+
+        clickAndWaitForContainerToChange(container,
+                "removeChildFromContainer2");
+        assertNodeOrder(container, "Client text", "Server text 3",
+                "Client text");
+    }
+
+    private void clickAndWaitForContainerToChange(WebElement container,
+            String buttonToclick) {
+        String innertText = container.getAttribute("innerText");
+        WebElement button = findInShadowRoot(root, By.id(buttonToclick)).get(0);
+        button.click();
+        waitUntilNot(driver -> container.getAttribute("innerText")
+                .equals(innertText));
+    }
+
+    private void assertNodeOrder(WebElement container, String... nodes) {
+        String texts = container.getText();
+        texts = texts.replace("\n", " ");
+        String expected = Stream.of(nodes).collect(Collectors.joining(" "));
+        Assert.assertEquals(expected, texts);
+    }
+
+}


### PR DESCRIPTION
Now the index 0 considers the first server-side mapped node after all the client-side-only nodes.

This basically means that from now on all server-side nodes will be added after the preexisting client-side nodes, and not before as it previously did.