### PR TITLE
Recompute eagerly for initial bindings

### DIFF
--- a/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtBasicElementBinderTest.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtBasicElementBinderTest.java
@@ -89,12 +89,20 @@ public class GwtBasicElementBinderTest extends GwtPropertyElementBinderTest {
         assertEquals("foo", element.getLang());
     }
 
-    public void testBindingBeforeFlush() {
+    public void testBindBeforeFlush() {
         titleProperty.setValue("foo");
 
         Binder.bind(node, element);
 
-        assertEquals("", element.getTitle());
+        assertEquals("foo", element.getTitle());
+    }
+
+    public void testSetBeforeFlush() {
+        Binder.bind(node, element);
+
+        titleProperty.setValue("foo");
+
+        assertEquals("null", element.getTitle());
     }
 
     public void testUnbindBeforeFlush() {
@@ -111,7 +119,7 @@ public class GwtBasicElementBinderTest extends GwtPropertyElementBinderTest {
 
         Reactive.flush();
 
-        assertEquals("", element.getTitle());
+        assertEquals("null", element.getTitle());
         assertEquals("", element.getId());
         assertEquals("", element.getLang());
     }
@@ -206,10 +214,18 @@ public class GwtBasicElementBinderTest extends GwtPropertyElementBinderTest {
         assertEquals("foo", element.getLang());
     }
 
-    public void testSetAttributeWithoutFlush() {
+    public void testBindAttributeWithoutFlush() {
         idAttribute.setValue("foo");
 
         Binder.bind(node, element);
+
+        assertEquals("foo", element.getId());
+    }
+
+    public void testSetAttributeWithoutFlush() {
+        Binder.bind(node, element);
+
+        idAttribute.setValue("foo");
 
         assertEquals("", element.getId());
     }
@@ -1821,7 +1837,9 @@ public class GwtBasicElementBinderTest extends GwtPropertyElementBinderTest {
         $wnd.Polymer.dom = function(node){
             return node;
         };
-        $wnd.Polymer.Element = {};
+        $wnd.Polymer.Element = {
+          set: function() {}
+        };
         element.__proto__ = $wnd.Polymer.Element;
         if( !element.removeAttribute ) {
             element.removeAttribute = function(attribute){

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ElementInitOrderView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ElementInitOrderView.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import java.util.stream.Stream;
+
+import com.vaadin.flow.component.Html;
+import com.vaadin.flow.component.dependency.HtmlImport;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+@Route(value = "com.vaadin.flow.uitest.ui.ElementInitOrderView", layout = ViewTestLayout.class)
+@HtmlImport("frontend://com/vaadin/flow/uitest/ui/ElementInitOrder.html")
+public class ElementInitOrderView extends AbstractDivView {
+    public ElementInitOrderView() {
+        NativeButton reattach = new NativeButton("Reattach components",
+                event -> reattachElements());
+        reattach.setId("reattach");
+
+        add(reattach, new Html("<br />"));
+
+        reattachElements();
+    }
+
+    private void reattachElements() {
+        Stream.of("init-order-polymer", "init-order-nopolymer")
+                // Remove old child if present
+                .peek(name -> getElement().getChildren()
+                        .filter(child -> child.getTag().equals(name))
+                        .findFirst().ifPresent(Element::removeFromParent))
+                // Create and attach new child
+                .map(ElementInitOrderView::createElement)
+                .forEach(getElement()::appendChild);
+    }
+
+    private static Element createElement(String tag) {
+        Element element = new Element(tag);
+        element.appendChild(new Element("span"));
+        element.getStyle().set("animationName", "style");
+        element.getClassList().add("class");
+        element.setAttribute("attribute", "attribute");
+        element.setProperty("property", "property");
+        return element;
+    }
+}

--- a/flow-tests/test-root-context/src/main/webapp/frontend/com/vaadin/flow/uitest/ui/ElementInitOrder.html
+++ b/flow-tests/test-root-context/src/main/webapp/frontend/com/vaadin/flow/uitest/ui/ElementInitOrder.html
@@ -1,0 +1,68 @@
+<!--
+  ~ Copyright 2000-2017 Vaadin Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+<!-- Using an absolute URL is a bad practice, but the nesting depth here makes it incovenient traverse up with ../.. -->
+<link rel="import" href="/frontend/bower_components/polymer/polymer-element.html">
+
+<dom-module id="init-order-polymer">
+    <template>
+         Init order with Polymer
+         <p id="status"></p>
+    </template>
+    <script>
+        function createStatusMessage(element) {
+        	return  "property = " + element.property +
+        	    ", attribute = " + element.getAttribute("attribute") + 
+        	    ", child count = " + element.childElementCount +
+        	    ", style = " + element.style.animationName + 
+        	    ", class = " + element.getAttribute("class"); 
+        }    
+        
+        class InitOrderPolymer extends Polymer.Element {
+            static get is() { return 'init-order-polymer' }
+            
+            ready() {
+            	super.ready();
+            	
+                var message = createStatusMessage(this);
+                this.$.status.textContent = message;
+            }
+        }
+        customElements.define(InitOrderPolymer.is, InitOrderPolymer);
+        
+        class InitOrderNopolymer extends HTMLElement {
+            static get is() { return 'init-order-nopolymer' }
+            
+            constructor() {
+            	super();
+            	
+            	var shadow = this.attachShadow({mode: 'open'});
+            	shadow.textContent = "Init order without Polymer";
+            	
+            	this.status = document.createElement("p");
+            	this.status.id = "status";
+            	shadow.appendChild(this.status);
+            }
+            
+            connectedCallback() {
+                var message = createStatusMessage(this);
+                
+                this.status.textContent = message;
+            }
+        }
+        customElements.define(InitOrderNopolymer.is, InitOrderNopolymer);
+        
+    </script>
+</dom-module>

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ElementInitOrderIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ElementInitOrderIT.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import java.net.URISyntaxException;
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+import com.vaadin.testbench.TestBenchElement;
+
+public class ElementInitOrderIT extends ChromeBrowserTest {
+
+    @Test
+    public void elementInitOrder() throws URISyntaxException {
+        open();
+
+        assertInitOrder();
+
+        findElement(By.id("reattach")).click();
+
+        assertInitOrder();
+    }
+
+    private void assertInitOrder() {
+        for (String name : Arrays.asList("init-order-polymer",
+                "init-order-nopolymer")) {
+            TestBenchElement element = $(name).first();
+            String status = findInShadowRoot(element, By.id("status")).get(0)
+                    .getText();
+            Assert.assertEquals(
+                    "property = property, attribute = attribute, child count = 1, style = style, class = class",
+                    status);
+        }
+    }
+}


### PR DESCRIPTION
Fixes the most pressing concern of #481 by eagerly recomputing the
computations that initialize properties, attributes and styles.

The ordering for initial bindings is changed to gradually go to more and
more likely risk of triggering observers. In this way, as many changes
as possible are applied by the time any observer is triggered.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4146)
<!-- Reviewable:end -->
