### PR TITLE
Lumo class is now loaded by default when no Theme is found

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/common/ThemedURLTranslator.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/common/ThemedURLTranslator.java
@@ -71,7 +71,7 @@ public class ThemedURLTranslator extends ClassPathIntrospector {
      * {@code otherIntrospector} to use its reflections tools.
      *
      * @param fileFactory
-     *            file factory to produce a file on the fielsystem by the given
+     *            file factory to produce a file on the filesystem by the given
      *            URL
      * @param otherIntrospector
      *            another introspector whose reflection tools will be reused to
@@ -173,7 +173,18 @@ public class ThemedURLTranslator extends ClassPathIntrospector {
         }
         return themedComponents.size() == 1
                 ? themedComponents.keySet().iterator().next()
-                : null;
+                : loadLumoThemeClassIfAvailable();
+    }
+
+    private Class<? extends AbstractTheme> loadLumoThemeClassIfAvailable() {
+        try {
+            return loadClassInProjectClassLoader(
+                    "com.vaadin.flow.theme.lumo.Lumo");
+        } catch (IllegalStateException e) {
+            LOGGER.trace("Lumo class was not found in the project classpath",
+                    e);
+        }
+        return null;
     }
 
     @SuppressWarnings("unchecked")

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -677,7 +677,7 @@ public class UI extends Component
      * @return the associated AbstractTheme, or empty if none is defined and the
      *         Lumo class is not in the classpath, or if the NoTheme annotation
      *         is being used.
-     * @see RouteRegistry#getThemeFor(Class)
+     * @see RouteRegistry#getThemeFor(Class, String)
      */
     public Optional<Class<? extends AbstractTheme>> getThemeFor(
             Class<?> navigationTarget, String path) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -671,25 +671,28 @@ public class UI extends Component
      * 
      * @param navigationTarget
      *            the navigation target class
+     * @param path
+     *            the resolved route path so we can determine what the rendered
+     *            target is for
      * @return the associated AbstractTheme, or empty if none is defined and the
      *         Lumo class is not in the classpath, or if the NoTheme annotation
      *         is being used.
      * @see RouteRegistry#getThemeFor(Class)
      */
     public Optional<Class<? extends AbstractTheme>> getThemeFor(
-            Class<?> navigationTarget) {
+            Class<?> navigationTarget, String path) {
+
+        RouteRegistry registry = null;
         Optional<Router> router = getRouter();
         if (router.isPresent()) {
-            return router.get().getRegistry().getThemeFor(navigationTarget);
-        }
-
-        if (getSession().getService() instanceof VaadinServletService) {
-            RouteRegistry registry = RouteRegistry.getInstance(
+            registry = router.get().getRegistry();
+        } else if (getSession().getService() instanceof VaadinServletService) {
+            registry = RouteRegistry.getInstance(
                     ((VaadinServletService) getSession().getService())
                             .getServlet().getServletContext());
-            if (registry != null) {
-                return registry.getThemeFor(navigationTarget);
-            }
+        }
+        if (registry != null) {
+            return registry.getThemeFor(navigationTarget, path);
         }
         return Optional.empty();
     }

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -671,16 +671,13 @@ public class UI extends Component
      * 
      * @param navigationTarget
      *            the navigation target class
-     * @param path
-     *            the resolved route path so we can determine what the rendered
-     *            target is for
      * @return the associated AbstractTheme, or empty if none is defined and the
      *         Lumo class is not in the classpath, or if the NoTheme annotation
      *         is being used.
      * @see RouteRegistry#getThemeFor(Class)
      */
     public Optional<Class<? extends AbstractTheme>> getThemeFor(
-            Class<?> navigationTarget, String path) {
+            Class<?> navigationTarget) {
 
         RouteRegistry registry = null;
         Optional<Router> router = getRouter();
@@ -692,7 +689,7 @@ public class UI extends Component
                             .getServlet().getServletContext());
         }
         if (registry != null) {
-            return registry.getThemeFor(navigationTarget, path);
+            return registry.getThemeFor(navigationTarget);
         }
         return Optional.empty();
     }

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -671,13 +671,16 @@ public class UI extends Component
      * 
      * @param navigationTarget
      *            the navigation target class
