### PR TITLE
Make it possible to use subtypes of JsonValue in ASPropertyField

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/AbstractSinglePropertyField.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/AbstractSinglePropertyField.java
@@ -22,7 +22,6 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.googlecode.gentyref.GenericTypeReflector;
-
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.PropertyChangeEvent;
 import com.vaadin.flow.function.SerializableBiConsumer;
@@ -127,13 +126,7 @@ public class AbstractSinglePropertyField<C extends AbstractField<C, T>, T>
                 Boolean.FALSE);
         addHandler(Element::setProperty, Element::getProperty, Integer.class,
                 Integer.valueOf(0));
-        addHandler(Element::setPropertyJson,
-                (element, property, defaultValue) -> {
-                    Serializable value = element.getPropertyRaw(property);
-                    // JsonValue is passed straight through, other primitive
-                    // values are jsonified
-                    return JsonCodec.encodeWithoutTypeInfo(value);
-                }, JsonValue.class, null);
+        typeHandlers.put(JsonValue.class, getHandler(JsonValue.class));
     }
 
     private final SerializableBiConsumer<C, T> propertyWriter;
@@ -237,18 +230,7 @@ public class AbstractSinglePropertyField<C extends AbstractField<C, T>, T>
             }
         }
 
-        @SuppressWarnings("unchecked")
-        TypeHandler<P> typeHandler = (TypeHandler<P>) typeHandlers
-                .get(elementPropertyType);
-        if (typeHandler == null) {
-            throw new IllegalArgumentException(
-                    "Unsupported element property type: "
-                            + elementPropertyType.getName()
-                            + ". Supported types are: "
-                            + typeHandlers.keySet().parallelStream()
-                                    .map(Class::getName)
-                                    .collect(Collectors.joining(", ")));
-        }
+        TypeHandler<P> typeHandler = findHandler(elementPropertyType);
 
         Element element = getElement();
 
@@ -262,6 +244,23 @@ public class AbstractSinglePropertyField<C extends AbstractField<C, T>, T>
 
         doSetSynchronizedEvent(
                 SharedUtil.camelCaseToDashSeparated(propertyName) + "-changed");
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private <P> TypeHandler<P> findHandler(Class<P> clazz) {
+        TypeHandler<P> typeHandler = (TypeHandler<P>) typeHandlers.get(clazz);
+        if (typeHandler == null && JsonValue.class.isAssignableFrom(clazz)) {
+            typeHandler = getHandler((Class) clazz);
+        }
+        if (typeHandler == null) {
+            throw new IllegalArgumentException(
+                    "Unsupported element property type: " + clazz.getName()
+                            + ". Supported types are: "
+                            + typeHandlers.keySet().parallelStream()
+                                    .map(Class::getName)
+                                    .collect(Collectors.joining(", ")));
+        }
+        return typeHandler;
     }
 
     @SuppressWarnings("unchecked")
@@ -332,6 +331,19 @@ public class AbstractSinglePropertyField<C extends AbstractField<C, T>, T>
     @Override
     protected void setPresentationValue(T newPresentationValue) {
         propertyWriter.accept((C) this, newPresentationValue);
+    }
+
+    private static <P extends JsonValue> TypeHandler<P> getHandler(
+            Class<P> type) {
+        ElementGetter<P> getter = (element, property, defaultValue) -> {
+            Serializable value = element.getPropertyRaw(property);
+            // JsonValue is passed straight through, other primitive
+            // values are jsonified
+            return type.cast(JsonCodec.encodeWithoutTypeInfo(value));
+        };
+        ElementSetter<P> setter = (element, property, value) -> element
+                .setPropertyJson(property, value);
+        return new TypeHandler<P>(setter, getter, null);
     }
 
     private static <T> void addHandler(ElementSetter<T> setter,

--- a/flow-server/src/test/java/com/vaadin/flow/component/AbstractSinglePropertyFieldTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/AbstractSinglePropertyFieldTest.java
@@ -434,6 +434,14 @@ public class AbstractSinglePropertyFieldTest {
         }
     }
 
+    @Tag("tag")
+    private static class JsonArrayField
+            extends AbstractSinglePropertyField<JsonArrayField, JsonArray> {
+        public JsonArrayField() {
+            super("property", Json.createArray(), false);
+        }
+    }
+
     @Test
     public void jsonField() {
         JsonField field = new JsonField();
@@ -456,6 +464,28 @@ public class AbstractSinglePropertyFieldTest {
         field.getElement().setProperty("property", "text");
         monitor.discard();
         Assert.assertEquals("\"text\"", field.getValue().toJson());
+    }
+
+    @Test
+    public void jsonArrayField() {
+        JsonArrayField field = new JsonArrayField();
+        ValueChangeMonitor<JsonArray> monitor = new ValueChangeMonitor<>(field);
+
+        Assert.assertEquals(JsonType.ARRAY, field.getValue().getType());
+        Assert.assertEquals(0, field.getValue().length());
+        monitor.assertNoEvent();
+
+        field.setValue(
+                JsonUtils.createArray(Json.create("foo"), Json.create(42)));
+        monitor.discard();
+        Assert.assertEquals("[\"foo\",42]",
+                ((JsonArray) field.getElement().getPropertyRaw("property"))
+                        .toJson());
+
+        field.getElement().setPropertyJson("property",
+                JsonUtils.createArray(Json.create(37), Json.create("bar")));
+        monitor.discard();
+        Assert.assertEquals("[37,\"bar\"]", field.getValue().toJson());
     }
 
     @Test


### PR DESCRIPTION
Fixes #4463

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4488)
<!-- Reviewable:end -->
