### PR TITLE
Anchor constructor that accepts a list of components 

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.html;
 
 import java.util.Optional;
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HtmlContainer;
 import com.vaadin.flow.component.PropertyDescriptor;
 import com.vaadin.flow.component.PropertyDescriptors;
@@ -77,6 +78,22 @@ public class Anchor extends HtmlContainer {
     public Anchor(AbstractStreamResource href, String text) {
         setHref(href);
         setText(text);
+    }
+
+    /**
+     * Creates an anchor component with the given text content and href.
+     *
+     * @see #setHref(String)
+     * @see #add(Component...)
+     *
+     * @param href
+     *            the href to set
+     * @param components
+     *            The components to add
+     */
+    public Anchor(String href, Component... components) {
+        setHref(href);
+        add(components);
     }
 
     /**

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
@@ -15,8 +15,13 @@
  */
 package com.vaadin.flow.component.html;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 import org.junit.Assert;
 import org.junit.Test;
+
+import com.vaadin.flow.component.Text;
 
 public class AnchorTest extends ComponentTest {
 
@@ -28,6 +33,15 @@ public class AnchorTest extends ComponentTest {
 
         anchor.removeHref();
         Assert.assertFalse(anchor.getElement().hasAttribute("href"));
+    }
+
+    @Test
+    public void createWithComponent() {
+        Text text = new Text("Text");
+        Label label = new Label("Label");
+        Anchor anchor = new Anchor("#", text, label);
+        Assert.assertEquals(anchor.getChildren().collect(Collectors.toList()),
+                Arrays.asList(text, label));
     }
 
     // Other test methods in super class

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/RouterLinkView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/RouterLinkView.java
@@ -31,7 +31,7 @@ public class RouterLinkView extends AbstractDivView {
     }
 
     private void addImageLink() {
-        Anchor anchor = new Anchor("image/link", null);
+        Anchor anchor = new Anchor("image/link", (String) null);
         anchor.getElement().setAttribute("router-link", true);
         anchor.getStyle().set("display", "block");
 


### PR DESCRIPTION
Solution to the issue:

https://github.com/vaadin/flow/issues/4775 

It adds a constructor and a test for Anchor component.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4791)
<!-- Reviewable:end -->
