### PR TITLE
Do not cache HTML dependencies in development

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentMetaData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentMetaData.java
@@ -205,11 +205,19 @@ public class ComponentMetaData {
      * @return the dependencies for the given class
      */
     public DependencyInfo getDependencyInfo(VaadinService service) {
-        return dependencyInfo.computeIfAbsent(service, ignore -> {
-            service.addServiceDestroyListener(
-                    event -> dependencyInfo.remove(service));
+        if (service.getDeploymentConfiguration().isProductionMode()) {
+            return dependencyInfo.computeIfAbsent(service, ignore -> {
+                service.addServiceDestroyListener(
+                        event -> dependencyInfo.remove(service));
+                return findDependencies(service, componentClass);
+            });
+        } else {
+            // Not using cache in development mode so that html imports added to
+            // templates do not require a server restart (when there is a themed
+            // version available)
+            // https://github.com/vaadin/flow/issues/4005
             return findDependencies(service, componentClass);
-        });
+        }
     }
 
     private static Collection<HtmlImportDependency> getHtmlImportDependencies(

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/HtmlDependencyParser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/HtmlDependencyParser.java
@@ -74,6 +74,7 @@ public class HtmlDependencyParser {
             return;
         }
         dependencies.add(path);
+        getLogger().debug("Parsing dependencies for {}", path);
         WebBrowser browser = FakeBrowser.getEs6();
         try (InputStream content = service.getResourceAsStream(path, browser,
                 null)) {


### PR DESCRIPTION
If this becomes a performance problem, should consider a cache which takes
timestamps into account or something similar.

Fixes #4005

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4025)
<!-- Reviewable:end -->
