### PR TITLE
Fix PWA file to contain es5 js.

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/default-pwa-prompt.html
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/default-pwa-prompt.html
@@ -9,7 +9,7 @@
 <script type="application/javascript">
     window.addEventListener('load', function() {
         window.Vaadin.Flow.pwaIPUI = document.getElementById("pwa-ip");
-        window.addEventListener('beforeinstallprompt', (e) => {
+        window.addEventListener('beforeinstallprompt', function(e) {
             e.preventDefault();
             window.Vaadin.Flow.deferredPrompt = e;
             window.Vaadin.Flow.pwaIPUI.style.display = "block";
@@ -19,7 +19,7 @@
             window.Vaadin.Flow.pwaIPUI.style.display = 'none';
             window.Vaadin.Flow.deferredPrompt.prompt();
             window.Vaadin.Flow.deferredPrompt.userChoice
-                .then((choiceResult) => {
+                .then(function() {
                     window.Vaadin.Flow.deferredPrompt = null;
                 });
         });


### PR DESCRIPTION
When PWA annotation is added to an app and the app page is opened in an older browser, console errors are thrown even though the PWA itself is a no-go for those browsers.
This PR removes the errors.