### PR TITLE
Redirect on error if there's no message to show

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/SystemErrorHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/SystemErrorHandler.java
@@ -18,7 +18,6 @@ package com.vaadin.client;
 import java.util.Set;
 
 import com.google.web.bindery.event.shared.UmbrellaException;
-
 import com.vaadin.client.bootstrap.ErrorMessage;
 
 import elemental.client.Browser;
@@ -85,6 +84,11 @@ public class SystemErrorHandler {
      */
     public void handleUnrecoverableError(String caption, String message,
             String details, String url) {
+        if (caption == null && message == null && details == null) {
+            WidgetUtil.redirect(url);
+            return;
+        }
+
         Document document = Browser.getDocument();
         Element systemErrorContainer = document.createDivElement();
         systemErrorContainer.setClassName("v-system-error");

--- a/flow-server/src/main/java/com/vaadin/flow/server/SystemMessages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/SystemMessages.java
@@ -29,7 +29,7 @@ import java.io.Serializable;
  * The defaults defined in this class are:
  * <ul>
  * <li><b>sessionExpiredURL</b> = null</li>
- * <li><b>sessionExpiredNotificationEnabled</b> = true</li>
+ * <li><b>sessionExpiredNotificationEnabled</b> = false</li>
  * <li><b>sessionExpiredCaption</b> = ""</li>
  * <li><b>sessionExpiredMessage</b> = "Take note of any unsaved data, and
  * <u>click here</u> to continue."</li>

--- a/flow-server/src/main/java/com/vaadin/flow/server/SystemMessages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/SystemMessages.java
@@ -30,21 +30,22 @@ import java.io.Serializable;
  * <ul>
  * <li><b>sessionExpiredURL</b> = null</li>
  * <li><b>sessionExpiredNotificationEnabled</b> = false</li>
- * <li><b>sessionExpiredCaption</b> = ""</li>
+ * <li><b>sessionExpiredCaption</b> = "Session Expired"</li>
  * <li><b>sessionExpiredMessage</b> = "Take note of any unsaved data, and
- * <u>click here</u> to continue."</li>
+ * <u>click here</u> or press ESC key to continue."</li>
  * <li><b>internalErrorURL</b> = null</li>
  * <li><b>internalErrorNotificationEnabled</b> = true</li>
  * <li><b>internalErrorCaption</b> = "Internal error"</li>
  * <li><b>internalErrorMessage</b> = "Please notify the administrator.<br>
- * Take note of any unsaved data, and <u>click here</u> to continue."</li>
+ * Take note of any unsaved data, and <u>click here</u> or press ESC to
+ * continue."</li>
  * <li><b>cookiesDisabledURL</b> = null</li>
  * <li><b>cookiesDisabledNotificationEnabled</b> = true</li>
  * <li><b>cookiesDisabledCaption</b> = "Cookies disabled"</li>
  * <li><b>cookiesDisabledMessage</b> = "This application requires cookies to
  * function.<br>
- * Please enable cookies in your browser and <u>click here</u> to try again.
- * </li>
+ * Please enable cookies in your browser and <u>click here</u> or press ESC to
+ * try again.</li>
  * </ul>
  */
 public class SystemMessages implements Serializable {

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ExpireSessionView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ExpireSessionView.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.flow.uitest.ui;
 
 import com.vaadin.flow.component.html.Div;
@@ -7,6 +22,9 @@ import com.vaadin.flow.server.CustomizedSystemMessages;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
 
+/**
+ * @author Vaadin Ltd.
+ */
 @Route("com.vaadin.flow.uitest.ui.ExpireSessionView")
 public class ExpireSessionView extends AbstractDivView {
 

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ExpireSessionView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ExpireSessionView.java
@@ -1,0 +1,41 @@
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.CustomizedSystemMessages;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
+
+@Route("com.vaadin.flow.uitest.ui.ExpireSessionView")
+public class ExpireSessionView extends AbstractDivView {
+
+    public ExpireSessionView() {
+        Div message = new Div();
+        message.setId("message");
+
+        NativeButton updateMessageButton = new NativeButton("Update",
+                event -> message.setText("Updated"));
+        updateMessageButton.setId("update");
+
+        NativeButton closeSessionButton = new NativeButton("Close session",
+                event -> VaadinSession.getCurrent().close());
+        closeSessionButton.setId("close-session");
+
+        NativeButton enableNotificationButton = new NativeButton(
+                "Enable session expired notification",
+                event -> enableSessionExpiredNotification());
+        enableNotificationButton.setId("enable-notification");
+
+        add(message, updateMessageButton, closeSessionButton,
+                enableNotificationButton);
+    }
+
+    private void enableSessionExpiredNotification() {
+        CustomizedSystemMessages sysMessages = new CustomizedSystemMessages();
+        sysMessages.setSessionExpiredNotificationEnabled(true);
+
+        VaadinService.getCurrent()
+                .setSystemMessagesProvider(systemMessagesInfo -> sysMessages);
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ExpireSessionIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ExpireSessionIT.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class ExpireSessionIT extends ChromeBrowserTest {
+
+    private static final String UPDATE = "update";
+    private static final String CLOSE_SESSION = "close-session";
+
+    @Test
+    public void sessionExpired_refreshByDefault() {
+        open();
+
+        clickButton(UPDATE);
+        clickButton(CLOSE_SESSION);
+
+        // Just click on any button to make a request after killing the session
+        clickButton(CLOSE_SESSION);
+
+        Assert.assertFalse(
+                "After killing the session, the page should be refreshed, "
+                        + "resetting the state of the UI.",
+                isMessageUpdated());
+        Assert.assertFalse(
+                "By default, the 'Session Expired' notification "
+                        + "should not be used",
+                isSessionExpiredNotificationPresent());
+    }
+
+    @Test
+    public void enableSessionExpiredNotification_sessionExpired_notificationShown() {
+        open();
+
+        clickButton("enable-notification");
+
+        // Refresh to take the new config into use
+        getDriver().navigate().refresh();
+
+        clickButton(UPDATE);
+        clickButton(CLOSE_SESSION);
+
+        // Just click on any button to make a request after killing the session
+        clickButton(CLOSE_SESSION);
+
+        Assert.assertTrue("After enabling the 'Session Expired' notification, "
+                + "the page should not be refreshed "
+                + "after killing the session", isMessageUpdated());
+        Assert.assertTrue("After enabling the 'Session Expired' notification "
+                + "and killing the session, the notification should be displayed",
+                isSessionExpiredNotificationPresent());
+    }
+
+    private boolean isMessageUpdated() {
+        return "Updated".equals(findElement(By.id("message")).getText());
+    }
+
+    private boolean isSessionExpiredNotificationPresent() {
+        if (!isElementPresent(By.className("v-system-error"))) {
+            return false;
+        }
+        return findElement(By.className("v-system-error"))
+                .getAttribute("innerHTML").contains("Session Expired");
+    }
+
+    private void clickButton(String id) {
+        findElement(By.id(id)).click();
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ExpireSessionIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ExpireSessionIT.java
@@ -21,6 +21,9 @@ import org.openqa.selenium.By;
 
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
+/**
+ * @author Vaadin Ltd.
+ */
 public class ExpireSessionIT extends ChromeBrowserTest {
 
     private static final String UPDATE = "update";


### PR DESCRIPTION
When an error occurs, don't show an empty error message box if there is no
message to show. Instead redirect immediately, (refresh if there is no
redirect url provided).

There are no messages when the notification is disabled. So for example, the
default value `sessionExpiredNotificationEnabled = false` means that by default
session expired causes a refresh.

Fixes #4070

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4113)
<!-- Reviewable:end -->
