### PR TITLE
Updated to jackson version without vulnerabilities

### DIFF
--- a/flow-components-parent/flow-code-generator-api/pom.xml
+++ b/flow-components-parent/flow-code-generator-api/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.8.7</version>
+            <version>2.9.7</version>
         </dependency>
         <dependency>
             <groupId>com.atlassian.commonmark</groupId>


### PR DESCRIPTION
Even though this isn't causing real security issues, it is still nice to get rid of warnings that tools are giving.