### PR TITLE
Use fixed version of shadycss

### DIFF
--- a/flow-components-parent/flow-component-demo-helpers/pom.xml
+++ b/flow-components-parent/flow-component-demo-helpers/pom.xml
@@ -14,6 +14,11 @@
     <name>Flow component demo helpers</name>
     <description>Includes a server and a base view for creating component demos</description>
 
+    <properties>
+        <!-- Components need the downgraded version until -->
+        <!-- https://github.com/eclipse/jetty.project/issues/2372 is released -->
+        <jetty.version>9.3.7.v20160115</jetty.version>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>javax.servlet</groupId>
@@ -49,6 +54,12 @@
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-lumo-theme</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <!-- Shadycss 1.3.0 causing flow components fail on loading files -->
+        <dependency>
+            <groupId>org.webjars.bowergithub.webcomponents</groupId>
+            <artifactId>shadycss</artifactId>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/flow-components-parent/flow-component-demo-helpers/pom.xml
+++ b/flow-components-parent/flow-component-demo-helpers/pom.xml
@@ -14,11 +14,6 @@
     <name>Flow component demo helpers</name>
     <description>Includes a server and a base view for creating component demos</description>
 
-    <properties>
-        <!-- Components need the downgraded version until -->
-        <!-- https://github.com/eclipse/jetty.project/issues/2372 is released -->
-        <jetty.version>9.3.7.v20160115</jetty.version>
-    </properties>
     <dependencies>
         <dependency>
             <groupId>javax.servlet</groupId>


### PR DESCRIPTION
Shadycss 1.3.0 causing flow components fail on loading files

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4272)
<!-- Reviewable:end -->
