### PR TITLE
Find component demo view by classname

### DIFF
--- a/flow-components-parent/flow-component-demo-helpers/src/main/java/com/vaadin/flow/demo/ComponentDemoTest.java
+++ b/flow-components-parent/flow-component-demo-helpers/src/main/java/com/vaadin/flow/demo/ComponentDemoTest.java
@@ -16,10 +16,10 @@
 package com.vaadin.flow.demo;
 
 import org.junit.Before;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.testutil.ChromeBrowserTest;
-import org.openqa.selenium.By;
 
 /**
  * Base class for the integration tests of component demos.
@@ -39,8 +39,8 @@ public abstract class ComponentDemoTest extends ChromeBrowserTest {
     @Before
     public void openDemoPageAndCheckForErrors() {
         open();
-        waitForElementPresent(By.tagName("div"));
-        layout = findElement(By.tagName("div"));
+        waitForElementPresent(By.className("demo-view"));
+        layout = findElement(By.className("demo-view"));
         checkLogsForErrors();
     }
 }


### PR DESCRIPTION
A new div has appeared into the component demos before the actual demo-views, which caused the tests to fail because the demo-view is no more the first div of the page like expected by the test. This fixes the component ITs and it's anyway safer to find the demo-view by its class name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3810)
<!-- Reviewable:end -->
