### PR TITLE
Cache dependencies parsed from each individual import

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentMetaData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentMetaData.java
@@ -38,7 +38,9 @@ import com.vaadin.flow.dom.DisabledUpdateMode;
 import com.vaadin.flow.internal.AnnotationReader;
 import com.vaadin.flow.internal.ReflectTools;
 import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.shared.ApplicationConstants;
 import com.vaadin.flow.shared.ui.LoadMode;
+import com.vaadin.flow.shared.util.SharedUtil;
 
 /**
  * Immutable meta data related to a component class.
@@ -223,11 +225,14 @@ public class ComponentMetaData {
 
     private static HtmlImportDependency getHtmlImportDependencies(
             VaadinService service, HtmlImport htmlImport) {
-        String value = htmlImport.value();
-        HtmlDependencyParser parser = new HtmlDependencyParser(value);
+        String importPath = SharedUtil.prefixIfRelative(htmlImport.value(),
+                ApplicationConstants.FRONTEND_PROTOCOL_PREFIX);
 
-        return new HtmlImportDependency(parser.parseDependencies(service),
-                htmlImport.loadMode());
+        DependencyTreeCache<String> cache = service.getHtmlImportDependencyCache();
+
+        Set<String> dependencies = cache.getDependencies(importPath);
+
+        return new HtmlImportDependency(dependencies, htmlImport.loadMode());
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/DependencyTreeCache.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/DependencyTreeCache.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.internal;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+
+import com.vaadin.flow.function.SerializableFunction;
+
+/**
+ * A caching tree traverser for collecting and parsing dependencies.
+ *
+ * @author Vaadin Ltd
+ * @param <T>
+ *            the value type
+ */
+public class DependencyTreeCache<T> implements Serializable {
+    /**
+     * Maps a path to a list of dependencies or a placeholder indicating that
+     * parsing is in progress.
+     */
+    private final ConcurrentHashMap<T, Object> cache = new ConcurrentHashMap<>();
+
+    private final SerializableFunction<T, Collection<T>> dependencyParser;
+
+    /**
+     * Creates a dependency cache with the given dependency parser.
+     *
+     * @param dependencyParser
+     *            a potentially slow callback function that finds the direct
+     *            dependencies for any given value
+     */
+    public DependencyTreeCache(
+            SerializableFunction<T, Collection<T>> dependencyParser) {
+        this.dependencyParser = dependencyParser;
+    }
+
+    /**
+     * Collects all transitive dependencies of the given node, including the
+     * node itself.
+     *
+     * @param node
+     *            the node for which to collect dependencies
+     * @return the transitive dependencies of the given node
+     */
+    public Set<T> getDependencies(T node) {
+        HashSet<T> result = new HashSet<>();
+
+        LinkedList<T> pendingKeys = new LinkedList<>();
+        pendingKeys.add(node);
+
+        try {
+            while (!pendingKeys.isEmpty()) {
+                T path = pendingKeys.removeLast();
+
+                if (result.add(path)) {
+                    getOrParseDependencies(path).forEach(pendingKeys::add);
+                }
+            }
+        } catch (InterruptedException e) {
+            // Restore interrupted state
+            Thread.currentThread().interrupt();
+
+            throw new RuntimeException(
+                    "Interrputed while finding dependencies for " + node, e);
+        }
+
+        return result;
+    }
+
+    private Collection<T> getOrParseDependencies(T node)
+            throws InterruptedException {
+        Object placeholder = new Object();
+        Object valueOrPlaceholder = cache.putIfAbsent(node, placeholder);
+        if (valueOrPlaceholder instanceof Collection<?>) {
+            /*
+             * Happy path: cache contained the dependencies.
+             */
+            @SuppressWarnings("unchecked")
+            Collection<T> dependencies = (Collection<T>) valueOrPlaceholder;
+
+            return dependencies;
+        } else if (valueOrPlaceholder == null) {
+            /*
+             * No previous value in the cache. This means that we were the first
+             * to look for this node. In that case, we should use the parser to
+             * find dependencies and then notify anyone else who have found the
+             * placeholder we put into the cache and is now waiting for the real
+             * result.
+             */
+            Collection<T> dependencies = dependencyParser.apply(node);
+
+            cache.put(node, dependencies);
+
+            synchronized (placeholder) {
+                placeholder.notifyAll();
+            }
+
+            return dependencies;
+        } else {
+            /*
+             * We got a placeholder that has been put there by another thread.
+             * Wait until the other thread is done parsing and has put the real
+             * dependencies into the cache.
+             */
+            return waitForDependencies(node, valueOrPlaceholder);
+        }
+    }
+
+    private Collection<T> waitForDependencies(T node, Object placeholder)
+            throws InterruptedException {
+        synchronized (placeholder) {
+            // Loop because of spurious wakeups
+            while (true) {
+                Object valueOrPlaceholder = cache.get(node);
+                if (valueOrPlaceholder == null) {
+                    /*
+                     * Special case if clear() happens after a result was added
+                     * to the cache, but before this thread got notified. Ensure
+                     * that parsing happens again. The end result is thus the
+                     * same as if clear() happened already before this thread
+                     * found the placeholder.
+                     */
+                    return getOrParseDependencies(node);
+                } else if (valueOrPlaceholder != placeholder) {
+
+                    @SuppressWarnings("unchecked")
+                    Collection<T> dependencies = (Collection<T>) valueOrPlaceholder;
+
+                    /*
+                     * The thread that did the parsing will most likely be
+                     * working on the first dependency by the time we get here.
+                     * To reduce the risk that we'll end up waiting for the same
+                     * thread again when traversing children, we randomize our
+                     * own traversal order. This increases the probability that
+                     * all threads querying for the same information will
+                     * contribute the needed parsing work.
+                     */
+                    List<T> shuffledDependencies = new ArrayList<>(
+                            dependencies);
+                    Collections.shuffle(shuffledDependencies,
+                            ThreadLocalRandom.current());
+                    return shuffledDependencies;
+                }
+
+                placeholder.wait();
+            }
+        }
+    }
+
+    /**
+     * Clears all the contents of the cache. A lookup that is in progress while
+     * the cache is cleared may return a result that combines previously cached
+     * dependencies with newly parsed dependencies.
+     */
+    public void clear() {
+        cache.clear();
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/HtmlDependencyParser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/HtmlDependencyParser.java
@@ -15,22 +15,12 @@
  */
 package com.vaadin.flow.component.internal;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.io.Serializable;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Stream;
 
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.WebBrowser;
 import com.vaadin.flow.server.startup.FakeBrowser;
@@ -43,10 +33,13 @@ import com.vaadin.flow.shared.util.SharedUtil;
  * It takes the an HTML import url as a root and parse the content recursively
  * collecting html import dependencies.
  *
+ * @deprecated Due for removal because of additional cache layer
+ *
  * @author Vaadin Ltd
  * @since 1.0
  *
  */
+@Deprecated
 public class HtmlDependencyParser implements Serializable {
 
     private final String root;
@@ -65,119 +58,25 @@ public class HtmlDependencyParser implements Serializable {
         Set<String> dependencies = new HashSet<>();
         String rooUri = SharedUtil.prefixIfRelative(root,
                 ApplicationConstants.FRONTEND_PROTOCOL_PREFIX);
-        parseDependencies(rooUri, dependencies, service);
+
+        SerializableConsumer<String> dependencyWalker = new SerializableConsumer<String>() {
+            private final WebBrowser browser = FakeBrowser.getEs6();
+
+            @Override
+            public void accept(String uri) {
+                if (dependencies.contains(uri)) {
+                    return;
+                }
+                dependencies.add(uri);
+                HtmlImportParser.parseImports(uri,
+                        path -> service.getResourceAsStream(path, browser,
+                                null),
+                        path -> service.resolveResource(path, browser), this);
+            }
+        };
+
+        dependencyWalker.accept(rooUri);
 
         return dependencies;
-    }
-
-    private void parseDependencies(String path, Set<String> dependencies,
-            VaadinService service) {
-        if (dependencies.contains(path) || isBlacklisted(path)) {
-            return;
-        }
-        dependencies.add(path);
-        WebBrowser browser = FakeBrowser.getEs6();
-        try (InputStream content = service.getResourceAsStream(path, browser,
-                null)) {
-            if (content == null) {
-                getLogger().trace(
-                        "Can't find resource '{}' to parse for imports via the servlet context",
-                        path);
-            } else {
-                String resolvedPath = service.resolveResource(path, browser);
-                parseHtmlImports(content, resolvedPath)
-                        .map(uri -> resolveUri(uri, path))
-                        .forEach(uri -> parseDependencies(uri, dependencies,
-                                service));
-            }
-        } catch (IOException exception) {
-            // ignore exception on close()
-            getLogger().debug("Couldn't close template input stream",
-                    exception);
-        }
-    }
-
-    private static boolean isBlacklisted(String path) {
-        // Speed things up by not parsing files that are known to not use themes
-        return path.startsWith(ApplicationConstants.FRONTEND_PROTOCOL_PREFIX
-                + "bower_components/polymer/");
-    }
-
-    private String resolveUri(String relative, String base) {
-        if (relative.startsWith("/")) {
-            return relative;
-        }
-        try {
-            URI uri = new URI(base);
-            return relativize(relative, uri);
-        } catch (URISyntaxException exception) {
-            getLogger().debug(
-                    "Couldn't make URI for {}. The path {} will be used as is.",
-                    base, relative, exception);
-        }
-        return relative;
-    }
-
-    private String relativize(String relative, URI base)
-            throws URISyntaxException {
-        URI newUri;
-        if (base.getPath().isEmpty()) {
-            String uriString = base.toString();
-            int index = uriString.lastIndexOf('/');
-            newUri = new URI(uriString.substring(0, index + 1) + relative);
-        } else {
-            newUri = base.resolve(relative);
-        }
-
-        return toNormalizedURI(newUri);
-    }
-
-    /**
-     * Returns a normalized version of the URI, converted to a string.
-     *
-     * @param uri
-     *            the URI to normalize
-     * @return a nonrmalized version of the URI
-     */
-    // Package private for testing purposes
-    static String toNormalizedURI(URI uri) {
-        URI normalized = uri.normalize();
-        // This is because of https://github.com/vaadin/flow/issues/3892
-        if ("frontend".equals(normalized.getScheme())
-                || "base".equals(normalized.getScheme())
-                || "context".equals(normalized.getScheme())) {
-            if (".".equals(normalized.getAuthority())
-                    && normalized.getHost() == null) {
-                // frontend://./foo.html
-                return normalized.toString().replace("//./", "//");
-            }
-            if (normalized.getPath().startsWith("/../")) {
-                return normalized.toString()
-                        .replace(normalized.getHost() + "/../", "");
-            }
-        }
-        return normalized.toString();
-    }
-
-    private Stream<String> parseHtmlImports(InputStream content, String path) {
-        assert content != null;
-        try {
-            Document parsedDocument = Jsoup.parse(content,
-                    StandardCharsets.UTF_8.name(), "");
-
-            return parsedDocument.getElementsByTag("link").stream()
-                    .filter(link -> link.hasAttr("rel") && link.hasAttr("href"))
-                    .filter(link -> link.attr("rel").equals("import"))
-                    .map(link -> link.attr("href"));
-        } catch (IOException exception) {
-            getLogger().info(
-                    "Can't parse the template declared using '{}' path", path,
-                    exception);
-        }
-        return Stream.empty();
-    }
-
-    private Logger getLogger() {
-        return LoggerFactory.getLogger(HtmlDependencyParser.class);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/HtmlImportParser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/HtmlImportParser.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.internal;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Helper for finding the HTML imports of a resource.
+ *
+ * @author Vaadin Ltd
+ */
+public class HtmlImportParser {
+
+    private HtmlImportParser() {
+        // Static helpers only
+    }
+
+    private static String resolveUri(String relative, String base) {
+        if (relative.startsWith("/")) {
+            return relative;
+        }
+        try {
+            URI uri = new URI(base);
+            return relativize(relative, uri);
+        } catch (URISyntaxException exception) {
+            getLogger().debug(
+                    "Couldn't make URI for {}. The path {} will be used as is.",
+                    base, relative, exception);
+        }
+        return relative;
+    }
+
+    private static String relativize(String relative, URI base)
+            throws URISyntaxException {
+        URI newUri;
+        if (base.getPath().isEmpty()) {
+            String uriString = base.toString();
+            int index = uriString.lastIndexOf('/');
+            newUri = new URI(uriString.substring(0, index + 1) + relative);
+        } else {
+            newUri = base.resolve(relative);
+        }
+
+        return toNormalizedURI(newUri);
+    }
+
+    /**
+     * Returns a normalized version of the URI, converted to a string.
+     *
+     * @param uri
+     *            the URI to normalize
+     * @return a nonrmalized version of the URI
+     */
+    // Package private for testing purposes
+    static String toNormalizedURI(URI uri) {
+        URI normalized = uri.normalize();
+        // This is because of https://github.com/vaadin/flow/issues/3892
+        if ("frontend".equals(normalized.getScheme())
+                || "base".equals(normalized.getScheme())
+                || "context".equals(normalized.getScheme())) {
+            if (".".equals(normalized.getAuthority())
+                    && normalized.getHost() == null) {
+                // frontend://./foo.html
+                return normalized.toString().replace("//./", "//");
+            }
+            if (normalized.getPath().startsWith("/../")) {
+                return normalized.toString()
+                        .replace(normalized.getHost() + "/../", "");
+            }
+        }
+        return normalized.toString();
+    }
+
+    private static Stream<String> parseHtmlImports(InputStream content,
+            String path) {
+        assert content != null;
+        try {
+            Document parsedDocument = Jsoup.parse(content,
+                    StandardCharsets.UTF_8.name(), "");
+
+            return parsedDocument.getElementsByTag("link").stream()
+                    .filter(link -> link.hasAttr("rel") && link.hasAttr("href"))
+                    .filter(link -> "import".equals(link.attr("rel")))
+                    .map(link -> link.attr("href"));
+        } catch (IOException exception) {
+            getLogger().info(
+                    "Can't parse the template declared using '{}' path", path,
+                    exception);
+        }
+        return Stream.empty();
+    }
+
+    /**
+     * Parses the contents of the given resource and passes any found HTML
+     * imports to the given consumer.
+     *
+     * @param resourcePath
+     *            the path of the resource from which to fin
+     * @param getResourceAsStream
+     *            a callback for opening an input stream with the contents of
+     *            the given resource
+     * @param resolveResource
+     *            a callback that resolves the given resource path
+     * @param importHandler
+     *            the callback to which found HTML imports should be passed
+     */
+    public static void parseImports(String resourcePath,
+            Function<String, InputStream> getResourceAsStream,
+            Function<String, String> resolveResource,
+            Consumer<String> importHandler) {
+        try (InputStream content = getResourceAsStream.apply(resourcePath)) {
+            if (content == null) {
+                getLogger().trace(
+                        "Can't find resource '{}' to parse for imports via the servlet context",
+                        resourcePath);
+            } else {
+                String resolvedPath = resolveResource.apply(resourcePath);
+                parseHtmlImports(content, resolvedPath)
+                        .map(uri -> resolveUri(uri, resourcePath))
+                        .forEach(importHandler);
+            }
+        } catch (IOException exception) {
+            // ignore exception on close()
+            getLogger().debug("Couldn't close template input stream",
+                    exception);
+        }
+    }
+
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(HtmlImportParser.class);
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/DependencyTreeCacheTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/DependencyTreeCacheTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.internal;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.function.SerializableFunction;
+
+public class DependencyTreeCacheTest {
+    @Test
+    public void multipleLevels_allIncluded_noneParsedAgain() {
+        MockParser parser = new MockParser().addResult("/a", "/b")
+                .addResult("/b", "/c").addResult("/c");
+
+        DependencyTreeCache<String> cache = new DependencyTreeCache<>(parser);
+        Set<String> dependencies = cache.getDependencies("/a");
+
+        parser.assertConsumed();
+        Assert.assertEquals(new HashSet<>(Arrays.asList("/a", "/b", "/c")),
+                dependencies);
+
+        // Parse again, should not trigger exception because things are parsed
+        // multiple times
+        Set<String> dependencies2 = cache.getDependencies("/a");
+        Assert.assertEquals(dependencies, dependencies2);
+    }
+
+    @Test
+    public void sharedDependency_onlyParsedOnce() {
+        MockParser parser = new MockParser().addResult("/a", "/b", "/c")
+                .addResult("/b", "/d").addResult("/c", "/d").addResult("/d");
+
+        DependencyTreeCache<String> cache = new DependencyTreeCache<>(parser);
+        Set<String> dependencies = cache.getDependencies("/a");
+
+        parser.assertConsumed();
+        Assert.assertEquals(
+                new HashSet<>(Arrays.asList("/a", "/b", "/c", "/d")),
+                dependencies);
+    }
+
+    @Test
+    public void concurrentParse_onlyParsedOnce() throws InterruptedException {
+        MockParser parser = new MockParser();
+        parser.addResult("/a", "/b");
+        parser.addResult("/b", 100);
+
+        DependencyTreeCache<String> cache = new DependencyTreeCache<>(parser);
+
+        long start = System.currentTimeMillis();
+
+        Set<String> threadResult = new HashSet<>();
+        Thread thread = new Thread(() -> {
+            threadResult.addAll(cache.getDependencies("/a"));
+        });
+        thread.start();
+
+        Set<String> dependencies = cache.getDependencies("/a");
+
+        thread.join();
+
+        long end = System.currentTimeMillis();
+
+        Assert.assertEquals(new HashSet<>(Arrays.asList("/a", "/b")),
+                dependencies);
+        Assert.assertEquals(dependencies, threadResult);
+
+        long duration = (end - start);
+
+        Assert.assertTrue("Parsing should take less than 200 ms",
+                duration < 200);
+        Assert.assertTrue(
+                "Parsing should take at least 100 ms, was " + duration,
+                duration >= 100);
+    }
+
+    @Test
+    public void parallelParsing_potentialSpeedup() throws InterruptedException {
+        // Eventually, we should see both a case when the randomization makes
+        // parsing progress in parallel and a case when it happens sequentially
+        int maxDuration = Integer.MIN_VALUE;
+        int minDuration = Integer.MAX_VALUE;
+
+        int iterationCount = 0;
+        while (minDuration > 75 || maxDuration < 75) {
+            if (iterationCount++ > 30) {
+                // Less than 1/10^9 chance that 50/50 randomization will give
+                // the same result 30 times in a row
+                Assert.fail(
+                        "Did not observe both slowdown and speedup. Max duration: "
+                                + maxDuration + ", min duration: "
+                                + minDuration);
+            }
+
+            MockParser parser = new MockParser().addResult("/a", 25, "/b", "/c")
+                    .addResult("/b", 25).addResult("/c", 25);
+            DependencyTreeCache<String> cache = new DependencyTreeCache<>(
+                    parser);
+
+            Thread thread = new Thread(() -> cache.getDependencies("/a"));
+
+            long start = System.currentTimeMillis();
+
+            thread.start();
+            cache.getDependencies("/a");
+            thread.join();
+
+            long end = System.currentTimeMillis();
+            int duration = (int) (end - start);
+
+            Assert.assertTrue(
+                    "Duration should never be less than 50, was " + duration,
+                    duration >= 50);
+
+            maxDuration = Math.max(maxDuration, duration);
+            minDuration = Math.min(minDuration, duration);
+        }
+    }
+
+    @FunctionalInterface
+    private interface Blocker {
+        public void block() throws InterruptedException;
+    }
+
+    private static class MockParser
+            implements SerializableFunction<String, Collection<String>> {
+        private static final Supplier<Collection<String>> USED_PLACEHOLDER = () -> Collections
+                .emptySet();
+
+        private Map<String, Supplier<Collection<String>>> items = new ConcurrentHashMap<>();
+
+        @Override
+        public Collection<String> apply(String path) {
+            path = path.replaceFirst("^frontend://", "");
+
+            // Get value and mark it as used
+            Supplier<Collection<String>> supplier = items.put(path,
+                    USED_PLACEHOLDER);
+
+            if (supplier == USED_PLACEHOLDER) {
+                Assert.fail("Path " + path + " has already been parsed");
+            } else if (supplier == null) {
+                Assert.fail("Parser cannot find " + path);
+            }
+
+            return supplier.get();
+        }
+
+        public MockParser addResult(String path, String... dependencies) {
+            return addResult(path, null, dependencies);
+        }
+
+        public MockParser addResult(String path, int duration,
+                String... dependencies) {
+            return addResult(path, () -> Thread.sleep(duration), dependencies);
+        }
+
+        public MockParser addResult(String path, Blocker blocker,
+                String... dependencies) {
+            items.put(path, () -> {
+                if (blocker != null) {
+                    try {
+                        blocker.block();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+                return Arrays.asList(dependencies);
+            });
+            return this;
+        }
+
+        public void assertConsumed() {
+            items.forEach((path, value) -> Assert.assertSame(
+                    path + " should have been parsed", USED_PLACEHOLDER,
+                    value));
+        }
+    }
+
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/HtmlImportParserTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/HtmlImportParserTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.internal;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HtmlImportParserTest {
+
+    @Test
+    public void emptyImport_noDependencies() {
+        String root = "/frontend/foo.html";
+
+        HtmlImportParser.parseImports(root, streamFactory(root),
+                Function.identity(), dependency -> {
+                    Assert.fail("There should be no dependencies");
+                });
+    }
+
+    @Test
+    public void variousURIs_URIsAreCollectedCorrectly() {
+        String root = "frontend://baz/foo.html";
+
+        Set<String> dependencies = new HashSet<>();
+
+        HtmlImportParser.parseImports(root,
+                streamFactory(root, "relative1.html", "foo/../relative1.html",
+                        "../relative2.html", "sub/relative3.html",
+                        "/absolute.html"),
+                Function.identity(), dependencies::add);
+
+        Assert.assertEquals(4, dependencies.size());
+
+        Assert.assertTrue(
+                "Dependencies parser doesn't return the simple relative URI (same parent)",
+                dependencies.contains("frontend://baz/relative1.html"));
+        Assert.assertTrue(
+                "Dependencies parser doesn't return the relative URI which is located in the parent folder",
+                dependencies.contains("frontend://relative2.html"));
+        Assert.assertTrue(
+                "Dependencies parser doesn't return the relative URI which is located sub folder",
+                dependencies.contains("frontend://baz/sub/relative3.html"));
+        Assert.assertTrue("Dependencies parser doesn't return the absolute URI",
+                dependencies.contains("/absolute.html"));
+    }
+
+    @Test
+    public void normalizeURI() throws Exception {
+        assertEquals("http://foo/bar", normalize("http://foo/bar"));
+        assertEquals("http://foo/../bar", normalize("http://foo/../bar"));
+        assertEquals("http://foo/bar", normalize("http://foo/./bar"));
+        assertEquals("http://foo/bar", normalize("http://foo/baz/../bar"));
+
+        for (String protocol : new String[] { "frontend", "context", "base" }) {
+            assertEquals(protocol + "://foo/bar",
+                    normalize(protocol + "://foo/bar"));
+            assertEquals(protocol + "://bar",
+                    normalize(protocol + "://foo/../bar"));
+            assertEquals(protocol + "://foo", normalize(protocol + "://./foo"));
+            assertEquals(protocol + "://foo",
+                    normalize(protocol + "://././foo"));
+            assertEquals(protocol + "://foo/bar",
+                    normalize(protocol + "://foo/./bar"));
+            assertEquals(protocol + "://foo/bar",
+                    normalize(protocol + "://foo/baz/../bar"));
+            assertEquals(
+                    protocol + "://bower_components/vaadin-button/src/vaadin-button.html",
+                    normalize(protocol
+                            + "://src/views/login/../../../bower_components/vaadin-button/src/vaadin-button.html"));
+            assertEquals(protocol + "://components/js/hash-actions.html",
+                    normalize(protocol
+                            + "://components/../components/js/hash-actions.html"));
+        }
+
+    }
+
+    private String normalize(String string) throws Exception {
+        return HtmlImportParser.toNormalizedURI(new URI(string));
+    }
+
+    private static Function<String, InputStream> streamFactory(
+            String expectedPath, String... imports) {
+        String contents = Stream.of(imports)
+                .map(imprt -> "<link rel='import' href='" + imprt + "'>")
+                .collect(Collectors.joining());
+        return path -> {
+            Assert.assertEquals(expectedPath, path);
+            return new ByteArrayInputStream(
+                    contents.getBytes(StandardCharsets.UTF_8));
+        };
+    }
+
+}

--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
@@ -55,7 +55,7 @@ import static java.lang.reflect.Modifier.isStatic;
  * tries to serialize every single class (except ones from whitelist) in the
  * classpath. Subclasses may adjust the whitelist by overriding
  * {@link #getExcludedPatterns()}, {@link #getBasePackages()},
- * {@link  #getJarPattern()}
+ * {@link #getJarPattern()}
  */
 
 public abstract class ClassesSerializableTest {
@@ -133,6 +133,7 @@ public abstract class ClassesSerializableTest {
                 "com\\.vaadin\\.flow\\.server\\.FutureAccess",
                 "com\\.vaadin\\.flow\\.internal\\.nodefeature\\.ElementPropertyMap\\$PutResult",
                 "com\\.vaadin\\.flow\\.osgi\\.Activator",
+                "com\\.vaadin\\.flow\\.component\\.internal\\.HtmlImportParser",
 
                 //Various test classes
                 ".*\\.test(s)?\\..*",


### PR DESCRIPTION
Previously, dependency parsing results were only cached per component
class. This means that if multiple components use the same import, that
import would have been parsed multiple times.

This patch adds a separate cache layer that keeps track of the imports
from individual files, and then traverses that cache to collect all
reachable imports.

Reduces total TTFB for the first view in Beverage Buddy from 1.2 to 0.6
seconds and from 1.1 to 0.3 seconds for opening the dialog.

Related to #4532.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4568)
<!-- Reviewable:end -->
