### PR TITLE
Add primitive default data support on evendata

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentEventBus.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentEventBus.java
@@ -30,7 +30,6 @@ import com.vaadin.flow.dom.DomListenerRegistration;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.AnnotationReader;
 import com.vaadin.flow.internal.JsonCodec;
-import com.vaadin.flow.internal.ReflectTools;
 import com.vaadin.flow.shared.Registration;
 
 import elemental.json.Json;
@@ -238,10 +237,7 @@ public class ComponentEventBus implements Serializable {
             if (jsonValue == null) {
                 jsonValue = Json.createNull();
             }
-            // primitive value may not fall back to null
-            Object value = JsonCodec.decodeAs(jsonValue,
-                    ReflectTools.convertPrimitiveType(type),
-                    !type.isPrimitive());
+            Object value = JsonCodec.decodeAs(jsonValue,type);
             eventDataObjects.add(value);
         });
         return eventDataObjects;

--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentEventBusUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentEventBusUtil.java
@@ -21,8 +21,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 
-import javafx.util.Pair;
-
 import com.vaadin.flow.dom.DomEvent;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.ReflectTools;

--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentEventBusUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentEventBusUtil.java
@@ -21,6 +21,8 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 
+import javafx.util.Pair;
+
 import com.vaadin.flow.dom.DomEvent;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.ReflectTools;
