### PR TITLE
Add option to use error message provider for StringTo converters

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/converter/AbstractStringToNumberConverter.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/converter/AbstractStringToNumberConverter.java
@@ -46,8 +46,8 @@ public abstract class AbstractStringToNumberConverter<T extends Number>
     private T emptyValue;
 
     /**
-     * Creates a new converter instance with the given empty string value and
-     * error message provider.
+     * Creates a new converter instance with the given presentation value for
+     * empty string and error message provider.
      *
      * @param emptyValue
      *            the presentation value to return when converting an empty
@@ -62,8 +62,8 @@ public abstract class AbstractStringToNumberConverter<T extends Number>
     }
 
     /**
-     * Creates a new converter instance with the given empty string value and
-     * error message.
+     * Creates a new converter instance with the given presentation value for
+     * empty string and error message.
      *
      * @param emptyValue
      *            the presentation value to return when converting an empty

--- a/flow-data/src/main/java/com/vaadin/flow/data/converter/AbstractStringToNumberConverter.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/converter/AbstractStringToNumberConverter.java
@@ -14,13 +14,13 @@
  * the License.
  */
 
-
 package com.vaadin.flow.data.converter;
 
 import java.text.NumberFormat;
 import java.text.ParsePosition;
 import java.util.Locale;
 
+import com.vaadin.flow.data.binder.ErrorMessageProvider;
 import com.vaadin.flow.data.binder.Result;
 import com.vaadin.flow.data.binder.ValueContext;
 
@@ -40,10 +40,26 @@ import com.vaadin.flow.data.binder.ValueContext;
  * @since 8.0
  */
 public abstract class AbstractStringToNumberConverter<T extends Number>
