### PR TITLE
flow-component-renderer: set focus-target attribute to the first focusable node

### DIFF
--- a/flow-data/src/main/resources/META-INF/resources/frontend/flow-component-renderer.html
+++ b/flow-data/src/main/resources/META-INF/resources/frontend/flow-component-renderer.html
@@ -146,22 +146,29 @@
     within the flow-component-renderer when used inside a vaadin-grid cell  */
     _defineFocusTarget(){
       var focusable = this._getFirstFocusableDescendant(this.firstChild);
-      if(focusable !== null) focusable.setAttribute('focus-target', 'true');
+      if(focusable !== null) {
+        focusable.setAttribute('focus-target', 'true');
+      }
     }
 
     _getFirstFocusableDescendant(node){
-      if(this._isFocusable(node)) return node;
+      if(this._isFocusable(node)) {
+        return node;
+      }
       for (var child of node.children) {
-        if(this._isFocusable(child)) return child;
         var focusable = this._getFirstFocusableDescendant(child);
-        if(focusable !== null) return focusable;
+        if(focusable !== null) {
+          return focusable;
+        }
       }
       return null;
     }
 
     _isFocusable(node){
       if (node.hasAttribute("disabled")
-              || node.style.hasAttribute("hidden")) return false;
+              || node.hasAttribute("hidden")) {
+        return false;
+      }
 
       return node.tabIndex === 0;
     }

--- a/flow-data/src/main/resources/META-INF/resources/frontend/flow-component-renderer.html
+++ b/flow-data/src/main/resources/META-INF/resources/frontend/flow-component-renderer.html
@@ -103,13 +103,17 @@
           this._asyncAttachRenderedComponentIfAble();
         } else if (this.firstChild !== renderedComponent){
           this.replaceChild(renderedComponent, this.firstChild);
+          this._defineFocusTarget();
           this.onComponentRendered();
+
         } else {
+          this._defineFocusTarget();
           this.onComponentRendered();
         }
       } else {
         if (renderedComponent) {
           this.appendChild(renderedComponent);
+          this._defineFocusTarget();
           this.onComponentRendered();
         } else {
           this._asyncAttachRenderedComponentIfAble();
@@ -135,6 +139,31 @@
 
     onComponentRendered(){
       // subclasses can override this method to execute custom logic on resize
+    }
+
+    /* Setting the `focus-target` attribute to the first focusable descendant
+    starting from the firstChild necessary for the focus to be delegated
+    within the flow-component-renderer when used inside a vaadin-grid cell  */
+    _defineFocusTarget(){
+      var focusable = this._getFirstFocusableDescendant(this.firstChild);
+      if(focusable !== null) focusable.setAttribute('focus-target', 'true');
+    }
+
+    _getFirstFocusableDescendant(node){
+      if(this._isFocusable(node)) return node;
+      for (var child of node.children) {
+        if(this._isFocusable(child)) return child;
+        var focusable = this._getFirstFocusableDescendant(child);
+        if(focusable !== null) return focusable;
+      }
+      return null;
+    }
+
+    _isFocusable(node){
+      if (node.hasAttribute("disabled")
+              || node.style.hasAttribute("hidden")) return false;
+
+      return node.tabIndex === 0;
     }
 
   }

--- a/flow-data/src/main/resources/META-INF/resources/frontend/flow-component-renderer.html
+++ b/flow-data/src/main/resources/META-INF/resources/frontend/flow-component-renderer.html
@@ -160,8 +160,8 @@
     }
 
     _isFocusable(node){
-      if (node.hasAttribute("disabled")
-              || node.style.hasAttribute("hidden")) return false;
+      if (!(node instanceof HTMLElement) || node.hasAttribute("disabled")
+              || node.hasAttribute("hidden")) return false;
 
       return node.tabIndex === 0;
     }


### PR DESCRIPTION
Fixes [#4191](https://github.com/vaadin/flow/issues/4191)

Defining focus-target is necessary for the grid cell delegating focus to the first focusable component within it when `Enter` key is used (tests available from another PR on vaadin-grid-flow repo)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5142)
<!-- Reviewable:end -->
