### PR TITLE
Clear current instances on InvalidUrlTest.tearDown

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/component/InvalidUrlTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/InvalidUrlTest.java
@@ -20,6 +20,8 @@ import javax.servlet.ServletException;
 import java.util.Arrays;
 import java.util.HashSet;
 
+import com.vaadin.flow.internal.CurrentInstance;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -54,8 +56,13 @@ public class InvalidUrlTest {
                 Integer.valueOf(404), statusCodeCaptor.getValue());
     }
 
+    @After
+    public void tearDown() {
+        CurrentInstance.clearAll();
+    }
+
     private static void initUI(UI ui, String initialLocation,
-            ArgumentCaptor<Integer> statusCodeCaptor)
+                               ArgumentCaptor<Integer> statusCodeCaptor)
             throws InvalidRouteConfigurationException {
         try {
             VaadinServletRequest request = Mockito


### PR DESCRIPTION
Current instances set by this test may break other tests.
In my environment `CompositeTest` fails on `Assert.assertNull(VaadinService.getCurrent());`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4876)
<!-- Reviewable:end -->
