### PR TITLE
Repackage webjar resources into "flow-test-root-context" jar file

### DIFF
--- a/flow-tests/test-root-context/pom.xml
+++ b/flow-tests/test-root-context/pom.xml
@@ -13,6 +13,7 @@
     <packaging>war</packaging>
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <ui.jar.classes>${project.build.directory}/ui-jar</ui.jar.classes>
     </properties>
 
     <dependencies>
@@ -126,7 +127,7 @@
                             <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <includes>**/webjars/*</includes>
+                            <includes>**/webjars/**</includes>
                         </configuration>
                     </execution>
                 </executions>
@@ -140,9 +141,9 @@
                         <configuration>
                             <tasks>
                                 <mkdir
-                                    dir="${project.build.directory}/ui-jar/bower_components"></mkdir>
+                                    dir="${ui.jar.classes}/frontend/bower_components"></mkdir>
                                 <move
-                                    todir="${project.build.directory}/ui-jar/bower_components">
+                                    todir="${ui.jar.classes}/frontend/bower_components">
                                     <fileset
                                         dir="${project.build.directory}/dependency/META-INF/resources/webjars/" />
                                 </move>
@@ -159,13 +160,18 @@
                 <version>1.7</version>
                 <executions>
                     <execution>
-                        <phase>process-classes</phase>
+                        <phase>package</phase>
                         <configuration>
                             <tasks>
                                 <copy
-                                    todir="${project.build.directory}/ui-jar/">
+                                    todir="${ui.jar.classes}">
                                     <fileset
                                         dir="${project.build.outputDirectory}" />
+                                </copy>
+                                <copy
+                                    todir="${ui.jar.classes}/META-INF/resources/frontend/bower_components">
+                                    <fileset
+                                        dir="${project.build.directory}/dependency/META-INF/resources/webjars/" />
                                 </copy>
                             </tasks>
                         </configuration>
@@ -251,7 +257,7 @@
                             <goal>jar</goal>
                         </goals>
                         <configuration>
-                        <classesDirectory>${project.build.directory}/ui-jar/</classesDirectory>
+                            <classesDirectory>${ui.jar.classes}</classesDirectory>
                             <!-- Class from the "test-common" module are 
                                 included into the resulting "root-context" jar. As a result we don't need 
                                 "test-common" as a dependency. Another option is to have it as a separate 

--- a/flow-tests/test-root-context/pom.xml
+++ b/flow-tests/test-root-context/pom.xml
@@ -127,6 +127,7 @@
                             <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
+                            <overWriteReleases>true</overWriteReleases>
                             <includes>**/webjars/**</includes>
                         </configuration>
                     </execution>

--- a/flow-tests/test-root-context/pom.xml
+++ b/flow-tests/test-root-context/pom.xml
@@ -73,7 +73,7 @@
             <groupId>org.webjars.bowergithub.webcomponents</groupId>
             <artifactId>webcomponentsjs</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.compendium</artifactId>
@@ -116,6 +116,66 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-dependencies</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includes>**/webjars/*</includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.7</version>
+                <executions>
+                    <execution>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <tasks>
+                                <mkdir
+                                    dir="${project.build.directory}/ui-jar/bower_components"></mkdir>
+                                <move
+                                    todir="${project.build.directory}/ui-jar/bower_components">
+                                    <fileset
+                                        dir="${project.build.directory}/dependency/META-INF/resources/webjars/" />
+                                </move>
+                            </tasks>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.7</version>
+                <executions>
+                    <execution>
+                        <phase>process-classes</phase>
+                        <configuration>
+                            <tasks>
+                                <copy
+                                    todir="${project.build.directory}/ui-jar/">
+                                    <fileset
+                                        dir="${project.build.outputDirectory}" />
+                                </copy>
+                            </tasks>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
                 <version>3.0.0</version>
@@ -128,24 +188,20 @@
                         </goals>
                         <configuration>
                             <resources>
-                                <!--  Copy resource files into META-INF/resources
-                                so that they becomes discoverable via HTTP 
-                                (there is an HttpService which registers them).
-                                But this is not enough since servlet context should
-                                also be able to find those resources and return 
-                                their content. Registering them for HTTP doesn't solve this.
-                                So there is one more resources registration below
-                                which makes them available for ServletContext.
-                                Technically only one of those registration should be needed.
-                                Needs to be fixed later on.-->
+                                <!-- Copy resource files into META-INF/resources 
+                                    so that they becomes discoverable via HTTP (there is an HttpService which 
+                                    registers them). But this is not enough since servlet context should also 
+                                    be able to find those resources and return their content. Registering them 
+                                    for HTTP doesn't solve this. So there is one more resources registration 
+                                    below which makes them available for ServletContext. Technically only one 
+                                    of those registration should be needed. Needs to be fixed later on. -->
                                 <resource>
                                     <directory>src/main/webapp</directory>
                                     <targetPath>META-INF/resources</targetPath>
                                 </resource>
-                                <!--  This should not be needed but servlet 
-                                    context doesn't find template files without this: 
-                                    files are copied into the root and they become available 
-                                    by their direct path-->
+                                <!-- This should not be needed but servlet 
+                                    context doesn't find template files without this: files are copied into the 
+                                    root and they become available by their direct path -->
                                 <resource>
                                     <directory>src/main/webapp</directory>
                                     <targetPath></targetPath>
@@ -156,20 +212,20 @@
                 </executions>
             </plugin>
             <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-war-plugin</artifactId>
-                    <version>${maven.war.plugin.version}</version>
-                    <configuration>
-                        <archive>
-                            <manifestEntries>
-                                <Implementation-Title>${project.name}
-                                </Implementation-Title>
-                                <Implementation-Version>${project.version}
-                                </Implementation-Version>
-                            </manifestEntries>
-                        </archive>
-                    </configuration>
-                </plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>${maven.war.plugin.version}</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Implementation-Title>${project.name}
+                            </Implementation-Title>
+                            <Implementation-Version>${project.version}
+                            </Implementation-Version>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
@@ -195,19 +251,16 @@
                             <goal>jar</goal>
                         </goals>
                         <configuration>
-                            <!-- 
-                            Class from the "test-common" module are included into 
-                            the resulting "root-context" jar.
-                            As a result we don't need "test-common" as a dependency.  
-                            Another option is to have it as a separate bundle.
-                            And later on may be we need a test which does it. 
-                            The lines below allows to exclude "test-common" module 
-                            classes from the "root-context" jar.
-                            I don't really know why jar plugin puts classes from 
-                            "test-common" module to the "root-context" jar.-->
-                            <!-- excludes>
-                                <exclude>**/servlet/*</exclude>
-                            </excludes-->
+                        <classesDirectory>${project.build.directory}/ui-jar/</classesDirectory>
+                            <!-- Class from the "test-common" module are 
+                                included into the resulting "root-context" jar. As a result we don't need 
+                                "test-common" as a dependency. Another option is to have it as a separate 
+                                bundle. And later on may be we need a test which does it. The lines below 
+                                allows to exclude "test-common" module classes from the "root-context" jar. 
+                                I don't really know why jar plugin puts classes from "test-common" module 
+                                to the "root-context" jar. -->
+                            <!-- excludes> <exclude>**/servlet/*</exclude> 
+                                </excludes -->
                             <classifier>ui</classifier>
                         </configuration>
                     </execution>

--- a/flow-tests/test-root-context/pom.xml
+++ b/flow-tests/test-root-context/pom.xml
@@ -140,6 +140,7 @@
                         <phase>generate-resources</phase>
                         <configuration>
                             <tasks>
+                                <delete dir="${ui.jar.classes}"></delete>
                                 <mkdir
                                     dir="${ui.jar.classes}/frontend/bower_components"></mkdir>
                                 <move

--- a/flow-tests/test-root-context/pom.xml
+++ b/flow-tests/test-root-context/pom.xml
@@ -127,7 +127,6 @@
                             <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <overWriteReleases>true</overWriteReleases>
                             <includes>**/webjars/**</includes>
                         </configuration>
                     </execution>
@@ -156,11 +155,11 @@
                             <tasks>
                                 <mkdir
                                     dir="${ui.jar.classes}/frontend/bower_components"></mkdir>
-                                <move
+                                <copy
                                     todir="${ui.jar.classes}/frontend/bower_components">
                                     <fileset
                                         dir="${project.build.directory}/dependency/META-INF/resources/webjars/" />
-                                </move>
+                                </copy>
                             </tasks>
                         </configuration>
                         <goals>

--- a/flow-tests/test-root-context/pom.xml
+++ b/flow-tests/test-root-context/pom.xml
@@ -137,6 +137,7 @@
                 <version>1.7</version>
                 <executions>
                     <execution>
+                        <id>repackage-webjars</id>
                         <phase>generate-resources</phase>
                         <configuration>
                             <tasks>
@@ -154,13 +155,8 @@
                             <goal>run</goal>
                         </goals>
                     </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.7</version>
-                <executions>
                     <execution>
+                        <id>ui-jar-classes</id>
                         <phase>package</phase>
                         <configuration>
                             <tasks>
@@ -172,7 +168,7 @@
                                 <copy
                                     todir="${ui.jar.classes}/META-INF/resources/frontend/bower_components">
                                     <fileset
-                                        dir="${project.build.directory}/dependency/META-INF/resources/webjars/" />
+                                        dir="${ui.jar.classes}/frontend/bower_components" />
                                 </copy>
                             </tasks>
                         </configuration>

--- a/flow-tests/test-root-context/pom.xml
+++ b/flow-tests/test-root-context/pom.xml
@@ -137,11 +137,22 @@
                 <version>1.7</version>
                 <executions>
                     <execution>
-                        <id>repackage-webjars</id>
-                        <phase>generate-resources</phase>
+                        <id>clean-ui-classes</id>
+                        <phase>initialize</phase>
                         <configuration>
                             <tasks>
                                 <delete dir="${ui.jar.classes}"></delete>
+                            </tasks>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>repackage-webjars</id>
+                        <phase>process-resources</phase>
+                        <configuration>
+                            <tasks>
                                 <mkdir
                                     dir="${ui.jar.classes}/frontend/bower_components"></mkdir>
                                 <move
@@ -160,8 +171,7 @@
                         <phase>package</phase>
                         <configuration>
                             <tasks>
-                                <copy
-                                    todir="${ui.jar.classes}">
+                                <copy todir="${ui.jar.classes}">
                                     <fileset
                                         dir="${project.build.outputDirectory}" />
                                 </copy>

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/AttachExistingElementIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/AttachExistingElementIT.java
@@ -20,16 +20,13 @@ import java.util.Locale;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.html.testbench.DivElement;
 import com.vaadin.flow.component.html.testbench.LabelElement;
-import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
-@Category(IgnoreOSGi.class)
 public class AttachExistingElementIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/AttachExistingElementIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/AttachExistingElementIT.java
@@ -20,13 +20,16 @@ import java.util.Locale;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.html.testbench.DivElement;
 import com.vaadin.flow.component.html.testbench.LabelElement;
+import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
+@Category(IgnoreOSGi.class)
 public class AttachExistingElementIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/CompositeIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/CompositeIT.java
@@ -17,12 +17,10 @@ package com.vaadin.flow.uitest.ui;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.html.testbench.InputTextElement;
-import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
@@ -51,7 +49,6 @@ public class CompositeIT extends ChromeBrowserTest {
     }
 
     @Test
-    @Category(IgnoreOSGi.class)
     public void htmlImportOfContentLoaded() {
         open();
         waitForElementPresent(By.id(CompositeView.COMPOSITE_PAPER_SLIDER));

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ElementInitOrderIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ElementInitOrderIT.java
@@ -20,14 +20,11 @@ import java.util.Arrays;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
 
-import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class ElementInitOrderIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/WebComponentsIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/WebComponentsIT.java
@@ -21,16 +21,13 @@ import java.util.stream.StreamSupport;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
 import org.openqa.selenium.logging.LogEntries;
 import org.openqa.selenium.logging.LogEntry;
 
-import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.parallel.BrowserUtil;
 
-@Category(IgnoreOSGi.class)
 public class WebComponentsIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/dependencies/AnnotatedFrontendInlineIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/dependencies/AnnotatedFrontendInlineIT.java
@@ -15,10 +15,6 @@
  */
 package com.vaadin.flow.uitest.ui.dependencies;
 
