### PR TITLE
WebComponentExporter throws on bad type parameter

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/WebComponentExporter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/WebComponentExporter.java
@@ -113,8 +113,13 @@ public abstract class WebComponentExporter<C extends Component>
         componentClass = (Class<C>) ReflectTools.getGenericInterfaceType(
                 this.getClass(), WebComponentExporter.class);
 
-        assert componentClass != null : "Failed to determine component class "
-                + "from WebComponentExporter's type parameter.";
+        if (componentClass == null) {
+            throw new IllegalStateException(String.format("Failed to " +
+                            "determine component type for '%s'. Please " +
+                            "provide a valid type for %s as a type parameter.",
+                    getClass().getName(),
+                    WebComponentExporter.class.getSimpleName()));
+        }
     }
 
     private <P extends Serializable> PropertyConfiguration<C, P> addProperty(

--- a/flow-server/src/test/java/com/vaadin/flow/component/WebComponentExporterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/WebComponentExporterTest.java
@@ -201,6 +201,11 @@ public class WebComponentExporterTest {
         Assert.assertFalse(config.hasProperty("does-not-exist"));
     }
 
+    @Test (expected = IllegalStateException.class)
+    public void exporterConstructorThrowsIfNoComponentDefined() {
+        NoComponentExporter exporter = new NoComponentExporter();
+    }
+
     @Tag("test")
     public static class MyComponent extends Component {
         private boolean flip = false;
@@ -279,6 +284,16 @@ public class WebComponentExporterTest {
         public void configureInstance(WebComponent<SharedTagComponent> webComponent, SharedTagComponent component) {
 
         }
+    }
+
+    public static class NoComponentExporter extends WebComponentExporter {
+        public NoComponentExporter() {
+            super("tag");
+        }
+
+        @Override
+        public void configureInstance(WebComponent webComponent,
+                                      Component component) { }
     }
 
     private static void assertProperty(WebComponentConfiguration<?> config,


### PR DESCRIPTION
Fixes #5362 

**Effects:**
- throws, if no type parameter given
  - `class Example extends WebComponentExporter`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5466)
<!-- Reviewable:end -->
