### PR TITLE
Check Lumo theme in OSGi via services mechanism (#4972)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -686,7 +686,7 @@ public class UI extends Component
      * <p>
      * Besides the navigation to the {@code location} this method also updates
      * the browser location (and page history).
-     * 
+     *
      * @param navigationTarget
      *            navigation target to navigate to
      */
@@ -706,7 +706,7 @@ public class UI extends Component
      * Note! A {@code null} parameter will be handled the same as
      * navigate(navigationTarget) and will throw an exception if HasUrlParameter
      * is not @OptionalParameter or @WildcardParameter.
-     * 
+     *
      * @param navigationTarget
      *            navigation target to navigate to
      * @param parameter

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/RouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/RouteRegistry.java
@@ -908,7 +908,7 @@ public class RouteRegistry implements Serializable {
         return Optional.ofNullable(LazyLoadLumoTheme.LUMO_CLASS_IF_AVAILABLE);
     }
 
-    private static final class LazyLoadLumoTheme {
+    private static final class LazyLoadLumoTheme implements Serializable {
 
         private static final ThemeDefinition LUMO_CLASS_IF_AVAILABLE = loadLumoClassIfAvailable();
 

--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -26,6 +26,8 @@
         <module>test-memory-leaks</module>
         <module>test-servlet</module>
         <module>test-themes</module>
+        <module>test-lumo-theme</module>
+        <module>test-material-theme</module>
         <module>servlet-containers</module>
     </modules>
 

--- a/flow-tests/test-lumo-theme/pom.xml
+++ b/flow-tests/test-lumo-theme/pom.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.vaadin</groupId>
+        <artifactId>flow-tests</artifactId>
+        <version>1.3-SNAPSHOT</version>
+    </parent>
+    <artifactId>flow-test-lumo-theme</artifactId>
+    <name>Flow Lumo theme tests</name>
+    <packaging>war</packaging>
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-test-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-html-components-testbench</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-lumo-theme</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        
+
+        <dependency>
+            <groupId>org.webjars.bowergithub.polymer</groupId>
+            <artifactId>polymer</artifactId>
+        </dependency>
+        
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- This module is mapped to default web context -->
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>${jetty.version}</version>
+                <executions>
+                    <!-- start and stop jetty (running our app) when running
+                        integration tests -->
+                    <execution>
+                        <id>start-jetty</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>stop-jetty</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>local-run</id>
+            <activation>
+                <property>
+                    <name>!test.use.hub</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.lazerycode.selenium</groupId>
+                        <artifactId>driver-binary-downloader-maven-plugin</artifactId>
+                        <version>${driver.binary.downloader.maven.plugin.version}</version>
+                        <configuration>
+                            <onlyGetDriversForHostOperatingSystem>true</onlyGetDriversForHostOperatingSystem>
+                            <rootStandaloneServerDirectory>${project.rootdir}/driver</rootStandaloneServerDirectory>
+                            <downloadedZipFileDirectory>${project.rootdir}/driver_zips</downloadedZipFileDirectory>
+                            <customRepositoryMap>${project.rootdir}/drivers.xml</customRepositoryMap>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>selenium</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>
+

--- a/flow-tests/test-lumo-theme/pom.xml
+++ b/flow-tests/test-lumo-theme/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>1.3-SNAPSHOT</version>
+        <version>1.2-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-lumo-theme</artifactId>
     <name>Flow Lumo theme tests</name>

--- a/flow-tests/test-lumo-theme/src/main/java/com/vaadin/flow/uitest/ui/lumo/ExplicitLumoTemplateView.java
+++ b/flow-tests/test-lumo-theme/src/main/java/com/vaadin/flow/uitest/ui/lumo/ExplicitLumoTemplateView.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.lumo;
+
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.HtmlImport;
+import com.vaadin.flow.component.polymertemplate.PolymerTemplate;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.templatemodel.TemplateModel;
+import com.vaadin.flow.theme.Theme;
+import com.vaadin.flow.theme.lumo.Lumo;
+
+@Tag("explicit-lumo-themed-template")
+@HtmlImport("frontend://bower_components/themed-template/src/LumoThemedTemplate.html")
+@Route(value = "com.vaadin.flow.uitest.ui.lumo.ExplicitLumoTemplateView")
+@Theme(Lumo.class)
+public class ExplicitLumoTemplateView extends PolymerTemplate<TemplateModel> {
+
+}

--- a/flow-tests/test-lumo-theme/src/main/java/com/vaadin/flow/uitest/ui/lumo/ImplicitLumoTemplateView.java
+++ b/flow-tests/test-lumo-theme/src/main/java/com/vaadin/flow/uitest/ui/lumo/ImplicitLumoTemplateView.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.lumo;
+
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.HtmlImport;
+import com.vaadin.flow.component.polymertemplate.PolymerTemplate;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.templatemodel.TemplateModel;
+
+@Tag("implicit-lumo-themed-template")
+@HtmlImport("frontend://bower_components/themed-template/src/ImplicitLumoThemedTemplate.html")
+@Route(value = "com.vaadin.flow.uitest.ui.lumo.ImplicitLumoTemplateView")
+public class ImplicitLumoTemplateView extends PolymerTemplate<TemplateModel> {
+
+}

--- a/flow-tests/test-lumo-theme/src/main/webapp/frontend/bower_components/themed-template/src/ImplicitLumoThemedTemplate.html
+++ b/flow-tests/test-lumo-theme/src/main/webapp/frontend/bower_components/themed-template/src/ImplicitLumoThemedTemplate.html
@@ -1,0 +1,31 @@
+<!--
+  ~ Copyright 2000-2018 Vaadin Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+<link rel="import" href="../../polymer/polymer-element.html">
+
+<dom-module id="implicit-lumo-themed-template">
+    <template>
+      <div id='div'>Template</div>
+    </template>
+
+    <script>
+        class ImplicitLumoThemedTemplate extends Polymer.Element {
+            static get is() {
+                return 'implicit-lumo-themed-template'
+            }
+        }
+        customElements.define(ImplicitLumoThemedTemplate.is, ImplicitLumoThemedTemplate);
+    </script>
+</dom-module>

--- a/flow-tests/test-lumo-theme/src/main/webapp/frontend/bower_components/themed-template/src/LumoThemedTemplate.html
+++ b/flow-tests/test-lumo-theme/src/main/webapp/frontend/bower_components/themed-template/src/LumoThemedTemplate.html
@@ -1,0 +1,31 @@
+<!--
+  ~ Copyright 2000-2018 Vaadin Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+<link rel="import" href="../../polymer/polymer-element.html">
+
+<dom-module id="explicit-lumo-themed-template">
+    <template>
+      <div id='div'>Template</div>
+    </template>
+
+    <script>
+        class LumoThemedTemplate extends Polymer.Element {
+            static get is() {
+                return 'explicit-lumo-themed-template'
+            }
+        }
+        customElements.define(LumoThemedTemplate.is, LumoThemedTemplate);
+    </script>
+</dom-module>

--- a/flow-tests/test-lumo-theme/src/main/webapp/frontend/bower_components/themed-template/theme/lumo/ImplicitLumoThemedTemplate.html
+++ b/flow-tests/test-lumo-theme/src/main/webapp/frontend/bower_components/themed-template/theme/lumo/ImplicitLumoThemedTemplate.html
@@ -1,0 +1,32 @@
+<!--
+  ~ Copyright 2000-2018 Vaadin Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+<link rel="import" href="../../../polymer/polymer-element.html">
+
+<dom-module id="implicit-lumo-themed-template">
+    <template>
+      <div id='div'>Lumo themed Template</div>
+    </template>
+
+    <script>
+        class ImplicitLumoThemedTemplate extends Polymer.Element {
+            static get is() {
+                return 'implicit-lumo-themed-template'
+            }
+        }
+        customElements.define(ImplicitLumoThemedTemplate.is, ImplicitLumoThemedTemplate);
+    </script>
+</dom-module>
+

--- a/flow-tests/test-lumo-theme/src/main/webapp/frontend/bower_components/themed-template/theme/lumo/LumoThemedTemplate.html
+++ b/flow-tests/test-lumo-theme/src/main/webapp/frontend/bower_components/themed-template/theme/lumo/LumoThemedTemplate.html
@@ -1,0 +1,31 @@
+<!--
+  ~ Copyright 2000-2018 Vaadin Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+<link rel="import" href="../../../polymer/polymer-element.html">
+
+<dom-module id="explicit-lumo-themed-template">
+    <template>
+      <div id='div'>Lumo themed Template</div>
+    </template>
+
+    <script>
+        class LumoThemedTemplate extends Polymer.Element {
+            static get is() {
+                return 'explicit-lumo-themed-template'
+            }
+        }
+        customElements.define(LumoThemedTemplate.is, LumoThemedTemplate);
+    </script>
+</dom-module>

--- a/flow-tests/test-lumo-theme/src/test/java/com/vaadin/flow/uitest/ui/lumo/AbstractThemedTemplateIT.java
+++ b/flow-tests/test-lumo-theme/src/test/java/com/vaadin/flow/uitest/ui/lumo/AbstractThemedTemplateIT.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.lumo;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+import com.vaadin.testbench.TestBenchElement;
+
+public abstract class AbstractThemedTemplateIT extends ChromeBrowserTest {
+
+    @Test
+    public void themedUrlsAreAdded() {
+        open();
+
+        // check that all imported templates are available in the DOM
+        TestBenchElement template = $(getTagName()).first();
+
+        TestBenchElement div = template.$("div").first();
+
+        Assert.assertEquals("Lumo themed Template", div.getText());
+
+        TestBenchElement head = $("head").first();
+
+        List<String> hrefs = head.$("link").attribute("rel", "import").all()
+                .stream().map(element -> element.getAttribute("href"))
+                .collect(Collectors.toList());
+
+        Collection<String> expectedSuffices = new LinkedList<>(Arrays.asList(
+                getThemedTemplate(), "vaadin-lumo-styles/color.html",
+                "vaadin-lumo-styles/typography.html",
+                "vaadin-lumo-styles/sizing.html",
+                "vaadin-lumo-styles/spacing.html",
+                "vaadin-lumo-styles/style.html",
+                "vaadin-lumo-styles/icons.html"));
+
+        for (String href : hrefs) {
+            Optional<String> matched = expectedSuffices.stream()
+                    .filter(suffix -> href.endsWith(suffix)).findFirst();
+            if (matched.isPresent()) {
+                expectedSuffices.remove(matched.get());
+            }
+        }
+
+        if (!expectedSuffices.isEmpty()) {
+            Assert.fail("No imports found for the lumo specific HTML file(s) : "
+                    + expectedSuffices);
+        }
+    }
+
+    protected abstract String getTagName();
+
+    protected abstract String getThemedTemplate();
+
+}

--- a/flow-tests/test-lumo-theme/src/test/java/com/vaadin/flow/uitest/ui/lumo/ExplicitLumoTemplateIT.java
+++ b/flow-tests/test-lumo-theme/src/test/java/com/vaadin/flow/uitest/ui/lumo/ExplicitLumoTemplateIT.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.lumo;
+
+public class ExplicitLumoTemplateIT extends AbstractThemedTemplateIT {
+
+    @Override
+    protected String getTagName() {
+        return "explicit-lumo-themed-template";
+    }
+
+    @Override
+    protected String getThemedTemplate() {
+        return "theme/lumo/LumoThemedTemplate.html";
+    }
+
+}

--- a/flow-tests/test-lumo-theme/src/test/java/com/vaadin/flow/uitest/ui/lumo/ImplicitLumoTemplateIT.java
+++ b/flow-tests/test-lumo-theme/src/test/java/com/vaadin/flow/uitest/ui/lumo/ImplicitLumoTemplateIT.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.lumo;
+
+public class ImplicitLumoTemplateIT extends AbstractThemedTemplateIT {
+
+    @Override
+    protected String getTagName() {
+        return "implicit-lumo-themed-template";
+    }
+
+    @Override
+    protected String getThemedTemplate() {
+        return "theme/lumo/ImplicitLumoThemedTemplate.html";
+    }
+}

--- a/flow-tests/test-material-theme/pom.xml
+++ b/flow-tests/test-material-theme/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.vaadin</groupId>
+        <artifactId>flow-tests</artifactId>
+        <version>1.3-SNAPSHOT</version>
+    </parent>
+    <artifactId>flow-test-material-theme</artifactId>
+    <name>Flow Material theme tests</name>
+    <packaging>war</packaging>
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-test-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-html-components-testbench</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-material-theme</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.webjars.bowergithub.polymer</groupId>
+            <artifactId>polymer</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- This module is mapped to default web context -->
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>${jetty.version}</version>
+                <executions>
+                    <!-- start and stop jetty (running our app) when running
+                        integration tests -->
+                    <execution>
+                        <id>start-jetty</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>stop-jetty</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>local-run</id>
+            <activation>
+                <property>
+                    <name>!test.use.hub</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.lazerycode.selenium</groupId>
+                        <artifactId>driver-binary-downloader-maven-plugin</artifactId>
+                        <version>${driver.binary.downloader.maven.plugin.version}</version>
+                        <configuration>
+                            <onlyGetDriversForHostOperatingSystem>true</onlyGetDriversForHostOperatingSystem>
+                            <rootStandaloneServerDirectory>${project.rootdir}/driver</rootStandaloneServerDirectory>
+                            <downloadedZipFileDirectory>${project.rootdir}/driver_zips</downloadedZipFileDirectory>
+                            <customRepositoryMap>${project.rootdir}/drivers.xml</customRepositoryMap>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>selenium</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>
+

--- a/flow-tests/test-material-theme/pom.xml
+++ b/flow-tests/test-material-theme/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>1.3-SNAPSHOT</version>
+        <version>1.2-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-material-theme</artifactId>
     <name>Flow Material theme tests</name>

--- a/flow-tests/test-material-theme/src/main/java/com/vaadin/flow/uitest/ui/material/MaterialThemedTemplateView.java
+++ b/flow-tests/test-material-theme/src/main/java/com/vaadin/flow/uitest/ui/material/MaterialThemedTemplateView.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.material;
+
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.HtmlImport;
+import com.vaadin.flow.component.polymertemplate.PolymerTemplate;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.templatemodel.TemplateModel;
+import com.vaadin.flow.theme.Theme;
+import com.vaadin.flow.theme.material.Material;
+
+@Tag("material-themed-template")
+@HtmlImport("frontend://bower_components/themed-template/src/MaterialThemedTemplate.html")
+@Route(value = "com.vaadin.flow.uitest.ui.material.MaterialThemedTemplateView")
+@Theme(Material.class)
+public class MaterialThemedTemplateView extends PolymerTemplate<TemplateModel> {
+
+}

--- a/flow-tests/test-material-theme/src/main/java/com/vaadin/flow/uitest/ui/material/NotThemedTemplateView.java
+++ b/flow-tests/test-material-theme/src/main/java/com/vaadin/flow/uitest/ui/material/NotThemedTemplateView.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.material;
+
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.HtmlImport;
+import com.vaadin.flow.component.polymertemplate.PolymerTemplate;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.templatemodel.TemplateModel;
+
+@Tag("not-themed-template")
+@HtmlImport("frontend://bower_components/themed-template/src/NotThemedTemplate.html")
+@Route(value = "com.vaadin.flow.uitest.ui.material.NotThemedTemplateView")
+public class NotThemedTemplateView extends PolymerTemplate<TemplateModel> {
+
+}

--- a/flow-tests/test-material-theme/src/main/webapp/frontend/bower_components/themed-template/src/MaterialThemedTemplate.html
+++ b/flow-tests/test-material-theme/src/main/webapp/frontend/bower_components/themed-template/src/MaterialThemedTemplate.html
@@ -1,0 +1,31 @@
+<!--
+  ~ Copyright 2000-2018 Vaadin Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+<link rel="import" href="../../polymer/polymer-element.html">
+
+<dom-module id="material-themed-template">
+    <template>
+      <div id='div'>Template</div>
+    </template>
+
+    <script>
+        class MaterialThemedTemplate extends Polymer.Element {
+            static get is() {
+                return 'material-themed-template'
+            }
+        }
+        customElements.define(MaterialThemedTemplate.is, MaterialThemedTemplate);
+    </script>
+</dom-module>

--- a/flow-tests/test-material-theme/src/main/webapp/frontend/bower_components/themed-template/src/NotThemedTemplate.html
+++ b/flow-tests/test-material-theme/src/main/webapp/frontend/bower_components/themed-template/src/NotThemedTemplate.html
@@ -1,0 +1,31 @@
+<!--
+  ~ Copyright 2000-2018 Vaadin Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+<link rel="import" href="../../polymer/polymer-element.html">
+
+<dom-module id="not-themed-template">
+    <template>
+      <div id='div'>Template</div>
+    </template>
+
+    <script>
+        class NotThemedTemplate extends Polymer.Element {
+            static get is() {
+                return 'not-themed-template'
+            }
+        }
+        customElements.define(NotThemedTemplate.is, NotThemedTemplate);
+    </script>
+</dom-module>

--- a/flow-tests/test-material-theme/src/main/webapp/frontend/bower_components/themed-template/theme/material/MaterialThemedTemplate.html
+++ b/flow-tests/test-material-theme/src/main/webapp/frontend/bower_components/themed-template/theme/material/MaterialThemedTemplate.html
@@ -1,0 +1,31 @@
+<!--
+  ~ Copyright 2000-2018 Vaadin Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+<link rel="import" href="../../../polymer/polymer-element.html">
+
+<dom-module id="material-themed-template">
+    <template>
+      <div id='div'>Material themed Template</div>
+    </template>
+
+    <script>
+        class MaterialThemedTemplate extends Polymer.Element {
+            static get is() {
+                return 'material-themed-template'
+            }
+        }
+        customElements.define(MaterialThemedTemplate.is, MaterialThemedTemplate);
+    </script>
+</dom-module>

--- a/flow-tests/test-material-theme/src/test/java/com/vaadin/flow/uitest/ui/material/MaterialThemedTemplateIT.java
+++ b/flow-tests/test-material-theme/src/test/java/com/vaadin/flow/uitest/ui/material/MaterialThemedTemplateIT.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.material;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+import com.vaadin.testbench.TestBenchElement;
+
+public class MaterialThemedTemplateIT extends ChromeBrowserTest {
+
+    @Test
+    public void themedUrlsAreAdded() {
+        open();
+
+        // check that all imported templates are available in the DOM
+        TestBenchElement template = $("material-themed-template").first();
+
+        TestBenchElement div = template.$("div").first();
+
+        Assert.assertEquals("Material themed Template", div.getText());
+
+        TestBenchElement head = $("head").first();
+
+        List<String> hrefs = head.$("link").attribute("rel", "import").all()
+                .stream().map(element -> element.getAttribute("href"))
+                .collect(Collectors.toList());
+
+        Collection<String> expectedSuffices = new LinkedList<>(Arrays.asList(
+                "themed-template/theme/material/MaterialThemedTemplate.html",
+                "vaadin-material-styles/color.html",
+                "vaadin-material-styles/typography.html"));
+
+        for (String href : hrefs) {
+            Optional<String> matched = expectedSuffices.stream()
+                    .filter(suffix -> href.endsWith(suffix)).findFirst();
+            if (matched.isPresent()) {
+                expectedSuffices.remove(matched.get());
+            }
+        }
+
+        if (!expectedSuffices.isEmpty()) {
+            Assert.fail("No imports found for the lumo specific HTML file(s) : "
+                    + expectedSuffices);
+        }
+    }
+
+}

--- a/flow-tests/test-material-theme/src/test/java/com/vaadin/flow/uitest/ui/material/NotThemedTemplateIT.java
+++ b/flow-tests/test-material-theme/src/test/java/com/vaadin/flow/uitest/ui/material/NotThemedTemplateIT.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.material;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+import com.vaadin.testbench.TestBenchElement;
+
+public class NotThemedTemplateIT extends ChromeBrowserTest {
+
+    @Test
+    public void no_anyThemedUrls() {
+        open();
+
+        // check that all imported templates are available in the DOM
+        TestBenchElement template = $("not-themed-template").first();
+
+        TestBenchElement div = template.$("div").first();
+
+        Assert.assertEquals("Template", div.getText());
+
+        TestBenchElement head = $("head").first();
+
+        List<String> hrefs = head.$("link").attribute("rel", "import").all()
+                .stream().map(element -> element.getAttribute("href"))
+                .collect(Collectors.toList());
+
+        for (String href : hrefs) {
+            Assert.assertThat(href,
+                    CoreMatchers.not(CoreMatchers.containsString("material")));
+            Assert.assertThat(href,
+                    CoreMatchers.not(CoreMatchers.containsString("lumo")));
+        }
+    }
+
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/VerifyBrowserVersionIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/VerifyBrowserVersionIT.java
@@ -26,7 +26,7 @@ public class VerifyBrowserVersionIT extends ChromeBrowserTest {
             // Chrome version does not necessarily match the desired version
             // because of auto updates...
             browserIdentifier = getExpectedUserAgentString(
-                    getDesiredCapabilities()) + "70";
+                    getDesiredCapabilities()) + "71";
         } else if (BrowserUtil.isFirefox(getDesiredCapabilities())) {
             browserIdentifier = getExpectedUserAgentString(
                     getDesiredCapabilities()) + "58";

--- a/flow-theme-integrations/lumo/pom.xml
+++ b/flow-theme-integrations/lumo/pom.xml
@@ -53,6 +53,12 @@
             <artifactId>iron-flex-layout</artifactId>
             <version>2.0.3</version>
         </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.cmpn</artifactId>
+            <version>${osgi.compendium.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/flow-theme-integrations/lumo/src/main/java/com/vaadin/flow/theme/lumo/LumoThemeDefinition.java
+++ b/flow-theme-integrations/lumo/src/main/java/com/vaadin/flow/theme/lumo/LumoThemeDefinition.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.theme.lumo;
+
+import org.osgi.service.component.annotations.Component;
+
+import com.vaadin.flow.theme.ThemeDefinition;
+
+/**
+ * {@link Lumo} theme definition.
+ *
+ * @author Vaadin Ltd
+ *
+ */
+@Component(service = ThemeDefinition.class)
+public class LumoThemeDefinition extends ThemeDefinition {
+
+    /**
+     * Creates a new instance of {@link Lumo} theme definition.
+     */
+    public LumoThemeDefinition() {
+        super(Lumo.class, "");
+    }
+
+}


### PR DESCRIPTION
Fixes #4847

Cherry pick for making Lumo be automatically selected as a default theme if it's in the classpath in OSGi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4998)
<!-- Reviewable:end -->
