### PR TITLE
Material theme should also use 1.1-SNAPSHOT version

### DIFF
--- a/flow-theme-integrations/material/pom.xml
+++ b/flow-theme-integrations/material/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-theme-integrations</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-material-theme</artifactId>


### PR DESCRIPTION
This should fix the CI build problem where parent pom is not found.