### PR TITLE
Don't check class for name in case of OSGi

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/theme/ThemeUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/theme/ThemeUtil.java
@@ -60,14 +60,7 @@ public final class ThemeUtil {
 
             ServiceReference<ThemeDefinition> reference = context
                     .getServiceReference(ThemeDefinition.class);
-            if (reference == null) {
-                return Optional
-                        .ofNullable(LazyLoadLumoTheme.LUMO_CLASS_IF_AVAILABLE);
-            }
-
-            ThemeDefinition definition = context.getService(reference);
-
-            return Optional.ofNullable(definition);
+            return Optional.ofNullable(reference).map(context::getService);
         }
         return Optional.ofNullable(LazyLoadLumoTheme.LUMO_CLASS_IF_AVAILABLE);
     }


### PR DESCRIPTION
If bundle is not null then the application is deployed to an OSGi
container. In this case the default theme definition service reference
presence is the same as a service presence. So instead of checking Lumo
theme via Class::forName we should check only the service reference.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4993)
<!-- Reviewable:end -->
