### PR TITLE
Make the focus call delayed

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/Focusable.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Focusable.java
@@ -24,8 +24,8 @@ package com.vaadin.flow.component;
  * @see BlurNotifier
  * @see FocusNotifier
  */
-public interface Focusable<T extends Component> extends HasElement,
-        BlurNotifier<T>, FocusNotifier<T>, HasEnabled {
+public interface Focusable<T extends Component>
+        extends HasElement, BlurNotifier<T>, FocusNotifier<T>, HasEnabled {
 
     /**
      * Sets the <code>tabindex</code> attribute in the component. The tabIndex
@@ -102,7 +102,14 @@ public interface Focusable<T extends Component> extends HasElement,
      *      at MDN</a>
      */
     default void focus() {
-        getElement().callFunction("focus");
+        /*
+         * Make sure to call the focus function only after the element is
+         * attached, and after the initial rendering cycle, so webcomponents can
+         * be ready by the time when the function is called.
+         */
+        getElement().getNode()
+                .runWhenAttached(ui -> ui.getPage().executeJavaScript(
+                        "setTimeout(function(){$0.focus();},0)", getElement()));
     }
 
     /**


### PR DESCRIPTION
The the focus call will execute under a setTimeout function, allowing
webcomponent to be attached and ready before the actual call. This fixes
the problem of calling focus() on components attached by the
flow-component-renderer inside a template, such as in Grid inline
editors.

See https://github.com/vaadin/vaadin-grid-flow/issues/404

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4767)
<!-- Reviewable:end -->
