### PR TITLE
Implement filtering for DOM events

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
@@ -18,11 +18,8 @@ package com.vaadin.client.flow.binding;
 import java.util.Objects;
 import java.util.function.Supplier;
 
-import jsinterop.annotations.JsFunction;
-
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.Scheduler;
-
 import com.vaadin.client.Command;
 import com.vaadin.client.Console;
 import com.vaadin.client.ExistingElementMap;
@@ -60,6 +57,7 @@ import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 import elemental.json.JsonValue;
+import jsinterop.annotations.JsFunction;
 
 /**
  * Binding strategy for a simple (not template) {@link Element} node.
@@ -81,16 +79,15 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
     }
 
     /**
-     * Callback interface for an event data expression parsed using new
-     * Function() in JavaScript.
+     * Callback interface for an event expression parsed using new Function() in
+     * JavaScript.
      */
     @FunctionalInterface
     @JsFunction
     @SuppressWarnings("unusable-by-js")
-
-    private interface EventDataExpression {
+    private interface EventExpression {
         /**
-         * Callback interface for an event data expression parsed using new
+         * Callback interface for an event expression parsed using new
          * Function() in JavaScript.
          *
          * @param event
@@ -102,7 +99,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
         JsonValue evaluate(Event event, Element element);
     }
 
-    private static final JsMap<String, EventDataExpression> expressionCache = JsCollections
+    private static final JsMap<String, EventExpression> expressionCache = JsCollections
             .map();
 
     /**
@@ -519,8 +516,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
                 + context.node.getId() + " is not an Element";
         Element element = (Element) context.htmlNode;
 
-        NodeMap visibilityData = context.node
-                .getMap(NodeFeatures.ELEMENT_DATA);
+        NodeMap visibilityData = context.node.getMap(NodeFeatures.ELEMENT_DATA);
         // Store the current "hidden" value to restore it when the element
         // becomes visible
 
@@ -548,8 +544,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
         assert context.htmlNode instanceof Element : "The HTML node for the StateNode with id="
                 + context.node.getId() + " is not an Element";
 
-        NodeMap visibilityData = context.node
-                .getMap(NodeFeatures.ELEMENT_DATA);
+        NodeMap visibilityData = context.node.getMap(NodeFeatures.ELEMENT_DATA);
 
         Element element = (Element) context.htmlNode;
 
@@ -1145,29 +1140,41 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
 
         assert constantPool.has(expressionConstantKey);
 
-        JsArray<String> dataExpressions = constantPool
-                .get(expressionConstantKey);
+        JsonObject expressionSettings = constantPool.get(expressionConstantKey);
+        String[] expressions = expressionSettings.keys();
+
+        boolean noFilters = true;
+        boolean atLeastOneFilterMatched = false;
 
         JsonObject eventData;
-        if (dataExpressions.isEmpty()) {
+        if (expressions.length == 0) {
             eventData = null;
         } else {
             eventData = Json.createObject();
 
-            for (int i = 0; i < dataExpressions.length(); i++) {
-                String expressionString = dataExpressions.get(i);
-
-                EventDataExpression expression = getOrCreateExpression(
+            for (String expressionString : expressions) {
+                EventExpression expression = getOrCreateExpression(
                         expressionString);
 
                 JsonValue expressionValue = expression.evaluate(event,
                         (Element) element);
 
                 eventData.put(expressionString, expressionValue);
+
+                boolean useAsFilter = expressionSettings
+                        .getBoolean(expressionString);
+                if (useAsFilter) {
+                    boolean filterMatched = expressionValue.asBoolean();
+
+                    noFilters = false;
+                    atLeastOneFilterMatched |= filterMatched;
+                }
             }
         }
 
-        node.getTree().sendEventToServer(node, type, eventData);
+        if (noFilters || atLeastOneFilterMatched) {
+            node.getTree().sendEventToServer(node, type, eventData);
+        }
     }
 
     private EventRemover bindClassList(Element element, StateNode node) {
@@ -1205,9 +1212,9 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
                 (Element) context.htmlNode, context.node);
     }
 
-    private static EventDataExpression getOrCreateExpression(
+    private static EventExpression getOrCreateExpression(
             String expressionString) {
-        EventDataExpression expression = expressionCache.get(expressionString);
+        EventExpression expression = expressionCache.get(expressionString);
 
         if (expression == null) {
             expression = NativeFunction.create("event", "element",

--- a/flow-server/src/main/java/com/vaadin/flow/dom/DomListenerRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/DomListenerRegistration.java
@@ -53,6 +53,36 @@ public interface DomListenerRegistration extends Registration {
     DomListenerRegistration addEventData(String eventData);
 
     /**
+     * Sets a JavaScript expression that is used for filtering events to this
+     * listener. When an event is fired in the browser, the expression is
+     * evaluated and an event is sent to the server only if the expression value
+     * is <code>true</code>-ish according to JavaScript type coercion rules. The
+     * expression is evaluated in a context where <code>element</code> refers to
+     * this element and <code>event</code> refers to the fired event.
+     * <p>
+     * An expression might be e.g. <code>event.button === 0</code> to only
+     * forward events triggered by the primary mouse button.
+     * <p>
+     * Any previous filter for this registration is discarded.
+     *
+     * @param filter
+     *            the JavaScript filter expression, or <code>null</code> to
+     *            clear the filter
+     * @return this registration, for chaining
+     */
+    DomListenerRegistration setFilter(String filter);
+
+    /**
+     * Gets the currently set filter expression.
+     *
+     * @see #setFilter(String)
+     *
+     * @return the current filter expression, or <code>null</code> if no filter
+     *         is in use
+     */
+    String getFilter();
+
+    /**
      * Configure whether this listener will be called even in cases when the
      * element is disabled.
      *

--- a/flow-server/src/main/java/com/vaadin/flow/internal/JsonUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JsonUtils.java
@@ -19,6 +19,7 @@ package com.vaadin.flow.internal;
 import java.util.AbstractList;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.BinaryOperator;
@@ -250,5 +251,24 @@ public final class JsonUtils {
      */
     public static JsonArray createArray(JsonValue... values) {
         return Stream.of(values).collect(asArray());
+    }
+
+    /**
+     * Converts the given map into a JSON object by converting each map value to
+     * a JSON value.
+     *
+     * @param map
+     *            the map to convert into a JSON object
+     * @param itemToJson
+     *            callback for converting map values to JSON
+     * @return the created object
+     */
+    public static <T> JsonObject createObject(Map<String, T> map,
+            Function<T, JsonValue> itemToJson) {
+        JsonObject object = Json.createObject();
+
+        map.forEach((key, value) -> object.put(key, itemToJson.apply(value)));
+
+        return object;
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/JsonUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/JsonUtilsTest.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.internal;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
@@ -22,8 +24,6 @@ import java.util.stream.Stream;
 
 import org.junit.Assert;
 import org.junit.Test;
-
-import com.vaadin.flow.internal.JsonUtils;
 
 import elemental.json.Json;
 import elemental.json.JsonArray;
@@ -199,6 +199,35 @@ public class JsonUtilsTest {
         JsonArray array = JsonUtils.createArray();
 
         Assert.assertEquals(0, array.length());
+    }
+
+    @Test
+    public void createObject() {
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("integer", Integer.valueOf(3));
+        map.put("string", "foo");
+
+        JsonObject object = JsonUtils.createObject(map, item -> {
+            if (item instanceof Integer) {
+                return Json.create(((Integer) item).doubleValue());
+            } else {
+                return Json.create(String.valueOf(item));
+            }
+        });
+
+        Assert.assertEquals(2, object.keys().length);
+        Assert.assertEquals(3, object.getNumber("integer"), 0);
+        Assert.assertEquals("foo", object.getString("string"));
+    }
+
+    @Test
+    public void testCreateEmptyObject() {
+        JsonObject object = JsonUtils.createObject(Collections.emptyMap(),
+                item -> {
+                    throw new AssertionError("Callback should not be called");
+                });
+
+        Assert.assertEquals(0, object.keys().length);
     }
 
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DomEventFilterView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DomEventFilterView.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+@Route(value = "com.vaadin.flow.uitest.ui.DomEventFilterView", layout = ViewTestLayout.class)
+public class DomEventFilterView extends AbstractDivView {
+    private final Element messages = new Element("div");
+
+    public DomEventFilterView() {
+        Element input = new Element("input");
+        input.setAttribute("id", "input");
+
+        input.addEventListener("keypress",
+                e -> addMessage("Space listener triggered"))
+                .setFilter("event.key == ' '");
+
+        messages.setAttribute("id", "messages");
+        getElement().appendChild(input, messages);
+    }
+
+    private void addMessage(String message) {
+        Element element = new Element("div");
+        element.setText(message);
+        messages.appendChild(element);
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DomEventFilterIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DomEventFilterIT.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class DomEventFilterIT extends ChromeBrowserTest {
+
+    @Test
+    public void filtering() {
+        open();
+
+        WebElement findElement = findElement(By.id("input"));
+
+        findElement.sendKeys("asdf");
+
+        Assert.assertEquals(0, getMessages().size());
+
+        findElement.sendKeys("foo  bar");
+
+        Assert.assertEquals(2, getMessages().size());
+    }
+
+    private List<WebElement> getMessages() {
+        WebElement messagesHolder = findElement(By.id("messages"));
+        List<WebElement> messages = messagesHolder
+                .findElements(By.cssSelector("div"));
+        return messages;
+    }
+}


### PR DESCRIPTION
The existing "event data" expressions feature is enhanced to also
include filter expressions, along with a boolean for each expression to
indicate whether that expressions should be used as a filter or not. The
value of filter expressions is sent back to the server in the same way
as regular data expressions, and then those are matched for true-ish
values when determining which listeners to notify.

This is an intermediate step for #468.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3912)
<!-- Reviewable:end -->
