### PR TITLE
Change push default to WEBSOCKET_XHR

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Push.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Push.java
@@ -54,6 +54,6 @@ public @interface Push {
      *
      * @return the transport type to use
      */
-    Transport transport() default Transport.WEBSOCKET;
+    Transport transport() default Transport.WEBSOCKET_XHR;
 
 }


### PR DESCRIPTION
This is closer to what people expect, i.e. all HTTP request/response
related methods are available but background pushes use websocket

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3990)
<!-- Reviewable:end -->
