### PR TITLE
Shortcuts: change click shortcut's default behavior

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
@@ -67,7 +67,7 @@ public interface ClickNotifier<T extends Component> extends Serializable {
      * This is used to make sure that value synchronization of input fields is
      * not blocked for the shortcut key (e.g. Enter key).
      * To change this behavior, call
-     * {@link ShortcutRegistration#setPreventBrowserDefault(boolean)}.
+     * {@link ShortcutRegistration#setBrowserDefaultPrevented(boolean)}.
      *
      * @param key
      *              primary {@link Key} used to trigger the shortcut. Cannot

--- a/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
@@ -63,7 +63,7 @@ public interface ClickNotifier<T extends Component> extends Serializable {
      * shortcut. By default, the returned {@code ShortcutRegistration} allows
      * browser's default behavior, unlike other {@code ShortcutRegistrations}.
      * To change this behavior, call
-     * {@link ShortcutRegistration#setAllowBrowserDefault(boolean)}.
+     * {@link ShortcutRegistration#setPreventBrowserDefault(boolean)}.
      *
      * @param key
      *              primary {@link Key} used to trigger the shortcut. Cannot

--- a/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
@@ -64,6 +64,8 @@ public interface ClickNotifier<T extends Component> extends Serializable {
      * <p>
      * By default, the returned {@code ShortcutRegistration} allows
      * browser's default behavior, unlike other {@code ShortcutRegistrations}.
+     * This is used to make sure that value synchronization of input fields is
+     * not blocked for the shortcut key (e.g. Enter key).
      * To change this behavior, call
      * {@link ShortcutRegistration#setPreventBrowserDefault(boolean)}.
      *

--- a/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
@@ -60,7 +60,9 @@ public interface ClickNotifier<T extends Component> extends Serializable {
      * component.
      * <p>
      * Use the returned {@link ShortcutRegistration} to fluently configure the
-     * shortcut. By default, the returned {@code ShortcutRegistration} allows
+     * shortcut.
+     * <p>
+     * By default, the returned {@code ShortcutRegistration} allows
      * browser's default behavior, unlike other {@code ShortcutRegistrations}.
      * To change this behavior, call
      * {@link ShortcutRegistration#setPreventBrowserDefault(boolean)}.

--- a/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
@@ -60,7 +60,10 @@ public interface ClickNotifier<T extends Component> extends Serializable {
      * component.
      * <p>
      * Use the returned {@link ShortcutRegistration} to fluently configure the
-     * shortcut.
+     * shortcut. By default, the returned {@code ShortcutRegistration} allows
+     * browser's default behavior, unlike other {@code ShortcutRegistrations}.
+     * To change this behavior, call
+     * {@link ShortcutRegistration#setAllowBrowserDefault(boolean)}.
      *
      * @param key
      *              primary {@link Key} used to trigger the shortcut. Cannot
@@ -90,6 +93,7 @@ public interface ClickNotifier<T extends Component> extends Serializable {
         return new ShortcutRegistration(thisComponent, UI::getCurrent,
                 event -> ComponentUtil.fireEvent(thisComponent,
                         new ClickEvent<>(thisComponent)),
-                key).withModifiers(keyModifiers);
+                key).withModifiers(keyModifiers)
+                .allowBrowserDefault();
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ClickNotifier.java
@@ -67,7 +67,7 @@ public interface ClickNotifier<T extends Component> extends Serializable {
      * This is used to make sure that value synchronization of input fields is
      * not blocked for the shortcut key (e.g. Enter key).
      * To change this behavior, call
-     * {@link ShortcutRegistration#setBrowserDefaultPrevented(boolean)}.
+     * {@link ShortcutRegistration#setBrowserDefaultAllowed(boolean)}.
      *
      * @param key
      *              primary {@link Key} used to trigger the shortcut. Cannot

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -294,30 +294,30 @@ public class ShortcutRegistration implements Registration, Serializable {
      *
      * @return Prevents default key behavior
      */
-    public boolean getPreventBrowserDefault() {
+    public boolean isBrowserDefaultPrevented() {
         return preventDefault;
     }
 
     /**
-     * Set whether default key behavior is prevented in the browser. If not
+     * Set whether the default key behavior is prevented in the browser. If not
      * changed, default key behavior is not allowed.
      *
-     * @param preventBrowserDefault   Prevent default key behavior
+     * @param browserDefaultPrevented   Prevent default key behavior
      */
-    public void setPreventBrowserDefault(boolean preventBrowserDefault) {
-        if (preventDefault != preventBrowserDefault) {
-            preventDefault = preventBrowserDefault;
+    public void setBrowserDefaultPrevented(boolean browserDefaultPrevented) {
+        if (preventDefault != browserDefaultPrevented) {
+            preventDefault = browserDefaultPrevented;
             prepareForClientResponse();
         }
     }
 
     /**
      * Checks if the shortcut is stopping key event (associated with the
-     * shortcut) propagation in the browser?
+     * shortcut) propagation in the browser.
      *
      * @return Stops event propagation
      */
-    public boolean getStopEventPropagation() {
+    public boolean isEventPropagationStopped() {
         return stopPropagation;
     }
 
@@ -325,11 +325,11 @@ public class ShortcutRegistration implements Registration, Serializable {
      * Set whether shortcut's key event is stopped from propagating up the DOM
      * tree in the browser. If not changed, event propagation is not allowed.
      *
-     * @param stopEventPropagation  Stop event propagation
+     * @param eventPropagationStopped  Stop event propagation
      */
-    public void setStopEventPropagation(boolean stopEventPropagation) {
-        if (stopPropagation != stopEventPropagation) {
-            stopPropagation = stopEventPropagation;
+    public void setEventPropagationStopped(boolean eventPropagationStopped) {
+        if (stopPropagation != eventPropagationStopped) {
+            stopPropagation = eventPropagationStopped;
             prepareForClientResponse();
         }
     }

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -303,19 +303,20 @@ public class ShortcutRegistration implements Registration, Serializable {
 
     /**
      * Checks if the default key behaviour in the browser is allowed by the
-     * shortcut. This is {@code false} by default.
+     * shortcut. The default value is {@code false}.
      *
-     * @return Prevents default key behavior
+     * @return Allows default key behavior
      */
     public boolean isBrowserDefaultAllowed() {
         return allowDefaultBehavior;
     }
 
     /**
-     * Set whether the default key behavior is allowed in the browser. If not
-     * changed, default key behavior is not allowed.
+     * Set whether the default key behavior is allowed in the browser. The
+     * default value is {@code false}, and it prevents the default key events
+     * from taking place in the browser.
      *
-     * @param browserDefaultAllowed   Prevent default key behavior
+     * @param browserDefaultAllowed   Allow default behavior on keydown
      */
     public void setBrowserDefaultAllowed(boolean browserDefaultAllowed) {
         if (allowDefaultBehavior != browserDefaultAllowed) {
@@ -337,10 +338,10 @@ public class ShortcutRegistration implements Registration, Serializable {
     }
 
     /**
-     * Checks if the shortcut is allowing keydown event (associated with the
-     * shortcut) propagation in the browser. This is {@code false} by default.
+     * Checks if the shortcut allows keydown event (associated with the
+     * shortcut) propagation in the browser. The default value is {@code false}.
      *
-     * @return Stops event propagation
+     * @return Allows event propagation
      */
     public boolean isEventPropagationAllowed() {
         return allowEventPropagation;
@@ -348,10 +349,10 @@ public class ShortcutRegistration implements Registration, Serializable {
 
     /**
      * Set whether shortcut's keydown event is allowed to propagate up the
-     * DOM tree in the browser. If not changed, event propagation is not
-     * allowed.
+     * DOM tree in the browser. The default value is {@code false}, and the
+     * DOM event is consumed by the shortcut handler.
      *
-     * @param eventPropagationAllowed  Stop event propagation
+     * @param eventPropagationAllowed  Allow event propagation
      */
     public void setEventPropagationAllowed(boolean eventPropagationAllowed) {
         if (allowEventPropagation != eventPropagationAllowed) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -291,6 +291,17 @@ public class ShortcutRegistration implements Registration, Serializable {
     }
 
     /**
+     * Is the shortcut preventing default key behaviour.
+     *
+     * @return Prevents default behavior
+     * @deprecated Replaced by {@link #isBrowserDefaultAllowed} in 1.4
+     */
+    @Deprecated
+    public boolean preventsDefault() {
+        return !allowDefaultBehavior;
+    }
+
+    /**
      * Checks if the default key behaviour in the browser is allowed by the
      * shortcut. This is {@code false} by default.
      *
@@ -311,6 +322,18 @@ public class ShortcutRegistration implements Registration, Serializable {
             allowDefaultBehavior = browserDefaultAllowed;
             prepareForClientResponse();
         }
+    }
+
+    /**
+     * Is the shortcut stopping the keyboard event from propagating up the DOM
+     * tree.
+     *
+     * @return Stops propagation
+     * @deprecated Replaced by {@link #isEventPropagationAllowed()} in 1.4
+     */
+    @Deprecated
+    public boolean stopsPropagation() {
+        return !allowEventPropagation;
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -289,7 +289,8 @@ public class ShortcutRegistration implements Registration, Serializable {
     }
 
     /**
-     * Checks if the shortcut preventing default key behaviour in the browser.
+     * Checks if the shortcut is preventing default key behaviour in the
+     * browser.
      *
      * @return Prevents default key behavior
      */
@@ -298,21 +299,21 @@ public class ShortcutRegistration implements Registration, Serializable {
     }
 
     /**
-     * Set whether default key behavior should be prevented in the browser. If
-     * not changed, default key behavior is not allowed.
+     * Set whether default key behavior is prevented in the browser. If not
+     * changed, default key behavior is not allowed.
      *
      * @param preventBrowserDefault   Prevent default key behavior
      */
     public void setPreventBrowserDefault(boolean preventBrowserDefault) {
         if (preventDefault != preventBrowserDefault) {
-            preventDefault = !preventBrowserDefault;
+            preventDefault = preventBrowserDefault;
             prepareForClientResponse();
         }
     }
 
     /**
-     * Checks if the shortcut stopping key event (associated with the shortcut)
-     * propagation in the browser?
+     * Checks if the shortcut is stopping key event (associated with the
+     * shortcut) propagation in the browser?
      *
      * @return Stops event propagation
      */
@@ -326,9 +327,9 @@ public class ShortcutRegistration implements Registration, Serializable {
      *
      * @param stopEventPropagation  Stop event propagation
      */
-    public void setAllowEventPropagation(boolean stopEventPropagation) {
-        if (stopPropagation == stopEventPropagation) {
-            stopPropagation = !stopEventPropagation;
+    public void setStopEventPropagation(boolean stopEventPropagation) {
+        if (stopPropagation != stopEventPropagation) {
+            stopPropagation = stopEventPropagation;
             prepareForClientResponse();
         }
     }

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -289,22 +289,48 @@ public class ShortcutRegistration implements Registration, Serializable {
     }
 
     /**
-     * Is the shortcut preventing default key behaviour.
+     * Checks if the shortcut preventing default key behaviour in the browser.
      *
-     * @return Prevents default behavior
+     * @return Prevents default key behavior
      */
-    public boolean preventsDefault() {
+    public boolean getPreventBrowserDefault() {
         return preventDefault;
     }
 
     /**
-     * Is the shortcut stopping the keyboard event from propagating up the DOM
-     * tree.
+     * Set whether default key behavior should be prevented in the browser. If
+     * not changed, default key behavior is not allowed.
      *
-     * @return Stops propagation
+     * @param preventBrowserDefault   Prevent default key behavior
      */
-    public boolean stopsPropagation() {
+    public void setPreventBrowserDefault(boolean preventBrowserDefault) {
+        if (preventDefault != preventBrowserDefault) {
+            preventDefault = !preventBrowserDefault;
+            prepareForClientResponse();
+        }
+    }
+
+    /**
+     * Checks if the shortcut stopping key event (associated with the shortcut)
+     * propagation in the browser?
+     *
+     * @return Stops event propagation
+     */
+    public boolean getStopEventPropagation() {
         return stopPropagation;
+    }
+
+    /**
+     * Set whether shortcut's key event is stopped from propagating up the DOM
+     * tree in the browser. If not changed, event propagation is not allowed.
+     *
+     * @param stopEventPropagation  Stop event propagation
+     */
+    public void setAllowEventPropagation(boolean stopEventPropagation) {
+        if (stopPropagation == stopEventPropagation) {
+            stopPropagation = !stopEventPropagation;
+            prepareForClientResponse();
+        }
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -43,8 +43,8 @@ import com.vaadin.flow.shared.Registration;
  * @since
  */
 public class ShortcutRegistration implements Registration, Serializable {
-    private boolean preventDefault = true;
-    private boolean stopPropagation = true;
+    private boolean allowDefaultBehavior = false;
+    private boolean allowEventPropagation = false;
 
     private Set<Key> modifiers = new HashSet<>(2);
     private Key primaryKey = null;
@@ -170,23 +170,25 @@ public class ShortcutRegistration implements Registration, Serializable {
     /**
      * Allows the default keyboard event handling when the shortcut is invoked.
      * @return this <code>ShortcutRegistration</code>
+     * @see #setBrowserDefaultAllowed(boolean)
      */
     public ShortcutRegistration allowBrowserDefault() {
-        if (preventDefault) {
-            preventDefault = false;
+        if (!allowDefaultBehavior) {
+            allowDefaultBehavior = true;
             prepareForClientResponse();
         }
         return this;
     }
 
     /**
-     * Allow the event to propagate upwards in the dom tree, when the
+     * Allow the event to propagate upwards in the DOM tree, when the
      * shortcut is invoked.
      * @return this <code>ShortcutRegistration</code>
+     * @see #setEventPropagationAllowed(boolean)
      */
     public ShortcutRegistration allowEventPropagation() {
-        if (stopPropagation) {
-            stopPropagation = false;
+        if (!allowEventPropagation) {
+            allowEventPropagation = true;
             prepareForClientResponse();
         }
         return this;
@@ -289,47 +291,48 @@ public class ShortcutRegistration implements Registration, Serializable {
     }
 
     /**
-     * Checks if the shortcut is preventing default key behaviour in the
-     * browser.
+     * Checks if the default key behaviour in the browser is allowed by the
+     * shortcut. This is {@code false} by default.
      *
      * @return Prevents default key behavior
      */
-    public boolean isBrowserDefaultPrevented() {
-        return preventDefault;
+    public boolean isBrowserDefaultAllowed() {
+        return allowDefaultBehavior;
     }
 
     /**
-     * Set whether the default key behavior is prevented in the browser. If not
+     * Set whether the default key behavior is allowed in the browser. If not
      * changed, default key behavior is not allowed.
      *
-     * @param browserDefaultPrevented   Prevent default key behavior
+     * @param browserDefaultAllowed   Prevent default key behavior
      */
-    public void setBrowserDefaultPrevented(boolean browserDefaultPrevented) {
-        if (preventDefault != browserDefaultPrevented) {
-            preventDefault = browserDefaultPrevented;
+    public void setBrowserDefaultAllowed(boolean browserDefaultAllowed) {
+        if (allowDefaultBehavior != browserDefaultAllowed) {
+            allowDefaultBehavior = browserDefaultAllowed;
             prepareForClientResponse();
         }
     }
 
     /**
-     * Checks if the shortcut is stopping key event (associated with the
-     * shortcut) propagation in the browser.
+     * Checks if the shortcut is allowing keydown event (associated with the
+     * shortcut) propagation in the browser. This is {@code false} by default.
      *
      * @return Stops event propagation
      */
-    public boolean isEventPropagationStopped() {
-        return stopPropagation;
+    public boolean isEventPropagationAllowed() {
+        return allowEventPropagation;
     }
 
     /**
-     * Set whether shortcut's key event is stopped from propagating up the DOM
-     * tree in the browser. If not changed, event propagation is not allowed.
+     * Set whether shortcut's keydown event is allowed to propagate up the
+     * DOM tree in the browser. If not changed, event propagation is not
+     * allowed.
      *
-     * @param eventPropagationStopped  Stop event propagation
+     * @param eventPropagationAllowed  Stop event propagation
      */
-    public void setEventPropagationStopped(boolean eventPropagationStopped) {
-        if (stopPropagation != eventPropagationStopped) {
-            stopPropagation = eventPropagationStopped;
+    public void setEventPropagationAllowed(boolean eventPropagationAllowed) {
+        if (allowEventPropagation != eventPropagationAllowed) {
+            allowEventPropagation = eventPropagationAllowed;
             prepareForClientResponse();
         }
     }
@@ -465,11 +468,11 @@ public class ShortcutRegistration implements Registration, Serializable {
                     able to use setEventData for these values, so we hack the
                     filter.
                  */
-                if (preventDefault) {
-                    filterText += "&& (event.preventDefault() || true)";
+                if (!allowDefaultBehavior) {
+                    filterText += " && (event.preventDefault() || true)";
                 }
-                if (stopPropagation) {
-                    filterText += "&& (event.stopPropagation() || true)";
+                if (!allowEventPropagation) {
+                    filterText += " && (event.stopPropagation() || true)";
                 }
                 listenerRegistration.setFilter(filterText);
 
@@ -636,13 +639,22 @@ public class ShortcutRegistration implements Registration, Serializable {
     @Override
     public String toString() {
         return  String.format(
-                "%s [key = %s, modifiers = %s, lifecycle owner = %s]",
+                "%s [key = %s, modifiers = %s, owner = %s, listenOn = %s, " +
+                        "default = %s, propagation = %s]",
                 getClass().getSimpleName(),
-                (primaryKey != null ? primaryKey.getKeys().get(0) : "null"),
-                Arrays.toString(modifiers.stream()
-                        .map(k -> k.getKeys().get(0)).toArray()),
-                (lifecycleOwner != null) ? lifecycleOwner.getClass()
-                        .getSimpleName() : "null");
+                primaryKey != null
+                        ? primaryKey.getKeys().get(0)
+                        : "null",
+                Arrays.toString(modifiers.stream().map(k -> k.getKeys().get(0))
+                        .toArray()),
+                lifecycleOwner != null
+                        ? lifecycleOwner.getClass().getSimpleName()
+                        : "null",
+                listenOnComponent != null
+                        ? listenOnComponent.getClass().getSimpleName()
+                        : "null",
+                allowDefaultBehavior,
+                allowEventPropagation);
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
@@ -21,12 +21,14 @@ import java.util.Optional;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.ExecutionContext;
 import com.vaadin.flow.shared.Registration;
 
+import static org.easymock.EasyMock.reset;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -36,6 +38,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 public class ShortcutRegistrationTest {
@@ -135,6 +138,35 @@ public class ShortcutRegistrationTest {
     }
 
     @Test
+    public void settersAndGettersChangeValuesCorrectly() {
+
+        //Component listenOn = mock(Component.class);
+        ShortcutRegistration registration =
+                new ShortcutRegistration(lifecycleOwner,
+                        () -> listenOn, event -> {}, Key.KEY_A);
+
+        registration.setPreventBrowserDefault(false);
+        registration.setStopEventPropagation(false);
+
+        clientResponse();
+
+        assertFalse("Prevent default was not set to false",
+                registration.getPreventBrowserDefault());
+        assertFalse("Stop propagation was not set to false",
+                registration.getStopEventPropagation());
+
+        registration.setPreventBrowserDefault(true);
+        registration.setStopEventPropagation(true);
+
+        clientResponse();
+
+        assertTrue("Prevent default was not set to true",
+                registration.getPreventBrowserDefault());
+        assertTrue("Stop propagation was not set to true",
+                registration.getStopEventPropagation());
+    }
+
+    @Test
     public void listenOnChangesTheComponentThatOwnsTheListener() {
         ShortcutRegistration registration = new ShortcutRegistration(
                 lifecycleOwner, () -> listenOn, event -> {}, Key.KEY_A);
@@ -178,7 +210,8 @@ public class ShortcutRegistrationTest {
         ArgumentCaptor<SerializableConsumer> captor =
                 ArgumentCaptor.forClass(SerializableConsumer.class);
 
-        verify(ui).beforeClientResponse(eq(lifecycleOwner), captor.capture());
+        verify(ui, atLeastOnce()).beforeClientResponse(eq(lifecycleOwner),
+                captor.capture());
 
         SerializableConsumer consumer = captor.getValue();
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
@@ -113,13 +113,13 @@ public class ShortcutRegistrationTest {
         ShortcutRegistration registration = new ShortcutRegistration(
                 lifecycleOwner, () -> listenOn, event -> {}, Key.KEY_A);
 
-        assertTrue(registration.getPreventBrowserDefault());
-        assertTrue(registration.getStopEventPropagation());
+        assertTrue(registration.isBrowserDefaultPrevented());
+        assertTrue(registration.isEventPropagationStopped());
 
         registration.allowBrowserDefault().allowEventPropagation();
 
-        assertFalse(registration.getPreventBrowserDefault());
-        assertFalse(registration.getStopEventPropagation());
+        assertFalse(registration.isBrowserDefaultPrevented());
+        assertFalse(registration.isEventPropagationStopped());
     }
 
     @Test
@@ -145,25 +145,25 @@ public class ShortcutRegistrationTest {
                 new ShortcutRegistration(lifecycleOwner,
                         () -> listenOn, event -> {}, Key.KEY_A);
 
-        registration.setPreventBrowserDefault(false);
-        registration.setStopEventPropagation(false);
+        registration.setBrowserDefaultPrevented(false);
+        registration.setEventPropagationStopped(false);
 
         clientResponse();
 
         assertFalse("Prevent default was not set to false",
-                registration.getPreventBrowserDefault());
+                registration.isBrowserDefaultPrevented());
         assertFalse("Stop propagation was not set to false",
-                registration.getStopEventPropagation());
+                registration.isEventPropagationStopped());
 
-        registration.setPreventBrowserDefault(true);
-        registration.setStopEventPropagation(true);
+        registration.setBrowserDefaultPrevented(true);
+        registration.setEventPropagationStopped(true);
 
         clientResponse();
 
         assertTrue("Prevent default was not set to true",
-                registration.getPreventBrowserDefault());
+                registration.isBrowserDefaultPrevented());
         assertTrue("Stop propagation was not set to true",
-                registration.getStopEventPropagation());
+                registration.isEventPropagationStopped());
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
@@ -110,13 +110,13 @@ public class ShortcutRegistrationTest {
         ShortcutRegistration registration = new ShortcutRegistration(
                 lifecycleOwner, () -> listenOn, event -> {}, Key.KEY_A);
 
-        assertTrue(registration.preventsDefault());
-        assertTrue(registration.stopsPropagation());
+        assertTrue(registration.getPreventBrowserDefault());
+        assertTrue(registration.getStopEventPropagation());
 
         registration.allowBrowserDefault().allowEventPropagation();
 
-        assertFalse(registration.preventsDefault());
-        assertFalse(registration.stopsPropagation());
+        assertFalse(registration.getPreventBrowserDefault());
+        assertFalse(registration.getStopEventPropagation());
     }
 
     @Test

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsView.java
@@ -135,7 +135,7 @@ public class ShortcutsView extends Div {
         clickButton2.addClickShortcut(Key.ENTER).listenOn(wrapper2)
                 // this matches the default of other shortcuts but changes
                 // the default of the click shortcut
-                .setPreventBrowserDefault(true);
+                .setBrowserDefaultPrevented(true);
 
         wrapper1.add(clickInput1, clickButton1);
         wrapper2.add(clickInput2, clickButton2);

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsView.java
@@ -16,6 +16,8 @@
 
 package com.vaadin.flow.uitest.ui;
 
+import com.vaadin.flow.component.ClickEvent;
+import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.Key;
 import com.vaadin.flow.component.KeyModifier;
 import com.vaadin.flow.component.ShortcutRegistration;
@@ -97,7 +99,7 @@ public class ShortcutsView extends Div {
             expected.setText("toggled!");
         }, Key.KEY_Y, KeyModifier.ALT);
 
-        // modifyingShortcutShouldChangeShortcutEvent
+            // modifyingShortcutShouldChangeShortcutEvent
         flipFloppingRegistration =
                 UI.getCurrent().addShortcutListener(event -> {
                     if (event.getKeyModifiers().contains(KeyModifier.ALT)) {
@@ -114,5 +116,31 @@ public class ShortcutsView extends Div {
                     }
 
                 }, Key.KEY_G, KeyModifier.ALT);
+
+        // clickShortcutAllowsKeyDefaults
+        Div wrapper1 = new Div();
+        Div wrapper2 = new Div();
+        final Input clickInput1 = new Input();
+        clickInput1.setType("text");
+        clickInput1.setId("click-input-1");
+
+        final Input clickInput2 = new Input();
+        clickInput2.setType("text");
+        clickInput2.setId("click-input-2");
+
+        NativeButton clickButton1 = new NativeButton("CB1",
+                event -> expected.setText("click: " + clickInput1.getValue()));
+        clickButton1.addClickShortcut(Key.ENTER).listenOn(wrapper1);
+
+        NativeButton clickButton2 = new NativeButton("CB2",
+                event -> expected.setText("click: " + clickInput2.getValue()));
+        clickButton2.addClickShortcut(Key.ENTER).listenOn(wrapper2)
+                // this matches the default of other shortcuts but changes
+                // the default of the click shortcut
+                .setPreventBrowserDefault(true);
+
+        wrapper1.add(clickInput1, clickButton1);
+        wrapper2.add(clickInput2, clickButton2);
+        add(wrapper1, wrapper2);
     }
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsView.java
@@ -16,8 +16,6 @@
 
 package com.vaadin.flow.uitest.ui;
 
-import com.vaadin.flow.component.ClickEvent;
-import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.Key;
 import com.vaadin.flow.component.KeyModifier;
 import com.vaadin.flow.component.ShortcutRegistration;
@@ -40,14 +38,14 @@ public class ShortcutsView extends Div {
     private ShortcutRegistration flipFloppingRegistration;
 
     public ShortcutsView() {
-        Paragraph expected = new Paragraph();
-        expected.setId("expected");
-        expected.setText("testing...");
+        Input actual = new Input();
+        actual.setId("actual");
+        actual.setValue("testing...");
 
         // clickShortcutWorks
         NativeButton button = new NativeButton();
         button.setId("button");
-        button.addClickListener(e -> expected.setText("button"));
+        button.addClickListener(e -> actual.setValue("button"));
         button.addClickShortcut(Key.KEY_B, KeyModifier.ALT);
 
         // focusShortcutWorks
@@ -58,13 +56,13 @@ public class ShortcutsView extends Div {
         // shortcutsOnlyWorkWhenComponentIsVisible
         UI.getCurrent().addShortcutListener(() -> {
             invisibleP.setVisible(!invisibleP.isVisible());
-            expected.setText("toggled!");
+            actual.setValue("toggled!");
         }, Key.KEY_I, KeyModifier.ALT);
 
-        Shortcuts.addShortcutListener(invisibleP, () -> expected
-                .setText("invisibleP"), Key.KEY_V).withAlt();
+        Shortcuts.addShortcutListener(invisibleP, () -> actual
+                .setValue("invisibleP"), Key.KEY_V).withAlt();
 
-        add(expected, button, input, invisibleP);
+        add(actual, button, input, invisibleP);
 
         // listenOnScopesTheShortcut
         Div subview = new Div();
@@ -76,7 +74,7 @@ public class ShortcutsView extends Div {
         subview.add(focusTarget);
 
         Shortcuts.addShortcutListener(subview,
-                () -> expected.setText("subview"), Key.KEY_S, KeyModifier.ALT)
+                () -> actual.setValue("subview"), Key.KEY_S, KeyModifier.ALT)
                 .listenOn(subview);
 
         add(subview);
@@ -85,8 +83,8 @@ public class ShortcutsView extends Div {
         Paragraph attachable = new Paragraph("attachable");
         attachable.setId("attachable");
 
-        Shortcuts.addShortcutListener(attachable, () -> expected
-                .setText("attachable"), Key.KEY_A).withAlt();
+        Shortcuts.addShortcutListener(attachable, () -> actual
+                .setValue("attachable"), Key.KEY_A).withAlt();
 
         UI.getCurrent().addShortcutListener(() -> {
             attached = !attached;
@@ -96,23 +94,23 @@ public class ShortcutsView extends Div {
             else {
                 remove(attachable);
             }
-            expected.setText("toggled!");
+            actual.setValue("toggled!");
         }, Key.KEY_Y, KeyModifier.ALT);
 
             // modifyingShortcutShouldChangeShortcutEvent
         flipFloppingRegistration =
                 UI.getCurrent().addShortcutListener(event -> {
                     if (event.getKeyModifiers().contains(KeyModifier.ALT)) {
-                        expected.setText("Alt");
+                        actual.setValue("Alt");
                         flipFloppingRegistration.withModifiers(
                                 KeyModifier.SHIFT);
                     } else if (event.getKeyModifiers().contains(
                             KeyModifier.SHIFT)) {
-                        expected.setText("Shift");
+                        actual.setValue("Shift");
                         flipFloppingRegistration.withModifiers(KeyModifier.ALT);
                     }
                     else {
-                        expected.setText("Failed");
+                        actual.setValue("Failed");
                     }
 
                 }, Key.KEY_G, KeyModifier.ALT);
@@ -129,11 +127,11 @@ public class ShortcutsView extends Div {
         clickInput2.setId("click-input-2");
 
         NativeButton clickButton1 = new NativeButton("CB1",
-                event -> expected.setText("click: " + clickInput1.getValue()));
+                event -> actual.setValue("click: " + clickInput1.getValue()));
         clickButton1.addClickShortcut(Key.ENTER).listenOn(wrapper1);
 
         NativeButton clickButton2 = new NativeButton("CB2",
-                event -> expected.setText("click: " + clickInput2.getValue()));
+                event -> actual.setValue("click: " + clickInput2.getValue()));
         clickButton2.addClickShortcut(Key.ENTER).listenOn(wrapper2)
                 // this matches the default of other shortcuts but changes
                 // the default of the click shortcut

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsView.java
@@ -128,14 +128,15 @@ public class ShortcutsView extends Div {
 
         NativeButton clickButton1 = new NativeButton("CB1",
                 event -> actual.setValue("click: " + clickInput1.getValue()));
-        clickButton1.addClickShortcut(Key.ENTER).listenOn(wrapper1);
+        ShortcutRegistration r1 =
+                clickButton1.addClickShortcut(Key.ENTER).listenOn(wrapper1);
 
         NativeButton clickButton2 = new NativeButton("CB2",
                 event -> actual.setValue("click: " + clickInput2.getValue()));
         clickButton2.addClickShortcut(Key.ENTER).listenOn(wrapper2)
                 // this matches the default of other shortcuts but changes
                 // the default of the click shortcut
-                .setBrowserDefaultPrevented(true);
+                .setBrowserDefaultAllowed(false);
 
         wrapper1.add(clickInput1, clickButton1);
         wrapper2.add(clickInput2, clickButton2);

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ShortcutsIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ShortcutsIT.java
@@ -36,7 +36,7 @@ public class ShortcutsIT extends ChromeBrowserTest {
     @Test
     public void clickShortcutWorks() {
         sendKeys(Keys.ALT, "b");
-        Assert.assertEquals("button", getValue());
+        Assert.assertEquals("button", getActual());
     }
 
     @Test
@@ -51,31 +51,31 @@ public class ShortcutsIT extends ChromeBrowserTest {
     @Test
     public void shortcutsOnlyWorkWhenComponentIsVisible() {
         sendKeys(Keys.ALT, "v");
-        Assert.assertEquals("invisibleP", getValue());
+        Assert.assertEquals("invisibleP", getActual());
 
         // make the paragraph disappear
         sendKeys(Keys.ALT, "i");
-        Assert.assertEquals("toggled!", getValue());
+        Assert.assertEquals("toggled!", getActual());
 
         sendKeys(Keys.ALT, "v");
-        Assert.assertEquals("toggled!", getValue()); // did not change
+        Assert.assertEquals("toggled!", getActual()); // did not change
 
         // make the paragraph appear
         sendKeys(Keys.ALT, "i");
-        Assert.assertEquals("toggled!", getValue());
+        Assert.assertEquals("toggled!", getActual());
 
         sendKeys(Keys.ALT, "v");
-        Assert.assertEquals("invisibleP", getValue());
+        Assert.assertEquals("invisibleP", getActual());
     }
 
     @Test
     public void listenOnScopesTheShortcut() {
         sendKeys(Keys.ALT, "s");
-        Assert.assertEquals("testing...", getValue()); // nothing happened
+        Assert.assertEquals("testing...", getActual()); // nothing happened
 
         WebElement innerInput = findElement(By.id("focusTarget"));
         innerInput.sendKeys(Keys.ALT, "s");
-        Assert.assertEquals("subview", getValue());
+        Assert.assertEquals("subview", getActual());
 
         // using the shortcut prevented "s" from being written
         Assert.assertEquals("", innerInput.getText());
@@ -84,35 +84,35 @@ public class ShortcutsIT extends ChromeBrowserTest {
     @Test
     public void shortcutsOnlyWorkWhenComponentIsAttached() {
         sendKeys(Keys.ALT, "a");
-        Assert.assertEquals("testing...", getValue()); // nothing happens
+        Assert.assertEquals("testing...", getActual()); // nothing happens
 
         // attaches the component
         sendKeys(Keys.ALT, "y");
-        Assert.assertEquals("toggled!", getValue());
+        Assert.assertEquals("toggled!", getActual());
 
         sendKeys(Keys.ALT, "a");
-        Assert.assertEquals("attachable", getValue());
+        Assert.assertEquals("attachable", getActual());
 
         // detaches the component
         sendKeys(Keys.ALT, "y");
-        Assert.assertEquals("toggled!", getValue());
+        Assert.assertEquals("toggled!", getActual());
 
         sendKeys(Keys.ALT, "a");
-        Assert.assertEquals("toggled!", getValue()); // nothing happens
+        Assert.assertEquals("toggled!", getActual()); // nothing happens
     }
 
     @Test
     public void modifyingShortcutShouldChangeShortcutEvent() {
         // the shortcut in this test flips its own modifiers
         sendKeys(Keys.ALT, "g");
-        Assert.assertEquals("Alt", getValue());
+        Assert.assertEquals("Alt", getActual());
 
         sendKeys("G");
-        Assert.assertEquals("Shift", getValue());
+        Assert.assertEquals("Shift", getActual());
 
         // check that things revert back.
         sendKeys(Keys.ALT, "g");
-        Assert.assertEquals("Alt", getValue());
+        Assert.assertEquals("Alt", getActual());
     }
 
     @Test
@@ -121,23 +121,19 @@ public class ShortcutsIT extends ChromeBrowserTest {
         WebElement textField2 = findElement(By.id("click-input-2"));
 
         // ClickButton1: has default values
-        textField1.sendKeys("value 1");
+        textField1.sendKeys("value 1", Keys.ENTER);
 
-        sendKeys(Keys.ENTER);
-
-        Assert.assertEquals("click: value 1", getValue());
+        Assert.assertEquals("click: value 1", getActual());
 
         // ClickButton2: prevents key default behavior
-        textField2.sendKeys("value 2");
+        textField2.sendKeys("value 2", Keys.ENTER);
 
-        sendKeys(Keys.ENTER);
-
-        Assert.assertEquals("click:", getValue());
+        Assert.assertEquals("click: ", getActual());
     }
 
-    private String getValue() {
-        WebElement expected = findElement(By.id("expected"));
-        return expected.getText();
+    private String getActual() {
+        WebElement actual = findElement(By.id("actual"));
+        return actual.getAttribute("value");
     }
 
     private void sendKeys(CharSequence... keys) {

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ShortcutsIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ShortcutsIT.java
@@ -16,8 +16,6 @@
 
 package com.vaadin.flow.uitest.ui;
 
-import java.util.concurrent.TimeUnit;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -115,6 +113,26 @@ public class ShortcutsIT extends ChromeBrowserTest {
         // check that things revert back.
         sendKeys(Keys.ALT, "g");
         Assert.assertEquals("Alt", getValue());
+    }
+
+    @Test
+    public void clickShortcutAllowsKeyDefaults() {
+        WebElement textField1 = findElement(By.id("click-input-1"));
+        WebElement textField2 = findElement(By.id("click-input-2"));
+
+        // ClickButton1: has default values
+        textField1.sendKeys("value 1");
+
+        sendKeys(Keys.ENTER);
+
+        Assert.assertEquals("click: value 1", getValue());
+
+        // ClickButton2: prevents key default behavior
+        textField2.sendKeys("value 2");
+
+        sendKeys(Keys.ENTER);
+
+        Assert.assertEquals("click:", getValue());
     }
 
     private String getValue() {

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <polymer.version>2.6.1</polymer.version>
 
         <!-- Plugins -->
-        <driver.binary.downloader.maven.plugin.version>1.0.14
+        <driver.binary.downloader.maven.plugin.version>1.0.17
         </driver.binary.downloader.maven.plugin.version>
         <frontend.maven.plugin.version>1.5</frontend.maven.plugin.version>
         <maven.surefire.plugin.version>2.20</maven.surefire.plugin.version>


### PR DESCRIPTION
Click shortcuts now allow default key event behavior in the browser. This fixes the problem where the user has to use `allowBrowserDefault` in conjunction with click shortcuts (forus post [here](https://vaadin.com/forum/thread/17464899/shortcut-keys-in-vaadin-10)).

```java
TextField field = new TextField("Name");
Button submit = new Button("Submit name", event -> {/* do a thing with field.getValue() */});
submit.addClickShortcut(Key.ENTER).allowBrowserDefault(); 
```

Also:
- Adds getter and setter (renamed) methods for browserDefault and stopPropagation
  - These methods follow javascript's naming convention
- Some tests
- API doc updates

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5058)
<!-- Reviewable:end -->
