### PR TITLE
Add route filter functionality

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/NavigationTargetFilter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/NavigationTargetFilter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.startup;
+
+import java.io.Serializable;
+import java.util.ServiceLoader;
+
+import com.vaadin.flow.component.Component;
+
+/**
+ * A filter that can prevent specific navigation targets from being registered.
+ * <p>
+ * Listener instances are by discovered and instantiated using
+ * {@link ServiceLoader}. This means that all implementations must have a
+ * zero-argument constructor and the fully qualified name of the implementation
+ * class must be listed on a separate line in a
+ * META-INF/services/cocom.vaadin.flow.server.startup.RouteFilter file present
+ * in the jar file containing the implementation class.
+ *
+ * @author Vaadin Ltd
+ */
+public interface NavigationTargetFilter extends Serializable {
+    /**
+     * Tests whether the given navigation target class should be included.
+     *
+     * @param navigationTarget
+     *            the navigation target class to test
+     * @return <code>true</code> to include the navigation target,
+     *         <code>false</code> to discard it
+     */
+    boolean testNavigationTarget(Class<? extends Component> navigationTarget);
+
+    /**
+     * Tests whether the given error navigation target class should be included.
+     *
+     * @param errorNavigationTarget
+     *            the error navigation target class to test
+     * @return <code>true</code> to include the error navigation target,
+     *         <code>false</code> to discard it
+     */
+    boolean testErrorNavigationTarget(Class<?> errorNavigationTarget);
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/RouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/RouteRegistry.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -113,6 +114,8 @@ public class RouteRegistry implements Serializable {
             .of(RouteNotFoundError.class, InternalServerError.class)
             .collect(Collectors.toSet());
 
+    private final ArrayList<NavigationTargetFilter> routeFilters = new ArrayList<>();
+
     private final AtomicReference<Map<String, RouteTarget>> routes = new AtomicReference<>();
     private final AtomicReference<Map<Class<? extends Component>, String>> targetRoutes = new AtomicReference<>();
     private final AtomicReference<Map<Class<? extends Exception>, Class<? extends Component>>> exceptionTargets = new AtomicReference<>();
@@ -122,6 +125,8 @@ public class RouteRegistry implements Serializable {
      * Creates a new uninitialized route registry.
      */
     protected RouteRegistry() {
+        ServiceLoader.load(NavigationTargetFilter.class)
+                .forEach(routeFilters::add);
     }
 
     /**
@@ -214,6 +219,11 @@ public class RouteRegistry implements Serializable {
         Map<Class<? extends Exception>, Class<? extends Component>> exceptionTargetsMap = new HashMap<>();
         errorNavigationTargets.removeAll(defaultErrorHandlers);
         for (Class<? extends Component> target : errorNavigationTargets) {
+            if (!routeFilters.stream().allMatch(
+                    filter -> filter.testErrorNavigationTarget(target))) {
+                continue;
+            }
+
             Class<? extends Exception> exceptionType = ReflectTools
                     .getGenericInterfaceType(target, HasErrorParameter.class)
                     .asSubclass(Exception.class);
@@ -523,6 +533,11 @@ public class RouteRegistry implements Serializable {
                         "No Route annotation is present for the given "
                                 + "navigation target component '%s'.",
                         navigationTarget.getName()));
+            }
+
+            if (!routeFilters.stream().allMatch(
+                    filter -> filter.testNavigationTarget(navigationTarget))) {
+                continue;
             }
 
             Set<String> paths = new HashSet<>();

--- a/flow-server/src/test/resources/META-INF/services/com.vaadin.flow.server.startup.NavigationTargetFilter
+++ b/flow-server/src/test/resources/META-INF/services/com.vaadin.flow.server.startup.NavigationTargetFilter
@@ -1,0 +1,2 @@
+com.vaadin.flow.server.startup.RouteRegistryInitializerTest$TestRouteFilter
+com.vaadin.flow.server.startup.RouteRegistryInitializerTest$AlwaysTrueRouterFilter


### PR DESCRIPTION
Route filters are loaded by RouterRegistry using a ServiceLoader. A
navigation target is added to the registry only if all loaded filters
accept the class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4027)
<!-- Reviewable:end -->
