### PR TITLE
Implement AbstractField

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/AbstractField.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/AbstractField.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component;
+
+import java.util.Objects;
+
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.shared.Registration;
+
+/**
+ * An abstract implementation of a field, or a {@code Component} allowing user
+ * input. Implements {@link HasValue} to represent the input value. Examples of
+ * typical field components include text fields, date pickers, and check boxes.
+ * <p>
+ * The field value is represented in two separate ways:
+ * <ol>
+ * <li>A presentation value that is shown to the user. This is typically
+ * represented in the component's server-side DOM element or through child
+ * components.
+ * <li>A model value that is available for programmatic use through the
+ * {@link HasValue} interface. This representation is handled by this class and
+ * should not be directly accessed by subclasses.
+ * </ol>
+ * <p>
+ * In order to keep the two value representations in sync with each other,
+ * subclasses must take care of the two following things:
+ * <ol>
+ * <li>Listen to changes from the user, and call
+ * {@link #setModelValue(Object, boolean)} with an updated value.
+ * <li>Implement {@link #setPresentationValue(Object)} to update the
+ * presentation value of the component so that the new value is shown to the
+ * user.
+ * </ol>
+ * See the detailed documentation for the two methods for further details.
+ *
+ * @author Vaadin Ltd
+ * @param <C>
+ *            the source type for value change events
+ * @param <T>
+ *            the value type
+ */
+public abstract class AbstractField<C extends AbstractField<C, T>, T>
+        extends Component implements HasValue<C, T>, HasEnabled {
+
+    private final T initialValue;
+
+    private T bufferedValue;
+
+    private boolean presentationUpdateInProgress;
+
+    private boolean valueSetFromPresentationUpdate;
+
+    private T pendingValueFromPresentation;
+
+    /**
+     * Creates a new field with an element created based on the {@link Tag}
+     * annotation of the sub class. The provided initial value is by default
+     * also used as {@link #getEmptyValue()}.
+     *
+     * @param initialValue
+     *            the initial value
+     */
+    public AbstractField(T initialValue) {
+        super();
+
+        this.initialValue = initialValue;
+        bufferedValue = initialValue;
+    }
+
+    /**
+     * Creates a new field with the given element instance. The provided initial
+     * value is by default also used as {@link #getEmptyValue()}.
+     *
+     * @param element
+     *            the root element for the component
+     * @param initialValue
+     *            the initial value
+     */
+    public AbstractField(Element element, T initialValue) {
+        super(element);
+
+        this.initialValue = initialValue;
+        bufferedValue = initialValue;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Registration addValueChangeListener(
+            HasValue.ValueChangeListener<C, T> listener) {
+        @SuppressWarnings("rawtypes")
+        ComponentEventListener componentListener = event -> {
+            ValueChangeEvent<C, T> valueChangeEvent = (ValueChangeEvent<C, T>) event;
+            listener.onComponentEvent(valueChangeEvent);
+        };
+        return addListener(ValueChangeEvent.class, componentListener);
+    }
+
+    @Override
+    public void setValue(T value) {
+        setValue(value, false, false);
+    }
+
+    private void setValue(T newValue, boolean fromInternal,
+            boolean fromClient) {
+        if (fromClient && isReadOnly()) {
+            applyValue(bufferedValue);
+            return;
+        }
+
+        T oldValue = this.getValue();
+
+        if (valueEquals(newValue, oldValue)) {
+            return;
+        }
+
+        this.bufferedValue = newValue;
+
+        if (!fromInternal) {
+            boolean pendingInternalUpdated;
+            try {
+                pendingInternalUpdated = applyValue(newValue);
+            } catch (RuntimeException e) {
+                this.bufferedValue = oldValue;
+                throw e;
+            }
+
+            if (pendingInternalUpdated) {
+                if (valueEquals(pendingValueFromPresentation, oldValue)) {
+                    bufferedValue = oldValue;
+                    return;
+                }
+                this.bufferedValue = pendingValueFromPresentation;
+            }
+        }
+
+        fireEvent(createValueChange(oldValue, fromClient));
+    }
+
+    private boolean applyValue(T value) {
+        presentationUpdateInProgress = true;
+        valueSetFromPresentationUpdate = false;
+
+        try {
+            setPresentationValue(value);
+        } finally {
+            presentationUpdateInProgress = false;
+        }
+
+        return valueSetFromPresentationUpdate;
+    }
+
+    private ValueChangeEvent<C, T> createValueChange(T oldValue,
+            boolean fromClient) {
+        @SuppressWarnings("unchecked")
+        C thisC = (C) this;
+
+        return new ValueChangeEvent<>(thisC, this, oldValue, fromClient);
+    }
+
+    /**
+     * Updates the presentation of this field to display the provided value.
+     * Subclasses should override this method to show the value to the user.
+     * This is typically done by setting an element property or by applying
+     * changes to child components.
+     * <p>
+     * If {@link #setModelValue(Object, boolean)} is called from within this
+     * method, then value of the last invocation will be used as the model value
+     * instead of the value passed to this method. In this case
+     * {@link #setPresentationValue(Object)} will not be called again. Changing
+     * the provided value might be useful if the provided value is sanitized.
+     *
+     * @param newPresentationValue
+     *            the new value to show
+     */
+    protected abstract void setPresentationValue(T newPresentationValue);
+
+    /**
+     * Updates the model value if the value has actually changed. Subclasses
+     * should call this method whenever the user has changed the value. A value
+     * change event is fired if the new value is different from the previous
+     * value according to {@link #valueEquals(Object, Object)}.
+     * <p>
+     * If the value is from the client-side and this field is in readonly mode,
+     * then the new model value will be ignored.
+     * {@link #setPresentationValue(Object)} will be called with the previous
+     * model value so that the representation shown to the user can be reverted.
+     *
+     * @param newModelValue
+     *            the new internal value to use
+     * @param fromClient
+     *            <code>true</code> if the new value originates from the client;
+     *            otherwise <code>false</code>
+     */
+    protected void setModelValue(T newModelValue, boolean fromClient) {
+        if (presentationUpdateInProgress) {
+            valueSetFromPresentationUpdate = true;
+            pendingValueFromPresentation = newModelValue;
+            return;
+        }
+        setValue(newModelValue, true, fromClient);
+    }
+
+    /**
+     * Compares to value instances to each other to determine whether they are
+     * equal. Equality is used to determine whether to update internal state and
+     * fire an event when {@link #setValue(Object)} or
+     * {@link #setModelValue(Object, boolean)} is called. Subclasses can
+     * override this method to define an alternative comparison method instead
+     * of {@link Objects#equals(Object)}.
+     *
+     * @param value1
+     *            the first instance
+     * @param value2
+     *            the second instance
+     * @return <code>true</code> if the instances are equal; otherwise
+     *         <code>false</code>
+     */
+    protected boolean valueEquals(T value1, T value2) {
+        return Objects.equals(value1, value2);
+    }
+
+    @Override
+    public T getValue() {
+        return bufferedValue;
+    }
+
+    @Override
+    public void setRequiredIndicatorVisible(boolean requiredIndicatorVisible) {
+        getElement().setProperty("required", requiredIndicatorVisible);
+    }
+
+    @Override
+    public boolean isRequiredIndicatorVisible() {
+        return getElement().getProperty("required", false);
+    }
+
+    @Override
+    public void setReadOnly(boolean readOnly) {
+        getElement().setProperty("readonly", readOnly);
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return getElement().getProperty("readonly", false);
+    }
+
+    @Override
+    public T getEmptyValue() {
+        return initialValue;
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/AbstractFieldTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/AbstractFieldTest.java
@@ -1,0 +1,534 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiPredicate;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.HasValue.ValueChangeEvent;
+import com.vaadin.flow.dom.Element;
+
+public class AbstractFieldTest {
+    // This isn't a test in itself, but it shows that no more than one method
+    // needs to be overridden
+    private static class SimpleAbstractField<T>
+            extends AbstractField<SimpleAbstractField<T>, T> {
+
+        public SimpleAbstractField() {
+            super(null);
+        }
+
+        @Override
+        protected void setPresentationValue(T value) {
+        }
+    }
+
+    @Tag("tag")
+    private static class TestAbstractField<T>
+            extends AbstractField<TestAbstractField<T>, T> {
+
+        public TestAbstractField() {
+            this(null);
+        }
+
+        public TestAbstractField(T initialValue) {
+            super(initialValue);
+        }
+
+        T presentationValue;
+
+        Consumer<T> setPresentationValue = value -> presentationValue = value;
+
+        BiPredicate<T, T> valueEquals;
+        Supplier<T> emptyValue;
+
+        @Override
+        protected void setPresentationValue(T value) {
+            setPresentationValue.accept(value);
+        }
+
+        @Override
+        protected boolean valueEquals(T value1, T value2) {
+            if (valueEquals != null) {
+                return valueEquals.test(value1, value2);
+            } else {
+                return super.valueEquals(value1, value2);
+            }
+        }
+
+        @Override
+        public T getEmptyValue() {
+            if (emptyValue != null) {
+                return emptyValue.get();
+            } else {
+                return super.getEmptyValue();
+            }
+        }
+
+        public void updatePresentationValue(T value, boolean fromClient) {
+            this.presentationValue = value;
+            setModelValue(value, fromClient);
+        }
+
+        @Override
+        public void setModelValue(T value, boolean fromClient) {
+            super.setModelValue(value, fromClient);
+        }
+
+        public void valueUpdatedFromClient(boolean fromClient) {
+            super.setModelValue(presentationValue, fromClient);
+        }
+    }
+
+    private static class EventMonitor<T> {
+
+        private TestAbstractField<T> observable;
+
+        public EventMonitor(TestAbstractField<T> obserable) {
+            this.observable = obserable;
+
+            obserable.addValueChangeListener(event -> {
+                if (capturedEvent != null) {
+                    Assert.fail("There is already an event. Old event: "
+                            + capturedEvent + ", new event: " + event);
+                }
+
+                Assert.assertSame(obserable, event.getSource());
+
+                capturedEvent = event;
+            });
+        }
+
+        ValueChangeEvent<TestAbstractField<T>, T> capturedEvent;
+
+        public void discard() {
+            Assert.assertNotNull("There should be an event", capturedEvent);
+            capturedEvent = null;
+        }
+
+        public void assertEvent(boolean fromClient, T oldValue, T newValue) {
+            Assert.assertNotNull("There should be an event", capturedEvent);
+            Assert.assertTrue(fromClient == capturedEvent.isFromClient());
+
+            assertEventValues(capturedEvent, oldValue, newValue);
+
+            discard();
+        }
+
+        public void assertNoEvent() {
+            Assert.assertNull("There should be no event", capturedEvent);
+        }
+    }
+
+    private static <T> void assertEventValues(ValueChangeEvent<?, T> event,
+            T oldValue, T newValue) {
+        Assert.assertEquals(oldValue, event.getOldValue());
+        Assert.assertEquals(newValue, event.getValue());
+    }
+
+    private static void assertNoEvents(HasValue<?, ?> observable) {
+        observable.addValueChangeListener(
+                event -> Assert.fail("Got unexpected event: " + event));
+    }
+
+    @Test
+    public void initialValue_used() {
+        TestAbstractField<String> field = new TestAbstractField<>("foo");
+
+        Assert.assertEquals("foo", field.getValue());
+    }
+
+    @Test
+    public void emptyValue_sameAsInitial() {
+        TestAbstractField<String> field = new TestAbstractField<>("foo");
+
+        Assert.assertEquals("foo", field.getEmptyValue());
+
+        field.setValue("bar");
+
+        Assert.assertEquals(
+                "Empty value shouldn't change when value is changed", "foo",
+                field.getEmptyValue());
+    }
+
+    @Test
+    public void initialValue_defaultNull() {
+        TestAbstractField<String> field = new TestAbstractField<>();
+
+        Assert.assertNull(field.getValue());
+        Assert.assertNull(field.getEmptyValue());
+    }
+
+    @Test
+    public void setValue_differentValue_firesOneEvent() {
+        TestAbstractField<String> field = new TestAbstractField<>();
+        EventMonitor<String> eventMonitor = new EventMonitor<>(field);
+
+        field.setValue("Foo");
+
+        eventMonitor.assertEvent(false, null, "Foo");
+        Assert.assertEquals("Foo", field.presentationValue);
+    }
+
+    @Test
+    public void setValue_sameValue_firesNoEvent() {
+        TestAbstractField<String> field = new TestAbstractField<>();
+        EventMonitor<String> eventMonitor = new EventMonitor<>(field);
+
+        field.setValue(field.getValue());
+
+        eventMonitor.assertNoEvent();
+    }
+
+    @Test
+    public void clear_firesIfNotEmpty() {
+        TestAbstractField<String> field = new TestAbstractField<>();
+        EventMonitor<String> eventMonitor = new EventMonitor<>(field);
+
+        field.clear();
+        eventMonitor.assertNoEvent();
+
+        field.setValue("foo");
+        eventMonitor.discard();
+        Assert.assertFalse(field.isEmpty());
+
+        field.clear();
+        eventMonitor.assertEvent(false, "foo", null);
+        Assert.assertTrue(field.isEmpty());
+
+        field.clear();
+        eventMonitor.assertNoEvent();
+    }
+
+    @Test
+    public void clear_customEmptyValue_emptyValueUsed() {
+        TestAbstractField<String> field = new TestAbstractField<>();
+        field.emptyValue = () -> "";
+
+        Assert.assertFalse(field.isEmpty());
+
+        field.clear();
+        Assert.assertTrue(field.isEmpty());
+        Assert.assertEquals("", field.getValue());
+    }
+
+    @Test
+    public void updateFromClient_differentValue_updatesAndFires() {
+        TestAbstractField<String> field = new TestAbstractField<>();
+        EventMonitor<String> eventMonitor = new EventMonitor<>(field);
+
+        field.updatePresentationValue("foo", true);
+        eventMonitor.assertEvent(true, null, "foo");
+
+        field.updatePresentationValue("foo", true);
+        eventMonitor.assertNoEvent();
+    }
+
+    @Test
+    public void customEquals() {
+        TestAbstractField<Integer> field = new TestAbstractField<>();
+        field.valueEquals = (value1, value2) -> value1 == value2;
+
+        Integer value1 = new Integer(0);
+        Integer value2 = new Integer(0);
+
+        field.setValue(value1);
+
+        EventMonitor<Integer> eventMonitor = new EventMonitor<>(field);
+
+        field.setValue(value1);
+        eventMonitor.assertNoEvent();
+
+        field.setValue(value2);
+        eventMonitor.assertEvent(false, value1, value2);
+
+        field.updatePresentationValue(value2, true);
+        eventMonitor.assertNoEvent();
+
+        field.updatePresentationValue(value1, true);
+        eventMonitor.assertEvent(true, value2, value1);
+    }
+
+    @Test
+    public void getValue_changesAfterUpdatedFromClient() {
+        TestAbstractField<String> field = new TestAbstractField<>();
+        Assert.assertNull(field.getValue());
+
+        field.presentationValue = "foo";
+        Assert.assertNull(field.getValue());
+
+        field.valueUpdatedFromClient(false);
+        Assert.assertEquals("foo", field.getValue());
+    }
+
+    @Test
+    public void setPresentation_setSameValue_notRunAgain() {
+        TestAbstractField<String> field = new TestAbstractField<>();
+        AtomicReference<String> lastWriteValue = new AtomicReference<>();
+        field.setPresentationValue = value -> {
+            Assert.assertNull("Unexpected update",
+                    lastWriteValue.getAndSet(value));
+            field.presentationValue = value;
+        };
+
+        field.setValue("foo");
+        Assert.assertEquals("foo", lastWriteValue.get());
+
+        lastWriteValue.set(null);
+
+        field.setValue("foo");
+        Assert.assertNull(lastWriteValue.get());
+    }
+
+    @Test
+    public void updatePresentation_doesntCallSetPresentation() {
+        TestAbstractField<String> field = new TestAbstractField<>();
+        field.setPresentationValue = value -> Assert
+                .fail("setPresentationValue should not run");
+
+        field.updatePresentationValue("foo", true);
+        Assert.assertEquals("foo", field.getValue());
+    }
+
+    @Test
+    public void setPresentation_throws_sameException_valuePreserved() {
+        TestAbstractField<String> field = new TestAbstractField<>();
+        EventMonitor<String> eventMonitor = new EventMonitor<>(field);
+
+        field.setPresentationValue = value -> {
+            throw new IllegalStateException(value);
+        };
+
+        try {
+            field.setValue("foo");
+            Assert.fail("Exception should have been thrown");
+        } catch (IllegalStateException e) {
+            Assert.assertEquals("foo", e.getMessage());
+        }
+
+        eventMonitor.assertNoEvent();
+        Assert.assertNull(field.getValue());
+    }
+
+    @Test
+    public void setPresentation_partialUpdates_onlyOneEvent() {
+        TestAbstractField<String> field = new TestAbstractField<>();
+        EventMonitor<String> eventMonitor = new EventMonitor<>(field);
+
+        field.setPresentationValue = value -> {
+            /*
+             * Emulate a situation where multiple element properties are
+             * modified, each firing its own value change event
+             */
+            field.updatePresentationValue("temp value", true);
+            field.updatePresentationValue(value, true);
+        };
+
+        field.setValue("foo");
+        eventMonitor.assertEvent(false, null, "foo");
+        Assert.assertEquals("foo", field.getValue());
+    }
+
+    @Test
+    public void setPresentation_changesValue_onlyOneEvent() {
+        TestAbstractField<String> field = new TestAbstractField<>();
+        EventMonitor<String> eventMonitor = new EventMonitor<>(field);
+
+        field.setPresentationValue = value -> {
+            field.setPresentationValue = value2 -> Assert
+                    .fail("setPresentationValue should not be called again");
+
+            field.updatePresentationValue(value.toUpperCase(Locale.ROOT),
+                    false);
+        };
+
+        field.setValue("foo");
+        eventMonitor.assertEvent(false, null, "FOO");
+        Assert.assertEquals("FOO", field.getValue());
+    }
+
+    @Test
+    public void setPresentation_revertsValue_noEvent() {
+        TestAbstractField<String> field = new TestAbstractField<>();
+        EventMonitor<String> eventMonitor = new EventMonitor<>(field);
+
+        field.setPresentationValue = value -> {
+            field.setPresentationValue = value2 -> Assert
+                    .fail("setPresentationValue should not be called again");
+            field.valueUpdatedFromClient(false);
+        };
+
+        field.setValue("foo");
+        eventMonitor.assertNoEvent();
+
+        Assert.assertNull(field.getValue());
+    }
+
+    @Test
+    public void setValueInEventHandler() {
+        TestAbstractField<String> field = new TestAbstractField<>();
+
+        List<ValueChangeEvent<TestAbstractField<String>, String>> beforeEvents = new ArrayList<>();
+        List<ValueChangeEvent<TestAbstractField<String>, String>> afterEvents = new ArrayList<>();
+
+        field.addValueChangeListener(beforeEvents::add);
+        field.addValueChangeListener(event -> {
+            event.getSource().setValue("bar");
+        });
+        field.addValueChangeListener(afterEvents::add);
+
+        field.setValue("foo");
+
+        Assert.assertEquals(2, beforeEvents.size());
+        assertEventValues(beforeEvents.get(0), null, "foo");
+        assertEventValues(beforeEvents.get(1), "foo", "bar");
+
+        // Does not make sense, but still testing so we know how it works
+        // Also, this is how Vaadin 8 works, and nobody has been too upset
+        Assert.assertEquals(2, afterEvents.size());
+        assertEventValues(afterEvents.get(0), "foo", "bar");
+        assertEventValues(afterEvents.get(1), null, "foo");
+    }
+
+    @Test
+    public void requiredIndicator_writtenToElement() {
+        TestAbstractField<String> field = new TestAbstractField<>();
+        Element element = field.getElement();
+
+        Assert.assertFalse(element.getProperty("required", false));
+
+        field.setRequiredIndicatorVisible(true);
+        Assert.assertTrue(element.getProperty("required", false));
+
+        field.setRequiredIndicatorVisible(false);
+        Assert.assertFalse(element.getProperty("required", false));
+    }
+
+    @Test
+    public void requiredIndicator_readFromElement() {
+        TestAbstractField<String> field = new TestAbstractField<>();
+        Element element = field.getElement();
+
+        Assert.assertFalse(field.isRequiredIndicatorVisible());
+
+        element.setProperty("required", true);
+        Assert.assertTrue(field.isRequiredIndicatorVisible());
+
+        element.setProperty("required", false);
+        Assert.assertFalse(field.isRequiredIndicatorVisible());
+    }
+
+    @Test
+    public void readonly_writtenToElement() {
+        TestAbstractField<String> field = new TestAbstractField<>();
+        Element element = field.getElement();
+
+        Assert.assertFalse(element.getProperty("readonly", false));
+
+        field.setReadOnly(true);
+        Assert.assertTrue(element.getProperty("readonly", false));
+
+        field.setReadOnly(false);
+        Assert.assertFalse(element.getProperty("readonly", false));
+    }
+
+    @Test
+    public void readonly_readFromElement() {
+        TestAbstractField<String> field = new TestAbstractField<>();
+        Element element = field.getElement();
+
+        Assert.assertFalse(field.isReadOnly());
+
+        element.setProperty("readonly", true);
+        Assert.assertTrue(field.isReadOnly());
+
+        element.setProperty("readonly", false);
+        Assert.assertFalse(field.isReadOnly());
+    }
+
+    @Test
+    public void readonly_setValue_accepted() {
+        TestAbstractField<String> field = new TestAbstractField<>();
+        EventMonitor<String> eventMonitor = new EventMonitor<>(field);
+        field.setReadOnly(true);
+
+        field.setValue("foo");
+
+        eventMonitor.discard();
+        Assert.assertEquals("foo", field.presentationValue);
+        Assert.assertEquals("foo", field.getValue());
+    }
+
+    @Test
+    public void readonly_presentationFromClient_reverted() {
+        TestAbstractField<String> field = new TestAbstractField<>();
+        EventMonitor<String> eventMonitor = new EventMonitor<>(field);
+        field.setReadOnly(true);
+
+        field.updatePresentationValue("foo", true);
+
+        eventMonitor.assertNoEvent();
+        Assert.assertEquals(null, field.getValue());
+        Assert.assertEquals(null, field.presentationValue);
+    }
+
+    @Test
+    public void readonly_presentationFromServer_accepted() {
+        TestAbstractField<String> field = new TestAbstractField<>();
+        EventMonitor<String> eventMonitor = new EventMonitor<>(field);
+        field.setReadOnly(true);
+
+        field.updatePresentationValue("foo", false);
+
+        eventMonitor.discard();
+        Assert.assertEquals("foo", field.presentationValue);
+        Assert.assertEquals("foo", field.getValue());
+    }
+
+    @Test
+    public void noOwnPublicApi() {
+        for (Method method : AbstractField.class.getMethods()) {
+            if (method.getDeclaringClass() == AbstractField.class) {
+                boolean matchInSupertype = Stream
+                        .concat(Stream.of(AbstractField.class.getSuperclass()),
+                                Stream.of(AbstractField.class.getInterfaces()))
+                        .anyMatch(superType -> {
+                            try {
+                                superType.getMethod(method.getName(),
+                                        method.getParameterTypes());
+                                return true;
+                            } catch (NoSuchMethodException ignore) {
+                                return false;
+                            }
+                        });
+                if (!matchInSupertype) {
+                    Assert.fail("Own public method: " + method);
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
This is the first step towards making the HasValue interface independent
of the Component API to fix the issues described in #383 and #3834.

Upcoming steps will:
* Introduce AbstractSinglePropertyField for binding a value to a single
element property
* Update the component generator to use AbstractSinglePropertyField
instead of HasValue
* Remove HasValue default implementations that are based on the
Component API
* Simplify the generic type parameters related to value change listeners
* Introduce AbstractCompositeField for creating HasValue component that
is a Composite of any component

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/3991)
<!-- Reviewable:end -->
