### PR TITLE
Fallback to npm package structure if no bower.json was found in a WebJar

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/production/ProductionModeCopyStep.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/production/ProductionModeCopyStep.java
@@ -132,9 +132,15 @@ public class ProductionModeCopyStep {
         }
         // try to find something here since there are bowergithub WebJars that have no
         // bower.json but have package.json like https://repo1.maven.org/maven2/org/webjars/bowergithub/webcomponents/shadycss/1.5.0-1/
-        return jarContentsManager
+        List<String> packageJsonFallback = jarContentsManager
                 .findFiles(webJar.getFileOrDirectory(), WEB_JAR_FILES_BASE,
                         PACKAGE_JSON_FILE_NAME);
+        if (packageJsonFallback.isEmpty()) {
+            LOGGER.warn(
+                    "Found no bower.json or package.json files inside {}. No files will be extracted.",
+                    webJar);
+        }
+        return packageJsonFallback;
     }
 
     private String getPackageDirectory(String bowerJsonPath) {


### PR DESCRIPTION
This PR is needed to support WebJars like shadycss-1.5.0 that have no bower.json but have package.json and still labelled as a bowergithub webjar.

T support is needed for the flow-maven-plugin that silently does not extract packages with no bower.json otherwise.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4641)
<!-- Reviewable:end -->
