### PR TITLE
Make inactive nodes mark their children as dirty on setInactive

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/internal/StateNodeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/StateNodeTest.java
@@ -659,8 +659,13 @@ public class StateNodeTest {
 
     private void assertCollectChanges_initiallyInactive(StateNode stateNode,
             ElementPropertyMap properties, Consumer<Boolean> activityUpdater) {
-        ElementData visibility = stateNode.getFeature(ElementData.class);
 
+        properties.setProperty("foo", "bar");
+
+        TestStateTree tree = (TestStateTree) stateNode.getOwner();
+        tree.dirtyNodes.clear();
+
+        ElementData visibility = stateNode.getFeature(ElementData.class);
         activityUpdater.accept(false);
 
         // activity updater may modify visibility of the node itself or its
@@ -668,22 +673,18 @@ public class StateNodeTest {
         // node is visible or not
         boolean visibilityChanged = !visibility.isVisible();
 
-        properties.setProperty("foo", "bar");
-
-        TestStateTree tree = (TestStateTree) stateNode.getOwner();
-
-        tree.dirtyNodes.clear();
-
         List<NodeChange> changes = new ArrayList<>();
         stateNode.collectChanges(changes::add);
 
         if (visibilityChanged) {
-            Assert.assertEquals(0, tree.dirtyNodes.size());
+            Assert.assertEquals(1, tree.dirtyNodes.size());
+            Assert.assertThat(tree.dirtyNodes, CoreMatchers.hasItem(stateNode));
         } else {
             // the target node should be marked as dirty because it's visible
             // but its parent is inactive
-            Assert.assertEquals(1, tree.dirtyNodes.size());
-            tree.dirtyNodes.contains(stateNode);
+            Assert.assertEquals(2, tree.dirtyNodes.size());
+            stateNode.visitNodeTree(node -> Assert.assertThat(tree.dirtyNodes,
+                    CoreMatchers.hasItem(node)));
         }
 
         Assert.assertEquals(visibilityChanged ? 3 : 2, changes.size());
@@ -698,7 +699,6 @@ public class StateNodeTest {
                 .filter(chang -> chang.getKey().equals("tag")).findFirst();
         Assert.assertTrue("No tag change found", tagFound.isPresent());
         MapPutChange tagChange = tagFound.get();
-
 
         MapPutChange change = (MapPutChange) changes.get(1);
         if (visibilityChanged) {
@@ -784,6 +784,9 @@ public class StateNodeTest {
 
         changes.clear();
 
+        TestStateTree tree = (TestStateTree) stateNode.getOwner();
+        tree.dirtyNodes.clear();
+
         // now make the node inactive via the VisibiltyData
 
         activityUpdater.accept(false);
@@ -792,9 +795,6 @@ public class StateNodeTest {
         // VisibiltyData, but don't loose changes for other features
 
         properties.setProperty("foo", "baz");
-
-        TestStateTree tree = (TestStateTree) stateNode.getOwner();
-        tree.dirtyNodes.clear();
 
         stateNode.collectChanges(changes::add);
 
@@ -808,7 +808,8 @@ public class StateNodeTest {
 
         MapPutChange change;
         if (visibilityChanged) {
-            Assert.assertEquals(0, tree.dirtyNodes.size());
+            Assert.assertEquals(1, tree.dirtyNodes.size());
+            Assert.assertThat(tree.dirtyNodes, CoreMatchers.hasItem(stateNode));
             Assert.assertThat(changes.get(0),
                     CoreMatchers.instanceOf(MapPutChange.class));
             change = (MapPutChange) changes.get(0);
@@ -816,8 +817,9 @@ public class StateNodeTest {
         } else {
             // the target node should be marked as dirty because it's visible
             // but its parent is inactive
-            Assert.assertEquals(1, tree.dirtyNodes.size());
-            tree.dirtyNodes.contains(stateNode);
+            Assert.assertEquals(2, tree.dirtyNodes.size());
+            stateNode.visitNodeTree(node -> Assert.assertThat(tree.dirtyNodes,
+                    CoreMatchers.hasItem(node)));
         }
 
         changes.clear();
@@ -841,7 +843,8 @@ public class StateNodeTest {
                     .equals(change.getFeature()) ? change
                             : (MapPutChange) changes.get(1);
             propertyChange = change.equals(visibilityChange)
-                    ? (MapPutChange) changes.get(1) : change;
+                    ? (MapPutChange) changes.get(1)
+                    : change;
         } else {
             propertyChange = change;
         }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/LongPollingPushView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/LongPollingPushView.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.page.Push;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.shared.ui.Transport;
+
+/**
+ * Class for reproducing the bug https://github.com/vaadin/flow/issues/4353
+ */
+@Route("com.vaadin.flow.uitest.ui.LongPollingPushView")
+@Push(transport = Transport.LONG_POLLING)
+public class LongPollingPushView extends AbstractDivView {
+
+    public LongPollingPushView() {
+        Div parent = new Div();
+        Span child = new Span("Some text");
+        child.setId("child");
+        parent.add(child);
+        add(parent);
+        parent.setVisible(false);
+
+        NativeButton visibility = new NativeButton("Toggle visibility",
+                e -> parent.setVisible(!parent.isVisible()));
+        visibility.setId("visibility");
+        add(visibility);
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/LongPollingPushIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/LongPollingPushIT.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class LongPollingPushIT extends ChromeBrowserTest {
+
+    @Test
+    public void openPage_thereAreNoErrorsInTheConsole() {
+        open();
+        checkLogsForErrors();
+
+        waitForElementNotPresent(By.id("child"));
+
+        WebElement button = findElement(By.id("visibility"));
+        button.click();
+
+        waitForElementPresent(By.id("child"));
+
+        WebElement span = findElement(By.id("child"));
+        Assert.assertEquals("Some text", span.getText());
+        checkLogsForErrors();
+    }
+
+}


### PR DESCRIPTION
This moves the setting of dirty nodes out of the collectChanges method.

When using long-polling push, the client keeps asking for changes from
the server. The server then collects all the changes and sends to the
client. The problem is: a child node is always considered `dirty`, if
its parent is invisible, and the node is always included in the changes
sent to the client.

Since there's not a single moment where there's nothing to send, the
server keeps sending the changes, and the client keeps asking for the
changes. This creates a busy loop between client and server, which only
ends when the parent node is made visible again.

To prevent this, this patch changes this logic to make the children
nodes only dirty when the parent visibility changes.