### PR TITLE
Do registry.clean on RouteConfiguration.update

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/RouteRegistryInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/RouteRegistryInitializer.java
@@ -54,7 +54,6 @@ public class RouteRegistryInitializer extends AbstractRouteRegistryInitializer
             RouteConfiguration routeConfiguration = RouteConfiguration
                     .forRegistry(routeRegistry);
             routeConfiguration.update(() -> {
-                routeConfiguration.getHandledRegistry().clean();
                 for (Class<? extends Component> navigationTarget : routes) {
                     routeConfiguration.setAnnotatedRoute(navigationTarget);
                 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/InvalidUrlTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/InvalidUrlTest.java
@@ -98,7 +98,6 @@ public class InvalidUrlTest {
             RouteConfiguration routeConfiguration = RouteConfiguration
                     .forRegistry(ui.getRouter().getRegistry());
             routeConfiguration.update(() -> {
-                routeConfiguration.getHandledRegistry().clean();
                 Arrays.asList(UITest.RootNavigationTarget.class,
                         UITest.FooBarNavigationTarget.class).forEach(routeConfiguration::setAnnotatedRoute);
             });

--- a/flow-server/src/test/java/com/vaadin/flow/component/UITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/UITest.java
@@ -177,7 +177,6 @@ public class UITest {
                     .forRegistry(ui.getRouter().getRegistry());
 
             routeConfiguration.update(() -> {
-                routeConfiguration.getHandledRegistry().clean();
                 Arrays.asList(RootNavigationTarget.class,
                         FooBarNavigationTarget.class).forEach(routeConfiguration::setAnnotatedRoute);
             });

--- a/flow-server/src/test/java/com/vaadin/flow/router/DefaultRouteResolverTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/DefaultRouteResolverTest.java
@@ -65,7 +65,6 @@ public class DefaultRouteResolverTest extends RoutingTestBase {
         RouteConfiguration routeConfiguration = RouteConfiguration
                 .forRegistry(registry);
         routeConfiguration.update(() -> {
-            routeConfiguration.getHandledRegistry().clean();
             routes.forEach(routeConfiguration::setAnnotatedRoute);
         });
     }

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouteConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouteConfigurationTest.java
@@ -327,7 +327,6 @@ public class RouteConfigurationTest {
         }).when(registry).update(Mockito.any(Command.class));
 
         routeConfiguration.update(() -> {
-            routeConfiguration.getHandledRegistry().clean();
             Arrays.asList(MyRoute.class, MyInfo.class, MyPalace.class,
                     MyModular.class).forEach(routeConfiguration::setAnnotatedRoute);
         });

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterLinkTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterLinkTest.java
@@ -64,7 +64,6 @@ public class RouterLinkTest extends HasCurrentService {
         RouteConfiguration routeConfiguration = RouteConfiguration
                 .forRegistry(registry);
         routeConfiguration.update(() -> {
-            routeConfiguration.getHandledRegistry().clean();
             Arrays.asList(TestView.class, FooNavigationTarget.class,
                     GreetingNavigationTarget.class)
                     .forEach(routeConfiguration::setAnnotatedRoute);

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
@@ -3027,7 +3027,6 @@ public class RouterTest extends RoutingTestBase {
         RouteConfiguration routeConfiguration = RouteConfiguration
                 .forRegistry(router.getRegistry());
         routeConfiguration.update(() -> {
-            routeConfiguration.getHandledRegistry().clean();
             Arrays.asList(navigationTargets)
                     .forEach(routeConfiguration::setAnnotatedRoute);
         });

--- a/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerPushConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerPushConfigurationTest.java
@@ -178,7 +178,6 @@ public class BootstrapHandlerPushConfigurationTest {
         RouteConfiguration routeConfiguration = RouteConfiguration
                 .forRegistry(service.getRouteRegistry());
         routeConfiguration.update(() -> {
-            routeConfiguration.getHandledRegistry().clean();
             routeConfiguration.setAnnotatedRoute(annotatedClazz);
         });
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
@@ -426,7 +426,6 @@ public class BootstrapHandlerTest {
         RouteConfiguration routeConfiguration = RouteConfiguration
                 .forRegistry(service.getRouteRegistry());
         routeConfiguration.update(() -> {
-            routeConfiguration.getHandledRegistry().clean();
             navigationTargets.forEach(routeConfiguration::setAnnotatedRoute);
         });
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/UidlWriterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/UidlWriterTest.java
@@ -432,7 +432,6 @@ public class UidlWriterTest {
         RouteConfiguration routeConfiguration = RouteConfiguration
                 .forRegistry(ui.getRouter().getRegistry());
         routeConfiguration.update(() -> {
-            routeConfiguration.getHandledRegistry().clean();
             routeConfiguration.setAnnotatedRoute(BaseClass.class);
         });
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/ServletDeployerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/ServletDeployerTest.java
@@ -255,7 +255,6 @@ public class ServletDeployerTest {
                         RouteConfiguration routeConfiguration = RouteConfiguration
                                 .forRegistry(registry);
                         routeConfiguration.update(() -> {
-                            routeConfiguration.getHandledRegistry().clean();
                             routeConfiguration.setAnnotatedRoute(ComponentWithRoute.class);
                         });
                         return registry;


### PR DESCRIPTION
This will remove redundant calls to clean and also the access to registry through configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5011)
<!-- Reviewable:end -->
