### PR TITLE
5316 moving components from one ui to another

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/Component.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Component.java
@@ -378,6 +378,16 @@ public abstract class Component
     }
 
     /**
+     * Detaches a component from its current UI. Calling this method is a
+     * precondition for adding a component that was already attached to an
+     * existing UI to another UI.
+     */
+    public void detachFromUI() {
+        getElement().removeFromParent();
+        getElement().getNode().removeFromTree();
+    }
+
+    /**
      * Sets the id of the root element of this component. The id is used with
      * various APIs to identify the element, and it should be unique on the
      * page.

--- a/flow-server/src/main/java/com/vaadin/flow/component/Component.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Component.java
@@ -383,8 +383,7 @@ public abstract class Component
      * existing UI to another UI.
      */
     public void detachFromUI() {
-        getElement().removeFromParent();
-        getElement().getNode().removeFromTree();
+        getElement().removeFromTree();
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/Component.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Component.java
@@ -378,15 +378,6 @@ public abstract class Component
     }
 
     /**
-     * Detaches a component from its current UI. Calling this method is a
-     * precondition for adding a component that was already attached to an
-     * existing UI to another UI.
-     */
-    public void detachFromUI() {
-        getElement().removeFromTree();
-    }
-
-    /**
      * Sets the id of the root element of this component. The id is used with
      * various APIs to identify the element, and it should be unique on the
      * page.

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -584,7 +584,11 @@ public class Element extends Node<Element> {
      * @return this element
      */
     public Element removeFromTree() {
-        removeFromParent();
+        Node<?> parent = getParentNode();
+        if (parent != null
+                && parent.getChildren().anyMatch(Predicate.isEqual(this))) {
+            parent.removeChild(this);
+        }
         getNode().removeFromTree();
         return this;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -579,6 +579,17 @@ public class Element extends Node<Element> {
     }
 
     /**
+     * Removes this element from its parent and state tree.
+     *
+     * @return this element
+     */
+    public Element removeFromTree() {
+        removeFromParent();
+        getNode().removeFromTree();
+        return this;
+    }
+
+    /**
      * Gets the parent element.
      * <p>
      * The method may return {@code null} if the parent is not an element but a
@@ -1745,6 +1756,8 @@ public class Element extends Node<Element> {
     public boolean isEnabled() {
         return getNode().isEnabled();
     }
+
+
 
     @Override
     protected Element getSelf() {

--- a/flow-server/src/main/java/com/vaadin/flow/internal/ConstantPoolKey.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/ConstantPoolKey.java
@@ -36,7 +36,6 @@ import elemental.json.JsonValue;
  * @since 1.0
  */
 public class ConstantPoolKey implements Serializable {
-    // Only stored until delivered to the client
     private JsonValue json;
     private final String id;
 
@@ -66,20 +65,17 @@ public class ConstantPoolKey implements Serializable {
 
     /**
      * Exports the this key into a JSON object to send to the client. This
-     * method should only be called once and only by the {@link ConstantPool}
-     * instance that manages this value.
+     * method should be called only by the {@link ConstantPool} instance that
+     * manages this value. It may be called multiple times.
      *
      * @param clientConstantPoolUpdate
      *            the constant pool update that is to be sent to the client, not
      *            <code>null</code>
      */
     public void export(JsonObject clientConstantPoolUpdate) {
-        assert json != null : "Process can only be called once";
         assert id.equals(calculateHash(json)) : "Json value has been changed";
 
         clientConstantPoolUpdate.put(id, json);
-
-        json = null;
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/internal/ConstantPoolKey.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/ConstantPoolKey.java
@@ -36,7 +36,7 @@ import elemental.json.JsonValue;
  * @since 1.0
  */
 public class ConstantPoolKey implements Serializable {
-    private JsonValue json;
+    private final JsonValue json;
     private final String id;
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
@@ -678,7 +678,7 @@ public class StateNode implements Serializable {
             throw new IllegalStateException(
                     "Can't move a node from one state tree to another. " +
                             "If this is intentional, first remove the " +
-                            "node from its current state tree by calling" +
+                            "node from its current state tree by calling " +
                             "removeFromTree");
         }
         owner = tree;

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
@@ -43,6 +43,7 @@ import com.vaadin.flow.internal.StateTree.ExecutionRegistration;
 import com.vaadin.flow.internal.change.NodeAttachChange;
 import com.vaadin.flow.internal.change.NodeChange;
 import com.vaadin.flow.internal.change.NodeDetachChange;
+import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
 import com.vaadin.flow.internal.nodefeature.NodeFeature;
 import com.vaadin.flow.internal.nodefeature.NodeFeatureRegistry;
 import com.vaadin.flow.server.Command;
@@ -365,6 +366,20 @@ public class StateNode implements Serializable {
     }
 
     /**
+     * Removes the node from its parent and unlinks the node (and children)
+     * from the state tree.
+     */
+    public void removeFromTree() {
+        visitNodeTree(node -> {
+                    node.owner = NullOwner.get();
+                    node.id = -1;
+                    node.wasAttached = false;
+                }
+        );
+        setParent(null);
+    }
+
+    /**
      * Gets the feature of the given type, creating one if necessary. This
      * method throws {@link IllegalStateException} if this node isn't configured
      * to use the desired feature. Use {@link #hasFeature(Class)} to check
@@ -655,7 +670,10 @@ public class StateNode implements Serializable {
 
         if (owner instanceof StateTree) {
             throw new IllegalStateException(
-                    "Can't move a node from one state tree to another");
+                    "Can't move a node from one state tree to another. " +
+                            "If this is intentional, first remove the " +
+                            "component from its current state tree " +
+                            "by calling detachFromUI");
         }
         owner = tree;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
@@ -43,7 +43,6 @@ import com.vaadin.flow.internal.StateTree.ExecutionRegistration;
 import com.vaadin.flow.internal.change.NodeAttachChange;
 import com.vaadin.flow.internal.change.NodeChange;
 import com.vaadin.flow.internal.change.NodeDetachChange;
-import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
 import com.vaadin.flow.internal.nodefeature.NodeFeature;
 import com.vaadin.flow.internal.nodefeature.NodeFeatureRegistry;
 import com.vaadin.flow.server.Command;

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
@@ -369,13 +369,20 @@ public class StateNode implements Serializable {
      * from the state tree.
      */
     public void removeFromTree() {
-        visitNodeTree(node -> {
-                    node.owner = NullOwner.get();
-                    node.id = -1;
-                    node.wasAttached = false;
-                }
-        );
+        visitNodeTree(StateNode::reset);
         setParent(null);
+    }
+
+    /**
+     * Resets the node to the initial state where it is not owned by a state
+     * tree.
+     */
+    private void reset() {
+        owner = NullOwner.get();
+        id = -1;
+        wasAttached = false;
+        hasBeenAttached = false;
+        hasBeenDetached = false;
     }
 
     /**
@@ -671,8 +678,8 @@ public class StateNode implements Serializable {
             throw new IllegalStateException(
                     "Can't move a node from one state tree to another. " +
                             "If this is intentional, first remove the " +
-                            "component from its current state tree " +
-                            "by calling detachFromUI");
+                            "node from its current state tree by calling" +
+                            "removeFromTree");
         }
         owner = tree;
     }

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
@@ -494,15 +494,6 @@ public class ComponentTest {
     }
 
     @Test
-    public void getUI_detachedFromUI_isEmpty() {
-        TestComponent child = new TestComponent();
-        UI ui = new UI();
-        ui.add(child);
-        child.detachFromUI();
-        assertEmpty(child.getUI());
-    }
-
-    @Test
     public void getUI_attachedThroughParent() {
         TestComponentContainer parent = new TestComponentContainer();
         TestComponent child = new TestComponent();
@@ -1583,20 +1574,6 @@ public class ComponentTest {
         TestComponent child = new TestComponent();
         UI ui1 = new UI();
         ui1.add(child);
-        UI ui2 = new UI();
-
-        // then
-        ui2.add(child);
-    }
-
-    @Test
-    public void add_componentIsAttachedToAnotherUIAndThenDetached_addedSuccessfully() {
-        // given
-        TestComponent child = new TestComponent();
-        UI ui1 = new UI();
-        ui1.add(child);
-
-        child.detachFromUI();
         UI ui2 = new UI();
 
         // then

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
@@ -494,6 +494,15 @@ public class ComponentTest {
     }
 
     @Test
+    public void getUI_detachedFromUI_isEmpty() {
+        TestComponent child = new TestComponent();
+        UI ui = new UI();
+        ui.add(child);
+        child.detachFromUI();
+        assertEmpty(child.getUI());
+    }
+
+    @Test
     public void getUI_attachedThroughParent() {
         TestComponentContainer parent = new TestComponentContainer();
         TestComponent child = new TestComponent();
@@ -1566,5 +1575,31 @@ public class ComponentTest {
         Assert.assertNotNull("Disabled attribute should exist for subSubChild",
                 subSubChild.getElement().getAttribute("disabled"));
 
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void add_componentIsAttachedToAnotherUI_throwsIllegalStateException() {
+        // given
+        TestComponent child = new TestComponent();
+        UI ui1 = new UI();
+        ui1.add(child);
+        UI ui2 = new UI();
+
+        // then
+        ui2.add(child);
+    }
+
+    @Test
+    public void add_componentIsAttachedToAnotherUIAndThenDetached_addedSuccessfully() {
+        // given
+        TestComponent child = new TestComponent();
+        UI ui1 = new UI();
+        ui1.add(child);
+
+        child.detachFromUI();
+        UI ui2 = new UI();
+
+        // then
+        ui2.add(child);
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
@@ -2051,6 +2051,19 @@ public class ElementTest extends AbstractNodeTest {
         Assert.assertEquals(1, detached.get());
     }
 
+    @Test
+    public void testRemoveFromTree_inDetachListener_removedFromParent() {
+        Element body = new UI().getElement();
+        Element child = ElementFactory.createDiv();
+        body.appendChild(child);
+
+        child.addDetachListener(event -> child.removeFromTree());
+
+        body.removeAllChildren();
+
+        Assert.assertEquals(null, child.getParent());
+    }
+
     private StreamResource createEmptyResource(String resName) {
         return new StreamResource(resName,
                 () -> new ByteArrayInputStream(new byte[0]));

--- a/flow-server/src/test/java/com/vaadin/flow/internal/StateNodeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/StateNodeTest.java
@@ -485,18 +485,18 @@ public class StateNodeTest {
     public void runWhenAttachedNodeNotAttached() {
         StateTree tree = createStateTree();
         AtomicInteger commandRun = new AtomicInteger(0);
-        StateNode n1 = createEmptyNode();
-        n1.runWhenAttached(ui -> {
+        StateNode node = createEmptyNode();
+        node.runWhenAttached(ui -> {
             Assert.assertEquals(tree.getUI(), ui);
             commandRun.incrementAndGet();
         });
 
         Assert.assertEquals(0, commandRun.get());
 
-        setParent(n1, tree.getRootNode());
+        setParent(node, tree.getRootNode());
         Assert.assertEquals(1, commandRun.get());
-        setParent(n1, null);
-        setParent(n1, tree.getRootNode());
+        setParent(node, null);
+        setParent(node, tree.getRootNode());
         Assert.assertEquals(1, commandRun.get());
     }
 
@@ -504,29 +504,29 @@ public class StateNodeTest {
     public void runMultipleWhenAttachedNodeNotAttached() {
         StateTree tree = createStateTree();
         AtomicInteger commandRun = new AtomicInteger(0);
-        StateNode n1 = createEmptyNode();
-        n1.runWhenAttached(ui -> {
+        StateNode node = createEmptyNode();
+        node.runWhenAttached(ui -> {
             Assert.assertEquals(tree.getUI(), ui);
             commandRun.incrementAndGet();
         });
-        n1.runWhenAttached(ui -> {
+        node.runWhenAttached(ui -> {
             Assert.assertEquals(tree.getUI(), ui);
             commandRun.incrementAndGet();
         });
 
         Assert.assertEquals(0, commandRun.get());
 
-        setParent(n1, tree.getRootNode());
+        setParent(node, tree.getRootNode());
         Assert.assertEquals(2, commandRun.get());
     }
 
     @Test
     public void runWhenAttachedNodeAttached() {
         AtomicInteger commandRun = new AtomicInteger(0);
-        StateNode n1 = createEmptyNode();
+        StateNode node = createEmptyNode();
         StateTree tree = createStateTree();
-        setParent(n1, tree.getRootNode());
-        n1.runWhenAttached(ui -> {
+        setParent(node, tree.getRootNode());
+        node.runWhenAttached(ui -> {
             Assert.assertEquals(tree.getUI(), ui);
             commandRun.incrementAndGet();
         });
@@ -794,19 +794,19 @@ public class StateNodeTest {
     public void detachParent_detachFirstChildOnDetachLast_oneDetachEvent() {
         TestStateTree tree = new TestStateTree();
 
-        StateNode a = createEmptyNode("a");
-        StateNode b = createEmptyNode("b");
+        StateNode childA = createEmptyNode("a");
+        StateNode childB = createEmptyNode("b");
 
         StateNode parent = createParentNode("parent");
 
-        addChild(parent, a);
-        addChild(parent, b);
+        addChild(parent, childA);
+        addChild(parent, childB);
 
         addChild(tree.getRootNode(), parent);
 
         AtomicInteger detachEvents = new AtomicInteger();
-        b.addDetachListener(() -> removeFromParent(a));
-        a.addDetachListener(() -> detachEvents.incrementAndGet());
+        childB.addDetachListener(() -> removeFromParent(childA));
+        childA.addDetachListener(() -> detachEvents.incrementAndGet());
 
         removeFromParent(parent);
 
@@ -817,19 +817,19 @@ public class StateNodeTest {
     public void detachParent_detachLastChildOnDetachFirst_oneDetachEvent() {
         TestStateTree tree = new TestStateTree();
 
-        StateNode a = createEmptyNode("a");
-        StateNode b = createEmptyNode("b");
+        StateNode childA = createEmptyNode("a");
+        StateNode childB = createEmptyNode("b");
 
         StateNode parent = createParentNode("parent");
 
-        addChild(parent, a);
-        addChild(parent, b);
+        addChild(parent, childA);
+        addChild(parent, childB);
 
         addChild(tree.getRootNode(), parent);
 
         AtomicInteger detachEvents = new AtomicInteger();
-        a.addDetachListener(() -> removeFromParent(a));
-        b.addDetachListener(() -> detachEvents.incrementAndGet());
+        childA.addDetachListener(() -> removeFromParent(childA));
+        childB.addDetachListener(() -> detachEvents.incrementAndGet());
 
         removeFromParent(parent);
 
@@ -840,16 +840,16 @@ public class StateNodeTest {
     public void detachParent_appendChildOnDetach_noEvents() {
         TestStateTree tree = new TestStateTree();
 
-        StateNode a = createEmptyNode("a");
+        StateNode childA = createEmptyNode("a");
 
         StateNode parent = createParentNode("parent");
 
-        addChild(parent, a);
+        addChild(parent, childA);
 
         addChild(tree.getRootNode(), parent);
 
         AtomicInteger events = new AtomicInteger();
-        a.addDetachListener(() -> {
+        childA.addDetachListener(() -> {
             StateNode b = createEmptyNode("b");
             b.addAttachListener(events::incrementAndGet);
             b.addDetachListener(events::incrementAndGet);
@@ -864,16 +864,16 @@ public class StateNodeTest {
     public void detachParent_insertChildAsFirstOnDetach_noEvents() {
         TestStateTree tree = new TestStateTree();
 
-        StateNode a = createEmptyNode("a");
+        StateNode child = createEmptyNode("a");
 
         StateNode parent = createParentNode("parent");
 
-        addChild(parent, a);
+        addChild(parent, child);
 
         addChild(tree.getRootNode(), parent);
 
         AtomicInteger events = new AtomicInteger();
-        a.addDetachListener(() -> {
+        child.addDetachListener(() -> {
             StateNode b = createEmptyNode("b");
             b.addAttachListener(events::incrementAndGet);
             b.addDetachListener(events::incrementAndGet);
@@ -890,21 +890,21 @@ public class StateNodeTest {
     public void attachParent_detachFirstOnAttachLast_noEvents() {
         TestStateTree tree = new TestStateTree();
 
-        StateNode a = createEmptyNode("a");
-        StateNode b = createEmptyNode("a");
+        StateNode childA = createEmptyNode("a");
+        StateNode childB = createEmptyNode("b");
 
         StateNode parent = createParentNode("parent");
 
-        addChild(parent, a);
-        addChild(parent, b);
+        addChild(parent, childA);
+        addChild(parent, childB);
 
         AtomicInteger events = new AtomicInteger();
-        b.addAttachListener(() -> {
-            removeFromParent(a);
+        childB.addAttachListener(() -> {
+            removeFromParent(childA);
         });
 
-        a.addAttachListener(events::incrementAndGet);
-        a.addDetachListener(events::incrementAndGet);
+        childA.addAttachListener(events::incrementAndGet);
+        childA.addDetachListener(events::incrementAndGet);
 
         addChild(tree.getRootNode(), parent);
 
@@ -919,21 +919,21 @@ public class StateNodeTest {
     public void attachParent_detachLastOnAttachFirst_attachDetachEvents() {
         TestStateTree tree = new TestStateTree();
 
-        StateNode a = createEmptyNode("a");
-        StateNode b = createEmptyNode("a");
+        StateNode childA = createEmptyNode("a");
+        StateNode childB = createEmptyNode("b");
 
         StateNode parent = createParentNode("parent");
 
-        addChild(parent, a);
-        addChild(parent, b);
+        addChild(parent, childA);
+        addChild(parent, childB);
 
-        a.addAttachListener(() -> {
-            removeFromParent(b);
+        childA.addAttachListener(() -> {
+            removeFromParent(childB);
         });
 
         List<Boolean> attachDetachEvents = new ArrayList<>();
-        b.addAttachListener(() -> attachDetachEvents.add(true));
-        b.addDetachListener(() -> attachDetachEvents.add(false));
+        childB.addAttachListener(() -> attachDetachEvents.add(true));
+        childB.addDetachListener(() -> attachDetachEvents.add(false));
 
         addChild(tree.getRootNode(), parent);
 
@@ -1086,24 +1086,24 @@ public class StateNodeTest {
      */
     @Test
     public void removeFromTree_nodeAttached_detachedAndDescendantsReset() {
-        // given a is parent of b is parent of c in tree
-        StateNode a = createParentNode("a");
-        StateNode b = createParentNode("b");
-        addChild(a, b);
-        StateNode c = createEmptyNode("c");
-        addChild(b, c);
+        // given grandParent -> parent -> child
+        StateNode grandParent = createParentNode("grandParent");
+        StateNode parent = createParentNode("parent");
+        addChild(grandParent, parent);
+        StateNode child = createEmptyNode("child");
+        addChild(parent, child);
 
         TestStateTree tree = new TestStateTree();
-        addChild(tree.getRootNode(), a);
+        addChild(tree.getRootNode(), grandParent);
 
-        // when b is removed from the tree
-        b.removeFromTree();
+        // when parent is removed from the tree
+        parent.removeFromTree();
 
-        // then b's parent is null
-        Assert.assertNull(b.getParent());
+        // then parent's parent is null
+        Assert.assertNull(parent.getParent());
 
-        // then b and its descendants are reset
-        assertNodesReset(b,c);
+        // then parent and its descendants are reset
+        assertNodesReset(parent,child);
     }
 
     /**
@@ -1112,24 +1112,24 @@ public class StateNodeTest {
      */
     @Test
     public void removeFromTree_nodeAttachedAndInDetachListener_detachedAndDescendantsReset() {
-        // given a is parent of b is parent of c in tree
-        StateNode a = createParentNode("a");
-        StateNode b = createParentNode("b");
-        addChild(a, b);
-        StateNode c = createEmptyNode("c");
-        addChild(b, c);
+        // given grandParent -> parent -> child
+        StateNode grandParent = createParentNode("grandParent");
+        StateNode parent = createParentNode("parent");
+        addChild(grandParent, parent);
+        StateNode child = createEmptyNode("child");
+        addChild(parent, child);
 
         TestStateTree tree = new TestStateTree();
-        addChild(tree.getRootNode(), a);
+        addChild(tree.getRootNode(), grandParent);
 
-        // given b's detach listener removes the node from the tree
-        b.addDetachListener(() -> b.removeFromTree());
+        // given parent's detach listener removes the node from the tree
+        parent.addDetachListener(() -> parent.removeFromTree());
 
-        // when b is removed from the tree
-        b.setParent(null);
+        // when parent is removed from the tree
+        parent.setParent(null);
 
-        // then b and its descendants are reset
-        assertNodesReset(b,c);
+        // then parent and its descendants are reset
+        assertNodesReset(parent,child);
     }
 
     private void assertNodesReset(StateNode... nodes) {
@@ -1146,9 +1146,9 @@ public class StateNodeTest {
         TestStateTree tree = new TestStateTree();
 
         // use the order from the list
-        StateNode a = nodes.get("a");
-        StateNode b = nodes.get("b");
-        StateNode c = nodes.get("c");
+        StateNode childA = nodes.get("a");
+        StateNode childB = nodes.get("b");
+        StateNode childC = nodes.get("c");
 
         // those are the same nodes that above but it's easier to have a
         // dedicate variables for them
@@ -1168,9 +1168,9 @@ public class StateNodeTest {
 
         StateNode parent = createParentNode("parent");
 
-        addChild(parent, a);
-        addChild(parent, b);
-        addChild(parent, c);
+        addChild(parent, childA);
+        addChild(parent, childB);
+        addChild(parent, childC);
 
         addChild(tree.getRootNode(), parent);
 
@@ -1197,9 +1197,9 @@ public class StateNodeTest {
         TestStateTree tree = new TestStateTree();
 
         // use the order from the list
-        StateNode a = nodes.get("a");
-        StateNode b = nodes.get("b");
-        StateNode c = nodes.get("c");
+        StateNode childA = nodes.get("a");
+        StateNode childB = nodes.get("b");
+        StateNode childC = nodes.get("c");
 
         // those are the same nodes that above but it's easier to have a
         // dedicate variables for them
@@ -1213,9 +1213,9 @@ public class StateNodeTest {
 
         StateNode parent = createParentNode("parent");
 
-        addChild(parent, a);
-        addChild(parent, b);
-        addChild(parent, c);
+        addChild(parent, childA);
+        addChild(parent, childB);
+        addChild(parent, childC);
 
         addChild(tree.getRootNode(), parent);
 

--- a/flow-server/src/test/java/com/vaadin/flow/internal/StateNodeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/StateNodeTest.java
@@ -1080,6 +1080,38 @@ public class StateNodeTest {
         assertDetachAttachEvents(createNodes(), "c", "b");
     }
 
+    /**
+     * #5316: removeFromTree recursively removes StateTree reference and resets
+     * node id to -1.
+     */
+    @Test
+    public void removeFromTree_nodeAttached_nodeDetachedAndChildrenReset() {
+        // given a is parent of b is parent c in tree
+        StateNode a = createParentNode("a");
+        StateNode b = createParentNode("b");
+        addChild(a, b);
+        StateNode c = createEmptyNode("c");
+        addChild(b, c);
+
+        TestStateTree tree = new TestStateTree();
+        addChild(tree.getRootNode(), a);
+
+        // when b is removed from the tree
+        b.removeFromTree();
+
+        // then b's parent is null
+        Assert.assertNull(b.getParent());
+
+        // then b and descendants are reset
+        final Consumer<StateNode> assertNodeReset = n -> {
+            Assert.assertEquals(-1, n.getId());
+            Assert.assertFalse(n.isAttached());
+            Assert.assertNotEquals(tree, n.getOwner());
+        };
+        assertNodeReset.accept(b);
+        assertNodeReset.accept(c);
+    }
+
     private void assertAttachDetachEvents(Map<String, StateNode> nodes,
             String newParent, String child, boolean expectSingleEvent) {
         TestStateTree tree = new TestStateTree();

--- a/flow-server/src/test/java/com/vaadin/flow/internal/StateNodeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/StateNodeTest.java
@@ -28,7 +28,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -297,106 +296,104 @@ public class StateNodeTest {
 
     @Test
     public void attachListener_onSetParent_listenerTriggered() {
-        Stream.of(new TestStateNode(), createMovedNode()).forEach(child -> {
-            StateNode root = new TestStateTree().getRootNode();
-            Assert.assertFalse(child.isAttached());
+        StateNode root = new TestStateTree().getRootNode();
+        TestStateNode child = new TestStateNode();
 
-            AtomicBoolean triggered = new AtomicBoolean(false);
-            child.addAttachListener(() -> triggered.set(true));
+        Assert.assertFalse(child.isAttached());
+        AtomicBoolean triggered = new AtomicBoolean(false);
 
-            setParent(child, root);
+        child.addAttachListener(() -> triggered.set(true));
 
-            Assert.assertTrue(triggered.get());
-        });
+        setParent(child, root);
+
+        Assert.assertTrue(triggered.get());
     }
 
     @Test
     public void attachListener_listenerRemoved_listenerNotTriggered() {
-        Stream.of(new TestStateNode(), createMovedNode()).forEach(child -> {
-            StateNode root = new TestStateTree().getRootNode();
-            Assert.assertFalse(child.isAttached());
-            AtomicBoolean triggered = new AtomicBoolean(false);
+        StateNode root = new TestStateTree().getRootNode();
+        TestStateNode child = new TestStateNode();
 
-            Registration registrationHandle = child
-                    .addAttachListener(() -> triggered.set(true));
-            registrationHandle.remove();
+        Assert.assertFalse(child.isAttached());
+        AtomicBoolean triggered = new AtomicBoolean(false);
 
-            setParent(child, root);
+        Registration registrationHandle = child
+                .addAttachListener(() -> triggered.set(true));
+        registrationHandle.remove();
 
-            Assert.assertFalse(triggered.get());
-        });
+        setParent(child, root);
+
+        Assert.assertFalse(triggered.get());
     }
 
     @Test
     public void detachListener_onSetParent_listenerTriggered() {
-        Stream.of(new TestStateNode(), createMovedNode()).forEach(child -> {
-            StateNode root = new TestStateTree().getRootNode();
+        StateNode root = new TestStateTree().getRootNode();
+        TestStateNode child = new TestStateNode();
 
-            setParent(child, root);
-            Assert.assertTrue(child.isAttached());
+        setParent(child, root);
+        Assert.assertTrue(child.isAttached());
 
-            AtomicBoolean triggered = new AtomicBoolean(false);
+        AtomicBoolean triggered = new AtomicBoolean(false);
 
-            child.addDetachListener(() -> triggered.set(true));
+        child.addDetachListener(() -> triggered.set(true));
 
-            setParent(child, null);
+        setParent(child, null);
 
-            Assert.assertTrue("Detach listener was not triggered.",
-                    triggered.get());
-        });
+        Assert.assertTrue("Detach listener was not triggered.",
+                triggered.get());
     }
 
     @Test
     public void detachListener_listenerRemoved_listenerNotTriggered() {
-        Stream.of(new TestStateNode(), createMovedNode()).forEach(child -> {
-            StateNode root = new TestStateTree().getRootNode();
+        StateNode root = new TestStateTree().getRootNode();
+        TestStateNode child = new TestStateNode();
 
-            setParent(child, root);
-            Assert.assertTrue(child.isAttached());
+        setParent(child, root);
+        Assert.assertTrue(child.isAttached());
 
-            AtomicBoolean triggered = new AtomicBoolean(false);
+        AtomicBoolean triggered = new AtomicBoolean(false);
 
-            Registration registrationHandle = child
-                    .addDetachListener(() -> triggered.set(true));
-            registrationHandle.remove();
+        Registration registrationHandle = child
+                .addDetachListener(() -> triggered.set(true));
+        registrationHandle.remove();
 
-            setParent(child, null);
+        setParent(child, null);
 
-            Assert.assertFalse(
-                    "Detach listener was triggered even though handler was removed.",
-                    triggered.get());
-        });
+        Assert.assertFalse(
+                "Detach listener was triggered even though handler was removed.",
+                triggered.get());
     }
 
     @Test
     public void detachListener_removesNode_notUnregisteredTwice() {
-        Stream.of(new TestStateNode(), createMovedNode()).forEach(child -> {
-            StateTree tree = createStateTree();
-            StateNode root = createParentNode("");
-            setParent(root, tree.getRootNode());
+        StateTree tree = createStateTree();
+        StateNode root = createParentNode("");
+        setParent(root, tree.getRootNode());
 
-            setParent(child, root);
-            Assert.assertTrue(child.isAttached());
+        TestStateNode child = new TestStateNode();
 
-            AtomicBoolean triggered = new AtomicBoolean(false);
+        setParent(child, root);
+        Assert.assertTrue(child.isAttached());
 
-            child.addDetachListener(() -> {
-                Assert.assertTrue(
-                        "Child node should still have a parent and be been seen as attached",
-                        child.isAttached());
-                Assert.assertFalse("Child node should have been unregistered",
-                        tree.hasNode(child));
+        AtomicBoolean triggered = new AtomicBoolean(false);
 
-                child.setParent(null);
+        child.addDetachListener(() -> {
+            Assert.assertTrue(
+                    "Child node should still have a parent and be been seen as attached",
+                    child.isAttached());
+            Assert.assertFalse("Child node should have been unregistered",
+                    tree.hasNode(child));
 
-                triggered.set(true);
-            });
+            child.setParent(null);
 
-            setParent(child, null);
-
-            Assert.assertTrue("Detach listener was not triggered.",
-                    triggered.get());
+            triggered.set(true);
         });
+
+        setParent(child, null);
+
+        Assert.assertTrue("Detach listener was not triggered.",
+                triggered.get());
     }
 
     public static StateNode createEmptyNode() {
@@ -436,17 +433,6 @@ public class StateNodeTest {
             }
 
         };
-    }
-
-    private static StateNode createMovedNode() {
-        return getMovedNode(new TestStateNode());
-    }
-
-    private static StateNode getMovedNode(StateNode node) {
-        final StateTree tree = createStateTree();
-        setParent(node, tree.getRootNode());
-        node.removeFromTree();
-        return node;
     }
 
     public static void setParent(StateNode child, StateNode parent) {
@@ -489,7 +475,7 @@ public class StateNodeTest {
         set.remove(node.getData());
     }
 
-    private static StateTree createStateTree() {
+    private StateTree createStateTree() {
         StateTree stateTree = new StateTree(new UI().getInternals(),
                 ElementChildrenList.class);
         return stateTree;
@@ -497,58 +483,55 @@ public class StateNodeTest {
 
     @Test
     public void runWhenAttachedNodeNotAttached() {
-        Stream.of(new TestStateNode(), createMovedNode()).forEach(n1 -> {
-            StateTree tree = createStateTree();
-            AtomicInteger commandRun = new AtomicInteger(0);
-            n1.runWhenAttached(ui -> {
-                Assert.assertEquals(tree.getUI(), ui);
-                commandRun.incrementAndGet();
-            });
-
-            Assert.assertEquals(0, commandRun.get());
-
-            setParent(n1, tree.getRootNode());
-            Assert.assertEquals(1, commandRun.get());
-            setParent(n1, null);
-            setParent(n1, tree.getRootNode());
-            Assert.assertEquals(1, commandRun.get());
+        StateTree tree = createStateTree();
+        AtomicInteger commandRun = new AtomicInteger(0);
+        StateNode n1 = createEmptyNode();
+        n1.runWhenAttached(ui -> {
+            Assert.assertEquals(tree.getUI(), ui);
+            commandRun.incrementAndGet();
         });
+
+        Assert.assertEquals(0, commandRun.get());
+
+        setParent(n1, tree.getRootNode());
+        Assert.assertEquals(1, commandRun.get());
+        setParent(n1, null);
+        setParent(n1, tree.getRootNode());
+        Assert.assertEquals(1, commandRun.get());
     }
 
     @Test
     public void runMultipleWhenAttachedNodeNotAttached() {
-        Stream.of(new TestStateNode(), createMovedNode()).forEach(n1 -> {
-            StateTree tree = createStateTree();
-            AtomicInteger commandRun = new AtomicInteger(0);
-            n1.runWhenAttached(ui -> {
-                Assert.assertEquals(tree.getUI(), ui);
-                commandRun.incrementAndGet();
-            });
-            n1.runWhenAttached(ui -> {
-                Assert.assertEquals(tree.getUI(), ui);
-                commandRun.incrementAndGet();
-            });
-
-            Assert.assertEquals(0, commandRun.get());
-
-            setParent(n1, tree.getRootNode());
-            Assert.assertEquals(2, commandRun.get());
+        StateTree tree = createStateTree();
+        AtomicInteger commandRun = new AtomicInteger(0);
+        StateNode n1 = createEmptyNode();
+        n1.runWhenAttached(ui -> {
+            Assert.assertEquals(tree.getUI(), ui);
+            commandRun.incrementAndGet();
         });
+        n1.runWhenAttached(ui -> {
+            Assert.assertEquals(tree.getUI(), ui);
+            commandRun.incrementAndGet();
+        });
+
+        Assert.assertEquals(0, commandRun.get());
+
+        setParent(n1, tree.getRootNode());
+        Assert.assertEquals(2, commandRun.get());
     }
 
     @Test
     public void runWhenAttachedNodeAttached() {
-        Stream.of(new TestStateNode(), createMovedNode()).forEach(n1 -> {
-            AtomicInteger commandRun = new AtomicInteger(0);
-            StateTree tree = createStateTree();
-            setParent(n1, tree.getRootNode());
-            n1.runWhenAttached(ui -> {
-                Assert.assertEquals(tree.getUI(), ui);
-                commandRun.incrementAndGet();
-            });
-
-            Assert.assertEquals(1, commandRun.get());
+        AtomicInteger commandRun = new AtomicInteger(0);
+        StateNode n1 = createEmptyNode();
+        StateTree tree = createStateTree();
+        setParent(n1, tree.getRootNode());
+        n1.runWhenAttached(ui -> {
+            Assert.assertEquals(tree.getUI(), ui);
+            commandRun.incrementAndGet();
         });
+
+        Assert.assertEquals(1, commandRun.get());
     }
 
     @Test
@@ -570,108 +553,102 @@ public class StateNodeTest {
 
     @Test
     public void collectChanges_initiallyActiveElement_sendOnlyDisalowFeatureChangesWhenInactive() {
-        Supplier<StateNode> mkTestNode = () -> createTestNode("Active node",
+        StateNode stateNode = createTestNode("Active node",
                 ElementPropertyMap.class, ElementData.class);
-        Stream.of(mkTestNode.get(), getMovedNode(mkTestNode.get()))
-                .forEach(stateNode -> {
-                    ElementData visibility = stateNode.getFeature(ElementData.class);
-                    ElementPropertyMap properties = stateNode
-                            .getFeature(ElementPropertyMap.class);
 
-                    TestStateTree tree = new TestStateTree();
+        ElementData visibility = stateNode.getFeature(ElementData.class);
+        ElementPropertyMap properties = stateNode
+                .getFeature(ElementPropertyMap.class);
 
-                    // attach the node to be able to get changes
-                    tree.getRootNode().getFeature(ElementChildrenList.class).add(0,
-                            stateNode);
+        TestStateTree tree = new TestStateTree();
 
-                    assertCollectChanges_initiallyVisible(stateNode, properties,
-                            isVisible -> {
-                                visibility.setVisible(isVisible);
-                                stateNode.updateActiveState();
-                            });
+        // attach the node to be able to get changes
+        tree.getRootNode().getFeature(ElementChildrenList.class).add(0,
+                stateNode);
+
+        assertCollectChanges_initiallyVisible(stateNode, properties,
+                isVisible -> {
+                    visibility.setVisible(isVisible);
+                    stateNode.updateActiveState();
                 });
     }
 
     @Test
     public void collectChanges_inactivateViaParent_initiallyActiveElement_sendOnlyDisalowFeatureChangesWhenInactive() {
-        Supplier<StateNode> mkTestNode = () -> createTestNode("Active node",
+        StateNode stateNode = createTestNode("Active node",
                 ElementPropertyMap.class, ElementData.class);
-        Stream.of(mkTestNode.get(), getMovedNode(mkTestNode.get()))
-                .forEach(stateNode -> {
 
-                    StateNode parent = createTestNode("Parent node",
-                            ElementPropertyMap.class, ElementData.class,
-                            ElementChildrenList.class);
+        StateNode parent = createTestNode("Parent node",
+                ElementPropertyMap.class, ElementData.class,
+                ElementChildrenList.class);
 
-                    parent.getFeature(ElementChildrenList.class).add(0, stateNode);
+        parent.getFeature(ElementChildrenList.class).add(0, stateNode);
 
-                    ElementData visibility = parent.getFeature(ElementData.class);
-                    ElementPropertyMap properties = stateNode
-                            .getFeature(ElementPropertyMap.class);
+        ElementData visibility = parent.getFeature(ElementData.class);
+        ElementPropertyMap properties = stateNode
+                .getFeature(ElementPropertyMap.class);
 
-                    TestStateTree tree = new TestStateTree();
+        TestStateTree tree = new TestStateTree();
 
-                    // attach the node to be able to get changes
-                    tree.getRootNode().getFeature(ElementChildrenList.class).add(0, parent);
+        // attach the node to be able to get changes
+        tree.getRootNode().getFeature(ElementChildrenList.class).add(0, parent);
 
-                    assertCollectChanges_initiallyVisible(stateNode, properties,
-                            isVisible -> {
-                                visibility.setVisible(isVisible);
-                                parent.updateActiveState();
-                            });
+        assertCollectChanges_initiallyVisible(stateNode, properties,
+                isVisible -> {
+                    visibility.setVisible(isVisible);
+                    parent.updateActiveState();
                 });
     }
 
     @Test
     public void collectChanges_initiallyInactiveElement_sendOnlyDisalowAndReportedFeatures_sendAllChangesWhenActive() {
-        Supplier<StateNode> mkTestNode = () -> ElementFactory.createAnchor().getNode();
-        Stream.of(mkTestNode.get(), getMovedNode(mkTestNode.get()))
-                .forEach(stateNode -> {
+        Element element = ElementFactory.createAnchor();
 
-                    ElementData visibility = stateNode.getFeature(ElementData.class);
-                    ElementPropertyMap properties = stateNode
-                            .getFeature(ElementPropertyMap.class);
+        StateNode stateNode = element.getNode();
 
-                    TestStateTree tree = new TestStateTree();
+        ElementData visibility = stateNode.getFeature(ElementData.class);
+        ElementPropertyMap properties = stateNode
+                .getFeature(ElementPropertyMap.class);
 
-                    // attach the node to be able to get changes
-                    tree.getRootNode().getFeature(ElementChildrenList.class).add(0,
-                            stateNode);
+        TestStateTree tree = new TestStateTree();
 
-                    assertCollectChanges_initiallyInactive(stateNode, properties,
-                            isVisible -> {
-                                visibility.setVisible(isVisible);
-                                stateNode.updateActiveState();
-                            });
+        // attach the node to be able to get changes
+        tree.getRootNode().getFeature(ElementChildrenList.class).add(0,
+                stateNode);
+
+        assertCollectChanges_initiallyInactive(stateNode, properties,
+                isVisible -> {
+                    visibility.setVisible(isVisible);
+                    stateNode.updateActiveState();
                 });
     }
 
     @Test
     public void collectChanges_initiallyInactiveViaParentElement_sendOnlyDisalowAndReportedFeatures_sendAllChangesWhenActive() {
-        Supplier<StateNode> mkTestNode = () -> ElementFactory.createAnchor().getNode();
-        Stream.of(mkTestNode.get(), getMovedNode(mkTestNode.get()))
-                .forEach(stateNode -> {
-                    StateNode parent = createTestNode("Parent node",
-                            ElementPropertyMap.class, ElementData.class,
-                            ElementChildrenList.class);
+        Element element = ElementFactory.createAnchor();
 
-                    parent.getFeature(ElementChildrenList.class).add(0, stateNode);
+        StateNode stateNode = element.getNode();
 
-                    ElementData visibility = parent.getFeature(ElementData.class);
+        StateNode parent = createTestNode("Parent node",
+                ElementPropertyMap.class, ElementData.class,
+                ElementChildrenList.class);
 
-                    ElementPropertyMap properties = stateNode
-                            .getFeature(ElementPropertyMap.class);
+        parent.getFeature(ElementChildrenList.class).add(0, stateNode);
 
-                    TestStateTree tree = new TestStateTree();
+        ElementData visibility = parent.getFeature(ElementData.class);
 
-                    // attach the node to be able to get changes
-                    tree.getRootNode().getFeature(ElementChildrenList.class).add(0, parent);
+        ElementPropertyMap properties = stateNode
+                .getFeature(ElementPropertyMap.class);
 
-                    assertCollectChanges_initiallyInactive(stateNode, properties,
-                            isVisible -> {
-                                visibility.setVisible(isVisible);
-                                parent.updateActiveState();
-                            });
+        TestStateTree tree = new TestStateTree();
+
+        // attach the node to be able to get changes
+        tree.getRootNode().getFeature(ElementChildrenList.class).add(0, parent);
+
+        assertCollectChanges_initiallyInactive(stateNode, properties,
+                isVisible -> {
+                    visibility.setVisible(isVisible);
+                    parent.updateActiveState();
                 });
     }
 
@@ -694,9 +671,7 @@ public class StateNodeTest {
      */
     @Test
     public void modifyNodeTreeInAttachListener_firstAsParent_lastAsChild() {
-        Stream.of(createNodes(), createMovedNodes()).forEach(nodes ->
-                assertAttachDetachEvents(createNodes(), "a", "c", false)
-        );
+        assertAttachDetachEvents(createNodes(), "a", "c", false);
     }
 
     /**
@@ -720,9 +695,7 @@ public class StateNodeTest {
      */
     @Test
     public void modifyNodeTreeInAttachListener_lastAsParent_firstAsChild() {
-        Stream.of(createNodes(), createMovedNodes()).forEach(nodes ->
-                assertAttachDetachEvents(nodes, "c", "a", true)
-        );
+        assertAttachDetachEvents(createNodes(), "c", "a", true);
     }
 
     /**
@@ -746,9 +719,7 @@ public class StateNodeTest {
      */
     @Test
     public void modifyNodeTreeInAttachListener_middleAsParent_firstAsChild() {
-        Stream.of(createNodes(), createMovedNodes()).forEach(nodes ->
-                assertAttachDetachEvents(nodes, "b", "a", true)
-        );
+        assertAttachDetachEvents(createNodes(), "b", "a", true);
     }
 
     /**
@@ -772,9 +743,7 @@ public class StateNodeTest {
      */
     @Test
     public void modifyNodeTreeInAttachListener_firstAsParent_middleAsChild() {
-        Stream.of(createNodes(), createMovedNodes()).forEach(nodes ->
-                assertAttachDetachEvents(nodes, "a", "b", true)
-        );
+        assertAttachDetachEvents(createNodes(), "a", "b", true);
     }
 
     /**
@@ -796,9 +765,7 @@ public class StateNodeTest {
      */
     @Test
     public void modifyNodeTreeInAttachListener_middleAsParent_lastAsChild() {
-        Stream.of(createNodes(), createMovedNodes()).forEach(nodes ->
-                assertAttachDetachEvents(nodes, "b", "c", false)
-        );
+        assertAttachDetachEvents(createNodes(), "b", "c", false);
     }
 
     /**
@@ -820,179 +787,165 @@ public class StateNodeTest {
      */
     @Test
     public void modifyNodeTreeInAttachListener_lastAsParent_middleAsChild() {
-        Stream.of(createNodes(), createMovedNodes()).forEach(nodes ->
-                assertAttachDetachEvents(nodes, "c", "b", false)
-        );
+        assertAttachDetachEvents(createNodes(), "c", "b", false);
     }
 
     @Test
     public void detachParent_detachFirstChildOnDetachLast_oneDetachEvent() {
-        final Supplier<StateNode> mkTestNode = () -> createParentNode("parent");
-        Stream.of(mkTestNode.get(), getMovedNode(mkTestNode.get())).forEach(
-                parent -> {
-                    TestStateTree tree = new TestStateTree();
+        TestStateTree tree = new TestStateTree();
 
-                    StateNode a = createEmptyNode("a");
-                    StateNode b = createEmptyNode("b");
+        StateNode a = createEmptyNode("a");
+        StateNode b = createEmptyNode("b");
 
-                    addChild(parent, a);
-                    addChild(parent, b);
+        StateNode parent = createParentNode("parent");
 
-                    addChild(tree.getRootNode(), parent);
+        addChild(parent, a);
+        addChild(parent, b);
 
-                    AtomicInteger detachEvents = new AtomicInteger();
-                    b.addDetachListener(() -> removeFromParent(a));
-                    a.addDetachListener(() -> detachEvents.incrementAndGet());
+        addChild(tree.getRootNode(), parent);
 
-                    removeFromParent(parent);
+        AtomicInteger detachEvents = new AtomicInteger();
+        b.addDetachListener(() -> removeFromParent(a));
+        a.addDetachListener(() -> detachEvents.incrementAndGet());
 
-                    Assert.assertEquals(1, detachEvents.get());
-                });
+        removeFromParent(parent);
+
+        Assert.assertEquals(1, detachEvents.get());
     }
 
     @Test
     public void detachParent_detachLastChildOnDetachFirst_oneDetachEvent() {
-        final Supplier<StateNode> mkTestNode = () -> createParentNode("parent");
-        Stream.of(mkTestNode.get(), getMovedNode(mkTestNode.get())).forEach(
-                parent -> {
-                    TestStateTree tree = new TestStateTree();
+        TestStateTree tree = new TestStateTree();
 
-                    StateNode a = createEmptyNode("a");
-                    StateNode b = createEmptyNode("b");
+        StateNode a = createEmptyNode("a");
+        StateNode b = createEmptyNode("b");
 
-                    addChild(parent, a);
-                    addChild(parent, b);
+        StateNode parent = createParentNode("parent");
 
-                    addChild(tree.getRootNode(), parent);
+        addChild(parent, a);
+        addChild(parent, b);
 
-                    AtomicInteger detachEvents = new AtomicInteger();
-                    a.addDetachListener(() -> removeFromParent(a));
-                    b.addDetachListener(() -> detachEvents.incrementAndGet());
+        addChild(tree.getRootNode(), parent);
 
-                    removeFromParent(parent);
+        AtomicInteger detachEvents = new AtomicInteger();
+        a.addDetachListener(() -> removeFromParent(a));
+        b.addDetachListener(() -> detachEvents.incrementAndGet());
 
-                    Assert.assertEquals(1, detachEvents.get());
-                });
+        removeFromParent(parent);
+
+        Assert.assertEquals(1, detachEvents.get());
     }
 
     @Test
     public void detachParent_appendChildOnDetach_noEvents() {
-        final Supplier<StateNode> mkTestNode = () -> createParentNode("parent");
-        Stream.of(mkTestNode.get(), getMovedNode(mkTestNode.get())).forEach(
-                parent -> {
-                    TestStateTree tree = new TestStateTree();
+        TestStateTree tree = new TestStateTree();
 
-                    StateNode a = createEmptyNode("a");
+        StateNode a = createEmptyNode("a");
 
-                    addChild(parent, a);
+        StateNode parent = createParentNode("parent");
 
-                    addChild(tree.getRootNode(), parent);
+        addChild(parent, a);
 
-                    AtomicInteger events = new AtomicInteger();
-                    a.addDetachListener(() -> {
-                        StateNode b = createEmptyNode("b");
-                        b.addAttachListener(events::incrementAndGet);
-                        b.addDetachListener(events::incrementAndGet);
-                        addChild(parent, b);
-                    });
+        addChild(tree.getRootNode(), parent);
 
-                    removeFromParent(parent);
-                    Assert.assertEquals(0, events.get());
-                });
+        AtomicInteger events = new AtomicInteger();
+        a.addDetachListener(() -> {
+            StateNode b = createEmptyNode("b");
+            b.addAttachListener(events::incrementAndGet);
+            b.addDetachListener(events::incrementAndGet);
+            addChild(parent, b);
+        });
+
+        removeFromParent(parent);
+        Assert.assertEquals(0, events.get());
     }
 
     @Test
     public void detachParent_insertChildAsFirstOnDetach_noEvents() {
-        final Supplier<StateNode> mkTestNode = () -> createParentNode("parent");
-        Stream.of(mkTestNode.get(), getMovedNode(mkTestNode.get())).forEach(
-                parent -> {
-                    TestStateTree tree = new TestStateTree();
+        TestStateTree tree = new TestStateTree();
 
-                    StateNode a = createEmptyNode("a");
+        StateNode a = createEmptyNode("a");
 
-                    addChild(parent, a);
+        StateNode parent = createParentNode("parent");
 
-                    addChild(tree.getRootNode(), parent);
+        addChild(parent, a);
 
-                    AtomicInteger events = new AtomicInteger();
-                    a.addDetachListener(() -> {
-                        StateNode b = createEmptyNode("b");
-                        b.addAttachListener(events::incrementAndGet);
-                        b.addDetachListener(events::incrementAndGet);
-                        ElementChildrenList list = parent
-                                .getFeature(ElementChildrenList.class);
-                        list.add(0, b);
-                    });
+        addChild(tree.getRootNode(), parent);
 
-                    removeFromParent(parent);
-                    Assert.assertEquals(0, events.get());
-                });
+        AtomicInteger events = new AtomicInteger();
+        a.addDetachListener(() -> {
+            StateNode b = createEmptyNode("b");
+            b.addAttachListener(events::incrementAndGet);
+            b.addDetachListener(events::incrementAndGet);
+            ElementChildrenList list = parent
+                    .getFeature(ElementChildrenList.class);
+            list.add(0, b);
+        });
+
+        removeFromParent(parent);
+        Assert.assertEquals(0, events.get());
     }
 
     @Test
     public void attachParent_detachFirstOnAttachLast_noEvents() {
-        final Supplier<StateNode> mkTestNode = () -> createParentNode("parent");
-        Stream.of(mkTestNode.get(), getMovedNode(mkTestNode.get())).forEach(
-                parent -> {
-                    TestStateTree tree = new TestStateTree();
+        TestStateTree tree = new TestStateTree();
 
-                    StateNode a = createEmptyNode("a");
-                    StateNode b = createEmptyNode("a");
+        StateNode a = createEmptyNode("a");
+        StateNode b = createEmptyNode("a");
 
-                    addChild(parent, a);
-                    addChild(parent, b);
+        StateNode parent = createParentNode("parent");
 
-                    AtomicInteger events = new AtomicInteger();
-                    b.addAttachListener(() -> {
-                        removeFromParent(a);
-                    });
+        addChild(parent, a);
+        addChild(parent, b);
 
-                    a.addAttachListener(events::incrementAndGet);
-                    a.addDetachListener(events::incrementAndGet);
+        AtomicInteger events = new AtomicInteger();
+        b.addAttachListener(() -> {
+            removeFromParent(a);
+        });
 
-                    addChild(tree.getRootNode(), parent);
+        a.addAttachListener(events::incrementAndGet);
+        a.addDetachListener(events::incrementAndGet);
 
-                    // events are fired from right to left, so <code>b</code> had been
-                    // handled first and <code>a</code> had been detached before attach
-                    // event has been fired for <code>a</code>. So no events for
-                    // <code>a</code>
-                    Assert.assertEquals(0, events.get());
-                });
+        addChild(tree.getRootNode(), parent);
+
+        // events are fired from right to left, so <code>b</code> had been
+        // handled first and <code>a</code> had been detached before attach
+        // event has been fired for <code>a</code>. So no events for
+        // <code>a</code>
+        Assert.assertEquals(0, events.get());
     }
 
     @Test
     public void attachParent_detachLastOnAttachFirst_attachDetachEvents() {
-        final Supplier<StateNode> mkTestNode = () -> createParentNode("parent");
-        Stream.of(mkTestNode.get(), getMovedNode(mkTestNode.get())).forEach(
-                parent -> {
-                    TestStateTree tree = new TestStateTree();
+        TestStateTree tree = new TestStateTree();
 
-                    StateNode a = createEmptyNode("a");
-                    StateNode b = createEmptyNode("a");
+        StateNode a = createEmptyNode("a");
+        StateNode b = createEmptyNode("a");
 
-                    addChild(parent, a);
-                    addChild(parent, b);
+        StateNode parent = createParentNode("parent");
 
-                    a.addAttachListener(() -> {
-                        removeFromParent(b);
-                    });
+        addChild(parent, a);
+        addChild(parent, b);
 
-                    List<Boolean> attachDetachEvents = new ArrayList<>();
-                    b.addAttachListener(() -> attachDetachEvents.add(true));
-                    b.addDetachListener(() -> attachDetachEvents.add(false));
+        a.addAttachListener(() -> {
+            removeFromParent(b);
+        });
 
-                    addChild(tree.getRootNode(), parent);
+        List<Boolean> attachDetachEvents = new ArrayList<>();
+        b.addAttachListener(() -> attachDetachEvents.add(true));
+        b.addDetachListener(() -> attachDetachEvents.add(false));
 
-                    /*
-                     * Here attach event for <code>b</code> had been fired first since it
-                     * had been handled first. Then on attach event for <code>a</code> the
-                     * <code>b</code> has been removed. So we should get also a detach
-                     * event.
-                     */
-                    Assert.assertEquals(2, attachDetachEvents.size());
-                    Assert.assertTrue(attachDetachEvents.get(0));
-                    Assert.assertFalse(attachDetachEvents.get(1));
-                });
+        addChild(tree.getRootNode(), parent);
+
+        /*
+         * Here attach event for <code>b</code> had been fired first since it
+         * had been handled first. Then on attach event for <code>a</code> the
+         * <code>b</code> has been removed. So we should get also a detach
+         * event.
+         */
+        Assert.assertEquals(2, attachDetachEvents.size());
+        Assert.assertTrue(attachDetachEvents.get(0));
+        Assert.assertFalse(attachDetachEvents.get(1));
     }
 
     /**
@@ -1014,9 +967,7 @@ public class StateNodeTest {
      */
     @Test
     public void modifyNodeTreeInDetachListener_firstAsParent_lastAsChild() {
-        Stream.of(createNodes(), createMovedNodes()).forEach(nodes ->
-                assertDetachAttachEvents(nodes, "a", "c")
-        );
+        assertDetachAttachEvents(createNodes(), "a", "c");
     }
 
     /**
@@ -1038,9 +989,7 @@ public class StateNodeTest {
      */
     @Test
     public void modifyNodeTreeInDetachListener_lastAsParent_firstAsChild() {
-        Stream.of(createNodes(), createMovedNodes()).forEach(nodes ->
-                assertDetachAttachEvents(nodes, "c", "a"))
-        ;
+        assertDetachAttachEvents(createNodes(), "c", "a");
     }
 
     /**
@@ -1062,9 +1011,7 @@ public class StateNodeTest {
      */
     @Test
     public void modifyNodeTreeInDetachListener_middleAsParent_firstAsChild() {
-        Stream.of(createNodes(), createMovedNodes()).forEach(nodes ->
-                assertDetachAttachEvents(nodes, "b", "a")
-        );
+        assertDetachAttachEvents(createNodes(), "b", "a");
     }
 
     /**
@@ -1086,9 +1033,7 @@ public class StateNodeTest {
      */
     @Test
     public void modifyNodeTreeInDetachListener_firstAsParent_middleAsChild() {
-        Stream.of(createNodes(), createMovedNodes()).forEach(nodes ->
-                assertDetachAttachEvents(nodes, "a", "b")
-        );
+        assertDetachAttachEvents(createNodes(), "a", "b");
     }
 
     /**
@@ -1110,9 +1055,7 @@ public class StateNodeTest {
      */
     @Test
     public void modifyNodeTreeInDetachListener_middleAsParent_lastAsChild() {
-        Stream.of(createNodes(), createMovedNodes()).forEach(nodes ->
-            assertDetachAttachEvents(nodes, "b", "c")
-        );
+        assertDetachAttachEvents(createNodes(), "b", "c");
     }
 
     /**
@@ -1134,9 +1077,7 @@ public class StateNodeTest {
      */
     @Test
     public void modifyNodeTreeInDetachListener_lastAsParent_middleAsChild() {
-        Stream.of(createNodes(), createMovedNodes()).forEach(nodes ->
-                assertDetachAttachEvents(nodes, "c", "b")
-        );
+        assertDetachAttachEvents(createNodes(), "c", "b");
     }
 
     /**
@@ -1145,7 +1086,7 @@ public class StateNodeTest {
      */
     @Test
     public void removeFromTree_nodeAttached_nodeDetachedAndChildrenReset() {
-        // given a is parent of b is a parent c in tree
+        // given a is parent of b is parent c in tree
         StateNode a = createParentNode("a");
         StateNode b = createParentNode("b");
         addChild(a, b);
@@ -1169,11 +1110,6 @@ public class StateNodeTest {
         };
         assertNodeReset.accept(b);
         assertNodeReset.accept(c);
-
-        List<NodeChange> changes = new ArrayList<>();
-        Consumer<NodeChange> collector = changes::add;
-
-        a.collectChanges(collector);
     }
 
     private void assertAttachDetachEvents(Map<String, StateNode> nodes,
@@ -1273,13 +1209,6 @@ public class StateNodeTest {
                         createParentNode("c"))
                 .collect(Collectors.toMap(node -> node.toString(),
                         Function.identity()));
-    }
-
-    private Map<String, StateNode> createMovedNodes() {
-        return createNodes().entrySet().stream()
-                .collect(Collectors.toMap(
-                        e -> e.getKey(),
-                        e -> getMovedNode(e.getValue())));
     }
 
     private void addChild(StateNode parent, StateNode node) {


### PR DESCRIPTION
Adds a method `detachFromUI` to `Component`. After calling, the component is in a state that allows it to be added to a another UI. The purpose of this change is to be able to emulate @PreserveOnRefresh like behavior, where the previous UI or components inside it are added to the current UI after refresh.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5445)
<!-- Reviewable:end -->
