### PR TITLE
Change the MessageHandler to accept payloads with multiple messages

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/communication/AtmospherePushConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/AtmospherePushConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2017 Vaadin Ltd.
+ * Copyright 2000-2018 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,6 +18,7 @@ package com.vaadin.client.communication;
 
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.Scheduler;
+
 import com.vaadin.client.Command;
 import com.vaadin.client.Console;
 import com.vaadin.client.Registry;
@@ -26,6 +27,7 @@ import com.vaadin.client.ResourceLoader.ResourceLoadEvent;
 import com.vaadin.client.ResourceLoader.ResourceLoadListener;
 import com.vaadin.client.ValueMap;
 import com.vaadin.client.WidgetUtil;
+import com.vaadin.client.flow.collection.JsArray;
 import com.vaadin.flow.shared.ApplicationConstants;
 import com.vaadin.flow.shared.communication.PushConstants;
 import com.vaadin.flow.shared.util.SharedUtil;
@@ -45,27 +47,27 @@ public class AtmospherePushConnection implements PushConnection {
      * Represents the connection state of a push connection.
      */
     protected enum State {
-        /**
-         * Opening request has been sent, but still waiting for confirmation.
-         */
-        CONNECT_PENDING,
+    /**
+     * Opening request has been sent, but still waiting for confirmation.
+     */
+    CONNECT_PENDING,
 
-        /**
-         * Connection is open and ready to use.
-         */
-        CONNECTED,
+    /**
+     * Connection is open and ready to use.
+     */
+    CONNECTED,
 
-        /**
-         * Connection was disconnected while the connection was pending. Wait
-         * for the connection to get established before closing it. No new
-         * messages are accepted, but pending messages will still be delivered.
-         */
-        DISCONNECT_PENDING,
+    /**
+     * Connection was disconnected while the connection was pending. Wait for
+     * the connection to get established before closing it. No new messages are
+     * accepted, but pending messages will still be delivered.
+     */
+    DISCONNECT_PENDING,
 
-        /**
-         * Connection has been disconnected and should not be used any more.
-         */
-        DISCONNECTED;
+    /**
+     * Connection has been disconnected and should not be used any more.
+     */
+    DISCONNECTED;
     }
 
     /**
@@ -369,15 +371,16 @@ public class AtmospherePushConnection implements PushConnection {
      */
     protected void onMessage(AtmosphereResponse response) {
         String message = response.getResponseBody();
-        ValueMap json = MessageHandler.parseWrappedJson(message);
-        if (json == null) {
+        JsArray<ValueMap> array = MessageHandler.parseWrappedJson(message);
+        if (array.isEmpty()) {
             // Invalid string (not wrapped as expected)
             getConnectionStateHandler().pushInvalidContent(this, message);
             return;
         } else {
             Console.log("Received push (" + getTransportType() + ") message: "
                     + message);
-            registry.getMessageHandler().handleMessage(json);
+            array.forEach(
+                    json -> registry.getMessageHandler().handleMessage(json));
         }
     }
 

--- a/flow-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2017 Vaadin Ltd.
+ * Copyright 2000-2018 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -18,6 +18,7 @@ package com.vaadin.client.communication;
 import com.google.gwt.core.client.Duration;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.user.client.Timer;
+
 import com.vaadin.client.Command;
 import com.vaadin.client.Console;
 import com.vaadin.client.DependencyLoader;
@@ -744,21 +745,66 @@ public class MessageHandler {
         }
     }
 
+    /**
+     * Splits a message in the format
+     * <p>
+     * {@code
+     * for(;;);["+ realJson1 +"]"for(;;);["+realJson2 +"]"...
+     * }
+     * <p>
+     * into an array of single messages.
+     * 
+     * @param wrappedJsonText
+     *            the original message
+     * @return an array of individual messages. It returns an empty array if the
+     *         original message cannot be parsed
+     */
+    // package protected for testing purposes
+    static JsArray<String> splitMultipleMessages(String wrappedJsonText) {
+        JsArray<String> array = JsCollections.array();
+        if (wrappedJsonText == null) {
+            return array;
+        }
+
+        int idx = wrappedJsonText.indexOf(JSON_COMMUNICATION_PREFIX);
+        while (idx >= 0 && idx < wrappedJsonText.length()) {
+            int next = wrappedJsonText.indexOf(JSON_COMMUNICATION_PREFIX,
+                    idx + JSON_COMMUNICATION_PREFIX.length());
+            if (next < 0) {
+                next = wrappedJsonText.length();
+            }
+            array.push(wrappedJsonText.substring(idx, next));
+            idx = next;
+        }
+
+        return array;
+    }
+
     private static native ValueMap parseJSONResponse(String jsonText)
     /*-{
        return JSON.parse(jsonText);
     }-*/;
 
     /**
-     * Parse the given wrapped JSON, received from the server, to a ValueMap.
+     * Parse the given wrapped JSON, received from the server, to an array of
+     * ValueMaps.
      *
      * @param wrappedJsonText
      *            the json, wrapped as done by the server
-     * @return a ValueMap, or null if the wrapping was incorrect or json could
-     *         not be parsed
+     * @return an array with all the parsed ValueMaps inside. An empty array is
+     *         returned if the wrapping was incorrect or the json could not be
+     *         parsed
      */
-    public static ValueMap parseWrappedJson(String wrappedJsonText) {
-        return parseJson(stripJSONWrapping(wrappedJsonText));
+    public static JsArray<ValueMap> parseWrappedJson(String wrappedJsonText) {
+        JsArray<ValueMap> array = JsCollections.array();
+        JsArray<String> messages = splitMultipleMessages(wrappedJsonText);
+        messages.forEach(message -> {
+            ValueMap value = parseJson(stripJSONWrapping(message));
+            if (value != null) {
+                array.push(value);
+            }
+        });
+        return array;
     }
 
     private static final native double getFetchStartTime()

--- a/flow-client/src/main/java/com/vaadin/client/communication/XhrConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/XhrConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2017 Vaadin Ltd.
+ * Copyright 2000-2018 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -17,12 +17,14 @@ package com.vaadin.client.communication;
 
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.xhr.client.XMLHttpRequest;
+
 import com.vaadin.client.BrowserInfo;
 import com.vaadin.client.Console;
 import com.vaadin.client.Profiler;
 import com.vaadin.client.Registry;
 import com.vaadin.client.ValueMap;
 import com.vaadin.client.WidgetUtil;
+import com.vaadin.client.flow.collection.JsArray;
 import com.vaadin.client.gwt.elemental.js.util.Xhr;
 import com.vaadin.flow.shared.ApplicationConstants;
 import com.vaadin.flow.shared.JsonConstants;
@@ -120,8 +122,9 @@ public class XhrConnection {
             // for(;;);["+ realJson +"]"
             String responseText = xhr.getResponseText();
 
-            ValueMap json = MessageHandler.parseWrappedJson(responseText);
-            if (json == null) {
+            JsArray<ValueMap> array = MessageHandler
+                    .parseWrappedJson(responseText);
+            if (array.isEmpty()) {
                 // Invalid string (not wrapped as expected or can't parse)
                 registry.getConnectionStateHandler().xhrInvalidContent(
                         new XhrConnectionError(xhr, payload, null));
@@ -130,7 +133,8 @@ public class XhrConnection {
 
             registry.getConnectionStateHandler().xhrOk();
             Console.log("Received xhr message: " + responseText);
-            registry.getMessageHandler().handleMessage(json);
+            array.forEach(
+                    json -> registry.getMessageHandler().handleMessage(json));
         }
 
         /**

--- a/flow-client/src/test/java/com/vaadin/client/communication/MessageHandlerTest.java
+++ b/flow-client/src/test/java/com/vaadin/client/communication/MessageHandlerTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.client.communication;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.client.flow.collection.JsArray;
+
+public class MessageHandlerTest {
+
+    @Test
+    public void messageWithMultipleJson_messagesAreSplit() {
+        String sampleMessage = "for(;;);[{\"syncId\":216,\"clientId\":0,\"meta\":{\"async\":true},\"timings\":[725,1]}]for(;;);[{\"syncId\":217,\"clientId\":0,\"meta\":{\"async\":true},\"timings\":[726,1]}]";
+        JsArray<String> array = MessageHandler
+                .splitMultipleMessages(sampleMessage);
+        Assert.assertEquals(2, array.length());
+        Assert.assertEquals(
+                "for(;;);[{\"syncId\":216,\"clientId\":0,\"meta\":{\"async\":true},\"timings\":[725,1]}]",
+                array.get(0));
+        Assert.assertEquals(
+                "for(;;);[{\"syncId\":217,\"clientId\":0,\"meta\":{\"async\":true},\"timings\":[726,1]}]",
+                array.get(1));
+    }
+
+    @Test
+    public void messageWithSingleJson_messageIsTheSame() {
+        String sampleMessage = "for(;;);[{\"syncId\":216,\"clientId\":0,\"meta\":{\"async\":true},\"timings\":[725,1]}]";
+        JsArray<String> array = MessageHandler
+                .splitMultipleMessages(sampleMessage);
+        Assert.assertEquals(1, array.length());
+        Assert.assertEquals(sampleMessage, array.get(0));
+    }
+
+    @Test
+    public void invalidMessage_arrayIsEmpty() {
+        String sampleMessage = "invalidMessage";
+        JsArray<String> array = MessageHandler
+                .splitMultipleMessages(sampleMessage);
+        Assert.assertEquals(0, array.length());
+    }
+}


### PR DESCRIPTION
Each individual message is processed independently, fixing the issue
with long polling when multiple messages are sent in the same payload.