### PR TITLE
Add property sync to DomListenerRegistration

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
@@ -1195,8 +1195,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
         assert !context.listenerRemovers.has(eventType);
 
         EventRemover remover = context.htmlNode.addEventListener(eventType,
-                event -> handleDomEvent(event, context.htmlNode, context.node),
-                false);
+                event -> handleDomEvent(event, context), false);
 
         context.listenerRemovers.set(eventType, remover);
     }
@@ -1205,8 +1204,13 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
         return node.getMap(NodeFeatures.ELEMENT_LISTENERS);
     }
 
-    private void handleDomEvent(Event event, Node element, StateNode node) {
+    private void handleDomEvent(Event event, BindingContext context) {
+        assert context != null;
+
+        Node element = context.htmlNode;
+        StateNode node = context.node;
         assert element instanceof Element : "Cannot handle DOM event for a Node";
+
         String type = event.getType();
 
         NodeMap listenerMap = getDomEventListenerMap(node);
@@ -1223,28 +1227,44 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
         String[] expressions = expressionSettings.keys();
 
         JsonObject eventData;
+        JsSet<String> synchronizeProperties = JsCollections.set();
+
         if (expressions.length == 0) {
             eventData = null;
         } else {
             eventData = Json.createObject();
 
             for (String expressionString : expressions) {
-                EventExpression expression = getOrCreateExpression(
-                        expressionString);
+                if (expressionString
+                        .startsWith(JsonConstants.SYNCHRONIZE_PROPERTY_TOKEN)) {
+                    String property = expressionString.substring(
+                            JsonConstants.SYNCHRONIZE_PROPERTY_TOKEN.length());
+                    synchronizeProperties.add(property);
+                } else {
+                    EventExpression expression = getOrCreateExpression(
+                            expressionString);
 
-                JsonValue expressionValue = expression.evaluate(event,
-                        (Element) element);
+                    JsonValue expressionValue = expression.evaluate(event,
+                            (Element) element);
 
-                eventData.put(expressionString, expressionValue);
+                    eventData.put(expressionString, expressionValue);
+                }
             }
         }
 
-        boolean sendNow = resolveFilters(element, node, type,
-                expressionSettings, eventData);
+        Consumer<String> sendCommand = debouncePhase -> {
+            synchronizeProperties
+                    .forEach(name -> syncPropertyIfNeeded(name, context));
+
+            sendEventToServer(node, type, eventData, debouncePhase);
+        };
+
+        boolean sendNow = resolveFilters(element, type, expressionSettings,
+                eventData, sendCommand);
 
         if (sendNow) {
             // Send if there were not filters or at least one matched
-            sendEventToServer(node, type, eventData, null);
+            sendCommand.accept(null);
         }
     }
 
@@ -1264,9 +1284,9 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
         node.getTree().sendEventToServer(node, type, eventData);
     }
 
-    private static boolean resolveFilters(Node element, StateNode node,
-            String eventType, JsonObject expressionSettings,
-            JsonObject eventData) {
+    private static boolean resolveFilters(Node element, String eventType,
+            JsonObject expressionSettings, JsonObject eventData,
+            Consumer<String> sendCommand) {
 
         boolean noFilters = true;
         boolean atLeastOneFilterMatched = false;
@@ -1288,9 +1308,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
 
                 // Count as a match only if at least one debounce is eager
                 filterMatched = resolveDebounces(element, debouncerId,
-                        (JsonArray) settings,
-                        triggerdPhase -> sendEventToServer(node, eventType,
-                                eventData, triggerdPhase));
+                        (JsonArray) settings, sendCommand);
             }
 
             atLeastOneFilterMatched |= filterMatched;

