### PR TITLE
Fix webcomponentsjs version for root context tests

### DIFF
--- a/flow-tests/test-root-context/pom.xml
+++ b/flow-tests/test-root-context/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
           <groupId>org.webjars.bowergithub.webcomponents</groupId>
           <artifactId>webcomponentsjs</artifactId>
-          <version>1.2.0</version>
+          <version>[1.1.0,1.999)</version>
         </dependency>
     </dependencies>
 

--- a/flow-tests/test-root-context/pom.xml
+++ b/flow-tests/test-root-context/pom.xml
@@ -49,6 +49,12 @@
             <artifactId>vaadin-usage-statistics</artifactId>
             <version>1.0.8</version>
         </dependency>
+
+        <dependency>
+          <groupId>org.webjars.bowergithub.webcomponents</groupId>
+          <artifactId>webcomponentsjs</artifactId>
+          <version>1.2.0</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Otherwise it will use version 2.0.0.beta3 which is for Polymer3 (because
of the webjar version range issue).

This should fix some integration tests on IE11.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4245)
<!-- Reviewable:end -->
