### PR TITLE
Find theme for RouteTarget's subclasses

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/RouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/RouteRegistry.java
@@ -671,8 +671,11 @@ public class RouteRegistry implements Serializable {
                 routeTarget = routes.get().get(routePath);
             }
             if (routeTarget != null) {
-                return Optional
-                        .ofNullable(routeTarget.getThemeFor(navigationTarget));
+                ThemeDefinition theme = routeTarget
+                        .getThemeFor(navigationTarget);
+                if (theme != null) {
+                    return Optional.of(theme);
+                }
             }
         }
         return Optional.ofNullable(

--- a/flow-server/src/main/java/com/vaadin/flow/theme/NoTheme.java
+++ b/flow-server/src/main/java/com/vaadin/flow/theme/NoTheme.java
@@ -22,7 +22,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Defines that there this class shouldn't log for missing theme.
+ * Defines that the class shouldn't log for missing theme.
  *
  * @author Vaadin Ltd
  */

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/RouteRegistryInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/RouteRegistryInitializerTest.java
@@ -63,6 +63,7 @@ import com.vaadin.flow.server.PageConfigurator;
 import com.vaadin.flow.server.startup.RouteRegistry.ErrorTargetEntry;
 import com.vaadin.flow.theme.AbstractTheme;
 import com.vaadin.flow.theme.Theme;
+import com.vaadin.flow.theme.ThemeDefinition;
 
 /**
  * Unit tests for RouteRegistryInitializer and RouteRegistry.
@@ -1280,6 +1281,10 @@ public class RouteRegistryInitializerTest {
     public static class ThemeAliasView extends Component {
     }
 
+    public static class ThemeSingleNavigationTargetSubclass
+            extends ThemeSingleNavigationTarget {
+    }
+
     @Test
     public void onStartUp_wrong_position_theme_view_layout_throws()
             throws ServletException {
@@ -1352,6 +1357,23 @@ public class RouteRegistryInitializerTest {
                 servletContext);
     }
 
+    @Test
+    public void registerNavigationTargetWithTheme_subclassGetsTheme()
+            throws ServletException {
+        routeRegistryInitializer
+                .onStartup(Stream.of(ThemeSingleNavigationTarget.class)
+                        .collect(Collectors.toSet()), servletContext);
+
+        Optional<ThemeDefinition> theme = registry.getThemeFor(
+                ThemeSingleNavigationTargetSubclass.class, "single");
+        Assert.assertTrue(
+                "Subclass should have a theme when the superclass has",
+                theme.isPresent());
+        Assert.assertEquals(
+                "Subclass should have the same theme as its superclass",
+                MyTheme.class, theme.get().getTheme());
+    }
+
     @Route("ignored")
     public static class IgnoredView extends Component {
     }
@@ -1372,7 +1394,8 @@ public class RouteRegistryInitializerTest {
 
     // An additional filter to test that it's not enough to have only one
     // passing filter
-    public static class AlwaysTrueRouterFilter implements NavigationTargetFilter {
+    public static class AlwaysTrueRouterFilter
+            implements NavigationTargetFilter {
         @Override
         public boolean testNavigationTarget(
                 Class<? extends Component> navigationTarget) {


### PR DESCRIPTION
The code expected that the RouteTarget has theme for the
NavigationTarget. But this is not the case if the NavigationTarget is a
subclass of the class which was registered with the Route and Theme.

Now if the theme is not found, it still tries to
findThemeForNavigationTarget() which performs the searching of Theme
annotation in the class hierarchy.

This hopefully fixes the problem with CDI proxy subclasses: #4140

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4231)
<!-- Reviewable:end -->
