### PR TITLE
Make abstract field classes serializable

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/AbstractFieldSupport.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/AbstractFieldSupport.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.internal;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 import com.vaadin.flow.component.AbstractCompositeField;
@@ -39,7 +40,8 @@ import com.vaadin.flow.shared.Registration;
  * @param <T>
  *            the value type
  */
-public class AbstractFieldSupport<C extends Component & HasValue<C, T>, T> {
+public class AbstractFieldSupport<C extends Component & HasValue<C, T>, T>
+        implements Serializable {
     private final T defaultValue;
     private final C component;
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/AbstractCompositeFieldTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/AbstractCompositeFieldTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component;
 
+import org.apache.commons.lang3.SerializationUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -121,4 +122,16 @@ public class AbstractCompositeFieldTest {
         field.rest.setValue("Vaadin");
         Assert.assertEquals("Hello Vaadin", field.getValue());
     }
+
+    @Test
+    public void serializable() {
+        ReverseCaseField field = new ReverseCaseField();
+        field.addValueChangeListener(ignore -> {
+        });
+        field.setValue("foo");
+
+        ReverseCaseField anotherField = SerializationUtils.roundtrip(field);
+        Assert.assertEquals("foo", anotherField.getValue());
+    }
+
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/AbstractFieldTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/AbstractFieldTest.java
@@ -21,16 +21,17 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiPredicate;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.SerializationUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
 import com.vaadin.flow.component.HasValue.ValueChangeEvent;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.function.SerializableBiPredicate;
+import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.function.SerializableSupplier;
 import com.vaadin.tests.PublicApiAnalyzer;
 
 public class AbstractFieldTest {
@@ -62,10 +63,10 @@ public class AbstractFieldTest {
 
         T presentationValue;
 
-        Consumer<T> setPresentationValue = value -> presentationValue = value;
+        SerializableConsumer<T> setPresentationValue = value -> presentationValue = value;
 
-        BiPredicate<T, T> valueEquals;
-        Supplier<T> emptyValue;
+        SerializableBiPredicate<T, T> valueEquals;
+        SerializableSupplier<T> emptyValue;
 
         @Override
         protected void setPresentationValue(T value) {
@@ -482,6 +483,18 @@ public class AbstractFieldTest {
                 .findNewPublicMethods(AbstractField.class)
                 .collect(Collectors.toList());
         Assert.assertEquals(Collections.emptyList(), newPublicMethods);
+    }
+
+    @Test
+    public void serializable() {
+        TestAbstractField<String> field = new TestAbstractField<>();
+        field.addValueChangeListener(ignore -> {
+        });
+        field.setValue("foo");
+
+        TestAbstractField<String> anotherField = SerializationUtils
+                .roundtrip(field);
+        Assert.assertEquals("foo", anotherField.getValue());
     }
 
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/AbstractSinglePropertyFieldTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/AbstractSinglePropertyFieldTest.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.SerializationUtils;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -364,6 +365,17 @@ public class AbstractSinglePropertyFieldTest {
                 .findNewPublicMethods(AbstractSinglePropertyField.class)
                 .collect(Collectors.toList());
         Assert.assertEquals(Collections.emptyList(), newPublicMethods);
+    }
+
+    @Test
+    public void serializable() {
+        StringField field = new StringField();
+        field.addValueChangeListener(ignore -> {
+        });
+        field.setValue("foo");
+
+        StringField anotherField = SerializationUtils.roundtrip(field);
+        Assert.assertEquals("foo", anotherField.getValue());
     }
 
 }


### PR DESCRIPTION
Serializability still requires the value type to be serializable, which
isn't required by the API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4014)
<!-- Reviewable:end -->
