### PR TITLE
Only print warnings for the first time we check the properties.

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
@@ -17,6 +17,7 @@
 package com.vaadin.flow.server;
 
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -80,7 +81,7 @@ public class DefaultDeploymentConfiguration
     private boolean syncIdCheck;
     private boolean sendUrlsAsParameters;
     private boolean requestTiming;
-    private static boolean warningsLogged = false;
+    private static AtomicBoolean loggWarning = new AtomicBoolean(true);
 
     /**
      * Create a new deployment configuration instance.
@@ -105,7 +106,7 @@ public class DefaultDeploymentConfiguration
         checkPushURL();
         checkSyncIdCheck();
         checkSendUrlsAsParameters();
-        warningsLogged = true;
+        loggWarning.set(false);
     }
 
     /**
@@ -206,7 +207,7 @@ public class DefaultDeploymentConfiguration
     private void checkProductionMode() {
         productionMode = getBooleanProperty(
                 Constants.SERVLET_PARAMETER_PRODUCTION_MODE, false);
-        if (!productionMode && !warningsLogged) {
+        if (!productionMode && loggWarning.get()) {
             getLogger().warn(NOT_PRODUCTION_MODE_INFO);
         }
     }
@@ -225,7 +226,7 @@ public class DefaultDeploymentConfiguration
     private void checkXsrfProtection() {
         xsrfProtectionEnabled = !getBooleanProperty(
                 Constants.SERVLET_PARAMETER_DISABLE_XSRF_PROTECTION, false);
-        if (!xsrfProtectionEnabled && !warningsLogged) {
+        if (!xsrfProtectionEnabled && loggWarning.get()) {
             getLogger().warn(WARNING_XSRF_PROTECTION_DISABLED);
         }
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
@@ -97,16 +97,17 @@ public class DefaultDeploymentConfiguration
             Properties initParameters) {
         super(systemPropertyBaseClass, initParameters);
 
-        checkProductionMode();
+        boolean log = loggWarning.getAndSet(false);
+
+        checkProductionMode(log);
         checkRequestTiming();
-        checkXsrfProtection();
+        checkXsrfProtection(log);
         checkHeartbeatInterval();
         checkCloseIdleSessions();
         checkPushMode();
         checkPushURL();
         checkSyncIdCheck();
         checkSendUrlsAsParameters();
-        loggWarning.set(false);
     }
 
     /**
@@ -204,10 +205,10 @@ public class DefaultDeploymentConfiguration
     /**
      * Log a warning if Vaadin is not running in production mode.
      */
