### PR TITLE
Cherry-pick: Fix getChildCount to always use filter  (#5101) 

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/TreeDataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/TreeDataProvider.java
@@ -24,6 +24,7 @@ import com.vaadin.flow.data.provider.InMemoryDataProvider;
 import com.vaadin.flow.function.SerializableComparator;
 import com.vaadin.flow.function.SerializablePredicate;
 
+
 /**
  * An in-memory data provider for listing components that display hierarchical
  * data. Uses an instance of {@link TreeData} as its source of data.
@@ -79,18 +80,16 @@ public class TreeDataProvider<T>
     @Override
     public int getChildCount(
             HierarchicalQuery<T, SerializablePredicate<T>> query) {
-        if (query.getFilter().isPresent()) {
-            Stream<T> childStream = getFilteredStream(
-                    treeData.getChildren(query.getParent()).stream(),
-                    query.getFilter());
-            return (int) childStream.skip(query.getOffset())
-                    .limit(query.getLimit()).count();
-        }
+        Stream<T> items;
+
         if (query.getParent() != null) {
-            return treeData.getChildren(query.getParent()).size();
+            items = treeData.getChildren(query.getParent()).stream();
         } else {
-            return treeData.getRootItems().size();
+            items = treeData.getRootItems().stream();
         }
+
+        return (int) getFilteredStream(items,
+                query.getFilter()).skip(query.getOffset()).limit(query.getLimit()).count();
     }
 
     @Override


### PR DESCRIPTION
Fixes vaadin-grid-flow/issues/464

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5126)
<!-- Reviewable:end -->
