### PR TITLE
Update Polymer template parser to use VaadinService resource methods

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/DefaultTemplateParser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/DefaultTemplateParser.java
@@ -38,8 +38,8 @@ import com.vaadin.flow.internal.ReflectionCache;
 import com.vaadin.flow.server.DependencyFilter;
 import com.vaadin.flow.server.DependencyFilter.FilterContext;
 import com.vaadin.flow.server.VaadinService;
-import com.vaadin.flow.server.VaadinServlet;
-import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.server.WebBrowser;
+import com.vaadin.flow.server.startup.FakeEs6Browser;
 import com.vaadin.flow.shared.ui.Dependency;
 import com.vaadin.flow.shared.ui.Dependency.Type;
 
@@ -74,10 +74,10 @@ public final class DefaultTemplateParser implements TemplateParser {
 
     @Override
     public TemplateData getTemplateContent(
-            Class<? extends PolymerTemplate<?>> clazz, String tag) {
-        VaadinServlet servlet = VaadinServlet.getCurrent();
-
+            Class<? extends PolymerTemplate<?>> clazz, String tag,
+            VaadinService service) {
         boolean logEnabled = LOG_CACHE.get(clazz).compareAndSet(false, true);
+        WebBrowser browser = FakeEs6Browser.get();
 
         List<Dependency> dependencies = AnnotationReader
                 .getAnnotationsFor(clazz, HtmlImport.class).stream()
@@ -85,10 +85,8 @@ public final class DefaultTemplateParser implements TemplateParser {
                         htmlImport.value(), htmlImport.loadMode()))
                 .collect(Collectors.toList());
 
-        FilterContext filterContext = new FilterContext(
-                VaadinSession.getCurrent());
-        for (DependencyFilter filter : VaadinService.getCurrent()
-                .getDependencyFilters()) {
+        FilterContext filterContext = new FilterContext(service);
+        for (DependencyFilter filter : service.getDependencyFilters()) {
             dependencies = filter.filter(new ArrayList<>(dependencies),
                     filterContext);
         }
@@ -99,13 +97,8 @@ public final class DefaultTemplateParser implements TemplateParser {
             }
 
             String url = dependency.getUrl();
-            String path = servlet.resolveResource(url);
-
-            if (logEnabled) {
-                getLogger().debug("Html import path '{}' is resolved to '{}'",
-                        url, path);
-            }
-            try (InputStream content = servlet.getResourceAsStream(path)) {
+            try (InputStream content = service.getResourceAsStream(url, browser,
+                    null)) {
                 if (content == null) {
                     throw new IllegalStateException(
                             String.format("Can't find resource '%s' "

--- a/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/PolymerTemplate.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/PolymerTemplate.java
@@ -32,6 +32,7 @@ import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.internal.nodefeature.ElementPropertyMap;
+import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.templatemodel.BeanModelType;
 import com.vaadin.flow.templatemodel.ListModelType;
 import com.vaadin.flow.templatemodel.ModelDescriptor;
@@ -75,8 +76,21 @@ public abstract class PolymerTemplate<M extends TemplateModel>
      *            a template parser
      */
     public PolymerTemplate(TemplateParser parser) {
+        this(parser, VaadinService.getCurrent());
+    }
+
+    /**
+     * Creates the component that is responsible for Polymer template
+     * functionality using the provided {@code parser}.
+     *
+     * @param parser
+     *            a template parser
+     * @param service
+     *            the related service instance
+     */
+    protected PolymerTemplate(TemplateParser parser, VaadinService service) {
         TemplateInitializer templateInitializer = new TemplateInitializer(this,
-                parser);
+                parser, service);
         templateInitializer.initChildElements();
 
         Set<String> twoWayBindingPaths = templateInitializer
@@ -90,7 +104,7 @@ public abstract class PolymerTemplate<M extends TemplateModel>
      * functionality.
      */
     public PolymerTemplate() {
-        this(DefaultTemplateParser.getInstance());
+        this(DefaultTemplateParser.getInstance(), VaadinService.getCurrent());
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/TemplateDataAnalyzer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/TemplateDataAnalyzer.java
@@ -38,6 +38,7 @@ import org.jsoup.select.NodeVisitor;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.polymertemplate.TemplateParser.TemplateData;
 import com.vaadin.flow.internal.AnnotationReader;
+import com.vaadin.flow.server.VaadinService;
 
 import elemental.json.Json;
 import elemental.json.JsonArray;
@@ -58,6 +59,7 @@ class TemplateDataAnalyzer {
     private final Class<? extends PolymerTemplate<?>> templateClass;
     private final TemplateParser parser;
     private final String tag;
+    private final VaadinService service;
 
     private final Map<String, String> tagById = new HashMap<>();
     private final Map<Field, String> idByField = new HashMap<>();
@@ -163,11 +165,14 @@ class TemplateDataAnalyzer {
      *            a template type
      * @param parser
      *            a template parser
+     * @param service
+     *            the related service instance
      */
     TemplateDataAnalyzer(Class<? extends PolymerTemplate<?>> templateClass,
-            TemplateParser parser) {
+            TemplateParser parser, VaadinService service) {
         this.templateClass = templateClass;
         this.parser = parser;
+        this.service = service;
         tag = getTag(templateClass);
     }
 
@@ -178,7 +183,7 @@ class TemplateDataAnalyzer {
      */
     ParserData parseTemplate() {
         TemplateData templateData = parser.getTemplateContent(templateClass,
-                tag);
+                tag, service);
         templateRoot = templateData.getTemplateElement();
         htmlImportUri = templateData.getHtmlImportUri();
         Elements templates = templateRoot.getElementsByTag("template");

--- a/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/TemplateInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/TemplateInitializer.java
@@ -66,14 +66,16 @@ public class TemplateInitializer {
      *            a template to initialize
      * @param parser
      *            a template parser instance
+     * @param service
+     *            the related service
      */
     @SuppressWarnings("unchecked")
     public TemplateInitializer(PolymerTemplate<?> template,
-            TemplateParser parser) {
+            TemplateParser parser, VaadinService service) {
         this.template = template;
 
-        boolean productionMode = VaadinService.getCurrent()
-                .getDeploymentConfiguration().isProductionMode();
+        boolean productionMode = service.getDeploymentConfiguration()
+                .isProductionMode();
 
         templateClass = (Class<? extends PolymerTemplate<?>>) template
                 .getClass();
@@ -82,12 +84,12 @@ public class TemplateInitializer {
         if (productionMode) {
             ReflectionCache<PolymerTemplate<?>, ParserData> cache = CACHE
                     .computeIfAbsent(parser, analyzer -> new ReflectionCache<>(
-                            clazz -> new TemplateDataAnalyzer(clazz, analyzer)
-                                    .parseTemplate()));
+                            clazz -> new TemplateDataAnalyzer(clazz, analyzer,
+                                    service).parseTemplate()));
             data = cache.get(templateClass);
         }
         if (data == null) {
-            data = new TemplateDataAnalyzer(templateClass, parser)
+            data = new TemplateDataAnalyzer(templateClass, parser, service)
                     .parseTemplate();
         }
         parserData = data;

--- a/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/TemplateParser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/TemplateParser.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.polymertemplate;
 import org.jsoup.nodes.Element;
 
 import com.vaadin.flow.component.dependency.HtmlImport;
+import com.vaadin.flow.server.VaadinService;
 
 /**
  * Template content parser.
@@ -79,9 +80,11 @@ public interface TemplateParser {
      *            the template class
      * @param tag
      *            the template tag name
+     * @param service
+     *            the related Vaadin service
      *
      * @return the template data
      */
     TemplateData getTemplateContent(Class<? extends PolymerTemplate<?>> clazz,
-            String tag);
+            String tag, VaadinService service);
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/DependencyFilter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DependencyFilter.java
@@ -21,7 +21,6 @@ import java.util.List;
 import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.StyleSheet;
-import com.vaadin.flow.component.polymertemplate.PolymerTemplate;
 import com.vaadin.flow.shared.ui.Dependency;
 
 /**
@@ -38,9 +37,7 @@ public interface DependencyFilter extends Serializable {
      * version.
      * <p>
      * Called whenever dependencies are about to be sent to the client side for
-     * loading. The filter is also called when a {@link PolymerTemplate} is
-     * about to be parsed - in this case the filter should return a file that
-     * contains the template definition for the corresponding PolymerTemplate.
+     * loading and when templates are parsed on the server side.
      *
      * @param dependencies
      *            the collected dependencies, possibly already modified by other
@@ -57,25 +54,16 @@ public interface DependencyFilter extends Serializable {
      */
     public static class FilterContext implements Serializable {
 
-        private VaadinSession session;
+        private VaadinService service;
 
         /**
          * Creates a new context for the given session.
          *
-         * @param session
-         *            the session which is loading dependencies
+         * @param service
+         *            the service which is loading dependencies
          */
-        public FilterContext(VaadinSession session) {
-            this.session = session;
-        }
-
-        /**
-         * Gets the related Vaadin session.
-         *
-         * @return the Vaadin session
-         */
-        public VaadinSession getSession() {
-            return session;
+        public FilterContext(VaadinService service) {
+            this.service = service;
         }
 
         /**
@@ -84,7 +72,7 @@ public interface DependencyFilter extends Serializable {
          * @return the Vaadin service
          */
         public VaadinService getService() {
-            return session.getService();
+            return service;
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlWriter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlWriter.java
@@ -122,7 +122,7 @@ public class UidlWriter implements Serializable {
 
         encodeChanges(ui, stateChanges);
 
-        populateDependencies(response, session,
+        populateDependencies(response, service,
                 uiInternals.getDependencyList());
 
         if (uiInternals.getConstantPool().hasNewConstants()) {
@@ -148,14 +148,13 @@ public class UidlWriter implements Serializable {
     }
 
     private static void populateDependencies(JsonObject response,
-            VaadinSession session, DependencyList dependencyList) {
+            VaadinService service, DependencyList dependencyList) {
         Collection<Dependency> pendingSendToClient = dependencyList
                 .getPendingSendToClient();
 
-        FilterContext context = new FilterContext(session);
+        FilterContext context = new FilterContext(service);
 
-        for (DependencyFilter filter : session.getService()
-                .getDependencyFilters()) {
+        for (DependencyFilter filter : service.getDependencyFilters()) {
             pendingSendToClient = filter
                     .filter(new ArrayList<>(pendingSendToClient), context);
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/BundleFilterInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/BundleFilterInitializer.java
@@ -46,6 +46,7 @@ import elemental.json.JsonObject;
  * @author Vaadin Ltd.
  */
 public class BundleFilterInitializer implements VaadinServiceInitListener {
+
     private static final String FLOW_BUNDLE_MANIFEST = "vaadin-flow-bundle-manifest.json";
 
     @Override
@@ -59,9 +60,11 @@ public class BundleFilterInitializer implements VaadinServiceInitListener {
         Map<String, Set<String>> importsInBundles = readBundleDependencies(
                 event.getSource());
         if (!importsInBundles.isEmpty()) {
-            if (!importsInBundles.containsKey(BundleDependencyFilter.MAIN_BUNDLE_URL) &&
-                    importsInBundles.values().stream().noneMatch(
-                            importSet ->importSet.contains(BundleDependencyFilter.MAIN_BUNDLE_URL))) {
+            if (!importsInBundles
+                    .containsKey(BundleDependencyFilter.MAIN_BUNDLE_URL)
+                    && importsInBundles.values().stream()
+                            .noneMatch(importSet -> importSet.contains(
+                                    BundleDependencyFilter.MAIN_BUNDLE_URL))) {
                 throw new IllegalArgumentException(String.format(
                         "Attempted to initialize BundleDependencyFilter with an "
                                 + "import to bundle mapping which does not contain the main bundle %s",
@@ -74,12 +77,7 @@ public class BundleFilterInitializer implements VaadinServiceInitListener {
 
     private Map<String, Set<String>> readBundleDependencies(
             VaadinService service) {
-        WebBrowser es6Browser = new WebBrowser() {
-            @Override
-            public boolean isEs6Supported() {
-                return true;
-            }
-        };
+        WebBrowser es6Browser = FakeEs6Browser.get();
         String manifestResource = ApplicationConstants.FRONTEND_PROTOCOL_PREFIX
                 + FLOW_BUNDLE_MANIFEST;
         try (InputStream bundleManifestStream = service

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/FakeEs6Browser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/FakeEs6Browser.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.startup;
+
+import com.vaadin.flow.server.WebBrowser;
+
+/**
+ * Browser instance targeted for server side resolving of resources.
+ */
+public class FakeEs6Browser extends WebBrowser {
+
+    private static FakeEs6Browser instance = new FakeEs6Browser();
+
+    private FakeEs6Browser() {
+        // Singleton, use get()
+    }
+
+    @Override
+    public boolean isEs6Supported() {
+        return true;
+    }
+
+    /**
+     * Gets the singleton instance.
+     *
+     * @return the one and only instance
+     */
+    public static FakeEs6Browser get() {
+        return instance;
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/CompositeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/CompositeTest.java
@@ -44,7 +44,7 @@ public class CompositeTest {
     public static class MyTemplate extends PolymerTemplate<TemplateModel> {
 
         public MyTemplate() {
-            super((clazz, tag) -> new TemplateData("",
+            super((clazz, tag, service) -> new TemplateData("",
                     Jsoup.parse("<dom-module id='div'></dom-module>")));
         }
     }

--- a/flow-server/src/test/java/com/vaadin/flow/component/polymertemplate/DefaultTemplateParserTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/polymertemplate/DefaultTemplateParserTest.java
@@ -45,6 +45,8 @@ import com.vaadin.flow.component.polymertemplate.PolymerTemplateTest.ModelClass;
 import com.vaadin.flow.component.polymertemplate.TemplateParser.TemplateData;
 import com.vaadin.flow.server.DependencyFilter;
 import com.vaadin.flow.server.MockServletServiceSessionSetup;
+import com.vaadin.flow.server.MockServletServiceSessionSetup.TestVaadinServletService;
+import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.shared.ui.Dependency;
 import com.vaadin.flow.shared.ui.Dependency.Type;
 import com.vaadin.flow.shared.ui.LoadMode;
@@ -55,6 +57,7 @@ import net.jcip.annotations.NotThreadSafe;
 public class DefaultTemplateParserTest {
 
     private MockServletServiceSessionSetup mocks;
+    private VaadinService service;
 
     @Tag("foo")
     @HtmlImport("/bar.html")
@@ -81,7 +84,7 @@ public class DefaultTemplateParserTest {
     @Before
     public void setUp() throws Exception {
         mocks = new MockServletServiceSessionSetup();
-
+        service = mocks.getService();
         ServletContext servletContext = mocks.getServletContext();
         Mockito.when(servletContext.getResource("/bar.html"))
                 .thenReturn(new URL("file://bar.html"));
@@ -116,7 +119,8 @@ public class DefaultTemplateParserTest {
     @Test
     public void defaultParser_hasTemplate_returnsContent() {
         TemplateData data = DefaultTemplateParser.getInstance()
-                .getTemplateContent(ImportsInspectTemplate.class, "foo");
+                .getTemplateContent(ImportsInspectTemplate.class, "foo",
+                        service);
         Element element = data.getTemplateElement();
 
         Assert.assertTrue(element.getElementById("foo") != null);
@@ -131,7 +135,8 @@ public class DefaultTemplateParserTest {
                                 .getBytes(StandardCharsets.UTF_8)));
 
         Element element = DefaultTemplateParser.getInstance()
-                .getTemplateContent(RootImportsInspectTemplate.class, "foo")
+                .getTemplateContent(RootImportsInspectTemplate.class, "foo",
+                        service)
                 .getTemplateElement();
 
         Assert.assertTrue(element.getElementById("foo") != null);
@@ -140,7 +145,8 @@ public class DefaultTemplateParserTest {
     @Test
     public void defaultParser_servletPathIsEmpty_returnsContent() {
         Element element = DefaultTemplateParser.getInstance()
-                .getTemplateContent(ImportsInspectTemplate.class, "foo")
+                .getTemplateContent(ImportsInspectTemplate.class, "foo",
+                        service)
                 .getTemplateElement();
 
         Assert.assertTrue(element.getElementById("foo") != null);
@@ -159,7 +165,8 @@ public class DefaultTemplateParserTest {
                                 .getBytes(StandardCharsets.UTF_8)));
 
         Element element = DefaultTemplateParser.getInstance()
-                .getTemplateContent(ImportsInspectTemplate.class, "foo")
+                .getTemplateContent(ImportsInspectTemplate.class, "foo",
+                        service)
                 .getTemplateElement();
 
         Assert.assertTrue(element.getElementById("foo") != null);
@@ -173,7 +180,8 @@ public class DefaultTemplateParserTest {
                                 .getBytes(StandardCharsets.UTF_8)));
 
         Element element = DefaultTemplateParser.getInstance()
-                .getTemplateContent(ImportsInspectTemplate.class, "foo")
+                .getTemplateContent(ImportsInspectTemplate.class, "foo",
+                        service)
                 .getTemplateElement();
         Assert.assertTrue(element.getElementById("foo") != null);
         assertThat("No comments should be present in the parsing result",
@@ -190,8 +198,8 @@ public class DefaultTemplateParserTest {
 
     @Test(expected = IllegalStateException.class)
     public void defaultParser_noTemplate_throws() {
-        DefaultTemplateParser.getInstance()
-                .getTemplateContent(ImportsInspectTemplate.class, "bar1");
+        DefaultTemplateParser.getInstance().getTemplateContent(
+                ImportsInspectTemplate.class, "bar1", service);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -200,8 +208,8 @@ public class DefaultTemplateParserTest {
                 mocks.getServletContext().getResourceAsStream("/bar1.html"))
                 .thenReturn(null);
 
-        DefaultTemplateParser.getInstance()
-                .getTemplateContent(ImportsInspectTemplate.class, "foo");
+        DefaultTemplateParser.getInstance().getTemplateContent(
+                ImportsInspectTemplate.class, "foo", service);
     }
 
     @Test
@@ -215,24 +223,23 @@ public class DefaultTemplateParserTest {
             return list;
         };
 
-        mocks.getService()
-                .setDependencyFilters(Collections.singletonList(filter));
+        TestVaadinServletService service = mocks.getService();
+        service.setDependencyFilters(Collections.singletonList(filter));
 
         TemplateParser parser = DefaultTemplateParser.getInstance();
 
         Element element = parser
-                .getTemplateContent(ImportsInspectTemplate.class, "foo")
+                .getTemplateContent(ImportsInspectTemplate.class, "foo",
+                        service)
                 .getTemplateElement();
         Assert.assertTrue(element.getElementById("foo") != null);
 
-        element = parser
-                .getTemplateContent(RootImportsInspectTemplate.class, "foo")
-                .getTemplateElement();
+        element = parser.getTemplateContent(RootImportsInspectTemplate.class,
+                "foo", service).getTemplateElement();
         Assert.assertTrue(element.getElementById("foo") != null);
 
-        element = parser
-                .getTemplateContent(OtherImportsInspectTemplate.class, "bar")
-                .getTemplateElement();
+        element = parser.getTemplateContent(OtherImportsInspectTemplate.class,
+                "bar", service).getTemplateElement();
         Assert.assertTrue(element.getElementById("bar") != null);
 
         Assert.assertEquals(
@@ -251,8 +258,8 @@ public class DefaultTemplateParserTest {
         mocks.getService()
                 .setDependencyFilters(Collections.singletonList(filter));
 
-        DefaultTemplateParser.getInstance()
-                .getTemplateContent(ImportsInspectTemplate.class, "foo");
+        DefaultTemplateParser.getInstance().getTemplateContent(
+                ImportsInspectTemplate.class, "foo", service);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -269,8 +276,8 @@ public class DefaultTemplateParserTest {
         mocks.getService()
                 .setDependencyFilters(Collections.singletonList(filter));
 
-        DefaultTemplateParser.getInstance()
-                .getTemplateContent(ImportsInspectTemplate.class, "foo");
+        DefaultTemplateParser.getInstance().getTemplateContent(
+                ImportsInspectTemplate.class, "foo", service);
     }
 
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/polymertemplate/PolymerTemplateTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/polymertemplate/PolymerTemplateTest.java
@@ -16,6 +16,12 @@
 
 package com.vaadin.flow.component.polymertemplate;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -27,7 +33,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
-import net.jcip.annotations.NotThreadSafe;
 import org.jsoup.Jsoup;
 import org.junit.After;
 import org.junit.Assert;
@@ -56,12 +61,7 @@ import com.vaadin.flow.templatemodel.TemplateModel;
 
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
+import net.jcip.annotations.NotThreadSafe;
 
 @NotThreadSafe
 public class PolymerTemplateTest extends HasCurrentService {
@@ -87,7 +87,8 @@ public class PolymerTemplateTest extends HasCurrentService {
 
         @Override
         public TemplateData getTemplateContent(
-                Class<? extends PolymerTemplate<?>> clazz, String tag) {
+                Class<? extends PolymerTemplate<?>> clazz, String tag,
+                VaadinService service) {
             callCount++;
             return new TemplateData("",
                     Jsoup.parse(templateProducer.apply(tag)));
@@ -212,7 +213,7 @@ public class PolymerTemplateTest extends HasCurrentService {
             extends PolymerTemplate<ModelClass> {
 
         public BundledTemplateInTemplate() {
-            super((clazz, tag) -> new TemplateData("",
+            super((clazz, tag, service) -> new TemplateData("",
                     Jsoup.parse("<dom-module id='child-template'>"
                             + "<template><ffs></template></dom-module>"
                             + "<dom-module id='ffs'><template></template></dom-module>"
@@ -230,7 +231,7 @@ public class PolymerTemplateTest extends HasCurrentService {
         private TemplateChild child;
 
         public TemplateInjectTemplate() {
-            super((clazz, tag) -> new TemplateData("",
+            super((clazz, tag, service) -> new TemplateData("",
                     Jsoup.parse("<dom-module id='" + tag
                             + "'><template><child-template id='child'></template></dom-module>")));
         }
@@ -243,7 +244,7 @@ public class PolymerTemplateTest extends HasCurrentService {
             extends PolymerTemplate<ModelClass> {
 
         public TemplateWithChildInDomRepeat() {
-            super((clazz, tag) -> new TemplateData("",
+            super((clazz, tag, service) -> new TemplateData("",
                     Jsoup.parse("<dom-module id='" + tag + "'><template><div>"
                             + "<dom-repeat items='[[messages]]'><template><child-template></template></dom-repeat>"
                             + "</div></template></dom-module>")));
@@ -307,7 +308,7 @@ public class PolymerTemplateTest extends HasCurrentService {
         private com.vaadin.flow.dom.Element label;
 
         public IdElementTemplate() {
-            this((clazz, tag) -> new TemplateData("",
+            this((clazz, tag, service) -> new TemplateData("",
                     Jsoup.parse("<dom-module id='" + tag
                             + "'><label id='labelId'></dom-module>")));
         }
@@ -321,7 +322,7 @@ public class PolymerTemplateTest extends HasCurrentService {
     private static class IdWrongElementTemplate extends IdElementTemplate {
 
         public IdWrongElementTemplate() {
-            super((clazz, tag) -> new TemplateData("",
+            super((clazz, tag, service) -> new TemplateData("",
                     Jsoup.parse("<dom-module id='" + tag
                             + "'><div id='foo'></dom-module>")));
         }
@@ -564,7 +565,8 @@ public class PolymerTemplateTest extends HasCurrentService {
 
             @Override
             public TemplateData getTemplateContent(
-                    Class<? extends PolymerTemplate<?>> clazz, String tag) {
+                    Class<? extends PolymerTemplate<?>> clazz, String tag,
+                    VaadinService service) {
                 String content;
                 parserCallCount.incrementAndGet();
                 if (clazz.equals(TemplateInitialization.class)) {

--- a/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/PolymerServerEventHandlersTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/PolymerServerEventHandlersTest.java
@@ -69,7 +69,7 @@ public class PolymerServerEventHandlersTest extends HasCurrentService {
             extends PolymerTemplate<TemplateModel> {
 
         CorrectAnnotationUsage() {
-            super((clazz, tag) -> new TemplateData("",
+            super((clazz, tag, service) -> new TemplateData("",
                     Jsoup.parse("<dom-module id='polymer'></dom-module>")));
         }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/PublishedServerEventHandlerRpcHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/PublishedServerEventHandlerRpcHandlerTest.java
@@ -54,7 +54,8 @@ public class PublishedServerEventHandlerRpcHandlerTest {
         private boolean isInvoked;
 
         ComponentWithMethod() {
-            super((clazz, tag) -> new TemplateData("", new Element("a")));
+            super((clazz, tag, service) -> new TemplateData("",
+                    new Element("a")));
         }
 
         protected void intMethod(int i) {
@@ -73,7 +74,8 @@ public class PublishedServerEventHandlerRpcHandlerTest {
         private boolean isInvoked;
 
         EnabledHandler() {
-            super((clazz, tag) -> new TemplateData("", new Element("div")));
+            super((clazz, tag, service) -> new TemplateData("",
+                    new Element("div")));
         }
 
         @EventHandler(DisabledUpdateMode.ALWAYS)

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/CustomElementsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/CustomElementsTest.java
@@ -103,8 +103,8 @@ public class CustomElementsTest {
         return clazz.getAnnotation(Tag.class).value();
     }
 
-    private static final TemplateParser TEST_PARSER = (clazz,
-            tag) -> new TemplateData("",
+    private static final TemplateParser TEST_PARSER = (clazz, tag,
+            service) -> new TemplateData("",
                     Jsoup.parse("<dom-module id='" + tag + "'></dom-module>"));
 
     @Tag("custom-element")

--- a/flow-server/src/test/java/com/vaadin/flow/templatemodel/TemplateModelTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/templatemodel/TemplateModelTest.java
@@ -250,7 +250,7 @@ public class TemplateModelTest extends HasCurrentService {
     public static class EmptyDivTemplate<M extends TemplateModel>
             extends PolymerTemplate<M> {
         public EmptyDivTemplate() {
-            super((clazz, tag) -> new TemplateData("",
+            super((clazz, tag, service) -> new TemplateData("",
                     Jsoup.parse("<dom-module id='div'></dom-module>")));
         }
 

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/dependencies/FrontendInlineApiView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/dependencies/FrontendInlineApiView.java
@@ -31,7 +31,7 @@ import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 public class FrontendInlineApiView extends PolymerTemplate<TemplateModel> {
 
     public FrontendInlineApiView() {
-        super((clazz, tag) -> new TemplateData(
+        super((clazz, tag, service) -> new TemplateData(
                 "components/frontend-inline-api.html", Jsoup.parse(
                         "<dom-module id='frontend-inline-api'></dom-module>")));
         setId("template");

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/LazyLoadingTemplateView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/LazyLoadingTemplateView.java
@@ -38,7 +38,7 @@ public class LazyLoadingTemplateView extends AbstractDivView {
     @Tag("lazy-widget")
     public static class LazyWidget extends PolymerTemplate<Message> {
         public LazyWidget() {
-            super((clazz, tag) -> new TemplateData("",
+            super((clazz, tag, service) -> new TemplateData("",
                     Jsoup.parse(getTemplateContent())));
             getModel().setText("foo");
         }


### PR DESCRIPTION
VaadinSession data is no longer used for parsing templates on the server
to avoid potential problems when one session is used for parsing and the
parsed result is used with another session

This change removes VaadinSessionn access from dependency filters to avoid
the session only sometimes being available.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3888)
<!-- Reviewable:end -->
