### PR TITLE
Apply full body size by default

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/page/BodySize.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/BodySize.java
@@ -24,6 +24,12 @@ import java.lang.annotation.Target;
 
 /**
  * Defines the body size that will be added to the HTML of the host pages.
+ * <p>
+ * If no {@code @BodySize} has been defined, the default values
+ * {@code height:100vh} and {@code width:100vw} will be used, so the body will
+ * fill the entire viewport. If you don't want any size to be set for the body,
+ * or if you want to define the values in CSS, you must use an empty
+ * {@code @BodySize} annotation to disable the default values.
  *
  * @author Vaadin Ltd
  */

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/BodySize.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/BodySize.java
@@ -25,11 +25,11 @@ import java.lang.annotation.Target;
 /**
  * Defines the body size that will be added to the HTML of the host pages.
  * <p>
- * If no {@code @BodySize} has been defined, the default values
+ * If no {@code @BodySize} has been applied, the default values
  * {@code height:100vh} and {@code width:100vw} will be used, so the body will
- * fill the entire viewport. If you don't want any size to be set for the body,
- * or if you want to define the values in CSS, you must use an empty
- * {@code @BodySize} annotation to disable the default values.
+ * fill the entire viewport. If you don't want to set any size for the body, you
+ * must apply an empty {@code @BodySize} annotation to disable the default
+ * values.
  *
  * @author Vaadin Ltd
  */

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -16,8 +16,6 @@
 
 package com.vaadin.flow.server;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -71,6 +69,8 @@ import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 import elemental.json.JsonValue;
 import elemental.json.impl.JsonUtil;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Request handler which handles bootstrapping of the application, i.e. the
@@ -602,8 +602,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                 CSS_TYPE_ATTRIBUTE_VALUE);
         // Add any body style that is defined for the application using
         // @BodySize