+     * @param path
+     *            the resolved route path so we can determine what the rendered
+     *            target is for
      * @return the associated AbstractTheme, or empty if none is defined and the
      *         Lumo class is not in the classpath, or if the NoTheme annotation
      *         is being used.
      * @see RouteRegistry#getThemeFor(Class)
      */
     public Optional<Class<? extends AbstractTheme>> getThemeFor(
-            Class<?> navigationTarget) {
+            Class<?> navigationTarget, String path) {
 
         RouteRegistry registry = null;
         Optional<Router> router = getRouter();
@@ -689,7 +692,7 @@ public class UI extends Component
                             .getServlet().getServletContext());
         }
         if (registry != null) {
-            return registry.getThemeFor(navigationTarget);
+            return registry.getThemeFor(navigationTarget, path);
         }
         return Optional.empty();
     }

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -670,20 +670,17 @@ public class UIInternals implements Serializable {
      * @param viewLocation
      *            the location of the route target relative to the servlet
      *            serving the UI, not <code>null</code>
-     * @param path
-     *            the resolved route path so we can determine what the rendered
-     *            target is for
      * @param target
      *            the component to show, not <code>null</code>
      * @param layouts
      *            the parent layouts
      */
-    public void showRouteTarget(Location viewLocation, String path,
-            Component target, List<RouterLayout> layouts) {
+    public void showRouteTarget(Location viewLocation, Component target,
+            List<RouterLayout> layouts) {
         assert target != null;
         assert viewLocation != null;
 
-        updateTheme(target, path);
+        updateTheme(target);
 
         this.viewLocation = viewLocation;
 
@@ -752,9 +749,9 @@ public class UIInternals implements Serializable {
         }
     }
 
-    private void updateTheme(Component target, String path) {
+    private void updateTheme(Component target) {
         Optional<Class<? extends AbstractTheme>> themeClass = ui
-                .getThemeFor(target.getClass(), path);
+                .getThemeFor(target.getClass());
 
         if (themeClass.isPresent()) {
             if (theme == null || !theme.getClass().equals(themeClass.get())) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -73,7 +73,6 @@ import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.shared.communication.PushMode;
 import com.vaadin.flow.theme.AbstractTheme;
 import com.vaadin.flow.theme.NoTheme;
-import com.vaadin.flow.theme.Theme;
 
 /**
  * Holds UI-specific methods and data which are intended for internal use by the
@@ -757,19 +756,15 @@ public class UIInternals implements Serializable {
     private void updateTheme(Component target, String path) {
         Class<? extends RouterLayout> topParentLayout = RouterUtil
                 .getTopParentLayout(target.getClass(), path);
-        Optional<Theme> themeAnnotation;
+        Optional<Class<? extends AbstractTheme>> themeClass;
         if (topParentLayout != null) {
-            themeAnnotation = AnnotationReader.getAnnotationFor(topParentLayout,
-                    Theme.class);
+            themeClass = ui.getThemeFor(topParentLayout);
         } else {
-            themeAnnotation = AnnotationReader
-                    .getAnnotationFor(target.getClass(), Theme.class);
+            themeClass = ui.getThemeFor(target.getClass());
         }
-        if (themeAnnotation.isPresent()) {
-            if (theme == null || !theme.getClass()
-                    .equals(themeAnnotation.get().value())) {
-                theme = ReflectTools
-                        .createInstance(themeAnnotation.get().value());
+        if (themeClass.isPresent()) {
+            if (theme == null || !theme.getClass().equals(themeClass.get())) {
+                theme = ReflectTools.createInstance(themeClass.get());
             }
         } else {
             theme = null;
@@ -777,7 +772,7 @@ public class UIInternals implements Serializable {
                     .getAnnotationFor(target.getClass(), NoTheme.class)
                     .isPresent()) {
                 getLogger().warn(
-                        "No @Theme defined for {}. See 'trace' level logs for exact components missing theming.",
+                        "No @Theme defined for {}. See 'trace' level logs for exactcomponents missing theming.",
                         target.getClass().getName());
             }
         }

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -61,7 +61,6 @@ import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.router.internal.AfterNavigationHandler;
 import com.vaadin.flow.router.internal.BeforeEnterHandler;
 import com.vaadin.flow.router.internal.BeforeLeaveHandler;
-import com.vaadin.flow.router.internal.RouterUtil;
 import com.vaadin.flow.router.legacy.HasChildView;
 import com.vaadin.flow.router.legacy.View;
 import com.vaadin.flow.server.VaadinRequest;
@@ -754,14 +753,9 @@ public class UIInternals implements Serializable {
     }
 
     private void updateTheme(Component target, String path) {
-        Class<? extends RouterLayout> topParentLayout = RouterUtil
-                .getTopParentLayout(target.getClass(), path);
-        Optional<Class<? extends AbstractTheme>> themeClass;
-        if (topParentLayout != null) {
-            themeClass = ui.getThemeFor(topParentLayout);
-        } else {
-            themeClass = ui.getThemeFor(target.getClass());
-        }
+        Optional<Class<? extends AbstractTheme>> themeClass = ui
+                .getThemeFor(target.getClass(), path);
+
         if (themeClass.isPresent()) {
             if (theme == null || !theme.getClass().equals(themeClass.get())) {
                 theme = ReflectTools.createInstance(themeClass.get());

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -672,15 +672,18 @@ public class UIInternals implements Serializable {
      *            serving the UI, not <code>null</code>
      * @param target
      *            the component to show, not <code>null</code>
+     * @param path
+     *            the resolved route path so we can determine what the rendered
+     *            target is for
      * @param layouts
      *            the parent layouts
      */
-    public void showRouteTarget(Location viewLocation, Component target,
-            List<RouterLayout> layouts) {
+    public void showRouteTarget(Location viewLocation, String path,
+            Component target, List<RouterLayout> layouts) {
         assert target != null;
         assert viewLocation != null;
 
-        updateTheme(target);
+        updateTheme(target, path);
 
         this.viewLocation = viewLocation;
 
@@ -749,9 +752,9 @@ public class UIInternals implements Serializable {
         }
     }
 
-    private void updateTheme(Component target) {
+    private void updateTheme(Component target, String path) {
         Optional<Class<? extends AbstractTheme>> themeClass = ui
-                .getThemeFor(target.getClass());
+                .getThemeFor(target.getClass(), path);
 
         if (themeClass.isPresent()) {
             if (theme == null || !theme.getClass().equals(themeClass.get())) {

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -15,13 +15,13 @@
  */
 package com.vaadin.flow.router.internal;
 
+import javax.servlet.http.HttpServletResponse;
+
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
-
-import javax.servlet.http.HttpServletResponse;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
@@ -200,8 +200,7 @@ public abstract class AbstractNavigationStateRenderer
         }
 
         ui.getInternals().showRouteTarget(event.getLocation(),
-                navigationState.getResolvedPath(), componentInstance,
-                routerLayouts);
+                componentInstance, routerLayouts);
 
         RouterUtil.updatePageTitle(event, componentInstance);
 

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -15,13 +15,13 @@
  */
 package com.vaadin.flow.router.internal;
 
-import javax.servlet.http.HttpServletResponse;
-
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
+
+import javax.servlet.http.HttpServletResponse;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
@@ -200,7 +200,8 @@ public abstract class AbstractNavigationStateRenderer
         }
 
         ui.getInternals().showRouteTarget(event.getLocation(),
-                componentInstance, routerLayouts);
+                navigationState.getResolvedPath(), componentInstance,
+                routerLayouts);
 
         RouterUtil.updatePageTitle(event, componentInstance);
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -317,7 +317,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          * 
          * @return the theme, or empty if none is found, or
          *         pageConfigurationHolder is <code>null</code>
-         * @see UI#getThemeFor(Class, String)
+         * @see UI#getThemeFor(Class)
          */
         protected Optional<Class<? extends AbstractTheme>> getTheme() {
             if (pageConfigurationHolder == null) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -323,7 +323,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             if (pageConfigurationHolder == null) {
                 return Optional.empty();
             } else {
-                return ui.getThemeFor(pageConfigurationHolder, null);
+                return ui.getThemeFor(pageConfigurationHolder);
             }
         }
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -320,11 +320,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          * @see UI#getThemeFor(Class, String)
          */
         protected Optional<Class<? extends AbstractTheme>> getTheme() {
-            if (pageConfigurationHolder == null) {
-                return Optional.empty();
-            } else {
-                return ui.getThemeFor(pageConfigurationHolder, null);
-            }
+            return ui.getThemeFor(pageConfigurationHolder, null);
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -16,8 +16,6 @@
 
 package com.vaadin.flow.server;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -65,12 +63,15 @@ import com.vaadin.flow.shared.VaadinUriResolver;
 import com.vaadin.flow.shared.communication.PushMode;
 import com.vaadin.flow.shared.ui.Dependency;
 import com.vaadin.flow.shared.ui.LoadMode;
+import com.vaadin.flow.theme.AbstractTheme;
 
 import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 import elemental.json.JsonValue;
 import elemental.json.impl.JsonUtil;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Request handler which handles bootstrapping of the application, i.e. the
@@ -307,6 +308,22 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             } else {
                 return AnnotationReader.getAnnotationsFor(
                         pageConfigurationHolder, annotationType);
+            }
+        }
+
+        /**
+         * Gets the {@link AbstractTheme} class associated with the
+         * pageConfigurationHolder of this context, if any.
+         * 
+         * @return the theme, or empty if none is found, or
+         *         pageConfigurationHolder is <code>null</code>
+         * @see UI#getThemeFor(Class)
+         */
+        protected Optional<Class<? extends AbstractTheme>> getTheme() {
+            if (pageConfigurationHolder == null) {
+                return Optional.empty();
+            } else {
+                return ui.getThemeFor(pageConfigurationHolder);
             }
         }
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -317,13 +317,13 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          * 
          * @return the theme, or empty if none is found, or
          *         pageConfigurationHolder is <code>null</code>
-         * @see UI#getThemeFor(Class)
+         * @see UI#getThemeFor(Class, String)
          */
         protected Optional<Class<? extends AbstractTheme>> getTheme() {
             if (pageConfigurationHolder == null) {
                 return Optional.empty();
             } else {
-                return ui.getThemeFor(pageConfigurationHolder);
+                return ui.getThemeFor(pageConfigurationHolder, null);
             }
         }
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -317,7 +317,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          * 
          * @return the theme, or empty if none is found, or
          *         pageConfigurationHolder is <code>null</code>
-         * @see UI#getThemeFor(Class)
+         * @see UI#getThemeFor(Class, String)
          */
         protected Optional<Class<? extends AbstractTheme>> getTheme() {
             if (pageConfigurationHolder == null) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -323,7 +323,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             if (pageConfigurationHolder == null) {
                 return Optional.empty();
             } else {
-                return ui.getThemeFor(pageConfigurationHolder);
+                return ui.getThemeFor(pageConfigurationHolder, null);
             }
         }
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/RouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/RouteRegistry.java
@@ -464,7 +464,7 @@ public class RouteRegistry implements Serializable {
             paths.add(route);
 
             targetRoutesMap.put(navigationTarget, route);
-            addRoute(routesMap, targetRoutesMap, navigationTarget, paths);
+            addRoute(routesMap, navigationTarget, paths);
         }
         if (!routes.compareAndSet(null,
                 Collections.unmodifiableMap(routesMap))) {
@@ -479,7 +479,6 @@ public class RouteRegistry implements Serializable {
     }
 
     private void addRoute(Map<String, RouteTarget> routesMap,
-            Map<Class<? extends Component>, String> targetRoutesMap,
             Class<? extends Component> navigationTarget,
             Collection<String> paths)
             throws InvalidRouteConfigurationException {

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/RouteTarget.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/RouteTarget.java
@@ -16,7 +16,9 @@
 package com.vaadin.flow.server.startup;
 
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.router.HasUrlParameter;
@@ -24,6 +26,7 @@ import com.vaadin.flow.router.OptionalParameter;
 import com.vaadin.flow.router.ParameterDeserializer;
 import com.vaadin.flow.router.WildcardParameter;
 import com.vaadin.flow.server.InvalidRouteConfigurationException;
+import com.vaadin.flow.theme.AbstractTheme;
 
 /**
  * Route target holder that handles getting the correct type of has parameter
@@ -34,6 +37,7 @@ public class RouteTarget implements Serializable {
     private Class<? extends Component> parameter;
     private Class<? extends Component> optionalParameter;
     private Class<? extends Component> wildCardParameter;
+    private Map<Class<?>, Class<? extends AbstractTheme>> routeThemes;
 
     /**
      * Create a new Route target holder.
@@ -155,5 +159,36 @@ public class RouteTarget implements Serializable {
                 OptionalParameter.class)
                 || ParameterDeserializer.isAnnotatedParameter(target,
                         WildcardParameter.class);
+    }
+
+    /**
+     * Sets the theme used by this RouteTarget for a given navigation target.
+     * 
+     * @param target
+     *            navigation target
+     * @param theme
+     *            theme class to be used when the navigation target is used
+     */
+    public void setThemeFor(Class<?> target,
+            Class<? extends AbstractTheme> theme) {
+        if (routeThemes == null) {
+            routeThemes = new HashMap<>();
+        }
+        routeThemes.put(target, theme);
+    }
+
+    /**
+     * Gets the theme that should be used for the given navigation target.
+     * 
+     * @param target
+     *            navigation target
+     * @return theme class to be used when the navigation target is used, or
+     *         <code>null</code> if no theme was set for it
+     */
+    public Class<? extends AbstractTheme> getThemeFor(Class<?> target) {
+        if (routeThemes == null) {
+            return null;
+        }
+        return routeThemes.get(target);
     }
 }


### PR DESCRIPTION
Restructured the code to place all Theme discovery code in a single place - RouteRegistry.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3785)
<!-- Reviewable:end -->
