### PR TITLE
Use correct parameter key to get fallback transport

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/PushConfigurationMap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/PushConfigurationMap.java
@@ -119,13 +119,7 @@ public class PushConfigurationMap extends NodeMap implements PushConfiguration {
             return null;
         }
 
-        Transport tr = Transport
-                .getByIdentifier(getParameters().get(TRANSPORT_KEY).toString());
-        if (tr == Transport.WEBSOCKET && contains(ALWAYS_USE_XHR_TO_SERVER)) {
-            return Transport.WEBSOCKET_XHR;
-        } else {
-            return tr;
-        }
+        return Transport.getByIdentifier(getParameters().get(FALLBACK_TRANSPORT_KEY).toString());
     }
 
     @Override

--- a/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/PushConfigurationMapTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/PushConfigurationMapTest.java
@@ -45,6 +45,27 @@ public class PushConfigurationMapTest
     }
 
     @Test
+    public void fallbackTransportLongPolling() {
+        ns.setFallbackTransport(Transport.LONG_POLLING);
+        Assert.assertEquals(Transport.LONG_POLLING.getIdentifier(),
+            ns.getParameter("fallbackTransport"));
+        Assert.assertEquals(Transport.LONG_POLLING, ns.getFallbackTransport());
+    }
+
+    @Test
+    public void fallbackTransportWebsocket() {
+        ns.setFallbackTransport(Transport.WEBSOCKET);
+        Assert.assertEquals(Transport.WEBSOCKET.getIdentifier(),
+            ns.getParameter("fallbackTransport"));
+        Assert.assertEquals(Transport.WEBSOCKET, ns.getFallbackTransport());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void fallbackTransportWebsocketXHR() {
+        ns.setFallbackTransport(Transport.WEBSOCKET_XHR);
+    }
+
+    @Test
     public void parameterNames() {
         ns.setParameter("foo", "bar");
         Assert.assertArrayEquals(new String[] { "foo" },


### PR DESCRIPTION
Uses the `FALLBACK_TRANSPORT_KEY` to access parameters map.
Also remove check for `ALWAYS_USE_XHR_TO_SERVER` because
this setting is forbidden in setter.
Fixes #3796

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3800)
<!-- Reviewable:end -->
