### PR TITLE
Changed pwa class setting public.

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/RouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/RouteRegistry.java
@@ -684,11 +684,26 @@ public class RouteRegistry implements Serializable {
                 findThemeForNavigationTarget(navigationTarget, path));
     }
 
+    /**
+     * Gets pwa configuration class.
+     *
+     * @return a class that has PWA-annotation.
+     */
     public Class<?> getPwaConfigurationClass() {
         return pwaConfigurationClass.get();
     }
 
-    protected void setPwaClass(Class<?> pwaClass) {
+    /**
+     * Sets pwa configuration class.
+     *
+     * Should be set along with setNavigationTargets, for scanning of proper
+     * pwa configuration class is done along route scanning.
+     * See {@link AbstractRouteRegistryInitializer}.
+     *
+     * @param pwaClass a class that has PWA -annotation, that's to be used in
+     *                 service initialization.
+     */
+    public void setPwaConfigurationClass(Class<?> pwaClass) {
         if (pwaClass != null && pwaClass.isAnnotationPresent(PWA.class)) {
             pwaConfigurationClass.set(pwaClass);
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/RouteRegistryInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/RouteRegistryInitializer.java
@@ -50,7 +50,7 @@ public class RouteRegistryInitializer extends AbstractRouteRegistryInitializer
             RouteRegistry routeRegistry = RouteRegistry
                     .getInstance(servletContext);
             routeRegistry.setNavigationTargets(routes);
-            routeRegistry.setPwaClass(getPwaClass());
+            routeRegistry.setPwaConfigurationClass(getPwaClass());
         } catch (InvalidRouteConfigurationException irce) {
             throw new ServletException(
                     "Exception while registering Routes on servlet startup",


### PR DESCRIPTION
Setting of pwa class was left to protected and so it can't be properly used. Needed to allow flow-spring initializer to support pwa.

* Changed to public to allow extending initializers to set pwaClass.
* Also fixed naming and comments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4492)
<!-- Reviewable:end -->
