### PR TITLE
Fix flow-component-render for comboboxes for Chrome72

### DIFF
--- a/flow-data/src/main/resources/META-INF/resources/frontend/flow-component-renderer.html
+++ b/flow-data/src/main/resources/META-INF/resources/frontend/flow-component-renderer.html
@@ -24,6 +24,13 @@
       this._runChrome72ShadowDomBugWorkaround();
     }
 
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      if(this._observer){
+        this._observer.disconnect();
+      }
+    }
+
   /* workaround for issue vaadin/flow#5025 */
     _runChrome72ShadowDomBugWorkaround() {
       const userAgent = navigator.userAgent;
@@ -42,6 +49,20 @@
               this.style.visibility = '';
               debouncedNotifyResize();
             });
+
+            /* workaround for issue vaadin/vaadin-grid-flow#557 */
+            this._observer = new Polymer.FlattenedNodesObserver(this, (info) => {
+              if(info.addedNodes &&  info.addedNodes[0] instanceof Vaadin.ComboBoxElement){
+                var combo = info.addedNodes[0];
+                combo.style.visibility = 'hidden';
+                requestAnimationFrame(() => {
+                  combo.style.visibility = '';
+                  debouncedNotifyResize();
+                });
+              }
+
+            });
+
           }
         }
       }


### PR DESCRIPTION
This is a temporal fix/workaround required only for Chrome 72 for the flow-component-renderer to be able to render comboboxes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5222)
<!-- Reviewable:end -->