--- a/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtBasicElementBinderTest.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtBasicElementBinderTest.java
@@ -686,6 +686,11 @@ public class GwtBasicElementBinderTest extends GwtPropertyElementBinderTest {
     }
 
     private void addToConstantPool(String key, JsonValue value) {
+        addToConstantPool(constantPool, key, value);
+    }
+
+    public static void addToConstantPool(ConstantPool constantPool, String key,
+            JsonValue value) {
         // https://github.com/gwtproject/gwt/issues/9225
         value = Json.instance().parse(value.toJson());
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/Synchronize.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Synchronize.java
@@ -59,6 +59,14 @@ public @interface Synchronize {
     /**
      * Controls updates for the property from the client side to the server side
      * when the element is disabled.
+     * <p>
+     * When multiple update mode settings are defined for the same property, the
+     * most permissive mode is used. This means that there might be unexpected
+     * updates for a disabled component if multiple parties independently
+     * configure different aspects for the same component. This is based on the
+     * assumption that if a property is explicitly safe to update for disabled
+     * components in one context, then the nature of that property is probably
+     * such that it's also safe to update in other contexts.
      *
      * @return the property update mode for disabled element
      */

--- a/flow-server/src/main/java/com/vaadin/flow/dom/DisabledUpdateMode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/DisabledUpdateMode.java
@@ -40,5 +40,27 @@ public enum DisabledUpdateMode {
      * If used then updates from the client side are allowed only if element is
      * enabled.
      */
-    ONLY_WHEN_ENABLED
+    ONLY_WHEN_ENABLED;
+
+    /**
+     * Gets the most permissive out of two update modes.
+     *
+     * @param mode1
+     *            the first mode, or <code>null</code>
+     * @param mode2
+     *            the second mode, or <code>null</code>
+     * @return the most permissive mode, or <code>null</code> if both parameters
+     *         are <code>null</code>
+     */
+    public static DisabledUpdateMode mostPermissive(DisabledUpdateMode mode1,
+            DisabledUpdateMode mode2) {
+        if (mode1 == ALWAYS || mode2 == ALWAYS) {
+            return ALWAYS;
+        } else if (mode1 == ONLY_WHEN_ENABLED || mode2 == ONLY_WHEN_ENABLED) {
+            return ONLY_WHEN_ENABLED;
+        } else {
+            assert mode1 == null && mode2 == null;
+            return null;
+        }
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ElementListenerMap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ElementListenerMap.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -33,9 +34,11 @@ import com.vaadin.flow.dom.DisabledUpdateMode;
 import com.vaadin.flow.dom.DomEvent;
 import com.vaadin.flow.dom.DomEventListener;
 import com.vaadin.flow.dom.DomListenerRegistration;
+import com.vaadin.flow.function.SerializableRunnable;
 import com.vaadin.flow.internal.ConstantPoolKey;
 import com.vaadin.flow.internal.JsonUtils;
 import com.vaadin.flow.internal.StateNode;
+import com.vaadin.flow.shared.JsonConstants;
 
 import elemental.json.Json;
 import elemental.json.JsonObject;
@@ -102,12 +105,13 @@ public class ElementListenerMap extends NodeMap {
         private final DomEventListener origin;
         private final ElementListenerMap listenerMap;
 
-        private DisabledUpdateMode mode;
+        private DisabledUpdateMode mode = DisabledUpdateMode.ONLY_WHEN_ENABLED;
         private Set<String> eventDataExpressions;
         private String filter;
 
         private int debounceTimeout = 0;
         private EnumSet<DebouncePhase> debouncePhases = null;
+        private List<SerializableRunnable> unregisterHandlers;
 
         private DomEventListenerWrapper(ElementListenerMap listenerMap,
                 String type, DomEventListener origin) {
@@ -118,6 +122,9 @@ public class ElementListenerMap extends NodeMap {
 
         @Override
         public void remove() {
+            if (unregisterHandlers != null) {
+                unregisterHandlers.forEach(SerializableRunnable::run);
+            }
             listenerMap.removeListener(type, this);
         }
 
@@ -213,6 +220,23 @@ public class ElementListenerMap extends NodeMap {
             } else {
                 return debouncePhases.contains(phase);
             }
+        }
+
+        @Override
+        public DomListenerRegistration onUnregister(
+                SerializableRunnable unregisterHandler) {
+            if (unregisterHandlers == null) {
+                unregisterHandlers = new ArrayList<>(1);
+            }
+            unregisterHandlers.add(Objects.requireNonNull(unregisterHandler,
+                    "Unregister handler cannot be null"));
+            return this;
+        }
+
+        private boolean isPropertySynchronized(String propertyName) {
+            return eventDataExpressions != null && eventDataExpressions
+                    .contains(JsonConstants.SYNCHRONIZE_PROPERTY_TOKEN
+                            + propertyName);
         }
     }
 
@@ -408,6 +432,29 @@ public class ElementListenerMap extends NodeMap {
     Set<String> getExpressions(String name) {
         assert name != null;
         return collectEventExpressions(name).keySet();
+    }
+
+    /**
+     * Gets the most permissive update mode for any event registration that is
+     * configured to synchronize the given property.
+     *
+     * @param propertyName
+     *            the property name to check, not <code>null</code>
+     * @return the most permissive update mode, or <code>null</code> if
+     *         synchronization is not configured for the given property
+     */
+    public DisabledUpdateMode getPropertySynchronizationMode(
+            String propertyName) {
+        assert propertyName != null;
+
+        if (listeners == null) {
+            return null;
+        }
+
+        return listeners.values().stream().flatMap(List::stream)
+                .filter(wrapper -> wrapper.isPropertySynchronized(propertyName))
+                .map(wrapper -> wrapper.mode)
+                .reduce(DisabledUpdateMode::mostPermissive).orElse(null);
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/shared/JsonConstants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/JsonConstants.java
@@ -295,4 +295,12 @@ public class JsonConstants implements Serializable {
      * Character used for representing {@link DebouncePhase#TRAILING}.
      */
     public static final String EVENT_PHASE_TRAILING = "trailing";
+
+    /**
+     * Token used as an event data expression to represent that properties
+     * should be synchronized. The token is chosen to avoid collisions with
+     * regular event data expressions by using a character that cannot be the
+     * start of a valid JS expression.
+     */
+    public static final String SYNCHRONIZE_PROPERTY_TOKEN = "}";
 }

--- a/flow-server/src/test/java/com/vaadin/flow/dom/DisabledUpdateModeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/DisabledUpdateModeTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.dom;
+
+import static com.vaadin.flow.dom.DisabledUpdateMode.ALWAYS;
+import static com.vaadin.flow.dom.DisabledUpdateMode.ONLY_WHEN_ENABLED;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DisabledUpdateModeTest {
+
+    @Test
+    public void permissiveOrdering() {
+        assertMostPermissive(ALWAYS, ALWAYS, ALWAYS);
+        assertMostPermissive(ALWAYS, ALWAYS, ONLY_WHEN_ENABLED);
+        assertMostPermissive(ALWAYS, ALWAYS, null);
+
+        assertMostPermissive(ONLY_WHEN_ENABLED, ONLY_WHEN_ENABLED,
+                ONLY_WHEN_ENABLED);
+        assertMostPermissive(ONLY_WHEN_ENABLED, ONLY_WHEN_ENABLED, null);
+
+        assertMostPermissive(null, null, null);
+    }
+
+    private static void assertMostPermissive(DisabledUpdateMode expectedResult,
+            DisabledUpdateMode first, DisabledUpdateMode second) {
+
+        Assert.assertEquals(expectedResult,
+                DisabledUpdateMode.mostPermissive(first, second));
+        Assert.assertEquals(expectedResult,
+                DisabledUpdateMode.mostPermissive(second, first));
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/MapSyncRpcHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/MapSyncRpcHandlerTest.java
@@ -190,7 +190,7 @@ public class MapSyncRpcHandlerTest {
     }
 
     @Test
-    public void disabledElement_updateIsAllowed_updateIsDone()
+    public void disabledElement_updateIsAllowedBySynchronizeProperty_updateIsDone()
             throws Exception {
         Element element = ElementFactory.createDiv();
         UI ui = new UI();
@@ -206,7 +206,24 @@ public class MapSyncRpcHandlerTest {
     }
 
     @Test
-    public void implicitlyDisabledElement_updateIsAllowed_updateIsDone()
+    public void disabledElement_updateIsAllowedByEventListener_updateIsDone()
+            throws Exception {
+        Element element = ElementFactory.createDiv();
+        UI ui = new UI();
+        ui.getElement().appendChild(element);
+
+        element.setEnabled(false);
+        element.addEventListener(DUMMY_EVENT, event -> {
+        }).synchronizeProperty(TEST_PROPERTY)
+                .setDisabledUpdateMode(DisabledUpdateMode.ALWAYS);
+
+        sendSynchronizePropertyEvent(element, ui, TEST_PROPERTY, NEW_VALUE);
+
+        Assert.assertEquals(NEW_VALUE, element.getPropertyRaw(TEST_PROPERTY));
+    }
+
+    @Test
+    public void implicitlyDisabledElement_updateIsAllowedBySynchronizeProperty_updateIsDone()
             throws Exception {
         Element element = ElementFactory.createDiv();
         UI ui = new UI();
@@ -215,6 +232,23 @@ public class MapSyncRpcHandlerTest {
         ui.setEnabled(false);
         element.synchronizeProperty(TEST_PROPERTY, DUMMY_EVENT,
                 DisabledUpdateMode.ALWAYS);
+
+        sendSynchronizePropertyEvent(element, ui, TEST_PROPERTY, NEW_VALUE);
+
+        Assert.assertEquals(NEW_VALUE, element.getPropertyRaw(TEST_PROPERTY));
+    }
+
+    @Test
+    public void implicitlyDisabledElement_updateIsAllowedByEventListener_updateIsDone()
+            throws Exception {
+        Element element = ElementFactory.createDiv();
+        UI ui = new UI();
+        ui.getElement().appendChild(element);
+
+        ui.setEnabled(false);
+        element.addEventListener(DUMMY_EVENT, event -> {
+        }).synchronizeProperty(TEST_PROPERTY)
+                .setDisabledUpdateMode(DisabledUpdateMode.ALWAYS);
 
         sendSynchronizePropertyEvent(element, ui, TEST_PROPERTY, NEW_VALUE);
 
@@ -238,7 +272,7 @@ public class MapSyncRpcHandlerTest {
     @Test
     public void handleNode_callsElementPropertyMapDeferredUpdateFromClient() {
         AtomicInteger deferredUpdateInvocations = new AtomicInteger();
-        AtomicReference<String> deferredKey = new AtomicReference<String>();
+        AtomicReference<String> deferredKey = new AtomicReference<>();
         StateNode node = new StateNode(ElementPropertyMap.class) {
 
             private ElementPropertyMap map = new ElementPropertyMap(this) {

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DebounceSynchronizePropertyView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DebounceSynchronizePropertyView.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import java.util.function.Consumer;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HtmlComponent;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.component.html.Paragraph;
+import com.vaadin.flow.dom.DebouncePhase;
+import com.vaadin.flow.dom.DomEvent;
+import com.vaadin.flow.dom.DomEventListener;
+import com.vaadin.flow.dom.DomListenerRegistration;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+@Route(value = "com.vaadin.flow.uitest.ui.DebounceSynchronizePropertyView", layout = ViewTestLayout.class)
+public class DebounceSynchronizePropertyView extends AbstractDivView {
+    private final HtmlComponent input = new HtmlComponent("input");
+    private final Element inputElement = input.getElement();
+    private final Div messages = new Div();
+
+    public DebounceSynchronizePropertyView() {
+        input.getElement().setAttribute("id", "input");
+        messages.getElement().setAttribute("id", "messages");
+
+        Component eagerToggle = createModeToggle("Eager (every keypress)",
+                "eager");
+        Component filteredToggle = createModeToggle("Filtered (even length)",
+                "filtered", registration -> registration
+                        .setFilter("element.value.length % 2 === 0"));
+        Component debounceToggle = createModeToggle(
+                "Debounce (when typing pauses)", "debounce",
+                registration -> registration.debounce(1000));
+        Component lazyToggle = createModeToggle("Lazy (while typing)", "lazy",
+                registration -> registration.debounce(1000,
+                        DebouncePhase.LEADING, DebouncePhase.INTERMEDIATE));
+
+        add(eagerToggle, filteredToggle, debounceToggle, lazyToggle, input,
+                messages);
+    }
+
+    private Component createModeToggle(String caption, String id,
+            Consumer<DomListenerRegistration> configurator) {
+        Element checkbox = new Element("input");
+        checkbox.setAttribute("type", "checkbox");
+        checkbox.setAttribute("id", id);
+
+        checkbox.addEventListener("change", new DomEventListener() {
+            private DomListenerRegistration registration = null;
+
+            @Override
+            public void handleEvent(DomEvent event) {
+                if (event.getEventData().getBoolean("element.checked")) {
+                    assert registration == null;
+
+                    registration = inputElement.addPropertyChangeListener(
+                            "value", "input",
+                            propertyChange -> messages.add(new Paragraph(
+                                    "Value: " + propertyChange.getValue())));
+
+                    configurator.accept(registration);
+                } else {
+                    registration.remove();
+                    registration = null;
+                }
+            }
+        }).addEventData("element.checked");
+
+        Label label = new Label(caption);
+        label.getElement().insertChild(0, checkbox);
+        label.getElement().getStyle().set("display", "block");
+        return label;
+    }
+
+    // Shorthand without configuration to keep UI building code clean
+    private Component createModeToggle(String caption, String id) {
+        return createModeToggle(caption, id, ignore -> {
+        });
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DebounceSynchronizePropertyIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DebounceSynchronizePropertyIT.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class DebounceSynchronizePropertyIT extends ChromeBrowserTest {
+    @Test
+    public void eager() {
+        open();
+        WebElement input = findElement(By.id("input"));
+
+        toggleMode("eager");
+
+        input.sendKeys("a");
+        assertMessages("a");
+
+        input.sendKeys("b");
+        assertMessages("a", "ab");
+
+        toggleMode("eager");
+        assertMessages("a", "ab");
+    }
+
+    @Test
+    public void filtered() {
+        open();
+        WebElement input = findElement(By.id("input"));
+
+        toggleMode("filtered");
+
+        input.sendKeys("a");
+        assertMessages();
+
+        input.sendKeys("b");
+        assertMessages("ab");
+
+        input.sendKeys("c");
+        assertMessages("ab");
+
+        input.sendKeys("d");
+        assertMessages("ab", "abcd");
+    }
+
+    @Test
+    public void debounce() throws InterruptedException {
+        open();
+        WebElement input = findElement(By.id("input"));
+
+        toggleMode("debounce");
+
+        // Should not sync while typing within 1000ms from last time
+        for (String keys : Arrays.asList("a", "b", "c")) {
+            input.sendKeys(keys);
+            Thread.sleep(500);
+            assertMessages();
+        }
+
+        // Should sync after some additional inactivity
+        Thread.sleep(700);
+        assertMessages("abc");
+    }
+
+    @Test
+    public void lazy() throws InterruptedException {
+        open();
+        WebElement input = findElement(By.id("input"));
+
+        toggleMode("lazy");
+
+        input.sendKeys("a");
+        assertMessages("a");
+
+        Thread.sleep(700);
+        input.sendKeys("b");
+
+        // T + 700, only first update registered
+        assertMessages("a");
+
+        Thread.sleep(800);
+
+        // T + 1500, second update registered
+        assertMessages("a", "ab");
+        input.sendKeys("c");
+        assertMessages("a", "ab");
+
+        Thread.sleep(700);
+
+        // T + 2200, third update registered
+        assertMessages("a", "ab", "abc");
+    }
+
+    private void assertMessages(String... expectedMessages) {
+        Assert.assertArrayEquals(expectedMessages,
+                findElements(By.cssSelector("#messages p")).stream()
+                        .map(WebElement::getText)
+                        .map(text -> text.replaceFirst("Value: ", ""))
+                        .toArray(String[]::new));
+    }
+
+    private void toggleMode(String name) {
+        findElement(By.id(name)).click();
+    }
+
+}


### PR DESCRIPTION
By configuring property synchronization through a
DomListenerRegistration, it becomes possible to debounce or filter
property synchronization. This in turn is needed to implement a
universal lazy change mode for HasValue implementations that rely on
property synchronization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4773)
<!-- Reviewable:end -->
