### PR TITLE
Add component-level API for customizing DOM event listeners

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentEventBus.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentEventBus.java
@@ -340,12 +340,10 @@ public class ComponentEventBus implements Serializable {
                     "No listener of the given type is registered");
         }
 
-        if (!eventData.contains(wrapper)) {
+        if (!eventData.remove(wrapper)) {
             throw new IllegalArgumentException(
                     "The given listener is not registered");
         }
-
-        eventData.remove(wrapper);
 
         if (wrapper.domRegistration != null) {
             wrapper.domRegistration.remove();

--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
@@ -31,6 +31,8 @@ import com.vaadin.flow.component.internal.ComponentMetaData;
 import com.vaadin.flow.component.internal.ComponentMetaData.DependencyInfo;
 import com.vaadin.flow.component.internal.ComponentMetaData.SynchronizedPropertyInfo;
 import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.dom.DomEvent;
+import com.vaadin.flow.dom.DomListenerRegistration;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableTriConsumer;
 import com.vaadin.flow.i18n.LocaleChangeEvent;
@@ -331,6 +333,41 @@ public class ComponentUtil {
             Component component, Class<T> eventType,
             ComponentEventListener<T> listener) {
         return component.addListener(eventType, listener);
+    }
+
+    /**
+     * Adds a listener for an event of the given type to the {@code component},
+     * and customizes the corresponding DOM event listener with the given
+     * consumer. This allows overriding eg. the debounce settings defined in the
+     * {@link DomEvent} annotation.
+     * <p>
+     * Note that customizing the DOM event listener works only for event types
+     * which are annotated with {@link DomEvent}. Use
+     * {@link #addListener(Component, Class, ComponentEventListener)} for other
+     * listeners, or if you don't need to customize the DOM listener.
+     *
+     * @param <T>
+     *            the event type
+     * @param component
+     *            the component to add the {@code listener}
+     * @param eventType
+     *            the event type for which to call the listener, must be
+     *            annotated with {@link DomEvent}
+     * @param listener
+     *            the listener to call when the event occurs, not {@code null}
+     * @param domListenerConsumer
+     *            a consumer to customize the behavior of the DOM event
+     *            listener, not {@code null}
+     * @return a handle that can be used for removing the listener
+     * @throws IllegalArgumentException
+     *             if the event type is not annotated with {@link DomEvent}
+     */
+    public <T extends ComponentEvent<?>> Registration addListener(
+            Component component, Class<T> eventType,
+            ComponentEventListener<T> listener,
+            Consumer<DomListenerRegistration> domListenerConsumer) {
+        return component.getEventBus().addListener(eventType, listener,
+                domListenerConsumer);
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentEventBusTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentEventBusTest.java
@@ -279,6 +279,45 @@ public class ComponentEventBusTest {
                 domRegistration -> domRegistration.debounce(200));
     }
 
+    private int calls = 0;
+
+    @Test
+    public void domEvent_addSameListenerTwice() {
+        TestComponent component = new TestComponent();
+
+        ComponentEventListener<MappedToDomEvent> listener = e -> calls++;
+
+        Registration reg1 = component.addListener(MappedToDomEvent.class,
+                listener);
+        Registration reg2 = component.addListener(MappedToDomEvent.class,
+                listener);
+
+        Assert.assertEquals(1,
+                component.getEventBus().componentEventData.size());
+        Assert.assertEquals(2, component.getEventBus().componentEventData
+                .get(MappedToDomEvent.class).size());
+
+        fireDomEvent(component, "dom-event", Json.createObject());
+        Assert.assertEquals(2, calls);
+
+        reg1.remove();
+        Assert.assertEquals(1,
+                component.getEventBus().componentEventData.size());
+        Assert.assertEquals(1, component.getEventBus().componentEventData
+                .get(MappedToDomEvent.class).size());
+
+        fireDomEvent(component, "dom-event", Json.createObject());
+
+        Assert.assertEquals(3, calls);
+
+        reg2.remove();
+        Assert.assertEquals(0,
+                component.getEventBus().componentEventData.size());
+
+        fireDomEvent(component, "dom-event", Json.createObject());
+        Assert.assertEquals(3, calls);
+    }
+
     @Test
     public void multipleEventsForSameDomEvent_removeListener() {
         TestComponent component = new TestComponent();

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentEventBusTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentEventBusTest.java
@@ -264,6 +264,22 @@ public class ComponentEventBusTest {
     }
 
     @Test
+    public void domEvent_addListenerWithDomListenerConsumer() {
+        TestComponent component = new TestComponent();
+        EventTracker<MappedToDomEvent> eventTracker = new EventTracker<>();
+        component.getEventBus().addListener(MappedToDomEvent.class,
+                eventTracker, domRegistration -> domRegistration.debounce(200));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void nonDomEvent_addListenerWithDomListenerConsumer_throws() {
+        TestComponent component = new TestComponent();
+        EventTracker<ServerEvent> eventTracker = new EventTracker<>();
+        component.getEventBus().addListener(ServerEvent.class, eventTracker,
+                domRegistration -> domRegistration.debounce(200));
+    }
+
+    @Test
     public void multipleEventsForSameDomEvent_removeListener() {
         TestComponent component = new TestComponent();
         EventTracker<MappedToDomEvent> eventTracker = new EventTracker<>();

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DomEventFilterIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DomEventFilterIT.java
@@ -78,6 +78,34 @@ public class DomEventFilterIT extends ChromeBrowserTest {
         assertMessages(4);
     }
 
+    @Test
+    public void componentWithDebounce() throws InterruptedException {
+        open();
+
+        WebElement input = findElement(By.id("debounce-component"));
+
+        input.sendKeys("a");
+        assertMessages(0);
+
+        Thread.sleep(750);
+        input.sendKeys("b");
+        assertMessages(0);
+
+        Thread.sleep(1100);
+        assertMessages(0, "Component: ab");
+
+        input.sendKeys("c");
+        Thread.sleep(200);
+        assertMessages(1);
+
+        input.sendKeys("d");
+        Thread.sleep(800);
+        assertMessages(1);
+        Thread.sleep(300);
+        assertMessages(1, "Component: abcd");
+
+    }
+
     private void assertMessages(int skip, String... expectedTail) {
         List<WebElement> messages = getMessages();
         if (messages.size() < skip) {


### PR DESCRIPTION
Each component-level event-listener is now mapped to its corresponding
DOM event listener registration.

An overload of ComponentEventBus::addListener is added which takes a
consumer for customizing the DOM event listener. The method still
returns a component-level registration.

This allows creating Component-level API for eg. overriding the debounce
or filter settings defined in the event's @DomEvent annotation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4445)
<!-- Reviewable:end -->
