### PR TITLE
StaticFileServer should use VaadinServletService.getStaticResource not getContext.

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
@@ -20,7 +20,6 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 
@@ -29,7 +28,6 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.ResponseWriter;
-import com.vaadin.flow.server.startup.FakeBrowser;
 import com.vaadin.flow.shared.ApplicationConstants;
 
 /**
@@ -52,10 +50,8 @@ public class StaticFileServer implements Serializable {
     /**
      * Constructs a file server.
      *
-     * @param servlet
-     *            the servlet using this server, not <code>null</code>
      * @param servletService
-     *            configuration for the deployment, not <code>null</code>
+     *            servlet service for the deployment, not <code>null</code>
      */
     public StaticFileServer(VaadinServletService servletService) {
         this.servletService = servletService;
@@ -87,13 +83,9 @@ public class StaticFileServer implements Serializable {
             // We rather serve 404 than let it fall through
             return true;
         }
-        resource = getResource(requestFilename);
+        resource = servletService.getStaticResource(requestFilename);
 
         return resource != null;
-    }
-
-    private URL getResource(String path) {
-            return servletService.getResource(path, FakeBrowser.getEs6(), null);
     }
 
     /**
@@ -113,7 +105,7 @@ public class StaticFileServer implements Serializable {
     public boolean serveStaticResource(HttpServletRequest request,
             HttpServletResponse response) throws IOException {
         String filenameWithPath = getRequestFilename(request);
-        URL resourceUrl = getResource(filenameWithPath);
+        URL resourceUrl = servletService.getStaticResource(filenameWithPath);
 
         if (resourceUrl == null) {
             // Not found in webcontent or in META-INF/resources in some JAR

--- a/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.server;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
@@ -22,14 +24,12 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.ResponseWriter;
+import com.vaadin.flow.server.startup.FakeBrowser;
 import com.vaadin.flow.shared.ApplicationConstants;
 
 /**
@@ -46,7 +46,7 @@ import com.vaadin.flow.shared.ApplicationConstants;
  */
 public class StaticFileServer implements Serializable {
     private final ResponseWriter responseWriter = new ResponseWriter();
-    private final VaadinServlet servlet;
+    private final VaadinServletService servletService;
     private DeploymentConfiguration deploymentConfiguration;
 
     /**
@@ -54,13 +54,13 @@ public class StaticFileServer implements Serializable {
      *
      * @param servlet
      *            the servlet using this server, not <code>null</code>
-     * @param deploymentConfiguration
+     * @param servletService
      *            configuration for the deployment, not <code>null</code>
      */
-    public StaticFileServer(VaadinServlet servlet,
-            DeploymentConfiguration deploymentConfiguration) {
-        this.servlet = servlet;
-        this.deploymentConfiguration = deploymentConfiguration;
+    public StaticFileServer(VaadinServletService servletService) {
+        this.servletService = servletService;
+        this.deploymentConfiguration = servletService
+                .getDeploymentConfiguration();
     }
 
     /**
@@ -93,14 +93,7 @@ public class StaticFileServer implements Serializable {
     }
 
     private URL getResource(String path) {
-        try {
-            return servlet.getServletContext().getResource(path);
-        } catch (MalformedURLException exception) {
-            LoggerFactory.getLogger(StaticFileServer.class)
-                    .trace("Failed to parse url {}.", path, exception);
-        }
-        return null;
-
+            return servletService.getResource(path, FakeBrowser.getEs6(), null);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -16,8 +16,9 @@
 
 package com.vaadin.flow.server;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
+import javax.servlet.Servlet;
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletResponse;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.InputStream;
@@ -45,10 +46,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-
-import javax.servlet.Servlet;
-import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServletResponse;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -79,6 +76,7 @@ import elemental.json.Json;
 import elemental.json.JsonException;
 import elemental.json.JsonObject;
 import elemental.json.impl.JsonUtil;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * An abstraction of the underlying technology, e.g. servlets, for handling
@@ -2150,6 +2148,18 @@ public abstract class VaadinService implements Serializable {
         UIInitEvent initEvent = new UIInitEvent(ui, this);
         uiInitListeners.forEach(listener -> listener.uiInit(initEvent));
     }
+
+    /**
+     * Returns a URL to the static resource at the given URI or null if no file
+     * found.
+     *
+     * @param url
+     *            the URL for the resource
+     *
+     * @return the resource located at the named path, or <code>null</code> if
+     *         there is no resource at that path
+     */
+    public abstract URL getStaticResource(String url);
 
     /**
      * Returns a URL to the resource at the given Vaadin URI.

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
@@ -80,7 +80,7 @@ public class VaadinServlet extends HttpServlet {
 
         DeploymentConfiguration deploymentConfiguration = servletService
                 .getDeploymentConfiguration();
-        staticFileServer = new StaticFileServer(this, deploymentConfiguration);
+        staticFileServer = new StaticFileServer(servletService);
 
         if (deploymentConfiguration.areWebJarsEnabled()) {
             webJarServer = new WebJarServer(deploymentConfiguration);

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
@@ -16,15 +16,14 @@
 
 package com.vaadin.flow.server;
 
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-
-import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServletRequest;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -192,6 +191,17 @@ public class VaadinServletService extends VaadinService {
     }
 
     @Override
+    public URL getStaticResource(String path) {
+        try {
+            return getServlet().getServletContext().getResource(path);
+        } catch (MalformedURLException e) {
+            getLogger().warn("Error finding resource for '{}'", path, e);
+        }
+
+        return null;
+    }
+
+    @Override
     public URL getResource(String path, WebBrowser browser,
             AbstractTheme theme) {
         return getResourceInServletContextOrWebJar(
@@ -208,8 +218,8 @@ public class VaadinServletService extends VaadinService {
     @Override
     public Optional<String> getThemedUrl(String url, WebBrowser browser,
             AbstractTheme theme) {
-        if (theme != null
-                && !resolveResource(url, browser).equals(getThemedOrRawPath(url, browser, theme))) {
+        if (theme != null && !resolveResource(url, browser)
+                .equals(getThemedOrRawPath(url, browser, theme))) {
             return Optional.of(theme.translateUrl(url));
         }
         return Optional.empty();

--- a/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
@@ -45,7 +45,6 @@ import org.mockito.Matchers;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.function.DeploymentConfiguration;
-import com.vaadin.flow.server.startup.FakeBrowser;
 
 public class StaticFileServerTest implements Serializable {
 
@@ -258,7 +257,7 @@ public class StaticFileServerTest implements Serializable {
     @Test
     public void isResourceRequest() throws Exception {
         setupRequestURI("", "/static", "/file.png");
-        Mockito.when(servletService.getResource("/static/file.png", FakeBrowser.getEs6(), null))
+        Mockito.when(servletService.getStaticResource("/static/file.png"))
                 .thenReturn(new URL("file:///static/file.png"));
         Assert.assertTrue(fileServer.isStaticResourceRequest(request));
     }
@@ -266,7 +265,7 @@ public class StaticFileServerTest implements Serializable {
     @Test
     public void isResourceRequestWithContextPath() throws Exception {
         setupRequestURI("/foo", "/static", "/file.png");
-        Mockito.when(servletService.getResource("/static/file.png", FakeBrowser.getEs6(), null))
+        Mockito.when(servletService.getStaticResource("/static/file.png"))
                 .thenReturn(new URL("file:///static/file.png"));
         Assert.assertTrue(fileServer.isStaticResourceRequest(request));
     }
@@ -440,7 +439,7 @@ public class StaticFileServerTest implements Serializable {
         setupRequestURI("", "/some", "/file.js");
         byte[] fileData = "function() {eval('foo');};"
                 .getBytes(StandardCharsets.UTF_8);
-        Mockito.when(servletService.getResource("/some/file.js", FakeBrowser.getEs6(), null)).thenReturn(
+        Mockito.when(servletService.getStaticResource("/some/file.js")).thenReturn(
                 createFileURLWithDataAndLength("/some/file.js", fileData));
         CapturingServletOutputStream out = new CapturingServletOutputStream();
         Mockito.when(response.getOutputStream()).thenReturn(out);
@@ -460,7 +459,7 @@ public class StaticFileServerTest implements Serializable {
 
         byte[] fileData = "function() {eval('foo');};"
                 .getBytes(StandardCharsets.UTF_8);
-        Mockito.when(servletService.getResource("/some/file.js", FakeBrowser.getEs6(), null))
+        Mockito.when(servletService.getStaticResource("/some/file.js"))
                 .thenReturn(createFileURLWithDataAndLength("/some/file.js",
                         fileData, fileModified));
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
@@ -45,6 +45,7 @@ import org.mockito.Matchers;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.startup.FakeBrowser;
 
 public class StaticFileServerTest implements Serializable {
 
@@ -99,9 +100,8 @@ public class StaticFileServerTest implements Serializable {
         private Boolean overrideBrowserHasNewestVersion;
         private Integer overrideCacheTime;
 
-        OverrideableStaticFileServer(VaadinServlet servlet,
-                DeploymentConfiguration configuration) {
-            super(servlet, configuration);
+        OverrideableStaticFileServer(VaadinServletService servletService) {
+            super(servletService);
         }
 
         @Override
@@ -132,7 +132,7 @@ public class StaticFileServerTest implements Serializable {
     private AtomicInteger responseCode;
     private AtomicLong responseContentLength;
 
-    private VaadinServlet servlet = Mockito.mock(VaadinServlet.class);
+    private VaadinServletService servletService = Mockito.mock(VaadinServletService.class);
     private DeploymentConfiguration configuration;
     private ServletContext servletContext;
 
@@ -175,10 +175,12 @@ public class StaticFileServerTest implements Serializable {
 
         configuration = Mockito.mock(DeploymentConfiguration.class);
         Mockito.when(configuration.isProductionMode()).thenReturn(true);
-        fileServer = new OverrideableStaticFileServer(servlet, configuration);
 
+        Mockito.when(servletService.getDeploymentConfiguration()).thenReturn(configuration);
+        fileServer = new OverrideableStaticFileServer(servletService);
+
+        // Required by the ResponseWriter
         servletContext = Mockito.mock(ServletContext.class);
-        Mockito.when(servlet.getServletContext()).thenReturn(servletContext);
         Mockito.when(request.getServletContext()).thenReturn(servletContext);
     }
 
@@ -256,7 +258,7 @@ public class StaticFileServerTest implements Serializable {
     @Test
     public void isResourceRequest() throws Exception {
         setupRequestURI("", "/static", "/file.png");
-        Mockito.when(servletContext.getResource("/static/file.png"))
+        Mockito.when(servletService.getResource("/static/file.png", FakeBrowser.getEs6(), null))
                 .thenReturn(new URL("file:///static/file.png"));
         Assert.assertTrue(fileServer.isStaticResourceRequest(request));
     }
@@ -264,7 +266,7 @@ public class StaticFileServerTest implements Serializable {
     @Test
     public void isResourceRequestWithContextPath() throws Exception {
         setupRequestURI("/foo", "/static", "/file.png");
-        Mockito.when(servletContext.getResource("/static/file.png"))
+        Mockito.when(servletService.getResource("/static/file.png", FakeBrowser.getEs6(), null))
                 .thenReturn(new URL("file:///static/file.png"));
         Assert.assertTrue(fileServer.isStaticResourceRequest(request));
     }
@@ -438,7 +440,7 @@ public class StaticFileServerTest implements Serializable {
         setupRequestURI("", "/some", "/file.js");
         byte[] fileData = "function() {eval('foo');};"
                 .getBytes(StandardCharsets.UTF_8);
-        Mockito.when(servletContext.getResource("/some/file.js")).thenReturn(
+        Mockito.when(servletService.getResource("/some/file.js", FakeBrowser.getEs6(), null)).thenReturn(
                 createFileURLWithDataAndLength("/some/file.js", fileData));
         CapturingServletOutputStream out = new CapturingServletOutputStream();
         Mockito.when(response.getOutputStream()).thenReturn(out);
@@ -458,7 +460,7 @@ public class StaticFileServerTest implements Serializable {
 
         byte[] fileData = "function() {eval('foo');};"
                 .getBytes(StandardCharsets.UTF_8);
-        Mockito.when(servletContext.getResource("/some/file.js"))
+        Mockito.when(servletService.getResource("/some/file.js", FakeBrowser.getEs6(), null))
                 .thenReturn(createFileURLWithDataAndLength("/some/file.js",
                         fileData, fileModified));
 


### PR DESCRIPTION
This due to the fact that if the getResource needs changes we can do it in
servlerService, but not in the StaticFileServer.

Change relates to getting spring-boot to be able to package as a jar.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4225)
<!-- Reviewable:end -->
