### PR TITLE
Reduce memory overhead caused by default collection sizes

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentEventBus.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentEventBus.java
@@ -69,7 +69,8 @@ public class ComponentEventBus implements Serializable {
     }
 
     // Package private to enable testing only
-    HashMap<Class<? extends ComponentEvent<?>>, ArrayList<ListenerWrapper<?>>> componentEventData = new HashMap<>();
+    HashMap<Class<? extends ComponentEvent<?>>, ArrayList<ListenerWrapper<?>>> componentEventData = new HashMap<>(
+            2);
 
     private Component component;
 
@@ -151,7 +152,7 @@ public class ComponentEventBus implements Serializable {
             domListenerConsumer.accept(wrapper.domRegistration);
         }
 
-        componentEventData.computeIfAbsent(eventType, t -> new ArrayList<>())
+        componentEventData.computeIfAbsent(eventType, t -> new ArrayList<>(1))
                 .add(wrapper);
 
         return () -> removeListener(eventType, wrapper);

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ElementListenerMap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ElementListenerMap.java
@@ -129,9 +129,17 @@ public class ElementListenerMap extends NodeMap {
             }
 
             if (eventDataExpressions == null) {
-                eventDataExpressions = new HashSet<>();
+                eventDataExpressions = Collections.singleton(eventData);
+            } else {
+                if (eventDataExpressions.size() == 1) {
+                    Set<String> oldExpressions = eventDataExpressions;
+                    // Don't use no-args or Collection constructors that
+                    // allocate for 16 entries
+                    eventDataExpressions = new HashSet<>(4);
+                    eventDataExpressions.addAll(oldExpressions);
+                }
+                eventDataExpressions.add(eventData);
             }
-            eventDataExpressions.add(eventData);
 
             listenerMap.updateEventSettings(type);
 
@@ -233,14 +241,22 @@ public class ElementListenerMap extends NodeMap {
         assert eventType != null;
         assert listener != null;
 
-        if (listeners == null) {
-            listeners = new HashMap<>();
-        }
-
         if (!contains(eventType)) {
-            assert !listeners.containsKey(eventType);
+            assert listeners == null || !listeners.containsKey(eventType);
 
-            listeners.put(eventType, new ArrayList<>());
+            ArrayList<DomEventListenerWrapper> listenerList = new ArrayList<>(
+                    1);
+
+            if (listeners == null) {
+                listeners = Collections.singletonMap(eventType, listenerList);
+            } else {
+                if (listeners.size() == 1 && !(listeners instanceof HashMap)) {
+                    listeners = new HashMap<>(listeners);
+                }
+
+                listeners.put(eventType, listenerList);
+            }
+
         }
 
         DomEventListenerWrapper listenerWrapper = new DomEventListenerWrapper(
@@ -337,10 +353,11 @@ public class ElementListenerMap extends NodeMap {
 
             // No more listeners of this type?
             if (listenerList.isEmpty()) {
-                listeners.remove(eventType);
-
-                if (listeners.isEmpty()) {
+                if (listeners.size() == 1) {
+                    assert listeners.containsKey(eventType);
                     listeners = null;
+                } else {
+                    listeners.remove(eventType);
                 }
 
                 // Remove from the set that is synchronized with the client

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ElementPropertyMap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ElementPropertyMap.java
@@ -85,8 +85,9 @@ public class ElementPropertyMap extends AbstractPropertyMap {
              */
             if (updateFromClientFilter != null
                     && !updateFromClientFilter.test(key)) {
-                getLogger().warn("Ignoring model update for {}. "
-                        + "For security reasons, the property must have a two-way binding in the template, be annotated with @{} in the model, or be defined as synchronized.",
+                getLogger().warn(
+                        "Ignoring model update for {}. "
+                                + "For security reasons, the property must have a two-way binding in the template, be annotated with @{} in the model, or be defined as synchronized.",
                         key, AllowClientUpdates.class.getSimpleName());
                 return () -> {
                     // nop
@@ -134,11 +135,18 @@ public class ElementPropertyMap extends AbstractPropertyMap {
             PropertyChangeListener listener) {
         assert hasElement();
 
+        List<PropertyChangeListener> propertyListeners;
         if (listeners == null) {
-            listeners = new HashMap<>();
+            propertyListeners = new ArrayList<>(1);
+            listeners = Collections.singletonMap(name, propertyListeners);
+        } else {
+            if (listeners.size() == 1 && !(listeners instanceof HashMap)) {
+                listeners = new HashMap<>(listeners);
+            }
+            propertyListeners = listeners.computeIfAbsent(name,
+                    key -> new ArrayList<>(1));
         }
-        List<PropertyChangeListener> propertyListeners = listeners
-                .computeIfAbsent(name, key -> new ArrayList<>());
+
         propertyListeners.add(listener);
         return () -> propertyListeners.remove(listener);
     }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/NodeList.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/NodeList.java
@@ -170,7 +170,7 @@ public abstract class NodeList<T extends Serializable> extends NodeFeature {
 
     private void ensureValues() {
         if (values == null) {
-            values = new ArrayList<>();
+            values = new ArrayList<>(1);
         }
     }
 
@@ -329,7 +329,7 @@ public abstract class NodeList<T extends Serializable> extends NodeFeature {
 
         if (isRemoveAllCalled && !hasRemoveAll) {
             changes = Stream
-                    .concat(Stream.of(new ListClearChange<T>(this)),
+                    .concat(Stream.of(new ListClearChange<>(this)),
                             allChanges.stream())
                     .filter(this::acceptChange).collect(Collectors.toList());
         } else {
@@ -398,7 +398,7 @@ public abstract class NodeList<T extends Serializable> extends NodeFeature {
         }
 
         isRemoveAllCalled = true;
-        addChange(new ListClearChange<T>(this));
+        addChange(new ListClearChange<>(this));
     }
 
     /**


### PR DESCRIPTION
There are various collections that are usually not used at all or with
only a small number of items. Allocating the default sizes for such
collections wastes quite some memory: HashSet and HashMap allocate for
16 items by default, ArrayList for 10 items and IdentityHashMap for 32.

Reduces BasicElementView memory use from 429706 to 419682 bytes and the
memory use in BeverageBuddy with an edit dialog open from 262257 to
251569 bytes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4562)
<!-- Reviewable:end -->
