### PR TITLE
Add navigation shorthands for Class navigation.

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -43,6 +43,7 @@ import com.vaadin.flow.router.AfterNavigationListener;
 import com.vaadin.flow.router.BeforeEnterListener;
 import com.vaadin.flow.router.BeforeLeaveListener;
 import com.vaadin.flow.router.EventUtil;
+import com.vaadin.flow.router.HasUrlParameter;
 import com.vaadin.flow.router.Location;
 import com.vaadin.flow.router.NavigationTrigger;
 import com.vaadin.flow.router.QueryParameters;
@@ -681,6 +682,48 @@ public class UI extends Component
     public Optional<ThemeDefinition> getThemeFor(Class<?> navigationTarget,
             String path) {
         return getRouter().getRegistry().getThemeFor(navigationTarget, path);
+    }
+
+    /**
+     * Updates this UI to show the view corresponding to the given navigation
+     * target.
+     * <p>
+     * Besides the navigation to the {@code location} this method also updates
+     * the browser location (and page history).
+     * 
+     * @param navigationTarget
+     *            navigation target to navigate to
+     */
+    public void navigate(Class<? extends Component> navigationTarget) {
+        String routeUrl = getRouter().getUrl(navigationTarget);
+        navigate(routeUrl);
+    }
+
+    /**
+     * Updates this UI to show the view corresponding to the given navigation
+     * target with the specified parameter. The parameter needs to be the same
+     * as defined in the route target HasUrlParameter.
+     * <p>
+     * Besides the navigation to the {@code location} this method also updates
+     * the browser location (and page history).
+     * <p>
+     * Note! A {@code null} parameter will be handled the same as
+     * navigate(navigationTarget) and will throw an exception if HasUrlParameter
+     * is not @OptionalParameter or @WildcardParameter.
+     * 
+     * @param navigationTarget
+     *            navigation target to navigate to
+     * @param parameter
+     *            parameter to pass to view
+     * @param <T>
+     *            url parameter type
+     * @param <C>
+     *            navigation target type
+     */
+    public <T, C extends Component & HasUrlParameter<T>> void navigate(
+            Class<? extends C> navigationTarget, T parameter) {
+        String routeUrl = getRouter().getUrl(navigationTarget, parameter);
+        navigate(routeUrl);
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
@@ -2753,6 +2753,70 @@ public class RouterTest extends RoutingTestBase {
                 AfterNavigationTarget.events.get(1));
     }
 
+    @Test // #3616
+    public void navigating_with_class_gets_correct_component()
+            throws InvalidRouteConfigurationException {
+        setNavigationTargets(RootNavigationTarget.class,
+                FooNavigationTarget.class, FooBarNavigationTarget.class);
+
+        ui.navigate(RootNavigationTarget.class);
+        Assert.assertEquals(RootNavigationTarget.class, getUIComponent());
+
+        ui.navigate(FooNavigationTarget.class);
+        Assert.assertEquals(FooNavigationTarget.class, getUIComponent());
+
+        ui.navigate(FooBarNavigationTarget.class);
+        Assert.assertEquals(FooBarNavigationTarget.class, getUIComponent());
+    }
+
+    @Test // #3616
+    public void navigating_with_class_and_parameter_gets_correct_component()
+            throws InvalidRouteConfigurationException {
+        setNavigationTargets(RouteWithParameter.class, BooleanParameter.class,
+                WildParameter.class, OptionalParameter.class);
+
+        ui.navigate(RouteWithParameter.class, "Parameter");
+        Assert.assertEquals(RouteWithParameter.class, getUIComponent());
+        Assert.assertEquals("Before navigation event was wrong.", "Parameter",
+                RouteWithParameter.param);
+
+        ui.navigate(OptionalParameter.class, "optional");
+        Assert.assertEquals(OptionalParameter.class, getUIComponent());
+        Assert.assertEquals("Before navigation event was wrong.", "optional",
+                OptionalParameter.param);
+        ui.navigate(OptionalParameter.class);
+        Assert.assertEquals(OptionalParameter.class, getUIComponent());
+        Assert.assertEquals("Before navigation event was wrong.", null,
+                OptionalParameter.param);
+        ui.navigate(OptionalParameter.class, null);
+        Assert.assertEquals(OptionalParameter.class, getUIComponent());
+        Assert.assertEquals("Before navigation event was wrong.", null,
+                OptionalParameter.param);
+
+        ui.navigate(BooleanParameter.class, false);
+        Assert.assertEquals(BooleanParameter.class, getUIComponent());
+        Assert.assertEquals("Before navigation event was wrong.", false,
+                BooleanParameter.param);
+
+        ui.navigate(WildParameter.class);
+        Assert.assertEquals(WildParameter.class, getUIComponent());
+        Assert.assertEquals("Before navigation event was wrong.", "",
+                WildParameter.param);
+        ui.navigate(WildParameter.class, null);
+        Assert.assertEquals(WildParameter.class, getUIComponent());
+        Assert.assertEquals("Before navigation event was wrong.", "",
+                WildParameter.param);
+        ui.navigate(WildParameter.class, "");
+        Assert.assertEquals(WildParameter.class, getUIComponent());
+        Assert.assertEquals("Before navigation event was wrong.", "",
+                WildParameter.param);
+        ui.navigate(WildParameter.class, "my/wild/param");
+        Assert.assertEquals(WildParameter.class, getUIComponent());
+        Assert.assertEquals("Before navigation event was wrong.",
+                "my/wild/param", WildParameter.param);
+
+    }
+
     private void setNavigationTargets(
             Class<? extends Component>... navigationTargets)
             throws InvalidRouteConfigurationException {

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
@@ -1200,6 +1200,7 @@ public class RouterTest extends RoutingTestBase {
     @Test
     public void before_navigation_event_is_triggered()
             throws InvalidRouteConfigurationException {
+        FooBarNavigationTarget.events.clear();
         setNavigationTargets(RootNavigationTarget.class,
                 FooNavigationTarget.class, FooBarNavigationTarget.class);
 


### PR DESCRIPTION
Now it is possible to programmatically navigate using
the navigationTarget class instead of having to create
or generate the url for the targer route.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3972)
<!-- Reviewable:end -->
