### PR TITLE
Introduce a fluent API for configuring DOM listeners

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/EventData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/EventData.java
@@ -21,8 +21,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import com.vaadin.flow.dom.DomEventListener;
-import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.DomListenerRegistration;
 
 /**
  * Maps data from a DOM event to a {@link ComponentEvent}.
@@ -39,7 +38,7 @@ import com.vaadin.flow.dom.Element;
  * {@link ComponentEvent} constructor parameter.
  *
  * @see DomEvent
- * @see Element#addEventListener(String, DomEventListener, String...)
+ * @see DomListenerRegistration#addEventData(String)
  * @author Vaadin Ltd
  */
 @Retention(RetentionPolicy.RUNTIME)
@@ -50,7 +49,7 @@ public @interface EventData {
      * A JavaScript expression that will be evaluated to collect data when an
      * event is handled.
      *
-     * @see Element#addEventListener(String, DomEventListener, String...)
+     * @see DomListenerRegistration#addEventData(String)
      *
      * @return the expression to use for fetching event data
      */

--- a/flow-server/src/main/java/com/vaadin/flow/dom/DomEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/DomEvent.java
@@ -69,7 +69,7 @@ public class DomEvent extends EventObject {
      * Gets additional data related to the event. An empty JSON object is
      * returned if no event data is available.
      *
-     * @see Element#addEventListener(String, DomEventListener, String...)
+     * @see DomListenerRegistration#addEventData(String)
      *
      * @return a JSON object containing event data, never <code>null</code>
      */

--- a/flow-server/src/main/java/com/vaadin/flow/dom/DomListenerRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/DomListenerRegistration.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.dom;
+
+import com.vaadin.flow.shared.Registration;
+
+/**
+ * A registration for configuring or removing a DOM event listener added to an
+ * element.
+ *
+ * @see Element#addEventListener(String, DomEventListener)
+ *
+ * @author Vaadin Ltd
+ */
+public interface DomListenerRegistration extends Registration {
+    /**
+     * Add a JavaScript expression for extracting event data. When an event is
+     * fired in the browser, the expression is evaluated and its value is sent
+     * back to the server. The expression is evaluated in a context where
+     * <code>element</code> refers to this element and <code>event</code> refers
+     * to the fired event. If multiple expressions are defined for the same
+     * event, their order of execution is undefined.
+     * <p>
+     * The result of the evaluation is available in
+     * {@link DomEvent#getEventData()} with the expression as the key in the
+     * JSON object. An expression might be e.g.
+     *
+     * <ul>
+     * <li><code>element.value</code> the get the value of an input element for
+     * a change event.
+     * <li><code>event.button === 0</code> to get true for click events
+     * triggered by the primary mouse button.
+     * </ul>
+     *
+     * @param eventData
+     *            definition for data that should be passed back to the server
+     *            together with the event, not <code>null</code>
+     * @return this registration, for chaining
+     */
+    DomListenerRegistration addEventData(String eventData);
+
+    /**
+     * Configure whether this listener will be called even in cases when the
+     * element is disabled.
+     *
+     * @param disabledUpdateMode
+     *            controls RPC communication from the client side to the server
+     *            side when the element is disabled, not {@code null}
+     *
+     * @return this registration, for chaining
+     */
+    DomListenerRegistration setDisabledUpdateMode(
+            DisabledUpdateMode disabledUpdateMode);
+}

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -477,110 +477,74 @@ public class Element extends Node<Element> {
      * <p>
      * Event listeners are triggered in the order they are registered.
      *
-     * @see #addEventListener(String, DomEventListener, DisabledUpdateMode,
-     *      String...)
+     * @see DomListenerRegistration
      *
      * @param eventType
      *            the type of event to listen to, not <code>null</code>
      * @param listener
      *            the listener to add, not <code>null</code>
-     * @return a handle that can be used for removing the listener
+     * @return a handle that can be used for configuring or removing the
+     *         listener
      */
-    public Registration addEventListener(String eventType,
+    public DomListenerRegistration addEventListener(String eventType,
             DomEventListener listener) {
-        return addEventListener(eventType, listener,
-                DisabledUpdateMode.ONLY_WHEN_ENABLED, new String[0]);
-    }
-
-    /**
-     * Adds an event listener and event data expressions for the given event
-     * type.
-     * <p>
-     * When an event is fired in the browser, custom JavaScript expressions
-     * defined in the <code>eventDataExpressions</code> parameter are evaluated
-     * to extract data that is sent back to the server. The expression is
-     * evaluated in a context where <code>element</code> refers to this element
-     * and <code>event</code> refers to the fired event. The result of the
-     * evaluation is available in {@link DomEvent#getEventData()} with the
-     * expression as the key in the JSON object. An expression might be e.g.
-     *
-     * <ul>
-     * <li><code>element.value</code> the get the value of an input element for
-     * a change event.
-     * <li><code>event.button === 0</code> to get true for click events
-     * triggered by the primary mouse button.
-     * </ul>
-     * <p>
-     * Event listeners are triggered in the order they are registered.
-     *
-     * @param eventType
-     *            the type of event to listen to, not <code>null</code>
-     * @param listener
-     *            the listener to add, not <code>null</code>
-     * @param eventDataExpressions
-     *            definitions for data that should be passed back to the server
-     *            together with the event
-     * @return a handle that can be used for removing the listener
-     */
-    public Registration addEventListener(String eventType,
-            DomEventListener listener, String... eventDataExpressions) {
-        return addEventListener(eventType, listener,
-                DisabledUpdateMode.ONLY_WHEN_ENABLED, eventDataExpressions);
-    }
-
-    /**
-     * Adds an event listener and event data expressions for the given event
-     * type.
-     * <p>
-     * When an event is fired in the browser, custom JavaScript expressions
-     * defined in the <code>eventDataExpressions</code> parameter are evaluated
-     * to extract data that is sent back to the server. The expression is
-     * evaluated in a context where <code>element</code> refers to this element
-     * and <code>event</code> refers to the fired event. The result of the
-     * evaluation is available in {@link DomEvent#getEventData()} with the
-     * expression as the key in the JSON object. An expression might be e.g.
-     *
-     * <ul>
-     * <li><code>element.value</code> the get the value of an input element for
-     * a change event.
-     * <li><code>event.button === 0</code> to get true for click events
-     * triggered by the primary mouse button.
-     * </ul>
-     * <p>
-     * Event listeners are triggered in the order they are registered.
-     *
-     * @param eventType
-     *            the type of event to listen to, not <code>null</code>
-     * @param listener
-     *            the listener to add, not <code>null</code>
-     * @param mode
-     *            controls RPC communication from the client side to the server
-     *            side when the element is disabled, not {@code null}
-     * @param eventDataExpressions
-     *            definitions for data that should be passed back to the server
-     *            together with the event
-     * @return a handle that can be used for removing the listener
-     */
-    public Registration addEventListener(String eventType,
-            DomEventListener listener, DisabledUpdateMode mode,
-            String... eventDataExpressions) {
         if (eventType == null) {
             throw new IllegalArgumentException(EVENT_TYPE_MUST_NOT_BE_NULL);
         }
         if (listener == null) {
             throw new IllegalArgumentException("Listener must not be null");
         }
+        return getStateProvider().addEventListener(getNode(), eventType,
+                listener);
+    }
+
+    /**
+     * Adds an event listener and event data expressions for the given event
+     * type.
+     * <p>
+     * When an event is fired in the browser, custom JavaScript expressions
+     * defined in the <code>eventDataExpressions</code> parameter are evaluated
+     * to extract data that is sent back to the server. The expression is
+     * evaluated in a context where <code>element</code> refers to this element
+     * and <code>event</code> refers to the fired event. The result of the
+     * evaluation is available in {@link DomEvent#getEventData()} with the
+     * expression as the key in the JSON object. An expression might be e.g.
+     *
+     * <ul>
+     * <li><code>element.value</code> the get the value of an input element for
+     * a change event.
+     * <li><code>event.button === 0</code> to get true for click events
+     * triggered by the primary mouse button.
+     * </ul>
+     * <p>
+     * Event listeners are triggered in the order they are registered.
+     *
+     * @param eventType
+     *            the type of event to listen to, not <code>null</code>
+     * @param listener
+     *            the listener to add, not <code>null</code>
+     * @param eventDataExpressions
+     *            definitions for data that should be passed back to the server
+     *            together with the event
+     * @return a handle that can be used for configuring or removing the
+     *         listener
+     *
+     * @deprecated Instead, use the returned registration instance for adding
+     *             event data expressions
+     */
+    @Deprecated
+    public DomListenerRegistration addEventListener(String eventType,
+            DomEventListener listener, String... eventDataExpressions) {
         if (eventDataExpressions == null) {
             throw new IllegalArgumentException(
                     "The event data expressions array must not be null");
         }
-        if (mode == null) {
-            throw new IllegalArgumentException(
-                    "RPC comunication control mode for disabled alement must not be null");
-        }
 
-        return getStateProvider().addEventListener(getNode(), eventType,
-                listener, mode, eventDataExpressions);
+        DomListenerRegistration registration = addEventListener(eventType,
+                listener);
+        Stream.of(eventDataExpressions).forEach(registration::addEventData);
+
+        return registration;
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/dom/ElementStateProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/ElementStateProvider.java
@@ -199,17 +199,10 @@ public interface ElementStateProvider extends Serializable {
      *            the event type
      * @param listener
      *            the listener
-     * @param mode
-     *            controls RPC communication from the client side to the server
-     *            side when the element is disabled, not {@code null}
-     * @param eventDataExpressions
-     *            the event data expressions
-     *
-     * @return a handle for removing the listener
+     * @return a handle for configuring or removing the listener
      */
-    Registration addEventListener(StateNode node, String eventType,
-            DomEventListener listener, DisabledUpdateMode mode,
-            String[] eventDataExpressions);
+    DomListenerRegistration addEventListener(StateNode node, String eventType,
+            DomEventListener listener);
 
     /**
      * Gets the value of the given property.

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/AbstractTextElementStateProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/AbstractTextElementStateProvider.java
@@ -24,6 +24,7 @@ import com.vaadin.flow.dom.ChildElementConsumer;
 import com.vaadin.flow.dom.ClassList;
 import com.vaadin.flow.dom.DisabledUpdateMode;
 import com.vaadin.flow.dom.DomEventListener;
+import com.vaadin.flow.dom.DomListenerRegistration;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementStateProvider;
 import com.vaadin.flow.dom.NodeVisitor;
@@ -109,9 +110,8 @@ public abstract class AbstractTextElementStateProvider
     }
 
     @Override
-    public Registration addEventListener(StateNode node, String eventType,
-            DomEventListener listener, DisabledUpdateMode mode,
-            String[] eventDataExpressions) {
+    public DomListenerRegistration addEventListener(StateNode node,
+            String eventType, DomEventListener listener) {
         throw new UnsupportedOperationException();
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/BasicElementStateProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/BasicElementStateProvider.java
@@ -26,6 +26,7 @@ import java.util.stream.Stream;
 import com.vaadin.flow.dom.ClassList;
 import com.vaadin.flow.dom.DisabledUpdateMode;
 import com.vaadin.flow.dom.DomEventListener;
+import com.vaadin.flow.dom.DomListenerRegistration;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementUtil;
 import com.vaadin.flow.dom.Node;
@@ -211,13 +212,12 @@ public class BasicElementStateProvider extends AbstractNodeStateProvider {
     }
 
     @Override
-    public Registration addEventListener(StateNode node, String eventType,
-            DomEventListener listener, DisabledUpdateMode mode,
-            String[] eventDataExpressions) {
+    public DomListenerRegistration addEventListener(StateNode node,
+            String eventType, DomEventListener listener) {
         ElementListenerMap listeners = node
                 .getFeature(ElementListenerMap.class);
 
-        return listeners.add(eventType, listener, mode, eventDataExpressions);
+        return listeners.add(eventType, listener);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/ShadowRootStateProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/ShadowRootStateProvider.java
@@ -22,6 +22,7 @@ import java.util.stream.Stream;
 import com.vaadin.flow.dom.ClassList;
 import com.vaadin.flow.dom.DisabledUpdateMode;
 import com.vaadin.flow.dom.DomEventListener;
+import com.vaadin.flow.dom.DomListenerRegistration;
 import com.vaadin.flow.dom.Node;
 import com.vaadin.flow.dom.NodeVisitor;
 import com.vaadin.flow.dom.PropertyChangeListener;
@@ -117,9 +118,8 @@ public class ShadowRootStateProvider extends AbstractNodeStateProvider {
     }
 
     @Override
-    public Registration addEventListener(StateNode node, String eventType,
-            DomEventListener listener, DisabledUpdateMode mode,
-            String[] eventDataExpressions) {
+    public DomListenerRegistration addEventListener(StateNode node,
+            String eventType, DomEventListener listener) {
         throw new UnsupportedOperationException();
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
@@ -2323,20 +2323,6 @@ public class ElementTest extends AbstractNodeTest {
                 DisabledUpdateMode.ONLY_WHEN_ENABLED);
     }
 
-    @Test
-    public void addEventListener_delegateTo3ArgsMethod() {
-        Element element = Mockito.mock(Element.class);
-
-        Mockito.doCallRealMethod().when(element)
-                .addEventListener(Mockito.anyString(), Mockito.any());
-
-        DomEventListener listener = Mockito.mock(DomEventListener.class);
-        element.addEventListener("foo", listener);
-
-        Mockito.verify(element).addEventListener("foo", listener,
-                DisabledUpdateMode.ONLY_WHEN_ENABLED);
-    }
-
     @Override
     protected Element createParentNode() {
         return ElementFactory.createDiv();

--- a/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/ElementListenersTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/ElementListenersTest.java
@@ -44,8 +44,7 @@ public class ElementListenersTest
 
         AtomicInteger eventCount = new AtomicInteger();
 
-        Registration handle = ns.add("foo", e -> eventCount.incrementAndGet(),
-                DisabledUpdateMode.ONLY_WHEN_ENABLED, new String[0]);
+        Registration handle = ns.add("foo", e -> eventCount.incrementAndGet());
 
         Assert.assertEquals(0, eventCount.get());
 
@@ -64,8 +63,7 @@ public class ElementListenersTest
     public void eventNameInClientData() {
         Assert.assertFalse(ns.contains("foo"));
 
-        Registration handle = ns.add("foo", noOp,
-                DisabledUpdateMode.ONLY_WHEN_ENABLED, new String[0]);
+        Registration handle = ns.add("foo", noOp);
 
         Assert.assertEquals(0, getExpressions("foo").size());
 
@@ -76,8 +74,7 @@ public class ElementListenersTest
 
     @Test
     public void addAndRemoveEventData() {
-        ns.add("eventType", noOp, DisabledUpdateMode.ONLY_WHEN_ENABLED,
-                new String[] { "data1", "data2" });
+        ns.add("eventType", noOp).addEventData("data1").addEventData("data2");
 
         Set<String> expressions = getExpressions("eventType");
         Assert.assertTrue(expressions.contains("data1"));
@@ -94,7 +91,7 @@ public class ElementListenersTest
             public void handleEvent(DomEvent event) {
                 // no op
             }
-        }, DisabledUpdateMode.ONLY_WHEN_ENABLED, new String[] { "data3" });
+        }).addEventData("data3");
 
         expressions = getExpressions("eventType");
         Assert.assertTrue(expressions.contains("data1"));
@@ -115,7 +112,7 @@ public class ElementListenersTest
         ns.add("foo", e -> {
             Assert.assertNull(eventDataReference.get());
             eventDataReference.set(e.getEventData());
-        }, DisabledUpdateMode.ONLY_WHEN_ENABLED, new String[0]);
+        });
 
         Assert.assertNull(eventDataReference.get());
 
@@ -134,8 +131,7 @@ public class ElementListenersTest
     public void disabledElement_listenerDoesntReceiveEvent() {
         AtomicInteger eventCount = new AtomicInteger();
 
-        ns.add("foo", e -> eventCount.incrementAndGet(),
-                DisabledUpdateMode.ONLY_WHEN_ENABLED, new String[0]);
+        ns.add("foo", e -> eventCount.incrementAndGet());
 
         Assert.assertEquals(0, eventCount.get());
         DomEvent event = createEvent("foo");
@@ -148,8 +144,7 @@ public class ElementListenersTest
     public void implicitlyDisabledElement_listenerDoesntReceiveEvent() {
         AtomicInteger eventCount = new AtomicInteger();
 
-        ns.add("foo", e -> eventCount.incrementAndGet(),
-                DisabledUpdateMode.ONLY_WHEN_ENABLED, new String[0]);
+        ns.add("foo", e -> eventCount.incrementAndGet());
 
         Assert.assertEquals(0, eventCount.get());
         DomEvent event = createEvent("foo");
@@ -166,8 +161,8 @@ public class ElementListenersTest
     public void disabledElement_listenerWithAlwaysUpdateModeReceivesEvent() {
         AtomicInteger eventCount = new AtomicInteger();
 
-        ns.add("foo", e -> eventCount.incrementAndGet(),
-                DisabledUpdateMode.ALWAYS, new String[0]);
+        ns.add("foo", e -> eventCount.incrementAndGet())
+                .setDisabledUpdateMode(DisabledUpdateMode.ALWAYS);
 
         Assert.assertEquals(0, eventCount.get());
         DomEvent event = createEvent("foo");


### PR DESCRIPTION
This is an intermediate step for #468.

The newly introduced overload that takes an update mode mode is removed
immediately, but the old varargs overload is left as deprecated since
it's expected to be used relatively widely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3885)
<!-- Reviewable:end -->
