### PR TITLE
Bump jackson-databind version

### DIFF
--- a/flow-components-parent/flow-code-generator-api/pom.xml
+++ b/flow-components-parent/flow-code-generator-api/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.7</version>
+            <version>2.9.8</version>
         </dependency>
         <dependency>
             <groupId>com.atlassian.commonmark</groupId>


### PR DESCRIPTION
This was in a security alert so bumping the version.
The infected module is not exposed to any users, only used internally with component generator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4930)
<!-- Reviewable:end -->
