### PR TITLE
Avoid creating unused node features

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -291,7 +292,9 @@ public class ComponentUtil {
     private static boolean isVirtualChild(Component component,
             Component parentComponent) {
         Iterator<StateNode> iterator = parentComponent.getElement().getNode()
-                .getFeature(VirtualChildrenList.class).iterator();
+                .getFeatureIfInitialized(VirtualChildrenList.class)
+                .map(VirtualChildrenList::iterator)
+                .orElse(Collections.emptyIterator());
         while (iterator.hasNext()) {
             if (iterator.next().equals(component.getElement().getNode())) {
                 return true;

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -1603,18 +1603,21 @@ public class Element extends Node<Element> {
         });
         if (component.getElement().getNode()
                 .hasFeature(VirtualChildrenList.class)) {
-            final Consumer<Component> stateChangeInformer = virtual -> {
-                virtual.onEnabledStateChanged(
-                        enabled ? virtual.getElement().isEnabled() : false);
-
-                informChildrenOfStateChange(enabled, virtual);
-            };
-            final Consumer<StateNode> childNodeConsumer = childNode -> Element
-                    .get(childNode).getComponent()
-                    .ifPresent(stateChangeInformer);
             component.getElement().getNode()
-                    .getFeature(VirtualChildrenList.class)
-                    .forEachChild(childNodeConsumer);
+                    .getFeatureIfInitialized(VirtualChildrenList.class)
+                    .ifPresent(list -> {
+                        final Consumer<Component> stateChangeInformer = virtual -> {
+                            virtual.onEnabledStateChanged(enabled
+                                    ? virtual.getElement().isEnabled() : false);
+
+                            informChildrenOfStateChange(enabled, virtual);
+                        };
+                        final Consumer<StateNode> childNodeConsumer = childNode -> Element
+                                .get(childNode).getComponent()
+                                .ifPresent(stateChangeInformer);
+
+                        list.forEachChild(childNodeConsumer);
+                    });
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/dom/ElementStateProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/ElementStateProvider.java
@@ -360,7 +360,7 @@ public interface ElementStateProvider extends Serializable {
      */
     default Optional<Component> getComponent(StateNode node) {
         assert node != null;
-        return node.getFeature(ComponentMapping.class).getComponent();
+        return ComponentMapping.getComponent(node);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Node.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Node.java
@@ -182,7 +182,7 @@ public abstract class Node<N extends Node<N>> implements Serializable {
 
     /**
      * Gets whether this element is a virtual child of its parent.
-     * 
+     *
      * @return <code>true</code> if the element has a parent and the element is
      *         a virtual child of it, <code>false</code> otherwise.
      */
@@ -191,7 +191,10 @@ public abstract class Node<N extends Node<N>> implements Serializable {
         if (parentNode == null) {
             return false;
         }
-        if (!parentNode.getNode().hasFeature(VirtualChildrenList.class)) {
+        if (!parentNode.getNode().hasFeature(VirtualChildrenList.class)
+                || !parentNode.getNode()
+                        .getFeatureIfInitialized(VirtualChildrenList.class)
+                        .isPresent()) {
             return false;
         }
         Iterator<StateNode> iterator = parentNode.getNode()

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/BasicElementStateProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/BasicElementStateProvider.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -153,6 +154,11 @@ public class BasicElementStateProvider extends AbstractNodeStateProvider {
         return node.getFeature(ElementAttributeMap.class);
     }
 
+    private static Optional<ElementAttributeMap> getAttributeFeatureIfInitialized(
+            StateNode node) {
+        return node.getFeatureIfInitialized(ElementAttributeMap.class);
+    }
+
     /**
      * Gets the property feature for the given node and asserts it is non-null.
      *
@@ -162,6 +168,11 @@ public class BasicElementStateProvider extends AbstractNodeStateProvider {
      */
     private static ElementPropertyMap getPropertyFeature(StateNode node) {
         return node.getFeature(ElementPropertyMap.class);
+    }
+
+    private static Optional<ElementPropertyMap> getPropertyFeatureIfInitialized(
+            StateNode node) {
+        return node.getFeatureIfInitialized(ElementPropertyMap.class);
     }
 
     @Override
@@ -178,7 +189,8 @@ public class BasicElementStateProvider extends AbstractNodeStateProvider {
         assert attribute != null;
         assert attribute.equals(attribute.toLowerCase(Locale.ENGLISH));
 
-        return getAttributeFeature(node).get(attribute);
+        return getAttributeFeatureIfInitialized(node)
+                .map(feature -> feature.get(attribute)).orElse(null);
     }
 
     @Override
@@ -186,7 +198,9 @@ public class BasicElementStateProvider extends AbstractNodeStateProvider {
         assert attribute != null;
         assert attribute.equals(attribute.toLowerCase(Locale.ENGLISH));
 
-        return getAttributeFeature(node).has(attribute);
+        Optional<ElementAttributeMap> maybeFeature = getAttributeFeatureIfInitialized(
+                node);
+        return maybeFeature.isPresent() && maybeFeature.get().has(attribute);
     }
 
     @Override
@@ -194,12 +208,14 @@ public class BasicElementStateProvider extends AbstractNodeStateProvider {
         assert attribute != null;
         assert attribute.equals(attribute.toLowerCase(Locale.ENGLISH));
 
-        getAttributeFeature(node).remove(attribute);
+        getAttributeFeatureIfInitialized(node)
+                .map(feature -> feature.remove(attribute));
     }
 
     @Override
     public Stream<String> getAttributeNames(StateNode node) {
-        return getAttributeFeature(node).attributes();
+        return getAttributeFeatureIfInitialized(node)
+                .map(ElementAttributeMap::attributes).orElseGet(Stream::empty);
     }
 
     @Override
@@ -236,7 +252,8 @@ public class BasicElementStateProvider extends AbstractNodeStateProvider {
         assert node != null;
         assert name != null;
 
-        return getPropertyFeature(node).getProperty(name);
+        return getPropertyFeatureIfInitialized(node)
+                .map(feature -> feature.getProperty(name)).orElse(null);
     }
 
     @Override
@@ -253,7 +270,8 @@ public class BasicElementStateProvider extends AbstractNodeStateProvider {
         assert node != null;
         assert name != null;
 
-        getPropertyFeature(node).removeProperty(name);
+        getPropertyFeatureIfInitialized(node)
+                .ifPresent(feature -> feature.removeProperty(name));
     }
 
     @Override
@@ -261,14 +279,22 @@ public class BasicElementStateProvider extends AbstractNodeStateProvider {
         assert node != null;
         assert name != null;
 
-        return getPropertyFeature(node).hasProperty(name);
+        Optional<ElementPropertyMap> maybeFeature = getPropertyFeatureIfInitialized(
+                node);
+        if (maybeFeature.isPresent()) {
+            return maybeFeature.get().hasProperty(name);
+        } else {
+            return false;
+        }
     }
 
     @Override
     public Stream<String> getPropertyNames(StateNode node) {
         assert node != null;
 
-        return getPropertyFeature(node).getPropertyNames();
+        return getPropertyFeatureIfInitialized(node)
+                .map(ElementPropertyMap::getPropertyNames)
+                .orElseGet(Stream::empty);
     }
 
     @Override
@@ -326,7 +352,8 @@ public class BasicElementStateProvider extends AbstractNodeStateProvider {
 
     @Override
     public StateNode getShadowRoot(StateNode node) {
-        return node.getFeature(ShadowRootData.class).getShadowRoot();
+        return node.getFeatureIfInitialized(ShadowRootData.class)
+                .map(ShadowRootData::getShadowRoot).orElse(null);
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ComponentMapping.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ComponentMapping.java
@@ -79,6 +79,23 @@ public class ComponentMapping extends ServerSideFeature {
         return Optional.ofNullable(component);
     }
 
+    /**
+     * Gets the component mapped to the given state node.
+     *
+     * @param node
+     *            the state node for which to find a component, not
+     *            <code>null</code>
+     * @return the mapped component, or an empty optional if no component is
+     *         mapped
+     */
+    public static Optional<Component> getComponent(StateNode node) {
+        assert node != null;
+        assert node.hasFeature(ComponentMapping.class);
+
+        return node.getFeatureIfInitialized(ComponentMapping.class)
+                .flatMap(ComponentMapping::getComponent);
+    }
+
     @Override
     public void onAttach(boolean initialAttach) {
         getComponent().ifPresent(

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlWriter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlWriter.java
@@ -336,8 +336,7 @@ public class UidlWriter implements Serializable {
         Set<Class<? extends Component>> componentsWithDependencies = new LinkedHashSet<>();
         stateTree.collectChanges(change -> {
             if (attachesComponent(change)) {
-                change.getNode().getFeature(ComponentMapping.class)
-                        .getComponent()
+                ComponentMapping.getComponent(change.getNode())
                         .ifPresent(component -> addComponentHierarchy(ui,
                                 componentsWithDependencies, component));
             }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/PublishedServerEventHandlerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/PublishedServerEventHandlerRpcHandler.java
@@ -89,8 +89,7 @@ public class PublishedServerEventHandlerRpcHandler
                     "Incorrect type for method arguments: " + args.getClass());
         }
         assert node.hasFeature(ComponentMapping.class);
-        Optional<Component> component = node.getFeature(ComponentMapping.class)
-                .getComponent();
+        Optional<Component> component = ComponentMapping.getComponent(node);
         if (!component.isPresent()) {
             throw new IllegalStateException(
                     "Unable to handle RPC template event JSON message: "

--- a/flow-server/src/test/java/com/vaadin/flow/dom/BasicElementStateProviderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/BasicElementStateProviderTest.java
@@ -10,8 +10,12 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.dom.NodeVisitor.ElementType;
 import com.vaadin.flow.dom.impl.BasicElementStateProvider;
 import com.vaadin.flow.internal.StateNode;
+import com.vaadin.flow.internal.nodefeature.ElementChildrenList;
 import com.vaadin.flow.internal.nodefeature.ElementData;
+import com.vaadin.flow.internal.nodefeature.NodeFeature;
 import com.vaadin.flow.internal.nodefeature.NodeProperties;
+import com.vaadin.flow.internal.nodefeature.ShadowRootData;
+import com.vaadin.flow.internal.nodefeature.VirtualChildrenList;
 import com.vaadin.flow.server.VaadinRequest;
 
 public class BasicElementStateProviderTest {
@@ -112,6 +116,27 @@ public class BasicElementStateProviderTest {
     }
 
     @Test
+    public void visitNode_noChildren_featuresNotInitialized() {
+        Element element = ElementFactory.createDiv();
+
+        assertNoChildFeatures(element);
+
+        element.accept(new TestNodeVisitor());
+
+        assertNoChildFeatures(element);
+    }
+
+    public static void assertNoChildFeatures(Element element) {
+        Assert.assertFalse("Node should not have a children list feature",
+                isFeatureInitialized(element, ElementChildrenList.class));
+        Assert.assertFalse(
+                "Node should not have a virtual children list feature",
+                isFeatureInitialized(element, VirtualChildrenList.class));
+        Assert.assertFalse("Node should not have a shadow root feature",
+                isFeatureInitialized(element, ShadowRootData.class));
+    }
+
+    @Test
     public void setVisible() {
         Element element = ElementFactory.createDiv();
 
@@ -128,6 +153,12 @@ public class BasicElementStateProviderTest {
         Assert.assertFalse(
                 element.getNode().getFeature(ElementData.class).isVisible());
 
+    }
+
+    private static boolean isFeatureInitialized(Element element,
+            Class<? extends NodeFeature> featureType) {
+        return element.getNode().getFeatureIfInitialized(featureType)
+                .isPresent();
     }
 
     private Element createHierarchy(Map<Node<?>, ElementType> map) {


### PR DESCRIPTION
Many node feature types are only used in some very specific situations,
e.g. only if an element has virtual children. Reduce memory overhead by
not allocating such instances until some data will actually be saved in
them.

Reduces BasicElementView memory use from 219100 to 149909 bytes and the
memory use in BeverageBuddy with an edit dialog open from 170041 to
151733 bytes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4574)
<!-- Reviewable:end -->
