### PR TITLE
Limit component renderer workaround for Chrome 72

### DIFF
--- a/flow-data/src/main/resources/META-INF/resources/frontend/flow-component-renderer.html
+++ b/flow-data/src/main/resources/META-INF/resources/frontend/flow-component-renderer.html
@@ -30,11 +30,10 @@
       if (userAgent && userAgent.match('Chrome\/')) {
         // example: ... Chrome/72.0.3626.96 ...
         const majorVersionString = userAgent.split('Chrome\/')[1].split('.')[0];
-        if (majorVersionString && parseInt(majorVersionString) > 71) {
+        if (majorVersionString && parseInt(majorVersionString) === 72) {
           const debouncedNotifyResize = this._getDebouncedNotifyResizeFunction();
 
           // if there is no notifyResize function, then just skip
-
           if (debouncedNotifyResize) {
             this.style.visibility = 'hidden';
             // need to use animation frame instead of timeout or focusing won't work


### PR DESCRIPTION
Chrome 73 is out and has fixed the regression.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5284)
<!-- Reviewable:end -->
