### PR TITLE
Autoregister frontend servlet in production mode when original frontend resources are used.

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletDeployer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletDeployer.java
@@ -48,7 +48,9 @@ import com.vaadin.flow.server.VaadinServletConfiguration;
  * annotation.</li>
  * <li>Frontend files servlet, mapped to '/frontend/*' <br>
  * The servlet is registered when the application is started in the development
- * mode.</li>
+ * mode or has
+ * {@link com.vaadin.flow.server.Constants#USE_ORIGINAL_FRONTEND_RESOURCES}
+ * parameter set to {@code true}.</li>
  * </ul>
  *
  * In addition to the rules above, a servlet won't be registered, if any servlet
@@ -109,7 +111,7 @@ public class ServletDeployer implements ServletContextListener {
             enableServlets = enableServlets
                     && !configuration.disableAutomaticServletRegistration();
             hasDevelopmentMode = hasDevelopmentMode
-                    || !configuration.isProductionMode();
+                    || !configuration.useCompiledFrontendResources();
         }
 
         if (enableServlets) {


### PR DESCRIPTION
Related to https://github.com/vaadin/flow/pull/4674

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4688)
<!-- Reviewable:end -->
