### PR TITLE
Aggregate dependency javadocs for flow

### DIFF
--- a/flow/pom.xml
+++ b/flow/pom.xml
@@ -1,55 +1,55 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>com.vaadin</groupId>
-		<artifactId>flow-project</artifactId>
-		<version>1.0-SNAPSHOT</version>
-	</parent>
-	<artifactId>flow</artifactId>
-	<packaging>jar</packaging>
-	<name>Flow</name>
-	<description>Flow</description>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.vaadin</groupId>
+        <artifactId>flow-project</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>flow</artifactId>
+    <packaging>jar</packaging>
+    <name>Flow</name>
+    <description>Flow</description>
 
-	<dependencies>
-		<dependency>
-			<groupId>com.vaadin</groupId>
-			<artifactId>flow-server</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>com.vaadin</groupId>
-			<artifactId>flow-push</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>com.vaadin</groupId>
-			<artifactId>flow-client</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>com.vaadin</groupId>
-			<artifactId>flow-html-components</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-	</dependencies>
-	<build>
-		<plugins>
-			<plugin>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.0.0</version>
-				<configuration>
-					<!-- Make combined javadocs so that platform can combine flow with everything -->
-					<includeDependencySources>true</includeDependencySources>
-					<dependencySourceExcludes>
-						<!-- Exclude client engine since it is not user facing API -->
-						<dependencySourceExclude>com.vaadin:flow-client</dependencySourceExclude>
-					</dependencySourceExcludes>
-					<!-- Don't fail on errors, there is plenty of those -->
-					<doclint>none</doclint>
-					<quiet>true</quiet>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-server</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-push</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-html-components</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <!-- Make combined javadocs so that platform can combine flow with everything -->
+                    <includeDependencySources>true</includeDependencySources>
+                    <dependencySourceExcludes>
+                        <!-- Exclude client engine since it is not user facing API -->
+                        <dependencySourceExclude>com.vaadin:flow-client</dependencySourceExclude>
+                    </dependencySourceExcludes>
+                    <!-- Don't fail on errors, there is plenty of those -->
+                    <doclint>none</doclint>
+                    <quiet>true</quiet>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/flow/pom.xml
+++ b/flow/pom.xml
@@ -33,4 +33,23 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>3.0.0</version>
+				<configuration>
+					<!-- Make combined javadocs so that platform can combine flow with everything -->
+					<includeDependencySources>true</includeDependencySources>
+					<dependencySourceExcludes>
+						<!-- Exclude client engine since it is not user facing API -->
+						<dependencySourceExclude>com.vaadin:flow-client</dependencySourceExclude>
+					</dependencySourceExcludes>
+					<!-- Don't fail on errors, there is plenty of those -->
+					<doclint>none</doclint>
+					<quiet>true</quiet>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -281,7 +281,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
Aggregation only works for one level transitive dependencies, thus need
to make aggredated javadocs for com.vaadin:flow dependency so that
aggregation also works for platform which uses flow dependency (instead
of flow-server etc.).
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4150)
<!-- Reviewable:end -->
