### PR TITLE
Use waitUntil() in ExpireSessionIT

### DIFF
--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ExpireSessionIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ExpireSessionIT.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.uitest.ui;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.TimeoutException;
 
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
@@ -39,10 +40,14 @@ public class ExpireSessionIT extends ChromeBrowserTest {
         // Just click on any button to make a request after killing the session
         clickButton(CLOSE_SESSION);
 
-        Assert.assertFalse(
-                "After killing the session, the page should be refreshed, "
-                        + "resetting the state of the UI.",
-                isMessageUpdated());
+        try {
+            waitUntil(driver -> !isMessageUpdated());
+        } catch (TimeoutException e) {
+            Assert.fail(
+                    "After killing the session, the page should be refreshed, "
+                            + "resetting the state of the UI.");
+        }
+
         Assert.assertFalse(
                 "By default, the 'Session Expired' notification "
                         + "should not be used",


### PR DESCRIPTION
The test has been un-stable at the point where it should verify that the
page is refreshed. This hopefully makes it more stable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4154)
<!-- Reviewable:end -->
