### PR TITLE
Make reconnect dialog fully visible

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -661,6 +661,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                 + "right: 1em;" //
                 + "border: 1px solid black;" //
                 + "padding: 1em;" //
+                + "z-index: 10000;" //
                 + "}");
 
         // Basic system error dialog style just to make it visible and outside


### PR DESCRIPTION
Currently reconnect dialog on beverage buddy shows like this
![image](https://user-images.githubusercontent.com/9820084/42206132-ee61c366-7eae-11e8-942e-aa7794adb767.png)
After the change it'll be like this
![image](https://user-images.githubusercontent.com/9820084/42206169-09985bcc-7eaf-11e8-99c5-cacfda1d6736.png)
