### PR TITLE
Find component test demo by className

### DIFF
--- a/flow-components-parent/flow-component-demo-helpers/src/main/java/com/vaadin/flow/demo/TabbedComponentDemoTest.java
+++ b/flow-components-parent/flow-component-demo-helpers/src/main/java/com/vaadin/flow/demo/TabbedComponentDemoTest.java
@@ -42,8 +42,8 @@ public abstract class TabbedComponentDemoTest extends ComponentDemoTest {
             testPath = testPath + (testPath.endsWith("/") ? tab : "/" + tab);
         }
         getDriver().get(testPath);
-        waitForElementPresent(By.tagName("div"));
-        layout = findElement(By.tagName("div"));
+        waitForElementPresent(By.className("demo-view"));
+        layout = findElement(By.className("demo-view"));
         checkLogsForErrors();
     }
 


### PR DESCRIPTION
after #3773, the order of the component test demo has been changed,
elements cannot be found by the first div, so we change to find it by
className

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3817)
<!-- Reviewable:end -->
