### PR TITLE
Avoid exception when Vaadin.ComboBoxElement is not available

### DIFF
--- a/flow-data/src/main/resources/META-INF/resources/frontend/flow-component-renderer.html
+++ b/flow-data/src/main/resources/META-INF/resources/frontend/flow-component-renderer.html
@@ -52,7 +52,7 @@
 
             /* workaround for issue vaadin/vaadin-grid-flow#557 */
             this._observer = new Polymer.FlattenedNodesObserver(this, (info) => {
-              if(info.addedNodes &&  info.addedNodes[0] instanceof Vaadin.ComboBoxElement){
+              if(Vaadin.ComboBoxElement && info.addedNodes &&  info.addedNodes[0] instanceof Vaadin.ComboBoxElement){
                 var combo = info.addedNodes[0];
                 combo.style.visibility = 'hidden';
                 requestAnimationFrame(() => {


### PR DESCRIPTION
This fix avoid exception being thrown in case when none of the nodes components being added inside the flow-component-render is a combo-box and the ComboBoxElement is not available at all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5282)
<!-- Reviewable:end -->
