### PR TITLE
Add a second function to allow update components on item updates

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractComponentDataGenerator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractComponentDataGenerator.java
@@ -42,7 +42,7 @@ public abstract class AbstractComponentDataGenerator<T>
         String itemKey = getItemKey(item);
         Component oldComponent = getRenderedComponent(itemKey);
         if (oldComponent != null) {
-            Component recreatedComponent = createComponent(item);
+            Component recreatedComponent = updateComponent(oldComponent, item);
 
             int oldId = oldComponent.getElement().getNode().getId();
             int newId = recreatedComponent.getElement().getNode().getId();
@@ -84,6 +84,23 @@ public abstract class AbstractComponentDataGenerator<T>
      * @return a {@link Component} which represents the provided item
      */
     protected abstract Component createComponent(T item);
+
+    /**
+     * Updates an existing component after the item has been updated. By
+     * default, it creates a new component instance via
+     * {@link #createComponent(Object)}.
+     * 
+     * @param currentComponent
+     *            the current component used to represent the item, not
+     *            <code>null</code>
+     * @param item
+     *            the updated item
+     * @return the component that should represent the updated item, not
+     *         <code>null</code>
+     */
+    protected Component updateComponent(Component currentComponent, T item) {
+        return createComponent(item);
+    }
 
     /**
      * Gets a unique key for a given item. Items with the same keys are

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/ComponentDataGenerator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/ComponentDataGenerator.java
@@ -91,6 +91,11 @@ public class ComponentDataGenerator<T>
     }
 
     @Override
+    protected Component updateComponent(Component currentComponent, T item) {
+        return componentRenderer.updateComponent(currentComponent, item);
+    }
+
+    @Override
     protected String getItemKey(T item) {
         if (keyMapper == null) {
             return null;

--- a/flow-data/src/test/java/com/vaadin/flow/data/renderer/ComponentRendererTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/renderer/ComponentRendererTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.data.renderer;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.Div;
+
+public class ComponentRendererTest {
+
+    @Test
+    public void componentFunction_invokedOnCreate() {
+        AtomicInteger createInvocations = new AtomicInteger();
+        ComponentRenderer<Div, String> renderer = new ComponentRenderer<>(
+                item -> {
+                    createInvocations.incrementAndGet();
+                    Assert.assertEquals("New item", item);
+                    return new Div();
+                });
+
+        renderer.createComponent("New item");
+
+        Assert.assertEquals(
+                "The component creation function should have been invoked once",
+                1, createInvocations.get());
+    }
+
+    @Test
+    public void componentFunction_noUpdateFunction_invokedOnUpdate() {
+        AtomicInteger createInvocations = new AtomicInteger();
+        Div div = new Div();
+        ComponentRenderer<Div, String> renderer = new ComponentRenderer<>(
+                item -> {
+                    createInvocations.incrementAndGet();
+                    Assert.assertEquals("New item", item);
+                    return div;
+                });
+
+        Component updatedComponent = renderer.updateComponent(div, "New item");
+
+        Assert.assertEquals(
+                "The component creation function should have been invoked once",
+                1, createInvocations.get());
+
+        Assert.assertEquals("The two components should be the same", div,
+                updatedComponent);
+    }
+
+    @Test
+    public void updateFunction_invokedOnUpdate() {
+        AtomicInteger createInvocations = new AtomicInteger();
+        AtomicInteger updateInvocations = new AtomicInteger();
+        ComponentRenderer<Div, String> renderer = new ComponentRenderer<>(
+                item -> {
+                    createInvocations.incrementAndGet();
+                    Assert.assertEquals("New item", item);
+                    return new Div();
+                }, (component, item) -> {
+                    updateInvocations.incrementAndGet();
+                    Assert.assertEquals("Updated item", item);
+                    return component;
+                });
+
+        Div div = renderer.createComponent("New item");
+        Component updatedComponent = renderer.updateComponent(div,
+                "Updated item");
+
+        Assert.assertEquals(
+                "The component creation function should have been invoked once",
+                1, createInvocations.get());
+        Assert.assertEquals(
+                "The component update function should have been invoked once",
+                1, updateInvocations.get());
+
+        Assert.assertEquals("The two components should be the same", div,
+                updatedComponent);
+    }
+
+}


### PR DESCRIPTION
This is important for cases like in Grid, when new a component is not
necessarily needed when an item is updated/edited. This new functions
gives the power to the developer to decide on when to update and when to
create new instances of the components.

See https://github.com/vaadin/vaadin-grid-flow/issues/368