### PR TITLE
Add custom page response for IE11 in devmode

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/UnsupportedBrowserHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/UnsupportedBrowserHandler.java
@@ -29,18 +29,66 @@ public class UnsupportedBrowserHandler extends SynchronizedRequestHandler {
 
     public static final String CLOSING_BRACKET = "    }";
 
+    private static final String UNSUPPORTED_PAGE_HEAD_CONTENT = "<head>"
+            + "  <style>"
+            + "    html {"
+            + "      background: #fff;"
+            + "      color: #444;"
+            + "      font: 400 1em/1.5 \"Helvetica Neue\", Roboto, \"Segoe UI\", sans-serif;"
+            + "      padding: 2em;"
+            + CLOSING_BRACKET
+            + "    body {"
+            + "      margin: 2em auto;"
+            + "      width: 28em;"
+            + "      max-width: 100%;"
+            + CLOSING_BRACKET
+            + "    h1 {"
+            + "      line-height: 1.1;"
+            + "      margin: 2em 0 1em;"
+            + "      color: #000;"
+            + "      font-weight: 400;"
+            + CLOSING_BRACKET
+            + "    p {"
+            + "      margin: 0.5em 0 0;"
+            + CLOSING_BRACKET
+            + "    a {"
+            + "      text-decoration: none;"
+            + "      color: #007df0;"
+            + CLOSING_BRACKET
+            + "    sub {"
+            + "      display: block;"
+            + "      margin-top: 2.5em;"
+            + "      text-align: center;"
+            + "      border-top: 1px solid #eee;"
+            + "      padding-top: 2em;"
+            + CLOSING_BRACKET
+            + "    sub,"
+            + "    small {"
+            + "      color: #999;"
+            + CLOSING_BRACKET
+            + "  </style>"
+            + "</head>";
+
     @Override
     public boolean synchronizedHandleRequest(VaadinSession session,
-            VaadinRequest request, VaadinResponse response) throws IOException {
+                                             VaadinRequest request, VaadinResponse response) throws IOException {
 
         // Check if the browser is supported
-        WebBrowser b = session.getBrowser();
-        if (b.isTooOldToFunctionProperly()) {
+        WebBrowser browser = session.getBrowser();
+        final String cookie = request.getHeader("Cookie");
+        if (browser.isTooOldToFunctionProperly()) {
             // bypass if cookie set
-            String c = request.getHeader("Cookie");
-            if (c == null || !c.contains(FORCE_LOAD_COOKIE)) {
+            if (cookie == null || !cookie.contains(FORCE_LOAD_COOKIE)) {
                 writeBrowserTooOldPage(request, response);
                 return true; // request handled
+            }
+        }
+        // check for trying to run ie11 in development mode
+        if (browser.isIE() && !session.getConfiguration().isProductionMode()) {
+            // bypass if cookie set
+            if (cookie == null || !cookie.contains(FORCE_LOAD_COOKIE)) {
+                writeIE11InDevelopmentModePage(response);
+                return true;
             }
         }
 
@@ -50,66 +98,19 @@ public class UnsupportedBrowserHandler extends SynchronizedRequestHandler {
     /**
      * Writes a page encouraging the user to upgrade to a more current browser.
      *
-     * @param request
-     *            The request to handle
-     * @param response
-     *            The response object to which a response can be written.
-     * @throws IOException
-     *             if an IO error occurred
+     * @param request  The request to handle
+     * @param response The response object to which a response can be written.
+     * @throws IOException if an IO error occurred
      */
     protected void writeBrowserTooOldPage(VaadinRequest request,
-            VaadinResponse response) throws IOException {
+                                          VaadinResponse response) throws IOException {
         Writer page = response.getWriter();
         WebBrowser browser = VaadinSession.getCurrent().getBrowser();
 
         // @formatter:off
         page.write(
                 "<html>"
-                        + "<head>"
-                        + "  <style>"
-                        + "    html {"
-                        + "      background: #fff;"
-                        + "      color: #444;"
-                        + "      font: 400 1em/1.5 \"Helvetica Neue\", Roboto, \"Segoe UI\", sans-serif;"
-                        + "      padding: 2em;"
-                        + CLOSING_BRACKET
-                        + "    body {"
-                        + "      margin: 2em auto;"
-                        + "      width: 27em;"
-                        + "      max-width: 100%;"
-                        + CLOSING_BRACKET
-                        + "    h1 {"
-                        + "      line-height: 1.1;"
-                        + "      margin: 2em 0 1em;"
-                        + "      color: #000;"
-                        + "      font-weight: 400;"
-                        + CLOSING_BRACKET
-                        + "    em {"
-                        + "      font-size: 1.2em;"
-                        + "      font-style: normal;"
-                        + "      display: block;"
-                        + "      margin-bottom: 1.2em;"
-                        + CLOSING_BRACKET
-                        + "    p {"
-                        + "      margin: 0.5em 0 0;"
-                        + CLOSING_BRACKET
-                        + "    a {"
-                        + "      text-decoration: none;"
-                        + "      color: #007df0;"
-                        + CLOSING_BRACKET
-                        + "    sub {"
-                        + "      display: block;"
-                        + "      margin-top: 2.5em;"
-                        + "      text-align: center;"
-                        + "      border-top: 1px solid #eee;"
-                        + "      padding-top: 2em;"
-                        + CLOSING_BRACKET
-                        + "    sub,"
-                        + "    small {"
-                        + "      color: #999;"
-                        + CLOSING_BRACKET
-                        + "  </style>"
-                        + "</head>"
+                        + UNSUPPORTED_PAGE_HEAD_CONTENT
                         + "<body><h1>I'm sorry, but your browser is not supported</h1>"
                         + "<p>The version (" + browser.getBrowserMajorVersion()
                         + "." + browser.getBrowserMinorVersion()
@@ -129,6 +130,40 @@ public class UnsupportedBrowserHandler extends SynchronizedRequestHandler {
                         + FORCE_LOAD_COOKIE
                         + "';window.location.reload();return false;\" href=\"#\">Continue without updating</a> (not recommended)</sub></p>"
                         + "</body>\n" + "</html>");
+        // @formatter:on
+
+        page.close();
+    }
+
+    /**
+     * Writes a page that explains that Production Mode is required for Internet Explorer 11 to work.
+     *
+     * @param response the response object to write response to
+     * @throws IOException if an IO error occurred
+     */
+    private void writeIE11InDevelopmentModePage(VaadinResponse response) throws IOException {
+        Writer page = response.getWriter();
+
+        // @formatter:off
+        page.write(
+                "<html>"
+                        + UNSUPPORTED_PAGE_HEAD_CONTENT
+                        + "<body style=\"width:34em;\"><h1>Internet Explorer 11 requires Vaadin Flow to be run in production mode.</h1>"
+                        + "<p>To test your app with IE11, you need make a production build and run the app in production mode.</p>"
+                        + "<p>The production build is made with e.g. a Maven profile that adds the <code>flow-server-production-mode</code> "
+                        + "dependency and executes the following goals for the <code>com.vaadin:vaadin-maven-plugin</code>"
+                        + "<ul><li><code>copy-production-files</code></li>"
+                        + "<li><code>package-for-production</code></li></ul></p>"
+                        + "<p>The production mode can be enabled by setting the <code>vaadin.productionMode=true</code> "
+                        + "property for the deployment configuration using an application or a system property.<p>"
+                        + "<p>You can find more information about the production mode from "
+                        + "<a href=\"https://vaadin.com/docs/flow/production/tutorial-production-mode-basic.html\">documentation</a>.</p>"
+                        + "<p><sub><a onclick=\"document.cookie='"
+                        + FORCE_LOAD_COOKIE
+                        + "';window.location.reload();return false;\" href=\"#\">Continue anyway<br>" +
+                        "(eg. if you've setup ES5 transpilation of frontend resources without running Flow in production mode)</sub></p>"
+                        + "</body>\n"
+                        + "</html>");
         // @formatter:on
 
         page.close();

--- a/flow-server/src/test/java/com/vaadin/flow/server/UnsupportedBrowserHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/UnsupportedBrowserHandlerTest.java
@@ -1,0 +1,114 @@
+package com.vaadin.flow.server;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.Writer;
+
+import com.vaadin.flow.function.DeploymentConfiguration;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+public class UnsupportedBrowserHandlerTest {
+
+    private VaadinRequest request;
+    private VaadinResponse response;
+    private VaadinSession session;
+    private UnsupportedBrowserHandler handler = new UnsupportedBrowserHandler();
+    private ArgumentCaptor<String> pageCapture = ArgumentCaptor.forClass(String.class);
+    private PrintWriter writer;
+
+    private void initMocks(boolean forceReloadCookie, boolean isTooOldToFunctionProperly, boolean isIE, boolean isProductionMode) throws IOException {
+        request = Mockito.mock(VaadinRequest.class);
+        Mockito.when(request.getHeader("Cookie")).thenReturn(forceReloadCookie ? UnsupportedBrowserHandler.FORCE_LOAD_COOKIE : null);
+
+        writer = Mockito.mock(PrintWriter.class);
+
+        response = Mockito.mock(VaadinServletResponse.class);
+        Mockito.when(response.getWriter()).thenReturn(writer);
+
+        WebBrowser webBrowser = Mockito.mock(WebBrowser.class);
+        Mockito.when(webBrowser.isTooOldToFunctionProperly()).thenReturn(isTooOldToFunctionProperly);
+        Mockito.when(webBrowser.isIE()).thenReturn(isIE);
+
+        DeploymentConfiguration configuration = Mockito.mock(DeploymentConfiguration.class);
+        Mockito.when(configuration.isProductionMode()).thenReturn(isProductionMode);
+
+        session = Mockito.mock(VaadinSession.class);
+        Mockito.when(session.getBrowser()).thenReturn(webBrowser);
+        Mockito.when(session.getConfiguration()).thenReturn(configuration);
+
+
+        VaadinSession.setCurrent(session);
+    }
+
+    @Test
+    public void testUnsupportedBrowserHandler_validBrowserInProductionMode_doesntHandleRequest() throws IOException {
+        initMocks(false, false, false, true);
+
+        Assert.assertFalse("Should not handle the request", handler.synchronizedHandleRequest(session, request, response));
+        Mockito.verify(writer, Mockito.never()).write(Mockito.anyString());
+    }
+
+    @Test
+    public void testUnsupportedBrowserHandler_validBrowserInDevelopmentMode_doesntHandleRequest() throws IOException {
+        initMocks(false, false, false, false);
+
+        Assert.assertFalse("Should not handle the request", handler.synchronizedHandleRequest(session, request, response));
+        Mockito.verify(writer, Mockito.never()).write(Mockito.anyString());
+    }
+
+    @Test
+    public void testUnsupportedBrowserHandler_tooOldBrowser_returnsUnsupportedBrowserPage() throws IOException {
+        initMocks(false, true, false, false);
+
+        Assert.assertTrue("Request should have been handled", handler.synchronizedHandleRequest(session, request, response));
+
+        Mockito.verify(writer).write(pageCapture.capture());
+
+        Assert.assertTrue("Unsupported browser page not used", pageCapture.getValue().contains("I'm sorry, but your browser is not supported"));
+    }
+
+    @Test
+    public void testUnsupportedBrowserHandler_tooOldBrowserWithForceReloadCookie_doesntHandleRequest() throws IOException {
+        initMocks(true, true, false, false);
+
+        Assert.assertFalse("Should not handle the request", handler.synchronizedHandleRequest(session, request, response));
+        Mockito.verify(writer, Mockito.never()).write(Mockito.anyString());
+    }
+
+    @Test
+    public void testUnsupportedBrowserHandler_IE11WithProductionMode_doesntHandleRequest() throws IOException {
+        initMocks(false, false, true, true);
+
+        Assert.assertFalse("Should not handle the request", handler.synchronizedHandleRequest(session, request, response));
+        Mockito.verify(writer, Mockito.never()).write(Mockito.anyString());
+    }
+
+    @Test
+    public void testUnsupportedBrowserHandler_IE11WithDevelopmentModeAndForceReload_doesntHandleRequest() throws IOException {
+        initMocks(true, false, true, false);
+
+        Assert.assertFalse("Should not handle the request", handler.synchronizedHandleRequest(session, request, response));
+        Mockito.verify(writer, Mockito.never()).write(Mockito.anyString());
+    }
+
+    @Test
+    public void testUnsupportedBrowserHandler_IE11WithDevelopmentMode_returnsIE11RequiresProductionModePage() throws IOException {
+        initMocks(false, false, true, false);
+
+        Assert.assertTrue("Request should have been handled", handler.synchronizedHandleRequest(session, request, response));
+
+        Mockito.verify(writer).write(pageCapture.capture());
+
+        Assert.assertTrue("Unsupported browser page not used", pageCapture.getValue().contains("Internet Explorer 11 requires Vaadin Flow to be run in production mode."));
+    }
+
+    @After
+    public void tearDown() {
+        VaadinSession.setCurrent(null);
+    }
+}


### PR DESCRIPTION
Makes it quite obvious that IE11 is still supported, but requires
production mode to be run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4821)
<!-- Reviewable:end -->
