### PR TITLE
Fix javadocs for getId() and setId()

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/Component.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Component.java
@@ -383,8 +383,8 @@ public abstract class Component
      * page.
      *
      * @param id
-     *            the id to set, or <code>null</code> to remove any previously
-     *            set id
+     *            the id to set, or <code>""</code> to remove any previously set
+     *            id
      */
     public void setId(String id) {
         set(idDescriptor, id);
@@ -395,7 +395,7 @@ public abstract class Component
      *
      * @see #setId(String)
      *
-     * @return the id, or <code>""</code> if no id has been set
+     * @return the id, or and empty optional if no id has been set
      */
     public Optional<String> getId() {
         return get(idDescriptor);


### PR DESCRIPTION
For some reason, the javadoc was based on representing absence of id as
`null`, whereas the implementation uses empty string in the setter and
empty optional in the getter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4960)
<!-- Reviewable:end -->
