### PR TITLE
Remove confusing "identifier" from javadocs.

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/EventData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/EventData.java
@@ -47,11 +47,12 @@ import com.vaadin.flow.dom.Element;
 @Documented
 public @interface EventData {
     /**
-     * The identifier used in
-     * {@link Element#addEventListener(String, DomEventListener, String...)} to
-     * identify the event data.
+     * A JavaScript expression that will be evaluated to collect data when an
+     * event is handled.
      *
-     * @return the identifier to use for fetching event data
+     * @see Element#addEventListener(String, DomEventListener, String...)
+     *
+     * @return the expression to use for fetching event data
      */
     String value();
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3827)
<!-- Reviewable:end -->
