### PR TITLE
Excluding OSGi packages from ClassesSerializableTest

### DIFF
--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
@@ -141,6 +141,8 @@ public abstract class ClassesSerializableTest {
                 "com\\.vaadin\\.flow\\.osgi\\.support\\.OsgiVaadinContributor(\\$.*)?",
                 "com\\.vaadin\\.flow\\.osgi\\.support\\.OsgiVaadinStaticResource(\\$.*)?",
                 "com\\.vaadin\\.flow\\.osgi\\.support\\.VaadinResourceTrackerComponent(\\$.*)?",
+                "com\\.vaadin\\.flow\\.client\\.osgi\\..*",
+                "com\\.vaadin\\.flow\\.data\\.osgi\\..*",
                 "com\\.vaadin\\.flow\\.component\\.internal\\.HtmlImportParser",
 
                 //Various test classes


### PR DESCRIPTION
Excluding osgi packages from serializable test to avoid any `NoClassDefFoundError` in validation of components that are not dependent on OSGi.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4815)
<!-- Reviewable:end -->
