### PR TITLE
Only make banner the target of pointer events

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/default-pwa-prompt.html
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/default-pwa-prompt.html
@@ -29,7 +29,6 @@
 
   #pwa-ip.visible {
     transform: translateY(0%);
-    pointer-events: auto;
   }
 
   #pwa-ip .banner {
@@ -46,6 +45,7 @@
     line-height: 1.125em;
     font-family: -apple-system, BlinkMacSystemFont, "Roboto", "Segoe UI", Helvetica, Arial, sans-serif;
     color: #fff;
+    pointer-events: auto;
   }
 
   #pwa-ip .app-icon {


### PR DESCRIPTION
Currently the prompt consists of a full width transparent `#pwa-ip` div which is preventing click in elements behind it, and a `.banner` div which should be clickable

Removing `pointer-events: auto;` from `#pwa-ip.visible` allows clicking in buttons behind it like the logout button in bookstore-starter-flow

![image](https://user-images.githubusercontent.com/9820084/54996903-2a6d2300-4fd3-11e9-91cd-b0f7c51c4b54.png)

Adding `pointer-events: auto;` in `#pwa-ip .banner` allows interacting correctly with PWA install prompt without preventing click on elements that are not behind it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5343)
<!-- Reviewable:end -->
