### PR TITLE
Reduce the number of repository lookups 

### DIFF
--- a/flow-test-util/pom.xml
+++ b/flow-test-util/pom.xml
@@ -39,13 +39,6 @@
         </dependency>
     </dependencies>
 
-    <repositories>
-        <repository>
-            <id>vaadin-addons</id>
-            <url>http://maven.vaadin.com/vaadin-addons</url>
-        </repository>
-    </repositories>
-
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -128,9 +128,20 @@
     </properties>
 
     <repositories>
+        <!-- The order of definitions matters. Explicitly defining central here to make sure it has the highest priority. -->
+        <repository>
+            <id>central</id>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
         <repository>
             <id>${flow.release.repo.id}</id>
             <url>${flow.release.repo.url}</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
         <repository>
             <id>${flow.snapshot.repo.id}</id>
@@ -142,13 +153,27 @@
         <repository>
             <id>${flow.addons.repo.id}</id>
             <url>${flow.addons.repo.url}</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
     </repositories>
 
     <pluginRepositories>
+        <!-- The order of definitions matters. Explicitly defining central here to make sure it has the highest priority. -->
+        <pluginRepository>
+            <id>central</id>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
         <pluginRepository>
             <id>${flow.release.repo.id}</id>
             <url>${flow.release.repo.url}</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </pluginRepository>
         <pluginRepository>
             <id>${flow.snapshot.repo.id}</id>


### PR DESCRIPTION
Currently snapshot builds are slow due to the fact that the majority of the artifacts are located in the Maven Central repo and it takes a few attempts before the repo is checked:

https://teamcity.vaadin.com/viewLog.html?buildId=46744&buildTypeId=Flow_FlowTests&tab=buildLog&_focus=692#_state=451

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5365)
<!-- Reviewable:end -->
