### PR TITLE
Speed up HTML import parsing by ignoring Polymer core files (#4554)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/HtmlDependencyParser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/HtmlDependencyParser.java
@@ -72,7 +72,7 @@ public class HtmlDependencyParser implements Serializable {
 
     private void parseDependencies(String path, Set<String> dependencies,
             VaadinService service) {
-        if (dependencies.contains(path)) {
+        if (dependencies.contains(path) || isBlacklisted(path)) {
             return;
         }
         dependencies.add(path);
@@ -95,6 +95,12 @@ public class HtmlDependencyParser implements Serializable {
             getLogger().debug("Couldn't close template input stream",
                     exception);
         }
+    }
+
+    private static boolean isBlacklisted(String path) {
+        // Speed things up by not parsing files that are known to not use themes
+        return path.startsWith(ApplicationConstants.FRONTEND_PROTOCOL_PREFIX
+                + "bower_components/polymer/");
     }
 
     private String resolveUri(String relative, String base) {

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/HtmlDependencyParserTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/HtmlDependencyParserTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.net.URI;
 import java.util.Collection;
+import java.util.Collections;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -174,6 +175,25 @@ public class HtmlDependencyParserTest {
         Assert.assertTrue(
                 "Dependencies parser doesn't return the simple relative URI",
                 dependencies.contains("frontend://relative.html"));
+    }
+
+    @Test
+    public void polymerDependency_ignored() {
+        String root = "foo.html";
+        HtmlDependencyParser parser = new HtmlDependencyParser(root);
+
+        String importContent = "<link rel='import' href='bower_components/polymer/polymer-element.html'>";
+
+        servlet.addServletContextResource("/frontend/foo.html", importContent);
+
+        Collection<String> dependencies = parser.parseDependencies(service);
+
+        servlet.verifyServletContextResourceLoadedOnce("/frontend/" + root);
+        servlet.verifyServletContextResourceNotLoaded(
+                "/frontend/bower_components/polymer/polymer-element.html");
+
+        Assert.assertEquals(Collections.singleton("frontend://" + root),
+                dependencies);
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/MockServletServiceSessionSetup.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/MockServletServiceSessionSetup.java
@@ -164,6 +164,11 @@ public class MockServletServiceSessionSetup {
                     .getResourceAsStream(resource);
 
         }
+
+        public void verifyServletContextResourceNotLoaded(String resource) {
+            Mockito.verify(servlet.getServletContext(), Mockito.never())
+                    .getResourceAsStream(resource);
+        }
     }
 
     public static class TestVaadinServletResponse


### PR DESCRIPTION
Reduces the TTFB for the first time the Beverage Buddy edit dialog is
opened from around 2200 ms to 550 ms.

Related to #4532

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4567)
<!-- Reviewable:end -->
