### PR TITLE
Minimize features array size

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/NodeFeatureTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/NodeFeatureTest.java
@@ -16,8 +16,11 @@
 
 package com.vaadin.flow.internal.nodefeature;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -120,6 +123,54 @@ public class NodeFeatureTest {
             Assert.assertEquals("Unexpected type for id " + id, expectedType,
                     NodeFeatureRegistry.getFeature(id));
         });
+    }
+
+    @Test
+    public void priorityOrder() {
+        List<Class<? extends NodeFeature>> priorityOrder = buildExpectedIdMap()
+                .keySet().stream()
+                .sorted(NodeFeatureRegistry.PRIORITY_COMPARATOR)
+                .collect(Collectors.toList());
+
+        List<Class<? extends NodeFeature>> expectedOrder = Arrays.asList(
+                /* Primary features */
+                ElementData.class, TextNodeMap.class, ModelList.class,
+                BasicTypeValue.class,
+
+                /* Common element features */
+                ElementChildrenList.class, ElementPropertyMap.class,
+
+                /* Component mapped features */
+                ComponentMapping.class, ClientCallableHandlers.class,
+
+                /* Supplementary element stuff */
+                ElementClassList.class, ElementAttributeMap.class,
+                ElementListenerMap.class, SynchronizedPropertiesList.class,
+                SynchronizedPropertyEventsList.class, VirtualChildrenList.class,
+
+                /* PolymerTemplate stuff */
+                PolymerEventListenerMap.class, PolymerServerEventHandlers.class,
+
+                /* Rarely used element stuff */
+                ElementStylePropertyMap.class, ShadowRootData.class,
+                ShadowRootHost.class, AttachExistingElementFeature.class,
+
+                /* Only used for the root node */
+                PushConfigurationMap.class,
+                PushConfigurationParametersMap.class,
+                LoadingIndicatorConfigurationMap.class,
+                PollConfigurationMap.class,
+                ReconnectDialogConfigurationMap.class);
+
+        Assert.assertEquals(expectedOrder.size(), priorityOrder.size());
+
+        for (int i = 0; i < priorityOrder.size(); i++) {
+            if (priorityOrder.get(i) != expectedOrder.get(i)) {
+                Assert.fail("Invalid priority ordering at index " + i
+                        + ". Expected " + expectedOrder.get(i).getSimpleName()
+                        + " but got " + priorityOrder.get(i).getSimpleName());
+            }
+        }
     }
 
 }


### PR DESCRIPTION
Order index mapping of feature types according to how often they are
actually used (based on actual use frequencies in Beverage Buddy and
Bakery). This allows allocating a smaller features array for each state
node to only hold the features that are actually instantiated.

The case with only one used feature is further optimized to directly
store the feature instance instead of using a one-item array.

Reduces BasicElementView memory use from 149909 to 136045 bytes and the
memory use in BeverageBuddy with an edit dialog open from 151733 to
146061 bytes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4584)
<!-- Reviewable:end -->
