### PR TITLE
Add support for setting pwa application start url.

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/PWA.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PWA.java
@@ -91,6 +91,21 @@ public @interface PWA {
     String iconPath() default PwaConfiguration.DEFAULT_ICON;
 
     /**
+     * (Root relative) start url, used in web-manifest, property start_url
+     * <p>
+     * Used in manifest as start_url of application. Must be relative to root
+     * context. ie. If install address of application would be
+     * https://foo.bar.org/sub/  and wanted start url would be
+     * https://foo.bar.org/sub/pwa-start then value of startPath would be
+     * "pwa-start" (without leading "/").
+     * <p>
+     * Defaults to root of application.
+     *
+     * @return application start url
+     */
+    String startPath() default "";
+
+    /**
      * Name of the application.
      *
      * @return name of the application

--- a/flow-server/src/main/java/com/vaadin/flow/server/PwaConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PwaConfiguration.java
@@ -54,9 +54,9 @@ public class PwaConfiguration implements Serializable {
 
     protected PwaConfiguration(PWA pwa, ServletContext servletContext) {
         serviceWorkerPath = "sw.js";
-        rootUrl = servletContext == null || servletContext.getContextPath() == null
-                || servletContext.getContextPath().isEmpty() ? "/"
-                : servletContext.getContextPath() + "/";
+        rootUrl = hasContextPath(servletContext)
+                ? servletContext.getContextPath() + "/"
+                : "/";
         if (pwa != null) {
             appName = pwa.name();
             shortName = pwa.shortName().substring(0,
@@ -87,6 +87,12 @@ public class PwaConfiguration implements Serializable {
             offlineResources = Collections.emptyList();
             enableInstallPrompt = false;
         }
+    }
+
+    private static boolean hasContextPath(ServletContext servletContext) {
+        return !(servletContext == null
+                || servletContext.getContextPath() == null
+                || servletContext.getContextPath().isEmpty());
     }
 
     private static String checkPath(String path) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/PwaConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PwaConfiguration.java
@@ -46,13 +46,17 @@ public class PwaConfiguration implements Serializable {
     private final String offlinePath;
     private final String serviceWorkerPath;
     private final String display;
-    private final String startUrl;
+    private final String rootUrl;
+    private final String startPath;
     private final boolean enabled;
     private final List<String> offlineResources;
     private boolean enableInstallPrompt;
 
     protected PwaConfiguration(PWA pwa, ServletContext servletContext) {
         serviceWorkerPath = "sw.js";
+        rootUrl = servletContext == null || servletContext.getContextPath() == null
+                || servletContext.getContextPath().isEmpty() ? "/"
+                : servletContext.getContextPath() + "/";
         if (pwa != null) {
             appName = pwa.name();
             shortName = pwa.shortName().substring(0,
@@ -64,7 +68,7 @@ public class PwaConfiguration implements Serializable {
             manifestPath = checkPath(pwa.manifestPath());
             offlinePath = checkPath(pwa.offlinePath());
             display = pwa.display();
-            startUrl = getStartUrl(servletContext);
+            startPath = pwa.startPath().replaceAll("^/+", "");
             enabled = true;
             offlineResources = Arrays.asList(pwa.offlineResources());
             enableInstallPrompt = pwa.enableInstallPrompt();
@@ -78,17 +82,11 @@ public class PwaConfiguration implements Serializable {
             manifestPath = DEFAULT_PATH;
             offlinePath = DEFAULT_OFFLINE_PATH;
             display = DEFAULT_DISPLAY;
-            startUrl = getStartUrl(servletContext);
+            startPath = "";
             enabled = false;
             offlineResources = Collections.emptyList();
             enableInstallPrompt = false;
         }
-    }
-
-    private static String getStartUrl(ServletContext context) {
-        return context == null || context.getContextPath() == null
-                || context.getContextPath().isEmpty() ? "/"
-                        : context.getContextPath() + "/";
     }
 
     private static String checkPath(String path) {
@@ -245,10 +243,21 @@ public class PwaConfiguration implements Serializable {
     /**
      * Gets the start url of the PWA application.
      *
+     * <p>Used in manifest as start url.
+     *
      * @return start url of the PWA application
      */
     public String getStartUrl() {
-        return startUrl;
+        return rootUrl + startPath;
+    }
+
+    /**
+     * Gets the application root url.
+     *
+     * @return application root url
+     */
+    public String getRootUrl() {
+        return rootUrl;
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/PwaRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PwaRegistry.java
@@ -172,7 +172,7 @@ public class PwaRegistry implements Serializable {
                 pwaConfiguration.getBackgroundColor());
         manifestData.put("theme_color", pwaConfiguration.getThemeColor());
         manifestData.put("start_url", pwaConfiguration.getStartUrl());
-        manifestData.put("scope", pwaConfiguration.getStartUrl());
+        manifestData.put("scope", pwaConfiguration.getRootUrl());
 
         // Add icons
         JsonArray iconList = Json.createArray();


### PR DESCRIPTION
- Allow developer to specify start_url
- Also solves the issue of having less than 100 in lighthouse (lighthouse requires non-root url in start-url in order to have 100/100)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4580)
<!-- Reviewable:end -->
