### PR TITLE
Do not process imports with context:// and base:// prefixes when creating a production build.

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/common/FrontendDataProvider.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/common/FrontendDataProvider.java
@@ -257,8 +257,8 @@ public class FrontendDataProvider {
     }
 
     private boolean canBeResolvedInFrontendDirectory(String url) {
-        return !url.startsWith(ApplicationConstants.CONTEXT_PROTOCOL_PREFIX)
-                && !url.startsWith(ApplicationConstants.BASE_PROTOCOL_PREFIX);
+        return url.startsWith(ApplicationConstants.FRONTEND_PROTOCOL_PREFIX)
+                || !url.contains("://");
     }
 
     private String removeFrontendPrefix(String url) {

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/common/FrontendDataProvider.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/common/FrontendDataProvider.java
@@ -176,7 +176,7 @@ public class FrontendDataProvider {
     protected ThemedURLTranslator getTranslator(File es6SourceDirectory,
             ClassPathIntrospector introspector) {
         return new ThemedURLTranslator(
-                url -> new File(es6SourceDirectory, removeFlowPrefixes(url)),
+                url -> new File(es6SourceDirectory, removeFrontendPrefix(url)),
                 introspector);
     }
 
@@ -247,7 +247,8 @@ public class FrontendDataProvider {
                         .applyTheme(htmlImportUrls));
 
         return annotationValues.values().stream().flatMap(Collection::stream)
-                .map(this::removeFlowPrefixes)
+                .filter(this::canBeResolvedInFrontendDirectory)
+                .map(this::removeFrontendPrefix)
                 .map(annotationImport -> getFileFromSourceDirectory(
                         es6SourceDirectory, annotationImport))
                 .filter(fileInSourceDirectory -> !fragmentFiles
@@ -255,10 +256,13 @@ public class FrontendDataProvider {
                 .collect(Collectors.toSet());
     }
 
-    private String removeFlowPrefixes(String url) {
-        return url.replace(ApplicationConstants.CONTEXT_PROTOCOL_PREFIX, "")
-                .replace(ApplicationConstants.FRONTEND_PROTOCOL_PREFIX, "")
-                .replace(ApplicationConstants.BASE_PROTOCOL_PREFIX, "");
+    private boolean canBeResolvedInFrontendDirectory(String url) {
+        return !url.startsWith(ApplicationConstants.CONTEXT_PROTOCOL_PREFIX)
+                && !url.startsWith(ApplicationConstants.BASE_PROTOCOL_PREFIX);
+    }
+
+    private String removeFrontendPrefix(String url) {
+        return url.replace(ApplicationConstants.FRONTEND_PROTOCOL_PREFIX, "");
     }
 
     private String createFragmentFile(File targetDirectory, String fragmentName,

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/common/FrontendDataProviderTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/common/FrontendDataProviderTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
@@ -43,6 +44,8 @@ import org.mockito.Matchers;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.dependency.HtmlImport;
+import com.vaadin.flow.component.dependency.JavaScript;
+import com.vaadin.flow.component.dependency.StyleSheet;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -68,7 +71,7 @@ public class FrontendDataProviderTest {
     private File cssFile;
     private File htmlFile;
 
-    private ThemedURLTranslator translator = Mockito
+    private final ThemedURLTranslator translator = Mockito
             .mock(ThemedURLTranslator.class);
 
     public class TestFrontendDataProvider extends FrontendDataProvider {
@@ -99,9 +102,8 @@ public class FrontendDataProviderTest {
         cssFile = createFile(sourceDirectory, "test.css");
         htmlFile = createFile(sourceDirectory, "test.html");
 
-        Mockito.doAnswer(invocation -> {
-            return invocation.getArgumentAt(0, Set.class);
-        }).when(translator).applyTheme(Matchers.any());
+        Mockito.doAnswer(invocation -> invocation.getArgumentAt(0, Set.class))
+                .when(translator).applyTheme(Matchers.any());
     }
 
     private File createFile(File directory, String fileName)
@@ -334,6 +336,68 @@ public class FrontendDataProviderTest {
 
         verify(annotationValuesExtractorMock, Mockito.times(2))
                 .extractAnnotationValues(anyMap());
+    }
+
+    @Test
+    public void importsWithContextOrBaseProtocolAreIgnored()
+            throws IOException {
+        List<String> expectedFiles = Arrays.asList("result1.js", "result2.js",
+                "result1.css", "result2.css", "result1.html", "result2.html");
+
+        for (String file : expectedFiles) {
+            assertTrue("Failed to create a test file",
+                    new File(sourceDirectory, file).createNewFile());
+        }
+
+        AnnotationValuesExtractor annotationValuesExtractorMock = mock(
+                AnnotationValuesExtractor.class);
+        when(annotationValuesExtractorMock.extractAnnotationValues(
+                ImmutableMap.of(StyleSheet.class, ThemedURLTranslator.VALUE,
+                        JavaScript.class, ThemedURLTranslator.VALUE)))
+                                .thenReturn(new HashMap<>(ImmutableMap.of(
+                                        JavaScript.class,
+                                        ImmutableSet.of(
+                                                "context://shouldBeIgnored.js",
+                                                "base://shouldBeIgnored.js",
+                                                "frontend://"
+                                                        + expectedFiles.get(0),
+                                                expectedFiles.get(1)),
+                                        StyleSheet.class,
+                                        ImmutableSet.of(
+                                                "context://shouldBeIgnored.css",
+                                                "base://shouldBeIgnored.css",
+                                                "frontend://"
+                                                        + expectedFiles.get(2),
+                                                expectedFiles.get(3)))));
+        when(annotationValuesExtractorMock.extractAnnotationValues(Collections
+                .singletonMap(HtmlImport.class, ThemedURLTranslator.VALUE)))
+                        .thenReturn(ImmutableMap.of(HtmlImport.class,
+                                ImmutableSet.of(
+                                        "context://shouldBeIgnored.html",
+                                        "base://shouldBeIgnored.html",
+                                        "frontend://" + expectedFiles.get(4),
+                                        expectedFiles.get(5))));
+
+        FrontendDataProvider dataProvider = new TestFrontendDataProvider(false,
+                false, sourceDirectory, annotationValuesExtractorMock, null,
+                Collections.emptyMap());
+
+        String shellFile = dataProvider.createShellFile(targetDirectory);
+        List<String> shellFileContents = Files.lines(Paths.get(shellFile))
+                .collect(Collectors.toList());
+
+        assertTrue(
+                "No imports with context:// or base:// prefix should be in the shell file",
+                shellFileContents.stream()
+                        .noneMatch(line -> line.contains("shouldBeIgnored")));
+
+        for (String expectedFile : expectedFiles) {
+            assertTrue(String.format(
+                    "Regular files or files with frontend:// prefix should be imported in the shell file, but the file '%s' is missing",
+                    expectedFile),
+                    shellFileContents.stream()
+                            .anyMatch(line -> line.contains(expectedFile)));
+        }
     }
 
     private void findAndVerifyFragment(Collection<String> outputFragmentNames,

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/common/FrontendDataProviderTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/common/FrontendDataProviderTest.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.plugin.common;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -354,29 +355,10 @@ public class FrontendDataProviderTest {
         when(annotationValuesExtractorMock.extractAnnotationValues(
                 ImmutableMap.of(StyleSheet.class, ThemedURLTranslator.VALUE,
                         JavaScript.class, ThemedURLTranslator.VALUE)))
-                                .thenReturn(new HashMap<>(ImmutableMap.of(
-                                        JavaScript.class,
-                                        ImmutableSet.of(
-                                                "context://shouldBeIgnored.js",
-                                                "base://shouldBeIgnored.js",
-                                                "frontend://"
-                                                        + expectedFiles.get(0),
-                                                expectedFiles.get(1)),
-                                        StyleSheet.class,
-                                        ImmutableSet.of(
-                                                "context://shouldBeIgnored.css",
-                                                "base://shouldBeIgnored.css",
-                                                "frontend://"
-                                                        + expectedFiles.get(2),
-                                                expectedFiles.get(3)))));
+                                .thenReturn(getCssAndJsImports(expectedFiles));
         when(annotationValuesExtractorMock.extractAnnotationValues(Collections
                 .singletonMap(HtmlImport.class, ThemedURLTranslator.VALUE)))
-                        .thenReturn(ImmutableMap.of(HtmlImport.class,
-                                ImmutableSet.of(
-                                        "context://shouldBeIgnored.html",
-                                        "base://shouldBeIgnored.html",
-                                        "frontend://" + expectedFiles.get(4),
-                                        expectedFiles.get(5))));
+                        .thenReturn(getHtmlImports(expectedFiles));
 
         FrontendDataProvider dataProvider = new TestFrontendDataProvider(false,
                 false, sourceDirectory, annotationValuesExtractorMock, null,
@@ -398,6 +380,25 @@ public class FrontendDataProviderTest {
                     shellFileContents.stream()
                             .anyMatch(line -> line.contains(expectedFile)));
         }
+    }
+
+    private ImmutableMap<Class<? extends Annotation>, Set<String>> getHtmlImports(
+            List<String> expectedFiles) {
+        return ImmutableMap.of(HtmlImport.class, ImmutableSet.of(
+                "context://shouldBeIgnored.html", "base://shouldBeIgnored.html",
+                "frontend://" + expectedFiles.get(4), expectedFiles.get(5)));
+    }
+
+    private HashMap<Class<? extends Annotation>, Set<String>> getCssAndJsImports(
+            List<String> expectedFiles) {
+        return new HashMap<>(ImmutableMap.of(JavaScript.class, ImmutableSet.of(
+                "context://shouldBeIgnored.js", "base://shouldBeIgnored.js",
+                "frontend://" + expectedFiles.get(0), expectedFiles.get(1)),
+                StyleSheet.class,
+                ImmutableSet.of("context://shouldBeIgnored.css",
+                        "base://shouldBeIgnored.css",
+                        "frontend://" + expectedFiles.get(2),
+                        expectedFiles.get(3))));
     }
 
     private void findAndVerifyFragment(Collection<String> outputFragmentNames,


### PR DESCRIPTION
Closes #4279

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4456)
<!-- Reviewable:end -->
