### PR TITLE
Working with local node and local yarn - feature

### DIFF
--- a/flow-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/DefaultGulpRunnerLocal.java
+++ b/flow-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/DefaultGulpRunnerLocal.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.github.eirslett.maven.plugins.frontend.lib;
+
+/**
+ * Gulp runner that uses an specific configuration(paths) of node, npm,
+ * installation directory and working directory and platform.
+ */
+public class DefaultGulpRunnerLocal {
+    private DefaultGulpRunner defaultGulpRunner;
+
+    /**
+     * Defines and configures a DefaultGulpRunner with a specific gulp
+     * configuration.
+     *
+     * @param config
+     *            Gulp configuration
+     */
+    public DefaultGulpRunnerLocal(NodeExecutorConfig config) {
+        defaultGulpRunner = new DefaultGulpRunner(config);
+    }
+
+    /**
+     * Gets the GulpRunner of the local default gulp runner.
+     *
+     * @return GulpRunner gulp node task
+     */
+    public GulpRunner getDefaultGulpRunner() {
+        return defaultGulpRunner;
+    }
+}

--- a/flow-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/DefaultYarnRunnerLocal.java
+++ b/flow-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/DefaultYarnRunnerLocal.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.github.eirslett.maven.plugins.frontend.lib;
+
+/**
+ * Yarn runner that uses an specific configuration(paths) of node, yarn, working
+ * directory and platform.
+ */
+public class DefaultYarnRunnerLocal {
+
+    /**
+     * yarn runner for executing yarn.
+     */
+    private DefaultYarnRunner defaultYarnRunner;
+
+    /**
+     * Creates a DefaultYarnRunner with an specific configuration.
+     * 
+     * @param config
+     *            yarn configuration
+     * @param proxyConfig
+     *            proxy configuration
+     * @param npmRegistryURL
+     *            npm registry website
+     */
+    public DefaultYarnRunnerLocal(YarnExecutorConfig config,
+            ProxyConfig proxyConfig, String npmRegistryURL) {
+        defaultYarnRunner = new DefaultYarnRunner(config, proxyConfig,
+                npmRegistryURL);
+    }
+
+    /**
+     * Gets the yarnRunner.
+     *
+     * @return defaultYarnRunner yarnRunner
+     */
+    public YarnRunner getDefaultYarnRunner() {
+        return defaultYarnRunner;
+    }
+}

--- a/flow-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeExecutorConfigLocal.java
+++ b/flow-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/NodeExecutorConfigLocal.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.github.eirslett.maven.plugins.frontend.lib;
+
+import java.io.File;
+
+/**
+ * Contains the configuration for running gulp {@link DefaultGulpRunnerLocal}.
+ * It specifies where node and npm are installed and the installation and
+ * working directory.
+ */
+public class NodeExecutorConfigLocal implements NodeExecutorConfig {
+
+    /**
+     * Where Node is installed.
+     */
+    private File nodePath;
+
+    /**
+     * Where npm is installed.
+     */
+    private File npmPath;
+
+    /**
+     * Installation directory.
+     */
+    private File installDirectory;
+
+    /**
+     * Working directory.
+     */
+    private File workingDirectory;
+
+    /**
+     * Creates the configuration for a {@link NodeExecutor}.
+     *
+     * @param nodePath
+     *            file where node is located
+     * @param npmPath
+     *            file where npm is located
+     * @param installDirectory
+     *            installation directory
+     * @param workingDirectory
+     *            working directory
+     */
+    public NodeExecutorConfigLocal(File nodePath, File npmPath,
+            File installDirectory, File workingDirectory) {
+        this.nodePath = nodePath;
+        this.npmPath = npmPath;
+        this.installDirectory = installDirectory;
+        this.workingDirectory = workingDirectory;
+    }
+
+    /**
+     * Gets the file where node is installed.
+     *
+     * @return nodePath File in which node is installed.
+     */
+    @Override
+    public File getNodePath() {
+        return nodePath;
+    }
+
+    /**
+     * Gets the filed in which npm is installed.
+     *
+     * @return File in which npm is installed.
+     */
+    @Override
+    public File getNpmPath() {
+        return npmPath;
+    }
+
+    /**
+     * Gets the installation directory.
+     *
+     * @return installDirectory Installation directory
+     */
+    @Override
+    public File getInstallDirectory() {
+        return installDirectory;
+    }
+
+    /**
+     * Gets the working directory.
+     *
+     * @return workingDirectory the working directory
+     */
+    @Override
+    public File getWorkingDirectory() {
+        return workingDirectory;
+    }
+
+    /**
+     * Get the platform in which the plugin is executed.
+     *
+     * @return Platform platform
+     */
+    @Override
+    public Platform getPlatform() {
+        return Platform.guess();
+    }
+}

