### PR TITLE
Detect frontend directory locations dynamically based on project

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/CopyProductionFilesMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/CopyProductionFilesMojo.java
@@ -29,6 +29,7 @@ import org.apache.maven.project.MavenProject;
 import com.vaadin.flow.plugin.common.ArtifactData;
 import com.vaadin.flow.plugin.common.JarContentsManager;
 import com.vaadin.flow.plugin.production.ProductionModeCopyStep;
+import java.util.Arrays;
 
 /**
  * Goal that copies all production mode files into the
@@ -57,6 +58,19 @@ public class CopyProductionFilesMojo extends AbstractMojo {
                 .map(artifact -> new ArtifactData(artifact.getFile(),
                         artifact.getArtifactId(), artifact.getVersion()))
                 .collect(Collectors.toList());
+        
+        if(!frontendWorkingDirectory.exists()) {
+            // No directory found from given (most likely default) location,
+            // check for alternative location like for Spring boot projects
+            for(String dir : Arrays.asList("src/main/resources/META-INF/resources/frontend","src/main/resources/public/frontend","src/main/resources/static/frontend")) {
+                File directory = new File(project.getBasedir(), dir);
+                if(directory.exists()) {
+                    frontendWorkingDirectory = directory;
+                    break;
+                }
+            }
+        }
+        
         new ProductionModeCopyStep(new JarContentsManager(), projectArtifacts)
                 .copyWebApplicationFiles(copyOutputDirectory,
                         frontendWorkingDirectory, excludes);

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/CopyProductionFilesMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/CopyProductionFilesMojo.java
@@ -61,11 +61,13 @@ public class CopyProductionFilesMojo extends AbstractMojo {
         
         if(frontendWorkingDirectory == null) {
             // No directory given, try to find from common locations
-            for(String dir : Arrays.asList(
-                    "src/main/webapp/frontend", 
+            final List<String> potentialFrontEndDirectories = Arrays.asList(
+                    "src/main/webapp/frontend",
                     "src/main/resources/META-INF/resources/frontend", 
                     "src/main/resources/public/frontend",
-                    "src/main/resources/static/frontend")) {
+                    "src/main/resources/static/frontend",
+                    "src/main/resources/resources/frontend");
+            for(String dir : potentialFrontEndDirectories) {
                 File directory = new File(project.getBasedir(), dir);
                 if(directory.exists()) {
                     frontendWorkingDirectory = directory;

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/CopyProductionFilesMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/CopyProductionFilesMojo.java
@@ -46,7 +46,7 @@ public class CopyProductionFilesMojo extends AbstractMojo {
     @Parameter(name = "excludes", defaultValue = "**/LICENSE*,**/LICENCE*,**/demo/**,**/docs/**,**/test*/**,**/.*,**/*.md,**/bower.json,**/package.json,**/package-lock.json", required = true)
     private String excludes;
 
-    @Parameter(name = "frontendWorkingDirectory", property = "frontend.working.directory", defaultValue = "${project.basedir}/src/main/webapp/frontend/", required = true)
+    @Parameter(name = "frontendWorkingDirectory", property = "frontend.working.directory")
     private File frontendWorkingDirectory;
 
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
@@ -59,10 +59,13 @@ public class CopyProductionFilesMojo extends AbstractMojo {
                         artifact.getArtifactId(), artifact.getVersion()))
                 .collect(Collectors.toList());
         
