### PR TITLE
WebComponentUI and WebComponentWrapper

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/PropertyValueChangeEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/PropertyValueChangeEvent.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.webcomponent;
+
+import java.util.EventObject;
+
+/**
+ * Event fired for a web component property value change.
+ *
+ * @param <T>
+ *         type of the {@link WebComponentProperty} value
+ */
+public class PropertyValueChangeEvent<T> extends EventObject {
+
+    private final T oldValue;
+    private final T newValue;
+
+    /**
+     * PropertyValueChangeEvent constructor.
+     *
+     * @param source
+     *         {@link WebComponentProperty} with the change
+     * @param oldValue
+     *         previous value
+     * @param newValue
+     *         new value
+     */
+    public PropertyValueChangeEvent(WebComponentProperty source, T oldValue,
+            T newValue) {
+        super(source);
+        this.oldValue = oldValue;
+        this.newValue = newValue;
+    }
+
+    @Override
+    public WebComponentProperty getSource() {
+        return (WebComponentProperty) super.getSource();
+    }
+
+    /**
+     * Previous value before the change.
+     *
+     * @return previous value
+     */
+    public T getOldValue() {
+        return oldValue;
+    }
+
+    /**
+     * New value after change.
+     *
+     * @return new value
+     */
+    public T getNewValue() {
+        return newValue;
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/PropertyValueChangeListener.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/PropertyValueChangeListener.java
@@ -1,0 +1,18 @@
+package com.vaadin.flow.component.webcomponent;
+
+import java.io.Serializable;
+
+/**
+ *
+ */
+@FunctionalInterface
+public interface PropertyValueChangeListener extends Serializable {
+
+    /**
+     * Method called when target property value has changed.
+     *
+     * @param event
+     *         property value change event
+     */
+    void valueChange(PropertyValueChangeEvent event);
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentMethod.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentMethod.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.flow.component;
+package com.vaadin.flow.component.webcomponent;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -22,13 +22,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation to mark a field or a method to be published and synced on client
+ * Annotation to mark a method to be published and synced on client
  * for the generated server side WebComponent.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.FIELD, ElementType.METHOD })
+@Target({ ElementType.METHOD })
 @Documented
-public @interface WebComponentProperty {
+public @interface WebComponentMethod {
 
     /**
      * Name of the property.

--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentProperty.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentProperty.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.webcomponent;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Property value class for web components that will be published and synced on
+ * client for the generated server side WebComponent.
+ *
+ * @param <T>
+ *         property type
+ */
+public class WebComponentProperty<T> implements Serializable {
+
+    private T value;
+    private final Class<T> propertyClass;
+    Set<PropertyValueChangeListener> listeners;
+
+    /**
+     * Create a property with the given initial value to be added to the
+     * generated file.
+     *
+     * @param initialValue
+     *         initial value to generate file with
+     */
+    public WebComponentProperty(T initialValue) {
+        Objects.requireNonNull(initialValue,
+                "For a null initial value Class<T> needs to be given.");
+        value = initialValue;
+        this.propertyClass = (Class<T>) initialValue.getClass();
+    }
+
+    /**
+     * Create a property with no initial value in the generated file.
+     *
+     * @param propertyClass
+     */
+    public WebComponentProperty(Class<T> propertyClass) {
+        value = null;
+        this.propertyClass = propertyClass;
+    }
+
+    /**
+     * Set the value for this property. Will fire a {@link
+     * PropertyValueChangeEvent} if listeners have been registered.
+     *
+     * @param value
+     */
+    public void set(T value) {
+        T oldValue = this.value;
+        this.value = value;
+
+        if (listeners != null) {
+            PropertyValueChangeEvent<T> event = new PropertyValueChangeEvent<>(
+                    this, oldValue, value);
+            for (PropertyValueChangeListener listener : listeners) {
+                listener.valueChange(event);
+            }
+        }
+
+    }
+
+    public T get() {
+        return value;
+    }
+
+    public Class<T> getValueType() {
+        return propertyClass;
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentProperty.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentProperty.java
@@ -16,8 +16,11 @@
 package com.vaadin.flow.component.webcomponent;
 
 import java.io.Serializable;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+
+import com.vaadin.flow.shared.Registration;
 
 /**
  * Property value class for web components that will be published and synced on
@@ -76,10 +79,37 @@ public class WebComponentProperty<T> implements Serializable {
 
     }
 
+    /**
+     * Add a property value change listener to this property.
+     *
+     * @param listener
+     *         listener to notify for value change
+     * @return registration to remove listener with
+     */
+    public Registration addValueChangeListener(
+            PropertyValueChangeListener listener) {
+        if (listeners == null) {
+            listeners = new HashSet<>();
+        }
+        listeners.add(listener);
+
+        return () -> listeners.remove(listener);
+    }
+
+    /**
+     * Get the current property value.
+     *
+     * @return current value
+     */
     public T get() {
         return value;
     }
 
+    /**
+     * Get the property class type.
+     *
+     * @return property class type
+     */
     public Class<T> getValueType() {
         return propertyClass;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentUI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentUI.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.webcomponent;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+
+import org.slf4j.LoggerFactory;
+
+import com.vaadin.flow.component.ClientCallable;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.internal.UIInternals;
+import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.internal.nodefeature.NodeProperties;
+import com.vaadin.flow.router.Router;
+import com.vaadin.flow.server.VaadinServlet;
+import com.vaadin.flow.server.webcomponent.WebComponentRegistry;
+import com.vaadin.flow.theme.ThemeDefinition;
+import com.vaadin.flow.theme.ThemeUtil;
+
+/**
+ * Custom UI for use with WebComponents served from the server.
+ */
+public class WebComponentUI extends UI {
+
+    /**
+     * Instantiate a UI for WebComponent communication.
+     */
+    public WebComponentUI() {
+        // TODO: What should be done with the theme?
+        assignLumoThemeIfAvailable();
+    }
+
+    /**
+     * Connect a client side web component element with a server side {@link
+     * Component} that's added as a virtual child to the UI as the actual
+     * relation of the elements is unknown.
+     *
+     * @param tag
+     *         web component tag
+     * @param webComponentElementId
+     *         client side id of the element
+     */
+    @ClientCallable
+    public void connectWebComponent(String tag, String webComponentElementId) {
+        Optional<Class<? extends Component>> webComponent = WebComponentRegistry
+                .getInstance(VaadinServlet.getCurrent().getServletContext())
+                .getWebComponent(tag);
+
+        if (!webComponent.isPresent()) {
+            LoggerFactory.getLogger(WebComponentUI.class)
+                    .warn("Received connect request for non existing WebComponent '{}'",
+                            tag);
+        }
+
+        Component wcInstance = Instantiator.get(this)
+                .getOrCreate(webComponent.get());
+
+        WebComponentWrapper wrapper = new WebComponentWrapper(tag, wcInstance);
+
+        getElement().getStateProvider()
+                .appendVirtualChild(getElement().getNode(),
+                        wrapper.getElement(), NodeProperties.INJECT_BY_ID,
+                        webComponentElementId);
+        wrapper.getElement().executeJavaScript("$0.serverConnected()");
+    }
+
+    @Override
+    public Router getRouter() {
+        return null;
+    }
+
+    @Override
+    public Optional<ThemeDefinition> getThemeFor(Class<?> navigationTarget,
+            String path) {
+        return Optional.empty();
+    }
+
+    private void assignLumoThemeIfAvailable() {
+        try {
+            Field field = UIInternals.class.getDeclaredField("theme");
+            boolean accessible = field.isAccessible();
+            field.setAccessible(true);
+            field.set(getInternals(), ThemeUtil.LUMO_CLASS_IF_AVAILABLE);
+            field.setAccessible(accessible);
+        } catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentUI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentUI.java
@@ -26,6 +26,8 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.internal.UIInternals;
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.internal.nodefeature.NodeProperties;
+import com.vaadin.flow.router.HasUrlParameter;
+import com.vaadin.flow.router.QueryParameters;
 import com.vaadin.flow.router.Router;
 import com.vaadin.flow.server.VaadinServlet;
 import com.vaadin.flow.server.webcomponent.WebComponentRegistry;
@@ -88,6 +90,31 @@ public class WebComponentUI extends UI {
     public Optional<ThemeDefinition> getThemeFor(Class<?> navigationTarget,
             String path) {
         return Optional.empty();
+    }
+
+    @Override
+    public void navigate(String location) {
+        throw new UnsupportedOperationException(
+                "Navigation is not available for WebComponents");
+    }
+
+    @Override
+    public void navigate(Class<? extends Component> navigationTarget) {
+        throw new UnsupportedOperationException(
+                "Navigation is not available for WebComponents");
+    }
+
+    @Override
+    public <T, C extends Component & HasUrlParameter<T>> void navigate(
+            Class<? extends C> navigationTarget, T parameter) {
+        throw new UnsupportedOperationException(
+                "Navigation is not available for WebComponents");
+    }
+
+    @Override
+    public void navigate(String location, QueryParameters queryParameters) {
+        throw new UnsupportedOperationException(
+                "Navigation is not available for WebComponents");
     }
 
     private void assignLumoThemeIfAvailable() {

--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentWrapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentWrapper.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.webcomponent;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.LoggerFactory;
+
+import com.vaadin.flow.component.ClientCallable;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.internal.JsonCodec;
+
+import elemental.json.Json;
+import elemental.json.JsonString;
+
+/**
+ * Wrapper component for a WebComponent that exposes client callable methods
+ * that the client side components expect to be available.
+ */
+public class WebComponentWrapper extends Component {
+
+    private final Component child;
+    private final Map<String, Field> fields;
+    private final Map<String, Method> methods;
+
+    /**
+     * Wrapper class for the server side WebComponent.
+     *
+     * @param tag
+     *         web component tag
+     * @param child
+     *         actual web component instance
+     */
+    public WebComponentWrapper(String tag, Component child) {
+        super(new Element(tag));
+
+        this.child = child;
+        getElement().appendChild(child.getElement());
+
+        this.fields = getPropertyFields(child.getClass());
+        this.methods = getPropertyMethods(child.getClass());
+    }
+
+    /**
+     * Synchronize method for client side to send property value updates to the
+     * server.
+     *
+     * @param property
+     *         property name to update
+     * @param newValue
+     *         the new value to set
+     */
+    @ClientCallable
+    public void sync(String property, String newValue) {
+        try {
+            if (methods.containsKey(property)) {
+                Method method = methods.get(property);
+                boolean accessible = method.isAccessible();
+                method.setAccessible(true);
+
+                Class<?>[] parameterTypes = method.getParameterTypes();
+
+                if (String.class.isAssignableFrom(parameterTypes[0])) {
+                    method.invoke(child, newValue);
+                } else {
+                    JsonString value = Json.create(newValue);
+                    if (JsonCodec.canEncodeWithoutTypeInfo(parameterTypes[0])) {
+                        method.invoke(child,
+                                JsonCodec.decodeAs(value, parameterTypes[0]));
+                    } else {
+                        throw new IllegalArgumentException(String.format(
+                                "Received value wasn't convertible to '%s'",
+                                parameterTypes[0].getName()));
+                    }
+                }
+
+                method.setAccessible(accessible);
+            } else if (fields.containsKey(property)) {
+                Field field = fields.get(property);
+                boolean accessible = field.isAccessible();
+                field.setAccessible(true);
+                WebComponentProperty fieldProperty = (WebComponentProperty) field
+                        .get(child);
+
+                if (String.class
+                        .isAssignableFrom(fieldProperty.getValueType())) {
+                    fieldProperty.set(newValue);
+                } else {
+
+                    JsonString value = Json.create(newValue);
+                    if (JsonCodec.canEncodeWithoutTypeInfo(
+                            fieldProperty.getValueType())) {
+                        fieldProperty.set(JsonCodec
+                                .decodeAs(value, fieldProperty.getValueType()));
+                    } else {
+                        throw new IllegalArgumentException(String.format(
+                                "Received value wasn't convertible to '%s'",
+                                fieldProperty.getValueType().getName()));
+                    }
+                }
+
+                //                    ((WCProperty<Object>) field.get(child)).set(newValue);
+                field.setAccessible(accessible);
+            } else {
+                System.err.println("No method found for " + property);
+            }
+        } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+            LoggerFactory.getLogger(child.getClass())
+                    .error("Failed to synchronise property '{}'", property, e);
+        }
+    }
+
+    /**
+     * Get all methods published to the client side as properties.
+     *
+     * @param webComponent
+     *         component to get all methods for
+     * @return map containing property name and {@link Method}
+     */
+    private static Map<String, Method> getPropertyMethods(
+            Class<?> webComponent) {
+        Map<String, Method> methods = new HashMap<>();
+
+        for (Method method : webComponent.getDeclaredMethods()) {
+            WebComponentMethod ann = method
+                    .getAnnotation(WebComponentMethod.class);
+            if (ann != null) {
+                methods.put(ann.value(), method);
+            }
+        }
+        return methods;
+    }
+
+    /**
+     * Get all fields published to the client side as properties.
+     *
+     * @param webComponent
+     *         component to get all fields for
+     * @return map containing property name and {@link Field}
+     */
+    private static Map<String, Field> getPropertyFields(Class<?> webComponent) {
+        Map<String, Field> fields = new HashMap<>();
+
+        for (Field field : webComponent.getDeclaredFields()) {
+            if (WebComponentProperty.class.isAssignableFrom(field.getType())) {
+                fields.put(field.getName(), field);
+            }
+        }
+        return fields;
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/webcomponent/WebComponentPropertyTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/webcomponent/WebComponentPropertyTest.java
@@ -1,0 +1,127 @@
+package com.vaadin.flow.component.webcomponent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.shared.Registration;
+
+public class WebComponentPropertyTest {
+
+    @Test
+    public void webComponentProperty_returnsCorrectType() {
+        // String
+        WebComponentProperty<String> string = new WebComponentProperty<>(
+                String.class);
+        Assert.assertEquals("Wrong class value type for given class type",
+                String.class, string.getValueType());
+
+        string = new WebComponentProperty<>("hi");
+        Assert.assertEquals(
+                "Wrong class value type received from initalValue.'",
+                String.class, string.getValueType());
+
+        // Integer
+        WebComponentProperty<Integer> integer = new WebComponentProperty<>(
+                Integer.class);
+        Assert.assertEquals("Wrong class value type for given class type",
+                Integer.class, integer.getValueType());
+
+        integer = new WebComponentProperty<>(15);
+        Assert.assertEquals(
+                "Wrong class value type received from initalValue.'",
+                Integer.class, integer.getValueType());
+
+        // Boolean
+        WebComponentProperty<Boolean> bool = new WebComponentProperty<>(
+                Boolean.class);
+        Assert.assertEquals("Wrong class value type for given class type",
+                Boolean.class, bool.getValueType());
+
+        bool = new WebComponentProperty<>(true);
+        Assert.assertEquals(
+                "Wrong class value type received from initalValue.'",
+                Boolean.class, bool.getValueType());
+
+        // Long
+        WebComponentProperty<Long> longProperty = new WebComponentProperty<>(
+                Long.class);
+        Assert.assertEquals("Wrong class value type for given class type",
+                Long.class, longProperty.getValueType());
+
+        longProperty = new WebComponentProperty<>(15l);
+        Assert.assertEquals(
+                "Wrong class value type received from initalValue.'",
+                Long.class, longProperty.getValueType());
+    }
+
+    @Test
+    public void webComponentProperty_changeEventFiredWithCorrectData() {
+
+        WebComponentProperty<String> string = new WebComponentProperty<>(
+                String.class);
+        WebComponentProperty<Long> longProperty = new WebComponentProperty<>(
+                Long.class);
+
+        List<PropertyValueChangeEvent<?>> events = new ArrayList<>();
+
+        string.addValueChangeListener(events::add);
+        longProperty.addValueChangeListener(events::add);
+
+        longProperty.set(20l);
+
+        string.set("new");
+
+        string.set("second");
+
+        longProperty.set(42l);
+
+        Assert.assertEquals(4, events.size());
+
+        Assert.assertEquals(longProperty, events.get(0).getSource());
+        Assert.assertEquals(string, events.get(1).getSource());
+        Assert.assertEquals(string, events.get(2).getSource());
+        Assert.assertEquals(longProperty, events.get(3).getSource());
+
+        Assert.assertNull("Unexpected non null value for longValue",
+                events.get(0).getOldValue());
+        Assert.assertEquals("Unexpected new value", 20l,
+                events.get(0).getNewValue());
+        Assert.assertEquals("Second update old value was wrong", 20l,
+                events.get(3).getOldValue());
+        Assert.assertEquals("Unexpected new value", 42l,
+                events.get(3).getNewValue());
+
+        Assert.assertNull("Unexpected non null value for string",
+                events.get(1).getOldValue());
+        Assert.assertEquals("Unexpected new value", "new",
+                events.get(1).getNewValue());
+        Assert.assertEquals("Second update old value was wrong", "new",
+                events.get(2).getOldValue());
+        Assert.assertEquals("Unexpected new value", "second",
+                events.get(2).getNewValue());
+    }
+
+    @Test
+    public void webComponentProperty_removedListenerGetsNoEvent() {
+        WebComponentProperty<String> string = new WebComponentProperty<>(
+                String.class);
+
+        List<PropertyValueChangeEvent<?>> events = new ArrayList<>();
+
+        Registration registration = string.addValueChangeListener(events::add);
+
+        string.set("new");
+
+        Assert.assertEquals("Listener should have fired", 1, events.size());
+
+        registration.remove();
+
+        string.set("old");
+
+        Assert.assertEquals("Removed listener should not get an event", 1,
+                events.size());
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/webcomponent/WebComponentWrapperTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/webcomponent/WebComponentWrapperTest.java
@@ -1,0 +1,94 @@
+package com.vaadin.flow.component.webcomponent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.WebComponent;
+import com.vaadin.flow.dom.Element;
+
+public class WebComponentWrapperTest {
+
+    @Test
+    public void wrappedMyComponent_syncSetsCorrectValuesToBothFieldAndMethod() {
+        MyComponent component = new MyComponent();
+        WebComponentWrapper wrapper = new WebComponentWrapper("my-component",
+                component);
+
+        wrapper.sync("response", "test value");
+
+        Assert.assertEquals("Response field should have updated with new value",
+                "test value", component.response.get());
+
+        wrapper.sync("message", "MyMessage");
+
+        Assert.assertEquals(
+                "Message should have updated through 'setMessage' method",
+                "MyMessage", component.message);
+
+        wrapper.sync("integerValue", "10");
+
+        Assert.assertEquals(
+                "IntegerValule field should contain a matching integer value",
+                Integer.valueOf(10), component.integerValue.get());
+    }
+
+    @Test
+    public void wrappedComponentPropertyListener_listenerFiredWithCorrectValuesOnSync() {
+        MyComponent component = new MyComponent();
+        WebComponentWrapper wrapper = new WebComponentWrapper("my-component",
+                component);
+
+        List<PropertyValueChangeEvent<?>> events = new ArrayList<>();
+
+        component.response.addValueChangeListener(events::add);
+        component.integerValue.addValueChangeListener(events::add);
+
+        wrapper.sync("response", "update");
+        wrapper.sync("integerValue", "15");
+
+        Assert.assertEquals(
+                "Only one event for each sync should have taken place", 2,
+                events.size());
+
+        Assert.assertEquals("First event source should be 'response'",
+                component.response, events.get(0).getSource());
+
+        Assert.assertEquals("Second event source should be 'integerValue'",
+                component.integerValue, events.get(1).getSource());
+
+        Assert.assertEquals("OldValue should match default value", "hello",
+                events.get(0).getOldValue());
+        Assert.assertEquals("NewValue should match updated value", "update",
+                events.get(0).getNewValue());
+
+        Assert.assertNull("OldValue should be null as no default was given",
+                events.get(1).getOldValue());
+        Assert.assertEquals("New value should be a matching Integer",
+                Integer.valueOf(15), events.get(1).getNewValue());
+
+    }
+
+    @WebComponent("my-component")
+    public static class MyComponent extends Component {
+
+        protected String message;
+        protected WebComponentProperty<String> response = new WebComponentProperty<>(
+                "hello");
+        protected WebComponentProperty<Integer> integerValue = new WebComponentProperty<>(
+                Integer.class);
+
+        public MyComponent() {
+            super(new Element("div"));
+        }
+
+        @WebComponentMethod("message")
+        public void setMessage(String message) {
+            this.message = message;
+        }
+
+    }
+}


### PR DESCRIPTION
Create a UI for use with WebComponents and a Wrapper component for handling property synchronization.

Splits `@WebComponentProperty` to `WebComponentProperty<T>` and `@WebComponentMethod`

Closes #4919 