### PR TITLE
Fix RouteRegistry access during ServiceInitListener

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteConfiguration.java
@@ -33,7 +33,9 @@ import com.vaadin.flow.server.Command;
 import com.vaadin.flow.server.InvalidRouteConfigurationException;
 import com.vaadin.flow.server.RouteRegistry;
 import com.vaadin.flow.server.SessionRouteRegistry;
+import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServlet;
+import com.vaadin.flow.server.VaadinServletService;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.startup.ApplicationRouteRegistry;
 import com.vaadin.flow.shared.Registration;
@@ -505,9 +507,19 @@ public class RouteConfiguration implements Serializable {
     /* Private methods */
 
     private static RouteRegistry getApplicationRegistry() {
-        return ApplicationRouteRegistry
-                .getInstance(VaadinServlet.getCurrent().getServletContext());
-    }
+        VaadinService service = VaadinService.getCurrent();
+        if (service instanceof VaadinServletService) {
+            return ApplicationRouteRegistry
+                    .getInstance(((VaadinServletService) service).getServlet()
+                            .getServletContext());
+        } else {
+            // TODO Once we have PortletService, this will explode
+            // we will need route registry for portlet context
+            throw new IllegalStateException("Cannot access "
+                    + ApplicationRouteRegistry.class.getName() + ", because no "
+                    + "VaadinServletService available for " +
+                    "fetching ServletContext");
+        }    }
 
     private static RouteRegistry getSessionRegistry() {
         return SessionRouteRegistry

--- a/flow-server/src/test/java/com/vaadin/flow/server/MockServletContext.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/MockServletContext.java
@@ -21,6 +21,7 @@ import java.net.URL;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.EventListener;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -42,6 +43,8 @@ import javax.servlet.descriptor.JspConfigDescriptor;
  * @since 1.0
  */
 public class MockServletContext implements ServletContext {
+
+    HashMap<String, Object> sessionAttributes = new HashMap<>();
 
     /*
      * (non-Javadoc)
@@ -243,7 +246,7 @@ public class MockServletContext implements ServletContext {
      */
     @Override
     public Object getAttribute(String name) {
-        return null;
+        return sessionAttributes.get(name);
     }
 
     /*
@@ -265,6 +268,7 @@ public class MockServletContext implements ServletContext {
      */
     @Override
     public void setAttribute(String name, Object object) {
+        sessionAttributes.put(name, object);
     }
 
     /*
@@ -274,6 +278,7 @@ public class MockServletContext implements ServletContext {
      */
     @Override
     public void removeAttribute(String name) {
+        sessionAttributes.remove(name);
     }
 
     /*

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServiceTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServiceTest.java
@@ -33,6 +33,12 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpSessionBindingEvent;
 
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouteConfiguration;
+import com.vaadin.flow.router.RouteData;
+import com.vaadin.flow.router.Router;
 import org.easymock.EasyMock;
 import org.junit.Assert;
 import org.junit.Test;
@@ -53,6 +59,11 @@ import net.jcip.annotations.NotThreadSafe;
  */
 @NotThreadSafe
 public class VaadinServiceTest {
+
+    @Tag("div")
+    public static class TestView extends Component {
+
+    }
 
     private class TestSessionDestroyListener implements SessionDestroyListener {
 
@@ -226,6 +237,38 @@ public class VaadinServiceTest {
 
         Assert.assertFalse(listener1Run.get());
         Assert.assertTrue(listener2Run.get());
+    }
+
+    @Test
+    public void testServiceInitListener_accessApplicationRouteRegistry_registryAvailable() {
+
+        VaadinServiceInitListener initListener = event -> {
+            Assert.assertNotNull("service init should have set thread local",
+                    VaadinService.getCurrent());
+
+            Router router = event.getSource().getRouter();
+            Assert.assertNotEquals("Router should be initialized", router);
+
+            Assert.assertNotEquals("registry should be initialized",
+                    router.getRegistry());
+
+            RouteConfiguration.forApplicationScope().setRoute("test",
+                    TestView.class);
+        };
+        MockInstantiator instantiator = new MockInstantiator(initListener);
+
+        MockVaadinServletService service = new MockVaadinServletService();
+
+        service.init(instantiator);
+
+        // the following will allow the route configuration call to work
+        VaadinService.setCurrent(service);
+        List<RouteData> availableRoutes = RouteConfiguration
+                .forApplicationScope().getAvailableRoutes();
+        VaadinService.setCurrent(null);
+
+        Assert.assertEquals(1, availableRoutes.size());
+        Assert.assertEquals(availableRoutes.get(0).getUrl(), "test");
     }
 
     @Test

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DynamicallyRegisteredRoute.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DynamicallyRegisteredRoute.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.html.Div;
+
+public class DynamicallyRegisteredRoute extends Div {
+
+    public static final String TEXT =
+            "This route has been registered dynamically with a ServiceInitListener";
+    public static final String ID = "foobar";
+
+    public DynamicallyRegisteredRoute() {
+        setId(ID);
+        setText(TEXT);
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TestingServiceInitListener.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TestingServiceInitListener.java
@@ -19,11 +19,13 @@ import java.io.Serializable;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.vaadin.flow.router.BeforeEnterListener;
+import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.flow.server.ServiceInitEvent;
 import com.vaadin.flow.server.UIInitListener;
 import com.vaadin.flow.server.VaadinServiceInitListener;
 
 public class TestingServiceInitListener implements VaadinServiceInitListener {
+    public static final String DYNAMICALLY_REGISTERED_ROUTE = "dynamically-registered-route";
     private static AtomicInteger initCount = new AtomicInteger();
     private static AtomicInteger requestCount = new AtomicInteger();
 
@@ -45,6 +47,13 @@ public class TestingServiceInitListener implements VaadinServiceInitListener {
                                     }
                                 }));
         initCount.incrementAndGet();
+
+        RouteConfiguration configuration = RouteConfiguration.forApplicationScope();
+        if (!configuration.isPathRegistered(DYNAMICALLY_REGISTERED_ROUTE)) {
+            configuration.setRoute(
+                    DYNAMICALLY_REGISTERED_ROUTE,
+                    DynamicallyRegisteredRoute.class);
+        }
 
         event.addRequestHandler((session, request, response) -> {
             requestCount.incrementAndGet();

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DynamicallyRegisteredRouteIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DynamicallyRegisteredRouteIT.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.uitest.ui;
+
+import java.util.List;
+
+import com.vaadin.flow.testcategory.IgnoreOSGi;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+@Category(IgnoreOSGi.class)
+public class DynamicallyRegisteredRouteIT extends ChromeBrowserTest {
+
+    @Test
+    public void testServiceInitListener_canRegisterRoutes() {
+        String testURL = getTestURL(getRootURL(), "/view/"
+                + TestingServiceInitListener.DYNAMICALLY_REGISTERED_ROUTE,
+                null);
+        getDriver().get(testURL);
+
+        List<WebElement> elements = findElements(
+                By.id(DynamicallyRegisteredRoute.ID));
+
+        Assert.assertEquals("Route registered during startup is not available",
+                1, elements.size());
+        Assert.assertEquals("Dynamically registered route not rendered",
+                DynamicallyRegisteredRoute.TEXT, elements.get(0).getText());
+    }
+}


### PR DESCRIPTION
Fixes editing of application scoped routes from service init listener.

Needs to be picked for 1.3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5018)
<!-- Reviewable:end -->
