### PR TITLE
Fix getChildCount to always use filter, filtering based on flatten hierarchy of children 

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/TreeDataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/TreeDataProvider.java
@@ -141,16 +141,11 @@ public class TreeDataProvider<T>
         refreshAll();
     }
 
-    private Stream<T> flatten(T parent) {
-        return Stream.concat(Stream.of(parent), treeData.getChildren(parent).stream().flatMap(o -> flatten(o)));
-    }
-
     private Stream<T> getFilteredStream(Stream<T> stream,
-                                        Optional<SerializablePredicate<T>> queryFilter) {
+            Optional<SerializablePredicate<T>> queryFilter) {
         if (filter != null) {
-            stream = stream.filter(parent -> flatten(parent).anyMatch(filter));
+            stream = stream.filter(filter);
         }
-
         return queryFilter.map(stream::filter).orElse(stream);
     }
 }

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/TreeDataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/TreeDataProvider.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.data.provider.hierarchy;
 
 import java.util.Comparator;
-import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;


### PR DESCRIPTION
Fixes [vaadin-grid-flow/issues/464](https://github.com/vaadin/vaadin-grid-flow/issues/464)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5101)
<!-- Reviewable:end -->
