### PR TITLE
Add flow-bom module to the main POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
         <module>flow-components-parent</module>
         <module>flow-maven-plugin</module>
         <module>flow-test-generic</module>
+        <module>flow-bom</module>
         <module>build-tools</module>
     </modules>
 


### PR DESCRIPTION
flow-bom was introduced during last alpha release but forgot to add to the Main POM, so it is missing from all the releases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4695)
<!-- Reviewable:end -->
