### PR TITLE
Update jetty version

### DIFF
--- a/flow-components-parent/flow-component-demo-helpers/pom.xml
+++ b/flow-components-parent/flow-component-demo-helpers/pom.xml
@@ -13,11 +13,6 @@
     <name>Flow component demo helpers</name>
     <description>Includes a server and a base view for creating component demos</description>
 
-    <properties>
-        <!-- Components need the downgraded version until -->
-        <!-- https://github.com/eclipse/jetty.project/issues/2372 is released  -->
-        <jetty.version>9.3.7.v20160115</jetty.version>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <maven.resources.plugin.version>3.0.2</maven.resources.plugin.version>
         <maven.clean.plugin.version>3.0.0</maven.clean.plugin.version>
         <testbench.version>6.0.0.beta6</testbench.version>
-        <jetty.version>9.4.9.v20180320</jetty.version>
+        <jetty.version>9.4.10.v20180503</jetty.version>
 
         <!-- Frontend -->
         <!-- Not the newest version because of https://www.polymer-project.org/2.0/docs/tools/node-support -->


### PR DESCRIPTION
The blocker in flow-component-demo-helper has been solved with the new
version

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4094)
<!-- Reviewable:end -->
