### PR TITLE
Add IgnoreIE11 test category

### DIFF
--- a/flow-test-util/src/main/java/com/vaadin/flow/testcategory/IgnoreIE11.java
+++ b/flow-test-util/src/main/java/com/vaadin/flow/testcategory/IgnoreIE11.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2000-2017 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.testcategory;
+
+/**
+ * Tests that should not be run with IE11 should be annotated with @
+ * {@code Category(IgnoreIE11.class)} so they can be optionally excluded from
+ * the build when running with IE11.
+ * 
+ * @author Vaadin Ltd
+ *
+ */
+public interface IgnoreIE11 {
+
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ElementStyleIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ElementStyleIT.java
@@ -2,13 +2,16 @@ package com.vaadin.flow.uitest.ui;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import com.vaadin.flow.component.html.testbench.DivElement;
+import com.vaadin.flow.testcategory.IgnoreIE11;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
 public class ElementStyleIT extends ChromeBrowserTest {
 
     @Test
+    @Category(IgnoreIE11.class)
     public void customPropertiesWork() {
         open();
         DivElement red = $(DivElement.class).id("red-border");


### PR DESCRIPTION
This should be used for at least those tests that don't make any sense
to test on IE11, like the CSS custom property test that I already marked
into this category.

The category should be disabled in the IE11 test build with
-Dtest.excludegroup=com.vaadin.flow.testcategory.IgnoreIE11