### PR TITLE
Add default loading indicator theme

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
@@ -18,14 +18,12 @@ package com.vaadin.client;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
-
+import com.vaadin.client.communication.LoadingIndicatorConfigurator;
 import com.vaadin.client.communication.PollConfigurator;
-import com.vaadin.client.communication.Poller;
 import com.vaadin.client.communication.ReconnectDialogConfiguration;
 import com.vaadin.client.flow.RouterLinkHandler;
 import com.vaadin.client.flow.StateNode;
 import com.vaadin.client.flow.binding.Binder;
-
 import elemental.client.Browser;
 import elemental.dom.Element;
 import elemental.dom.Node;
@@ -57,6 +55,7 @@ public class ApplicationConnection {
         // Bind UI configuration objects
         PollConfigurator.observe(rootNode, registry.getPoller());
         ReconnectDialogConfiguration.bind(registry.getConnectionStateHandler());
+        LoadingIndicatorConfigurator.observe(rootNode, registry.getLoadingIndicator());
 
         new PopStateHandler(registry).bind();
 

--- a/flow-client/src/main/java/com/vaadin/client/LoadingIndicator.java
+++ b/flow-client/src/main/java/com/vaadin/client/LoadingIndicator.java
@@ -119,7 +119,7 @@ public class LoadingIndicator {
     private Element element;
 
     private Element styleElement;
-    private boolean defaultThemeApplied = true;
+    private boolean applyDefaultTheme = true;
 
     /**
      * Returns the delay (in ms) which must pass before the loading indicator
@@ -288,9 +288,9 @@ public class LoadingIndicator {
         }
 
         boolean attached = styleElement.getParentElement() != null;
-        if (defaultThemeApplied && !attached) {
+        if (isApplyDefaultTheme() && !attached) {
             Browser.getDocument().getHead().appendChild(styleElement);
-        } else if (!defaultThemeApplied && attached) {
+        } else if (!isApplyDefaultTheme() && attached) {
             styleElement.getParentElement().removeChild(styleElement);
         }
     }
@@ -300,11 +300,11 @@ public class LoadingIndicator {
      * <p>
      * Default is {@code true}.
      *
-     * @param defaultThemeApplied
+     * @param applyDefaultTheme
      *         {@code true} for applying the default theming, {@code false} for not
      */
-    public void setDefaultThemeApplied(boolean defaultThemeApplied) {
-        this.defaultThemeApplied = defaultThemeApplied;
+    public void setApplyDefaultTheme(boolean applyDefaultTheme) {
+        this.applyDefaultTheme = applyDefaultTheme;
         setupTheming();
     }
 
@@ -315,7 +315,7 @@ public class LoadingIndicator {
      *
      * @return {@code true} for applying the default theming, {@code false} for not
      */
-    public boolean isDefaultThemeApplied() {
-        return defaultThemeApplied;
+    public boolean isApplyDefaultTheme() {
+        return applyDefaultTheme;
     }
 }

--- a/flow-client/src/main/java/com/vaadin/client/LoadingIndicator.java
+++ b/flow-client/src/main/java/com/vaadin/client/LoadingIndicator.java
@@ -18,7 +18,6 @@ package com.vaadin.client;
 
 import com.google.gwt.user.client.Timer;
 import com.vaadin.flow.internal.nodefeature.LoadingIndicatorConfigurationMap;
-
 import elemental.client.Browser;
 import elemental.css.CSSStyleDeclaration.Display;
 import elemental.dom.Element;
@@ -37,6 +36,60 @@ import elemental.dom.Element;
 public class LoadingIndicator {
 
     private static final String PRIMARY_STYLE_NAME = "v-loading-indicator";
+
+    private static final String DEFAULT_THEMING = "@-webkit-keyframes v-progress-start {" +
+            "0% {width: 0%;}" +
+            "100% {width: 50%;}}" +
+            "@-moz-keyframes v-progress-start {" +
+            "0% {width: 0%;}" +
+            "100% {width: 50%;}}" +
+            "@keyframes v-progress-start {" +
+            "0% {width: 0%;}" +
+            "100% {width: 50%;}}" +
+            "@keyframes v-progress-delay {" +
+            "0% {width: 50%;}" +
+            "100% {width: 90%;}}" +
+            "@keyframes v-progress-wait {" +
+            "0% {width: 90%;height: 4px;}" +
+            "3% {width: 91%;height: 7px;}" +
+            "100% {width: 96%;height: 7px;}}" +
+            "@-webkit-keyframes v-progress-wait-pulse {" +
+            "0% {opacity: 1;}" +
+            "50% {opacity: 0.1;}" +
+            "100% {opacity: 1;}}" +
+            "@-moz-keyframes v-progress-wait-pulse {" +
+            "0% {opacity: 1;}" +
+            "50% {opacity: 0.1;}" +
+            "100% {opacity: 1;}}" +
+            "@keyframes v-progress-wait-pulse {" +
+            "0% {opacity: 1;}" +
+            "50% {opacity: 0.1;}" +
+            "100% {opacity: 1;}}" +
+            ".v-loading-indicator {" +
+            "position: fixed !important;" +
+            "z-index: 99999;" +
+            "left: 0;" +
+            "right: auto;" +
+            "top: 0;" +
+            "width: 50%;" +
+            "opacity: 1;" +
+            "height: 4px;" +
+            "background-color: var(--lumo-primary-color, blue);" +
+            "pointer-events: none;" +
+            "transition: none;" +
+            "animation: v-progress-start 1000ms 200ms both;}" +
+            ".v-loading-indicator[style*=\"none\"] {" +
+            "display: block !important;" +
+            "width: 100% !important;" +
+            "opacity: 0;" +
+            "animation: none !important;" +
+            "transition: opacity 500ms 300ms, width 300ms;}" +
+            ".v-loading-indicator.second {" +
+            "width: 90%;" +
+            "animation: v-progress-delay 3.8s forwards;}" +
+            ".v-loading-indicator.third {" +
+            "width: 96%;" +
+            "animation: v-progress-wait 5s forwards, v-progress-wait-pulse 1s 4s infinite backwards;}";
 
     private int firstDelay = LoadingIndicatorConfigurationMap.FIRST_DELAY_DEFAULT;
     private int secondDelay = LoadingIndicatorConfigurationMap.SECOND_DELAY_DEFAULT;
@@ -65,12 +118,15 @@ public class LoadingIndicator {
 
     private Element element;
 
+    private Element styleElement;
+    private boolean defaultThemeApplied = true;
+
     /**
      * Returns the delay (in ms) which must pass before the loading indicator
      * moves into the "first" state and is shown to the user
      *
      * @return The delay (in ms) until moving into the "first" state. Counted
-     *         from when {@link #trigger()} is called.
+     * from when {@link #trigger()} is called.
      */
     public int getFirstDelay() {
         return firstDelay;
@@ -81,8 +137,8 @@ public class LoadingIndicator {
      * into the "first" state and is shown to the user
      *
      * @param firstDelay
-     *            The delay (in ms) until moving into the "first" state. Counted
-     *            from when {@link #trigger()} is called.
+     *         The delay (in ms) until moving into the "first" state. Counted
+     *         from when {@link #trigger()} is called.
      */
     public void setFirstDelay(int firstDelay) {
         this.firstDelay = firstDelay;
@@ -93,7 +149,7 @@ public class LoadingIndicator {
      * moves to its "second" state.
      *
      * @return The delay (in ms) until the loading indicator moves into its
-     *         "second" state. Counted from when {@link #trigger()} is called.
+     * "second" state. Counted from when {@link #trigger()} is called.
      */
     public int getSecondDelay() {
         return secondDelay;
@@ -104,9 +160,9 @@ public class LoadingIndicator {
      * to its "second" state.
      *
      * @param secondDelay
-     *            The delay (in ms) until the loading indicator moves into its
-     *            "second" state. Counted from when {@link #trigger()} is
-     *            called.
+     *         The delay (in ms) until the loading indicator moves into its
+     *         "second" state. Counted from when {@link #trigger()} is
+     *         called.
      */
     public void setSecondDelay(int secondDelay) {
         this.secondDelay = secondDelay;
@@ -117,7 +173,7 @@ public class LoadingIndicator {
      * moves to its "third" state.
      *
      * @return The delay (in ms) until the loading indicator moves into its
-     *         "third" state. Counted from when {@link #trigger()} is called.
+     * "third" state. Counted from when {@link #trigger()} is called.
      */
     public int getThirdDelay() {
         return thirdDelay;
@@ -128,9 +184,9 @@ public class LoadingIndicator {
      * to its "third" state.
      *
      * @param thirdDelay
-     *            The delay (in ms) from the event until changing the loading
-     *            indicator into its "third" state. Counted from when
-     *            {@link #trigger()} is called.
+     *         The delay (in ms) from the event until changing the loading
+     *         indicator into its "third" state. Counted from when
+     *         {@link #trigger()} is called.
      */
     public void setThirdDelay(int thirdDelay) {
         this.thirdDelay = thirdDelay;
@@ -216,10 +272,50 @@ public class LoadingIndicator {
      */
     public Element getElement() {
         if (element == null) {
+            setupTheming();
+
             element = Browser.getDocument().createElement("div");
             Browser.getDocument().getBody().appendChild(element);
         }
         return element;
     }
 
+    private void setupTheming() {
+        if (styleElement == null) {
+            styleElement = Browser.getDocument().createStyleElement();
+            styleElement.setAttribute("type", "text/css");
+            styleElement.setInnerHTML(DEFAULT_THEMING);
+        }
+
+        boolean attached = styleElement.getParentElement() != null;
+        if (defaultThemeApplied && !attached) {
+            Browser.getDocument().getHead().appendChild(styleElement);
+        } else if (!defaultThemeApplied && attached) {
+            styleElement.getParentElement().removeChild(styleElement);
+        }
+    }
+
+    /**
+     * Sets whether the default theming should be applied for the loading indicator or not.
+     * <p>
+     * Default is {@code true}.
+     *
+     * @param defaultThemeApplied
+     *         {@code true} for applying the default theming, {@code false} for not
+     */
+    public void setDefaultThemeApplied(boolean defaultThemeApplied) {
+        this.defaultThemeApplied = defaultThemeApplied;
+        setupTheming();
+    }
+
+    /**
+     * Returns whether the default theming should be applied for the loading indicator or not.
+     * <p>
+     * Default is {@code true}.
+     *
+     * @return {@code true} for applying the default theming, {@code false} for not
+     */
+    public boolean isDefaultThemeApplied() {
+        return defaultThemeApplied;
+    }
 }

--- a/flow-client/src/main/java/com/vaadin/client/communication/LoadingIndicatorConfigurator.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/LoadingIndicatorConfigurator.java
@@ -62,7 +62,7 @@ public class LoadingIndicatorConfigurator {
                 LoadingIndicatorConfigurationMap.THIRD_DELAY_DEFAULT);
 
         MapProperty defaultThemeProperty = configMap.getProperty(LoadingIndicatorConfigurationMap.DEFAULT_THEME_APPLIED_KEY);
-        defaultThemeProperty.addChangeListener(event -> loadingIndicator.setDefaultThemeApplied(event.getSource().getValueOrDefault(LoadingIndicatorConfigurationMap.DEFAULT_THEME_APPLIED_DEFAULT)));
+        defaultThemeProperty.addChangeListener(event -> loadingIndicator.setApplyDefaultTheme(event.getSource().getValueOrDefault(LoadingIndicatorConfigurationMap.DEFAULT_THEME_APPLIED_DEFAULT)));
     }
 
     /**

--- a/flow-client/src/main/java/com/vaadin/client/communication/LoadingIndicatorConfigurator.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/LoadingIndicatorConfigurator.java
@@ -60,6 +60,9 @@ public class LoadingIndicatorConfigurator {
         bindInteger(configMap, LoadingIndicatorConfigurationMap.THIRD_DELAY_KEY,
                 loadingIndicator::setThirdDelay,
                 LoadingIndicatorConfigurationMap.THIRD_DELAY_DEFAULT);
+
+        MapProperty defaultThemeProperty = configMap.getProperty(LoadingIndicatorConfigurationMap.DEFAULT_THEME_APPLIED_KEY);
+        defaultThemeProperty.addChangeListener(event -> loadingIndicator.setDefaultThemeApplied(event.getSource().getValueOrDefault(LoadingIndicatorConfigurationMap.DEFAULT_THEME_APPLIED_DEFAULT)));
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/LoadingIndicatorConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/LoadingIndicatorConfiguration.java
@@ -77,4 +77,8 @@ public interface LoadingIndicatorConfiguration extends Serializable {
      * @return The delay before going into the "third" state (in ms)
      */
     int getThirdDelay();
+
+    boolean isDefaultThemeApplied();
+
+    void setDefaultThemeApplied(boolean defaultThemeApplied);
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/LoadingIndicatorConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/LoadingIndicatorConfiguration.java
@@ -28,8 +28,7 @@ public interface LoadingIndicatorConfiguration extends Serializable {
      * Sets the delay before the loading indicator is shown. The default is
      * 300ms.
      *
-     * @param firstDelay
-     *            The first delay (in ms)
+     * @param firstDelay The first delay (in ms)
      */
     void setFirstDelay(int firstDelay);
 
@@ -45,8 +44,7 @@ public interface LoadingIndicatorConfiguration extends Serializable {
      * The delay is calculated from the time when the loading indicator was
      * triggered. The default is 1500ms.
      *
-     * @param secondDelay
-     *            The delay before going into the "second" state (in ms)
+     * @param secondDelay The delay before going into the "second" state (in ms)
      */
     void setSecondDelay(int secondDelay);
 
@@ -64,8 +62,7 @@ public interface LoadingIndicatorConfiguration extends Serializable {
      * The delay is calculated from the time when the loading indicator was
      * triggered. The default is 5000ms.
      *
-     * @param thirdDelay
-     *            The delay before going into the "third" state (in ms)
+     * @param thirdDelay The delay before going into the "third" state (in ms)
      */
     void setThirdDelay(int thirdDelay);
 
@@ -78,7 +75,26 @@ public interface LoadingIndicatorConfiguration extends Serializable {
      */
     int getThirdDelay();
 
+    /**
+     * Returns whether the default theming is applied for the loading indicator,
+     * making it visible for users.
+     * <p>
+     * By default, it is shown ({@code true}) and there is a progress bar on top
+     * of the viewport shown after a delay to the users while there is an active
+     * server request in process.
+     *
+     * @return {@code true} for applying default theme, {@code false} for not
+     */
     boolean isDefaultThemeApplied();
 
+    /**
+     * Sets whether the default theming is applied for the loading indicator.
+     * <p>
+     * By default, it is shown ({@code true}) and there is a progress bar on top
+     * of the viewport shown after a delay to the users while there is an active
+     * server request in process.
+     *
+     * @param defaultThemeApplied {@code true} to apply default theming, {@code false} for not
+     */
     void setDefaultThemeApplied(boolean defaultThemeApplied);
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/LoadingIndicatorConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/LoadingIndicatorConfiguration.java
@@ -85,7 +85,7 @@ public interface LoadingIndicatorConfiguration extends Serializable {
      *
      * @return {@code true} for applying default theme, {@code false} for not
      */
-    boolean isDefaultThemeApplied();
+    boolean isApplyDefaultTheme();
 
     /**
      * Sets whether the default theming is applied for the loading indicator.
@@ -94,7 +94,7 @@ public interface LoadingIndicatorConfiguration extends Serializable {
      * of the viewport shown after a delay to the users while there is an active
      * server request in process.
      *
-     * @param defaultThemeApplied {@code true} to apply default theming, {@code false} for not
+     * @param applyDefaultTheme {@code true} to apply default theming, {@code false} for not
      */
-    void setDefaultThemeApplied(boolean defaultThemeApplied);
+    void setApplyDefaultTheme(boolean applyDefaultTheme);
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/LoadingIndicatorConfigurationMap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/LoadingIndicatorConfigurationMap.java
@@ -31,12 +31,14 @@ public class LoadingIndicatorConfigurationMap extends NodeMap
     public static final int SECOND_DELAY_DEFAULT = 1500;
     public static final String THIRD_DELAY_KEY = "third";
     public static final int THIRD_DELAY_DEFAULT = 5000;
+    public static final String DEFAULT_THEME_APPLIED_KEY = "theme";
+    public static final boolean DEFAULT_THEME_APPLIED_DEFAULT = true;
 
     /**
      * Creates a new map for the given node.
      *
      * @param node
-     *            the node that the map belongs to
+     *         the node that the map belongs to
      */
     public LoadingIndicatorConfigurationMap(StateNode node) {
         super(node);
@@ -70,5 +72,15 @@ public class LoadingIndicatorConfigurationMap extends NodeMap
     @Override
     public int getThirdDelay() {
         return getOrDefault(THIRD_DELAY_KEY, THIRD_DELAY_DEFAULT);
+    }
+
+    @Override
+    public boolean isDefaultThemeApplied() {
+        return getOrDefault(DEFAULT_THEME_APPLIED_KEY, DEFAULT_THEME_APPLIED_DEFAULT);
+    }
+
+    @Override
+    public void setDefaultThemeApplied(boolean defaultThemeApplied) {
+        put(DEFAULT_THEME_APPLIED_KEY, defaultThemeApplied);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/LoadingIndicatorConfigurationMap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/LoadingIndicatorConfigurationMap.java
@@ -75,12 +75,12 @@ public class LoadingIndicatorConfigurationMap extends NodeMap
     }
 
     @Override
-    public boolean isDefaultThemeApplied() {
+    public boolean isApplyDefaultTheme() {
         return getOrDefault(DEFAULT_THEME_APPLIED_KEY, DEFAULT_THEME_APPLIED_DEFAULT);
     }
 
     @Override
-    public void setDefaultThemeApplied(boolean defaultThemeApplied) {
-        put(DEFAULT_THEME_APPLIED_KEY, defaultThemeApplied);
+    public void setApplyDefaultTheme(boolean applyDefaultTheme) {
+        put(DEFAULT_THEME_APPLIED_KEY, applyDefaultTheme);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -16,8 +16,6 @@
 
 package com.vaadin.flow.server;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -41,17 +39,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.DataNode;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.DocumentType;
-import org.jsoup.nodes.Element;
-import org.jsoup.parser.Parser;
-import org.jsoup.parser.Tag;
-import org.jsoup.select.Elements;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.vaadin.flow.component.PushConfiguration;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.page.Inline;
@@ -71,12 +58,21 @@ import com.vaadin.flow.shared.communication.PushMode;
 import com.vaadin.flow.shared.ui.Dependency;
 import com.vaadin.flow.shared.ui.LoadMode;
 import com.vaadin.flow.theme.ThemeDefinition;
-
 import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 import elemental.json.JsonValue;
 import elemental.json.impl.JsonUtil;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.DataNode;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.DocumentType;
+import org.jsoup.nodes.Element;
+import org.jsoup.parser.Parser;
+import org.jsoup.parser.Tag;
+import org.jsoup.select.Elements;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitialPageSettings.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitialPageSettings.java
@@ -22,16 +22,17 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.jsoup.nodes.Element;
-import org.jsoup.parser.Tag;
-
+import com.vaadin.flow.component.PushConfiguration;
+import com.vaadin.flow.component.ReconnectDialogConfiguration;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.page.LoadingIndicatorConfiguration;
 import com.vaadin.flow.router.AfterNavigationEvent;
 import com.vaadin.flow.shared.ui.Dependency;
 import com.vaadin.flow.shared.ui.LoadMode;
-
 import elemental.json.Json;
 import elemental.json.JsonObject;
+import org.jsoup.nodes.Element;
+import org.jsoup.parser.Tag;
 
 /**
  * Initial page settings class for modifying the bootstrap page.
@@ -69,16 +70,16 @@ public class InitialPageSettings implements Serializable {
      * Create new initial page settings object.
      *
      * @param request
-     *            initial request
+     *         initial request
      * @param ui
-     *            target ui
+     *         target ui
      * @param afterNavigationEvent
-     *            after navigation event
+     *         after navigation event
      * @param browser
-     *            browser information
+     *         browser information
      */
     public InitialPageSettings(VaadinRequest request, UI ui,
-            AfterNavigationEvent afterNavigationEvent, WebBrowser browser) {
+                               AfterNavigationEvent afterNavigationEvent, WebBrowser browser) {
         this.request = request;
         this.ui = ui;
         this.afterNavigationEvent = afterNavigationEvent;
@@ -125,7 +126,7 @@ public class InitialPageSettings implements Serializable {
      * Set the viewport value.
      *
      * @param viewport
-     *            viewport value to set
+     *         viewport value to set
      */
     public void setViewport(String viewport) {
         this.viewport = viewport;
@@ -147,9 +148,9 @@ public class InitialPageSettings implements Serializable {
      * Inline contents from classpath file to append to head of initial page.
      *
      * @param file
-     *            dependency file to read and write to head
+     *         dependency file to read and write to head
      * @param type
-     *            dependency type
+     *         dependency type
      */
     public void addInlineFromFile(String file, WrapMode type) {
         addInlineFromFile(Position.APPEND, file, type);
@@ -159,14 +160,14 @@ public class InitialPageSettings implements Serializable {
      * Inline contents from classpath file to head of initial page.
      *
      * @param position
-     *            prepend or append
+     *         prepend or append
      * @param file
-     *            dependency file to read and write to head
+     *         dependency file to read and write to head
      * @param type
-     *            dependency type
+     *         dependency type
      */
     public void addInlineFromFile(Position position, String file,
-            WrapMode type) {
+                                  WrapMode type) {
         JsonObject prepend = createInlineObject(type);
         prepend.put(Dependency.KEY_CONTENTS,
                 BootstrapUtils.getDependencyContents(request, file));
@@ -177,9 +178,9 @@ public class InitialPageSettings implements Serializable {
      * Add content to append to head of initial page.
      *
      * @param contents
-     *            dependency content
+     *         dependency content
      * @param type
-     *            dependency type
+     *         dependency type
      */
     public void addInlineWithContents(String contents, WrapMode type) {
         addInlineWithContents(Position.APPEND, contents, type);
@@ -189,14 +190,14 @@ public class InitialPageSettings implements Serializable {
      * Add content to head of initial page.
      *
      * @param position
-     *            prepend or append
+     *         prepend or append
      * @param contents
-     *            dependency content
+     *         dependency content
      * @param type
-     *            dependency type
+     *         dependency type
      */
     public void addInlineWithContents(Position position, String contents,
-            WrapMode type) {
+                                      WrapMode type) {
         JsonObject prepend = createInlineObject(type);
         prepend.put(Dependency.KEY_CONTENTS, contents);
         getInline(position).add(prepend);
@@ -206,7 +207,7 @@ public class InitialPageSettings implements Serializable {
      * Get the list of inline objects to append to head.
      *
      * @param position
-     *            prepend or append
+     *         prepend or append
      * @return current list of inline objects
      */
     protected List<JsonObject> getInline(Position position) {
@@ -217,7 +218,7 @@ public class InitialPageSettings implements Serializable {
      * Get the list of links to append to head.
      *
      * @param position
-     *            prepend or append
+     *         prepend or append
      * @return current list of links
      */
     protected List<Element> getElement(Position position) {
@@ -228,7 +229,7 @@ public class InitialPageSettings implements Serializable {
      * Add a link to be appended to initial page head.
      *
      * @param href
-     *            link href
+     *         link href
      */
     public void addLink(String href) {
         addLink(Position.APPEND, href);
@@ -238,9 +239,9 @@ public class InitialPageSettings implements Serializable {
      * Add a link to initial page head.
      *
      * @param position
-     *            prepend or append
+     *         prepend or append
      * @param href
-     *            link href
+     *         link href
      */
     public void addLink(Position position, String href) {
         addLink(position, href, new HashMap<>());
@@ -250,9 +251,9 @@ public class InitialPageSettings implements Serializable {
      * Append a link to initial page head.
      *
      * @param href
-     *            location of the linked document
+     *         location of the linked document
      * @param attributes
-     *            map of attributes for link element
+     *         map of attributes for link element
      */
     public void addLink(String href, Map<String, String> attributes) {
         addLink(Position.APPEND, href, attributes);
@@ -262,14 +263,14 @@ public class InitialPageSettings implements Serializable {
      * Add a link to initial page head.
      *
      * @param position
-     *            prepend or append
+     *         prepend or append
      * @param href
-     *            location of the linked document
+     *         location of the linked document
      * @param attributes
-     *            map of attributes for link element
+     *         map of attributes for link element
      */
     public void addLink(Position position, String href,
-            Map<String, String> attributes) {
+                        Map<String, String> attributes) {
         Element link = new Element(Tag.valueOf("link"), "").attr("href", href);
         attributes.forEach((key, value) -> link.attr(key, value));
         getElement(position).add(link);
@@ -277,11 +278,11 @@ public class InitialPageSettings implements Serializable {
 
     /**
      * Append a link to initial page head.
-     * 
+     *
      * @param rel
-     *            link relationship
+     *         link relationship
      * @param href
-     *            location of the linked document
+     *         location of the linked document
      */
     public void addLink(String rel, String href) {
         addLink(Position.APPEND, rel, href);
@@ -289,13 +290,13 @@ public class InitialPageSettings implements Serializable {
 
     /**
      * Add a link to initial page head.
-     * 
+     *
      * @param position
-     *            prepend or append
+     *         prepend or append
      * @param rel
-     *            link relationship
+     *         link relationship
      * @param href
-     *            location of the linked document
+     *         location of the linked document
      */
     public void addLink(Position position, String rel, String href) {
         Element link = new Element(Tag.valueOf("link"), "").attr("href", href);
@@ -305,13 +306,13 @@ public class InitialPageSettings implements Serializable {
 
     /**
      * Append a fav icon link to initial page head.
-     * 
+     *
      * @param rel
-     *            link relationship
+     *         link relationship
      * @param href
-     *            location of the fav icon
+     *         location of the fav icon
      * @param sizes
-     *            size of the linked fav icon
+     *         size of the linked fav icon
      */
     public void addFavIcon(String rel, String href, String sizes) {
         addFavIcon(Position.APPEND, rel, href, sizes);
@@ -321,16 +322,16 @@ public class InitialPageSettings implements Serializable {
      * Append a fav icon link to initial page head.
      *
      * @param position
-     *            prepend or append
+     *         prepend or append
      * @param rel
-     *            link relationship
+     *         link relationship
      * @param href
-     *            location of the fav icon
+     *         location of the fav icon
      * @param sizes
-     *            size of the linked fav icon
+     *         size of the linked fav icon
      */
     public void addFavIcon(Position position, String rel, String href,
-            String sizes) {
+                           String sizes) {
         Element link = new Element(Tag.valueOf("link"), "").attr("href", href);
         link.attr("rel", rel);
         link.attr("sizes", sizes);
@@ -341,9 +342,9 @@ public class InitialPageSettings implements Serializable {
      * Add a meta tag to be appended to initial page head.
      *
      * @param name
-     *            meta tag name
+     *         meta tag name
      * @param content
-     *            meta tag content
+     *         meta tag content
      */
     public void addMetaTag(String name, String content) {
         addMetaTag(Position.APPEND, name, content);
@@ -353,16 +354,43 @@ public class InitialPageSettings implements Serializable {
      * Add a meta tag to initial page head.
      *
      * @param position
-     *            prepend or append
+     *         prepend or append
      * @param name
-     *            meta tag name
+     *         meta tag name
      * @param content
-     *            meta tag content
+     *         meta tag content
      */
     public void addMetaTag(Position position, String name, String content) {
         Element meta = new Element(Tag.valueOf("meta"), "").attr("name", name)
                 .attr("content", content);
         getElement(position).add(meta);
+    }
+
+    /**
+     * Returns the configuration object for loading indicator.
+     *
+     * @return the instance used for configuring the loading indicator
+     */
+    public LoadingIndicatorConfiguration getLoadingIndicatorConfiguration() {
+        return getUi().getLoadingIndicatorConfiguration();
+    }
+
+    /**
+     * Returns the configuration object for reconnect dialog.
+     *
+     * @return The instance used for reconnect dialog configuration
+     */
+    public ReconnectDialogConfiguration getReconnectDialogConfiguration() {
+        return getUi().getReconnectDialogConfiguration();
+    }
+
+    /**
+     * Returns the object used for configuring the push channel.
+     *
+     * @return the instance used for push channel configuration
+     */
+    public PushConfiguration getPushConfiguration() {
+        return getUi().getPushConfiguration();
     }
 
     private JsonObject createInlineObject(WrapMode type) {

--- a/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/LoadingIndicatorConfigurationMapTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/LoadingIndicatorConfigurationMapTest.java
@@ -35,7 +35,7 @@ public class LoadingIndicatorConfigurationMapTest
                 map.getThirdDelay());
         Assert.assertEquals(
                 LoadingIndicatorConfigurationMap.DEFAULT_THEME_APPLIED_DEFAULT,
-                map.isDefaultThemeApplied());
+                map.isApplyDefaultTheme());
     }
 
     @Test
@@ -59,6 +59,6 @@ public class LoadingIndicatorConfigurationMapTest
     @Test
     public void setGetDefaultThemeApplied() {
         testBoolean(map, LoadingIndicatorConfigurationMap.DEFAULT_THEME_APPLIED_KEY,
-                map::setDefaultThemeApplied, map::isDefaultThemeApplied);
+                map::setApplyDefaultTheme, map::isApplyDefaultTheme);
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/LoadingIndicatorConfigurationMapTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/LoadingIndicatorConfigurationMapTest.java
@@ -18,8 +18,6 @@ package com.vaadin.flow.internal.nodefeature;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.vaadin.flow.internal.nodefeature.LoadingIndicatorConfigurationMap;
-
 public class LoadingIndicatorConfigurationMapTest
         extends AbstractMapFeatureTest<LoadingIndicatorConfigurationMap> {
     private final LoadingIndicatorConfigurationMap map = createFeature();
@@ -35,6 +33,9 @@ public class LoadingIndicatorConfigurationMapTest
         Assert.assertEquals(
                 LoadingIndicatorConfigurationMap.THIRD_DELAY_DEFAULT,
                 map.getThirdDelay());
+        Assert.assertEquals(
+                LoadingIndicatorConfigurationMap.DEFAULT_THEME_APPLIED_DEFAULT,
+                map.isDefaultThemeApplied());
     }
 
     @Test
@@ -55,4 +56,9 @@ public class LoadingIndicatorConfigurationMapTest
                 map::setThirdDelay, map::getThirdDelay);
     }
 
+    @Test
+    public void setGetDefaultThemeApplied() {
+        testBoolean(map, LoadingIndicatorConfigurationMap.DEFAULT_THEME_APPLIED_KEY,
+                map::setDefaultThemeApplied, map::isDefaultThemeApplied);
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
@@ -339,7 +339,7 @@ public class BootstrapHandlerTest {
 
         @Override
         public void configurePage(InitialPageSettings settings) {
-            settings.getLoadingIndicatorConfiguration().setDefaultThemeApplied(false);
+            settings.getLoadingIndicatorConfiguration().setApplyDefaultTheme(false);
             settings.getLoadingIndicatorConfiguration().setSecondDelay(SECOND_DELAY);
 
             settings.getPushConfiguration().setPushMode(PushMode.MANUAL);
@@ -1573,13 +1573,13 @@ public class BootstrapHandlerTest {
 
     @Test
     public void testUIConfiguration_usingPageSettings() throws Exception {
-        Assert.assertTrue("By default loading indicator is themed", testUI.getLoadingIndicatorConfiguration().isDefaultThemeApplied());
+        Assert.assertTrue("By default loading indicator is themed", testUI.getLoadingIndicatorConfiguration().isApplyDefaultTheme());
 
         initUI(testUI, createVaadinRequest(), Collections.singleton(InitialPageConfiguratorRoute.class));
         Document page = BootstrapHandler.getBootstrapPage(
                 new BootstrapContext(request, null, session, testUI));
 
-        Assert.assertFalse("Default indicator theme is not themed anymore", testUI.getLoadingIndicatorConfiguration().isDefaultThemeApplied());
+        Assert.assertFalse("Default indicator theme is not themed anymore", testUI.getLoadingIndicatorConfiguration().isApplyDefaultTheme());
 
         Assert.assertEquals(InitialPageConfiguratorRoute.SECOND_DELAY, testUI.getLoadingIndicatorConfiguration().getSecondDelay());
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
@@ -1,11 +1,6 @@
 package com.vaadin.flow.server;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-
+import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -17,19 +12,6 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-
-import javax.servlet.http.HttpServletRequest;
-
-import org.apache.commons.io.IOUtils;
-import org.hamcrest.CoreMatchers;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
-import org.jsoup.select.Elements;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Html;
@@ -56,11 +38,28 @@ import com.vaadin.flow.server.MockServletServiceSessionSetup.TestVaadinServletSe
 import com.vaadin.flow.shared.ApplicationConstants;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.shared.VaadinUriResolver;
+import com.vaadin.flow.shared.communication.PushMode;
 import com.vaadin.flow.shared.ui.Dependency;
 import com.vaadin.flow.shared.ui.LoadMode;
 import com.vaadin.flow.theme.AbstractTheme;
 import com.vaadin.flow.theme.Theme;
 import com.vaadin.tests.util.MockDeploymentConfiguration;
+import org.apache.commons.io.IOUtils;
+import org.hamcrest.CoreMatchers;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class BootstrapHandlerTest {
 
@@ -331,6 +330,24 @@ public class BootstrapHandlerTest {
     public static class ExtendingView extends AbstractMain {
     }
 
+    @Route("")
+    @Tag(Tag.DIV)
+    public static class InitialPageConfiguratorRoute extends Component
+            implements PageConfigurator {
+
+        public static final int SECOND_DELAY = 700000;
+
+        @Override
+        public void configurePage(InitialPageSettings settings) {
+            settings.getLoadingIndicatorConfiguration().setDefaultThemeApplied(false);
+            settings.getLoadingIndicatorConfiguration().setSecondDelay(SECOND_DELAY);
+
+            settings.getPushConfiguration().setPushMode(PushMode.MANUAL);
+
+            settings.getReconnectDialogConfiguration().setDialogModal(true);
+        }
+    }
+
     private TestUI testUI;
     private BootstrapContext context;
     private VaadinRequest request;
@@ -395,7 +412,7 @@ public class BootstrapHandlerTest {
     }
 
     private void initUI(UI ui, VaadinRequest request,
-            Set<Class<? extends Component>> navigationTargets)
+                        Set<Class<? extends Component>> navigationTargets)
             throws InvalidRouteConfigurationException {
 
         service.getRouteRegistry().setNavigationTargets(navigationTargets);
@@ -1464,7 +1481,7 @@ public class BootstrapHandlerTest {
     }
 
     private void assertStringEquals(String message, String expected,
-            String actual) {
+                                    String actual) {
         Assert.assertThat(message,
                 actual.replaceAll(System.getProperty("line.separator"), "\n"),
                 CoreMatchers.equalTo(expected));
@@ -1496,7 +1513,7 @@ public class BootstrapHandlerTest {
     }
 
     private void checkInlinedScript(Element head, String scriptName,
-            boolean shouldBeInlined) {
+                                    boolean shouldBeInlined) {
         StringBuilder builder = new StringBuilder();
         try (InputStream stream = getClass().getResourceAsStream(scriptName)) {
             IOUtils.readLines(stream, StandardCharsets.UTF_8)
@@ -1552,5 +1569,22 @@ public class BootstrapHandlerTest {
         Assert.assertEquals("viewport-annotation-value",
                 viewport.attr(BootstrapHandler.CONTENT_ATTRIBUTE));
 
+    }
+
+    @Test
+    public void testUIConfiguration_usingPageSettings() throws Exception {
+        Assert.assertTrue("By default loading indicator is themed", testUI.getLoadingIndicatorConfiguration().isDefaultThemeApplied());
+
+        initUI(testUI, createVaadinRequest(), Collections.singleton(InitialPageConfiguratorRoute.class));
+        Document page = BootstrapHandler.getBootstrapPage(
+                new BootstrapContext(request, null, session, testUI));
+
+        Assert.assertFalse("Default indicator theme is not themed anymore", testUI.getLoadingIndicatorConfiguration().isDefaultThemeApplied());
+
+        Assert.assertEquals(InitialPageConfiguratorRoute.SECOND_DELAY, testUI.getLoadingIndicatorConfiguration().getSecondDelay());
+
+        Assert.assertEquals(PushMode.MANUAL, testUI.getPushConfiguration().getPushMode());
+
+        Assert.assertTrue(testUI.getReconnectDialogConfiguration().isDialogModal());
     }
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/LoadingIndicatorView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/LoadingIndicatorView.java
@@ -30,9 +30,10 @@ public class LoadingIndicatorView extends AbstractDivView {
     public void beforeEnter(BeforeEnterEvent event) {
 
         NativeButton disableButton = new NativeButton("Disable default loading indicator theme and add custom");
+        disableButton.setId("disable-theme");
         disableButton.addClickListener(
                 clickEvent -> {
-                    clickEvent.getSource().getUI().get().getLoadingIndicatorConfiguration().setDefaultThemeApplied(false);
+                    clickEvent.getSource().getUI().get().getLoadingIndicatorConfiguration().setApplyDefaultTheme(false);
                     clickEvent.getSource().getUI().get().getPage().addStyleSheet("frontend://com/vaadin/flow/uitest/ui/loading-indicator.css");
                 }
         );

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/LoadingIndicatorView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/LoadingIndicatorView.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.uitest.ui;
 
 import com.vaadin.flow.component.UI;
-import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.page.LoadingIndicatorConfiguration;
@@ -25,12 +24,19 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 
 @Route(value = "com.vaadin.flow.uitest.ui.LoadingIndicatorView", layout = ViewTestLayout.class)
-@StyleSheet("/com/vaadin/flow/uitest/ui/loading-indicator.css")
 public class LoadingIndicatorView extends AbstractDivView {
 
     @Override
     public void beforeEnter(BeforeEnterEvent event) {
 
+        NativeButton disableButton = new NativeButton("Disable default loading indicator theme and add custom");
+        disableButton.addClickListener(
+                clickEvent -> {
+                    clickEvent.getSource().getUI().get().getLoadingIndicatorConfiguration().setDefaultThemeApplied(false);
+                    clickEvent.getSource().getUI().get().getPage().addStyleSheet("frontend://com/vaadin/flow/uitest/ui/loading-indicator.css");
+                }
+        );
+        add(disableButton);
         add(divWithText("First delay: "
                 + getLoadingIndicatorConfiguration().getFirstDelay()));
         add(divWithText("Second delay: "
@@ -38,7 +44,7 @@ public class LoadingIndicatorView extends AbstractDivView {
         add(divWithText("Third delay: "
                 + getLoadingIndicatorConfiguration().getThirdDelay()));
 
-        int[] delays = new int[] { 100, 200, 500, 1000, 2000, 5000, 10000 };
+        int[] delays = new int[]{100, 200, 500, 1000, 2000, 5000, 10000};
         for (int delay : delays) {
             NativeButton button = new NativeButton(
                     "Trigger event which takes " + delay + "ms",

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/LoadingIndicatorIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/LoadingIndicatorIT.java
@@ -35,4 +35,50 @@ public class LoadingIndicatorIT extends ChromeBrowserTest {
         Thread.sleep(2000);
         Assert.assertTrue(hasCssClass(loadingIndicator, "second"));
     }
+
+    @Test
+    public void byDefault_loadingIndicator_usesDefaultTheme() throws InterruptedException {
+        open();
+
+        WebElement loadingIndicator = findElement(
+                By.className("v-loading-indicator"));
+        String height = (String) executeScript("return getComputedStyle(arguments[0]).height", loadingIndicator);
+
+        Assert.assertEquals("Default loading indicator theming should be applied", "4px", height);
+
+        // if the next part of the test gets unstable in some environment, just delete it
+        testBench().disableWaitForVaadin();
+        findElement(By.id("wait10000")).click();
+
+        Thread.sleep(6000);
+
+        height = (String) executeScript("return getComputedStyle(arguments[0]).height", loadingIndicator);
+
+        // during third stage (wait) the height is bumped to 7px
+        Assert.assertEquals("Default loading indicator theming is not applied", "7px", height);
+    }
+
+    @Test
+    public void loadingIndicator_switchingToCustomTheme_noDefaultThemeApplied() throws InterruptedException {
+        open();
+
+        findElement(By.id("disable-theme")).click();
+
+        WebElement loadingIndicator = findElement(
+                By.className("v-loading-indicator"));
+        String height = (String) executeScript("return getComputedStyle(arguments[0]).height", loadingIndicator);
+
+        Assert.assertEquals("Default loading indicator theming should not be applied", "auto", height);
+
+        // if the next part of the test gets unstable in some environment, just delete it
+        testBench().disableWaitForVaadin();
+        findElement(By.id("wait10000")).click();
+
+        Thread.sleep(2000);
+
+        String zIndex = (String) executeScript("return getComputedStyle(arguments[0]).zIndex", loadingIndicator);
+
+        // during third stage (wait) the height is bumped to 7px
+        Assert.assertEquals("Custom loading indicator theming is not applied", "2147483647", zIndex);
+    }
 }


### PR DESCRIPTION
Adds default loading indicator theming, and a way to disable it.
The theming is the same as in Vaadin 8 (Valo).
Makes `UI` configuration objects available via `InitialPageSettings`.
Fixes the loading indicator configuration not working from server side (at all), broken since 0.0.1.

Tested on macOS with
- Chrome, Safari and FF
Tested on Windows 10 with
- Chrome, FF, Edge and IE11

Related to #3763

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4174)
<!-- Reviewable:end -->