-import org.junit.experimental.categories.Category;
-
-import com.vaadin.flow.testcategory.IgnoreOSGi;
-
 /**
  * The test for {@link AnnotatedFrontendInlineView}.
  * <p>
@@ -29,7 +25,6 @@ import com.vaadin.flow.testcategory.IgnoreOSGi;
  * @since 1.0
  *
  */
-@Category(IgnoreOSGi.class)
 public class AnnotatedFrontendInlineIT extends AbstractFrontendInlineIT {
 
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/dependencies/FrontendInlineApiIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/dependencies/FrontendInlineApiIT.java
@@ -29,7 +29,6 @@ import com.vaadin.flow.testcategory.IgnoreOSGi;
  * @since 1.0
  *
  */
-@Category(IgnoreOSGi.class)
 public class FrontendInlineApiIT extends AbstractFrontendInlineIT {
 
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/scroll/ServerRequestScrollIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/scroll/ServerRequestScrollIT.java
@@ -17,14 +17,11 @@ package com.vaadin.flow.uitest.ui.scroll;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.html.testbench.NativeButtonElement;
-import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
-@Category(IgnoreOSGi.class)
 public class ServerRequestScrollIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/AfterServerChangesIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/AfterServerChangesIT.java
@@ -19,15 +19,12 @@ import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class AfterServerChangesIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/AttachExistingDomElementByIdIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/AttachExistingDomElementByIdIT.java
@@ -17,15 +17,12 @@ package com.vaadin.flow.uitest.ui.template;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class AttachExistingDomElementByIdIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/BasicTypeInListIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/BasicTypeInListIT.java
@@ -19,14 +19,11 @@ import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
 
-import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class BasicTypeInListIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/BeanInListingIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/BeanInListingIT.java
@@ -18,16 +18,13 @@ package com.vaadin.flow.uitest.ui.template;
 import java.util.List;
 
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 
-import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class BeanInListingIT extends ChromeBrowserTest {
 
     private static final class SelectedCondition

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/ChangeInjectedComponentTextIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/ChangeInjectedComponentTextIT.java
@@ -17,15 +17,12 @@ package com.vaadin.flow.uitest.ui.template;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class ChangeInjectedComponentTextIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/ChildOrderIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/ChildOrderIT.java
@@ -36,7 +36,6 @@ import com.vaadin.testbench.TestBenchElement;
  * @author Vaadin Ltd
  * @since 1.0.
  */
-@Category(IgnoreOSGi.class)
 public class ChildOrderIT extends ChromeBrowserTest {
 
     private TestBenchElement root;

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/ClearNodeChildrenIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/ClearNodeChildrenIT.java
@@ -37,7 +37,6 @@ import com.vaadin.testbench.TestBenchElement;
  * @author Vaadin Ltd
  * @since 1.0.
  */
-@Category(IgnoreOSGi.class)
 public class ClearNodeChildrenIT extends ChromeBrowserTest {
 
     private TestBenchElement root;

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/ConvertToBeanIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/ConvertToBeanIT.java
@@ -23,7 +23,6 @@ import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class ConvertToBeanIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/DomRepeatIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/DomRepeatIT.java
@@ -28,7 +28,6 @@ import com.vaadin.testbench.TestBenchElement;
  * @author Vaadin Ltd
  * @since 1.0.
  */
-@Category(IgnoreOSGi.class)
 public class DomRepeatIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/EmptyListsIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/EmptyListsIT.java
@@ -30,7 +30,6 @@ import org.openqa.selenium.logging.LogEntry;
 import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
-@Category(IgnoreOSGi.class)
 public class EmptyListsIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/EventHandlerIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/EventHandlerIT.java
@@ -19,14 +19,11 @@ import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
 
-import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class EventHandlerIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/HiddenTemplateIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/HiddenTemplateIT.java
@@ -24,7 +24,6 @@ import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class HiddenTemplateIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/InjectScriptTagIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/InjectScriptTagIT.java
@@ -17,15 +17,12 @@ package com.vaadin.flow.uitest.ui.template;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class InjectScriptTagIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/InjectedElementInsideMixinBehaviorIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/InjectedElementInsideMixinBehaviorIT.java
@@ -24,7 +24,6 @@ import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class InjectedElementInsideMixinBehaviorIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/InjectsJsTemplateIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/InjectsJsTemplateIT.java
@@ -24,7 +24,6 @@ import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class InjectsJsTemplateIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/InvisibleDefaultPropertyValueIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/InvisibleDefaultPropertyValueIT.java
@@ -17,14 +17,11 @@ package com.vaadin.flow.uitest.ui.template;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class InvisibleDefaultPropertyValueIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/JsGrandParentIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/JsGrandParentIT.java
@@ -16,14 +16,11 @@
 package com.vaadin.flow.uitest.ui.template;
 
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class JsGrandParentIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/LazyLoadingTemplateIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/LazyLoadingTemplateIT.java
@@ -19,16 +19,13 @@ import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class LazyLoadingTemplateIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/MutationSeveralSyncedPropsIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/MutationSeveralSyncedPropsIT.java
@@ -17,15 +17,12 @@ package com.vaadin.flow.uitest.ui.template;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class MutationSeveralSyncedPropsIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/OneWayPolymerBindingIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/OneWayPolymerBindingIT.java
@@ -20,9 +20,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
-import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
@@ -30,7 +28,6 @@ import com.vaadin.testbench.TestBenchElement;
  * @author Vaadin Ltd
  * @since 1.0.
  */
-@Category(IgnoreOSGi.class)
 public class OneWayPolymerBindingIT extends ChromeBrowserTest {
 
     // Numerous tests are carried out in the single test case, because it's

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/PolymerDefaultPropertyValueIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/PolymerDefaultPropertyValueIT.java
@@ -25,7 +25,6 @@ import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class PolymerDefaultPropertyValueIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/PolymerModelPropertiesIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/PolymerModelPropertiesIT.java
@@ -28,7 +28,6 @@ import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class PolymerModelPropertiesIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/PolymerPropertiesIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/PolymerPropertiesIT.java
@@ -23,7 +23,6 @@ import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class PolymerPropertiesIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/PolymerPropertyChangeEventIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/PolymerPropertyChangeEventIT.java
@@ -19,15 +19,12 @@ import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class PolymerPropertyChangeEventIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/PolymerPropertyMutationInObserverIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/PolymerPropertyMutationInObserverIT.java
@@ -19,16 +19,13 @@ import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class PolymerPropertyMutationInObserverIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/PropertiesUpdatedBeforeChangeEventsIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/PropertiesUpdatedBeforeChangeEventsIT.java
@@ -10,7 +10,6 @@ import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class PropertiesUpdatedBeforeChangeEventsIT extends ChromeBrowserTest {
 
     private WebElement firstPropInput;

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/RestoreViewWithAttachedByIdIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/RestoreViewWithAttachedByIdIT.java
@@ -25,7 +25,6 @@ import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class RestoreViewWithAttachedByIdIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/SubPropertyModelIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/SubPropertyModelIT.java
@@ -28,7 +28,6 @@ import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class SubPropertyModelIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/TemplateHasInjectedSubTemplateIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/TemplateHasInjectedSubTemplateIT.java
@@ -23,7 +23,6 @@ import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class TemplateHasInjectedSubTemplateIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/TemplateInTemplateIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/TemplateInTemplateIT.java
@@ -25,7 +25,6 @@ import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class TemplateInTemplateIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/TemplateInTemplateWithIdIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/TemplateInTemplateWithIdIT.java
@@ -24,7 +24,6 @@ import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class TemplateInTemplateWithIdIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/TemplateMappingDetectorIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/TemplateMappingDetectorIT.java
@@ -17,13 +17,10 @@ package com.vaadin.flow.uitest.ui.template;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
-import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class TemplateMappingDetectorIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/TemplateWithConnectedCallbacksIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/TemplateWithConnectedCallbacksIT.java
@@ -17,15 +17,12 @@ package com.vaadin.flow.uitest.ui.template;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class TemplateWithConnectedCallbacksIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/TemplatesVisibilityIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/TemplatesVisibilityIT.java
@@ -25,7 +25,6 @@ import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class TemplatesVisibilityIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/TwoWayPolymerBindingIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/TwoWayPolymerBindingIT.java
@@ -18,15 +18,12 @@ package com.vaadin.flow.uitest.ui.template;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class TwoWayPolymerBindingIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/UpdatableModelPropertiesIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/UpdatableModelPropertiesIT.java
@@ -17,14 +17,11 @@ package com.vaadin.flow.uitest.ui.template;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class UpdatableModelPropertiesIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/UpgradeElementIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/UpgradeElementIT.java
@@ -26,7 +26,6 @@ import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class UpgradeElementIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/collections/ClearListIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/collections/ClearListIT.java
@@ -18,7 +18,6 @@ import com.vaadin.testbench.TestBenchElement;
  * @author Vaadin Ltd
  * @since 1.0.
  */
-@Category(IgnoreOSGi.class)
 public class ClearListIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/collections/ListBindingIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/collections/ListBindingIT.java
@@ -22,10 +22,8 @@ import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
@@ -33,7 +31,6 @@ import com.vaadin.testbench.TestBenchElement;
  * Normal tests with @Before are not implemented because each @Test starts new
  * Chrome process.
  */
-@Category(IgnoreOSGi.class)
 public class ListBindingIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/collections/ListInsideListBindingIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/collections/ListInsideListBindingIT.java
@@ -30,7 +30,6 @@ import com.vaadin.testbench.TestBenchElement;
  * Normal tests with @Before are not implemented because each @Test starts new
  * Chrome process.
  */
-@Category(IgnoreOSGi.class)
 public class ListInsideListBindingIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/collections/ModelListIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/collections/ModelListIT.java
@@ -8,17 +8,14 @@ import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.html.testbench.DivElement;
 import com.vaadin.flow.component.html.testbench.NativeButtonElement;
-import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-@Category(IgnoreOSGi.class)
 public class ModelListIT extends ChromeBrowserTest {
 
     private TestBenchElement modelList;

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/collections/ToggleNullListIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/collections/ToggleNullListIT.java
@@ -10,7 +10,6 @@ import org.openqa.selenium.WebElement;
 import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
-@Category(IgnoreOSGi.class)
 public class ToggleNullListIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/collections/TwoWayListBindingIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/collections/TwoWayListBindingIT.java
@@ -28,7 +28,6 @@ import com.vaadin.flow.component.html.testbench.DivElement;
 import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
-@Category(IgnoreOSGi.class)
 public class TwoWayListBindingIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/imports/LazyWidgetIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/imports/LazyWidgetIT.java
@@ -18,10 +18,8 @@ package com.vaadin.flow.uitest.ui.template.imports;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
 
-import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
@@ -32,7 +30,6 @@ import com.vaadin.testbench.TestBenchElement;
  * @author Vaadin Ltd
  * @since 1.0.
  */
-@Category(IgnoreOSGi.class)
 public class LazyWidgetIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/webcomponent/PaperInputIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/webcomponent/PaperInputIT.java
@@ -26,7 +26,6 @@ import org.openqa.selenium.WebElement;
 import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
-@Category(IgnoreOSGi.class)
 public class PaperInputIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/webcomponent/PaperSliderIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/webcomponent/PaperSliderIT.java
@@ -19,14 +19,11 @@ import static org.hamcrest.CoreMatchers.is;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.flow.testcategory.IgnoreOSGi;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
-@Category(IgnoreOSGi.class)
 public class PaperSliderIT extends ChromeBrowserTest {
 
     @Test


### PR DESCRIPTION
Verification for #4490.

This allows to execute all polymer and web component tests (and make all views that depends on webjars working) in OSGi.
Webjars are not needed in the result at all : all resources are packaged with `flow-test-root-context`(`ui` classifier) jar bundle.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4629)
<!-- Reviewable:end -->
