### PR TITLE
ShortcutEventListener + associated event

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
@@ -87,8 +87,8 @@ public interface ClickNotifier<T extends Component> extends Serializable {
 
         final Component thisComponent = (Component) this;
         return new ShortcutRegistration(thisComponent, UI::getCurrent,
-                () -> ComponentUtil.fireEvent(thisComponent, new ClickEvent<>(
-                        thisComponent)),
+                event -> ComponentUtil.fireEvent(thisComponent,
+                        new ClickEvent<>(thisComponent)),
                 key).withModifiers(keyModifiers);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
@@ -63,7 +63,8 @@ public interface ClickNotifier<T extends Component> extends Serializable {
      * shortcut.
      *
      * @param key
-     *              Primary {@link Key} used to trigger the shortcut
+     *              primary {@link Key} used to trigger the shortcut. Cannot
+     *              be null.
      * @param keyModifiers
      *              {@link KeyModifier KeyModifiers} that need to be pressed
      *              along with the {@code key} for the shortcut to trigger

--- a/flow-server/src/main/java/com/vaadin/flow/component/Focusable.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Focusable.java
@@ -139,7 +139,8 @@ public interface Focusable<T extends Component>
      * shortcut.
      *
      * @param key
-     *              Primary {@link Key} used to trigger the shortcut
+     *              primary {@link Key} used to trigger the shortcut. Cannot
+     *              be null.
      * @param keyModifiers
      *              {@link KeyModifier KeyModifiers} that need to be pressed
      *              along with the {@code key} for the shortcut to trigger

--- a/flow-server/src/main/java/com/vaadin/flow/component/Focusable.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Focusable.java
@@ -27,6 +27,8 @@ import com.vaadin.flow.shared.Registration;
  *            the type of the component which implements the interface
  * @see BlurNotifier
  * @see FocusNotifier
+ * @author  Vaadin Ltd.
+ * @since
  */
 public interface Focusable<T extends Component>
         extends HasElement, BlurNotifier<T>, FocusNotifier<T>, HasEnabled {
@@ -160,7 +162,6 @@ public interface Focusable<T extends Component>
         }
 
         return new ShortcutRegistration((Component) this, UI::getCurrent,
-                this::focus, key).withModifiers(keyModifiers);
-
+                event -> this.focus(), key).withModifiers(keyModifiers);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutEvent.java
@@ -1,62 +1,79 @@
 package com.vaadin.flow.component;
 
-import java.util.Arrays;
+import java.io.Serializable;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.EventObject;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class ShortcutEvent extends ComponentEvent<Component> {
+/**
+ * Event when shortcut is detected
+ *
+ * @author  Vaadin Ltd.
+ * @since
+ */
+public class ShortcutEvent extends EventObject implements Serializable {
     private Component lifecycleOwner;
     private Key key;
     private Set<KeyModifier> keyModifiers;
 
     /**
-     * Creates a new event using the given source and indicator whether the
-     * event originated from the client side or the server side.
+     * Creates a new {@code ShortcutEvent}
      *
-     * @param source     the source component
-     * @param fromClient <code>true</code> if the event originated from the client
-     */
-    public ShortcutEvent(Component source, boolean fromClient) {
-        this(source, fromClient, null, null);
-    }
-
-    /**
      * @param source
-     * @param fromClient
+     *          shortcut's {@code listenOn} {@link Component}
      * @param lifecycleOwner
+     *          shortcut's {@code lifecycleOwner} {@link Component}
      * @param key
+     *          primary {@link Key} of the shortcut
      * @param keyModifiers
+     *          set of {@link KeyModifier KeyModifiers} of the shortcut
      */
-    public ShortcutEvent(Component source, boolean fromClient,
-                         Component lifecycleOwner, Key key,
-                         KeyModifier... keyModifiers) {
-        super(source, fromClient);
+    public ShortcutEvent(Component source, Component lifecycleOwner, Key key,
+                         Set<KeyModifier> keyModifiers) {
+        super(source);
         this.lifecycleOwner = lifecycleOwner;
         this.key = key;
-        this.keyModifiers = Collections.unmodifiableSet(
-                new HashSet<>(Arrays.asList(keyModifiers)));
+        this.keyModifiers = keyModifiers == null ? Collections.emptySet() :
+                Collections.unmodifiableSet(keyModifiers);
     }
 
     /**
+     * Component which listened for the shortcut.
      * @return
+     *          listening {@link Component}
+     */
+    @Override
+    public Component getSource() {
+        return (Component) super.getSource();
+    }
+
+    /**
+     * Component which owns the shortcut.
+     * @return
+     *          owning {@link Component}
      */
     public Component getLifecycleOwner() {
         return lifecycleOwner;
     }
 
     /**
+     * Primary {@link Key} that triggered the shortcut. Primary key can be
+     * anything that is not a {@link KeyModifier}.
      * @return
+     *          primary key
      */
     public Key getKey() {
         return key;
     }
 
     /**
+     * Set of {@link KeyModifier KeyModifiers} that, in combination with the
+     * primary key, triggered the shortcut.
      * @return
+     *          set of key modifiers
      */
     public Set<KeyModifier> getKeyModifiers() {
         return keyModifiers;

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutEvent.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package com.vaadin.flow.component;
 
 import java.io.Serializable;

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutEvent.java
@@ -1,0 +1,87 @@
+package com.vaadin.flow.component;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ShortcutEvent extends ComponentEvent<Component> {
+    private Component lifecycleOwner;
+    private Key key;
+    private Set<KeyModifier> keyModifiers;
+
+    /**
+     * Creates a new event using the given source and indicator whether the
+     * event originated from the client side or the server side.
+     *
+     * @param source     the source component
+     * @param fromClient <code>true</code> if the event originated from the client
+     */
+    public ShortcutEvent(Component source, boolean fromClient) {
+        this(source, fromClient, null, null);
+    }
+
+    /**
+     * @param source
+     * @param fromClient
+     * @param lifecycleOwner
+     * @param key
+     * @param keyModifiers
+     */
+    public ShortcutEvent(Component source, boolean fromClient,
+                         Component lifecycleOwner, Key key,
+                         KeyModifier... keyModifiers) {
+        super(source, fromClient);
+        this.lifecycleOwner = lifecycleOwner;
+        this.key = key;
+        this.keyModifiers = Collections.unmodifiableSet(
+                new HashSet<>(Arrays.asList(keyModifiers)));
+    }
+
+    /**
+     * @return
+     */
+    public Component getLifecycleOwner() {
+        return lifecycleOwner;
+    }
+
+    /**
+     * @return
+     */
+    public Key getKey() {
+        return key;
+    }
+
+    /**
+     * @return
+     */
+    public Set<KeyModifier> getKeyModifiers() {
+        return keyModifiers;
+    }
+
+    /**
+     * Checks if the event matches the given {@link Key} and (optional)
+     * {@link KeyModifier KeyModifiers}. If {@code key} is null or a wrong
+     * number of {@code keyModifiers} is given, returns {@code false}.
+     *
+     * @param key           {@code key} to compare
+     * @param keyModifiers  {@code keyModifiers} to compare
+     * @return Did the given parameters match those in the event?
+     */
+    public boolean matches(Key key, KeyModifier... keyModifiers) {
+        if (key == null) {
+            return false;
+        }
+        if (keyModifiers.length != this.keyModifiers.size()) {
+            return false;
+        }
+        List<String> keyStrings = Stream.of(keyModifiers)
+                .map(k -> k.getKeys().get(0)).collect(Collectors.toList());
+        return key.matches(this.key.getKeys().get(0)) && this.keyModifiers
+                .stream().allMatch(k -> keyStrings.stream()
+                        .anyMatch(k::matches));
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutEvent.java
@@ -9,7 +9,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Event when shortcut is detected
+ * Event when shortcut is detected.
  *
  * @author  Vaadin Ltd.
  * @since
@@ -20,7 +20,7 @@ public class ShortcutEvent extends EventObject implements Serializable {
     private Set<KeyModifier> keyModifiers;
 
     /**
-     * Creates a new {@code ShortcutEvent}
+     * Creates a new {@code ShortcutEvent}.
      *
      * @param source
      *          shortcut's {@code listenOn} {@link Component}

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutEventListener.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutEventListener.java
@@ -20,13 +20,15 @@ import java.io.Serializable;
 import java.util.EventListener;
 
 /**
- * Listener for shortcut events
+ * Listener for shortcut events.
  * @author  Vaadin Ltd.
  * @since
  */
 @FunctionalInterface
 public interface ShortcutEventListener extends EventListener, Serializable {
     /**
+     * Invoked when shortcut has been used.
+     *
      * @param event
      *          {@link ShortcutEvent} based on the registered shortcut
      */

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutEventListener.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutEventListener.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.component;
+
+import java.io.Serializable;
+import java.util.EventListener;
+
+/**
+ * Listener for shortcut events
+ * @author  Vaadin Ltd.
+ * @since
+ */
+@FunctionalInterface
+public interface ShortcutEventListener extends EventListener, Serializable {
+    /**
+     * @param event
+     *          {@link ShortcutEvent} based on the registered shortcut
+     */
+    void onShortcut(ShortcutEvent event);
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutEventListener.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutEventListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2019 Vaadin Ltd.
+ * Copyright 2000-2018 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -66,7 +66,6 @@ public class ShortcutRegistration implements Registration, Serializable {
     // used to determine, if we need to do something before client response
     private AtomicBoolean isDirty = new AtomicBoolean(false);
 
-    //private Command shortcutCommand;
     private ShortcutEventListener eventListener;
 
     // beforeClientResponse callback

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import java.security.InvalidParameterException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -32,7 +33,6 @@ import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableSupplier;
 import com.vaadin.flow.internal.ExecutionContext;
 import com.vaadin.flow.internal.StateTree;
-import com.vaadin.flow.server.Command;
 import com.vaadin.flow.shared.Registration;
 
 /**
@@ -66,7 +66,8 @@ public class ShortcutRegistration implements Registration, Serializable {
     // used to determine, if we need to do something before client response
     private AtomicBoolean isDirty = new AtomicBoolean(false);
 
-    private Command shortcutCommand;
+    //private Command shortcutCommand;
+    private ShortcutEventListener eventListener;
 
     // beforeClientResponse callback
     private final SerializableConsumer<ExecutionContext>
@@ -90,21 +91,22 @@ public class ShortcutRegistration implements Registration, Serializable {
      *              bound to. Supplier is given in order to get around some
      *              cases where the component might not be immediately
      *              available.
-     * @param command
-     *              The code to execute when the shortcut is invoked
+     * @param eventListener
+     *              The listener to invoke when the shortcut detected
      * @param key
-     *              Primary key of the shortcut. This can not be a modifier key.
+     *              Primary key of the shortcut. This can not be a
+     *              {@link KeyModifier}.
      */
     ShortcutRegistration(Component lifecycleOwner,
                          SerializableSupplier<Component> listenOnSupplier,
-                         Command command, Key key) {
+                         ShortcutEventListener eventListener, Key key) {
         if (Key.isModifier(key)) {
             throw new InvalidParameterException(String.format("Parameter " +
                     "'key' cannot belong to %s",
                     KeyModifier.class.getSimpleName()));
         }
 
-        shortcutCommand = command;
+        this.eventListener = eventListener;
         this.listenOnSupplier = listenOnSupplier;
         setLifecycleOwner(lifecycleOwner);
 
@@ -253,7 +255,7 @@ public class ShortcutRegistration implements Registration, Serializable {
         lifecycleOwner = null;
         listenOnComponent = null;
 
-        shortcutCommand = null;
+        eventListener = null;
     }
 
     /**
@@ -284,7 +286,7 @@ public class ShortcutRegistration implements Registration, Serializable {
      * @return Set of modifier keys
      */
     public Set<Key> getModifiers() {
-        return new HashSet<>(modifiers);
+        return Collections.unmodifiableSet(modifiers);
     }
 
     /**
@@ -404,7 +406,7 @@ public class ShortcutRegistration implements Registration, Serializable {
                         KeyDownEvent.class,
                         e -> {
                             if (lifecycleOwner.isVisible()) {
-                                shortcutCommand.execute();
+                                invokeShortcutEventListener();
                             }
                         },
                         domRegistration -> {
@@ -448,6 +450,16 @@ public class ShortcutRegistration implements Registration, Serializable {
                 shortcutActive = true;
             });
         }
+    }
+
+    private void invokeShortcutEventListener() {
+        // construct the event
+        final ShortcutEvent event = new ShortcutEvent(listenOnComponent,
+                lifecycleOwner, primaryKey,
+                modifiers.stream().map(k -> (KeyModifier)((HashableKey)k).key)
+                        .collect(Collectors.toSet()));
+
+        eventListener.onShortcut(event);
     }
 
     private void registerLifecycleOwner(Component owner) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2019 Vaadin Ltd.
+ * Copyright 2000-2018 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/flow-server/src/main/java/com/vaadin/flow/component/Shortcuts.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Shortcuts.java
@@ -55,7 +55,7 @@ public final class Shortcuts {
      *              {@link ShortcutRegistration} for configuring and removing the
      *              shortcut
      */
-    public static ShortcutRegistration addShortcut(
+    public static ShortcutRegistration addShortcutListener(
             Component lifecycleOwner, Command command, Key key,
             KeyModifier... keyModifiers) {
         if (lifecycleOwner == null) {
@@ -69,6 +69,43 @@ public final class Shortcuts {
             throw new InvalidParameterException(String.format(NULL, "key"));
         }
         return new ShortcutRegistration(lifecycleOwner, UI::getCurrent,
-                command, key).withModifiers(keyModifiers);
+                event -> command.execute(), key).withModifiers(keyModifiers);
+    }
+
+    /**
+     *
+     * @param lifecycleOwner
+     *              The component that controls, when the shortcut is active. If
+     *              the component is either invisible or detached, the shortcut
+     *              won't work
+     * @param listener
+     *              Listener to execute when the shortcut is invoked. Receives a
+     *              {@link ShortcutEvent}
+     * @param key
+     *              Primary {@link Key} used to trigger the shortcut
+     * @param keyModifiers
+     *              {@link KeyModifier KeyModifiers} which also need to be
+     *              pressed for the shortcut to trigger
+     * @return
+     *              {@link ShortcutRegistration} for configuring and removing the
+     *              shortcut
+     */
+    public ShortcutRegistration addShortcutListener(
+            Component lifecycleOwner, ShortcutEventListener listener, Key key,
+            KeyModifier... keyModifiers) {
+
+        if (lifecycleOwner == null) {
+            throw new InvalidParameterException(String.format(NULL,
+                    "lifecycleOwner"));
+        }
+        if (listener == null) {
+            throw new InvalidParameterException(String.format(NULL,
+                    "listener"));
+        }
+        if (key == null) {
+            throw new InvalidParameterException(String.format(NULL, "key"));
+        }
+        return new ShortcutRegistration(lifecycleOwner, UI::getCurrent,
+                listener, key).withModifiers(keyModifiers);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/Shortcuts.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Shortcuts.java
@@ -73,6 +73,14 @@ public final class Shortcuts {
     }
 
     /**
+     * Invoke a {@link ShortcutEventListener} when the shortcut is invoked.
+     * <p>
+     * Registering a shortcut using this method will tie it to
+     * {@code lifecycleOwner} and the shortcut is available in the global scope.
+     * <p>
+     * By default, the shortcut's listener is bound to {@link UI}. The listening
+     * component can be changed by calling
+     * {@link ShortcutRegistration#listenOn(Component)}.
      *
      * @param lifecycleOwner
      *              The component that controls, when the shortcut is active. If

--- a/flow-server/src/main/java/com/vaadin/flow/component/Shortcuts.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Shortcuts.java
@@ -41,13 +41,14 @@ public final class Shortcuts {
      * {@link ShortcutRegistration#listenOn(Component)}.
      *
      * @param lifecycleOwner
-     *              The component that controls, when the shortcut is active. If
+     *              the component that controls, when the shortcut is active. If
      *              the component is either invisible or detached, the shortcut
-     *              won't work
+     *              won't work. Cannot be null
      * @param command
-     *              Code to execute when the shortcut is invoked
+     *              code to execute when the shortcut is invoked. Cannot be null
      * @param key
-     *              Primary {@link Key} used to trigger the shortcut
+     *              primary {@link Key} used to trigger the shortcut. Cannot
+     *              be null
      * @param keyModifiers
      *              {@link KeyModifier KeyModifiers} which also need to be
      *              pressed for the shortcut to trigger
@@ -83,14 +84,15 @@ public final class Shortcuts {
      * {@link ShortcutRegistration#listenOn(Component)}.
      *
      * @param lifecycleOwner
-     *              The component that controls, when the shortcut is active. If
+     *              the component that controls, when the shortcut is active. If
      *              the component is either invisible or detached, the shortcut
-     *              won't work
+     *              won't work. Cannot be null
      * @param listener
-     *              Listener to execute when the shortcut is invoked. Receives a
-     *              {@link ShortcutEvent}
+     *              listener to execute when the shortcut is invoked. Receives a
+     *              {@link ShortcutEvent}. Cannot be null
      * @param key
-     *              Primary {@link Key} used to trigger the shortcut
+     *              primary {@link Key} used to trigger the shortcut. Cannot
+     *              be null
      * @param keyModifiers
      *              {@link KeyModifier KeyModifiers} which also need to be
      *              pressed for the shortcut to trigger

--- a/flow-server/src/main/java/com/vaadin/flow/component/Shortcuts.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Shortcuts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2019 Vaadin Ltd.
+ * Copyright 2000-2018 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -1009,19 +1009,19 @@ public class UI extends Component
      * {@link ShortcutRegistration#remove()} is called.
      *
      * @param command
-     *            Code to execute when the shortcut is invoked
+     *              Code to execute when the shortcut is invoked
      * @param key
-     *            Primary {@link Key} used to trigger the shortcut
+     *              Primary {@link Key} used to trigger the shortcut
      * @param keyModifiers
-     *            {@link KeyModifier KeyModifiers} which also need to be pressed
-     *            for the shortcut to trigger
-     * @return  {@link ShortcutRegistration} for configuring the shortcut and
-     *          removing
-     * @see #addShortcutListener(ComponentEventListener, Key, KeyModifier...)
-     *          For registering a listener which receives a
-     *          {@link ShortcutEvent}
+     *              {@link KeyModifier KeyModifiers} which also need to be
+     *              pressed for the shortcut to trigger
+     * @return      {@link ShortcutRegistration} for configuring the shortcut
+     *              and removing
+     * @see #addShortcutListener(ShortcutEventListener, Key, KeyModifier...)
+     *              For registering a listener which receives a {@link
+     *              ShortcutEvent}
      * @see Shortcuts
-     *          For a more generic way to add a shortcut
+     *              For a more generic way to add a shortcut
      */
     public ShortcutRegistration addShortcutListener(
             Command command, Key key, KeyModifier... keyModifiers) {
@@ -1046,17 +1046,17 @@ public class UI extends Component
      * {@link ShortcutRegistration#remove()} is called.
      *
      * @param listener
-     *            Listener to execute when the shortcut is invoked. Receives a
-     *            {@link ShortcutEvent}
+     *                  Listener to execute when the shortcut is invoked.
+     *                  Receives a {@link ShortcutEvent}
      * @param key
-     *            Primary {@link Key} used to trigger the shortcut
+     *                  Primary {@link Key} used to trigger the shortcut
      * @param keyModifiers
-     *            {@link KeyModifier KeyModifiers} which also need to be pressed
-     *            for the shortcut to trigger
-     * @return  {@link ShortcutRegistration} for configuring the shortcut and
-     *          removing
+     *                  {@link KeyModifier KeyModifiers} which also need to be
+     *                  pressed for the shortcut to trigger
+     * @return          {@link ShortcutRegistration} for configuring the
+     *                  shortcut and removing
      * @see Shortcuts
-     *          For a more generic way to add a shortcut
+     *                  For a more generic way to add a shortcut
      */
     public ShortcutRegistration addShortcutListener(
             ShortcutEventListener listener, Key key,

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -1009,19 +1009,21 @@ public class UI extends Component
      * {@link ShortcutRegistration#remove()} is called.
      *
      * @param command
-     *              Code to execute when the shortcut is invoked
+     *              code to execute when the shortcut is invoked. Cannot be
+     *              null
      * @param key
-     *              Primary {@link Key} used to trigger the shortcut
+     *              primary {@link Key} used to trigger the shortcut. Cannot
+     *              be null
      * @param keyModifiers
      *              {@link KeyModifier KeyModifiers} which also need to be
      *              pressed for the shortcut to trigger
      * @return      {@link ShortcutRegistration} for configuring the shortcut
      *              and removing
      * @see #addShortcutListener(ShortcutEventListener, Key, KeyModifier...)
-     *              For registering a listener which receives a {@link
+     *              for registering a listener which receives a {@link
      *              ShortcutEvent}
      * @see Shortcuts
-     *              For a more generic way to add a shortcut
+     *              for a more generic way to add a shortcut
      */
     public ShortcutRegistration addShortcutListener(
             Command command, Key key, KeyModifier... keyModifiers) {
@@ -1046,17 +1048,17 @@ public class UI extends Component
      * {@link ShortcutRegistration#remove()} is called.
      *
      * @param listener
-     *                  Listener to execute when the shortcut is invoked.
-     *                  Receives a {@link ShortcutEvent}
+     *                  listener to execute when the shortcut is invoked.
+     *                  Receives a {@link ShortcutEvent}. Cannot be null
      * @param key
-     *                  Primary {@link Key} used to trigger the shortcut
+     *                  primary {@link Key} used to trigger the shortcut
      * @param keyModifiers
      *                  {@link KeyModifier KeyModifiers} which also need to be
      *                  pressed for the shortcut to trigger
      * @return          {@link ShortcutRegistration} for configuring the
      *                  shortcut and removing
      * @see Shortcuts
-     *                  For a more generic way to add a shortcut
+     *                  for a more generic way to add a shortcut
      */
     public ShortcutRegistration addShortcutListener(
             ShortcutEventListener listener, Key key,

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -16,6 +16,7 @@
 
 package com.vaadin.flow.component;
 
+import java.security.InvalidParameterException;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -1000,12 +1001,12 @@ public class UI extends Component
     }
 
     /**
-     * Registers a global shortcut tied to the {@code UI} and returns
-     * {@link ShortcutRegistration} which can be used to fluently configure the
-     * shortcut. The shortcut will be present until
-     * {@link ShortcutRegistration#remove()} is called.
+     * Registers a global shortcut tied to the {@code UI} which executes the
+     * given {@link Command} when invoked.
      * <p>
-     * For more configuration option, use a method in {@link Shortcuts}.
+     * Returns {@link ShortcutRegistration} which can be used to fluently
+     * configure the shortcut. The shortcut will be present until
+     * {@link ShortcutRegistration#remove()} is called.
      *
      * @param command
      *            Code to execute when the shortcut is invoked
@@ -1016,11 +1017,59 @@ public class UI extends Component
      *            for the shortcut to trigger
      * @return  {@link ShortcutRegistration} for configuring the shortcut and
      *          removing
+     * @see #addShortcutListener(ComponentEventListener, Key, KeyModifier...)
+     *          For registering a listener which receives a
+     *          {@link ShortcutEvent}
      * @see Shortcuts
+     *          For a more generic way to add a shortcut
      */
-    public ShortcutRegistration addShortcut(Command command, Key key,
-                                            KeyModifier... keyModifiers) {
-        return new ShortcutRegistration(this, () -> this, command,
-                key).withModifiers(keyModifiers);
+    public ShortcutRegistration addShortcutListener(
+            Command command, Key key, KeyModifier... keyModifiers) {
+        if (command == null) {
+            throw new InvalidParameterException(String.format(Shortcuts.NULL,
+                    "command"));
+        }
+        if (key == null) {
+            throw new InvalidParameterException(String.format(Shortcuts.NULL,
+                    "key"));
+        }
+        return new ShortcutRegistration(this, () -> this,
+                event -> command.execute(), key).withModifiers(keyModifiers);
+    }
+
+    /**
+     * Registers a global shortcut tied to the {@code UI} which executes the
+     * given {@link ComponentEventListener} when invoked.
+     * <p>
+     * Returns {@link ShortcutRegistration} which can be used to fluently
+     * configure the shortcut. The shortcut will be present until
+     * {@link ShortcutRegistration#remove()} is called.
+     *
+     * @param listener
+     *            Listener to execute when the shortcut is invoked. Receives a
+     *            {@link ShortcutEvent}
+     * @param key
+     *            Primary {@link Key} used to trigger the shortcut
+     * @param keyModifiers
+     *            {@link KeyModifier KeyModifiers} which also need to be pressed
+     *            for the shortcut to trigger
+     * @return  {@link ShortcutRegistration} for configuring the shortcut and
+     *          removing
+     * @see Shortcuts
+     *          For a more generic way to add a shortcut
+     */
+    public ShortcutRegistration addShortcutListener(
+            ShortcutEventListener listener, Key key,
+            KeyModifier... keyModifiers) {
+        if (listener == null) {
+            throw new InvalidParameterException(String.format(Shortcuts.NULL,
+                    "listener"));
+        }
+        if (key == null) {
+            throw new InvalidParameterException(String.format(Shortcuts.NULL,
+                    "key"));
+        }
+        return new ShortcutRegistration(this, () -> this,
+                listener, key).withModifiers(keyModifiers);
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutEventTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutEventTest.java
@@ -35,7 +35,7 @@ public class ShortcutEventTest {
 
     private static ShortcutEvent event(Key key, KeyModifier... modifiers) {
         Component component = mock(Component.class);
-        return new ShortcutEvent(component, false, component, key,
+        return new ShortcutEvent(component, component, key,
                 new HashSet<>(Arrays.asList(modifiers)));
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutEventTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutEventTest.java
@@ -1,0 +1,41 @@
+package com.vaadin.flow.component;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+
+public class ShortcutEventTest {
+
+    private ShortcutEvent eventNoModifiers = event(Key.KEY_F);
+    private ShortcutEvent eventOneModifier = event(Key.KEY_F, KeyModifier.ALT);
+    private ShortcutEvent eventTwoModifiers = event(Key.KEY_F, KeyModifier.ALT,
+            KeyModifier.CONTROL);
+
+    @Test
+    public void matches() {
+        assertFalse("Null key should return false",
+                eventNoModifiers.matches(null));
+        assertFalse("Extra modifier should return false",
+                eventNoModifiers.matches(Key.KEY_F, KeyModifier.ALT));
+        assertFalse("Missing modifier should return false",
+                eventOneModifier.matches(Key.KEY_F));
+
+        assertTrue("Matching key should return true",
+                eventNoModifiers.matches(Key.KEY_F));
+        assertTrue("Matching key and modifier should return true",
+                eventOneModifier.matches(Key.KEY_F, KeyModifier.ALT));
+        assertTrue("Matching key and two modifiers should return true",
+                eventTwoModifiers.matches(Key.KEY_F, KeyModifier.ALT,
+                        KeyModifier.CONTROL));
+    }
+
+    private static ShortcutEvent event(Key key, KeyModifier... modifiers) {
+        Component component = mock(Component.class);
+        return new ShortcutEvent(component, false, component, key,
+                new HashSet<>(Arrays.asList(modifiers)));
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
@@ -60,7 +60,7 @@ public class ShortcutRegistrationTest {
     @Test
     public void registrationWillBeCompletedBeforeClientResponse() {
         ShortcutRegistration registration = new ShortcutRegistration(
-                lifecycleOwner, () -> listenOn, () -> {}, Key.KEY_A);
+                lifecycleOwner, () -> listenOn, event -> {}, Key.KEY_A);
 
         clientResponse();
 
@@ -75,7 +75,7 @@ public class ShortcutRegistrationTest {
     @Test
     public void constructedRegistrationIsDirty() {
         ShortcutRegistration registration = new ShortcutRegistration(
-                lifecycleOwner, () -> listenOn, () -> {}, Key.KEY_A);
+                lifecycleOwner, () -> listenOn, event -> {}, Key.KEY_A);
 
         assertTrue(registration.isDirty());
     }
@@ -83,7 +83,7 @@ public class ShortcutRegistrationTest {
     @Test
     public void lateUpdateOfModifiersDirtiesRegistration() {
         ShortcutRegistration registration = new ShortcutRegistration(
-                lifecycleOwner, () -> listenOn, () -> {}, Key.KEY_A);
+                lifecycleOwner, () -> listenOn, event -> {}, Key.KEY_A);
 
         clientResponse();
 
@@ -98,7 +98,7 @@ public class ShortcutRegistrationTest {
     @Test
     public void fluentModifiersAreAddedCorrectly() {
         ShortcutRegistration registration = new ShortcutRegistration(
-                lifecycleOwner, () -> listenOn, () -> {}, Key.KEY_A);
+                lifecycleOwner, () -> listenOn, event -> {}, Key.KEY_A);
 
         registration.withAlt().withCtrl().withMeta().withShift();
 
@@ -108,7 +108,7 @@ public class ShortcutRegistrationTest {
     @Test
     public void preventDefaultAndStopPropagationValuesDefaultToTrue() {
         ShortcutRegistration registration = new ShortcutRegistration(
-                lifecycleOwner, () -> listenOn, () -> {}, Key.KEY_A);
+                lifecycleOwner, () -> listenOn, event -> {}, Key.KEY_A);
 
         assertTrue(registration.preventsDefault());
         assertTrue(registration.stopsPropagation());
@@ -124,7 +124,7 @@ public class ShortcutRegistrationTest {
         Component newOwner = mock(Component.class);
 
         ShortcutRegistration registration = new ShortcutRegistration(
-                lifecycleOwner, () -> listenOn, () -> {}, Key.KEY_A);
+                lifecycleOwner, () -> listenOn, event -> {}, Key.KEY_A);
 
         assertEquals(lifecycleOwner, registration.getLifecycleOwner());
 
@@ -137,7 +137,7 @@ public class ShortcutRegistrationTest {
     @Test
     public void listenOnChangesTheComponentThatOwnsTheListener() {
         ShortcutRegistration registration = new ShortcutRegistration(
-                lifecycleOwner, () -> listenOn, () -> {}, Key.KEY_A);
+                lifecycleOwner, () -> listenOn, event -> {}, Key.KEY_A);
 
         // No response, no listenOn component
         assertNull(registration.getOwner());

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2019 Vaadin Ltd.
+ * Copyright 2000-2018 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2019 Vaadin Ltd.
+ * Copyright 2000-2018 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ShortcutsIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ShortcutsIT.java
@@ -19,6 +19,7 @@ package com.vaadin.flow.uitest.ui;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
@@ -29,18 +30,19 @@ import com.vaadin.flow.testutil.ChromeBrowserTest;
 
 public class ShortcutsIT extends ChromeBrowserTest {
 
+    @Before
+    public void before() {
+        open();
+    }
+
     @Test
     public void clickShortcutWorks() {
-        open();
-
         sendKeys(Keys.ALT, "b");
         Assert.assertEquals("button", getValue());
     }
 
     @Test
     public void focusShortcutWorks() {
-        open();
-
         sendKeys(Keys.ALT, "f") ;
 
         WebElement input = findElement(By.id("input"));
@@ -50,8 +52,6 @@ public class ShortcutsIT extends ChromeBrowserTest {
 
     @Test
     public void shortcutsOnlyWorkWhenComponentIsVisible() {
-        open();
-
         sendKeys(Keys.ALT, "v");
         Assert.assertEquals("invisibleP", getValue());
 
@@ -72,8 +72,6 @@ public class ShortcutsIT extends ChromeBrowserTest {
 
     @Test
     public void listenOnScopesTheShortcut() {
-        open();
-
         sendKeys(Keys.ALT, "s");
         Assert.assertEquals("testing...", getValue()); // nothing happened
 
@@ -87,8 +85,6 @@ public class ShortcutsIT extends ChromeBrowserTest {
 
     @Test
     public void shortcutsOnlyWorkWhenComponentIsAttached() {
-        open();
-
         sendKeys(Keys.ALT, "a");
         Assert.assertEquals("testing...", getValue()); // nothing happens
 
@@ -107,6 +103,20 @@ public class ShortcutsIT extends ChromeBrowserTest {
         Assert.assertEquals("toggled!", getValue()); // nothing happens
     }
 
+    @Test
+    public void modifyingShortcutShouldChangeShortcutEvent() {
+        // the shortcut in this test flips its own modifiers
+        sendKeys(Keys.ALT, "g");
+        Assert.assertEquals("Alt", getValue());
+
+        sendKeys("G");
+        Assert.assertEquals("Shift", getValue());
+
+        // check that things revert back.
+        sendKeys(Keys.ALT, "g");
+        Assert.assertEquals("Alt", getValue());
+    }
+
     private String getValue() {
         WebElement expected = findElement(By.id("expected"));
         return expected.getText();
@@ -120,9 +130,5 @@ public class ShortcutsIT extends ChromeBrowserTest {
 
     private void resetKeys() {
         new Actions(driver).sendKeys(Keys.NULL).build().perform();
-    }
-
-    private void _wait(long millis) {
-        driver.manage().timeouts().implicitlyWait(millis, TimeUnit.MILLISECONDS);
     }
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ShortcutsIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ShortcutsIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2019 Vaadin Ltd.
+ * Copyright 2000-2018 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of


### PR DESCRIPTION
This PR adds `ShortcutEventListener` interface and `ShortcutEvent` given to the listener implementing the interface. Each method used to register shortcuts that took `Command` now have an overload which takes a `ShortcutEventListener`.

The `ShortcutEventListener` does not extend `ComponentEventListener<T extends ComponentEvent>` since I could not perceive a nice way to implement shortcuts which can be registered using `Component#addListener(ComponentEv...)`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/4999)
<!-- Reviewable:end -->
