### PR TITLE
Redirect with esc-key after internal error

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/SystemErrorHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/SystemErrorHandler.java
@@ -23,6 +23,9 @@ import com.vaadin.client.bootstrap.ErrorMessage;
 import elemental.client.Browser;
 import elemental.dom.Document;
 import elemental.dom.Element;
+import elemental.events.Event;
+import elemental.events.KeyboardEvent;
+import elemental.events.KeyboardEvent.KeyCode;
 
 /**
  * Class handling system errors in the application.
@@ -117,6 +120,13 @@ public class SystemErrorHandler {
 
         systemErrorContainer.addEventListener("click",
                 e -> WidgetUtil.redirect(url), false);
+
+        document.addEventListener(Event.KEYDOWN, e -> {
+            int keyCode = ((KeyboardEvent) e).getKeyCode();
+            if (keyCode == KeyCode.ESC) {
+                WidgetUtil.redirect(url);
+            }
+        }, false);
 
         document.getBody().appendChild(systemErrorContainer);
     }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/InternalErrorView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/InternalErrorView.java
@@ -19,16 +19,17 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.CustomizedSystemMessages;
+import com.vaadin.flow.server.DefaultSystemMessagesProvider;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
 
 /**
  * @author Vaadin Ltd.
  */
-@Route("com.vaadin.flow.uitest.ui.ExpireSessionView")
-public class ExpireSessionView extends AbstractDivView {
+@Route("com.vaadin.flow.uitest.ui.InternalErrorView")
+public class InternalErrorView extends AbstractDivView {
 
-    public ExpireSessionView() {
+    public InternalErrorView() {
         Div message = new Div();
         message.setId("message");
 
@@ -45,8 +46,17 @@ public class ExpireSessionView extends AbstractDivView {
                 event -> enableSessionExpiredNotification());
         enableNotificationButton.setId("enable-notification");
 
+        NativeButton causeExceptionButton = new NativeButton("Cause exception",
+                event -> System.out.println(1 / 0));
+        causeExceptionButton.setId("cause-exception");
+
+        NativeButton resetSystemMessagesButton = new NativeButton(
+                "Reset system messages", event -> resetSystemMessages());
+        resetSystemMessagesButton.setId("reset-system-messages");
+
         add(message, updateMessageButton, closeSessionButton,
-                enableNotificationButton);
+                enableNotificationButton, causeExceptionButton,
+                resetSystemMessagesButton);
     }
 
     private void enableSessionExpiredNotification() {
@@ -55,5 +65,10 @@ public class ExpireSessionView extends AbstractDivView {
 
         VaadinService.getCurrent()
                 .setSystemMessagesProvider(systemMessagesInfo -> sysMessages);
+    }
+
+    private void resetSystemMessages() {
+        VaadinService.getCurrent()
+                .setSystemMessagesProvider(DefaultSystemMessagesProvider.get());
     }
 }


### PR DESCRIPTION
The message inside the internal error dialog claims that you can
continue either by clicking the dialog or pressing the esc-key. However,
it seems that continuing with the esc-key was never implemented.

Fixes partly #4089

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4190)
<!-- Reviewable:end -->
