### PR TITLE
Cache component dependencies separately for each service

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
@@ -36,6 +36,7 @@ import com.vaadin.flow.i18n.LocaleChangeObserver;
 import com.vaadin.flow.internal.ReflectionCache;
 import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.internal.nodefeature.VirtualChildrenList;
+import com.vaadin.flow.server.VaadinService;
 
 /**
  * Utility methods for {@link Component}.
@@ -396,13 +397,16 @@ public class ComponentUtil {
      * {@link HtmlImport}, {@link JavaScript}, {@link StyleSheet} and
      * {@link Uses}).
      *
+     * @param service
+     *            the service to use for resolving dependencies
      * @param componentClass
      *            the component class to check
      * @return the dependencies for the given class
      */
-    public static DependencyInfo getDependencies(
+    public static DependencyInfo getDependencies(VaadinService service,
             Class<? extends Component> componentClass) {
-        return componentMetaDataCache.get(componentClass).getDependencyInfo();
+        return componentMetaDataCache.get(componentClass)
+                .getDependencyInfo(service);
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -750,7 +750,7 @@ public class UIInternals implements Serializable {
             Class<? extends Component> componentClass) {
         Page page = ui.getPage();
         DependencyInfo dependencies = ComponentUtil
-                .getDependencies(componentClass);
+                .getDependencies(session.getService(), componentClass);
         dependencies.getHtmlImports().stream()
                 .forEach(html -> addHtmlImport(html, page));
         dependencies.getJavaScripts()

--- a/flow-server/src/main/java/com/vaadin/flow/internal/ReflectionCache.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/ReflectionCache.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.internal;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
@@ -38,24 +39,49 @@ public class ReflectionCache<C, T> {
 
     private final ConcurrentHashMap<Class<? extends C>, T> values = new ConcurrentHashMap<>();
 
-    private final Function<? extends Class<C>, T> valueProvider;
+    private final Function<Class<? extends C>, T> valueProvider;
 
     /**
      * Creates a new reflection cache with the given value provider. The value
      * provider will be used to produce a new cached value whenever there is a
-     * cache miss.
+     * cache miss. It will be run in a context where no {@link CurrentInstance}
+     * is available to prevent accidentally caching values that are computed
+     * differently depending on external circumstances.
      *
      * @param valueProvider
      *            a function that computes the cached value for a class, not
      *            <code>null</code>
      */
-    public ReflectionCache(Function<? extends Class<C>, T> valueProvider) {
+    public ReflectionCache(Function<Class<C>, T> valueProvider) {
         if (valueProvider == null) {
             throw new IllegalArgumentException("value provider cannot be null");
         }
-        this.valueProvider = valueProvider;
+        this.valueProvider = wrapValueProvider(valueProvider);
 
         caches.add(this);
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private static <C, T> Function<Class<? extends C>, T> wrapValueProvider(
+            Function<Class<C>, T> valueProvider) {
+        return type -> {
+            Map<Class<?>, CurrentInstance> instances = CurrentInstance
+                    .getInstances();
+            try {
+                CurrentInstance.clearAll();
+
+                /*
+                 * Raw cast to deal with weird generics of valueProvider which
+                 * in turn is there to deal with the fact that javac in some
+                 * cases cannot infer type parameters for Foo::new as a
+                 * Function<Class<? extends C>, T> even when Foo has a
+                 * constructor that takes Class<? extends Something>.
+                 */
+                return (T) ((Function) valueProvider).apply(type);
+            } finally {
+                CurrentInstance.restoreInstances(instances);
+            }
+        };
     }
 
     /**
@@ -67,16 +93,8 @@ public class ReflectionCache<C, T> {
      *            the type for which to get reflection results
      * @return the reflection results
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     public T get(Class<? extends C> type) {
-        /*
-         * Raw cast since the mapping function is declared to accept <? super
-         * K>, which in this case becomes <? super Class<?>>, which isn't
-         * compatible with Class<C>.
-         */
-        Object value = values.computeIfAbsent(type, (Function) valueProvider);
-        // Explicit cast since javac doesn't agree with ecj
-        return (T) value;
+        return values.computeIfAbsent(type, valueProvider);
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
@@ -49,6 +49,7 @@ import com.vaadin.flow.server.MockServletServiceSessionSetup;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.shared.ui.Dependency;
+import com.vaadin.tests.util.MockUI;
 import com.vaadin.tests.util.TestUtil;
 
 import elemental.json.Json;
@@ -1053,7 +1054,7 @@ public class ComponentTest {
     @Test
     public void usesComponent() {
         UsesComponentWithDependencies s = new UsesComponentWithDependencies();
-        UI ui = new UI();
+        UI ui = new MockUI();
         ui.getInternals().addComponentDependencies(s.getClass());
 
         Map<String, Dependency> pendingDependencies = getDependenciesMap(
@@ -1072,7 +1073,7 @@ public class ComponentTest {
 
     @Test
     public void usesChain() {
-        UIInternals internals = new UI().getInternals();
+        UIInternals internals = new MockUI().getInternals();
         internals.addComponentDependencies(
                 UsesUsesComponentWithDependencies.class);
         Map<String, Dependency> pendingDependencies = getDependenciesMap(
@@ -1093,7 +1094,7 @@ public class ComponentTest {
 
     @Test
     public void circularDependencies() {
-        UIInternals internals = new UI().getInternals();
+        UIInternals internals = new MockUI().getInternals();
         DependencyList dependencyList = internals.getDependencyList();
 
         internals.addComponentDependencies(CircularDependencies1.class);
@@ -1106,7 +1107,7 @@ public class ComponentTest {
         assertDependency(Dependency.Type.JAVASCRIPT, "dep2.js",
                 pendingDependencies);
 
-        internals = new UI().getInternals();
+        internals = new MockUI().getInternals();
         dependencyList = internals.getDependencyList();
         internals.addComponentDependencies(CircularDependencies2.class);
         pendingDependencies = getDependenciesMap(

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/HtmlDependencyParserTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/HtmlDependencyParserTest.java
@@ -19,19 +19,15 @@ import static org.junit.Assert.assertEquals;
 
 import java.net.URI;
 import java.util.Collection;
-import java.util.List;
 
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.vaadin.flow.component.ComponentUtil;
-import com.vaadin.flow.component.internal.ComponentMetaData.HtmlImportDependency;
 import com.vaadin.flow.server.MockServletServiceSessionSetup;
 import com.vaadin.flow.server.MockServletServiceSessionSetup.TestVaadinServlet;
 import com.vaadin.flow.server.MockServletServiceSessionSetup.TestVaadinServletService;
-import com.vaadin.flow.server.VaadinService;
 
 import net.jcip.annotations.NotThreadSafe;
 
@@ -204,25 +200,6 @@ public class HtmlDependencyParserTest {
                     normalize(protocol
                             + "://src/views/login/../../../bower_components/vaadin-button/src/vaadin-button.html"));
         }
-
-    }
-
-    @Test
-    public void createComponentWithoutServiceSucceedsButPopulatesGlobalCacheWithWrongMetadata() {
-        VaadinService.setCurrent(null);
-        new ComponentWithHtmlDeps();
-        List<HtmlImportDependency> imports = ComponentUtil
-                .getDependencies(ComponentWithHtmlDeps.class).getHtmlImports();
-        Assert.assertEquals(1, imports.size());
-
-        // This should not really happen
-        Assert.assertEquals(0, imports.get(0).getUris().size());
-
-        // This is what should happen when the underlying issue is fixed
-        // (it happens when service != null)
-        // Assert.assertEquals(1, imports.get(0).getUris().size());
-        // Assert.assertEquals("frontend://foobar.html",
-        // imports.get(0).getUris().iterator().next());
 
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/internal/ReflectionCacheTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/ReflectionCacheTest.java
@@ -92,4 +92,26 @@ public class ReflectionCacheTest {
         cache1 = null;
         Assert.assertTrue(TestUtil.isGarbageCollected(ref));
     }
+
+    @Test
+    public void currentInstancesNotAvailable() {
+        String currentString = "My string";
+        CurrentInstance.set(String.class, currentString);
+
+        ReflectionCache<Object, String> cache = new ReflectionCache<>(
+                type -> type.getSimpleName() + ": "
+                        + CurrentInstance.get(String.class));
+
+        try {
+            String result = cache.get(Object.class);
+
+            Assert.assertEquals("Current instance should not be in the result",
+                    "Object: null", result);
+            Assert.assertEquals(
+                    "Current instance should be preserved after running",
+                    currentString, CurrentInstance.get(String.class));
+        } finally {
+            CurrentInstance.set(String.class, null);
+        }
+    }
 }


### PR DESCRIPTION
It's in theory not necessary to cache separately for each service since
any service (of the same type) should produce the same result. What is
necessary is to avoid caching the dummy result produced when there is no
service at all.

Also adds protection in ReflectionCache to avoid accidentally relying on
any current instance when computing cache values.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3967)
<!-- Reviewable:end -->