@@ -45,7 +47,7 @@ public class ComponentEventBusUtil {
             EventTypeInfo::new);
 
     private static class EventTypeInfo {
-        private final LinkedHashMap<String, Class<?>> dataExpressions;
+        private final LinkedHashMap<String, Pair<Class<?>, Boolean>> dataExpressions;
         private final Constructor<? extends ComponentEvent<?>> eventConstructor;
 
         public EventTypeInfo(Class<? extends ComponentEvent<?>> type) {
@@ -71,7 +73,7 @@ public class ComponentEventBusUtil {
      * @return a map of event expressions, ordered in constructor parameter
      *         order
      */
-    public static LinkedHashMap<String, Class<?>> getEventDataExpressions(
+    public static LinkedHashMap<String, Pair<Class<?>, Boolean>> getEventDataExpressions(
             Class<? extends ComponentEvent<?>> eventType) {
         return cache.get(eventType).dataExpressions;
     }
@@ -85,9 +87,9 @@ public class ComponentEventBusUtil {
      * @return a map of event data expressions, in the order defined by the
      *         component event constructor parameters
      */
-    private static LinkedHashMap<String, Class<?>> findEventDataExpressions(
+    private static LinkedHashMap<String, Pair<Class<?>, Boolean>> findEventDataExpressions(
             Constructor<? extends ComponentEvent<?>> eventConstructor) {
-        LinkedHashMap<String, Class<?>> eventDataExpressions = new LinkedHashMap<>();
+        LinkedHashMap<String, Pair<Class<?>, Boolean>> eventDataExpressions = new LinkedHashMap<>();
         // Parameter 0 is always "Component source"
         // Parameter 1 is always "boolean fromClient"
         for (int i = 2; i < eventConstructor.getParameterCount(); i++) {
@@ -102,7 +104,8 @@ public class ComponentEventBusUtil {
                         EventData.class.getSimpleName()));
             }
             eventDataExpressions.put(eventData.value(),
-                    ReflectTools.convertPrimitiveType(p.getType()));
+                    new Pair<>(ReflectTools.convertPrimitiveType(p.getType()),
+                            p.getType().isPrimitive()));
         }
         return eventDataExpressions;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentEventBusUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentEventBusUtil.java
@@ -47,7 +47,7 @@ public class ComponentEventBusUtil {
             EventTypeInfo::new);
 
     private static class EventTypeInfo {
-        private final LinkedHashMap<String, Pair<Class<?>, Boolean>> dataExpressions;
+        private final LinkedHashMap<String, Class<?>> dataExpressions;
         private final Constructor<? extends ComponentEvent<?>> eventConstructor;
 
         public EventTypeInfo(Class<? extends ComponentEvent<?>> type) {
@@ -73,7 +73,7 @@ public class ComponentEventBusUtil {
      * @return a map of event expressions, ordered in constructor parameter
      *         order
      */
-    public static LinkedHashMap<String, Pair<Class<?>, Boolean>> getEventDataExpressions(
+    public static LinkedHashMap<String, Class<?>> getEventDataExpressions(
             Class<? extends ComponentEvent<?>> eventType) {
         return cache.get(eventType).dataExpressions;
     }
@@ -87,9 +87,9 @@ public class ComponentEventBusUtil {
      * @return a map of event data expressions, in the order defined by the
      *         component event constructor parameters
      */
-    private static LinkedHashMap<String, Pair<Class<?>, Boolean>> findEventDataExpressions(
+    private static LinkedHashMap<String, Class<?>> findEventDataExpressions(
             Constructor<? extends ComponentEvent<?>> eventConstructor) {
-        LinkedHashMap<String, Pair<Class<?>, Boolean>> eventDataExpressions = new LinkedHashMap<>();
+        LinkedHashMap<String, Class<?>> eventDataExpressions = new LinkedHashMap<>();
         // Parameter 0 is always "Component source"
         // Parameter 1 is always "boolean fromClient"
         for (int i = 2; i < eventConstructor.getParameterCount(); i++) {
@@ -103,9 +103,7 @@ public class ComponentEventBusUtil {
                         p.getName(), eventConstructor.toString(),
                         EventData.class.getSimpleName()));
             }
-            eventDataExpressions.put(eventData.value(),
-                    new Pair<>(ReflectTools.convertPrimitiveType(p.getType()),
-                            p.getType().isPrimitive()));
+            eventDataExpressions.put(eventData.value(),p.getType());
         }
         return eventDataExpressions;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/JsonCodec.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JsonCodec.java
@@ -194,7 +194,7 @@ public class JsonCodec {
      * Decodes the given JSON value as the given type.
      * <p>
      * Supported types are {@link String}, {@link Boolean}, {@link Integer},
-     * {@link Double}.
+     * {@link Double} and primitives boolean, int, double
      *
      * @param <T>
      *            the decoded type
@@ -207,43 +207,19 @@ public class JsonCodec {
      *             if the type was unsupported
      */
     public static <T> T decodeAs(JsonValue json, Class<T> type) {
-        return decodeAs(json, type, true);
-    }
-
-    /**
-     * Decodes the given JSON value as the given type.
-     * <p>
-     * Supported types are {@link String}, {@link Boolean}, {@link Integer},
-     * {@link Double}.
-     *
-     * @param <T>
-     *            the decoded type
-     * @param json
-     *            the JSON value
-     * @param type
-     *            the type to decode as
-     * @param allowNull
-     *            if return type of null is allowed - check to false in case
-     *            you would like to have default values in case of nulls
-     *            (for example, when having primitives)
-     * @return the value decoded as the given type
-     * @throws IllegalArgumentException
-     *             if the type was unsupported
-     */
-    public static <T> T decodeAs(JsonValue json, Class<T> type, boolean allowNull) {
         assert json != null;
-        if (json.getType() == JsonType.NULL && allowNull) {
+        if (json.getType() == JsonType.NULL && !type.isPrimitive()) {
             return null;
         }
-
+        Class<?> convertedType = ReflectTools.convertPrimitiveType(type);
         if (type == String.class) {
             return type.cast(json.asString());
-        } else if (type == Boolean.class) {
-            return type.cast(Boolean.valueOf(json.asBoolean()));
-        } else if (type == Double.class) {
-            return type.cast(Double.valueOf(json.asNumber()));
-        } else if (type == Integer.class) {
-            return type.cast(Integer.valueOf((int) json.asNumber()));
+        } else if (convertedType == Boolean.class) {
+            return (T) convertedType.cast(Boolean.valueOf(json.asBoolean()));
+        } else if (convertedType == Double.class) {
+            return (T) convertedType.cast(Double.valueOf(json.asNumber()));
+        } else if (convertedType == Integer.class) {
+            return (T) convertedType.cast(Integer.valueOf((int) json.asNumber()));
         } else if (JsonValue.class.isAssignableFrom(type)) {
             return type.cast(json);
         } else {

--- a/flow-server/src/main/java/com/vaadin/flow/internal/JsonCodec.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JsonCodec.java
@@ -207,8 +207,32 @@ public class JsonCodec {
      *             if the type was unsupported
      */
     public static <T> T decodeAs(JsonValue json, Class<T> type) {
+        return decodeAs(json, type, true);
+    }
+
+    /**
+     * Decodes the given JSON value as the given type.
+     * <p>
+     * Supported types are {@link String}, {@link Boolean}, {@link Integer},
+     * {@link Double}.
+     *
+     * @param <T>
+     *            the decoded type
+     * @param json
+     *            the JSON value
+     * @param type
+     *            the type to decode as
+     * @param allowNull
+     *            if return type of null is allowed - check to false in case
+     *            you would like to have default values in case of nulls
+     *            (for example, when having primitives)
+     * @return the value decoded as the given type
+     * @throws IllegalArgumentException
+     *             if the type was unsupported
+     */
+    public static <T> T decodeAs(JsonValue json, Class<T> type, boolean allowNull) {
         assert json != null;
-        if (json.getType() == JsonType.NULL) {
+        if (json.getType() == JsonType.NULL && allowNull) {
             return null;
         }
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentEventBusTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentEventBusTest.java
@@ -167,6 +167,8 @@ public class ComponentEventBusTest {
         eventListener.assertEventCalled(c, true);
         Assert.assertEquals(2, eventListener.getEvent().getSomeData());
         Assert.assertNull(eventListener.getEvent().getMoreData());
+        Assert.assertFalse(eventListener.getEvent().getPrimitiveBoolean());
+        Assert.assertNull(eventListener.getEvent().getObjectBoolean());
     }
 
     private JsonObject createData(String key, Object value) {

--- a/flow-server/src/test/java/com/vaadin/flow/component/MappedToDomEvent.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/MappedToDomEvent.java
@@ -10,6 +10,8 @@ public class MappedToDomEvent extends ComponentEvent<Component> {
 
     private int someData;
     private String moreData;
+    private boolean primitiveBoolean;
+    private Boolean objectBoolean;
 
     public MappedToDomEvent(Component source) {
         super(source, false);
@@ -25,10 +27,14 @@ public class MappedToDomEvent extends ComponentEvent<Component> {
 
     public MappedToDomEvent(Component source, boolean fromClient,
             @EventData("event.someData") int someData,
-            @EventData("event.moreData") String moreData) {
+            @EventData("event.moreData") String moreData,
+            @EventData("event.primitiveBoolean") boolean primitiveBoolean,
+            @EventData("event.objectBoolean") Boolean objectBoolean) {
         super(source, fromClient);
         this.someData = someData;
         this.moreData = moreData;
+        this.primitiveBoolean = primitiveBoolean;
+        this.objectBoolean = objectBoolean;
     }
 
     public int getSomeData() {
@@ -37,5 +43,13 @@ public class MappedToDomEvent extends ComponentEvent<Component> {
 
     public String getMoreData() {
         return moreData;
+    }
+
+    public boolean getPrimitiveBoolean() {
+        return primitiveBoolean;
+    }
+
+    public Boolean getObjectBoolean() {
+        return objectBoolean;
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/JsonCodecTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/JsonCodecTest.java
@@ -195,13 +195,30 @@ public class JsonCodecTest {
     public void decodeAs_jsonValue() {
         JsonObject json = Json.createObject();
         json.put("foo", "bar");
-        Assert.assertTrue(JsonCodec.decodeAs(json, Boolean.class));
         Assert.assertEquals("[object Object]",
                 JsonCodec.decodeAs(json, String.class));
+        Assert.assertEquals(json, JsonCodec.decodeAs(json, JsonValue.class));
+        // boolean
+        Assert.assertTrue(JsonCodec.decodeAs(json, Boolean.class));
+        Assert.assertNull(JsonCodec.decodeAs(Json.createNull(), Boolean.class));
+        Assert.assertTrue(JsonCodec.decodeAs(json, boolean.class));
+        Assert.assertFalse(
+                JsonCodec.decodeAs(Json.createNull(), boolean.class));
+        // integer
         Assert.assertEquals(Integer.valueOf(0),
                 JsonCodec.decodeAs(json, Integer.class));
+        Assert.assertNull(JsonCodec.decodeAs(Json.createNull(), Integer.class));
+        Assert.assertEquals(Integer.valueOf(0),
+                JsonCodec.decodeAs(json, int.class));
+        Assert.assertEquals(Integer.valueOf(0),
+                JsonCodec.decodeAs(Json.createNull(), int.class));
+        //double
+        Assert.assertNull(JsonCodec.decodeAs(Json.createNull(), Double.class));
         Assert.assertTrue(JsonCodec.decodeAs(json, Double.class).isNaN());
-        Assert.assertEquals(json, JsonCodec.decodeAs(json, JsonValue.class));
+        Assert.assertTrue(JsonCodec.decodeAs(json, double.class).isNaN());
+        Assert.assertEquals(0.0d,
+                JsonCodec.decodeAs(Json.createNull(), double.class),
+                0.0001d);
     }
 
     @Test(expected = ClassCastException.class)
@@ -214,6 +231,6 @@ public class JsonCodecTest {
     @Test(expected = IllegalArgumentException.class)
     public void decodeAs_unsupportedType() {
         Assert.assertNull(
-                JsonCodec.decodeAs(Json.create("foo"), boolean.class));
+                JsonCodec.decodeAs(Json.create("foo"), float.class));
     }
 }


### PR DESCRIPTION
Added primitive checking on event data value decoding, so that primitive values get default values instead of null.

Fixes issue #4112

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4132)
<!-- Reviewable:end -->
