### PR TITLE
m2eclipse integration

### DIFF
--- a/flow-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/flow-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lifecycleMappingMetadata>
+  <pluginExecutions>
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <goals>
+          <goal>copy-production-files</goal>
+          <goal>package-for-production</goal>
+        </goals>
+      </pluginExecutionFilter>
+      <action>
+        <ignore></ignore>
+      </action>
+    </pluginExecution>
+  </pluginExecutions>
+</lifecycleMappingMetadata>


### PR DESCRIPTION
It prevents eclipse marking the project with errors, thus developer does not need to add m2e exceptions in their pom.xml file or tweak eclipse to ignore these errors.

`Plugin execution not covered by lifecycle configuration: com.vaadin:flow-maven-plugin:1.0.5:copy-production-files`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4648)
<!-- Reviewable:end -->
