### PR TITLE
Generate webpack.config.js considering the Java project package mode

### DIFF
--- a/flow-client/pom.xml
+++ b/flow-client/pom.xml
@@ -78,12 +78,19 @@
             <version>${osgi.core.version}</version>
             <scope>provided</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>osgi.cmpn</artifactId>
             <version>${osgi.compendium.version}</version>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/flow-client/pom.xml
+++ b/flow-client/pom.xml
@@ -39,7 +39,7 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
-         <dependency>
+        <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>flow-osgi</artifactId>
             <version>${project.version}</version>

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/NodeUpdatePackagesMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/NodeUpdatePackagesMojo.java
@@ -47,22 +47,23 @@ public class NodeUpdatePackagesMojo extends NodeUpdateAbstractMojo {
     protected NodeUpdater getUpdater() {
         if (updater == null) {
             AnnotationValuesExtractor extractor = new AnnotationValuesExtractor(getClassFinder(project));
-            updater = new NodeUpdatePackages(extractor, webpackTemplate,
-                    npmFolder, nodeModulesPath, getOutputDirectory(),
-                    convertHtml);
+            updater = new NodeUpdatePackages(extractor,
+                    getWebpackOutputDirectory(), webpackTemplate, npmFolder,
+                    nodeModulesPath, convertHtml);
         }
         return updater;
     }
 
-    private File getOutputDirectory() {
+    private File getWebpackOutputDirectory() {
         Build buildInformation = project.getBuild();
         switch (project.getPackaging()) {
-        case "war": {
-            return new File(buildInformation.getOutputDirectory(),
-                    "classes/META-INF/resources");
-        }
         case "jar": {
-            return new File("target", buildInformation.getDirectory());
+            return new File(buildInformation.getOutputDirectory(),
+                    "META-INF/resources");
+        }
+        case "war": {
+            return new File(buildInformation.getDirectory(),
+                    buildInformation.getFinalName());
         }
         default:
             throw new IllegalStateException(String.format(

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/NodeUpdatePackagesMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/NodeUpdatePackagesMojo.java
@@ -46,10 +46,15 @@ public class NodeUpdatePackagesMojo extends NodeUpdateAbstractMojo {
     @Override
     protected NodeUpdater getUpdater() {
         if (updater == null) {
-            AnnotationValuesExtractor extractor = new AnnotationValuesExtractor(getClassFinder(project));
+            AnnotationValuesExtractor extractor = new AnnotationValuesExtractor(
+                    getClassFinder(project));
+            File webpackOutputRelativeToProjectDir = project.getBasedir()
+                    .toPath().relativize(getWebpackOutputDirectory().toPath())
+                    .toFile();
+
             updater = new NodeUpdatePackages(extractor,
-                    getWebpackOutputDirectory(), webpackTemplate, npmFolder,
-                    nodeModulesPath, convertHtml);
+                    webpackOutputRelativeToProjectDir, webpackTemplate,
+                    npmFolder, nodeModulesPath, convertHtml);
         }
         return updater;
     }

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/NodeUpdatePackagesMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/NodeUpdatePackagesMojo.java
@@ -62,14 +62,12 @@ public class NodeUpdatePackagesMojo extends NodeUpdateAbstractMojo {
     private File getWebpackOutputDirectory() {
         Build buildInformation = project.getBuild();
         switch (project.getPackaging()) {
-        case "jar": {
+        case "jar":
             return new File(buildInformation.getOutputDirectory(),
                     "META-INF/resources");
-        }
-        case "war": {
+        case "war":
             return new File(buildInformation.getDirectory(),
                     buildInformation.getFinalName());
-        }
         default:
             throw new IllegalStateException(String.format(
                     "Unsupported packaging '%s'", project.getPackaging()));

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/NodeUpdatePackagesMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/NodeUpdatePackagesMojo.java
@@ -15,6 +15,9 @@
  */
 package com.vaadin.flow.plugin.maven;
 
+import java.io.File;
+
+import org.apache.maven.model.Build;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -44,9 +47,26 @@ public class NodeUpdatePackagesMojo extends NodeUpdateAbstractMojo {
     protected NodeUpdater getUpdater() {
         if (updater == null) {
             AnnotationValuesExtractor extractor = new AnnotationValuesExtractor(getClassFinder(project));
-            updater = new NodeUpdatePackages(extractor, webpackTemplate, npmFolder, nodeModulesPath,
+            updater = new NodeUpdatePackages(extractor, webpackTemplate,
+                    npmFolder, nodeModulesPath, getOutputDirectory(),
                     convertHtml);
         }
         return updater;
+    }
+
+    private File getOutputDirectory() {
+        Build buildInformation = project.getBuild();
+        switch (project.getPackaging()) {
+        case "war": {
+            return new File(buildInformation.getOutputDirectory(),
+                    "classes/META-INF/resources");
+        }
+        case "jar": {
+            return new File("target", buildInformation.getDirectory());
+        }
+        default:
+            throw new IllegalStateException(String.format(
+                    "Unsupported packaging '%s'", project.getPackaging()));
+        }
     }
 }

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/UpdateNpmDependenciesMojoTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/UpdateNpmDependenciesMojoTest.java
@@ -79,6 +79,7 @@ public class UpdateNpmDependenciesMojoTest {
         when(buildMock.getFinalName()).thenReturn("finalName");
 
         MavenProject project = mock(MavenProject.class);
+        when(project.getBasedir()).thenReturn(new File("."));
         when(project.getPackaging()).thenReturn(packaging);
         when(project.getBuild()).thenReturn(buildMock);
         when(project.getRuntimeClasspathElements()).thenReturn(getClassPath());

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/UpdateNpmDependenciesMojoTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/UpdateNpmDependenciesMojoTest.java
@@ -76,6 +76,7 @@ public class UpdateNpmDependenciesMojoTest {
         Build buildMock = mock(Build.class);
         when(buildMock.getOutputDirectory()).thenReturn(outputDirectory);
         when(buildMock.getDirectory()).thenReturn(outputDirectory);
+        when(buildMock.getFinalName()).thenReturn("finalName");
 
         MavenProject project = mock(MavenProject.class);
         when(project.getPackaging()).thenReturn(packaging);

--- a/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/NpmTemplateParser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/NpmTemplateParser.java
@@ -64,8 +64,8 @@ public class NpmTemplateParser implements TemplateParser {
 
     private static final TemplateParser INSTANCE = new NpmTemplateParser();
 
-    private HashMap<String, String> cache = new HashMap<>();
-    private ReentrantLock lock = new ReentrantLock();
+    private final HashMap<String, String> cache = new HashMap<>();
+    private final ReentrantLock lock = new ReentrantLock();
     private JsonObject jsonStats;
 
     private NpmTemplateParser() {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdatePackages.java
@@ -68,7 +68,7 @@ public class NodeUpdatePackages extends NodeUpdater {
      * @param extractor
      *            a reusable annotation extractor
      * @param webpackOutputDirectory
-     *            the directory to set for
+     *            the directory to set for webpack to output its build results
      * @param webpackTemplate
      *            name of the webpack resource to be used as template when
      *            creating the <code>webpack.config.js</code> file
@@ -100,7 +100,7 @@ public class NodeUpdatePackages extends NodeUpdater {
      *            a reusable annotation extractor
      */
     public NodeUpdatePackages(AnnotationValuesExtractor extractor) {
-        this(extractor, new File("/src/main/webapp"), WEBPACK_CONFIG, new File("."),
+        this(extractor, new File("./src/main/webapp"), WEBPACK_CONFIG, new File("."),
                 new File("./node_modules/"), true);
     }
 
@@ -142,7 +142,7 @@ public class NodeUpdatePackages extends NodeUpdater {
             try (BufferedReader br = new BufferedReader(
                     new InputStreamReader(resource.openStream()))) {
                 List<String> webpackConfigLines = br.lines()
-                    .map(line -> line.replace("{{OUTPUT_DIRECTORY}}", webpackOutputDirectory.getPath()))
+                    .map(line -> line.replace("{{OUTPUT_DIRECTORY}}", webpackOutputDirectory.getAbsolutePath()))
                         .collect(Collectors.toList());
                 Files.write(configFile.toPath(), webpackConfigLines);
                 log().info("Created {} from {}", WEBPACK_CONFIG, resource);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdatePackages.java
@@ -60,31 +60,34 @@ public class NodeUpdatePackages extends NodeUpdater {
 
     private static final String VALUE = "value";
     private final String webpackTemplate;
-    private final File outputDirectory;
+    private final File webpackOutputDirectory;
 
     /**
      * Create an instance of the updater given all configurable parameters.
      *
      * @param extractor
      *            a reusable annotation extractor
+     * @param webpackOutputDirectory
+     *            the directory to set for
      * @param webpackTemplate
      *            name of the webpack resource to be used as template when
      *            creating the <code>webpack.config.js</code> file
      * @param npmFolder
      *            folder with the `package.json` file
-     * @param outputDirectory
-     *          TODO kb
      * @param nodeModulesPath
-     *            the path to the {@literal node_modules} directory of the project
+     *            the path to the {@literal node_modules} directory of the
+     *            project
      * @param convertHtml
-     *            true to enable polymer-2 annotated classes to be considered
+     *            whether to convert html imports or not during the package
+     *            updatesΩ
      */
-    public NodeUpdatePackages(AnnotationValuesExtractor extractor, String webpackTemplate, File npmFolder, File outputDirectory,
+    public NodeUpdatePackages(AnnotationValuesExtractor extractor,
+            File webpackOutputDirectory, String webpackTemplate, File npmFolder,
             File nodeModulesPath, boolean convertHtml) {
         this.annotationValuesExtractor = extractor;
         this.npmFolder = npmFolder;
         this.nodeModulesPath = nodeModulesPath;
-        this.outputDirectory = outputDirectory;
+        this.webpackOutputDirectory = webpackOutputDirectory;
         this.webpackTemplate = webpackTemplate;
         this.convertHtml = convertHtml;
     }
@@ -97,7 +100,7 @@ public class NodeUpdatePackages extends NodeUpdater {
      *            a reusable annotation extractor
      */
     public NodeUpdatePackages(AnnotationValuesExtractor extractor) {
-        this(extractor, WEBPACK_CONFIG, new File("."), null, // TODO kb
+        this(extractor, null, WEBPACK_CONFIG, new File("."),
                 new File("./node_modules/"), true);
     }
 
@@ -139,7 +142,7 @@ public class NodeUpdatePackages extends NodeUpdater {
             try (BufferedReader br = new BufferedReader(
                     new InputStreamReader(resource.openStream()))) {
                 List<String> webpackConfigLines = br.lines()
-                    .map(line -> line.replace("{{OUTPUT_DIRECTORY}}", outputDirectory.getPath()))
+                    .map(line -> line.replace("{{OUTPUT_DIRECTORY}}", webpackOutputDirectory.getPath()))
                         .collect(Collectors.toList());
                 Files.write(configFile.toPath(), webpackConfigLines);
                 log().info("Created {} from {}", WEBPACK_CONFIG, resource);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdatePackages.java
@@ -100,7 +100,7 @@ public class NodeUpdatePackages extends NodeUpdater {
      *            a reusable annotation extractor
      */
     public NodeUpdatePackages(AnnotationValuesExtractor extractor) {
-        this(extractor, null, WEBPACK_CONFIG, new File("."),
+        this(extractor, new File("./target/build"), WEBPACK_CONFIG, new File("."),
                 new File("./node_modules/"), true);
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdatePackages.java
@@ -139,8 +139,8 @@ public class NodeUpdatePackages extends NodeUpdater {
                 resource = new URL(webpackTemplate);
             }
 
-            try (BufferedReader br = new BufferedReader(
-                    new InputStreamReader(resource.openStream()))) {
+            try (BufferedReader br = new BufferedReader(new InputStreamReader(
+                    resource.openStream(), StandardCharsets.UTF_8))) {
                 List<String> webpackConfigLines = br.lines()
                     .map(line -> line.replace("{{OUTPUT_DIRECTORY}}", webpackOutputDirectory.getAbsolutePath()))
                         .collect(Collectors.toList());

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdatePackages.java
@@ -142,7 +142,7 @@ public class NodeUpdatePackages extends NodeUpdater {
             try (BufferedReader br = new BufferedReader(new InputStreamReader(
                     resource.openStream(), StandardCharsets.UTF_8))) {
                 List<String> webpackConfigLines = br.lines()
-                    .map(line -> line.replace("{{OUTPUT_DIRECTORY}}", webpackOutputDirectory.getAbsolutePath()))
+                    .map(line -> line.replace("{{OUTPUT_DIRECTORY}}", webpackOutputDirectory.getPath()))
                         .collect(Collectors.toList());
                 Files.write(configFile.toPath(), webpackConfigLines);
                 log().info("Created {} from {}", WEBPACK_CONFIG, resource);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdatePackages.java
@@ -100,7 +100,7 @@ public class NodeUpdatePackages extends NodeUpdater {
      *            a reusable annotation extractor
      */
     public NodeUpdatePackages(AnnotationValuesExtractor extractor) {
-        this(extractor, new File("./target/build"), WEBPACK_CONFIG, new File("."),
+        this(extractor, new File("/src/main/webapp"), WEBPACK_CONFIG, new File("."),
                 new File("./node_modules/"), true);
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdatePackages.java
@@ -79,7 +79,7 @@ public class NodeUpdatePackages extends NodeUpdater {
      *            project
      * @param convertHtml
      *            whether to convert html imports or not during the package
-     *            updatesΩ
+     *            updates
      */
     public NodeUpdatePackages(AnnotationValuesExtractor extractor,
             File webpackOutputDirectory, String webpackTemplate, File npmFolder,

--- a/flow-server/src/main/resources/webpack.config.js
+++ b/flow-server/src/main/resources/webpack.config.js
@@ -12,7 +12,7 @@ const baseDir = require('path').resolve(__dirname);
 // the folder of app resources (main.js and flow templates)
 const frontendFolder = `${baseDir}/frontend`;
 // the folder that java takes as webapp context
-const webappFolder = `${baseDir}/target/generated-frontend`;
+const webappFolder = "{{OUTPUT_DIRECTORY}}";
 
 // public path for resources, must match flow that requests /build/index.js /build/stats.json
 const build = 'build';

--- a/flow-server/src/main/resources/webpack.config.js
+++ b/flow-server/src/main/resources/webpack.config.js
@@ -12,7 +12,7 @@ const baseDir = require('path').resolve(__dirname);
 // the folder of app resources (main.js and flow templates)
 const frontendFolder = `${baseDir}/frontend`;
 // the folder that java takes as webapp context
-const webappFolder = "{{OUTPUT_DIRECTORY}}";
+const webappFolder = `${baseDir}/{{OUTPUT_DIRECTORY}}`;
 
 // public path for resources, must match flow that requests /build/index.js /build/stats.json
 const build = 'build';

--- a/flow-tests/test-npm/pom.xml
+++ b/flow-tests/test-npm/pom.xml
@@ -71,7 +71,6 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <webAppSourceDirectory>${project.build.directory}/generated-frontend</webAppSourceDirectory>
                     <systemProperties>
                         <systemProperty>
                             <name>vaadin.devmode.webpack.options</name>
@@ -92,13 +91,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
                 <version>${maven.war.plugin.version}</version>
-                <configuration>
-                    <webResources>
-                        <resource>
-                            <directory>${project.build.directory}/generated-frontend</directory>
-                        </resource>
-                    </webResources>
-                </configuration>
             </plugin>
 
             <!--

--- a/flow-tests/test-npm/pom.xml
+++ b/flow-tests/test-npm/pom.xml
@@ -81,6 +81,13 @@
                             <value>${project.basedir}</value>
                         </systemProperty>
                     </systemProperties>
+                    <!-- Use war output directory to get the webpack files -->
+                    <webAppConfig>
+                        <allowDuplicateFragmentNames>true</allowDuplicateFragmentNames>
+                        <resourceBases>
+                            <resourceBase>${project.build.directory}/${project.build.finalName}</resourceBase>
+                        </resourceBases>
+                    </webAppConfig>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Now the plugin generates the `build` directory in the project's output directory

Closes #5321
Closes https://github.com/vaadin/flow/issues/5293

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5371)
<!-- Reviewable:end -->
