### PR TITLE
Exception in setParameter should throw normally.

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/NavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/NavigationStateRenderer.java
@@ -70,23 +70,22 @@ public class NavigationStateRenderer extends AbstractNavigationStateRenderer {
         Optional<List<String>> urlParameters = navigationState
                 .getUrlParameters();
         if (urlParameters.isPresent()) {
-            final Object deserializedParameter;
+            Object deserializedParameter = null;
             try {
                 deserializedParameter = ParameterDeserializer
                         .deserializeUrlParameters(routeTargetType,
                                 urlParameters.get());
 
-                @SuppressWarnings("unchecked")
-                HasUrlParameter<Object> hasUrlParameter = (HasUrlParameter<Object>) componentInstance;
-
-                hasUrlParameter.setParameter(beforeEnterEvent,
-                        deserializedParameter);
             } catch (Exception e) {
                 beforeEnterEvent.rerouteToError(NotFoundException.class,
                         String.format(
                                 "Failed to parse url parameter, exception: %s",
                                 e));
             }
+            @SuppressWarnings("unchecked")
+            HasUrlParameter<Object> hasUrlParameter = (HasUrlParameter<Object>) componentInstance;
+            hasUrlParameter.setParameter(beforeEnterEvent,
+                    deserializedParameter);
         }
     }
 

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/MyException.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/MyException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest;
+
+/**
+ * Exception throw in HasUrlParameterErrorView.
+ */
+public class MyException extends RuntimeException {
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HasUrlParameterErrorView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HasUrlParameterErrorView.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.BeforeEvent;
+import com.vaadin.flow.router.HasUrlParameter;
+import com.vaadin.flow.router.OptionalParameter;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.uitest.MyException;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+@Route(value = "com.vaadin.flow.uitest.ui.HasUrlParameterErrorView", layout = ViewTestLayout.class)
+public class HasUrlParameterErrorView extends Div implements HasUrlParameter<String> {
+
+    @Override
+    public void setParameter(BeforeEvent event, @OptionalParameter String parameter) {
+        throw new MyException();
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/MyExceptionHandler.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/MyExceptionHandler.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.ErrorParameter;
+import com.vaadin.flow.router.HasErrorParameter;
+import com.vaadin.flow.uitest.MyException;
+
+/**
+ * The exception handler for the
+ */
+public class MyExceptionHandler extends Div
+        implements HasErrorParameter<MyException> {
+
+    public MyExceptionHandler() {
+        Label label = new Label("My exception handler.");
+        label.setId("custom-exception");
+        add(label);
+    }
+
+    @Override
+    public int setErrorParameter(BeforeEnterEvent event,
+            ErrorParameter<MyException> parameter) {
+        return 404;
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HasUrlParameterErrorIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HasUrlParameterErrorIT.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class HasUrlParameterErrorIT extends ChromeBrowserTest {
+
+    @Test
+    public void testNavigationTriggers() {
+        open();
+
+        Assert.assertNotNull("Expected custom error handler to render", findElement(By.id("custom-exception")));
+    }
+}


### PR DESCRIPTION
When there is an exception in setParameter for
HasUrlParameter the thrown exception should not
be changed to a reroute to NotFoundException.

Fixes #3860 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3861)
<!-- Reviewable:end -->
