### PR TITLE
Serve ClientEngine as Brotli compressed if possible

### DIFF
--- a/flow-client/pom.xml
+++ b/flow-client/pom.xml
@@ -175,6 +175,23 @@
                 </configuration>
             </plugin>
 
+            <plugin>
+                <groupId>com.github.ryanholdren</groupId>
+                <artifactId>resourcecompressor</artifactId>
+                <version>2017-06-24</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compress</goal>
+                        </goals>
+                        <phase>prepare-package</phase>
+                        <configuration>
+                            <directory>${gwt.module.output}/client/</directory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
             <!-- Include separate source dir for GWT tests -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Brotli is supported by many browsers, but only over https (or on
localhost). Using Brotli instead of gzip reduces the download size for
the client engine by about 15%.

Fixes #3764

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4556)
<!-- Reviewable:end -->
