### PR TITLE
Use WebElement.click() to fix IE11 tests

### DIFF
--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/AbstractBasicElementComponentIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/AbstractBasicElementComponentIT.java
@@ -7,8 +7,8 @@ import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.flow.component.html.testbench.NativeButtonElement;
 import com.vaadin.flow.component.html.testbench.InputTextElement;
+import com.vaadin.flow.component.html.testbench.NativeButtonElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
 public abstract class AbstractBasicElementComponentIT
@@ -20,7 +20,11 @@ public abstract class AbstractBasicElementComponentIT
 
         Assert.assertEquals(0, getThankYouCount());
         $(InputTextElement.class).first().setValue("abc");
-        $(NativeButtonElement.class).first().click();
+
+        // Need to call WebElement.click(), because TestBenchElement.click()
+        // clicks with JS which doesn't move the mouse on IE11, and breaks the
+        // mouse coordinate test.
+        $(NativeButtonElement.class).first().getWrappedElement().click();
 
         Assert.assertEquals(1, getThankYouCount());
 

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/AbstractBasicElementComponentIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/AbstractBasicElementComponentIT.java
@@ -17,7 +17,10 @@ public abstract class AbstractBasicElementComponentIT
     @Test
     public void ensureDomUpdatesAndEventsDoSomething() {
         open();
+        assertDomUpdatesAndEventsDoSomething();
+    }
 
+    protected void assertDomUpdatesAndEventsDoSomething() {
         Assert.assertEquals(0, getThankYouCount());
         $(InputTextElement.class).first().setValue("abc");
 

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/BasicElementIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/BasicElementIT.java
@@ -20,10 +20,7 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
-import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
-
-import com.vaadin.flow.component.Tag;
 
 public class BasicElementIT extends AbstractBasicElementComponentIT {
 
@@ -41,23 +38,6 @@ public class BasicElementIT extends AbstractBasicElementComponentIT {
         Assert.assertEquals("ok",
                 addremovecontainerChildren.get(1).getAttribute("id"));
         // verify the UI still works
-
-        Assert.assertEquals(0, getThankYouCount());
-
-        findElement(By.tagName(Tag.INPUT)).sendKeys("abc" + Keys.TAB);
-        findElement(By.tagName(Tag.BUTTON)).click();
-
-        Assert.assertEquals(1, getThankYouCount());
-
-        String buttonText = getThankYouElements().get(0).getText();
-        String expected = "Thank you for clicking \"Click me\" at \\((\\d+),(\\d+)\\)! The field value is abc";
-        Assert.assertTrue(
-                "Expected '" + expected + "', was '" + buttonText + "'",
-                buttonText.matches(expected));
-
-        // Clicking removes the element
-        getThankYouElements().get(0).click();
-
-        Assert.assertEquals(0, getThankYouCount());
+        assertDomUpdatesAndEventsDoSomething();
     }
 }


### PR DESCRIPTION
TestBenchElement is clicking with js, which doesn't move the mouse position when testing with IE11. So this fixes some tests that check the click position.

Also refactored the code by removing the duplicate code in subclass.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4254)
<!-- Reviewable:end -->
