### PR TITLE
Make it possible to fire events for any component

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/AbstractCompositeField.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/AbstractCompositeField.java
@@ -52,7 +52,7 @@ public abstract class AbstractCompositeField<C extends Component, S extends Abst
         S thisAsS = (S) this;
 
         fieldSupport = new AbstractFieldSupport<>(thisAsS, defaultValue,
-                this::valueEquals, this::setPresentationValue, this::fireEvent);
+                this::valueEquals, this::setPresentationValue);
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/component/AbstractField.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/AbstractField.java
@@ -98,7 +98,7 @@ public abstract class AbstractField<C extends AbstractField<C, T>, T>
         @SuppressWarnings("unchecked")
         C thisC = (C) this;
         return new AbstractFieldSupport<>(thisC, defaultValue,
-                this::valueEquals, this::setPresentationValue, this::fireEvent);
+                this::valueEquals, this::setPresentationValue);
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/component/Component.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Component.java
@@ -331,6 +331,8 @@ public abstract class Component
     /**
      * Dispatches the event to all listeners registered for the event type.
      *
+     * @see ComponentUtil#fireEvent(Component, ComponentEvent)
+     *
      * @param componentEvent
      *            the event to fire
      */

--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
@@ -221,9 +221,8 @@ public class ComponentUtil {
 
         AttachEvent attachEvent = new AttachEvent(component, initialAttach);
         component.onAttach(attachEvent);
-        if (component.hasListener(AttachEvent.class)) {
-            component.getEventBus().fireEvent(attachEvent);
-        }
+        fireEvent(component, attachEvent);
+
         // inform component about onEnabledState if new state differs from
         // internal state
         if (component instanceof HasEnabled
@@ -254,9 +253,8 @@ public class ComponentUtil {
 
         DetachEvent detachEvent = new DetachEvent(component);
         component.onDetach(detachEvent);
-        if (component.hasListener(DetachEvent.class)) {
-            component.getEventBus().fireEvent(detachEvent);
-        }
+        fireEvent(component, detachEvent);
+
         // inform component about onEnabledState if parent and child states
         // differ.
         if (component instanceof HasEnabled
@@ -309,6 +307,21 @@ public class ComponentUtil {
         }
 
         return true;
+    }
+
+    /**
+     * Dispatches the event to all listeners registered for the event type.
+     *
+     * @see Component#fireEvent(ComponentEvent)
+     * 
+     * @param component
+     *            the component for which to fire events
+     * @param componentEvent
+     *            the event to fire
+     */
+    public static <T extends Component> void fireEvent(T component,
+            ComponentEvent<? extends T> componentEvent) {
+        component.fireEvent(componentEvent);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/AbstractFieldSupport.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/AbstractFieldSupport.java
@@ -21,8 +21,8 @@ import java.util.Objects;
 import com.vaadin.flow.component.AbstractCompositeField;
 import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.HasValue.ValueChangeEvent;
 import com.vaadin.flow.function.SerializableBiPredicate;
@@ -47,7 +47,6 @@ public class AbstractFieldSupport<C extends Component & HasValue<C, T>, T>
 
     private final SerializableBiPredicate<T, T> valueEquals;
     private final SerializableConsumer<T> setPresentationValue;
-    private final SerializableConsumer<ComponentEvent<?>> fireEvent;
 
     private T bufferedValue;
 
@@ -66,20 +65,16 @@ public class AbstractFieldSupport<C extends Component & HasValue<C, T>, T>
      *            a callback for comparing values
      * @param setPresentationValue
      *            a callback for setting presentation values
-     * @param fireEvent
-     *            a callback for firing events
      */
     public AbstractFieldSupport(C component, T defaultValue,
             SerializableBiPredicate<T, T> valueEquals,
-            SerializableConsumer<T> setPresentationValue,
-            SerializableConsumer<ComponentEvent<?>> fireEvent) {
+            SerializableConsumer<T> setPresentationValue) {
         this.component = component;
 
         this.defaultValue = defaultValue;
         bufferedValue = defaultValue;
         this.valueEquals = valueEquals;
         this.setPresentationValue = setPresentationValue;
-        this.fireEvent = fireEvent;
     }
 
     /**
@@ -207,7 +202,8 @@ public class AbstractFieldSupport<C extends Component & HasValue<C, T>, T>
             }
         }
 
-        fireEvent.accept(createValueChange(oldValue, fromClient));
+        ComponentUtil.fireEvent(component,
+                createValueChange(oldValue, fromClient));
     }
 
     private boolean applyValue(T value) {


### PR DESCRIPTION
* Adds a public method for firing events for any component. The method
is in ComponentUtil to avoid polluting the Component API
* Use this method internally in ComponentUtil. The hasEvent check is no
longer necessary since it's done through the delegated method.
* Simplify AbstractFieldSupport creation by using the new API

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4021)
<!-- Reviewable:end -->
