### PR TITLE
Cherry pick from master #4798

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.10.3</version>
+            <version>${jsoup.version}</version>
         </dependency>
         <!-- ph-css for parsing style attribute in Element API -->
         <dependency>

--- a/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/DefaultTemplateParser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/DefaultTemplateParser.java
@@ -163,7 +163,7 @@ public final class DefaultTemplateParser implements TemplateParser {
 
     private static void removeCommentsRecursively(Node node) {
         int i = 0;
-        while (i < node.childNodes().size()) {
+        while (i < node.childNodeSize()) {
             Node child = node.childNode(i);
             if (child instanceof Comment) {
                 child.remove();

--- a/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/TemplateDataAnalyzer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/TemplateDataAnalyzer.java
@@ -249,7 +249,17 @@ class TemplateDataAnalyzer {
                 // Two way bindings should only be in property bindings, not
                 // inside text content.
                 for (Attribute attribute : node.attributes()) {
-                    matcher.reset(attribute.getValue());
+                    String value = attribute.getValue();
+
+                    //It is legal for attributes in templates not to have values,
+                    //which is a short form for giving the attribute the value 'true'.
+                    //These attributes don't contain bindings (they're just 'true'), so we
+                    //skip them.
+                    if (value == null) {
+                        continue;
+                    }
+
+                    matcher.reset(value);
                     if (matcher.matches()) {
                         String path = matcher.group(1);
                         addTwoWayBindingPath(path);

--- a/flow-server/src/test/java/com/vaadin/flow/component/polymertemplate/PolymerTemplateTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/polymertemplate/PolymerTemplateTest.java
@@ -98,7 +98,7 @@ public class PolymerTemplateTest extends HasCurrentService {
     private static class SimpleTemplateParser extends TestTemplateParser {
 
         SimpleTemplateParser() {
-            super(tag -> "<dom-module id='" + tag + "'></dom-module>");
+            super(tag -> "<dom-module id='" + tag + "' someattrtibute></dom-module>");
         }
 
     }
@@ -148,7 +148,7 @@ public class PolymerTemplateTest extends HasCurrentService {
 
         public IdChildTemplate() {
             this(new TestTemplateParser(tag -> "<dom-module id='" + tag
-                    + "'><template><div id='child'></template></dom-module>"));
+                    + "'><template><div id='child' someattrtibute></template></dom-module>"));
         }
 
         IdChildTemplate(TestTemplateParser parser) {
@@ -196,7 +196,7 @@ public class PolymerTemplateTest extends HasCurrentService {
 
         public TemplateInTemplate() {
             this(new TestTemplateParser(tag -> "<dom-module id='" + tag
-                    + "'><template><div><ffs></div><span></span><child-template></template></dom-module>"));
+                    + "'><template><div><ffs></div><span></span><child-template someattrtibute></template></dom-module>"));
         }
 
         public TemplateInTemplate(TestTemplateParser parser) {
@@ -218,7 +218,7 @@ public class PolymerTemplateTest extends HasCurrentService {
                             + "<template><ffs></template></dom-module>"
                             + "<dom-module id='ffs'><template></template></dom-module>"
                             + "<dom-module id='" + tag
-                            + "'><template><div><ffs></div><span></span><child-template></template></dom-module>")));
+                            + "'><template><div><ffs someattrtibute></div><span></span><child-template></template></dom-module>")));
         }
 
     }
@@ -246,7 +246,7 @@ public class PolymerTemplateTest extends HasCurrentService {
         public TemplateWithChildInDomRepeat() {
             super((clazz, tag, service) -> new TemplateData("",
                     Jsoup.parse("<dom-module id='" + tag + "'><template><div>"
-                            + "<dom-repeat items='[[messages]]'><template><child-template></template></dom-repeat>"
+                            + "<dom-repeat items='[[messages]]'><template><child-template someattrtibute></template></dom-repeat>"
                             + "</div></template></dom-module>")));
         }
 
@@ -285,7 +285,7 @@ public class PolymerTemplateTest extends HasCurrentService {
                 "      <style>\n"+
                 "      </style>\n"+
                 "      <label></label>\n"+
-                "      <child-template></child-template>\n"+
+                "      <child-template someattrtibute></child-template>\n"+
                 "      \n"+
                 "      <div class='content-wrap'></div><dom-module>";
         // @formatter:on
@@ -310,7 +310,7 @@ public class PolymerTemplateTest extends HasCurrentService {
         public IdElementTemplate() {
             this((clazz, tag, service) -> new TemplateData("",
                     Jsoup.parse("<dom-module id='" + tag
-                            + "'><label id='labelId'></dom-module>")));
+                            + "'><label id='labelId' someattrtibute></dom-module>")));
         }
 
         IdElementTemplate(TemplateParser parser) {
@@ -378,7 +378,7 @@ public class PolymerTemplateTest extends HasCurrentService {
 
         public ExecutionOrder() {
             super(new TestTemplateParser(tag -> "<dom-module id='" + tag
-                    + "'><template><div id='div'></div><execution-child></execution-child></template></dom-module>"));
+                    + "'><template><div id='div'></div><execution-child someattrtibute></execution-child></template></dom-module>"));
         }
     }
 
@@ -420,8 +420,8 @@ public class PolymerTemplateTest extends HasCurrentService {
 
     @SuppressWarnings("serial")
     @Before
-    public void setUp() throws NoSuchFieldException, SecurityException,
-            IllegalArgumentException, IllegalAccessException {
+    public void setUp() throws SecurityException,
+            IllegalArgumentException {
         executionOrder.clear();
         executionParams.clear();
 
@@ -571,7 +571,7 @@ public class PolymerTemplateTest extends HasCurrentService {
                 parserCallCount.incrementAndGet();
                 if (clazz.equals(TemplateInitialization.class)) {
                     content = "<dom-module id='" + tag + "'><template>"
-                            + "<ffs id='foo'></ffs>"
+                            + "<ffs id='foo' someattrtibute></ffs>"
                             + "<child-template></child-template>"
                             + "</template></dom-module>";
                 } else {
@@ -642,7 +642,7 @@ public class PolymerTemplateTest extends HasCurrentService {
         // Make a new HTML template which contains style on the top
         TemplateInTemplate template = new TemplateInTemplate(
                 new TestTemplateParser(tag -> "<dom-module id='" + tag
-                        + "'><template><style> a { width:100%; } </style><div><ffs></div><span></span>"
+                        + "'><template><style> a { width:100%; } </style><div><ffs someattrtibute></div><span></span>"
                         + "<child-template></template></dom-module>"));
         // Nothing should be changed in the logic
         doParseTemplate_hasChildTemplate_elementIsCreatedAndSetAsVirtualChild(
@@ -788,7 +788,7 @@ public class PolymerTemplateTest extends HasCurrentService {
     }
 
     private void attachComponentAndVerifyChild(PolymerTemplate<?> template,
-            CustomComponent templateChild) {
+                                               CustomComponent templateChild) {
         VirtualChildrenList feature = template.getStateNode()
                 .getFeature(VirtualChildrenList.class);
         List<StateNode> templateNodes = new ArrayList<>();

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <npm.version>6.1.0</npm.version>
 
         <!-- Used in OSGi manifests -->
-        <jsoup.version>1.11.2</jsoup.version>
+        <jsoup.version>1.10.3</jsoup.version>
         <!-- Note that this should be kept in sync with the class Constants -->
         <atmosphere.runtime.version>2.4.30.vaadin1</atmosphere.runtime.version>
 


### PR DESCRIPTION
avoid NPE for template-files that have xml-attributes with no values (#4798)

   - attributes with no values are being skipped in the TemplateDataAnalyzer ( they cannot contain any bindings anyways )
   - flow-server now uses the same jsoup-version as the rest of the project
   - PolymerTemplateTest now has templates with value-less attributes

(cherry picked from commit 64657bfbc62a85a076d88c29871b4901c23157ba)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4817)
<!-- Reviewable:end -->
