### PR TITLE
Added PWA scanning for all Route-annotated views.

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractRouteRegistryInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractRouteRegistryInitializer.java
@@ -272,22 +272,22 @@ public abstract class AbstractRouteRegistryInitializer implements Serializable {
     protected Class<?> validatePwaClass(Stream<Class<?>> routeClasses) {
         pwaClass = null;
         routeClasses.forEach(route -> {
-            // test route pwa annotation
-            testPwa(route);
+            // check and validate route pwa annotation
+            validatePwa(route);
 
             Route routeAnnotation = route.getAnnotation(Route.class);
             if (!UI.class.equals(routeAnnotation.layout())) {
                 Class<? extends RouterLayout> topParentLayout = RouterUtil
                         .getTopParentLayout(route,
                                 Router.resolve(route, routeAnnotation));
-                // test top parent layout pwa annotation
-                testPwa(topParentLayout);
+                // check and validate top parent layout pwa annotation
+                validatePwa(topParentLayout);
             }
         });
         return pwaClass;
     }
 
-    private void testPwa(Class<?> pwaClassCandidate) {
+    private void validatePwa(Class<?> pwaClassCandidate) {
         if (pwaClassCandidate == null ||
                 !pwaClassCandidate.isAnnotationPresent(PWA.class)) {
             return;

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractRouteRegistryInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractRouteRegistryInitializer.java
@@ -115,6 +115,9 @@ public abstract class AbstractRouteRegistryInitializer implements Serializable {
     private void validateRouteImplementation(Class<?> route,
             Class<?> implementation) {
         Route annotation = route.getAnnotation(Route.class);
+        if (route.isAnnotationPresent(PWA.class)) {
+            setPwaClass(route);
+        }
         if (!UI.class.equals(annotation.layout())) {
             if (implementation.isAssignableFrom(route)) {
                 throw new InvalidRouteLayoutConfigurationException(String
@@ -184,15 +187,7 @@ public abstract class AbstractRouteRegistryInitializer implements Serializable {
 
         if (topParentLayout != null
                 && topParentLayout.isAnnotationPresent(PWA.class)) {
-            if (pwaClass == null || pwaClass == topParentLayout) {
-                pwaClass = topParentLayout;
-            } else {
-                throw new InvalidRouteLayoutConfigurationException(String
-                        .format("Expected only one '%s' annotation that is placed on the main layout of the application. Got multiple annotations in '%s' and '%s'",
-                                PWA.class.getSimpleName(),
-                                pwaClass.getSimpleName(),
-                                topParentLayout.getSimpleName()));
-            }
+            setPwaClass(topParentLayout);
         }
     }
 
@@ -270,6 +265,18 @@ public abstract class AbstractRouteRegistryInitializer implements Serializable {
                                 topParentLayout.getName(), layout.getName()));
             }
         });
+    }
+
+    private void setPwaClass(Class<?> pwaClassCandidate) {
+        if (pwaClass == null || pwaClass == pwaClassCandidate) {
+            pwaClass = pwaClassCandidate;
+        } else {
+            throw new InvalidRouteLayoutConfigurationException(String
+                    .format("Expected only one '%s' annotation that is placed on the main layout of the application. Got multiple annotations in '%s' and '%s'",
+                            PWA.class.getSimpleName(),
+                            pwaClass.getSimpleName(),
+                            pwaClassCandidate.getSimpleName()));
+        }
     }
 
     protected Class<?> getPwaClass() {

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/RouteRegistryInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/RouteRegistryInitializer.java
@@ -50,7 +50,7 @@ public class RouteRegistryInitializer extends AbstractRouteRegistryInitializer
             RouteRegistry routeRegistry = RouteRegistry
                     .getInstance(servletContext);
             routeRegistry.setNavigationTargets(routes);
-            routeRegistry.setPwaClass(getPwaClass());
+            routeRegistry.setPwaClass(validatePwaClass(classSet.stream()));
         } catch (InvalidRouteConfigurationException irce) {
             throw new ServletException(
                     "Exception while registering Routes on servlet startup",


### PR DESCRIPTION
PWA annotation was not scanned if view wasn't a RouterLayout or parent layout. 

Added scanning to all Route -annotated views.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4487)
<!-- Reviewable:end -->
