### PR TITLE
Do not stop webpack when servlet is destroyed.

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
@@ -75,7 +75,6 @@ public class DevModeHandler implements Serializable {
     static final String WEBPACK_SERVER = BASEDIR + "/node_modules/.bin/webpack-dev-server";
 
     private int port;
-    private transient Process exec;
 
     // For testing purposes
     DevModeHandler(int port) {
@@ -107,8 +106,8 @@ public class DevModeHandler implements Serializable {
                 "--port", String.valueOf(port) });
 
         try {
-            exec = process.start();
-            Runtime.getRuntime().addShutdownHook(new Thread(this::destroy));
+            Process exec = process.start();
+            Runtime.getRuntime().addShutdownHook(new Thread(exec::destroy));
 
             // Start a timer to avoid waiting for ever if pattern not found in webpack output.
             Thread timer = new Thread(() -> {
@@ -311,19 +310,6 @@ public class DevModeHandler implements Serializable {
 
     private static Logger getLogger() {
         return LoggerFactory.getLogger("c.v.f.s." + DevModeHandler.class.getSimpleName());
-    }
-
-    /**
-     * Call this method to stop webpack.
-     *
-     * It should be run whenever the servlet using this handler is destroyed or
-     * the runtime exists, so as we don not leave any webpack running as a daemon.
-     */
-    public void destroy() {
-      if (exec != null && exec.isAlive()) {
-        exec.destroy();
-        getLogger().info("Webpack server stopped");
-      }
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
@@ -486,9 +486,6 @@ public class VaadinServlet extends HttpServlet {
     @Override
     public void destroy() {
         super.destroy();
-        if (devmodeHandler != null) {
-            devmodeHandler.destroy();
-        }
         getService().destroy();
     }
 


### PR DESCRIPTION
Althought stoping webpack is positive when running IT tests suite, it
causes issues when enabling hot reload in dev-mode servlet container

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5188)
<!-- Reviewable:end -->
