### PR TITLE
Generate web component module files to the dedicated file.

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/common/FrontendDataProvider.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/common/FrontendDataProvider.java
@@ -78,7 +78,7 @@ public class FrontendDataProvider {
      *            {@code null}
      * @param webComponentOutputDirectoryName
      *            folder name inside {@code es6SourceDirectory} where web
-     *            component module files will be genetated
+     *            component module files will be generated, not {@code null}
      * @param userDefinedFragments
      *            another list of fragments, if user preferred to specify them
      *            without external configuration file, not {@code null}

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/common/FrontendDataProvider.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/common/FrontendDataProvider.java
@@ -76,6 +76,9 @@ public class FrontendDataProvider {
      * @param fragmentConfigurationFile
      *            path to external configuration file with fragments, may be
      *            {@code null}
+     * @param webComponentOutputDirectoryName
+     *            folder name inside {@code es6SourceDirectory} where web
+     *            component module files will be genetated
      * @param userDefinedFragments
      *            another list of fragments, if user preferred to specify them
      *            without external configuration file, not {@code null}
@@ -84,6 +87,7 @@ public class FrontendDataProvider {
             boolean shouldHash, File es6SourceDirectory,
             AnnotationValuesExtractor annotationValuesExtractor,
             File fragmentConfigurationFile,
+            String webComponentOutputDirectoryName,
             Map<String, Set<String>> userDefinedFragments) {
         this.shouldBundle = shouldBundle;
         this.shouldMinify = shouldMinify;
@@ -96,7 +100,8 @@ public class FrontendDataProvider {
                 annotationValuesExtractor, fragments.values().stream()
                         .flatMap(Set::stream).collect(Collectors.toSet()));
 
-        shellFileImports.addAll(generateWebComponentModules(es6SourceDirectory,
+        shellFileImports.addAll(generateWebComponentModules(
+                new File(es6SourceDirectory, webComponentOutputDirectoryName),
                 annotationValuesExtractor));
     }
 
@@ -349,6 +354,14 @@ public class FrontendDataProvider {
 
     private Collection<File> generateWebComponentModules(File outputDir,
             AnnotationValuesExtractor annotationValuesExtractor) {
+        if (outputDir.isFile()) {
+            throw new IllegalStateException(String.format(
+                    "The path '%s' already exists and it is not a diretory",
+                    outputDir));
+        }
+        if (!outputDir.exists()) {
+            outputDir.mkdir();
+        }
         WebComponentModulesGenerator generator = getWebComponentGenerator(
                 annotationValuesExtractor);
         return generator.getExporters().map(

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PackageForProductionMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PackageForProductionMojo.java
@@ -24,7 +24,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
@@ -39,6 +38,7 @@ import org.apache.maven.settings.crypto.DefaultSettingsDecryptionRequest;
 import org.apache.maven.settings.crypto.SettingsDecrypter;
 import org.apache.maven.settings.crypto.SettingsDecryptionResult;
 
+import com.github.eirslett.maven.plugins.frontend.lib.ProxyConfig;
 import com.vaadin.flow.plugin.common.AnnotationValuesExtractor;
 import com.vaadin.flow.plugin.common.FlowPluginFileUtils;
 import com.vaadin.flow.plugin.common.FrontendDataProvider;
@@ -126,6 +126,14 @@ public class PackageForProductionMojo extends AbstractMojo {
      */
     @Parameter(property = "bundleConfiguration", defaultValue = "${project.basedir}/bundle-configuration.json")
     private File bundleConfiguration;
+
+    /**
+     * Set the web components module files output folder name. The default is
+     * <code>vaadin-web-components</code>. The folder is used to generate the
+     * web component module files.
+     */
+    @Parameter(property = "webComponentOutputDirectoryName", defaultValue = "vaadin-web-components")
+    private String webComponentOutputDirectoryName;
 
     /**
      * Defines the path to node executable to use. If specified,
@@ -218,7 +226,8 @@ public class PackageForProductionMojo extends AbstractMojo {
         FrontendDataProvider frontendDataProvider = new FrontendDataProvider(
                 bundle, minify, hash, transpileEs6SourceDirectory,
                 new AnnotationValuesExtractor(getProjectClassPathUrls()),
-                bundleConfiguration, getFragmentsData(fragments));
+                bundleConfiguration, webComponentOutputDirectoryName,
+                getFragmentsData(fragments));
 
         FrontendToolsManager frontendToolsManager = new FrontendToolsManager(
                 transpileWorkingDirectory, es5OutputDirectoryName,

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/common/FrontendDataProviderTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/common/FrontendDataProviderTest.java
@@ -90,10 +90,11 @@ public class FrontendDataProviderTest {
                 boolean shouldMinify, File es6SourceDirectory,
                 AnnotationValuesExtractor annotationValuesExtractor,
                 File fragmentConfigurationFile,
+                String webComponentOutputDirectoryName,
                 Map<String, Set<String>> userDefinedFragments) {
             super(shouldBundle, shouldMinify, false, es6SourceDirectory,
                     annotationValuesExtractor, fragmentConfigurationFile,
-                    userDefinedFragments);
+                    webComponentOutputDirectoryName, userDefinedFragments);
         }
 
         @Override
@@ -158,7 +159,7 @@ public class FrontendDataProviderTest {
                         .getAbsolutePath());
 
         new TestFrontendDataProvider(true, true, sourceDirectory,
-                mock(AnnotationValuesExtractor.class), null,
+                mock(AnnotationValuesExtractor.class), null, null,
                 Collections.singletonMap("fragmentName",
                         Collections.singleton(nonExistentFragmentFile)));
     }
@@ -179,7 +180,8 @@ public class FrontendDataProviderTest {
                 new File(sourceDirectory, nonExistentImport).getAbsolutePath());
 
         new TestFrontendDataProvider(true, true, sourceDirectory,
-                annotationValuesExtractorMock, null, Collections.emptyMap());
+                annotationValuesExtractorMock, null, null,
+                Collections.emptyMap());
 
         verify(annotationValuesExtractorMock, Mockito.times(2))
                 .extractAnnotationValues(anyMap());
@@ -202,7 +204,8 @@ public class FrontendDataProviderTest {
 
         FrontendDataProvider frontendDataProvider = new TestFrontendDataProvider(
                 shouldBundle, shouldMinify, sourceDirectory,
-                annotationValuesExtractorMock, null, Collections.emptyMap());
+                annotationValuesExtractorMock, null, "bar",
+                Collections.emptyMap());
 
         boolean actualShouldBundle = frontendDataProvider.shouldBundle();
         boolean actualShouldMinify = frontendDataProvider.shouldMinify();
@@ -247,7 +250,7 @@ public class FrontendDataProviderTest {
                         "src/component2.html")));
 
         FrontendDataProvider provider = new TestFrontendDataProvider(true, true,
-                sourceDirectory, annotationValuesExtractorMock, null,
+                sourceDirectory, annotationValuesExtractorMock, null, "bar",
                 Collections.emptyMap());
 
         provider.createShellFile(targetDirectory);
@@ -270,9 +273,9 @@ public class FrontendDataProviderTest {
         Mockito.when(generator.getExporters())
                 .thenReturn(Stream.of(TestExporter.class));
 
-        File webModule = new File(sourceDirectory, "web-module-gen.html");
+        File webModule = new File(sourceDirectory, "bar/web-module-gen.html");
         Mockito.when(generator.generateModuleFile(TestExporter.class,
-                sourceDirectory)).thenReturn(webModule);
+                new File(sourceDirectory, "bar"))).thenReturn(webModule);
 
         AnnotationValuesExtractor annotationValuesExtractorMock = mock(
                 AnnotationValuesExtractor.class);
@@ -287,7 +290,7 @@ public class FrontendDataProviderTest {
         createFile(src, "foo.html");
 
         FrontendDataProvider provider = new TestFrontendDataProvider(true, true,
-                sourceDirectory, annotationValuesExtractorMock, null,
+                sourceDirectory, annotationValuesExtractorMock, null, "bar",
                 Collections.emptyMap());
 
         String file = provider.createShellFile(targetDirectory);
@@ -296,8 +299,8 @@ public class FrontendDataProviderTest {
 
         Assert.assertThat(bundle,
                 CoreMatchers.containsString("es6Source/src/foo.html"));
-        Assert.assertThat(bundle,
-                CoreMatchers.containsString("es6Source/web-module-gen.html"));
+        Assert.assertThat(bundle, CoreMatchers
+                .containsString("es6Source/bar/web-module-gen.html"));
     }
 
     @Test
@@ -309,7 +312,7 @@ public class FrontendDataProviderTest {
 
         FrontendDataProvider frontendDataProvider = new TestFrontendDataProvider(
                 false, true, sourceDirectory, annotationValuesExtractorMock,
-                null, Collections.singletonMap("whatever",
+                null, "bar", Collections.singletonMap("whatever",
                         Collections.singleton("doesNotMatter")));
         Set<String> fragmentFiles = frontendDataProvider
                 .createFragmentFiles(targetDirectory);
@@ -343,7 +346,8 @@ public class FrontendDataProviderTest {
 
         FrontendDataProvider frontendDataProvider = new TestFrontendDataProvider(
                 true, true, sourceDirectory, annotationValuesExtractorMock,
-                null, Collections.singletonMap(fragmentName, fragmentImports));
+                null, "bar",
+                Collections.singletonMap(fragmentName, fragmentImports));
 
         Set<String> fragmentFilePaths = frontendDataProvider
                 .createFragmentFiles(targetDirectory);
@@ -385,7 +389,8 @@ public class FrontendDataProviderTest {
 
         FrontendDataProvider frontendDataProvider = new TestFrontendDataProvider(
                 true, true, sourceDirectory, annotationValuesExtractorMock,
-                configurationFile, Collections.singletonMap(firstFragment,
+                configurationFile, "bar",
+                Collections.singletonMap(firstFragment,
                         Collections.singleton(firstFragmentImport)));
 
         Set<String> fragmentFilePaths = frontendDataProvider
@@ -429,7 +434,7 @@ public class FrontendDataProviderTest {
 
         FrontendDataProvider dataProvider = new TestFrontendDataProvider(false,
                 false, sourceDirectory, annotationValuesExtractorMock, null,
-                Collections.emptyMap());
+                "foo", Collections.emptyMap());
 
         String shellFile = dataProvider.createShellFile(targetDirectory);
         List<String> shellFileContents = Files.lines(Paths.get(shellFile))

--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentConfiguration.java
@@ -28,7 +28,8 @@ import com.vaadin.flow.server.webcomponent.PropertyData;
  * The configuration is used to construct the web component, and further-more
  * the {@link WebComponentBinding}.
  *
- * @param <C> type of the component being exported
+ * @param <C>
+ *            type of the component being exported
  */
 public interface WebComponentConfiguration<C extends Component>
         extends Serializable {
@@ -37,7 +38,8 @@ public interface WebComponentConfiguration<C extends Component>
      * Check if the configuration has a property identified by the {@code
      * propertyName}.
      *
-     * @param propertyName  name of the property, not null
+     * @param propertyName
+     *            name of the property, not null
      * @return has property
      */
     boolean hasProperty(String propertyName);
@@ -46,7 +48,8 @@ public interface WebComponentConfiguration<C extends Component>
      * Retrieve the type of a property's value. If the property is not known,
      * returns {@code null}
      *
-     * @param propertyName  name of the property, not null
+     * @param propertyName
+     *            name of the property, not null
      * @return property type or null
      */
     Class<? extends Serializable> getPropertyType(String propertyName);
@@ -59,8 +62,8 @@ public interface WebComponentConfiguration<C extends Component>
     Class<C> getComponentClass();
 
     /**
-     * Set of all the {@link PropertyData} objects defining the web
-     * component's properties.
+     * Set of all the {@link PropertyData} objects defining the web component's
+     * properties.
      *
      * @return set of {@code PropertyData}
      */
@@ -73,13 +76,21 @@ public interface WebComponentConfiguration<C extends Component>
      * fashion defined by the associated
      * {@link com.vaadin.flow.component.WebComponentExporter}.
      *
-     * @param instantiator  {@link Instantiator} using to construct component
-                            instance
-     * @param el            element which acts as the root element for the
-     *                      {@code component instance}
-     * @return  web component binding which can be used by the web component
-     *          host to communicate with the component it is hosting
+     * @param instantiator
+     *            {@link Instantiator} using to construct component instance
+     * @param el
+     *            element which acts as the root element for the
+     *            {@code component instance}
+     * @return web component binding which can be used by the web component host
+     *         to communicate with the component it is hosting
      */
     WebComponentBinding<C> createWebComponentBinding(Instantiator instantiator,
-    Element el);
+            Element el);
+
+    /**
+     * Gets the tag of the web component.
+     *
+     * @return the tag name
+     */
+    String getWebComponentTag();
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentUI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentUI.java
@@ -73,9 +73,9 @@ public class WebComponentUI extends UI {
             /*
              * This code adds a number of HTML dependencies to the page but in
              * fact there are no such HTML files: they should have been
-             * generated during tranpilation via maven plugin. To be able to
-             * activate tranpiled code the application should add the
-             * dependencies which "have been transpiled".
+             * generated during transpilation via maven plugin. To be able to
+             * activate transpiled code the embedded application should add the
+             * "dependencies" which have been transpiled.
              */
             registry.getConfigurations().stream().forEach(config -> getPage()
                     .addHtmlImport(getWebComponentPath(config)));

--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentUI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentUI.java
@@ -75,7 +75,7 @@ public class WebComponentUI extends UI {
              * fact there are no such HTML files: they should have been
              * generated during transpilation via maven plugin. To be able to
              * activate transpiled code the embedded application imports the
-             * "dependencies" which represents the transpiled files.
+             * "dependencies" which represent the transpiled files.
              */
             registry.getConfigurations().stream().forEach(config -> getPage()
                     .addHtmlImport(getWebComponentPath(config)));

--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentUI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentUI.java
@@ -74,8 +74,8 @@ public class WebComponentUI extends UI {
              * This code adds a number of HTML dependencies to the page but in
              * fact there are no such HTML files: they should have been
              * generated during transpilation via maven plugin. To be able to
-             * activate transpiled code the embedded application should add the
-             * "dependencies" which have been transpiled.
+             * activate transpiled code the embedded application imports the
+             * "dependencies" which represents the transpiled files.
              */
             registry.getConfigurations().stream().forEach(config -> getPage()
                     .addHtmlImport(getWebComponentPath(config)));

--- a/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
@@ -271,6 +271,7 @@ public interface DeploymentConfiguration extends Serializable {
     default String getRootElementId() {
         return getStringProperty(ApplicationConstants.UI_ELEMENT_ID, "");
     }
+
     /**
      * Determines if webJars mechanism is enabled. It is disabled if the user
      * have explicitly set the {@link Constants#DISABLE_WEBJARS} property to
@@ -323,5 +324,10 @@ public interface DeploymentConfiguration extends Serializable {
      */
     default boolean isBrotli() {
         return getBooleanProperty(Constants.SERVLET_PARAMETER_BROTLI, false);
+    }
+
+    default String getCompiledWebComponentsPath() {
+        return getStringProperty(Constants.COMPILED_WEB_COMPONENTS_PATH,
+                "vaadin-web-components");
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -99,10 +99,20 @@ public final class Constants implements Serializable {
     public static final String I18N_PROVIDER = "i18n.provider";
 
     /**
-     * Configuration name for the parameter that determines if Flow should automatically
-     * register servlets needed for the application to work.
+     * Configuration name for the parameter that determines if Flow should
+     * automatically register servlets needed for the application to work.
      */
     public static final String DISABLE_AUTOMATIC_SERVLET_REGISTRATION = "disable.automatic.servlet.registration";
+
+    /**
+     * Configuration name for the parameter that sets the compiled web
+     * components path. The path should be the same as
+     * {@code webComponentOutputDirectoryName} in the maven plugin that
+     * transpiles ES6 code. This path is only used for generated web components
+     * (server side web components) module in case they are transpiled: web
+     * component UI imports them as dependencies.
+     */
+    public static final String COMPILED_WEB_COMPONENTS_PATH = "compiled.web.components.path";
 
     private Constants() {
         // prevent instantiation constants class only

--- a/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentConfigurationImpl.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentConfigurationImpl.java
@@ -122,6 +122,7 @@ public class WebComponentConfigurationImpl<C extends Component> extends
         return configurationImp;
     }
 
+    @Override
     public String getWebComponentTag() {
         return tag;
     }


### PR DESCRIPTION
To be able to load the transpiled code for web components we should add
a dependency to the UI. As a result the generated module file should
have a dedicated name/path which should be used by the application to
import it.

Fixes #5425

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5429)
<!-- Reviewable:end -->
