### PR TITLE
Avoid babel transpiling at all when producing es6 bundle

### DIFF
--- a/flow-maven-plugin/src/main/resources/webpack.config.js
+++ b/flow-maven-plugin/src/main/resources/webpack.config.js
@@ -42,12 +42,10 @@ module.exports = {
       targets: {
         'es6': {
           browsers: [
-            'last 2 Chrome major versions',
-            'last 2 ChromeAndroid major versions',
-            'last 2 Edge major versions',
-            'last 2 Firefox major versions',
-            'last 2 Safari major versions',
-            'last 2 iOS major versions'
+            // It guarantees that babel outputs pure es6 in bundle and in stats.json
+            // In the case of browsers no supporting certain feature it will be
+            // covered by the webcomponents-loader.js
+            'last 1 Chrome major versions'
           ],
         },
         'es5': {


### PR DESCRIPTION
A fix in latest babel makes the output unreadable by closure compiler, because it  enables `transform-template-literals` when Safari browsers are in the list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5318)
<!-- Reviewable:end -->
