### PR TITLE
Use dash separated property name for the default event

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/AbstractSinglePropertyField.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/AbstractSinglePropertyField.java
@@ -27,6 +27,7 @@ import com.vaadin.flow.dom.PropertyChangeEvent;
 import com.vaadin.flow.function.SerializableBiFunction;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableFunction;
+import com.vaadin.flow.shared.util.SharedUtil;
 
 /**
  * Abstract field that is based on a single element property.
@@ -213,7 +214,8 @@ public class AbstractSinglePropertyField<C extends AbstractField<C, T>, T>
         element.addPropertyChangeListener(propertyName,
                 this::handlePropertyChange);
 
-        doSetSynchronizedEvent(propertyName + "-changed");
+        doSetSynchronizedEvent(
+                SharedUtil.camelCaseToDashSeparated(propertyName) + "-changed");
     }
 
     @SuppressWarnings("unchecked")

--- a/flow-server/src/test/java/com/vaadin/flow/component/AbstractSinglePropertyFieldTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/AbstractSinglePropertyFieldTest.java
@@ -36,8 +36,13 @@ public class AbstractSinglePropertyFieldTest {
     @Tag("tag")
     public static class StringField
             extends AbstractSinglePropertyField<StringField, String> {
+
+        public StringField(String synchronizedPropertyName) {
+            super(synchronizedPropertyName, "", false);
+        }
+
         public StringField() {
-            super("property", "", false);
+            this("property");
         }
 
         // Exposed as public for testing purposes
@@ -127,6 +132,16 @@ public class AbstractSinglePropertyFieldTest {
         List<String> synchronizedProperties = stringField
                 .getSynchronizedEvents();
         Assert.assertEquals(Arrays.asList(), synchronizedProperties);
+    }
+
+    @Test
+    public void synchronizedEvent_camelCaseProperty_dashCaseEvent() {
+        StringField stringField = new StringField("immediateValue");
+
+        List<String> synchronizedProperties = stringField
+                .getSynchronizedEvents();
+        Assert.assertEquals(Arrays.asList("immediate-value-changed"),
+                synchronizedProperties);
     }
 
     @Tag("tag")


### PR DESCRIPTION
Fixes #4012

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4015)
<!-- Reviewable:end -->
