### PR TITLE
Fixed a NPE problem in WebComponentConfigurationRegistry

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentConfigurationRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentConfigurationRegistry.java
@@ -47,9 +47,9 @@ public class WebComponentConfigurationRegistry implements Serializable {
      */
     private final ReentrantLock configurationLock = new ReentrantLock(true);
 
-    private Map<String, Class<? extends WebComponentExporter<?
+    private HashMap<String, Class<? extends WebComponentExporter<?
             extends Component>>> exporterClasses = null;
-    private Map<String, WebComponentConfigurationImpl<? extends Component>>
+    private HashMap<String, WebComponentConfigurationImpl<? extends Component>>
             builderCache = new HashMap<>();
 
     /**
@@ -131,7 +131,7 @@ public class WebComponentConfigurationRegistry implements Serializable {
         configurationLock.lock();
         try {
             if (exporters.isEmpty()) {
-                exporterClasses = Collections.emptyMap();
+                exporterClasses = new HashMap<>(0);
             } else {
                 exporterClasses = new HashMap<>(exporters);
             }

--- a/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentConfigurationRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentConfigurationRegistry.java
@@ -48,7 +48,7 @@ public class WebComponentConfigurationRegistry implements Serializable {
     private final ReentrantLock configurationLock = new ReentrantLock(true);
 
     private Map<String, Class<? extends WebComponentExporter<?
-            extends Component>>> exporterClasses;
+            extends Component>>> exporterClasses = null;
     private Map<String, WebComponentConfigurationImpl<? extends Component>>
             builderCache = new HashMap<>();
 
@@ -94,6 +94,9 @@ public class WebComponentConfigurationRegistry implements Serializable {
     }
 
     /**
+     * Get an unmodifiable set containing all registered web component
+     * configurations for a specific {@link Component} type.
+     *
      * @param componentClass    type of the exported {@link Component}
      * @param <T>               component
      * @return  set of {@link WebComponentConfiguration} or an empty set.
@@ -107,10 +110,10 @@ public class WebComponentConfigurationRegistry implements Serializable {
             if (!areAllConfigurationsAvailable()) {
                 populateCacheWithMissingConfigurations();
             }
-            return builderCache.values().stream()
+            return Collections.unmodifiableSet(builderCache.values().stream()
                     .filter(b -> componentClass.equals(b.getComponentClass()))
                     .map(b -> (WebComponentConfiguration<T>)b)
-                    .collect(Collectors.toSet());
+                    .collect(Collectors.toSet()));
 
         } finally {
             configurationLock.unlock();
@@ -167,10 +170,16 @@ public class WebComponentConfigurationRegistry implements Serializable {
         }
     }
 
+    public boolean hasExporters() {
+        return exporterClasses != null;
+    }
+
     /**
-     * Get map containing all registered web component builders.
+     * Get an unmodifiable set containing all registered web component
+     * configurations.
      *
-     * @return unmodifiable set of web component builders in registry
+     * @return  unmodifiable set of web component builders in registry or
+     *          empty set
      */
     public Set<WebComponentConfiguration<? extends Component>> getConfigurations() {
         configurationLock.lock();
@@ -265,6 +274,9 @@ public class WebComponentConfigurationRegistry implements Serializable {
      * builderCache} based on the exporters.
      */
     protected void populateCacheWithMissingConfigurations() {
+        if (exporterClasses == null) {
+            return;
+        }
         exporterClasses.forEach((key, value) -> builderCache.put(key,
                 constructConfigurations(key, value)));
         // empty the exporter data bank - every builder has been constructed

--- a/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/OSGiWebComponentConfigurationRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/OSGiWebComponentConfigurationRegistryTest.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.server.webcomponent;
 
 import javax.servlet.ServletContext;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.Callable;
@@ -44,7 +45,7 @@ import com.vaadin.flow.server.startup.EnableOSGiRunner;
 public class OSGiWebComponentConfigurationRegistryTest extends WebComponentConfigurationRegistryTest {
 
     @After
-    public void cleanUp() {
+    public void cleanUpOSGi() {
         if (OSGiAccess.getInstance().getOsgiServletContext() != null) {
             OSGiWebComponentConfigurationRegistry.getInstance(
                     OSGiAccess.getInstance().getOsgiServletContext());
@@ -92,6 +93,21 @@ public class OSGiWebComponentConfigurationRegistryTest extends WebComponentConfi
         Assert.assertEquals("Builder should be linked to UserBox.class",
                 UserBox.class, registry.getConfigurationInternal("user-box")
                         .getComponentClass());
+    }
+
+    @Override
+    public void hasExporters() {
+        // being a singleton caused this test to fail when inherited
+
+        OSGiWebComponentConfigurationRegistry registry =
+                new OSGiWebComponentConfigurationRegistry();
+
+        Assert.assertFalse("Should have no exporters", registry.hasExporters());
+
+        registry.setExporters(Collections.emptyMap());
+
+        Assert.assertTrue("Should have exporters, albeit empty",
+                registry.hasExporters());
     }
 
     @Override

--- a/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/WebComponentConfigurationRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/WebComponentConfigurationRegistryTest.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.server.webcomponent;
 
 import javax.servlet.ServletContext;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -79,7 +80,7 @@ public class WebComponentConfigurationRegistryTest {
     }
 
     @After
-    public void cleanUp() {
+    public void cleanUpOSGi() {
         CurrentInstance.clearAll();
     }
 
@@ -167,6 +168,26 @@ public class WebComponentConfigurationRegistryTest {
         Assert.assertNull(
                 "Components from the second Set should not have been added",
                 registry.getConfigurationInternal("user-box"));
+    }
+
+    @Test
+    public void getConfigurations_uninitializedReturnsEmptySet() {
+        WebComponentConfigurationRegistry uninitializedRegistry =
+                new WebComponentConfigurationRegistry();
+
+        Set<?> set = uninitializedRegistry.getConfigurations();
+
+        Assert.assertEquals("Configuration set should be empty", 0, set.size());
+    }
+
+    @Test
+    public void hasExporters() {
+        Assert.assertFalse("Should have no exporters", registry.hasExporters());
+
+        registry.setExporters(Collections.emptyMap());
+
+        Assert.assertTrue("Should have exporters, albeit empty",
+                registry.hasExporters());
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/WebComponentConfigurationRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/WebComponentConfigurationRegistryTest.java
@@ -80,7 +80,7 @@ public class WebComponentConfigurationRegistryTest {
     }
 
     @After
-    public void cleanUpOSGi() {
+    public void cleanUp() {
         CurrentInstance.clearAll();
     }
 


### PR DESCRIPTION
Requesting configurations before any had been registered caused a NPE to be raised in `WebComponentConfigurationRegistry`.

With this fix, the Spring addon should be fixable.
- [x] verify the fix against the spring fix proposal

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5304)
<!-- Reviewable:end -->
