### PR TITLE
All components do not support removeAttribute.

### DIFF
--- a/flow-components-parent/flow-code-generator-api/src/main/java/com/vaadin/generator/ComponentGenerator.java
+++ b/flow-components-parent/flow-code-generator-api/src/main/java/com/vaadin/generator/ComponentGenerator.java
@@ -630,7 +630,9 @@ public class ComponentGenerator {
         removeMethod.setBody(
                 String.format("for (Component component : components) {%n"
                         + "if (getElement().equals(component.getElement().getParent())) {%n"
+                        + "if(component.getElement().hasAttribute(\"slot\")) {%n"
                         + "component.getElement().removeAttribute(\"slot\");%n"
+                        + "}%n"
                         + "getElement().removeChild(component.getElement());%n "
                         + "}%n" + "else {%n"
                         + "throw new IllegalArgumentException(\"The given component (\" + component + \") is not a child of this component\");%n"
@@ -653,7 +655,8 @@ public class ComponentGenerator {
         setMethodVisibility(removeAllMethod);
 
         removeAllMethod.setBody(String.format(
-                "getElement().getChildren().forEach(child -> child.removeAttribute(\"slot\"));%n"
+                "getElement().getChildren().forEach(child -> {%nif(child.hasAttribute(\"slot\")) {%n"
+                        + "child.removeAttribute(\"slot\");%n}%n});%n"
                         + "getElement().removeAllChildren();"));
         if (useOverrideAnnotation) {
             removeAllMethod.addAnnotation(Override.class);

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/button/GeneratedVaadinButton.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/button/GeneratedVaadinButton.java
@@ -219,7 +219,9 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
     protected void remove(Component... components) {
         for (Component component : components) {
             if (getElement().equals(component.getElement().getParent())) {
-                component.getElement().removeAttribute("slot");
+                if (component.getElement().hasAttribute("slot")) {
+                    component.getElement().removeAttribute("slot");
+                }
                 getElement().removeChild(component.getElement());
             } else {
                 throw new IllegalArgumentException("The given component ("
@@ -234,8 +236,11 @@ public abstract class GeneratedVaadinButton<R extends GeneratedVaadinButton<R>>
      * this component using the {@link Element} API.
      */
     protected void removeAll() {
-        getElement().getChildren()
-                .forEach(child -> child.removeAttribute("slot"));
+        getElement().getChildren().forEach(child -> {
+            if (child.hasAttribute("slot")) {
+                child.removeAttribute("slot");
+            }
+        });
         getElement().removeAllChildren();
     }
 

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/combobox/GeneratedVaadinComboBox.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/combobox/GeneratedVaadinComboBox.java
@@ -1010,7 +1010,9 @@ public abstract class GeneratedVaadinComboBox<R extends GeneratedVaadinComboBox<
     protected void remove(Component... components) {
         for (Component component : components) {
             if (getElement().equals(component.getElement().getParent())) {
-                component.getElement().removeAttribute("slot");
+                if (component.getElement().hasAttribute("slot")) {
+                    component.getElement().removeAttribute("slot");
+                }
                 getElement().removeChild(component.getElement());
             } else {
                 throw new IllegalArgumentException("The given component ("
@@ -1025,8 +1027,11 @@ public abstract class GeneratedVaadinComboBox<R extends GeneratedVaadinComboBox<
      * this component using the {@link Element} API.
      */
     protected void removeAll() {
-        getElement().getChildren()
-                .forEach(child -> child.removeAttribute("slot"));
+        getElement().getChildren().forEach(child -> {
+            if (child.hasAttribute("slot")) {
+                child.removeAttribute("slot");
+            }
+        });
         getElement().removeAllChildren();
     }
 }

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePicker.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/datepicker/GeneratedVaadinDatePicker.java
@@ -1157,7 +1157,9 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
     protected void remove(Component... components) {
         for (Component component : components) {
             if (getElement().equals(component.getElement().getParent())) {
-                component.getElement().removeAttribute("slot");
+                if (component.getElement().hasAttribute("slot")) {
+                    component.getElement().removeAttribute("slot");
+                }
                 getElement().removeChild(component.getElement());
             } else {
                 throw new IllegalArgumentException("The given component ("
@@ -1172,8 +1174,11 @@ public abstract class GeneratedVaadinDatePicker<R extends GeneratedVaadinDatePic
      * this component using the {@link Element} API.
      */
     protected void removeAll() {
-        getElement().getChildren()
-                .forEach(child -> child.removeAttribute("slot"));
+        getElement().getChildren().forEach(child -> {
+            if (child.hasAttribute("slot")) {
+                child.removeAttribute("slot");
+            }
+        });
         getElement().removeAllChildren();
     }
 }

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/formlayout/GeneratedVaadinFormItem.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/formlayout/GeneratedVaadinFormItem.java
@@ -202,7 +202,9 @@ public abstract class GeneratedVaadinFormItem<R extends GeneratedVaadinFormItem<
     protected void remove(Component... components) {
         for (Component component : components) {
             if (getElement().equals(component.getElement().getParent())) {
-                component.getElement().removeAttribute("slot");
+                if (component.getElement().hasAttribute("slot")) {
+                    component.getElement().removeAttribute("slot");
+                }
                 getElement().removeChild(component.getElement());
             } else {
                 throw new IllegalArgumentException("The given component ("
@@ -217,8 +219,11 @@ public abstract class GeneratedVaadinFormItem<R extends GeneratedVaadinFormItem<
      * this component using the {@link Element} API.
      */
     protected void removeAll() {
-        getElement().getChildren()
-                .forEach(child -> child.removeAttribute("slot"));
+        getElement().getChildren().forEach(child -> {
+            if (child.hasAttribute("slot")) {
+                child.removeAttribute("slot");
+            }
+        });
         getElement().removeAllChildren();
     }
 }

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/notification/GeneratedVaadinNotificationContainer.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/notification/GeneratedVaadinNotificationContainer.java
@@ -261,7 +261,9 @@ public abstract class GeneratedVaadinNotificationContainer<R extends GeneratedVa
     protected void remove(Component... components) {
         for (Component component : components) {
             if (getElement().equals(component.getElement().getParent())) {
-                component.getElement().removeAttribute("slot");
+                if (component.getElement().hasAttribute("slot")) {
+                    component.getElement().removeAttribute("slot");
+                }
                 getElement().removeChild(component.getElement());
             } else {
                 throw new IllegalArgumentException("The given component ("
@@ -276,8 +278,11 @@ public abstract class GeneratedVaadinNotificationContainer<R extends GeneratedVa
      * this component using the {@link Element} API.
      */
     protected void removeAll() {
-        getElement().getChildren()
-                .forEach(child -> child.removeAttribute("slot"));
+        getElement().getChildren().forEach(child -> {
+            if (child.hasAttribute("slot")) {
+                child.removeAttribute("slot");
+            }
+        });
         getElement().removeAllChildren();
     }
 }

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/splitlayout/GeneratedVaadinSplitLayout.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/splitlayout/GeneratedVaadinSplitLayout.java
@@ -322,7 +322,9 @@ public abstract class GeneratedVaadinSplitLayout<R extends GeneratedVaadinSplitL
     protected void remove(Component... components) {
         for (Component component : components) {
             if (getElement().equals(component.getElement().getParent())) {
-                component.getElement().removeAttribute("slot");
+                if (component.getElement().hasAttribute("slot")) {
+                    component.getElement().removeAttribute("slot");
+                }
                 getElement().removeChild(component.getElement());
             } else {
                 throw new IllegalArgumentException("The given component ("
@@ -337,8 +339,11 @@ public abstract class GeneratedVaadinSplitLayout<R extends GeneratedVaadinSplitL
      * this component using the {@link Element} API.
      */
     protected void removeAll() {
-        getElement().getChildren()
-                .forEach(child -> child.removeAttribute("slot"));
+        getElement().getChildren().forEach(child -> {
+            if (child.hasAttribute("slot")) {
+                child.removeAttribute("slot");
+            }
+        });
         getElement().removeAllChildren();
     }
 }

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextArea.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextArea.java
@@ -849,7 +849,9 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
     protected void remove(Component... components) {
         for (Component component : components) {
             if (getElement().equals(component.getElement().getParent())) {
-                component.getElement().removeAttribute("slot");
+                if (component.getElement().hasAttribute("slot")) {
+                    component.getElement().removeAttribute("slot");
+                }
                 getElement().removeChild(component.getElement());
             } else {
                 throw new IllegalArgumentException("The given component ("
@@ -864,8 +866,11 @@ public abstract class GeneratedVaadinTextArea<R extends GeneratedVaadinTextArea<
      * this component using the {@link Element} API.
      */
     protected void removeAll() {
-        getElement().getChildren()
-                .forEach(child -> child.removeAttribute("slot"));
+        getElement().getChildren().forEach(child -> {
+            if (child.hasAttribute("slot")) {
+                child.removeAttribute("slot");
+            }
+        });
         getElement().removeAllChildren();
     }
 }

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextField.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/textfield/GeneratedVaadinTextField.java
@@ -967,7 +967,9 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
     protected void remove(Component... components) {
         for (Component component : components) {
             if (getElement().equals(component.getElement().getParent())) {
-                component.getElement().removeAttribute("slot");
+                if (component.getElement().hasAttribute("slot")) {
+                    component.getElement().removeAttribute("slot");
+                }
                 getElement().removeChild(component.getElement());
             } else {
                 throw new IllegalArgumentException("The given component ("
@@ -982,8 +984,11 @@ public abstract class GeneratedVaadinTextField<R extends GeneratedVaadinTextFiel
      * this component using the {@link Element} API.
      */
     protected void removeAll() {
-        getElement().getChildren()
-                .forEach(child -> child.removeAttribute("slot"));
+        getElement().getChildren().forEach(child -> {
+            if (child.hasAttribute("slot")) {
+                child.removeAttribute("slot");
+            }
+        });
         getElement().removeAllChildren();
     }
 }

--- a/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/upload/GeneratedVaadinUpload.java
+++ b/flow-components-parent/flow-generated-components/src/main/java/com/vaadin/flow/component/upload/GeneratedVaadinUpload.java
@@ -1376,7 +1376,9 @@ public abstract class GeneratedVaadinUpload<R extends GeneratedVaadinUpload<R>>
     protected void remove(Component... components) {
         for (Component component : components) {
             if (getElement().equals(component.getElement().getParent())) {
-                component.getElement().removeAttribute("slot");
+                if (component.getElement().hasAttribute("slot")) {
+                    component.getElement().removeAttribute("slot");
+                }
                 getElement().removeChild(component.getElement());
             } else {
                 throw new IllegalArgumentException("The given component ("
@@ -1391,8 +1393,11 @@ public abstract class GeneratedVaadinUpload<R extends GeneratedVaadinUpload<R>>
      * this component using the {@link Element} API.
      */
     protected void removeAll() {
-        getElement().getChildren()
-                .forEach(child -> child.removeAttribute("slot"));
+        getElement().getChildren().forEach(child -> {
+            if (child.hasAttribute("slot")) {
+                child.removeAttribute("slot");
+            }
+        });
         getElement().removeAllChildren();
     }
 }


### PR DESCRIPTION
When removing child components we should
check that the child has the attribute before
trying to remove it. For instance a TextProvider
will fail with an exception for removeAttribute.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3949)
<!-- Reviewable:end -->
