### PR TITLE
@Route annotation now can be used without explicit value

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/NavigationState.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/NavigationState.java
@@ -75,7 +75,7 @@ public class NavigationState implements Serializable {
         if (resolvedPath == null) {
             resolvedPath = AnnotationReader
                     .getAnnotationFor(navigationTarget, Route.class)
-                    .map( r -> Router.resolve(navigationTarget, r)).orElse(null);
+                    .map( route -> Router.resolve(navigationTarget, route)).orElse(null);
         }
         return resolvedPath;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/router/NavigationState.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/NavigationState.java
@@ -75,7 +75,7 @@ public class NavigationState implements Serializable {
         if (resolvedPath == null) {
             resolvedPath = AnnotationReader
                     .getAnnotationFor(navigationTarget, Route.class)
-                    .map(Route::value).orElse(null);
+                    .map( r -> Router.resolve(navigationTarget, r)).orElse(null);
         }
         return resolvedPath;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/router/Route.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/Route.java
@@ -22,7 +22,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
 
 /**

--- a/flow-server/src/main/java/com/vaadin/flow/router/Route.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/Route.java
@@ -39,18 +39,18 @@ import com.vaadin.flow.component.UI;
 @Documented
 public @interface Route {
 
-    static final String NAMING_CONVENTION = "___NAMING_CONVENTION___";
+    String NAMING_CONVENTION = "___NAMING_CONVENTION___";
 
     /**
      * Gets the route path value of the annotated class.
      *
      * <p>If no value is provided, the path will be derived from the class
-     * name of the component. The derived name will be lower case and possibly
+     * name of the component. The derived name will be in lower case and
      * trailing "View" will be removed. Also, MainView or Main names will be
      * mapped to root (value will be "").</p>
      *
-     * <p>Note, framework should not use the value directly, but use the
-     * helper method {@link Router#resolve(Class, Route)}, so that
+     * <p>Note for framework developers: do not use the value directly, but
+     * use the helper method {@link Router#resolve(Class, Route)}, so that
      * naming convention based values are dealt correctly.</p>
      *
      * @return the explicit path value of this route

--- a/flow-server/src/main/java/com/vaadin/flow/router/Route.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/Route.java
@@ -45,7 +45,16 @@ public @interface Route {
     /**
      * Gets the route path value of the annotated class.
      *
-     * @return the path value of this route
+     * <p>If no value is provided, the path will be derived from the class
+     * name of the component. The derived name will be lower case and possibly
+     * trailing "View" will be removed. Also, MainView or Main names will be
+     * mapped to root (value will be "").</p>
+     *
+     * <p>Note, framework should not use the value directly, but use the
+     * helper method {@link Router#resolve(Class, Route)}, so that
+     * naming convention based values are dealt correctly.</p>
+     *
+     * @return the explicit path value of this route
      */
     String value() default NAMING_CONVENTION;
 

--- a/flow-server/src/main/java/com/vaadin/flow/router/Route.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/Route.java
@@ -22,6 +22,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
 
 /**
@@ -39,12 +40,14 @@ import com.vaadin.flow.component.UI;
 @Documented
 public @interface Route {
 
+    static final String NAMING_CONVENTION = "___NAMING_CONVENTION___";
+
     /**
      * Gets the route path value of the annotated class.
      *
      * @return the path value of this route
      */
-    String value();
+    String value() default NAMING_CONVENTION;
 
     /**
      * Sets the parent component for the route target component.
@@ -64,4 +67,5 @@ public @interface Route {
      * @return route up to here should be absolute
      */
     boolean absolute() default false;
+
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/Router.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/Router.java
@@ -446,6 +446,14 @@ public class Router implements Serializable {
         return grouped;
     }
 
+    /**
+     * Gets the effective route path value of the annotated class.
+     *
+     * @param component the component where the route points to
+     * @param route the annotation
+     * @return The value of the annotation or naming convention based value
+     * if no explicit value is given.
+     */
     public static String resolve(Class<?> component, Route route) {
         if(route.value().equals(Route.NAMING_CONVENTION)) {
             String simpleName = component.getSimpleName();

--- a/flow-server/src/main/java/com/vaadin/flow/router/Router.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/Router.java
@@ -445,4 +445,18 @@ public class Router implements Serializable {
 
         return grouped;
     }
+
+    public static String resolve(Class<?> component, Route route) {
+        if(route.value().equals(Route.NAMING_CONVENTION)) {
+            String simpleName = component.getSimpleName();
+            if(simpleName.equals("MainView") || simpleName.equals("Main")) {
+                return "";
+            }
+            if(simpleName.endsWith("View")) {
+                return simpleName.substring(0, simpleName.length() - "View".length()).toLowerCase();
+            }
+            return simpleName.toLowerCase();
+        }
+        return route.value();
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -28,24 +28,8 @@ import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.internal.ReflectTools;
-import com.vaadin.flow.router.AfterNavigationEvent;
-import com.vaadin.flow.router.BeforeEnterEvent;
-import com.vaadin.flow.router.BeforeEnterObserver;
-import com.vaadin.flow.router.BeforeEvent;
-import com.vaadin.flow.router.BeforeLeaveEvent;
+import com.vaadin.flow.router.*;
 import com.vaadin.flow.router.BeforeLeaveEvent.ContinueNavigationAction;
-import com.vaadin.flow.router.BeforeLeaveObserver;
-import com.vaadin.flow.router.ErrorNavigationEvent;
-import com.vaadin.flow.router.ErrorParameter;
-import com.vaadin.flow.router.EventUtil;
-import com.vaadin.flow.router.Location;
-import com.vaadin.flow.router.LocationChangeEvent;
-import com.vaadin.flow.router.NavigationEvent;
-import com.vaadin.flow.router.NavigationHandler;
-import com.vaadin.flow.router.NavigationState;
-import com.vaadin.flow.router.NavigationTrigger;
-import com.vaadin.flow.router.Route;
-import com.vaadin.flow.router.RouterLayout;
 
 /**
  * Base class for navigation handlers that target a navigation state.
@@ -354,8 +338,9 @@ public abstract class AbstractNavigationStateRenderer
                     NavigationTrigger.PROGRAMMATIC, errorParameter);
         }
 
-        Location location = new Location(beforeNavigation.getRouteTargetType()
-                .getAnnotation(Route.class).value());
+        final Class<?> routeTargetType = beforeNavigation.getRouteTargetType();
+        Location location = new Location(Router.resolve(routeTargetType, routeTargetType
+                .getAnnotation(Route.class)));
 
         return new NavigationEvent(event.getSource(), location, event.getUI(),
                 NavigationTrigger.PROGRAMMATIC);

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -28,8 +28,25 @@ import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.internal.ReflectTools;
-import com.vaadin.flow.router.*;
+import com.vaadin.flow.router.AfterNavigationEvent;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.BeforeEnterObserver;
+import com.vaadin.flow.router.BeforeEvent;
+import com.vaadin.flow.router.BeforeLeaveEvent;
 import com.vaadin.flow.router.BeforeLeaveEvent.ContinueNavigationAction;
+import com.vaadin.flow.router.BeforeLeaveObserver;
+import com.vaadin.flow.router.ErrorNavigationEvent;
+import com.vaadin.flow.router.ErrorParameter;
+import com.vaadin.flow.router.EventUtil;
+import com.vaadin.flow.router.Location;
+import com.vaadin.flow.router.LocationChangeEvent;
+import com.vaadin.flow.router.NavigationEvent;
+import com.vaadin.flow.router.NavigationHandler;
+import com.vaadin.flow.router.NavigationState;
+import com.vaadin.flow.router.NavigationTrigger;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.Router;
+import com.vaadin.flow.router.RouterLayout;
 
 /**
  * Base class for navigation handlers that target a navigation state.

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/RouterUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/RouterUtil.java
@@ -29,15 +29,7 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.internal.AnnotationReader;
-import com.vaadin.flow.router.HasDynamicTitle;
-import com.vaadin.flow.router.LocationChangeEvent;
-import com.vaadin.flow.router.NavigationEvent;
-import com.vaadin.flow.router.PageTitle;
-import com.vaadin.flow.router.ParentLayout;
-import com.vaadin.flow.router.Route;
-import com.vaadin.flow.router.RouteAlias;
-import com.vaadin.flow.router.RoutePrefix;
-import com.vaadin.flow.router.RouterLayout;
+import com.vaadin.flow.router.*;
 
 /**
  * Utility class with methods for router layout handling.
@@ -112,10 +104,10 @@ public final class RouterUtil {
      */
     public static String getRoutePath(Class<?> component, Route route) {
         if (route.absolute()) {
-            return route.value();
+            return Router.resolve(component, route);
         }
         List<String> parentRoutePrefixes = getRoutePrefixes(component,
-                route.layout(), route.value());
+                route.layout(), Router.resolve(component, route));
         return parentRoutePrefixes.stream().collect(Collectors.joining("/"));
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/RouterUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/RouterUtil.java
@@ -29,7 +29,16 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.internal.AnnotationReader;
-import com.vaadin.flow.router.*;
+import com.vaadin.flow.router.HasDynamicTitle;
+import com.vaadin.flow.router.LocationChangeEvent;
+import com.vaadin.flow.router.NavigationEvent;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.ParentLayout;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouteAlias;
+import com.vaadin.flow.router.RoutePrefix;
+import com.vaadin.flow.router.Router;
+import com.vaadin.flow.router.RouterLayout;
 
 /**
  * Utility class with methods for router layout handling.

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractRouteRegistryInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractRouteRegistryInitializer.java
@@ -26,11 +26,7 @@ import javax.servlet.annotation.HandlesTypes;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
-import com.vaadin.flow.router.HasDynamicTitle;
-import com.vaadin.flow.router.PageTitle;
-import com.vaadin.flow.router.Route;
-import com.vaadin.flow.router.RouteAlias;
-import com.vaadin.flow.router.RouterLayout;
+import com.vaadin.flow.router.*;
 import com.vaadin.flow.router.internal.RouterUtil;
 import com.vaadin.flow.server.InvalidRouteLayoutConfigurationException;
 import com.vaadin.flow.server.PageConfigurator;
@@ -117,14 +113,14 @@ public abstract class AbstractRouteRegistryInitializer {
                         .format("%s needs to be the top parent layout '%s' not '%s'",
                                 implementation.getSimpleName(),
                                 RouterUtil.getTopParentLayout(route,
-                                        annotation.value()).getName(),
+                                        Router.resolve(route,annotation)).getName(),
                                 route.getName()));
             }
 
             List<Class<? extends RouterLayout>> parentLayouts = RouterUtil
-                    .getParentLayouts(route, annotation.value());
+                    .getParentLayouts(route, Router.resolve(route,annotation));
             Class<? extends RouterLayout> topParentLayout = RouterUtil
-                    .getTopParentLayout(route, annotation.value());
+                    .getTopParentLayout(route, Router.resolve(route,annotation));
 
             validateParentImplementation(parentLayouts, topParentLayout,
                     implementation);
@@ -186,15 +182,15 @@ public abstract class AbstractRouteRegistryInitializer {
                 throw new InvalidRouteLayoutConfigurationException(String
                         .format("%s annotation needs to be on the top parent layout '%s' not on '%s'",
                                 annotation.getSimpleName(),
-                                RouterUtil.getTopParentLayout(route,
-                                        routeAnnotation.value()).getName(),
+                                RouterUtil.getTopParentLayout(route, Router.resolve(route,
+                                        routeAnnotation)).getName(),
                                 route.getName()));
             }
 
             List<Class<? extends RouterLayout>> parentLayouts = RouterUtil
-                    .getParentLayouts(route, routeAnnotation.value());
+                    .getParentLayouts(route, Router.resolve(route, routeAnnotation));
             Class<? extends RouterLayout> topParentLayout = RouterUtil
-                    .getTopParentLayout(route, routeAnnotation.value());
+                    .getTopParentLayout(route, Router.resolve(route, routeAnnotation));
 
             validateParentAnnotation(parentLayouts, topParentLayout,
                     annotation);

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractRouteRegistryInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractRouteRegistryInitializer.java
@@ -26,7 +26,12 @@ import javax.servlet.annotation.HandlesTypes;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
-import com.vaadin.flow.router.*;
+import com.vaadin.flow.router.HasDynamicTitle;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouteAlias;
+import com.vaadin.flow.router.Router;
+import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.router.internal.RouterUtil;
 import com.vaadin.flow.server.InvalidRouteLayoutConfigurationException;
 import com.vaadin.flow.server.PageConfigurator;

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
@@ -1106,6 +1106,31 @@ public class RouterTest extends RoutingTestBase {
     public static class ExtendingView extends AbstractMain {
     }
 
+    @Route
+    @Tag(Tag.DIV)
+    public static class Main extends Component {
+    }
+
+    @Route
+    @Tag(Tag.DIV)
+    public static class MainView extends Component {
+    }
+
+    @Route
+    @Tag(Tag.DIV)
+    public static class NamingConvention extends Component {
+    }
+
+    @Route
+    @Tag(Tag.DIV)
+    public static class NamingConventionView extends Component {
+    }
+
+    @Route
+    @Tag(Tag.DIV)
+    public static class View extends Component {
+    }
+
     @Override
     @Before
     public void init() throws NoSuchFieldException, SecurityException,
@@ -2854,6 +2879,52 @@ public class RouterTest extends RoutingTestBase {
                 NavigationTrigger.PAGE_LOAD);
 
         Assert.assertEquals(NavigationTrigger.PAGE_LOAD, FileNotFound.trigger);
+    }
+
+    @Test
+    public void basic_naming_based_routes() throws InvalidRouteConfigurationException {
+        setNavigationTargets(NamingConvention.class, Main.class);
+
+        Assert.assertEquals(Main.class,
+                router.resolveNavigationTarget("/", Collections.emptyMap()).get()
+                        .getNavigationTarget());
+
+        Assert.assertEquals(NamingConvention.class,
+                router.resolveNavigationTarget("/namingconvention",
+                        Collections.emptyMap()).get().getNavigationTarget());
+    }
+
+    @Test
+    public void basic_naming_based_routes_with_trailing_view() throws InvalidRouteConfigurationException {
+        setNavigationTargets(NamingConventionView.class, MainView.class);
+
+        Assert.assertEquals(MainView.class,
+                router.resolveNavigationTarget("/", Collections.emptyMap()).get()
+                        .getNavigationTarget());
+
+        Assert.assertEquals(NamingConventionView.class,
+                router.resolveNavigationTarget("/namingconvention",
+                        Collections.emptyMap()).get().getNavigationTarget());
+    }
+
+    @Test
+    public void test_naming_based_routes_with_name_view() throws InvalidRouteConfigurationException {
+        setNavigationTargets(View.class);
+
+        Assert.assertEquals(View.class,
+                router.resolveNavigationTarget("/", Collections.emptyMap()).get()
+                        .getNavigationTarget());
+    }
+
+    @Test
+    public void verify_collisions_not_allowed_with_naming_convention() {
+        InvalidRouteConfigurationException exception = null;
+        try {
+            setNavigationTargets(NamingConvention.class, NamingConventionView.class);
+        } catch (InvalidRouteConfigurationException e) {
+            exception = e;
+        }
+        Assert.assertNotNull("Routes with same navigation target should not be allowed", exception);
     }
 
     private void setNavigationTargets(

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
@@ -2881,6 +2881,20 @@ public class RouterTest extends RoutingTestBase {
         Assert.assertEquals(NavigationTrigger.PAGE_LOAD, FileNotFound.trigger);
     }
 
+    private String resolve(Class<?> clazz) {
+        Route annotation = clazz.getAnnotation(Route.class);
+        return Router.resolve(clazz, annotation);
+    }
+
+    @Test
+    public void test_router_resolve() {
+        Assert.assertEquals("", resolve(Main.class));
+        Assert.assertEquals("", resolve(MainView.class));
+        Assert.assertEquals("", resolve(View.class));
+        Assert.assertEquals("namingconvention", resolve(NamingConvention.class));
+        Assert.assertEquals("namingconvention", resolve(NamingConventionView.class));
+    }
+
     @Test
     public void basic_naming_based_routes() throws InvalidRouteConfigurationException {
         setNavigationTargets(NamingConvention.class, Main.class);


### PR DESCRIPTION
If value is not given for Route annotation, route value is derived from the component class name

Only for preliminary comments at this point, needs some documentation and tests to core at least. Maybe changes to vaadin-spring too? I only tested this in external project.

closes #3604

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4104)
<!-- Reviewable:end -->
