### PR TITLE
Add material theme to demo-helpers

### DIFF
--- a/flow-components-parent/flow-component-demo-helpers/pom.xml
+++ b/flow-components-parent/flow-component-demo-helpers/pom.xml
@@ -50,6 +50,11 @@
             <artifactId>vaadin-lumo-theme</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-material-theme</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <!-- Shadycss 1.3.0 causing flow components fail on loading files -->
         <dependency>
             <groupId>org.webjars.bowergithub.webcomponents</groupId>


### PR DESCRIPTION
If we plan to show Material theme examples, we need this dependency for it.

Part of https://github.com/vaadin/flow/issues/4318