### PR TITLE
Make it possible to use subtypes of JsonValue in ASPropertyField (#4488)

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/component/AbstractSinglePropertyFieldTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/AbstractSinglePropertyFieldTest.java
@@ -434,6 +434,14 @@ public class AbstractSinglePropertyFieldTest {
         }
     }
 
+    @Tag("tag")
+    private static class JsonArrayField
+            extends AbstractSinglePropertyField<JsonArrayField, JsonArray> {
+        public JsonArrayField() {
+            super("property", Json.createArray(), false);
+        }
+    }
+
     @Test
     public void jsonField() {
         JsonField field = new JsonField();
@@ -456,6 +464,28 @@ public class AbstractSinglePropertyFieldTest {
         field.getElement().setProperty("property", "text");
         monitor.discard();
         Assert.assertEquals("\"text\"", field.getValue().toJson());
+    }
+
+    @Test
+    public void jsonArrayField() {
+        JsonArrayField field = new JsonArrayField();
+        ValueChangeMonitor<JsonArray> monitor = new ValueChangeMonitor<>(field);
+
+        Assert.assertEquals(JsonType.ARRAY, field.getValue().getType());
+        Assert.assertEquals(0, field.getValue().length());
+        monitor.assertNoEvent();
+
+        field.setValue(
+                JsonUtils.createArray(Json.create("foo"), Json.create(42)));
+        monitor.discard();
+        Assert.assertEquals("[\"foo\",42]",
+                ((JsonArray) field.getElement().getPropertyRaw("property"))
+                        .toJson());
+
+        field.getElement().setPropertyJson("property",
+                JsonUtils.createArray(Json.create(37), Json.create("bar")));
+        monitor.discard();
+        Assert.assertEquals("[37,\"bar\"]", field.getValue().toJson());
     }
 
     @Test


### PR DESCRIPTION
Fixes #4463

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4515)
<!-- Reviewable:end -->
