### PR TITLE
Fix FlowComponentRenderer._clear() for some browsers (#4460)

### DIFF
--- a/flow-data/src/main/resources/META-INF/resources/frontend/flow-component-renderer.html
+++ b/flow-data/src/main/resources/META-INF/resources/frontend/flow-component-renderer.html
@@ -74,8 +74,8 @@
     }
     
     _clear() {
-      while (this.hasChildNodes()) {
-        this.removeChild(this.lastChild);
+      while (this.firstChild) {
+        this.removeChild(this.firstChild);
       }
     }
 


### PR DESCRIPTION
Fix FlowComponentRenderer._clear() for some browsers

Fix vaadin-grid-flow#274

The previous implementation works with Chrome, but causes client-side
exceptions for Firefox and Edge at least when filtering a Grid that
uses ComponentRenderer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4465)
<!-- Reviewable:end -->
