### PR TITLE
Give RouterLayout control over how old content is removed

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/RouterLayout.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouterLayout.java
@@ -15,9 +15,10 @@
  */
 package com.vaadin.flow.router;
 
-import com.vaadin.flow.component.HasElement;
-
 import java.util.Objects;
+
+import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.dom.Element;
 
 /**
  * Implementations of this interface represent a parent for a navigation target
@@ -33,16 +34,37 @@ public interface RouterLayout extends HasElement {
      * annotated with a {@link Route @Route}.
      * <p>
      * <strong>Note</strong> implementors should not care about old
-     * {@code @Route} content, because {@link Router} automatically removes
-     * it before calling the method.
+     * {@code @Route} content, since it's handled separately by
+     * {@link #removeRouterLayoutContent(HasElement)} which by default simply
+     * removes the old content.
      * </p>
      *
-     * @param content the content component or {@code null} if the layout content is to be cleared.
+     * @param content
+     *            the content component or {@code null} if the layout content is
+     *            to be cleared.
      */
     default void showRouterLayoutContent(HasElement content) {
         if (content != null) {
-            getElement().appendChild(Objects.requireNonNull(content.getElement()));
+            getElement()
+                    .appendChild(Objects.requireNonNull(content.getElement()));
         }
+    }
+
+    /**
+     * Removes content that should no longer be shown in this router layout. If
+     * {@link #showRouterLayoutContent(HasElement)} was previously called with a
+     * non-null parameter, then this method will be called with the same
+     * parameter immediately before calling
+     * {@link #showRouterLayoutContent(HasElement)} again.
+     * <p>
+     * By default, the old content is removed from its parent using
+     * {@link Element#removeFromParent()}.
+     *
+     * @param oldContent
+     *            the old content to remove, not <code>null</code>
+     */
+    default void removeRouterLayoutContent(HasElement oldContent) {
+        oldContent.getElement().removeFromParent();
     }
 
 }

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterLayoutTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterLayoutTest.java
@@ -1,10 +1,11 @@
 package com.vaadin.flow.router;
 
-import com.vaadin.flow.component.ComponentTest;
-import com.vaadin.flow.dom.Element;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import com.vaadin.flow.component.ComponentTest;
+import com.vaadin.flow.dom.Element;
 
 public class RouterLayoutTest {
 
@@ -17,25 +18,39 @@ public class RouterLayoutTest {
     }
 
     @Test
-    public void testNotNull() {
+    public void show_nonNull_childrenUpdated() {
         Assert.assertEquals(0, testRouterLayout.getElement().getChildCount());
+
         ComponentTest.TestDiv content = new ComponentTest.TestDiv();
         testRouterLayout.showRouterLayoutContent(content);
+
         Assert.assertEquals(1, testRouterLayout.getElement().getChildCount());
+
         ComponentTest.TestDiv newContent = new ComponentTest.TestDiv();
         newContent.setId(NEW_ID);
         content.getElement().removeFromParent();
         testRouterLayout.showRouterLayoutContent(newContent);
+
         Assert.assertEquals(1, testRouterLayout.getElement().getChildCount());
-        Assert.assertSame(NEW_ID, testRouterLayout.getElement().getChild(0).getAttribute("id"));
+        Assert.assertSame(NEW_ID,
+                testRouterLayout.getElement().getChild(0).getAttribute("id"));
     }
 
     @Test
-    public void testNull() {
+    public void show_null_noChildren() {
         testRouterLayout.showRouterLayoutContent(null);
         Assert.assertEquals(0, testRouterLayout.getElement().getChildCount());
     }
 
+    @Test
+    public void remove_removesContent() {
+        ComponentTest.TestDiv content = new ComponentTest.TestDiv();
+        testRouterLayout.element.appendChild(content.getElement());
+
+        testRouterLayout.removeRouterLayoutContent(content);
+
+        Assert.assertEquals(0, testRouterLayout.getElement().getChildCount());
+    }
 
     private static class TestRouterLayout implements RouterLayout {
         private final Element element = new Element("span");

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
@@ -44,6 +44,7 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.Html;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
@@ -1152,6 +1153,27 @@ public class RouterTest extends RoutingTestBase {
     @Route
     @Tag(Tag.DIV)
     public static class View extends Component {
+    }
+
+    @Route(value = "1", layout = NoRemoveLayout.class)
+    @Tag(Tag.DIV)
+    public static class NoRemoveContent1 extends Component {
+
+    }
+
+    @Route(value = "2", layout = NoRemoveLayout.class)
+    @Tag(Tag.DIV)
+    public static class NoRemoveContent2 extends Component {
+
+    }
+
+    @Tag(Tag.DIV)
+    public static class NoRemoveLayout extends Component
+            implements RouterLayout {
+        @Override
+        public void removeRouterLayoutContent(HasElement oldContent) {
+            // Do nothing
+        }
     }
 
     @Override
@@ -3019,6 +3041,26 @@ public class RouterTest extends RoutingTestBase {
         router.navigate(ui, new Location(""), NavigationTrigger.PROGRAMMATIC);
 
         Assert.assertEquals(ui.getElement(), specialChild.getParent());
+    }
+
+    @Test
+    public void noRemoveLayout_oldContentRetained() {
+        setNavigationTargets(NoRemoveContent1.class, NoRemoveContent2.class);
+
+        ui.navigate(NoRemoveContent1.class);
+        NoRemoveLayout layout = (NoRemoveLayout) ui.getChildren().findFirst()
+                .get();
+
+        Assert.assertEquals(Arrays.asList(NoRemoveContent1.class),
+                layout.getChildren().map(Component::getClass)
+                        .collect(Collectors.toList()));
+
+        ui.navigate(NoRemoveContent2.class);
+
+        Assert.assertEquals(
+                Arrays.asList(NoRemoveContent1.class, NoRemoveContent2.class),
+                layout.getChildren().map(Component::getClass)
+                        .collect(Collectors.toList()));
     }
 
     private void setNavigationTargets(


### PR DESCRIPTION
When building an application where the old view is removed with an
animation, the old content needs to be retained in the DOM until the
animation has completed. To enable that kind of functionality, the
hardcoded logic that detaches old content must be overrideable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5385)
<!-- Reviewable:end -->
