### PR TITLE
Add a fingerprint to bundled files to avoid cache issues

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/common/FrontendDataProvider.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/common/FrontendDataProvider.java
@@ -48,6 +48,8 @@ public class FrontendDataProvider {
 
     private final boolean shouldBundle;
     private final boolean shouldMinify;
+    private final boolean shouldHash;
+
     private final Map<String, Set<File>> fragments;
     private final Set<File> shellFileImports;
 
@@ -58,6 +60,7 @@ public class FrontendDataProvider {
      *            whether bundling data should be prepared
      * @param shouldMinify
      *            whether the output files should be minified
+     * @param hash
      * @param es6SourceDirectory
      *            the directory with original ES6 files, not {@code null}
      * @param annotationValuesExtractor
@@ -71,12 +74,13 @@ public class FrontendDataProvider {
      *            without external configuration file, not {@code null}
      */
     public FrontendDataProvider(boolean shouldBundle, boolean shouldMinify,
-            File es6SourceDirectory,
+            boolean shouldHash, File es6SourceDirectory,
             AnnotationValuesExtractor annotationValuesExtractor,
             File fragmentConfigurationFile,
             Map<String, Set<String>> userDefinedFragments) {
         this.shouldBundle = shouldBundle;
         this.shouldMinify = shouldMinify;
+        this.shouldHash = shouldHash;
         fragments = shouldBundle
                 ? resolveFragmentFiles(es6SourceDirectory,
                         fragmentConfigurationFile, userDefinedFragments)
@@ -106,6 +110,17 @@ public class FrontendDataProvider {
      */
     public boolean shouldMinify() {
         return shouldMinify;
+    }
+
+
+    /**
+     * Gets the information whether should the plugin rename the output files by adding
+     * a hash fragment.
+     *
+     * @return {@code true} if renaming of fragments to include a hash part should be performed
+     */
+    public boolean shouldHash() {
+        return shouldHash;
     }
 
     /**

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/common/FrontendDataProvider.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/common/FrontendDataProvider.java
@@ -60,7 +60,8 @@ public class FrontendDataProvider {
      *            whether bundling data should be prepared
      * @param shouldMinify
      *            whether the output files should be minified
-     * @param hash
+     * @param shouldHash
+     *            whether the output file names should containt a fingerprint
      * @param es6SourceDirectory
      *            the directory with original ES6 files, not {@code null}
      * @param annotationValuesExtractor

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/common/FrontendToolsManager.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/common/FrontendToolsManager.java
@@ -168,6 +168,7 @@ public class FrontendToolsManager {
                 .put("{es6_configuration_name}", es6OutputDirectoryName)
                 .put("{bundle}", Boolean.toString(frontendDataProvider.shouldBundle()))
                 .put("{minify}", Boolean.toString(frontendDataProvider.shouldMinify()))
+                .put("{hash}", Boolean.toString(frontendDataProvider.shouldHash()))
                 .put("{shell_file}", frontendDataProvider.createShellFile(workingDirectory))
                 .put("{fragment_files}", combineFilePathsIntoString(frontendDataProvider.createFragmentFiles(workingDirectory)));
         createFileFromTemplateResource("gulpfile.js", gulpFileParameters.build());

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PackageForProductionMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PackageForProductionMojo.java
@@ -79,6 +79,9 @@ public class PackageForProductionMojo extends AbstractMojo {
     @Parameter(property = "minify", defaultValue = "true", required = true)
     private boolean minify;
 
+    @Parameter(property = "hash", defaultValue = "true", required = true)
+    private boolean hash;
+
     @Parameter(property = "bundleConfiguration", defaultValue = "${project.basedir}/bundle-configuration.json")
     private File bundleConfiguration;
 
@@ -103,7 +106,7 @@ public class PackageForProductionMojo extends AbstractMojo {
     @Override
     public void execute() {
         FrontendDataProvider frontendDataProvider = new FrontendDataProvider(
-                bundle, minify, transpileEs6SourceDirectory,
+                bundle, minify, hash, transpileEs6SourceDirectory,
                 new AnnotationValuesExtractor(getProjectClassPathUrls()),
                 bundleConfiguration, getFragmentsData(fragments));
         FrontendToolsManager frontendToolsManager = new FrontendToolsManager(

--- a/flow-maven-plugin/src/main/resources/package.json
+++ b/flow-maven-plugin/src/main/resources/package.json
@@ -18,7 +18,9 @@
     "polymer-build": "2.1.1",
     "merge-stream": "1.0.1",
     "vinyl": "2.1.0",
-    "parse5": "4.0.0"
+    "parse5": "4.0.0",
+    "gulp-tap": "^1.0.1",
+    "hasha": "^3.0.0"
   },
   "author": "Vaadin Ltd.",
   "license": "Apache-2.0",

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/common/FrontendDataProviderTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/common/FrontendDataProviderTest.java
@@ -77,7 +77,7 @@ public class FrontendDataProviderTest {
                 AnnotationValuesExtractor annotationValuesExtractor,
                 File fragmentConfigurationFile,
                 Map<String, Set<String>> userDefinedFragments) {
-            super(shouldBundle, shouldMinify, es6SourceDirectory,
+            super(shouldBundle, shouldMinify, false, es6SourceDirectory,
                     annotationValuesExtractor, fragmentConfigurationFile,
                     userDefinedFragments);
         }


### PR DESCRIPTION
Each fragment is suffixed with `hash.cache.html` where `hash` is a fingerprint based on the content of the file, hence it's always the same unless the content changes for some reason, and the `cache` suffix is added in order to server side sets correctly control cache headers to be cached for a long time.

maven plugin has now a new parameter `hash` which when false disables renaming bundles.

Original filename is still maintained in file name, but it might be eventually be removed if there is a strong reason for obfuscating the name.

Fixes #3501

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3918)
<!-- Reviewable:end -->
