### PR TITLE
Allows configuring listenOn component for Focus and Click shortcuts

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
@@ -57,17 +57,20 @@ public interface ClickNotifier<T extends Component> extends Serializable {
      * Adds a shortcut which 'clicks' the {@link Component} which implements
      * {@link ClickNotifier} interface. The shortcut's event listener is in
      * global scope and the shortcut's lifecycle is tied to {@code this}
-     * component. For more configuration options, use {@link
-     * #registerClickShortcut(Key)}.
+     * component.
+     * <p>
+     * Use the returned {@link ShortcutRegistration} to fluently configure the
+     * shortcut.
      *
      * @param key
      *              Primary {@link Key} used to trigger the shortcut
      * @param keyModifiers
      *              {@link KeyModifier KeyModifiers} that need to be pressed
      *              along with the {@code key} for the shortcut to trigger
-     * @return {@link Registration} used to remove the shortcut
+     * @return {@link ShortcutRegistration} used to remove the shortcut
      */
-    default Registration addClickShortcut(Key key, KeyModifier... keyModifiers) {
+    default ShortcutRegistration addClickShortcut(Key key,
+                                                  KeyModifier... keyModifiers) {
         if (!(this instanceof Component)) {
             throw new IllegalStateException(String.format(
                     "The class '%s' doesn't extend '%s'. "
@@ -81,39 +84,9 @@ public interface ClickNotifier<T extends Component> extends Serializable {
                     String.format(Shortcuts.NULL, key));
         }
 
-        return registerClickShortcut(key).withModifiers(keyModifiers);
-    }
-
-    /**
-     * Registers a shortcut which 'clicks' the {@link Component} which
-     * implements {@link ClickNotifier} interface. The shortcut's event listener
-     * is in global scope and the shortcut's lifecycle is tied to {@code this}
-     * component.
-     * <p>
-     * Use the returned {@link ShortcutRegistration} to fluently configure the
-     * {@link KeyModifier KeyModifiers} and other values.
-     *
-     * @param key
-     *              Primary {@link Key} used to trigger the shortcut
-     * @return {@link ShortcutRegistration} used to configure the shortcut
-     */
-    default ShortcutRegistration registerClickShortcut(Key key) {
-        if (!(this instanceof Component)) {
-            throw new IllegalStateException(String.format(
-                    "The class '%s' doesn't extend '%s'. "
-                            + "Make your implementation for the method '%s'.",
-                    getClass().getName(), Component.class.getSimpleName(),
-                    "registerClickShortcut(Key)"));
-        }
-
-        if (key == null) {
-            throw new InvalidParameterException(
-                    String.format(Shortcuts.NULL, key));
-        }
-
         final Component _this = (Component) this;
         return new ShortcutRegistration(_this, UI::getCurrent,
                 () -> ComponentUtil.fireEvent(_this, new ClickEvent<>(_this)),
-                key);
+                key).withModifiers(keyModifiers);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
@@ -67,7 +67,8 @@ public interface ClickNotifier<T extends Component> extends Serializable {
      * @param keyModifiers
      *              {@link KeyModifier KeyModifiers} that need to be pressed
      *              along with the {@code key} for the shortcut to trigger
-     * @return {@link ShortcutRegistration} used to remove the shortcut
+     * @return  {@link ShortcutRegistration} for configuring the shortcut and
+     *          removing
      */
     default ShortcutRegistration addClickShortcut(Key key,
                                                   KeyModifier... keyModifiers) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
@@ -84,9 +84,10 @@ public interface ClickNotifier<T extends Component> extends Serializable {
                     String.format(Shortcuts.NULL, key));
         }
 
-        final Component _this = (Component) this;
-        return new ShortcutRegistration(_this, UI::getCurrent,
-                () -> ComponentUtil.fireEvent(_this, new ClickEvent<>(_this)),
+        final Component thisComponent = (Component) this;
+        return new ShortcutRegistration(thisComponent, UI::getCurrent,
+                () -> ComponentUtil.fireEvent(thisComponent, new ClickEvent<>(
+                        thisComponent)),
                 key).withModifiers(keyModifiers);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
@@ -82,7 +82,7 @@ public interface ClickNotifier<T extends Component> extends Serializable {
 
         if (key == null) {
             throw new InvalidParameterException(
-                    String.format(Shortcuts.NULL, key));
+                    String.format(Shortcuts.NULL, "key"));
         }
 
         final Component thisComponent = (Component) this;

--- a/flow-server/src/main/java/com/vaadin/flow/component/Focusable.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Focusable.java
@@ -156,7 +156,7 @@ public interface Focusable<T extends Component>
 
         if (key == null) {
             throw new InvalidParameterException(
-                    String.format(Shortcuts.NULL, key));
+                    String.format(Shortcuts.NULL, "key"));
         }
 
         return new ShortcutRegistration((Component) this, UI::getCurrent,

--- a/flow-server/src/main/java/com/vaadin/flow/component/Focusable.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Focusable.java
@@ -131,17 +131,20 @@ public interface Focusable<T extends Component>
     /**
      * Adds a shortcut which focuses the {@link Component} which implements
      * {@link Focusable} interface. The shortcut's event listener is in global
-     * scope and the shortcut's lifecycle is tied to {@code this} component. For
-     * more configuration options, use {@link #registerFocusShortcut(Key)}.
+     * scope and the shortcut's lifecycle is tied to {@code this} component.
+     * <p>
+     * Use the returned {@link ShortcutRegistration} to fluently configure the
+     * shortcut.
      *
      * @param key
      *              Primary {@link Key} used to trigger the shortcut
      * @param keyModifiers
      *              {@link KeyModifier KeyModifiers} that need to be pressed
      *              along with the {@code key} for the shortcut to trigger
-     * @return {@link Registration} used to remove the shortcut
+     * @return {@link ShortcutRegistration} used to remove the shortcut
      */
-    default Registration addFocusShortcut(Key key, KeyModifier... keyModifiers) {
+    default ShortcutRegistration addFocusShortcut(Key key,
+                                                  KeyModifier... keyModifiers) {
         if (!(this instanceof Component)) {
             throw new IllegalStateException(String.format(
                     "The class '%s' doesn't extend '%s'. "
@@ -155,36 +158,7 @@ public interface Focusable<T extends Component>
                     String.format(Shortcuts.NULL, key));
         }
 
-        return this.registerFocusShortcut(key).withModifiers(keyModifiers);
-    }
-
-    /**
-     * Registers a shortcut which focuses the {@link Component} which implements
-     * {@link Focusable} interface. The shortcut's event listener is in global
-     * scope and the shortcut's lifecycle is tied to {@code this} component.
-     * <p>
-     * Use the returned {@link ShortcutRegistration} to fluently configure the
-     * {@link KeyModifier KeyModifiers} and other values.
-     *
-     * @param key
-     *              Primary {@link Key} used to trigger the shortcut
-     * @return {@link ShortcutRegistration} used to configure the shortcut
-     */
-    default ShortcutRegistration registerFocusShortcut(Key key) {
-        if (!(this instanceof Component)) {
-            throw new IllegalStateException(String.format(
-                    "The class '%s' doesn't extend '%s'. "
-                            + "Make your implementation for the method '%s'.",
-                    getClass().getName(), Component.class.getSimpleName(),
-                    "registerFocusShortcut(Key)"));
-        }
-
-        if (key == null) {
-            throw new InvalidParameterException(
-                    String.format(Shortcuts.NULL, key));
-        }
-
         return new ShortcutRegistration((Component) this, UI::getCurrent,
-                this::focus, key);
+                this::focus, key).withModifiers(keyModifiers);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/Focusable.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Focusable.java
@@ -141,7 +141,8 @@ public interface Focusable<T extends Component>
      * @param keyModifiers
      *              {@link KeyModifier KeyModifiers} that need to be pressed
      *              along with the {@code key} for the shortcut to trigger
-     * @return {@link ShortcutRegistration} used to remove the shortcut
+     * @return  {@link ShortcutRegistration} for configuring the shortcut and
+     *          removing
      */
     default ShortcutRegistration addFocusShortcut(Key key,
                                                   KeyModifier... keyModifiers) {
@@ -160,5 +161,6 @@ public interface Focusable<T extends Component>
 
         return new ShortcutRegistration((Component) this, UI::getCurrent,
                 this::focus, key).withModifiers(keyModifiers);
+
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -532,7 +532,9 @@ public class ShortcutRegistration implements Registration, Serializable {
     private static String generateEventModifierFilter(
             Collection<Key> modifiers) {
 
-        if (modifiers.size() == 0) return "true";
+        if (modifiers.isEmpty()) {
+            return "true";
+        }
 
         return modifiers.stream().filter(Key::isModifier)
                 .map(modifier ->
@@ -542,8 +544,8 @@ public class ShortcutRegistration implements Registration, Serializable {
     }
 
     private static String generateEventKeyFilter(Key key) {
-        // will now allow shortcut to happen without primary key
-        if (key == null) return "false";
+        assert key != null;
+
         String keyList = "[" + key.getKeys().stream().map(s -> "'" + s + "'")
                 .collect(Collectors.joining(",")) + "]";
         return  "(" + keyList + ".indexOf(event.code) !== -1 || " +
@@ -611,7 +613,7 @@ public class ShortcutRegistration implements Registration, Serializable {
      * together.
      */
     private static class CompoundRegistration implements Registration {
-        Set<Registration> registrations;
+        private Set<Registration> registrations;
 
         CompoundRegistration(Registration... registrations) {
             this.registrations = new HashSet<>(Arrays.asList(registrations));

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -226,7 +226,7 @@ public class ShortcutRegistration implements Registration, Serializable {
      */
     public ShortcutRegistration listenOn(Component listenOnComponent) {
             removeAllListenerRegistrations();
-            this. listenOnSupplier = () -> listenOnComponent;
+            this.listenOnSupplier = () -> listenOnComponent;
             prepareForClientResponse();
 
             return this;

--- a/flow-server/src/main/java/com/vaadin/flow/component/Shortcuts.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Shortcuts.java
@@ -29,8 +29,8 @@ public final class Shortcuts {
      * Registering a shortcut using this method will tie it to
      * {@code lifecycleOwner} and the shortcut is available in the global scope.
      * <p>
-     * By default, the shortcut's listener is bound to the given
-     * {@code lifecycleOwner}. The listening component can be changed by calling
+     * By default, the shortcut's listener is bound to {@link UI}. The listening
+     * component can be changed by calling
      * {@link ShortcutRegistration#listenOn(Component)}.
      *
      * @param lifecycleOwner
@@ -61,7 +61,7 @@ public final class Shortcuts {
         if (key == null) {
             throw new InvalidParameterException(String.format(NULL, "key"));
         }
-        return new ShortcutRegistration(lifecycleOwner, () -> lifecycleOwner,
-                command, key);
+        return new ShortcutRegistration(lifecycleOwner, UI::getCurrent,
+                command, key).withModifiers(keyModifiers);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/Shortcuts.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Shortcuts.java
@@ -1,11 +1,17 @@
 /*
  * Copyright 2000-2019 Vaadin Ltd.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 
 package com.vaadin.flow.component;
@@ -13,7 +19,6 @@ package com.vaadin.flow.component;
 import java.security.InvalidParameterException;
 
 import com.vaadin.flow.server.Command;
-import com.vaadin.flow.shared.Registration;
 
 
 /**
@@ -22,6 +27,8 @@ import com.vaadin.flow.shared.Registration;
  */
 public final class Shortcuts {
     static final String NULL = "Parameter '%s' must not be null!";
+
+    private Shortcuts() {}
 
     /**
      * Invoke a {@link Command} when the shortcut is invoked.

--- a/flow-server/src/main/java/com/vaadin/flow/component/Shortcuts.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Shortcuts.java
@@ -26,13 +26,12 @@ public final class Shortcuts {
     /**
      * Invoke a {@link Command} when the shortcut is invoked.
      * <p>
-     * Registering a shortcut using this method will tie it to the current UI
-     * and the shortcut is available in the global scope.
+     * Registering a shortcut using this method will tie it to
+     * {@code lifecycleOwner} and the shortcut is available in the global scope.
      * <p>
-     * In order to change the owner (listener) of the shortcut from {@link UI}
-     * to something else, use
-     * {@link #addShortcut(Component, Component, Command, Key, KeyModifier...)}
-     * instead.
+     * By default, the shortcut's listener is bound to the given
+     * {@code lifecycleOwner}. The listening component can be changed by calling
+     * {@link ShortcutRegistration#listenOn(Component)}.
      *
      * @param lifecycleOwner
      *              The component that controls, when the shortcut is active. If
@@ -45,9 +44,11 @@ public final class Shortcuts {
      * @param keyModifiers
      *              {@link KeyModifier KeyModifiers} which also need to be
      *              pressed for the shortcut to trigger
-     * @return {@link Registration} for removing the shortcut
+     * @return
+     *              {@link ShortcutRegistration} for configuring and removing the
+     *              shortcut
      */
-    public static Registration addShortcut(
+    public static ShortcutRegistration addShortcut(
             Component lifecycleOwner, Command command, Key key,
             KeyModifier... keyModifiers) {
         if (lifecycleOwner == null) {
@@ -60,122 +61,7 @@ public final class Shortcuts {
         if (key == null) {
             throw new InvalidParameterException(String.format(NULL, "key"));
         }
-        return registerShortcut(lifecycleOwner, command, key)
-                .withModifiers(keyModifiers);
-    }
-
-    /**
-     * Invoke a {@link Command} when the shortcut is invoked.
-     * <p>
-     * Allows for the configuration of {@code owner} which owns the shortcut
-     * event handler.
-     *
-     * @param owner
-     *              {@link Component} which listens for the shortcut event
-     * @param lifecycleOwner
-     *              The component that controls, when the shortcut is active. If
-     *              the component is either invisible or detached, the shortcut
-     *              won't work
-     * @param command
-     *              Code to execute when the shortcut is invoked
-     * @param key
-     *              Primary {@link Key} used to trigger the shortcut
-     * @param keyModifiers
-     *              {@link KeyModifier KeyModifiers} which also need to be
-     *              pressed for the shortcut to trigger
-     * @return {@link Registration} for removing the shortcut
-     */
-    public static Registration addShortcut(
-            Component owner, Component lifecycleOwner, Command command, Key key,
-            KeyModifier... keyModifiers) {
-        if (owner == null) {
-            throw new InvalidParameterException(String.format(NULL, "owner"));
-        }
-        if (command == null) {
-            throw new InvalidParameterException(String.format(NULL, "command"));
-        }
-        if (key == null) {
-            throw new InvalidParameterException(String.format(NULL, "key"));
-        }
-        return registerShortcut(owner, lifecycleOwner, command, key)
-                .withModifiers(keyModifiers);
-    }
-
-    /**
-     * Invoke a {@link Command} when the shortcut is invoked.
-     * <p>
-     * Registering a shortcut using this method will tie it to the current UI
-     * and the shortcut is available in the global scope. Further configuration
-     * can be done using the returned {@link ShortcutRegistration}.
-     * <p>
-     * In order to change the owner (listener) of the shortcut from {@link UI}
-     * to something else, use
-     * {@link #registerShortcut(Component, Component, Command, Key)} instead.
-     *
-     * @param lifecycleOwner
-     *              The component that controls, when the shortcut is active. If
-     *              the component is either invisible or detached, the shortcut
-     *              won't work
-     * @param command
-     *              Code to execute when the shortcut is invoked
-     * @param key
-     *              Primary {@link Key} used to trigger the shortcut
-     * @return {@link ShortcutRegistration} for configuring
-     */
-    public static ShortcutRegistration registerShortcut(
-            Component lifecycleOwner, Command command, Key key) {
-        if (lifecycleOwner == null) {
-            throw new InvalidParameterException(String.format(NULL,
-                    "lifecycleOwner"));
-        }
-        if (command == null) {
-            throw new InvalidParameterException(String.format(NULL, "command"));
-        }
-        if (key == null) {
-            throw new InvalidParameterException(String.format(NULL, "key"));
-        }
-
-        return new ShortcutRegistration(lifecycleOwner, UI::getCurrent, command,
-                key);
-    }
-
-    /**
-     * Invoke a {@link Command} when the shortcut is invoked.
-     * <p>
-     * Allows for the configuration of {@code owner} which owns the shortcut
-     * event handler. Further configuration can be done using the returned
-     * {@link ShortcutRegistration}.
-     *
-     * @param owner
-     *              {@link Component} which listens for the shortcut event
-     * @param lifecycleOwner
-     *              The component that controls, when the shortcut is active. If
-     *              the component is either invisible or detached, the shortcut
-     *              won't work
-     * @param command
-     *              Code to execute when the shortcut is invoked
-     * @param key
-     *              Primary {@link Key} used to trigger the shortcut
-     * @return {@link ShortcutRegistration} for configuring
-     */
-    public static ShortcutRegistration registerShortcut(
-            Component owner, Component lifecycleOwner, Command command,
-            Key key) {
-        if (owner == null) {
-            throw new InvalidParameterException(String.format(NULL, "owner"));
-        }
-        if (lifecycleOwner == null) {
-            throw new InvalidParameterException(String.format(NULL,
-                    "lifecycleOwner"));
-        }
-        if (command == null) {
-            throw new InvalidParameterException(String.format(NULL, "command"));
-        }
-        if (key == null) {
-            throw new InvalidParameterException(String.format(NULL, "key"));
-        }
-
-        return new ShortcutRegistration(lifecycleOwner, () -> owner, command,
-                key);
+        return new ShortcutRegistration(lifecycleOwner, () -> lifecycleOwner,
+                command, key);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -1014,7 +1014,8 @@ public class UI extends Component
      * @param keyModifiers
      *            {@link KeyModifier KeyModifiers} which also need to be pressed
      *            for the shortcut to trigger
-     * @return {@link ShortcutRegistration} for configuring the shortcut
+     * @return  {@link ShortcutRegistration} for configuring the shortcut and
+     *          removing
      * @see Shortcuts
      */
     public ShortcutRegistration addShortcut(Command command, Key key,

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -1019,6 +1019,7 @@ public class UI extends Component
      */
     public ShortcutRegistration addShortcut(Command command, Key key,
                                             KeyModifier... keyModifiers) {
-        return Shortcuts.addShortcut(this, command, key);
+        return new ShortcutRegistration(this, () -> this, command,
+                key).withModifiers(keyModifiers);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -1000,28 +1000,6 @@ public class UI extends Component
     }
 
     /**
-     * Adds a global shortcut tied to the {@code UI}. The shortcut will be
-     * present until {@link Registration#remove()} is called.
-     * <p>
-     * For more configuration option, use
-     * {@link #registerShortcut(Command, Key)} or a method in {@link Shortcuts}.
-     *
-     * @param command
-     *            Code to execute when the shortcut is invoked
-     * @param key
-     *            Primary {@link Key} used to trigger the shortcut
-     * @param keyModifiers
-     *            {@link KeyModifier KeyModifiers} which also need to be pressed
-     *            for the shortcut to trigger
-     * @return {@link Registration} for removing the shortcut
-     * @see Shortcuts
-     */
-    public Registration addShortcut(Command command, Key key,
-            KeyModifier... keyModifiers) {
-        return Shortcuts.addShortcut(this, this, command, key, keyModifiers);
-    }
-
-    /**
      * Registers a global shortcut tied to the {@code UI} and returns
      * {@link ShortcutRegistration} which can be used to fluently configure the
      * shortcut. The shortcut will be present until
@@ -1033,10 +1011,14 @@ public class UI extends Component
      *            Code to execute when the shortcut is invoked
      * @param key
      *            Primary {@link Key} used to trigger the shortcut
+     * @param keyModifiers
+     *            {@link KeyModifier KeyModifiers} which also need to be pressed
+     *            for the shortcut to trigger
      * @return {@link ShortcutRegistration} for configuring the shortcut
      * @see Shortcuts
      */
-    public ShortcutRegistration registerShortcut(Command command, Key key) {
-        return Shortcuts.registerShortcut(this, this, command, key);
+    public ShortcutRegistration addShortcut(Command command, Key key,
+                                            KeyModifier... keyModifiers) {
+        return Shortcuts.addShortcut(this, command, key);
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
@@ -21,19 +21,20 @@ import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.verification.VerificationMode;
 
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.ExecutionContext;
 import com.vaadin.flow.shared.Registration;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
@@ -163,7 +163,7 @@ public class ShortcutRegistrationTest {
      * Simulates a "beforeClientResponse" callback for the given
      * {@link ShortcutRegistration}
      */
-    public void clientResponse() {
+    private void clientResponse() {
         /*
             In all honesty, this should be an integration test and it relies
             too heavily on the internals of ShortcutRegistration and other
@@ -192,7 +192,7 @@ public class ShortcutRegistrationTest {
      * Simulates a "beforeClientResponse" callback for the given
      * {@link ShortcutRegistration}
      */
-    public void clientResponse(Component listenOnMock) {
+    private void clientResponse(Component listenOnMock) {
         when(listenOnMock.getElement()).thenReturn(new Element("tag"));
         when(listenOnMock.getEventBus()).thenReturn(new ComponentEventBus(
                 listenOnMock));

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.verification.VerificationMode;
 
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableConsumer;
@@ -14,6 +15,7 @@ import com.vaadin.flow.shared.Registration;
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -22,26 +24,26 @@ import static org.mockito.Mockito.when;
 public class ShortcutRegistrationTest {
 
     private UI ui;
-    private Component lifeOwner;
-    private Component handlerOwner;
+    private Component lifecycleOwner;
+    private Component listenOn;
 
     @Before
     public void initTests() {
         ui = mock(UI.class);
-        lifeOwner = mock(Component.class);
-        handlerOwner = mock(Component.class);
+        lifecycleOwner = mock(Component.class);
+        listenOn = mock(Component.class);
 
-        when(lifeOwner.getUI()).thenReturn(Optional.of(ui));
-        when(lifeOwner.addAttachListener(any())).thenReturn(mock(Registration.class));
-        when(lifeOwner.addDetachListener(any())).thenReturn(mock(Registration.class));
+        when(lifecycleOwner.getUI()).thenReturn(Optional.of(ui));
+        when(lifecycleOwner.addAttachListener(any())).thenReturn(mock(Registration.class));
+        when(lifecycleOwner.addDetachListener(any())).thenReturn(mock(Registration.class));
 
-        when(handlerOwner.getUI()).thenReturn(Optional.of(ui));
+        when(listenOn.getUI()).thenReturn(Optional.of(ui));
     }
 
     @Test
     public void registrationWillBeCompletedBeforeClientResponse() {
-        ShortcutRegistration registration = new ShortcutRegistration(lifeOwner,
-                () -> handlerOwner, () -> {}, Key.KEY_A);
+        ShortcutRegistration registration = new ShortcutRegistration(
+                lifecycleOwner, () -> listenOn, () -> {}, Key.KEY_A);
 
         clientResponse();
 
@@ -55,16 +57,16 @@ public class ShortcutRegistrationTest {
 
     @Test
     public void constructedRegistrationIsDirty() {
-        ShortcutRegistration registration = new ShortcutRegistration(lifeOwner,
-                () -> handlerOwner, () -> {}, Key.KEY_A);
+        ShortcutRegistration registration = new ShortcutRegistration(
+                lifecycleOwner, () -> listenOn, () -> {}, Key.KEY_A);
 
         assertTrue(registration.isDirty());
     }
 
     @Test
     public void lateUpdateOfModifiersDirtiesRegistration() {
-        ShortcutRegistration registration = new ShortcutRegistration(lifeOwner,
-                () -> handlerOwner, () -> {}, Key.KEY_A);
+        ShortcutRegistration registration = new ShortcutRegistration(
+                lifecycleOwner, () -> listenOn, () -> {}, Key.KEY_A);
 
         clientResponse();
 
@@ -78,8 +80,8 @@ public class ShortcutRegistrationTest {
 
     @Test
     public void fluentModifiersAreAddedCorrectly() {
-        ShortcutRegistration registration = new ShortcutRegistration(lifeOwner,
-                () -> handlerOwner, () -> {}, Key.KEY_A);
+        ShortcutRegistration registration = new ShortcutRegistration(
+                lifecycleOwner, () -> listenOn, () -> {}, Key.KEY_A);
 
         registration.withAlt().withCtrl().withMeta().withShift();
 
@@ -88,8 +90,8 @@ public class ShortcutRegistrationTest {
 
     @Test
     public void preventDefaultAndStopPropagationValuesDefaultToTrue() {
-        ShortcutRegistration registration = new ShortcutRegistration(lifeOwner,
-                () -> handlerOwner, () -> {}, Key.KEY_A);
+        ShortcutRegistration registration = new ShortcutRegistration(
+                lifecycleOwner, () -> listenOn, () -> {}, Key.KEY_A);
 
         assertTrue(registration.preventsDefault());
         assertTrue(registration.stopsPropagation());
@@ -104,15 +106,39 @@ public class ShortcutRegistrationTest {
     public void bindLifecycleToChangesLifecycleOwner() {
         Component newOwner = mock(Component.class);
 
-        ShortcutRegistration registration = new ShortcutRegistration(lifeOwner,
-                () -> handlerOwner, () -> {}, Key.KEY_A);
+        ShortcutRegistration registration = new ShortcutRegistration(
+                lifecycleOwner, () -> listenOn, () -> {}, Key.KEY_A);
 
-        assertEquals(lifeOwner, registration.getLifecycleOwner());
+        assertEquals(lifecycleOwner, registration.getLifecycleOwner());
 
         registration.bindLifecycleTo(newOwner);
 
         assertEquals(newOwner, registration.getLifecycleOwner());
 
+    }
+
+    @Test
+    public void listenOnChangesTheComponentThatOwnsTheListener() {
+        ShortcutRegistration registration = new ShortcutRegistration(
+                lifecycleOwner, () -> listenOn, () -> {}, Key.KEY_A);
+
+        // No response, no listenOn component
+        assertNull(registration.getOwner());
+
+        clientResponse();
+
+        // listenOn component should be set after client response
+        assertEquals(listenOn, registration.getOwner());
+
+        // Change the listenOn component
+        Component newListenOn = mock(Component.class);
+        when(newListenOn.getUI()).thenReturn(Optional.empty());
+        registration.listenOn(newListenOn);
+
+        clientResponse(newListenOn);
+
+        // listenOn component should be set to the new component
+        assertEquals(newListenOn, registration.getOwner());
     }
 
     /**
@@ -128,14 +154,39 @@ public class ShortcutRegistrationTest {
             components, but it did help catch a bug so here it is!
          */
 
-        when(handlerOwner.getElement()).thenReturn(new Element("tag"));
-        when(handlerOwner.getEventBus()).thenReturn(new ComponentEventBus(handlerOwner));
+        when(listenOn.getElement()).thenReturn(new Element("tag"));
+        when(listenOn.getEventBus()).thenReturn(new ComponentEventBus(
+                listenOn));
 
         ArgumentCaptor<SerializableConsumer> captor =
                 ArgumentCaptor.forClass(SerializableConsumer.class);
 
-        verify(ui, times(1)).beforeClientResponse(
-                eq(lifeOwner), captor.capture());
+        verify(ui).beforeClientResponse(
+                eq(lifecycleOwner), captor.capture());
+
+        SerializableConsumer consumer = captor.getValue();
+
+        // Fake beforeClientExecution call.
+        consumer.accept(mock(ExecutionContext.class));
+    }
+
+    /**
+     * Works only with the {@code registration} member variable, but allows
+     * configuring the {@code listenOn} component
+     *
+     * Simulates a "beforeClientResponse" callback for the given
+     * {@link ShortcutRegistration}
+     */
+    public void clientResponse(Component listenOnMock) {
+        when(listenOnMock.getElement()).thenReturn(new Element("tag"));
+        when(listenOnMock.getEventBus()).thenReturn(new ComponentEventBus(
+                listenOnMock));
+
+        ArgumentCaptor<SerializableConsumer> captor =
+                ArgumentCaptor.forClass(SerializableConsumer.class);
+
+        verify(ui, atLeastOnce()).beforeClientResponse(
+                eq(lifecycleOwner), captor.capture());
 
         SerializableConsumer consumer = captor.getValue();
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package com.vaadin.flow.component;
 
 import java.util.Optional;
@@ -161,8 +177,7 @@ public class ShortcutRegistrationTest {
         ArgumentCaptor<SerializableConsumer> captor =
                 ArgumentCaptor.forClass(SerializableConsumer.class);
 
-        verify(ui).beforeClientResponse(
-                eq(lifecycleOwner), captor.capture());
+        verify(ui).beforeClientResponse(eq(lifecycleOwner), captor.capture());
 
         SerializableConsumer consumer = captor.getValue();
 

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsView.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package com.vaadin.flow.uitest.ui;
 
 import com.vaadin.flow.component.Key;

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsView.java
@@ -37,7 +37,7 @@ public class ShortcutsView extends Div {
             expected.setText("toggled!");
         }, Key.KEY_I, KeyModifier.ALT);
 
-        Shortcuts.registerShortcut(UI.getCurrent(), invisibleP, () -> expected
+        Shortcuts.addShortcut(invisibleP, () -> expected
                 .setText("invisibleP"), Key.KEY_V).withAlt();
 
         add(expected, button, input, invisibleP);
@@ -51,15 +51,16 @@ public class ShortcutsView extends Div {
         subview.add(focusTarget);
 
         // only works, when focusTarget is focused
-        Shortcuts.addShortcut(subview, subview,
-                () -> expected.setText("subview"), Key.KEY_S, KeyModifier.ALT);
+        Shortcuts.addShortcut(subview,
+                () -> expected.setText("subview"), Key.KEY_S, KeyModifier.ALT)
+                .listenOn(subview);
 
         add(subview);
 
         Paragraph attachable = new Paragraph("attachable");
         attachable.setId("attachable");
 
-        Shortcuts.registerShortcut(UI.getCurrent(), attachable, () -> expected
+        Shortcuts.addShortcut(attachable, () -> expected
                 .setText("attachable"), Key.KEY_A).withAlt();
 
         UI.getCurrent().addShortcut(() -> {

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ShortcutsIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ShortcutsIT.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package com.vaadin.flow.uitest.ui;
 
 import java.util.concurrent.TimeUnit;

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ShortcutsIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ShortcutsIT.java
@@ -55,7 +55,7 @@ public class ShortcutsIT extends ChromeBrowserTest {
     }
 
     @Test
-    public void ownerScopesTheShortcut() {
+    public void listenOnScopesTheShortcut() {
         open();
 
         sendKeys(Keys.ALT, "s");


### PR DESCRIPTION
+ and all the other shortcuts, of course.

This PR also narrows down the existing API by removing all `registerShortcut...` type of methods. All `addShortcut...` methods now always return `ShortcutRegistration`.

See the original issue for more details!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4992)
<!-- Reviewable:end -->