-        String bodySizeContent = BootstrapUtils.getBodySizeContent(context)
-                .orElse("body {margin:0;}");
+        String bodySizeContent = BootstrapUtils.getBodySizeContent(context);
         styles.appendText(bodySizeContent);
         // Basic reconnect dialog style just to make it visible and outside of
         // normal flow

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapUtils.java
@@ -147,20 +147,24 @@ class BootstrapUtils {
      *            the bootstrap context
      * @return the content value string for body size style element
      */
-    static Optional<String> getBodySizeContent(
+    static String getBodySizeContent(
             BootstrapHandler.BootstrapContext context) {
-        return context.getPageConfigurationAnnotation(BodySize.class)
-                .map(BootstrapUtils::composeBodySizeString);
-    }
 
-    private static String composeBodySizeString(BodySize bodySize) {
+        Optional<BodySize> bodySize = context
+                .getPageConfigurationAnnotation(BodySize.class);
+
+        // Set full size by default if @BodySize is not used
+        String height = bodySize.map(BodySize::height).orElse("100vh");
+        String width = bodySize.map(BodySize::width).orElse("100vw");
+
         StringBuilder bodyString = new StringBuilder();
+
         bodyString.append("body {");
-        if (!bodySize.height().isEmpty()) {
-            bodyString.append("height:").append(bodySize.height()).append(";");
+        if (!height.isEmpty()) {
+            bodyString.append("height:").append(height).append(";");
         }
-        if (!bodySize.width().isEmpty()) {
-            bodyString.append("width:").append(bodySize.width()).append(";");
+        if (!width.isEmpty()) {
+            bodyString.append("width:").append(width).append(";");
         }
         bodyString.append("margin:0;");
         bodyString.append("}");
@@ -226,11 +230,10 @@ class BootstrapUtils {
                 .getResourceAsStream(file);
 
         if (stream == null) {
-            throw new IllegalStateException(
-                    String.format(
-                            "File '%s' for inline resource is not available through "
-                                    + "the servlet context class loader.",
-                            file));
+            throw new IllegalStateException(String.format(
+                    "File '%s' for inline resource is not available through "
+                            + "the servlet context class loader.",
+                    file));
         }
         return stream;
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
@@ -208,6 +208,13 @@ public class BootstrapHandlerTest {
 
     @Route("")
     @Tag(Tag.DIV)
+    @BodySize(height = "10px", width = "20px")
+    @StyleSheet("bodysize.css")
+    public static class BodySizeAnnotatedAndCss extends Component {
+    }
+
+    @Route("")
+    @Tag(Tag.DIV)
     @Viewport("width=device-width")
     public static class RootNavigationTarget extends Component {
     }
@@ -728,6 +735,44 @@ public class BootstrapHandlerTest {
                 "The first style tag should start with body style from @BodySize",
                 styleTag.get().toString().startsWith(
                         "<style type=\"text/css\">body {height:10px;width:20px;margin:0;}"));
+    }
+
+    @Test
+    public void css_body_size_overrides_annotated_body_size()
+            throws InvalidRouteConfigurationException {
+
+        initUI(testUI, createVaadinRequest(),
+                Collections.singleton(BodySizeAnnotatedAndCss.class));
+
+        Document page = BootstrapHandler.getBootstrapPage(
+                new BootstrapContext(request, null, session, testUI));
+
+        Elements allElements = page.head().getAllElements();
+
+        Optional<Element> styleTag = allElements.stream()
+                .filter(element -> element.tagName().equals("style"))
+                .findFirst();
+
+        Assert.assertTrue("Expected a style element in head.",
+                styleTag.isPresent());
+
+        Assert.assertTrue(
+                "The first style tag should start with body style from @BodySize",
+                styleTag.get().toString().startsWith(
+                        "<style type=\"text/css\">body {height:10px;width:20px;margin:0;}"));
+
+        Optional<Element> cssImportTag = allElements.stream().filter(
+                element -> element.attr("href").contains("bodysize.css"))
+                .findFirst();
+
+        Assert.assertTrue("Expected import for bodysize.css in head.",
+                cssImportTag.isPresent());
+
+        Assert.assertTrue(
+                "Styles defined with @BodySize should be imported before css-files in the head,"
+                        + " so that body size defined in css overrides the annotated values.",
+                allElements.indexOf(styleTag.get()) < allElements
+                        .indexOf(cssImportTag.get()));
     }
 
     @Test // 3749

--- a/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
@@ -1,10 +1,6 @@
 package com.vaadin.flow.server;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import javax.servlet.http.HttpServletRequest;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -18,8 +14,6 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-
-import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.CoreMatchers;
@@ -61,6 +55,12 @@ import com.vaadin.flow.shared.ui.LoadMode;
 import com.vaadin.flow.theme.AbstractTheme;
 import com.vaadin.flow.theme.Theme;
 import com.vaadin.tests.util.MockDeploymentConfiguration;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class BootstrapHandlerTest {
 
@@ -196,8 +196,14 @@ public class BootstrapHandlerTest {
 
     @Route("")
     @Tag(Tag.DIV)
-    @BodySize(height = "100vh", width = "100vw")
+    @BodySize(height = "10px", width = "20px")
     public static class BodySizeAnnotated extends Component {
+    }
+
+    @Route("")
+    @Tag(Tag.DIV)
+    @BodySize
+    public static class EmptyBodySizeAnnotated extends Component {
     }
 
     @Route("")
@@ -721,11 +727,11 @@ public class BootstrapHandlerTest {
         Assert.assertTrue(
                 "The first style tag should start with body style from @BodySize",
                 styleTag.get().toString().startsWith(
-                        "<style type=\"text/css\">body {height:100vh;width:100vw;margin:0;}"));
+                        "<style type=\"text/css\">body {height:10px;width:20px;margin:0;}"));
     }
 
-    @Test // 2344
-    public void no_body_size_or_page_configurator_still_adds_margin_for_body()
+    @Test // 3749
+    public void no_body_size_or_page_configurator_adds_margin_and_full_size_for_body()
             throws InvalidRouteConfigurationException {
 
         initUI(testUI, createVaadinRequest(),
@@ -744,7 +750,32 @@ public class BootstrapHandlerTest {
                 styleTag.isPresent());
 
         Assert.assertTrue(
-                "The first style tag should start with body style containing margin",
+                "The first style tag should start with body style containing default body size and margin",
+                styleTag.get().toString().startsWith(
+                        "<style type=\"text/css\">body {height:100vh;width:100vw;margin:0;}"));
+    }
+
+    @Test // 3749
+    public void empty_body_size_adds_margin_but_no_size_for_body()
+            throws InvalidRouteConfigurationException {
+
+        initUI(testUI, createVaadinRequest(),
+                Collections.singleton(EmptyBodySizeAnnotated.class));
+
+        Document page = BootstrapHandler.getBootstrapPage(
+                new BootstrapContext(request, null, session, testUI));
+
+        Elements allElements = page.head().getAllElements();
+
+        Optional<Element> styleTag = allElements.stream()
+                .filter(element -> element.tagName().equals("style"))
+                .findFirst();
+
+        Assert.assertTrue("Expected a style element in head.",
+                styleTag.isPresent());
+
+        Assert.assertTrue(
+                "The first style tag should start with body style containing only margin",
                 styleTag.get().toString().startsWith(
                         "<style type=\"text/css\">body {margin:0;}"));
     }


### PR DESCRIPTION
If no `@BodySize` has been defined, set width:100vw and height:100vh for
the body.

Also refactored the code a bit to avoid setting margin in two places.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3821)
<!-- Reviewable:end -->
