### PR TITLE
Update shadycss version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
             <dependency>
                 <groupId>org.webjars.bowergithub.webcomponents</groupId>
                 <artifactId>shadycss</artifactId>
-                <version>1.5.0-1</version>
+                <version>1.8.0</version>
             </dependency>
             <dependency>
                 <groupId>org.webjars.bowergithub.polymer</groupId>


### PR DESCRIPTION
The 1.5.0-1 version is not bower based but npm, and is breaking when used in a Flow production build.
1.8.0 is bower based. This is a breaking change for V12, but should still be included to fix the issue.

Fixes #4944

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4954)
<!-- Reviewable:end -->
