### PR TITLE
Shortcuts no longer work, when element is disabled (#5099)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -458,7 +458,8 @@ public class ShortcutRegistration implements Registration, Serializable {
                         listenOnComponent,
                         KeyDownEvent.class,
                         e -> {
-                            if (lifecycleOwner.isVisible()) {
+                            if (lifecycleOwner.isVisible() && lifecycleOwner
+                                    .getElement().isEnabled()) {
                                 invokeShortcutEventListener();
                             }
                         },

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsView.java
@@ -38,9 +38,13 @@ public class ShortcutsView extends Div {
     private ShortcutRegistration flipFloppingRegistration;
 
     public ShortcutsView() {
+        Paragraph blur = new Paragraph();
+        blur.setId("blur");
         Input actual = new Input();
         actual.setId("actual");
         actual.setValue("testing...");
+
+        add(actual, blur);
 
         // clickShortcutWorks
         NativeButton button = new NativeButton();
@@ -62,7 +66,18 @@ public class ShortcutsView extends Div {
         Shortcuts.addShortcutListener(invisibleP, () -> actual
                 .setValue("invisibleP"), Key.KEY_V).withAlt();
 
-        add(actual, button, input, invisibleP);
+        add(button, input, invisibleP);
+
+        // shortcutOnlyWorksWhenComponentIsEnabled
+        NativeButton disabledButton = new NativeButton();
+        disabledButton.addClickListener(event -> {
+            actual.setValue("DISABLED CLICKED");
+            disabledButton.setEnabled(false);
+        });
+        disabledButton.addClickShortcut(Key.KEY_U, KeyModifier.SHIFT,
+                KeyModifier.CONTROL);
+
+        add(disabledButton);
 
         // listenOnScopesTheShortcut
         Div subview = new Div();
@@ -128,8 +143,7 @@ public class ShortcutsView extends Div {
 
         NativeButton clickButton1 = new NativeButton("CB1",
                 event -> actual.setValue("click: " + clickInput1.getValue()));
-        ShortcutRegistration r1 =
-                clickButton1.addClickShortcut(Key.ENTER).listenOn(wrapper1);
+        clickButton1.addClickShortcut(Key.ENTER).listenOn(wrapper1);
 
         NativeButton clickButton2 = new NativeButton("CB2",
                 event -> actual.setValue("click: " + clickInput2.getValue()));


### PR DESCRIPTION
* Shortcuts no longer work, when element is disabled

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5102)
<!-- Reviewable:end -->
