### PR TITLE
Add shorthand for appending a text node to HasComponents. (#4114)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/HasComponents.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasComponents.java
@@ -52,6 +52,16 @@ public interface HasComponents extends HasElement, HasEnabled {
     }
 
     /**
+     * Add the given text as children of this component.
+     *
+     * @param text
+     *            the text to add
+     */
+    default void add(String text) {
+        add(new Text(text));
+    }
+
+    /**
      * Removes the given child components from this component.
      *
      * @param components

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasComponentsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasComponentsTest.java
@@ -27,6 +27,15 @@ public class HasComponentsTest {
     }
 
     @Test
+    public void addStringToComponent() {
+        String text = "Add text";
+        TestComponent component = new TestComponent();
+        component.add(text);
+
+        Assert.assertEquals(text, component.getElement().getText());
+    }
+
+    @Test
     public void insertComponentAtFirst() {
         TestComponent component = createTestStructure();
         TestComponent innerComponent = new TestComponent();


### PR DESCRIPTION
Fixes #4114
Implement new overload method `add` to `HasComponetns`.