-    private void checkProductionMode() {
+    private void checkProductionMode(boolean loggWarning) {
         productionMode = getBooleanProperty(
                 Constants.SERVLET_PARAMETER_PRODUCTION_MODE, false);
-        if (!productionMode && loggWarning.get()) {
+        if (!productionMode && loggWarning) {
             getLogger().warn(NOT_PRODUCTION_MODE_INFO);
         }
     }
@@ -223,10 +224,10 @@ public class DefaultDeploymentConfiguration
     /**
      * Log a warning if cross-site request forgery protection is disabled.
      */
-    private void checkXsrfProtection() {
+    private void checkXsrfProtection(boolean loggWarning) {
         xsrfProtectionEnabled = !getBooleanProperty(
                 Constants.SERVLET_PARAMETER_DISABLE_XSRF_PROTECTION, false);
-        if (!xsrfProtectionEnabled && loggWarning.get()) {
+        if (!xsrfProtectionEnabled && loggWarning) {
             getLogger().warn(WARNING_XSRF_PROTECTION_DISABLED);
         }
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
@@ -135,36 +135,40 @@ public final class DeploymentConfigurationFactory implements Serializable {
         Optional<VaadinServletConfiguration> optionalConfigAnnotation = AnnotationReader
                 .getAnnotationFor(systemPropertyBaseClass,
                         VaadinServletConfiguration.class);
-        if (optionalConfigAnnotation.isPresent()) {
-            VaadinServletConfiguration configuration = optionalConfigAnnotation
-                    .get();
-            Method[] methods = VaadinServletConfiguration.class
-                    .getDeclaredMethods();
-            for (Method method : methods) {
-                VaadinServletConfiguration.InitParameterName name = method
-                        .getAnnotation(
-                                VaadinServletConfiguration.InitParameterName.class);
-                assert name != null : "All methods declared in VaadinServletConfiguration should have a @InitParameterName annotation";
 
-                try {
-                    Object value = method.invoke(configuration);
+        if (!optionalConfigAnnotation.isPresent()) {
+            return;
+        }
 
-                    String stringValue;
-                    if (value instanceof Class<?>) {
-                        stringValue = ((Class<?>) value).getName();
-                    } else {
-                        stringValue = value.toString();
-                    }
+        VaadinServletConfiguration configuration = optionalConfigAnnotation
+                .get();
+        Method[] methods = VaadinServletConfiguration.class
+                .getDeclaredMethods();
+        for (Method method : methods) {
+            VaadinServletConfiguration.InitParameterName name = method
+                    .getAnnotation(
+                            VaadinServletConfiguration.InitParameterName.class);
+            assert name
+                    != null : "All methods declared in VaadinServletConfiguration should have a @InitParameterName annotation";
 
-                    initParameters.setProperty(name.value(), stringValue);
-                } catch (Exception e) {
-                    // This should never happen
-                    throw new ServletException(
-                            "Could not read @VaadinServletConfiguration value "
-                                    + method.getName(),
-                            e);
+            try {
+                Object value = method.invoke(configuration);
+
+                String stringValue;
+                if (value instanceof Class<?>) {
+                    stringValue = ((Class<?>) value).getName();
+                } else {
+                    stringValue = value.toString();
                 }
+
+                initParameters.setProperty(name.value(), stringValue);
+            } catch (Exception e) {
+                // This should never happen
+                throw new ServletException(
+                        "Could not read @VaadinServletConfiguration value "
+                                + method.getName(), e);
             }
         }
+
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
@@ -81,7 +81,19 @@ public final class DeploymentConfigurationFactory implements Serializable {
                 createInitParameters(systemPropertyBaseClass, servletConfig));
     }
 
-    private static Properties createInitParameters(
+    /**
+     * Generate Property containing parameters for with all parameters contained in current application.
+     * @param systemPropertyBaseClass
+     *            the class to look for properties defined with annotations
+     * @param servletConfig
+     *            the config to get the rest of the properties from
+     * @return {@link Properties} instance
+     *
+     * @throws ServletException
+     *             if construction of the {@link Properties} for the parameters
+     *             fails
+     */
+    protected static Properties createInitParameters(
             Class<?> systemPropertyBaseClass, ServletConfig servletConfig)
             throws ServletException {
         Properties initParameters = new Properties();

--- a/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
@@ -59,6 +59,28 @@ public final class DeploymentConfigurationFactory implements Serializable {
                 createInitParameters(systemPropertyBaseClass, servletConfig));
     }
 
+    /**
+     * Creates a {@link DeploymentConfiguration} instance that has
+     * all parameters, specified for the current app without doing checks so
+     * property states and only returns default.
+     *
+     * @param systemPropertyBaseClass
+     *            the class to look for properties defined with annotations
+     * @param servletConfig
+     *            the config to get the rest of the properties from
+     * @return {@link DeploymentConfiguration} instance
+     *
+     * @throws ServletException
+     *             if construction of the {@link Properties} for the parameters
+     *             fails
+     */
+    public static DeploymentConfiguration createPropertyDeploymentConfiguration(
+            Class<?> systemPropertyBaseClass, ServletConfig servletConfig)
+            throws ServletException {
+        return new PropertyDeploymentConfiguration(systemPropertyBaseClass,
+                createInitParameters(systemPropertyBaseClass, servletConfig));
+    }
+
     private static Properties createInitParameters(
             Class<?> systemPropertyBaseClass, ServletConfig servletConfig)
             throws ServletException {

--- a/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server;
+
+import java.util.Locale;
+import java.util.Properties;
+import java.util.function.Function;
+
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.shared.communication.PushMode;
+
+/**
+ * The property handling implementation of {@link DeploymentConfiguration} based
+ * on a base
+ * class for resolving system properties and a set of init parameters.
+ */
+public class PropertyDeploymentConfiguration
+        extends AbstractDeploymentConfiguration {
+
+    private final Properties initParameters;
+    private final Class<?> systemPropertyBaseClass;
+
+    /**
+     * Create a new property deployment configuration instance.
+     *
+     * @param systemPropertyBaseClass
+     *         the class that should be used as a basis when reading system
+     *         properties
+     * @param initParameters
+     *         the init parameters that should make up the foundation for
+     *         this configuration
+     */
+    public PropertyDeploymentConfiguration(Class<?> systemPropertyBaseClass,
+            Properties initParameters) {
+        this.initParameters = initParameters;
+        this.systemPropertyBaseClass = systemPropertyBaseClass;
+    }
+
+    @Override
+    public <T> T getApplicationOrSystemProperty(String propertyName,
+            T defaultValue, Function<String, T> converter) {
+        // Try system properties
+        String val = getSystemProperty(propertyName);
+        if (val != null) {
+            return converter.apply(val);
+        }
+
+        // Try application properties
+        val = getApplicationProperty(propertyName);
+        if (val != null) {
+            return converter.apply(val);
+        }
+
+        return defaultValue;
+    }
+
+    /**
+     * Gets an system property value.
+     *
+     * @param parameterName
+     *         the Name or the parameter.
+     * @return String value or null if not found
+     */
+    protected String getSystemProperty(String parameterName) {
+        String pkgName;
+        final Package pkg = systemPropertyBaseClass.getPackage();
+        if (pkg != null) {
+            pkgName = pkg.getName();
+        } else {
+            final String className = systemPropertyBaseClass.getName();
+            int index = className.lastIndexOf('.');
+            if (index >= 0) {
+                pkgName = className.substring(0, index);
+            } else {
+                pkgName = null;
+            }
+        }
+        if (pkgName == null) {
+            pkgName = "";
+        } else if (!pkgName.isEmpty()) {
+            pkgName += '.';
+        }
+        String val = System.getProperty(pkgName + parameterName);
+        if (val != null) {
+            return val;
+        }
+
+        // Try lowercased system properties
+        val = System.getProperty(
+                pkgName + parameterName.toLowerCase(Locale.ENGLISH));
+
+        if (val != null) {
+            return val;
+        }
+
+        // version prefixed with just "vaadin."
+        val = System.getProperty("vaadin." + parameterName);
+
+        return val;
+    }
+
+    /**
+     * Gets an application property value.
+     *
+     * @param parameterName
+     *         the Name or the parameter.
+     * @return String value or null if not found
+     */
+    public String getApplicationProperty(String parameterName) {
+
+        String val = initParameters.getProperty(parameterName);
+        if (val != null) {
+            return val;
+        }
+
+        // Try lower case application properties for backward compatibility with
+        // 3.0.2 and earlier
+        val = initParameters.getProperty(parameterName.toLowerCase());
+
+        return val;
+    }
+
+    @Override
+    public boolean isProductionMode() {
+        return getBooleanProperty(Constants.SERVLET_PARAMETER_PRODUCTION_MODE,
+                false);
+    }
+
+    @Override
+    public boolean isRequestTiming() {
+        return getBooleanProperty(Constants.SERVLET_PARAMETER_REQUEST_TIMING,
+                !isProductionMode());
+    }
+
+    @Override
+    public boolean isXsrfProtectionEnabled() {
+        return !getBooleanProperty(
+                Constants.SERVLET_PARAMETER_DISABLE_XSRF_PROTECTION, false);
+    }
+
+    @Override
+    public boolean isSyncIdCheckEnabled() {
+        return getBooleanProperty(Constants.SERVLET_PARAMETER_SYNC_ID_CHECK,
+                true);
+    }
+
+    @Override
+    public int getHeartbeatInterval() {
+        return DefaultDeploymentConfiguration.DEFAULT_HEARTBEAT_INTERVAL;
+    }
+
+    @Override
+    public boolean isSendUrlsAsParameters() {
+        return getBooleanProperty(
+                Constants.SERVLET_PARAMETER_SEND_URLS_AS_PARAMETERS, true);
+    }
+
+    @Override
+    public boolean isCloseIdleSessions() {
+        return getBooleanProperty(
+                Constants.SERVLET_PARAMETER_CLOSE_IDLE_SESSIONS, false);
+    }
+
+    @Override
+    public PushMode getPushMode() {
+        return PushMode.DISABLED;
+    }
+
+    @Override
+    public String getPushURL() {
+        return "";
+    }
+
+    @Override
+    public Properties getInitParameters() {
+        return initParameters;
+    }
+
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
@@ -130,8 +130,8 @@ public class VaadinServlet extends HttpServlet {
      */
     protected DeploymentConfiguration createDeploymentConfiguration()
             throws ServletException {
-        return DeploymentConfigurationFactory
-                .createDeploymentConfiguration(getClass(), getServletConfig());
+        return createDeploymentConfiguration(DeploymentConfigurationFactory
+                .createInitParameters(getClass(), getServletConfig()));
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
@@ -126,27 +126,12 @@ public class VaadinServlet extends HttpServlet {
      *
      * @throws ServletException
      *             if construction of the {@link Properties} for
-     *             {@link #createDeploymentConfiguration(Properties)} fails
+     *             {@link DeploymentConfigurationFactory#createInitParameters(Class, ServletConfig)} fails
      */
     protected DeploymentConfiguration createDeploymentConfiguration()
             throws ServletException {
-        return createDeploymentConfiguration(DeploymentConfigurationFactory
-                .createDeploymentConfiguration(getClass(), getServletConfig())
-                .getInitParameters());
-    }
-
-    /**
-     * Creates a deployment configuration to be used for the creation of a
-     * {@link VaadinService}. Override this if you want to override certain
-     * properties.
-     *
-     * @param initParameters
-     *            the context-param and init-param values as properties
-     * @return the created deployment configuration
-     */
-    protected DeploymentConfiguration createDeploymentConfiguration(
-            Properties initParameters) {
-        return new DefaultDeploymentConfiguration(getClass(), initParameters);
+        return DeploymentConfigurationFactory
+                .createDeploymentConfiguration(getClass(), getServletConfig());
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
@@ -135,6 +135,20 @@ public class VaadinServlet extends HttpServlet {
     }
 
     /**
+     * Creates a deployment configuration to be used for the creation of a
+     * {@link VaadinService}. Override this if you want to override certain
+     * properties.
+     *
+     * @param initParameters
+     *            the context-param and init-param values as properties
+     * @return the created deployment configuration
+     */
+    protected DeploymentConfiguration createDeploymentConfiguration(
+            Properties initParameters) {
+        return new DefaultDeploymentConfiguration(getClass(), initParameters);
+    }
+
+    /**
      * Creates a vaadin servlet service. This method functions as a layer of
      * indirection between {@link #init(ServletConfig)} and
      * {@link #createServletService(DeploymentConfiguration)} so dependency

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletDeployer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletDeployer.java
@@ -67,7 +67,7 @@ public class ServletDeployer implements ServletContextListener {
     private static final String SKIPPING_AUTOMATIC_SERVLET_REGISTRATION_BECAUSE = "Skipping automatic servlet registration because";
 
     private static class StubServletConfig
-            implements ServletConfig, Serializable {
+            implements ServletConfig {
         private final ServletContext context;
         private final ServletRegistration registration;
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletDeployer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletDeployer.java
@@ -145,7 +145,7 @@ public class ServletDeployer implements ServletContextListener {
             ServletConfig servletConfig, Class<?> servletClass) {
         try {
             return DeploymentConfigurationFactory
-                    .createDeploymentConfiguration(servletClass, servletConfig);
+                    .createPropertyDeploymentConfiguration(servletClass, servletConfig);
         } catch (ServletException e) {
             throw new IllegalStateException(String.format(
                     "Failed to get deployment configuration data for servlet with name '%s' and class '%s'",

--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
@@ -100,6 +100,7 @@ public abstract class ClassesSerializableTest {
                 "com\\.vaadin\\.flow\\.server\\.VaadinServletResponse",
                 "com\\.vaadin\\.flow\\.server\\.startup\\.AnnotationValidator",
                 "com\\.vaadin\\.flow\\.server\\.startup\\.ServletDeployer",
+                "com\\.vaadin\\.flow\\.server\\.startup\\.ServletDeployer\\$StubServletConfig",
                 "com\\.vaadin\\.flow\\.server\\.startup\\.ServletContextListeners",
                 "com\\.vaadin\\.flow\\.server\\.communication.JSR356WebsocketInitializer(\\$.*)?",
                 "com\\.vaadin\\.flow\\.server\\.BootstrapHandler(\\$.*)?",


### PR DESCRIPTION
Added PropertyDeploymentConfiguration as there are cases where
we want to use the system/application/initParameters but wouldn't
want to do the state checking of the application.

Removed double creation of DeplymentConfiguration in VaadinServlet

Fixes https://github.com/vaadin/skeleton-starter-flow/issues/113

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4766)
<!-- Reviewable:end -->
