### PR TITLE
Pin all theme dependencies

### DIFF
--- a/flow-theme-integrations/lumo/pom.xml
+++ b/flow-theme-integrations/lumo/pom.xml
@@ -28,6 +28,27 @@
         </dependency>
         <dependency>
             <groupId>org.webjars.bowergithub.polymerelements</groupId>
+            <artifactId>iron-icon</artifactId>
+            <version>2.1.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.webjars.bowergithub.polymerelements</groupId>
+                    <artifactId>iron-flex-layout</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars.bowergithub.polymerelements</groupId>
+            <artifactId>iron-meta</artifactId>
+            <version>2.1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars.bowergithub.polymerelements</groupId>
+            <artifactId>iron-iconset-svg</artifactId>
+            <version>2.2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars.bowergithub.polymerelements</groupId>
             <artifactId>iron-flex-layout</artifactId>
             <version>2.0.3</version>
         </dependency>

--- a/flow-theme-integrations/pom.xml
+++ b/flow-theme-integrations/pom.xml
@@ -18,6 +18,22 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.webjars.bowergithub.polymer</groupId>
+            <artifactId>polymer</artifactId>
+            <version>2.6.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars.bowergithub.webcomponents</groupId>
+            <artifactId>webcomponentsjs</artifactId>
+            <version>1.2.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.webjars.bowergithub.webcomponents</groupId>
+            <artifactId>shadycss</artifactId>
+            <version>1.2.1</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>flow-server</artifactId>
             <version>${project.version}</version>


### PR DESCRIPTION
If all WebJars' transitive dependencies are explicitly mentioned in the theme integrations modules' pom.xml, then those dependencies become pinned and no longer have version range which means that no bom is needed to resolve their dependencies.

See https://github.com/vaadin/flow-component-base/pull/65 for details.