-implements Converter<String, T> {
+        implements Converter<String, T> {
 
-    private final String errorMessage;
+    private final ErrorMessageProvider errorMessageProvider;
     private T emptyValue;
+
+    /**
+     * Creates a new converter instance with the given empty string value and
+     * error message provider.
+     *
+     * @param emptyValue
+     *            the presentation value to return when converting an empty
+     *            string, may be <code>null</code>
+     * @param errorMessageProvider
+     *            the error message provider to use if conversion fails
+     */
+    protected AbstractStringToNumberConverter(T emptyValue,
+            ErrorMessageProvider errorMessageProvider) {
+        this.emptyValue = emptyValue;
+        this.errorMessageProvider = errorMessageProvider;
+    }
 
     /**
      * Creates a new converter instance with the given empty string value and
@@ -57,8 +73,7 @@ implements Converter<String, T> {
      */
     protected AbstractStringToNumberConverter(T emptyValue,
             String errorMessage) {
-        this.emptyValue = emptyValue;
-        this.errorMessage = errorMessage;
+        this(emptyValue, ctx -> errorMessage);
     }
 
     /**
@@ -84,11 +99,12 @@ implements Converter<String, T> {
      *
      * @param value
      *            The value to convert
-     * @param locale
-     *            The locale to use for conversion
+     * @param context
+     *            The value context for conversion
      * @return The converted value
      */
-    protected Result<Number> convertToNumber(String value, Locale locale) {
+    protected Result<Number> convertToNumber(String value,
+            ValueContext context) {
         if (value == null) {
             return Result.ok(null);
         }
@@ -99,9 +115,10 @@ implements Converter<String, T> {
         // Parse and detect errors. If the full string was not used, it is
         // an error.
         ParsePosition parsePosition = new ParsePosition(0);
-        Number parsedValue = getFormat(locale).parse(value, parsePosition);
+        Number parsedValue = getFormat(context.getLocale().orElse(null))
+                .parse(value, parsePosition);
         if (parsePosition.getIndex() != value.length()) {
-            return Result.error(getErrorMessage());
+            return Result.error(getErrorMessage(context));
         }
 
         if (parsedValue == null) {
@@ -117,8 +134,8 @@ implements Converter<String, T> {
      *
      * @return the error message
      */
-    protected String getErrorMessage() {
-        return errorMessage;
+    protected String getErrorMessage(ValueContext context) {
+        return errorMessageProvider.apply(context);
     }
 
     @Override

--- a/flow-data/src/main/java/com/vaadin/flow/data/converter/StringToBigDecimalConverter.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/converter/StringToBigDecimalConverter.java
@@ -53,8 +53,8 @@ public class StringToBigDecimalConverter
     }
 
     /**
-     * Creates a new converter instance with the given empty string value and
-     * error message.
+     * Creates a new converter instance with the given presentation value for
+     * empty string and error message.
      *
      * @param emptyValue
      *            the presentation value to return when converting an empty
@@ -80,8 +80,8 @@ public class StringToBigDecimalConverter
     }
 
     /**
-     * Creates a new converter instance with the given empty string value and
-     * error message provider.
+     * Creates a new converter instance with the given presentation value for
+     * empty string and error message provider.
      *
      * @param emptyValue
      *            the presentation value to return when converting an empty

--- a/flow-data/src/main/java/com/vaadin/flow/data/converter/StringToBigDecimalConverter.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/converter/StringToBigDecimalConverter.java
@@ -20,6 +20,7 @@ import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.Locale;
 
+import com.vaadin.flow.data.binder.ErrorMessageProvider;
 import com.vaadin.flow.data.binder.Result;
 import com.vaadin.flow.data.binder.ValueContext;
 
@@ -38,7 +39,7 @@ import com.vaadin.flow.data.binder.ValueContext;
  * @since 8.0
  */
 public class StringToBigDecimalConverter
-extends AbstractStringToNumberConverter<BigDecimal> {
+        extends AbstractStringToNumberConverter<BigDecimal> {
 
     /**
      * Creates a new converter instance with the given error message. Empty
@@ -66,6 +67,33 @@ extends AbstractStringToNumberConverter<BigDecimal> {
         super(emptyValue, errorMessage);
     }
 
+    /**
+     * Creates a new converter instance with the given error message provider.
+     * Empty strings are converted to <code>null</code>.
+     *
+     * @param errorMessageProvider
+     *            the error message provider to use if conversion fails
+     */
+    public StringToBigDecimalConverter(
+            ErrorMessageProvider errorMessageProvider) {
+        this(null, errorMessageProvider);
+    }
+
+    /**
+     * Creates a new converter instance with the given empty string value and
+     * error message provider.
+     *
+     * @param emptyValue
+     *            the presentation value to return when converting an empty
+     *            string, may be <code>null</code>
+     * @param errorMessageProvider
+     *            the error message provider to use if conversion fails
+     */
+    public StringToBigDecimalConverter(BigDecimal emptyValue,
+            ErrorMessageProvider errorMessageProvider) {
+        super(emptyValue, errorMessageProvider);
+    }
+
     @Override
     protected NumberFormat getFormat(Locale locale) {
         NumberFormat numberFormat = super.getFormat(locale);
@@ -79,7 +107,7 @@ extends AbstractStringToNumberConverter<BigDecimal> {
     @Override
     public Result<BigDecimal> convertToModel(String value,
             ValueContext context) {
-        return convertToNumber(value, context.getLocale().orElse(null))
+        return convertToNumber(value, context)
                 .map(number -> (BigDecimal) number);
     }
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/converter/StringToBigIntegerConverter.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/converter/StringToBigIntegerConverter.java
@@ -21,6 +21,7 @@ import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.Locale;
 
+import com.vaadin.flow.data.binder.ErrorMessageProvider;
 import com.vaadin.flow.data.binder.Result;
 import com.vaadin.flow.data.binder.ValueContext;
 
@@ -39,7 +40,7 @@ import com.vaadin.flow.data.binder.ValueContext;
  * @since 8.0
  */
 public class StringToBigIntegerConverter
-extends AbstractStringToNumberConverter<BigInteger> {
+        extends AbstractStringToNumberConverter<BigInteger> {
 
     /**
      * Creates a new converter instance with the given error message. Empty
@@ -67,6 +68,33 @@ extends AbstractStringToNumberConverter<BigInteger> {
         super(emptyValue, errorMessage);
     }
 
+    /**
+     * Creates a new converter instance with the given error message provider.
+     * Empty strings are converted to <code>null</code>.
+     *
+     * @param errorMessageProvider
+     *            the error message provider to use if conversion fails
+     */
+    public StringToBigIntegerConverter(
+            ErrorMessageProvider errorMessageProvider) {
+        this(null, errorMessageProvider);
+    }
+
+    /**
+     * Creates a new converter instance with the given empty string value and
+     * error message provider.
+     *
+     * @param emptyValue
+     *            the presentation value to return when converting an empty
+     *            string, may be <code>null</code>
+     * @param errorMessageProvider
+     *            the error message provider to use if conversion fails
+     */
+    public StringToBigIntegerConverter(BigInteger emptyValue,
+            ErrorMessageProvider errorMessageProvider) {
+        super(emptyValue, errorMessageProvider);
+    }
+
     @Override
     protected NumberFormat getFormat(Locale locale) {
         NumberFormat numberFormat = super.getFormat(locale);
@@ -80,18 +108,16 @@ extends AbstractStringToNumberConverter<BigInteger> {
     @Override
     public Result<BigInteger> convertToModel(String value,
             ValueContext context) {
-        return convertToNumber(value, context.getLocale().orElse(null))
-                .map(number -> {
-                    if (number == null) {
-                        return null;
-                    } else {
-                        // Empty value will be a BigInteger
-                        if (number instanceof BigInteger) {
-                            return (BigInteger) number;
-                        }
-                        return ((BigDecimal) number).toBigInteger();
-                    }
-                });
+        return convertToNumber(value, context).map(number -> {
+            if (number == null) {
+                return null;
+            }
+            // Empty value will be a BigInteger
+            if (number instanceof BigInteger) {
+                return (BigInteger) number;
+            }
+            return ((BigDecimal) number).toBigInteger();
+        });
     }
 
 }

--- a/flow-data/src/main/java/com/vaadin/flow/data/converter/StringToBigIntegerConverter.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/converter/StringToBigIntegerConverter.java
@@ -54,8 +54,8 @@ public class StringToBigIntegerConverter
     }
 
     /**
-     * Creates a new converter instance with the given empty string value and
-     * error message.
+     * Creates a new converter instance with the given presentation value for
+     * empty string and error message.
      *
      * @param emptyValue
      *            the presentation value to return when converting an empty
@@ -81,8 +81,8 @@ public class StringToBigIntegerConverter
     }
 
     /**
-     * Creates a new converter instance with the given empty string value and
-     * error message provider.
+     * Creates a new converter instance with the given presentation value for
+     * empty string and error message provider.
      *
      * @param emptyValue
      *            the presentation value to return when converting an empty

--- a/flow-data/src/main/java/com/vaadin/flow/data/converter/StringToBooleanConverter.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/converter/StringToBooleanConverter.java
@@ -18,13 +18,15 @@ package com.vaadin.flow.data.converter;
 
 import java.util.Locale;
 
+import com.vaadin.flow.data.binder.ErrorMessageProvider;
 import com.vaadin.flow.data.binder.Result;
 import com.vaadin.flow.data.binder.ValueContext;
 
 /**
  * A converter that converts from {@link String} to {@link Boolean} and back.
  * The String representation is given by {@link Boolean#toString()} or provided
- * in constructor {@link StringToBooleanConverter#StringToBooleanConverter(String, String, String)}.
+ * in constructor
+ * {@link StringToBooleanConverter#StringToBooleanConverter(String, String, String)}.
  * <p>
  * Leading and trailing white spaces are ignored when converting from a String.
  * </p>
@@ -42,7 +44,7 @@ public class StringToBooleanConverter implements Converter<String, Boolean> {
 
     private final String falseString;
 
-    private String errorMessage;
+    private ErrorMessageProvider errorMessageProvider;
 
     /**
      * Creates converter with default string representations - "true" and
@@ -53,6 +55,18 @@ public class StringToBooleanConverter implements Converter<String, Boolean> {
      */
     public StringToBooleanConverter(String errorMessage) {
         this(errorMessage, Boolean.TRUE.toString(), Boolean.FALSE.toString());
+    }
+
+    /**
+     * Creates a new converter instance with the given error message provider.
+     * Empty strings are converted to <code>null</code>.
+     *
+     * @param errorMessageProvider
+     *            the error message provider to use if conversion fails
+     */
+    public StringToBooleanConverter(ErrorMessageProvider errorMessageProvider) {
+        this(Boolean.TRUE.toString(), Boolean.FALSE.toString(),
+                errorMessageProvider);
     }
 
     /**
@@ -67,7 +81,22 @@ public class StringToBooleanConverter implements Converter<String, Boolean> {
      */
     public StringToBooleanConverter(String errorMessage, String trueString,
             String falseString) {
-        this.errorMessage = errorMessage;
+        this(trueString, falseString, ctx -> errorMessage);
+    }
+
+    /**
+     * Creates converter with custom string representation.
+     *
+     * @param falseString
+     *            string representation for <code>false</code>
+     * @param trueString
+     *            string representation for <code>true</code>
+     * @param errorMessageProvider
+     *            the error message provider to use if conversion fails
+     */
+    public StringToBooleanConverter(String trueString, String falseString,
+            ErrorMessageProvider errorMessageProvider) {
+        this.errorMessageProvider = errorMessageProvider;
         this.trueString = trueString;
         this.falseString = falseString;
     }
@@ -89,7 +118,7 @@ public class StringToBooleanConverter implements Converter<String, Boolean> {
         } else if (value.isEmpty()) {
             return Result.ok(null);
         } else {
-            return Result.error(errorMessage);
+            return Result.error(errorMessageProvider.apply(context));
         }
     }
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/converter/StringToDoubleConverter.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/converter/StringToDoubleConverter.java
@@ -19,6 +19,7 @@ package com.vaadin.flow.data.converter;
 import java.text.NumberFormat;
 import java.util.Locale;
 
+import com.vaadin.flow.data.binder.ErrorMessageProvider;
 import com.vaadin.flow.data.binder.Result;
 import com.vaadin.flow.data.binder.ValueContext;
 
@@ -37,7 +38,7 @@ import com.vaadin.flow.data.binder.ValueContext;
  * @since 8.0
  */
 public class StringToDoubleConverter
-extends AbstractStringToNumberConverter<Double> {
+        extends AbstractStringToNumberConverter<Double> {
 
     /**
      * Creates a new converter instance with the given error message. Empty
@@ -64,10 +65,35 @@ extends AbstractStringToNumberConverter<Double> {
         super(emptyValue, errorMessage);
     }
 
+    /**
+     * Creates a new converter instance with the given error message provider.
+     * Empty strings are converted to <code>null</code>.
+     *
+     * @param errorMessageProvider
+     *            the error message provider to use if conversion fails
+     */
+    public StringToDoubleConverter(ErrorMessageProvider errorMessageProvider) {
+        this(null, errorMessageProvider);
+    }
+
+    /**
+     * Creates a new converter instance with the given empty string value and
+     * error message provider.
+     *
+     * @param emptyValue
+     *            the presentation value to return when converting an empty
+     *            string, may be <code>null</code>
+     * @param errorMessageProvider
+     *            the error message provider to use if conversion fails
+     */
+    public StringToDoubleConverter(Double emptyValue,
+            ErrorMessageProvider errorMessageProvider) {
+        super(emptyValue, errorMessageProvider);
+    }
+
     @Override
     public Result<Double> convertToModel(String value, ValueContext context) {
-        Result<Number> n = convertToNumber(value,
-                context.getLocale().orElse(null));
+        Result<Number> n = convertToNumber(value, context);
 
         return n.map(number -> {
             if (number == null) {

--- a/flow-data/src/main/java/com/vaadin/flow/data/converter/StringToDoubleConverter.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/converter/StringToDoubleConverter.java
@@ -52,8 +52,8 @@ public class StringToDoubleConverter
     }
 
     /**
-     * Creates a new converter instance with the given empty string value and
-     * error message.
+     * Creates a new converter instance with the given presentation value for
+     * empty string and error message.
      *
      * @param emptyValue
      *            the presentation value to return when converting an empty
@@ -77,8 +77,8 @@ public class StringToDoubleConverter
     }
 
     /**
-     * Creates a new converter instance with the given empty string value and
-     * error message provider.
+     * Creates a new converter instance with the given presentation value for
+     * empty string and error message provider.
      *
      * @param emptyValue
      *            the presentation value to return when converting an empty

--- a/flow-data/src/main/java/com/vaadin/flow/data/converter/StringToFloatConverter.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/converter/StringToFloatConverter.java
@@ -14,12 +14,12 @@
  * the License.
  */
 
-
 package com.vaadin.flow.data.converter;
 
 import java.text.NumberFormat;
 import java.util.Locale;
 
+import com.vaadin.flow.data.binder.ErrorMessageProvider;
 import com.vaadin.flow.data.binder.Result;
 import com.vaadin.flow.data.binder.ValueContext;
 
@@ -36,7 +36,7 @@ import com.vaadin.flow.data.binder.ValueContext;
  * @since 8.0
  */
 public class StringToFloatConverter
-extends AbstractStringToNumberConverter<Float> {
+        extends AbstractStringToNumberConverter<Float> {
 
     /**
      * Creates a new converter instance with the given error message. Empty
@@ -63,10 +63,35 @@ extends AbstractStringToNumberConverter<Float> {
         super(emptyValue, errorMessage);
     }
 
+    /**
+     * Creates a new converter instance with the given error message provider.
+     * Empty strings are converted to <code>null</code>.
+     *
+     * @param errorMessageProvider
+     *            the error message provider to use if conversion fails
+     */
+    public StringToFloatConverter(ErrorMessageProvider errorMessageProvider) {
+        this(null, errorMessageProvider);
+    }
+
+    /**
+     * Creates a new converter instance with the given empty string value and
+     * error message provider.
+     *
+     * @param emptyValue
+     *            the presentation value to return when converting an empty
+     *            string, may be <code>null</code>
+     * @param errorMessageProvider
+     *            the error message provider to use if conversion fails
+     */
+    public StringToFloatConverter(Float emptyValue,
+            ErrorMessageProvider errorMessageProvider) {
+        super(emptyValue, errorMessageProvider);
+    }
+
     @Override
     public Result<Float> convertToModel(String value, ValueContext context) {
-        Result<Number> n = convertToNumber(value,
-                context.getLocale().orElse(null));
+        Result<Number> n = convertToNumber(value, context);
 
         return n.map(number -> {
             if (number == null) {

--- a/flow-data/src/main/java/com/vaadin/flow/data/converter/StringToFloatConverter.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/converter/StringToFloatConverter.java
@@ -50,8 +50,8 @@ public class StringToFloatConverter
     }
 
     /**
-     * Creates a new converter instance with the given empty string value and
-     * error message.
+     * Creates a new converter instance with the given presentation value for
+     * empty string and error message.
      *
      * @param emptyValue
      *            the presentation value to return when converting an empty
@@ -75,8 +75,8 @@ public class StringToFloatConverter
     }
 
     /**
-     * Creates a new converter instance with the given empty string value and
-     * error message provider.
+     * Creates a new converter instance with the given presentation value for
+     * empty string and error message provider.
      *
      * @param emptyValue
      *            the presentation value to return when converting an empty

--- a/flow-data/src/main/java/com/vaadin/flow/data/converter/StringToIntegerConverter.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/converter/StringToIntegerConverter.java
@@ -19,6 +19,7 @@ package com.vaadin.flow.data.converter;
 import java.text.NumberFormat;
 import java.util.Locale;
 
+import com.vaadin.flow.data.binder.ErrorMessageProvider;
 import com.vaadin.flow.data.binder.Result;
 import com.vaadin.flow.data.binder.ValueContext;
 
@@ -34,7 +35,7 @@ import com.vaadin.flow.data.binder.ValueContext;
  * @since 8.0
  */
 public class StringToIntegerConverter
-extends AbstractStringToNumberConverter<Integer> {
+        extends AbstractStringToNumberConverter<Integer> {
 
     /**
      * Creates a new converter instance with the given error message. Empty
@@ -62,6 +63,32 @@ extends AbstractStringToNumberConverter<Integer> {
     }
 
     /**
+     * Creates a new converter instance with the given error message provider.
+     * Empty strings are converted to <code>null</code>.
+     *
+     * @param errorMessageProvider
+     *            the error message provider to use if conversion fails
+     */
+    public StringToIntegerConverter(ErrorMessageProvider errorMessageProvider) {
+        this(null, errorMessageProvider);
+    }
+
+    /**
+     * Creates a new converter instance with the given empty string value and
+     * error message provider.
+     *
+     * @param emptyValue
+     *            the presentation value to return when converting an empty
+     *            string, may be <code>null</code>
+     * @param errorMessageProvider
+     *            the error message provider to use if conversion fails
+     */
+    public StringToIntegerConverter(Integer emptyValue,
+            ErrorMessageProvider errorMessageProvider) {
+        super(emptyValue, errorMessageProvider);
+    }
+
+    /**
      * Returns the format used by
      * {@link #convertToPresentation(Object, ValueContext)} and
      * {@link #convertToModel(String, ValueContext)}.
@@ -80,8 +107,7 @@ extends AbstractStringToNumberConverter<Integer> {
 
     @Override
     public Result<Integer> convertToModel(String value, ValueContext context) {
-        Result<Number> n = convertToNumber(value,
-                context.getLocale().orElse(null));
+        Result<Number> n = convertToNumber(value, context);
         return n.flatMap(number -> {
             if (number == null) {
                 return Result.ok(null);
@@ -94,7 +120,7 @@ extends AbstractStringToNumberConverter<Integer> {
                     // long and thus does not need to consider wrap-around.
                     return Result.ok(intValue);
                 } else {
-                    return Result.error(getErrorMessage());
+                    return Result.error(getErrorMessage(context));
                 }
             }
         });

--- a/flow-data/src/main/java/com/vaadin/flow/data/converter/StringToIntegerConverter.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/converter/StringToIntegerConverter.java
@@ -49,8 +49,8 @@ public class StringToIntegerConverter
     }
 
     /**
-     * Creates a new converter instance with the given empty string value and
-     * error message.
+     * Creates a new converter instance with the given presentation value for
+     * empty string and error message.
      *
      * @param emptyValue
      *            the presentation value to return when converting an empty
@@ -74,8 +74,8 @@ public class StringToIntegerConverter
     }
 
     /**
-     * Creates a new converter instance with the given empty string value and
-     * error message provider.
+     * Creates a new converter instance with the given presentation value for
+     * empty string and error message provider.
      *
      * @param emptyValue
      *            the presentation value to return when converting an empty

--- a/flow-data/src/main/java/com/vaadin/flow/data/converter/StringToLongConverter.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/converter/StringToLongConverter.java
@@ -49,8 +49,8 @@ public class StringToLongConverter
     }
 
     /**
-     * Creates a new converter instance with the given empty string value and
-     * error message.
+     * Creates a new converter instance with the given presentation value for
+     * empty string and error message.
      *
      * @param emptyValue
      *            the presentation value to return when converting an empty
@@ -74,8 +74,8 @@ public class StringToLongConverter
     }
 
     /**
-     * Creates a new converter instance with the given empty string value and
-     * error message provider.
+     * Creates a new converter instance with the given presentation value for
+     * empty string and error message provider.
      *
      * @param emptyValue
      *            the presentation value to return when converting an empty

--- a/flow-data/src/main/java/com/vaadin/flow/data/converter/StringToLongConverter.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/converter/StringToLongConverter.java
@@ -19,6 +19,7 @@ package com.vaadin.flow.data.converter;
 import java.text.NumberFormat;
 import java.util.Locale;
 
+import com.vaadin.flow.data.binder.ErrorMessageProvider;
 import com.vaadin.flow.data.binder.Result;
 import com.vaadin.flow.data.binder.ValueContext;
 
@@ -34,7 +35,7 @@ import com.vaadin.flow.data.binder.ValueContext;
  * @since 8.0
  */
 public class StringToLongConverter
-extends AbstractStringToNumberConverter<Long> {
+        extends AbstractStringToNumberConverter<Long> {
 
     /**
      * Creates a new converter instance with the given error message. Empty
@@ -62,6 +63,32 @@ extends AbstractStringToNumberConverter<Long> {
     }
 
     /**
+     * Creates a new converter instance with the given error message provider.
+     * Empty strings are converted to <code>null</code>.
+     *
+     * @param errorMessageProvider
+     *            the error message provider to use if conversion fails
+     */
+    public StringToLongConverter(ErrorMessageProvider errorMessageProvider) {
+        this(null, errorMessageProvider);
+    }
+
+    /**
+     * Creates a new converter instance with the given empty string value and
+     * error message provider.
+     *
+     * @param emptyValue
+     *            the presentation value to return when converting an empty
+     *            string, may be <code>null</code>
+     * @param errorMessageProvider
+     *            the error message provider to use if conversion fails
+     */
+    public StringToLongConverter(Long emptyValue,
+            ErrorMessageProvider errorMessageProvider) {
+        super(emptyValue, errorMessageProvider);
+    }
+
+    /**
      * Returns the format used by
      * {@link #convertToPresentation(Object, ValueContext)} and
      * {@link #convertToModel(String, ValueContext)}.
@@ -80,8 +107,7 @@ extends AbstractStringToNumberConverter<Long> {
 
     @Override
     public Result<Long> convertToModel(String value, ValueContext context) {
-        Result<Number> n = convertToNumber(value,
-                context.getLocale().orElse(null));
+        Result<Number> n = convertToNumber(value, context);
         return n.map(number -> {
             if (number == null) {
                 return null;


### PR DESCRIPTION
Ported change from https://github.com/vaadin/framework/pull/10711

Only difference is in the added unit test: Flow components don't have `setLocale()` method like in FW8, and as there is no `UI` present, I had to change the default locale.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4202)
<!-- Reviewable:end -->
