### PR TITLE
Cherry-pick: Only make banner the target of pointer events (#5343) 

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/default-pwa-prompt.html
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/default-pwa-prompt.html
@@ -29,7 +29,6 @@
 
   #pwa-ip.visible {
     transform: translateY(0%);
-    pointer-events: auto;
   }
 
   #pwa-ip .banner {
@@ -46,6 +45,7 @@
     line-height: 1.125em;
     font-family: -apple-system, BlinkMacSystemFont, "Roboto", "Segoe UI", Helvetica, Arial, sans-serif;
     color: #fff;
+    pointer-events: auto;
   }
 
   #pwa-ip .app-icon {


### PR DESCRIPTION
Currently the prompt consists of a full width transparent `#pwa-ip` div which is preventing click in elements behind it, and a `.banner` div which should be clickable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5345)
<!-- Reviewable:end -->
