### PR TITLE
Fix part of #4264 and include failing test for the more complex situation of circular dependencies

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/templatemodel/PropertyMapBuilder.java
+++ b/flow-server/src/main/java/com/vaadin/flow/templatemodel/PropertyMapBuilder.java
@@ -70,7 +70,6 @@ class PropertyMapBuilder {
                 PropertyFilter propertyFilter,
                 PathLookup<ModelEncoder<?, ?>> outerConverters,
                 PathLookup<ClientUpdateMode> outerClientModes) {
-
             PropertyFilter innerFilter = new PropertyFilter(propertyFilter,
                     propertyName, getExcludeFieldsFilter());
             String prefix = innerFilter.getPrefix();
@@ -165,6 +164,8 @@ class PropertyMapBuilder {
                 .collect(Collectors.toMap(PropertyData::getPropertyName,
                         Function.identity(), PropertyData::merge))
                 .entrySet().stream()
+                .filter(e -> TemplateModelUtil.isNotSelfReferencing(
+                        e.getValue().propertyType, javaType))
                 .collect(Collectors.toMap(Map.Entry::getKey,
                         entry -> entry.getValue().buildProperty(propertyFilter,
                                 converterLookup, updateModeLookup)));

--- a/flow-server/src/main/java/com/vaadin/flow/templatemodel/TemplateModelUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/templatemodel/TemplateModelUtil.java
@@ -184,12 +184,17 @@ public final class TemplateModelUtil {
             Class<?> javaType) {
         if (propertyType instanceof ParameterizedType) {
             ParameterizedType type = (ParameterizedType) propertyType;
-            if (List.class.isAssignableFrom((Class<?>) type.getRawType())) {
+            while (List.class.isAssignableFrom((Class<?>) type.getRawType())) {
                 if (type.getActualTypeArguments().length > 0) {
-                    Class<?> actualType = (Class<?>) type
-                            .getActualTypeArguments()[0];
+                    Type actualType = type.getActualTypeArguments()[0];
                     if (Objects.equals(actualType, javaType)) {
                         return false;
+                    }
+                    
+                    if (actualType instanceof ParameterizedType) {
+                        type = (ParameterizedType) actualType;
+                    } else {
+                        return true;
                     }
                 }
             }

--- a/flow-server/src/main/java/com/vaadin/flow/templatemodel/TemplateModelUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/templatemodel/TemplateModelUtil.java
@@ -16,8 +16,12 @@
 package com.vaadin.flow.templatemodel;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
@@ -164,5 +168,32 @@ public final class TemplateModelUtil {
 
             return true;
         };
+    }
+
+    /**
+     * Checks whether the type of propertyType is the same as the javaType or if
+     * it refers to it through a generic type parameter of a list which is the
+     * only case of parameterized type currently supported in
+     * {@link TemplateModel}
+     * 
+     * @param propertyType
+     * @param javaType
+     * @return true if it's not self referencing
+     */
+    public static boolean isNotSelfReferencing(Type propertyType,
+            Class<?> javaType) {
+        if (propertyType instanceof ParameterizedType) {
+            ParameterizedType type = (ParameterizedType) propertyType;
+            if (List.class.isAssignableFrom((Class<?>) type.getRawType())) {
+                if (type.getActualTypeArguments().length > 0) {
+                    Class<?> actualType = (Class<?>) type
+                            .getActualTypeArguments()[0];
+                    if (Objects.equals(actualType, javaType)) {
+                        return false;
+                    }
+                }
+            }
+        }
+        return !Objects.equals(propertyType, javaType);
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/templatemodel/CircularDependencyBean.java
+++ b/flow-server/src/test/java/com/vaadin/flow/templatemodel/CircularDependencyBean.java
@@ -1,0 +1,23 @@
+package com.vaadin.flow.templatemodel;
+
+public class CircularDependencyBean {
+    private String name;
+
+    private CircularDependencyBeanB relativeBean;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public CircularDependencyBeanB getRelativeBean() {
+        return relativeBean;
+    }
+
+    public void setRelativeBean(CircularDependencyBeanB relativeBean) {
+        this.relativeBean = relativeBean;
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/templatemodel/CircularDependencyBeanB.java
+++ b/flow-server/src/test/java/com/vaadin/flow/templatemodel/CircularDependencyBeanB.java
@@ -1,0 +1,23 @@
+package com.vaadin.flow.templatemodel;
+
+public class CircularDependencyBeanB {
+    private String name;
+
+    private CircularDependencyBean otherRelative;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public CircularDependencyBean getOherRelativeBean() {
+        return otherRelative;
+    }
+
+    public void setOtherRelativeBean(CircularDependencyBean otherRelative) {
+        this.otherRelative = otherRelative;
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/templatemodel/SelfReferentialBean.java
+++ b/flow-server/src/test/java/com/vaadin/flow/templatemodel/SelfReferentialBean.java
@@ -1,0 +1,22 @@
+package com.vaadin.flow.templatemodel;
+
+public class SelfReferentialBean {
+    private String name;
+    private SelfReferentialBean parent;
+    
+    public void setName(String name) {
+        this.name = name;
+    }
+    
+    public String getName() {
+        return name;
+    }
+
+    public void setParent(SelfReferentialBean parent) {
+        this.parent = parent;
+    }
+    
+    public SelfReferentialBean getParent() {
+        return parent;
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/templatemodel/SelfReferentialListBean.java
+++ b/flow-server/src/test/java/com/vaadin/flow/templatemodel/SelfReferentialListBean.java
@@ -1,0 +1,25 @@
+package com.vaadin.flow.templatemodel;
+
+import java.util.List;
+
+public class SelfReferentialListBean {
+    private String name;
+    private List<SelfReferentialListBean> children;
+    
+    public void setName(String name) {
+        this.name = name;
+    }
+    
+    public String getName() {
+        return name;
+    }
+
+    public void setChildren(List<SelfReferentialListBean> children) {
+        this.children = children;
+    }
+    
+    public List<SelfReferentialListBean> getChildren() {
+        return children;
+    }
+    
+}

--- a/flow-server/src/test/java/com/vaadin/flow/templatemodel/TemplateModelTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/templatemodel/TemplateModelTest.java
@@ -171,6 +171,16 @@ public class TemplateModelTest extends HasCurrentService {
         void setValue(int value);
     }
 
+    public interface SelfReferentialModel extends TemplateModel{
+        void setItem(SelfReferentialBean item);
+        
+        SelfReferentialBean getItem();
+        
+        void setChildren(SelfReferentialListBean children);
+        
+        List<SelfReferentialListBean> getChildren();
+    }
+    
     public static class SuperBean {
 
         public void setSubBean(SubSubBean bean) {
@@ -1410,4 +1420,10 @@ public class TemplateModelTest extends HasCurrentService {
         return map.getPropertyNames().collect(Collectors.toSet());
     }
 
+    @Test
+    public void modelHasReferencesToItself_modelIsCreated() {
+        new EmptyDivTemplate<SelfReferentialModel>() {
+            
+        };
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/templatemodel/TemplateModelTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/templatemodel/TemplateModelTest.java
@@ -181,6 +181,16 @@ public class TemplateModelTest extends HasCurrentService {
         List<SelfReferentialListBean> getChildren();
     }
     
+    public interface CircularDependencyModel extends TemplateModel {
+        void setItem(CircularDependencyBean bean);
+
+        CircularDependencyBean getItem();
+
+        void setItems(List<CircularDependencyBean> bean);
+
+        List<CircularDependencyBean> getItems();
+    }
+    
     public static class SuperBean {
 
         public void setSubBean(SubSubBean bean) {
@@ -1423,6 +1433,13 @@ public class TemplateModelTest extends HasCurrentService {
     @Test
     public void modelHasReferencesToItself_modelIsCreated() {
         new EmptyDivTemplate<SelfReferentialModel>() {
+            
+        };
+    }
+    
+    @Test
+    public void modelHasBeanWithCircularDependency_modelIsCreated() {
+        new EmptyDivTemplate<CircularDependencyModel>() {
             
         };
     }

--- a/flow-server/src/test/java/com/vaadin/flow/templatemodel/TemplateModelTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/templatemodel/TemplateModelTest.java
@@ -13,6 +13,7 @@ import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
 import org.jsoup.Jsoup;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -1438,6 +1439,7 @@ public class TemplateModelTest extends HasCurrentService {
     }
     
     @Test
+    @Ignore
     public void modelHasBeanWithCircularDependency_modelIsCreated() {
         new EmptyDivTemplate<CircularDependencyModel>() {
             

--- a/flow-server/src/test/java/com/vaadin/flow/templatemodel/TemplateModelTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/templatemodel/TemplateModelTest.java
@@ -174,11 +174,11 @@ public class TemplateModelTest extends HasCurrentService {
 
     public interface SelfReferentialModel extends TemplateModel{
         void setItem(SelfReferentialBean item);
-        
+        @AllowClientUpdates(ClientUpdateMode.ALLOW)
         SelfReferentialBean getItem();
         
         void setChildren(SelfReferentialListBean children);
-        
+        @AllowClientUpdates(ClientUpdateMode.ALLOW)
         List<SelfReferentialListBean> getChildren();
     }
     

--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
@@ -139,6 +139,10 @@ public abstract class ClassesSerializableTest {
                 "com\\.vaadin\\.flow\\.server\\.MockServletConfig",
                 "com\\.vaadin\\.flow\\.server\\.MockServletContext",
                 "com\\.vaadin\\.flow\\.templatemodel\\.Bean",
+                "com\\.vaadin\\.flow\\.templatemodel\\.SelfReferentialBean",
+                "com\\.vaadin\\.flow\\.templatemodel\\.SelfReferentialListBean",
+                "com\\.vaadin\\.flow\\.templatemodel\\.CircularDependencyBean",
+                "com\\.vaadin\\.flow\\.templatemodel\\.CircularDependencyBeanB",
                 "com\\.vaadin\\.flow\\.internal\\.HasCurrentService",
                 "com\\.vaadin\\.flow\\.component\\.ValueChangeMonitor",
                 "com\\.vaadin\\.flow\\.templatemodel\\.BeanContainingBeans(\\$.*)?");


### PR DESCRIPTION
Fix stack overflow error with self-referential beans, a case that should be common when creating the model of a Tree Item e.g. for navigation menus.

The remaining case is left to analysis as checking for circular dependencies of every type can induce overhead. The PR introduces a failing test for two beans that introduce a Circular Dependency in the simplest manner `CircularDependencyBean` -> `CircularDependencyBeanB` -> `CircularDependencyBean`  to help in debugging and solving the issue

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4267)
<!-- Reviewable:end -->
