### PR TITLE
Use latest bean instance from data provider

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -625,6 +625,8 @@ public class DataCommunicator<T> implements Serializable {
             boolean mapperHasKey = keyMapper.has(bean);
             String key = keyMapper.key(bean);
             if (mapperHasKey) {
+                // Ensure latest instance from provider is used
+                keyMapper.refresh(bean);
                 passivatedByUpdate.values().stream()
                         .forEach(set -> set.remove(key));
             }


### PR DESCRIPTION
To be able to test this, DataCommuniatorTest is changed to use a simple
Item bean instead of a raw String so that multiple instances with the
same identity can be distinguished.

Fixes #4761

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4830)
<!-- Reviewable:end -->
