### PR TITLE
flow-component-renderer: set focus-target attribute to the first focu…

### DIFF
--- a/flow-data/src/main/resources/META-INF/resources/frontend/flow-component-renderer.html
+++ b/flow-data/src/main/resources/META-INF/resources/frontend/flow-component-renderer.html
@@ -103,13 +103,17 @@
           this._asyncAttachRenderedComponentIfAble();
         } else if (this.firstChild !== renderedComponent){
           this.replaceChild(renderedComponent, this.firstChild);
+          this._defineFocusTarget();
           this.onComponentRendered();
+
         } else {
+          this._defineFocusTarget();
           this.onComponentRendered();
         }
       } else {
         if (renderedComponent) {
           this.appendChild(renderedComponent);
+          this._defineFocusTarget();
           this.onComponentRendered();
         } else {
           this._asyncAttachRenderedComponentIfAble();
@@ -135,6 +139,38 @@
 
     onComponentRendered(){
       // subclasses can override this method to execute custom logic on resize
+    }
+
+    /* Setting the `focus-target` attribute to the first focusable descendant
+    starting from the firstChild necessary for the focus to be delegated
+    within the flow-component-renderer when used inside a vaadin-grid cell  */
+    _defineFocusTarget(){
+      var focusable = this._getFirstFocusableDescendant(this.firstChild);
+      if(focusable !== null) {
+        focusable.setAttribute('focus-target', 'true');
+      }
+    }
+
+    _getFirstFocusableDescendant(node){
+      if(this._isFocusable(node)) {
+        return node;
+      }
+      for (var child of node.children) {
+        var focusable = this._getFirstFocusableDescendant(child);
+        if(focusable !== null) {
+          return focusable;
+        }
+      }
+      return null;
+    }
+
+    _isFocusable(node){
+      if (node.hasAttribute("disabled")
+              || node.hasAttribute("hidden")) {
+        return false;
+      }
+
+      return node.tabIndex === 0;
     }
 
   }


### PR DESCRIPTION
…sable node (#5142)

Fixes #4191

Defining focus-target is necessary for the grid cell delegating focus to the first focusable component within it when Enter key is used (tests available from another PR on vaadin-grid-flow repo)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5155)
<!-- Reviewable:end -->