--- a/flow-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/YarnConfigurationLocal.java
+++ b/flow-maven-plugin/src/main/java/com/github/eirslett/maven/plugins/frontend/lib/YarnConfigurationLocal.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.github.eirslett.maven.plugins.frontend.lib;
+
+import java.io.File;
+
+/**
+ * Yarn configuration needed for its running. It specifies where node and yarn
+ * are installed and where is the working directory.
+ */
+public class YarnConfigurationLocal implements YarnExecutorConfig {
+
+    /**
+     * Where Node is installed.
+     */
+    private File nodePath;
+
+    /**
+     * Where Yarn is installed.
+     */
+    private File yarnPath;
+
+    /**
+     * Working directory.
+     */
+    private File workingDirectory;
+
+    /**
+     * Creates the configuration for a {@link YarnExecutor}.
+     *
+     * @param nodePath
+     *            file where node is located
+     * @param yarnPath
+     *            file where yarn is located
+     * @param workingDirectory
+     *            working directory
+     */
+    public YarnConfigurationLocal(File nodePath, File yarnPath,
+            File workingDirectory) {
+        this.nodePath = nodePath;
+        this.yarnPath = yarnPath;
+        this.workingDirectory = workingDirectory;
+    }
+
+    /**
+     * Gets the file where node is installed.
+     *
+     * @return nodePath File in which node is installed
+     */
+    @Override
+    public File getNodePath() {
+        return nodePath;
+    }
+
+    /**
+     * Gets the file where yarn is installed.
+     *
+     * @return nodePath File in which yarn is installed
+     */
+    @Override
+    public File getYarnPath() {
+        return yarnPath;
+    }
+
+    /**
+     * Gets the working directory.
+     *
+     * @return workingDirectory the working directory
+     */
+    @Override
+    public File getWorkingDirectory() {
+        return workingDirectory;
+    }
+
+    /**
+     * Get the platform in which the plugin is executed.
+     *
+     * @return Platform platform
+     */
+    @Override
+    public Platform getPlatform() {
+        return Platform.guess();
+    }
+}

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/common/RunnerManager.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/common/RunnerManager.java
@@ -31,36 +31,28 @@ import com.github.eirslett.maven.plugins.frontend.lib.YarnInstaller;
 import com.github.eirslett.maven.plugins.frontend.lib.YarnRunner;
 
 /**
- * Creates and configures the runners used by the FrontendToolsManager,
+ * Creates and configures the runners used by the {@link FrontendToolsManager},
  * providing an extra layer of abstraction.
  *
  * RunnerManager can be used to grab the local node and yarn from the local
  * environment or to download and install them.
  */
 public class RunnerManager {
-
-    /**
-     * It is used in the installation of the dependencies.
-     */
     private final YarnRunner yarnRunner;
-
-    /**
-     * It is used in the transpilation process.
-     */
     private final GulpRunner gulpRunner;
 
     /**
-     * Creates the yarn and gulp runners downloading it dependencies(node and
-     * yarn).
+     * Initializes the manager, downloading node and yarn of the versions
+     * specified.
      * 
      * @param workingDirectory
-     *            working directory
+     *            the directory to install and run the tools into
      * @param proxyConfig
-     *            proxy configuration
+     *            the configuration used when installing and running the tools
      * @param nodeVersion
-     *            node version
+     *            node version to install
      * @param yarnVersion
-     *            yarn version
+     *            yarn version to install
      */
     public RunnerManager(File workingDirectory, ProxyConfig proxyConfig,
             String nodeVersion, String yarnVersion) {
@@ -84,17 +76,17 @@ public class RunnerManager {
     }
 
     /**
-     * Creates the yarn runner and gulp runners with out downloading node and
+     * Initializes the manager using the paths to locally installed node and
      * yarn.
      * 
      * @param workingDirectory
-     *            working directory
+     *            the directory to run the tools into
      * @param proxyConfig
-     *            proxy configuration
+     *            the configuration used when running the tools
      * @param nodePath
-     *            file which contains node
+     *            the path to locally installed node
      * @param yarnPath
-     *            file which contains yarn
+     *            the path to locally installed yarn
      */
     public RunnerManager(File workingDirectory, ProxyConfig proxyConfig,
             File nodePath, File yarnPath) {

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/common/RunnerManager.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/common/RunnerManager.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.plugin.common;
+
+import java.io.File;
+
+import com.github.eirslett.maven.plugins.frontend.lib.DefaultGulpRunnerLocal;
+import com.github.eirslett.maven.plugins.frontend.lib.DefaultYarnRunnerLocal;
+import com.github.eirslett.maven.plugins.frontend.lib.FrontendPluginFactory;
+import com.github.eirslett.maven.plugins.frontend.lib.GulpRunner;
+import com.github.eirslett.maven.plugins.frontend.lib.InstallationException;
+import com.github.eirslett.maven.plugins.frontend.lib.NodeExecutorConfigLocal;
+import com.github.eirslett.maven.plugins.frontend.lib.NodeInstaller;
+import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
+import com.github.eirslett.maven.plugins.frontend.lib.YarnConfigurationLocal;
+import com.github.eirslett.maven.plugins.frontend.lib.YarnInstaller;
+import com.github.eirslett.maven.plugins.frontend.lib.YarnRunner;
+
+/**
+ * Creates and configures the runners used by the FrontendToolsManager,
+ * providing an extra layer of abstraction.
+ *
+ * RunnerManager can be used to grab the local node and yarn from the local
+ * environment or to download and install them.
+ */
+public class RunnerManager {
+
+    /**
+     * It is used in the installation of the dependencies.
+     */
+    private final YarnRunner yarnRunner;
+
+    /**
+     * It is used in the transpilation process.
+     */
+    private final GulpRunner gulpRunner;
+
+    /**
+     * Creates the yarn and gulp runners downloading it dependencies(node and
+     * yarn).
+     * 
+     * @param workingDirectory
+     *            working directory
+     * @param proxyConfig
+     *            proxy configuration
+     * @param nodeVersion
+     *            node version
+     * @param yarnVersion
+     *            yarn version
+     */
+    public RunnerManager(File workingDirectory, ProxyConfig proxyConfig,
+            String nodeVersion, String yarnVersion) {
+        FrontendPluginFactory factory = new FrontendPluginFactory(
+                workingDirectory, workingDirectory);
+        try {
+            factory.getNodeInstaller(proxyConfig).setNodeVersion(nodeVersion)
+                    .setNodeDownloadRoot(
+                            NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT)
+                    .install();
+            factory.getYarnInstaller(proxyConfig).setYarnVersion(yarnVersion)
+                    .setYarnDownloadRoot(
+                            YarnInstaller.DEFAULT_YARN_DOWNLOAD_ROOT)
+                    .install();
+        } catch (InstallationException e) {
+            throw new IllegalStateException(
+                    "Failed to install required frontend dependencies", e);
+        }
+        yarnRunner = factory.getYarnRunner(proxyConfig, null);
+        gulpRunner = factory.getGulpRunner();
+    }
+
+    /**
+     * Creates the yarn runner and gulp runners with out downloading node and
+     * yarn.
+     * 
+     * @param workingDirectory
+     *            working directory
+     * @param proxyConfig
+     *            proxy configuration
+     * @param nodePath
+     *            file which contains node
+     * @param yarnPath
+     *            file which contains yarn
+     */
+    public RunnerManager(File workingDirectory, ProxyConfig proxyConfig,
+            File nodePath, File yarnPath) {
+        NodeExecutorConfigLocal nodeExecutorConfig = new NodeExecutorConfigLocal(
+                nodePath, null, workingDirectory, workingDirectory);
+        YarnConfigurationLocal yarnConfigurationLocal = new YarnConfigurationLocal(
+                nodePath, yarnPath, workingDirectory);
+
+        yarnRunner = new DefaultYarnRunnerLocal(yarnConfigurationLocal,
+                proxyConfig, null).getDefaultYarnRunner();
+        gulpRunner = new DefaultGulpRunnerLocal(nodeExecutorConfig)
+                .getDefaultGulpRunner();
+    }
+
+    /**
+     * Gets the {@link YarnRunner} that is used to install dependencies.
+     * 
+     * @return yarnRunner YarnRunner
+     */
+    public YarnRunner getYarnRunner() {
+        return yarnRunner;
+    }
+
+    /**
+     * Gets the {@link GulpRunner} that will be used in the transpilation.
+     *
+     * @return gulpRunner GulpRunner
+     */
+    public GulpRunner getGulpRunner() {
+        return gulpRunner;
+    }
+}

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PackageForProductionMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PackageForProductionMojo.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
@@ -38,7 +39,6 @@ import org.apache.maven.settings.crypto.DefaultSettingsDecryptionRequest;
 import org.apache.maven.settings.crypto.SettingsDecrypter;
 import org.apache.maven.settings.crypto.SettingsDecryptionResult;
 
-import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
 import com.vaadin.flow.plugin.common.AnnotationValuesExtractor;
 import com.vaadin.flow.plugin.common.FlowPluginFileUtils;
 import com.vaadin.flow.plugin.common.FrontendDataProvider;
@@ -129,27 +129,31 @@ public class PackageForProductionMojo extends AbstractMojo {
     private File bundleConfiguration;
 
     /**
-     * Defines the node path.
+     * Defines the path to node executable to use. If specified,
+     * {@code nodeVersion} parameter is ignored.
      */
     @Parameter(name = "nodePath")
     private File nodePath;
 
     /**
-     * Defines the node version. The default is <code>v8.11.1</code>.
+     * Defines the node version to download and use, if {@code nodePath} is not
+     * set. The default is <code>v8.11.1</code>.
      */
-    @Parameter(name = "nodeVersion", defaultValue = "v8.11.1", required = true)
+    @Parameter(name = "nodeVersion", defaultValue = "v8.11.1")
     private String nodeVersion;
 
     /**
-     * Defines the node path.
+     * Defines the path to yarn executable to use. If specified,
+     * {@code yarnVersion} parameter is ignored.
      */
     @Parameter(name = "yarnPath")
     private File yarnPath;
 
     /**
-     * Defines the yarn version.The default is <code>v1.6.0</code>.
+     * Defines the yarn version to download and use, if {@code yarnVersion} is
+     * not set. The default is <code>v1.6.0</code>.
      */
-    @Parameter(name = "yarnVersion", defaultValue = "v1.6.0", required = true)
+    @Parameter(name = "yarnVersion", defaultValue = "v1.6.0")
     private String yarnVersion;
 
     /**

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/production/TranspilationStep.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/production/TranspilationStep.java
@@ -21,8 +21,6 @@ import java.io.UncheckedIOException;
 import java.util.Map;
 import java.util.Objects;
 
-import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
-
 import com.vaadin.flow.plugin.common.FrontendToolsManager;
 
 /**
@@ -39,23 +37,14 @@ public class TranspilationStep {
      *
      * @param frontendToolsManager
      *            the manager to be used to transpile files, not {@code null}
-     * @param proxyConfig
-     *            proxy config to use when downloading frontend tools, not
-     *            {@code null}
-     * @param nodeVersion
-     *            node version to install, not {@code null}
-     * @param yarnVersion
-     *            yarn version to install, not {@code null}
      * @param networkConcurrency
      *            maximum number of concurrent network requests
      */
     public TranspilationStep(FrontendToolsManager frontendToolsManager,
-            ProxyConfig proxyConfig, String nodeVersion, String yarnVersion,
             int networkConcurrency) {
         this.frontendToolsManager = Objects
                 .requireNonNull(frontendToolsManager);
-        frontendToolsManager.installFrontendTools(proxyConfig, nodeVersion,
-                yarnVersion, networkConcurrency);
+        frontendToolsManager.installFrontendTools(networkConcurrency);
     }
 
     /**

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/production/RunnerManagerTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/production/RunnerManagerTest.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.util.Collections;
 
 import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
-import com.github.eirslett.maven.plugins.frontend.lib.TaskRunnerException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -28,46 +27,26 @@ import org.junit.rules.TemporaryFolder;
 
 import com.vaadin.flow.plugin.common.RunnerManager;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 public class RunnerManagerTest {
 
     private final ProxyConfig proxyConfig = new ProxyConfig(
             Collections.emptyList());
-    private final String nodeVersion = "v8.11.1";
-    private final String yarnVersion = "v1.6.0";
 
     @Rule
-    public final ExpectedException exception = ExpectedException.none();
+    public ExpectedException exception = ExpectedException.none();
 
     @Rule
-    public TemporaryFolder donwloadDirectory = new TemporaryFolder();
+    public TemporaryFolder downloadDirectory = new TemporaryFolder();
 
     @Test
-    public void getLocalRunnerManagerWithoutInstalling()
-            throws TaskRunnerException {
+    public void getLocalRunnerManagerWithoutInstalling() {
         File nonExistingFile = new File("desNotExist");
-        new RunnerManager(donwloadDirectory.getRoot(), proxyConfig,
+        new RunnerManager(downloadDirectory.getRoot(), proxyConfig,
                 nonExistingFile, nonExistingFile);
 
-        assertTrue("In the local mode, no file is downloaded!",
-                donwloadDirectory.getRoot().list().length == 0);
-    }
-
-    @Test
-    public void getRunnerManagerInstalling() {
-        try {
-            RunnerManager runnerManager = new RunnerManager(
-                    donwloadDirectory.getRoot(), proxyConfig, nodeVersion,
-                    yarnVersion);
-            // in the case that node and yarn are installed correctly, the
-            // download directory should not be empty
-            assertTrue(
-                    "In the installation mode, node and yarn(files) should be downloaded!",
-                    donwloadDirectory.getRoot().list().length > 0);
-        } catch (IllegalStateException e) {
-            // skip: it was not possible to install node and yarn.
-        }
-
+        assertEquals("In the local mode, no file should be downloaded", 0,
+                downloadDirectory.getRoot().list().length);
     }
 }

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/production/RunnerManagerTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/production/RunnerManagerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.plugin.production;
+
+import java.io.File;
+import java.util.Collections;
+
+import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
+import com.github.eirslett.maven.plugins.frontend.lib.TaskRunnerException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+import com.vaadin.flow.plugin.common.RunnerManager;
+
+import static org.junit.Assert.assertTrue;
+
+public class RunnerManagerTest {
+
+    private final ProxyConfig proxyConfig = new ProxyConfig(
+            Collections.emptyList());
+    private final String nodeVersion = "v8.11.1";
+    private final String yarnVersion = "v1.6.0";
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @Rule
+    public TemporaryFolder donwloadDirectory = new TemporaryFolder();
+
+    @Test
+    public void getLocalRunnerManagerWithoutInstalling()
+            throws TaskRunnerException {
+        File nonExistingFile = new File("desNotExist");
+        new RunnerManager(donwloadDirectory.getRoot(), proxyConfig,
+                nonExistingFile, nonExistingFile);
+
+        assertTrue("In the local mode, no file is downloaded!",
+                donwloadDirectory.getRoot().list().length == 0);
+    }
+
+    @Test
+    public void getRunnerManagerInstalling() {
+        try {
+            RunnerManager runnerManager = new RunnerManager(
+                    donwloadDirectory.getRoot(), proxyConfig, nodeVersion,
+                    yarnVersion);
+            // in the case that node and yarn are installed correctly, the
+            // download directory should not be empty
+            assertTrue(
+                    "In the installation mode, node and yarn(files) should be downloaded!",
+                    donwloadDirectory.getRoot().list().length > 0);
+        } catch (IllegalStateException e) {
+            // skip: it was not possible to install node and yarn.
+        }
+
+    }
+}

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/production/TranspilationStepTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/production/TranspilationStepTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package com.vaadin.flow.plugin.production;
 
 import static org.junit.Assert.assertEquals;
@@ -23,9 +39,11 @@ import org.junit.rules.TemporaryFolder;
 
 import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
 import com.google.common.collect.ImmutableMap;
+
 import com.vaadin.flow.plugin.TestUtils;
 import com.vaadin.flow.plugin.common.FrontendDataProvider;
 import com.vaadin.flow.plugin.common.FrontendToolsManager;
+import com.vaadin.flow.plugin.common.RunnerManager;
 
 /**
  * @author Vaadin Ltd
@@ -53,11 +71,15 @@ public class TranspilationStepTest {
         when(frontendDataProviderMock.createFragmentFiles(outputDirectory))
                 .thenReturn(Collections.singleton("fragment"));
 
+        RunnerManager runnerManagerMock = mock(RunnerManager.class);
         FrontendToolsManager frontendToolsManager = spy(
                 new FrontendToolsManager(outputDirectory, "frontend-es5",
-                        "frontend-es6", frontendDataProviderMock));
+                        "frontend-es6", frontendDataProviderMock,
+                        runnerManagerMock));
+
         doNothing().when(frontendToolsManager).installFrontendTools(proxyConfig,
                 nodeVersion, yarnVersion, networkConcurrency);
+
         return frontendToolsManager;
     }
 

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/production/TranspilationStepTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/production/TranspilationStepTest.java
@@ -16,6 +16,23 @@
 
 package com.vaadin.flow.plugin.production;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Collections;
+import java.util.List;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+import com.vaadin.flow.plugin.TestUtils;
+import com.vaadin.flow.plugin.common.FrontendDataProvider;
+import com.vaadin.flow.plugin.common.FrontendToolsManager;
+import com.vaadin.flow.plugin.common.RunnerManager;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -25,25 +42,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.util.Collections;
-import java.util.List;
-
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
-
-import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
-import com.google.common.collect.ImmutableMap;
-
-import com.vaadin.flow.plugin.TestUtils;
-import com.vaadin.flow.plugin.common.FrontendDataProvider;
-import com.vaadin.flow.plugin.common.FrontendToolsManager;
-import com.vaadin.flow.plugin.common.RunnerManager;
 
 /**
  * @author Vaadin Ltd
@@ -57,11 +55,7 @@ public class TranspilationStepTest {
     public final ExpectedException exception = ExpectedException.none();
 
     private final boolean skipEs5 = true;
-    private final String nodeVersion = "1";
-    private final String yarnVersion = "1";
     private final int networkConcurrency = 1;
-    private final ProxyConfig proxyConfig = new ProxyConfig(
-            Collections.emptyList());
 
     private FrontendToolsManager getFrontendToolsManager(File outputDirectory) {
         FrontendDataProvider frontendDataProviderMock = mock(
@@ -77,8 +71,8 @@ public class TranspilationStepTest {
                         "frontend-es6", frontendDataProviderMock,
                         runnerManagerMock));
 
-        doNothing().when(frontendToolsManager).installFrontendTools(proxyConfig,
-                nodeVersion, yarnVersion, networkConcurrency);
+        doNothing().when(frontendToolsManager)
+                .installFrontendTools(networkConcurrency);
 
         return frontendToolsManager;
     }
@@ -90,9 +84,9 @@ public class TranspilationStepTest {
         exception.expectMessage(fileNotDirectory.toString());
 
         new TranspilationStep(
-                getFrontendToolsManager(temporaryFolder.getRoot()), proxyConfig,
-                nodeVersion, yarnVersion, networkConcurrency).transpileFiles(
-                        temporaryFolder.getRoot(), fileNotDirectory, skipEs5);
+                getFrontendToolsManager(temporaryFolder.getRoot()),
+                networkConcurrency).transpileFiles(temporaryFolder.getRoot(),
+                        fileNotDirectory, skipEs5);
     }
 
     @Test
@@ -102,9 +96,9 @@ public class TranspilationStepTest {
         exception.expectMessage(nonExistingFile.toString());
 
         new TranspilationStep(
-                getFrontendToolsManager(temporaryFolder.getRoot()), proxyConfig,
-                nodeVersion, yarnVersion, networkConcurrency).transpileFiles(
-                        nonExistingFile, temporaryFolder.getRoot(), skipEs5);
+                getFrontendToolsManager(temporaryFolder.getRoot()),
+                networkConcurrency).transpileFiles(nonExistingFile,
+                        temporaryFolder.getRoot(), skipEs5);
     }
 
     @Test
@@ -114,9 +108,9 @@ public class TranspilationStepTest {
         exception.expectMessage(fileNotDirectory.toString());
 
         new TranspilationStep(
-                getFrontendToolsManager(temporaryFolder.getRoot()), proxyConfig,
-                nodeVersion, yarnVersion, networkConcurrency).transpileFiles(
-                        fileNotDirectory, temporaryFolder.getRoot(), skipEs5);
+                getFrontendToolsManager(temporaryFolder.getRoot()),
+                networkConcurrency).transpileFiles(fileNotDirectory,
+                        temporaryFolder.getRoot(), skipEs5);
     }
 
     @Test
@@ -129,15 +123,14 @@ public class TranspilationStepTest {
                 skipEs5)).thenReturn(Collections.emptyMap());
 
         try {
-            new TranspilationStep(toolsManagerMock, proxyConfig, nodeVersion,
-                    yarnVersion, networkConcurrency).transpileFiles(
-                            es6Directory, outputDirectory, skipEs5);
+            new TranspilationStep(toolsManagerMock, networkConcurrency)
+                    .transpileFiles(es6Directory, outputDirectory, skipEs5);
             fail("Frontend manager had returned empty transpilation results, but the step does not fail");
         } catch (IllegalStateException expected) {
             // expected
         }
-        verify(toolsManagerMock, times(1)).installFrontendTools(proxyConfig,
-                nodeVersion, yarnVersion, networkConcurrency);
+        verify(toolsManagerMock, times(1))
+                .installFrontendTools(networkConcurrency);
         verify(toolsManagerMock, times(1)).transpileFiles(es6Directory,
                 outputDirectory, skipEs5);
     }
@@ -155,17 +148,16 @@ public class TranspilationStepTest {
                                 nonExistingFile));
 
         try {
-            new TranspilationStep(toolsManagerMock, proxyConfig, nodeVersion,
-                    yarnVersion, networkConcurrency).transpileFiles(
-                            es6Directory, outputDirectory, skipEs5);
+            new TranspilationStep(toolsManagerMock, networkConcurrency)
+                    .transpileFiles(es6Directory, outputDirectory, skipEs5);
             fail(String.format(
                     "Directory '%s' does not contain transpilation results, but the step does not fail",
                     nonExistingFile));
         } catch (IllegalStateException expected) {
             // expected
         }
-        verify(toolsManagerMock, times(1)).installFrontendTools(proxyConfig,
-                nodeVersion, yarnVersion, networkConcurrency);
+        verify(toolsManagerMock, times(1))
+                .installFrontendTools(networkConcurrency);
         verify(toolsManagerMock, times(1)).transpileFiles(es6Directory,
                 outputDirectory, skipEs5);
     }
@@ -196,9 +188,8 @@ public class TranspilationStepTest {
                         ImmutableMap.of("frontend-es5", es5TranspiledDirectory,
                                 "frontend-es6", es6TranspiledDirectory));
 
-        new TranspilationStep(toolsManagerMock, proxyConfig, nodeVersion,
-                yarnVersion, networkConcurrency).transpileFiles(
-                        es6SourceDirectory, outputDirectory, skipEs5);
+        new TranspilationStep(toolsManagerMock, networkConcurrency)
+                .transpileFiles(es6SourceDirectory, outputDirectory, skipEs5);
 
         assertEquals("Es6 source files should be left untouched", sourceFiles,
                 TestUtils.listFilesRecursively(es6SourceDirectory));
@@ -212,8 +203,8 @@ public class TranspilationStepTest {
                 pathsAfterTranspilation.stream().anyMatch(
                         path1 -> path1.endsWith(es6transpiledFile.getName())));
 
-        verify(toolsManagerMock, times(1)).installFrontendTools(proxyConfig,
-                nodeVersion, yarnVersion, networkConcurrency);
+        verify(toolsManagerMock, times(1))
+                .installFrontendTools(networkConcurrency);
         verify(toolsManagerMock, times(1)).transpileFiles(es6SourceDirectory,
                 outputDirectory, skipEs5);
     }


### PR DESCRIPTION
In production, the flow maven plugin can be configured to work with the local Node and Yarn, that are already installed on the computer. This way, it is not necessary to download them from the internet.

<configuration>
   <nodePath>/usr/local/Cellar/node/10.8.0/bin/node
   </nodePath>
   <yarnPath>/usr/local/Cellar/yarn/1.9.4/bin/yarn
   </yarnPath>
 </configuration>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4543)
<!-- Reviewable:end -->
