### PR TITLE
Use the ExpectedException rule.

### DIFF
--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/common/AnnotationValuesExtractorTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/common/AnnotationValuesExtractorTest.java
@@ -27,7 +27,9 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.maven.plugins.annotations.Mojo;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.component.dependency.JavaScript;
@@ -38,6 +40,9 @@ import com.vaadin.flow.plugin.TestUtils;
  * @author Vaadin Ltd.
  */
 public class AnnotationValuesExtractorTest {
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
     private final AnnotationValuesExtractor extractor = new AnnotationValuesExtractor(
             TestUtils.getTestResource(
                     "annotation-extractor-test/flow-server-1.0-SNAPSHOT.jar"),
@@ -46,14 +51,20 @@ public class AnnotationValuesExtractorTest {
             TestUtils.getTestResource(
                     "annotation-extractor-test/flow-data-1.0-SNAPSHOT.jar"));
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void extractAnnotationValues_incorrectMethod() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("");
+
         extractor.extractAnnotationValues(
                 Collections.singletonMap(HtmlImport.class, "doomed to fail"));
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void extractAnnotationValues_annotationNotInClassLoader() {
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("");
+
         extractor.extractAnnotationValues(
                 Collections.singletonMap(Mojo.class, "whatever"));
     }

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/common/ArtifactDataTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/common/ArtifactDataTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 /**
@@ -30,18 +31,24 @@ public class ArtifactDataTest {
     @Rule
     public TemporaryFolder testDirectory = new TemporaryFolder();
 
-    @Test(expected = NullPointerException.class)
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    @Test
     public void constructor_nullFile() {
+        expectedException.expect(NullPointerException.class);
         new ArtifactData(null, "one", "two");
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void constructor_nullArtifactId() throws IOException {
+        expectedException.expect(NullPointerException.class);
         new ArtifactData(testDirectory.newFile("test"), null, "two");
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void constructor_nullVersion() throws IOException {
+        expectedException.expect(NullPointerException.class);
         new ArtifactData(testDirectory.newFile("test"), "one", null);
     }
 

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/common/JarContentsManagerTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/common/JarContentsManagerTest.java
@@ -30,6 +30,7 @@ import nl.jqno.equalsverifier.internal.exceptions.AssertionException;
 import nl.jqno.equalsverifier.internal.util.Formatter;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import com.vaadin.flow.plugin.TestUtils;
@@ -50,23 +51,38 @@ public class JarContentsManagerTest {
     @Rule
     public TemporaryFolder testDirectory = new TemporaryFolder();
 
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
     private final JarContentsManager jarContentsManager = new JarContentsManager();
     private final File testJar = TestUtils.getTestJar();
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void getFileContents_directoryInsteadOfJar() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(String.format("Expect '%s' to be an existing file", testDirectory.getRoot()));
+
         jarContentsManager.getFileContents(testDirectory.getRoot(), "test");
     }
 
-    @Test(expected = UncheckedIOException.class)
+    @Test
     public void getFileContents_notAJarFile() throws IOException {
         File testFile = testDirectory.newFile("test");
+
+        expectedException.expect(UncheckedIOException.class);
+        expectedException.expectMessage(String.format("Failed to retrieve file '%s' from jar '%s'", "test", testFile));
+
         jarContentsManager.getFileContents(testFile, "test");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void getFileContents_nonExistingJarFile() {
-        jarContentsManager.getFileContents(new File("test"), "test");
+        File test = new File("test");
+
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(String.format("Expect '%s' to be an existing file", test));
+
+        jarContentsManager.getFileContents(test, "test");
     }
 
     @Test
@@ -84,20 +100,32 @@ public class JarContentsManagerTest {
         assertTrue("Expect to have non-empty file from jar", fileContents.length > 0);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void containsPath_directoryInsteadOfJar() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(String.format("Expect '%s' to be an existing file", testDirectory.getRoot()));
+
         jarContentsManager.containsPath(testDirectory.getRoot(), "test");
     }
 
-    @Test(expected = UncheckedIOException.class)
+    @Test
     public void containsPath_notAJarFile() throws IOException {
         File testFile = testDirectory.newFile("test");
+
+        expectedException.expect(UncheckedIOException.class);
+        expectedException.expectMessage(String.format("Failed to retrieve file '%s' from jar '%s'", "test", testFile));
+
         jarContentsManager.containsPath(testFile, "test");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void containsPath_nonExistingJarFile() {
-        jarContentsManager.containsPath(new File("test"), "test");
+        File test = new File("test");
+
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(String.format("Expect '%s' to be an existing file", test));
+
+        jarContentsManager.containsPath(test, "test");
     }
 
     @Test
@@ -114,20 +142,32 @@ public class JarContentsManagerTest {
         assertTrue(String.format("Test jar '%s' should contain path '%s'", testJar, existingPath), jarContentsManager.containsPath(testJar, existingPath));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void findFiles_directoryInsteadOfJar() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(String.format("Expect '%s' to be an existing file", testDirectory.getRoot()));
+
         jarContentsManager.findFiles(testDirectory.getRoot(), "test", "test");
     }
 
-    @Test(expected = UncheckedIOException.class)
+    @Test
     public void findFiles_notAJarFile() throws IOException {
         File testFile = testDirectory.newFile("test");
+
+        expectedException.expect(UncheckedIOException.class);
+        expectedException.expectMessage("java.util.zip.ZipException: zip file is empty");
+
         jarContentsManager.findFiles(testFile, "test", "test");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void findFiles_nonExistingJarFile() {
-        jarContentsManager.findFiles(new File("test"), "test", "test");
+        File test = new File("test");
+
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(String.format("Expect '%s' to be an existing file", test));
+
+        jarContentsManager.findFiles(test, "test", "test");
     }
 
     @Test
@@ -163,34 +203,53 @@ public class JarContentsManagerTest {
                 1, bowerJson.size());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void copyFilesFromJar_nullJarFile() {
+        expectedException.expect(NullPointerException.class);
+
         jarContentsManager.copyFilesFromJarTrimmingBasePath(null, null, testDirectory.getRoot());
     }
 
-    @Test(expected = UncheckedIOException.class)
+    @Test
     public void copyFilesFromJar_notAJarFile() throws IOException {
         File testFile = testDirectory.newFile("test");
+
+        expectedException.expect(UncheckedIOException.class);
+        expectedException.expectMessage(String.format("Failed to extract files from jarFile '%s' to directory '%s'", testFile, testDirectory.getRoot()));
+
         jarContentsManager.copyFilesFromJarTrimmingBasePath(testFile, null, testDirectory.getRoot());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void copyFilesFromJar_nonExistingJarFile() {
-        jarContentsManager.copyFilesFromJarTrimmingBasePath(new File("test"), null, testDirectory.getRoot());
+        File test = new File("test");
+
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(String.format("Expect '%s' to be an existing file", test));
+
+        jarContentsManager.copyFilesFromJarTrimmingBasePath(test, null, testDirectory.getRoot());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void copyFilesFromJar_directoryInsteadOfJar() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(String.format("Expect '%s' to be an existing file", testDirectory.getRoot()));
+
         jarContentsManager.copyFilesFromJarTrimmingBasePath(testDirectory.getRoot(), null, testDirectory.getRoot());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void copyFilesFromJar_nullOutputDirectory() {
+        expectedException.expect(NullPointerException.class);
+
         jarContentsManager.copyFilesFromJarTrimmingBasePath(testJar, null, null);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void copyFilesFromJar_fileInsteadOfDirectory() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(String.format("Expect '%s' to be an existing directory", testJar));
+
         jarContentsManager.copyFilesFromJarTrimmingBasePath(testJar, null, testJar);
     }
 


### PR DESCRIPTION
All tests that test a thrown exception should use the
Rule ExpectedException to verify that the message
is the expected one and we fail the correct way.