### PR TITLE
Log more details from UIDL serialization fails

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlRequestHandler.java
@@ -43,7 +43,7 @@ import elemental.json.JsonObject;
 
 /**
  * Processes a UIDL request from the client.
- *
+ * <p>
  * Uses {@link ServerRpcHandler} to execute client-to-server RPC invocations and
  * {@link UidlWriter} to write state changes and client RPC calls back to the
  * client.
@@ -118,8 +118,23 @@ public class UidlRequestHandler extends SynchronizedRequestHandler
     private static void writeUidl(UI ui, Writer writer) throws IOException {
         JsonObject uidl = new UidlWriter().createUidl(ui, false);
 
-        // some dirt to prevent cross site scripting
-        String responseString = "for(;;);[" + uidl.toJson() + "]";
+        String responseString;
+        try {
+            // some dirt to prevent cross site scripting
+            responseString = "for(;;);[" + uidl.toJson() + "]";
+        } catch (Exception exception) {
+            // provide more details to if the UIDL could not be serialized to JSON to help debugging
+            // there are cases with NPE thrown from inside elementa.json without details to what is the issue
+            StringBuilder messageBuilder = new StringBuilder("Error trying to serialize UIDL to JSON, active location was ");
+            try {
+                messageBuilder.append(ui.getInternals().getActiveViewLocation().getPathWithQueryParameters());
+            } catch (Exception another) {
+                messageBuilder.append("<could not parse location due to ").append(another.getMessage()).append(">");
+            }
+            getLogger().error(messageBuilder.toString(), exception);
+            // let any registered error handlers take care of what happens next
+            throw exception;
+        }
         writer.write(responseString);
     }
 


### PR DESCRIPTION
There has been an NPE without good details on the website, so added current location to the case when JSON serialization fails due to internal errors in elemental.json.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4971)
<!-- Reviewable:end -->
