### PR TITLE
Fix exported web components when using a /web-component/* servlet mapping

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
@@ -36,7 +36,10 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
     @Override
     protected boolean canHandleRequest(VaadinRequest request) {
         VaadinServletRequest servletRequest = (VaadinServletRequest) request;
-        String pathInfo = servletRequest.getPathInfo();
+        String pathInfo = servletRequest.getPathInfo() == null
+                ? servletRequest.getServletPath()
+                : servletRequest.getServletPath()
+                        + servletRequest.getPathInfo();
         if (pathInfo == null || pathInfo.isEmpty()) {
             return false;
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentProvider.java
@@ -51,7 +51,10 @@ public class WebComponentProvider extends SynchronizedRequestHandler {
     public boolean synchronizedHandleRequest(VaadinSession session,
             VaadinRequest request, VaadinResponse response) throws IOException {
         VaadinServletRequest servletRequest = (VaadinServletRequest) request;
-        String pathInfo = servletRequest.getPathInfo();
+        String pathInfo = servletRequest.getPathInfo() == null
+                ? servletRequest.getServletPath()
+                : servletRequest.getServletPath()
+                        + servletRequest.getPathInfo();
 
         if (pathInfo == null || pathInfo.isEmpty()) {
             return false;

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/WebComponentProviderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/WebComponentProviderTest.java
@@ -122,6 +122,7 @@ public class WebComponentProviderTest {
 
         Mockito.when(request.getPathInfo())
                 .thenReturn("/web-component/my-component.html");
+        Mockito.when(request.getServletPath()).thenReturn("");
         Assert.assertTrue("Provider should handle web-component request",
                 provider.handleRequest(session, request, response));
         Mockito.verify(response).sendError(HttpServletResponse.SC_NOT_FOUND,
@@ -144,6 +145,7 @@ public class WebComponentProviderTest {
 
         Mockito.when(request.getPathInfo())
                 .thenReturn("/web-component/my-component.html");
+        Mockito.when(request.getServletPath()).thenReturn("");
         Assert.assertTrue("Provider should handle web-component request",
                 provider.handleRequest(session, request, response));
 
@@ -171,6 +173,7 @@ public class WebComponentProviderTest {
 
         Mockito.when(request.getPathInfo())
                 .thenReturn("/web-component/my-component.html");
+        Mockito.when(request.getServletPath()).thenReturn("");
         Assert.assertTrue("Provider should handle first web-component request",
                 provider.handleRequest(session, request, response));
 


### PR DESCRIPTION
When you have an existing application you want to embed into, you rarely have the luxury of being able to map a Vaadin servlet to `/*`. This makes exported web components work with a mapping like
```
    <servlet-mapping>
        <servlet-name>Vaadin Servlet</servlet-name>
        <url-pattern>/web-component/*</url-pattern>
    </servlet-mapping>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5352)
<!-- Reviewable:end -->
