### PR TITLE
Get path info from VaadinRequest

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PwaHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PwaHandler.java
@@ -33,7 +33,6 @@ import com.vaadin.flow.server.PwaRegistry;
 import com.vaadin.flow.server.RequestHandler;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
-import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.server.VaadinSession;
 
 /**
@@ -124,8 +123,7 @@ public class PwaHandler implements RequestHandler {
     @Override
     public boolean handleRequest(VaadinSession session, VaadinRequest request,
             VaadinResponse response) throws IOException {
-        VaadinServletRequest httpRequest = (VaadinServletRequest) request;
-        String requestUri = httpRequest.getPathInfo();
+        String requestUri = request.getPathInfo();
 
         if (pwaRegistry.getPwaConfiguration().isEnabled()) {
             if (requestHandlerMap.containsKey(requestUri)) {


### PR DESCRIPTION
Avoids cast to `VaadinServletRequest` getting path info directly from `VaadinRequest`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4756)
<!-- Reviewable:end -->
