### PR TITLE
Avoid using java.util.Date

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.client.communication;
 
-import java.util.Date;
-
 import com.google.gwt.core.client.Duration;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.user.client.Timer;
@@ -259,7 +257,7 @@ public class MessageHandler {
             return;
         }
 
-        final Date start = new Date();
+        double start = Duration.currentTimeMillis();
         /*
          * Lock response handling to avoid a situation where something pushed
          * from the server gets processed while waiting for e.g. lazily loaded
@@ -359,7 +357,7 @@ public class MessageHandler {
      * @param start
      *            the time stamp when processing started
      */
-    private void processMessage(ValueMap valueMap, Object lock, Date start) {
+    private void processMessage(ValueMap valueMap, Object lock, double start) {
         assert getServerId(valueMap) == -1
                 || getServerId(valueMap) == lastSeenServerSyncId;
 
@@ -417,8 +415,7 @@ public class MessageHandler {
             nextResponseSessionExpiredHandler = null;
             Reactive.flush();
 
-            lastProcessingTime = (int) ((new Date().getTime())
-                    - start.getTime());
+            lastProcessingTime = (int) (Duration.currentTimeMillis() - start);
             totalProcessingTime += lastProcessingTime;
             if (!initialMessageHandled) {
                 initialMessageHandled = true;


### PR DESCRIPTION
Reduces the gzipped size of the client engine with around 1200 bytes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4170)
<!-- Reviewable:end -->
