### PR TITLE
Return incorrect HTML dependencies if constructor is run without service available

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentMetaData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentMetaData.java
@@ -218,7 +218,10 @@ public class ComponentMetaData {
         // (VaadinServletService) as the methods are only using the servlet
         // context
         VaadinService service = VaadinService.getCurrent();
-        assert service != null;
+        if (service == null) {
+            return new HtmlImportDependency(Collections.emptySet(),
+                    htmlImport.loadMode());
+        }
         return new HtmlImportDependency(parser.parseDependencies(service),
                 htmlImport.loadMode());
     }

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/ComponentWithHtmlDeps.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/ComponentWithHtmlDeps.java
@@ -1,0 +1,11 @@
+package com.vaadin.flow.component.internal;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.HtmlImport;
+
+@HtmlImport("foobar.html")
+@Tag("foo-bar")
+public class ComponentWithHtmlDeps extends Component {
+
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/HtmlDependencyParserTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/HtmlDependencyParserTest.java
@@ -19,15 +19,19 @@ import static org.junit.Assert.assertEquals;
 
 import java.net.URI;
 import java.util.Collection;
+import java.util.List;
 
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.internal.ComponentMetaData.HtmlImportDependency;
 import com.vaadin.flow.server.MockServletServiceSessionSetup;
 import com.vaadin.flow.server.MockServletServiceSessionSetup.TestVaadinServlet;
 import com.vaadin.flow.server.MockServletServiceSessionSetup.TestVaadinServletService;
+import com.vaadin.flow.server.VaadinService;
 
 import net.jcip.annotations.NotThreadSafe;
 
@@ -200,6 +204,25 @@ public class HtmlDependencyParserTest {
                     normalize(protocol
                             + "://src/views/login/../../../bower_components/vaadin-button/src/vaadin-button.html"));
         }
+
+    }
+
+    @Test
+    public void createComponentWithoutServiceSucceedsButPopulatesGlobalCacheWithWrongMetadata() {
+        VaadinService.setCurrent(null);
+        new ComponentWithHtmlDeps();
+        List<HtmlImportDependency> imports = ComponentUtil
+                .getDependencies(ComponentWithHtmlDeps.class).getHtmlImports();
+        Assert.assertEquals(1, imports.size());
+
+        // This should not really happen
+        Assert.assertEquals(0, imports.get(0).getUris().size());
+
+        // This is what should happen when the underlying issue is fixed
+        // (it happens when service != null)
+        // Assert.assertEquals(1, imports.get(0).getUris().size());
+        // Assert.assertEquals("frontend://foobar.html",
+        // imports.get(0).getUris().iterator().next());
 
     }
 


### PR DESCRIPTION
As requested to make broken tests pass

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3963)
<!-- Reviewable:end -->
