### PR TITLE
Fix flow-component-render so to render comboboxes for Chrome72 (#557)

### DIFF
--- a/flow-data/src/main/resources/META-INF/resources/frontend/flow-component-renderer.html
+++ b/flow-data/src/main/resources/META-INF/resources/frontend/flow-component-renderer.html
@@ -24,6 +24,13 @@
       this._runChrome72ShadowDomBugWorkaround();
     }
 
+    disconnectedCallback() {
+      super.disconnectedCallback();
+      if(this._observer){
+        this._observer.disconnect();
+      }
+    }
+
   /* workaround for issue vaadin/flow#5025 */
     _runChrome72ShadowDomBugWorkaround() {
       const userAgent = navigator.userAgent;
@@ -42,6 +49,20 @@
               this.style.visibility = '';
               debouncedNotifyResize();
             });
+
+            /* workaround for issue vaadin/vaadin-grid-flow#557 */
+            this._observer = new Polymer.FlattenedNodesObserver(this, (info) => {
+              if(info.addedNodes &&  info.addedNodes[0] instanceof Vaadin.ComboBoxElement){
+              var combo = info.addedNodes[0];
+              combo.style.visibility = 'hidden';
+              requestAnimationFrame(() => {
+                combo.style.visibility = '';
+              debouncedNotifyResize();
+            });
+            }
+
+          });
+
           }
         }
       }

--- a/flow-data/src/main/resources/META-INF/resources/frontend/flow-component-renderer.html
+++ b/flow-data/src/main/resources/META-INF/resources/frontend/flow-component-renderer.html
@@ -53,15 +53,15 @@
             /* workaround for issue vaadin/vaadin-grid-flow#557 */
             this._observer = new Polymer.FlattenedNodesObserver(this, (info) => {
               if(info.addedNodes &&  info.addedNodes[0] instanceof Vaadin.ComboBoxElement){
-              var combo = info.addedNodes[0];
-              combo.style.visibility = 'hidden';
-              requestAnimationFrame(() => {
-                combo.style.visibility = '';
-              debouncedNotifyResize();
-            });
-            }
+                var combo = info.addedNodes[0];
+                combo.style.visibility = 'hidden';
+                requestAnimationFrame(() => {
+                  combo.style.visibility = '';
+                  debouncedNotifyResize();
+                });
+              }
 
-          });
+            });
 
           }
         }


### PR DESCRIPTION
Workaround resolving the issue (caused by Chrome 72) of comboboxes not always being rendered when used inside the flow-component-renderer. 
The fix observes when the combobox node has been added into the flow-component-render in order to debounce a notifyResize event.

Fixes [vaadin-grid-flow/issues/557](https://github.com/vaadin/vaadin-grid-flow/issues/557)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5223)
<!-- Reviewable:end -->
