### PR TITLE
Clear the KeyMapper when a new DataProvider is set

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -215,6 +215,7 @@ public class DataCommunicator<T> implements Serializable {
         handleDetach();
 
         reset();
+        getKeyMapper().removeAll();
 
         this.dataProvider = dataProvider;
 
@@ -433,8 +434,10 @@ public class DataCommunicator<T> implements Serializable {
         if (passivated != null) {
             passivated.forEach(key -> {
                 T item = keyMapper.get(key);
-                dataGenerator.destroyData(item);
-                keyMapper.remove(item);
+                if (item != null) {
+                    dataGenerator.destroyData(item);
+                    keyMapper.remove(item);
+                }
             });
         }
     }

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
@@ -171,6 +171,20 @@ public class DataCommunicatorTest {
         Assert.assertNull("Expected no communication after reattach", lastSet);
     }
 
+    @Test
+    public void setDataProvider_keyMapperIsReset() {
+        dataCommunicator.setDataProvider(createDataProvider(), null);
+        dataCommunicator.setRequestedRange(0, 50);
+        fakeClientCommunication();
+
+        Assert.assertEquals("0", dataCommunicator.getKeyMapper().get("1"));
+
+        dataCommunicator.setDataProvider(createDataProvider(), null);
+        Assert.assertNull(
+                "The KeyMapper should be reset when a new DataProvider is set",
+                dataCommunicator.getKeyMapper().get("1"));
+    }
+
     private void fakeClientCommunication() {
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
         ui.getInternals().getStateTree().collectChanges(ignore -> {


### PR DESCRIPTION
This prevents different objects from different DataProviders to be stuck in memory when they should be discarded.

Fix #3783

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3901)
<!-- Reviewable:end -->
