### PR TITLE
Correctly normalize URLs containing "/js/" and other two letter paths

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/HtmlDependencyParser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/HtmlDependencyParser.java
@@ -141,11 +141,11 @@ public class HtmlDependencyParser {
             if (".".equals(normalized.getAuthority())
                     && normalized.getHost() == null) {
                 // frontend://./foo.html
-                return normalized.toString().replaceAll("//./", "//");
+                return normalized.toString().replace("//./", "//");
             }
             if (normalized.getPath().startsWith("/../")) {
                 return normalized.toString()
-                        .replaceAll(normalized.getHost() + "/../", "");
+                        .replace(normalized.getHost() + "/../", "");
             }
         }
         return normalized.toString();

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/HtmlDependencyParserTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/HtmlDependencyParserTest.java
@@ -199,6 +199,9 @@ public class HtmlDependencyParserTest {
                     + "://bower_components/vaadin-button/src/vaadin-button.html",
                     normalize(protocol
                             + "://src/views/login/../../../bower_components/vaadin-button/src/vaadin-button.html"));
+            assertEquals(protocol + "://components/js/hash-actions.html",
+                    normalize(protocol
+                            + "://components/../components/js/hash-actions.html"));
         }
 
     }


### PR DESCRIPTION
Fixes #4096

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4097)
<!-- Reviewable:end -->