-        if(!frontendWorkingDirectory.exists()) {
-            // No directory found from given (most likely default) location,
-            // check for alternative location like for Spring boot projects
-            for(String dir : Arrays.asList("src/main/resources/META-INF/resources/frontend","src/main/resources/public/frontend","src/main/resources/static/frontend")) {
+        if(frontendWorkingDirectory == null) {
+            // No directory given, try to find from common locations
+            for(String dir : Arrays.asList(
+                    "src/main/webapp/frontend", 
+                    "src/main/resources/META-INF/resources/frontend", 
+                    "src/main/resources/public/frontend",
+                    "src/main/resources/static/frontend")) {
                 File directory = new File(project.getBasedir(), dir);
                 if(directory.exists()) {
                     frontendWorkingDirectory = directory;

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PackageForProductionMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PackageForProductionMojo.java
@@ -108,6 +108,13 @@ public class PackageForProductionMojo extends AbstractMojo {
 
     @Override
     public void execute() {
+        
+        if("jar".equals(project.getPackaging()) && 
+                transpileOutputDirectory.equals(new File(project.getBuild().getOutputDirectory(), project.getBuild().getFinalName()))) {
+            // jar packaging and default value for transpile directory, assume sprinb boot project
+            transpileOutputDirectory = new File(project.getBuild().getOutputDirectory(), "classes");
+        }
+        
         FrontendDataProvider frontendDataProvider = new FrontendDataProvider(
                 bundle, minify, hash, transpileEs6SourceDirectory,
                 new AnnotationValuesExtractor(getProjectClassPathUrls()),

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PackageForProductionMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PackageForProductionMojo.java
@@ -52,6 +52,7 @@ import com.vaadin.flow.plugin.production.TranspilationStep;
  */
 @Mojo(name = "package-for-production", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, defaultPhase = LifecyclePhase.PROCESS_CLASSES)
 public class PackageForProductionMojo extends AbstractMojo {
+
     @Parameter(name = "transpileEs6SourceDirectory", defaultValue = "${project.build.directory}/frontend/", required = true)
     private File transpileEs6SourceDirectory;
 
@@ -109,18 +110,18 @@ public class PackageForProductionMojo extends AbstractMojo {
     @Override
     public void execute() {
 
-        if(transpileOutputDirectory == null) {
-            if("jar".equals(project.getPackaging()) && 
-                    project.getArtifactMap().containsKey("com.vaadin:spring-boot-starter")) {
+        if (transpileOutputDirectory == null) {
+            if ("jar".equals(project.getPackaging())
+                    && project.getArtifactMap().containsKey("com.vaadin:vaadin-spring-boot-starter")) {
                 // in spring boot project there is not web app directory
-                transpileOutputDirectory = new File(project.getBuild().getDirectory(), "classes");
+                transpileOutputDirectory = new File(project.getBuild().getDirectory(), "classes/META-INF/resources");
             } else {
                 // the default assumes basic war project
-                transpileOutputDirectory = new File(project.getBuild().getDirectory(), 
+                transpileOutputDirectory = new File(project.getBuild().getDirectory(),
                         project.getBuild().getFinalName());
             }
         }
-        
+
         FrontendDataProvider frontendDataProvider = new FrontendDataProvider(
                 bundle, minify, hash, transpileEs6SourceDirectory,
                 new AnnotationValuesExtractor(getProjectClassPathUrls()),
@@ -130,8 +131,8 @@ public class PackageForProductionMojo extends AbstractMojo {
                 es6OutputDirectoryName, frontendDataProvider);
         new TranspilationStep(frontendToolsManager, getProxyConfig(),
                 nodeVersion, yarnVersion, yarnNetworkConcurrency)
-                        .transpileFiles(transpileEs6SourceDirectory,
-                                transpileOutputDirectory, skipEs5);
+                .transpileFiles(transpileEs6SourceDirectory,
+                        transpileOutputDirectory, skipEs5);
     }
 
     private Map<String, Set<String>> getFragmentsData(
@@ -139,7 +140,7 @@ public class PackageForProductionMojo extends AbstractMojo {
         return Optional.ofNullable(mavenFragments)
                 .orElse(Collections.emptyList()).stream()
                 .peek(this::verifyFragment).collect(Collectors
-                        .toMap(Fragment::getName, Fragment::getFiles));
+                .toMap(Fragment::getName, Fragment::getFiles));
     }
 
     private void verifyFragment(Fragment fragment) {
@@ -171,7 +172,7 @@ public class PackageForProductionMojo extends AbstractMojo {
         return new ProxyConfig(getMavenProxies().stream()
                 .filter(Proxy::isActive)
                 .map(proxy -> decrypter
-                        .decrypt(new DefaultSettingsDecryptionRequest(proxy)))
+                .decrypt(new DefaultSettingsDecryptionRequest(proxy)))
                 .map(SettingsDecryptionResult::getProxy).map(this::createProxy)
                 .collect(Collectors.toList()));
     }

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PackageForProductionMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PackageForProductionMojo.java
@@ -58,7 +58,7 @@ public class PackageForProductionMojo extends AbstractMojo {
     @Parameter(name = "transpileWorkingDirectory", defaultValue = "${project.build.directory}/", required = true)
     private File transpileWorkingDirectory;
 
-    @Parameter(name = "transpileOutputDirectory", defaultValue = "${project.build.directory}/${project.build.finalName}/", required = true)
+    @Parameter(name = "transpileOutputDirectory")
     private File transpileOutputDirectory;
 
     @Parameter(name = "es6OutputDirectoryName", defaultValue = "frontend-es6", required = true)
@@ -108,11 +108,17 @@ public class PackageForProductionMojo extends AbstractMojo {
 
     @Override
     public void execute() {
-        
-        if("jar".equals(project.getPackaging()) && 
-                transpileOutputDirectory.equals(new File(project.getBuild().getOutputDirectory(), project.getBuild().getFinalName()))) {
-            // jar packaging and default value for transpile directory, assume sprinb boot project
-            transpileOutputDirectory = new File(project.getBuild().getOutputDirectory(), "classes");
+
+        if(transpileOutputDirectory == null) {
+            if("jar".equals(project.getPackaging()) && 
+                    project.getArtifactMap().containsKey("com.vaadin:spring-boot-starter")) {
+                // in spring boot project there is not web app directory
+                transpileOutputDirectory = new File(project.getBuild().getDirectory(), "classes");
+            } else {
+                // the default assumes basic war project
+                transpileOutputDirectory = new File(project.getBuild().getDirectory(), 
+                        project.getBuild().getFinalName());
+            }
         }
         
         FrontendDataProvider frontendDataProvider = new FrontendDataProvider(

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PackageForProductionMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PackageForProductionMojo.java
@@ -114,7 +114,7 @@ public class PackageForProductionMojo extends AbstractMojo {
             if ("jar".equals(project.getPackaging())
                     && project.getArtifactMap().containsKey("com.vaadin:vaadin-spring-boot-starter")) {
                 // in spring boot project there is not web app directory
-                transpileOutputDirectory = new File(project.getBuild().getDirectory(), "classes/META-INF/resources");
+                transpileOutputDirectory = new File(project.getBuild().getOutputDirectory(), "META-INF/resources");
             } else {
                 // the default assumes basic war project
                 transpileOutputDirectory = new File(project.getBuild().getDirectory(),


### PR DESCRIPTION
If source and target directories are not explicitly defined, those are now detected dynamically based on the project type, so that spring boot projects don't need special settings.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4237)
<!-- Reviewable:end -->
