### PR TITLE
Context-specific attributes through VaadinService

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentUI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentUI.java
@@ -15,11 +15,6 @@
  */
 package com.vaadin.flow.component.webcomponent;
 
-import javax.servlet.ServletContext;
-import java.util.Optional;
-
-import org.slf4j.LoggerFactory;
-
 import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
@@ -31,14 +26,15 @@ import com.vaadin.flow.router.HasUrlParameter;
 import com.vaadin.flow.router.QueryParameters;
 import com.vaadin.flow.router.Router;
 import com.vaadin.flow.server.VaadinRequest;
-import com.vaadin.flow.server.VaadinServlet;
-import com.vaadin.flow.server.VaadinServletService;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.webcomponent.WebComponentBinding;
 import com.vaadin.flow.server.webcomponent.WebComponentConfigurationRegistry;
 import com.vaadin.flow.theme.Theme;
 import com.vaadin.flow.theme.ThemeDefinition;
 import com.vaadin.flow.theme.ThemeUtil;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
 
 /**
  * Custom UI for use with WebComponents served from the server.
@@ -67,10 +63,8 @@ public class WebComponentUI extends UI {
         DeploymentConfiguration deploymentConfiguration = session.getService()
                 .getDeploymentConfiguration();
         if (deploymentConfiguration.useCompiledFrontendResources()) {
-            ServletContext context = ((VaadinServletService) request
-                    .getService()).getServlet().getServletContext();
             WebComponentConfigurationRegistry registry = WebComponentConfigurationRegistry
-                    .getInstance(context);
+                    .getInstance();
 
             /*
              * This code adds a number of HTML dependencies to the page but in
@@ -98,7 +92,7 @@ public class WebComponentUI extends UI {
     public void connectWebComponent(String tag, String webComponentElementId) {
         Optional<WebComponentConfiguration<? extends Component>> webComponentExporter =
                 WebComponentConfigurationRegistry
-                        .getInstance(VaadinServlet.getCurrent().getServletContext())
+                        .getInstance()
                         .getConfiguration(tag);
 
         if (!webComponentExporter.isPresent()) {
@@ -161,7 +155,7 @@ public class WebComponentUI extends UI {
 
     private void assignTheme() {
         WebComponentConfigurationRegistry registry = WebComponentConfigurationRegistry
-                .getInstance(VaadinServlet.getCurrent().getServletContext());
+                .getInstance();
         Optional<Theme> theme = registry
                 .getEmbeddedApplicationAnnotation(Theme.class);
         if (theme.isPresent()) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -16,6 +16,40 @@
 
 package com.vaadin.flow.server;
 
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.internal.DependencyTreeCache;
+import com.vaadin.flow.component.internal.HtmlImportParser;
+import com.vaadin.flow.di.DefaultInstantiator;
+import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.i18n.I18NProvider;
+import com.vaadin.flow.internal.CurrentInstance;
+import com.vaadin.flow.internal.LocaleUtil;
+import com.vaadin.flow.internal.ReflectionCache;
+import com.vaadin.flow.router.Router;
+import com.vaadin.flow.server.ServletHelper.RequestType;
+import com.vaadin.flow.server.communication.AtmospherePushConnection;
+import com.vaadin.flow.server.communication.HeartbeatHandler;
+import com.vaadin.flow.server.communication.PwaHandler;
+import com.vaadin.flow.server.communication.SessionRequestHandler;
+import com.vaadin.flow.server.communication.StreamRequestHandler;
+import com.vaadin.flow.server.communication.UidlRequestHandler;
+import com.vaadin.flow.server.communication.WebComponentBootstrapHandler;
+import com.vaadin.flow.server.communication.WebComponentProvider;
+import com.vaadin.flow.server.startup.BundleFilterFactory;
+import com.vaadin.flow.server.startup.FakeBrowser;
+import com.vaadin.flow.shared.ApplicationConstants;
+import com.vaadin.flow.shared.JsonConstants;
+import com.vaadin.flow.shared.Registration;
+import com.vaadin.flow.shared.communication.PushMode;
+import com.vaadin.flow.theme.AbstractTheme;
+import elemental.json.Json;
+import elemental.json.JsonException;
+import elemental.json.JsonObject;
+import elemental.json.impl.JsonUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.servlet.Servlet;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletResponse;
@@ -44,45 +78,11 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.vaadin.flow.component.UI;
-import com.vaadin.flow.component.internal.DependencyTreeCache;
-import com.vaadin.flow.component.internal.HtmlImportParser;
-import com.vaadin.flow.di.DefaultInstantiator;
-import com.vaadin.flow.di.Instantiator;
-import com.vaadin.flow.function.DeploymentConfiguration;
-import com.vaadin.flow.i18n.I18NProvider;
-import com.vaadin.flow.internal.CurrentInstance;
-import com.vaadin.flow.internal.LocaleUtil;
-import com.vaadin.flow.internal.ReflectionCache;
-import com.vaadin.flow.router.Router;
-import com.vaadin.flow.server.ServletHelper.RequestType;
-import com.vaadin.flow.server.communication.AtmospherePushConnection;
-import com.vaadin.flow.server.communication.HeartbeatHandler;
-import com.vaadin.flow.server.communication.PwaHandler;
-import com.vaadin.flow.server.communication.SessionRequestHandler;
-import com.vaadin.flow.server.communication.StreamRequestHandler;
-import com.vaadin.flow.server.communication.UidlRequestHandler;
-import com.vaadin.flow.server.communication.WebComponentBootstrapHandler;
-import com.vaadin.flow.server.communication.WebComponentProvider;
-import com.vaadin.flow.server.startup.BundleFilterFactory;
-import com.vaadin.flow.server.startup.FakeBrowser;
-import com.vaadin.flow.shared.ApplicationConstants;
-import com.vaadin.flow.shared.JsonConstants;
-import com.vaadin.flow.shared.Registration;
-import com.vaadin.flow.shared.communication.PushMode;
-import com.vaadin.flow.theme.AbstractTheme;
-
-import elemental.json.Json;
-import elemental.json.JsonException;
-import elemental.json.JsonObject;
-import elemental.json.impl.JsonUtil;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
@@ -2249,4 +2249,31 @@ public abstract class VaadinService implements Serializable {
     public DependencyTreeCache<String> getHtmlImportDependencyCache() {
         return htmlImportDependencyCache;
     }
+
+    /**
+     * Returns value of the specified attribute, creating a default value if not present.
+
+     * @param name Name of the attribute.
+     * @param defaultValueSupplier {@link Supplier} of the default value, called when there is
+     *                                            no value already present. May be {@code null}.
+     * @return Value of the specified attribute.
+     */
+    public abstract Object getAttribute(String name, Supplier<?> defaultValueSupplier);
+
+    /**
+     * Returns value of the specified attribute.
+
+     * @param name Name of the attribute.
+     * @return Value of the specified attribute.
+     */
+    public Object getAttribute(String name) {
+        return this.getAttribute(name, null);
+    }
+
+    /**
+     * Sets the attribute value, overriding previously existing one.
+     * @param name Name of the attribute.
+     * @param value Value of the attribute.
+     */
+    public abstract void setAttribute(String name, Object value);
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
@@ -15,13 +15,6 @@
  */
 package com.vaadin.flow.server.communication;
 
-import java.lang.annotation.Annotation;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Optional;
-
-import javax.servlet.ServletContext;
-
 import com.vaadin.flow.component.PushConfiguration;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.webcomponent.WebComponentUI;
@@ -29,12 +22,15 @@ import com.vaadin.flow.server.BootstrapHandler;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
 import com.vaadin.flow.server.VaadinServletRequest;
-import com.vaadin.flow.server.VaadinServletService;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.webcomponent.WebComponentConfigurationRegistry;
 import com.vaadin.flow.shared.ApplicationConstants;
-
 import elemental.json.JsonObject;
+
+import java.lang.annotation.Annotation;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Optional;
 
 /**
  * Bootstrap handler for WebComponent requests.
@@ -55,10 +51,8 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
         @Override
         public <T extends Annotation> Optional<T> getPageConfigurationAnnotation(
                 Class<T> annotationType) {
-            ServletContext servletContext = ((VaadinServletService) getRequest()
-                    .getService()).getServlet().getServletContext();
             WebComponentConfigurationRegistry registry = WebComponentConfigurationRegistry
-                    .getInstance(servletContext);
+                    .getInstance();
             return registry.getEmbeddedApplicationAnnotation(annotationType);
         }
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
@@ -59,8 +59,7 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
 
     @Override
     protected boolean canHandleRequest(VaadinRequest request) {
-        VaadinServletRequest servletRequest = (VaadinServletRequest) request;
-        String pathInfo = servletRequest.getPathInfo();
+        String pathInfo = request.getPathInfo();
         if (pathInfo == null || pathInfo.isEmpty()) {
             return false;
         }
@@ -76,8 +75,13 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
                 request, response, session);
         JsonObject config = context.getApplicationParameters();
 
-        VaadinServletRequest servletRequest = (VaadinServletRequest) request;
-        String requestURL = servletRequest.getRequestURL().toString();
+        final String requestURL;
+        if(request instanceof VaadinServletRequest) {
+            VaadinServletRequest servletRequest = (VaadinServletRequest) request;
+            requestURL = servletRequest.getRequestURL().toString();
+        }
+        else
+            requestURL = request.getContextPath();
 
         if (!requestURL.endsWith(PATH_PREFIX)) {
             throw new IllegalStateException("Unexpected request URL '"

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentProvider.java
@@ -23,7 +23,6 @@ import com.vaadin.flow.server.ServletHelper;
 import com.vaadin.flow.server.SynchronizedRequestHandler;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
-import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.webcomponent.WebComponentConfigurationRegistry;
 import com.vaadin.flow.server.webcomponent.WebComponentGenerator;
@@ -55,8 +54,7 @@ public class WebComponentProvider extends SynchronizedRequestHandler {
     @Override
     public boolean synchronizedHandleRequest(
             VaadinSession session, VaadinRequest request, VaadinResponse response) throws IOException {
-        VaadinServletRequest servletRequest = (VaadinServletRequest) request;
-        String pathInfo = servletRequest.getPathInfo();
+        String pathInfo = request.getPathInfo();
 
         if (pathInfo == null || pathInfo.isEmpty()) {
             return false;
@@ -86,7 +84,7 @@ public class WebComponentProvider extends SynchronizedRequestHandler {
                     .get();
             String generated = cache.computeIfAbsent(tag.get(),
                     moduleTag -> generateModule(webComponentConfiguration,
-                            session, servletRequest));
+                            session, request));
 
             IOUtils.write(generated, response.getOutputStream(),
                     StandardCharsets.UTF_8);
@@ -100,7 +98,7 @@ public class WebComponentProvider extends SynchronizedRequestHandler {
 
     private String generateModule(
             WebComponentConfiguration<? extends Component> configuration,
-            VaadinSession session, VaadinServletRequest request) {
+            VaadinSession session, VaadinRequest request) {
         if (session.getConfiguration().useCompiledFrontendResources()) {
             return generateCompiledUIDeclaration(session, request);
         } else {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentProvider.java
@@ -15,16 +15,6 @@
  */
 package com.vaadin.flow.server.communication;
 
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-
-import org.apache.commons.io.IOUtils;
-import org.slf4j.LoggerFactory;
-
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.webcomponent.WebComponentConfiguration;
 import com.vaadin.flow.server.BootstrapHandler;
@@ -37,6 +27,15 @@ import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.webcomponent.WebComponentConfigurationRegistry;
 import com.vaadin.flow.server.webcomponent.WebComponentGenerator;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * Request handler that supplies the script/html of the web component matching
@@ -76,8 +75,7 @@ public class WebComponentProvider extends SynchronizedRequestHandler {
         }
 
         Optional<WebComponentConfiguration<? extends Component>> optionalWebComponentConfiguration =
-                WebComponentConfigurationRegistry.getInstance(
-                        ((VaadinServletRequest) request).getServletContext())
+                WebComponentConfigurationRegistry.getInstance()
                         .getConfiguration(tag.get());
 
         if (optionalWebComponentConfiguration.isPresent()) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletDeployer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletDeployer.java
@@ -15,11 +15,14 @@
  */
 package com.vaadin.flow.server.startup;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.Optional;
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.DeploymentConfigurationFactory;
+import com.vaadin.flow.server.VaadinServlet;
+import com.vaadin.flow.server.VaadinServletConfiguration;
+import com.vaadin.flow.server.webcomponent.WebComponentConfigurationRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
@@ -27,16 +30,11 @@ import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRegistration;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.vaadin.flow.function.DeploymentConfiguration;
-import com.vaadin.flow.router.Route;
-import com.vaadin.flow.server.DeploymentConfigurationFactory;
-import com.vaadin.flow.server.VaadinServlet;
-import com.vaadin.flow.server.VaadinServletConfiguration;
-import com.vaadin.flow.server.webcomponent.WebComponentConfigurationRegistry;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Optional;
 
 /**
  * Context listener that automatically registers Vaadin servlets.
@@ -159,7 +157,7 @@ public class ServletDeployer implements ServletContextListener {
                 .hasNavigationTargets();
 
         createServlet = createServlet || WebComponentConfigurationRegistry
-                .getInstance(context).hasConfigurations();
+                .getInstance().hasConfigurations();
 
         if (!createServlet) {
             getLogger().info(

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/WebComponentConfigurationRegistryInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/WebComponentConfigurationRegistryInitializer.java
@@ -15,6 +15,13 @@
  */
 package com.vaadin.flow.server.startup;
 
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.WebComponentExporter;
+import com.vaadin.flow.component.webcomponent.WebComponentConfiguration;
+import com.vaadin.flow.internal.CustomElementNameValidator;
+import com.vaadin.flow.server.InvalidCustomElementNameException;
+import com.vaadin.flow.server.webcomponent.WebComponentConfigurationRegistry;
+
 import javax.servlet.ServletContainerInitializer;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
@@ -26,13 +33,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.WebComponentExporter;
-import com.vaadin.flow.component.webcomponent.WebComponentConfiguration;
-import com.vaadin.flow.internal.CustomElementNameValidator;
-import com.vaadin.flow.server.InvalidCustomElementNameException;
-import com.vaadin.flow.server.webcomponent.WebComponentConfigurationRegistry;
 
 /**
  * Servlet initializer for collecting all classes that extend {@link
@@ -51,7 +51,7 @@ public class WebComponentConfigurationRegistryInitializer
     public void onStartup(Set<Class<?>> set, ServletContext servletContext)
             throws ServletException {
         WebComponentConfigurationRegistry instance = WebComponentConfigurationRegistry
-                .getInstance(servletContext);
+                .getInstance();
 
         if (set == null || set.isEmpty()) {
             instance.setConfigurations(Collections.emptySet());

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/WebComponentProviderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/WebComponentProviderTest.java
@@ -16,26 +16,6 @@
 
 package com.vaadin.flow.server.communication;
 
-import static org.mockito.Mockito.times;
-
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServletResponse;
-
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.WebComponentExporter;
@@ -52,8 +32,25 @@ import com.vaadin.flow.server.webcomponent.WebComponentConfigurationRegistry;
 import com.vaadin.flow.shared.communication.PushMode;
 import com.vaadin.flow.theme.AbstractTheme;
 import com.vaadin.flow.theme.Theme;
-
 import net.jcip.annotations.NotThreadSafe;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletResponse;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.mockito.Mockito.times;
 
 @NotThreadSafe
 public class WebComponentProviderTest {
@@ -277,7 +274,7 @@ public class WebComponentProviderTest {
         Mockito.when(request.getServletContext()).thenReturn(servletContext);
         Mockito.when(request.getContextPath()).thenReturn("");
         WebComponentConfigurationRegistry registry = WebComponentConfigurationRegistry
-                .getInstance(servletContext);
+                .getInstance();
         Mockito.when(servletContext.getAttribute(
                 WebComponentConfigurationRegistry.class.getName()))
                 .thenReturn(registry);

--- a/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/OSGiWebComponentConfigurationRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/OSGiWebComponentConfigurationRegistryTest.java
@@ -44,7 +44,7 @@ public class OSGiWebComponentConfigurationRegistryTest extends WebComponentConfi
     @Before
     @Override
     public void init() {
-
+        super.init();
         registry = WebComponentConfigurationRegistry
                 .getInstance(); // OSGiAccess.getInstance().getOsgiServletContext()
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/OSGiWebComponentConfigurationRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/OSGiWebComponentConfigurationRegistryTest.java
@@ -16,6 +16,15 @@
 
 package com.vaadin.flow.server.webcomponent;
 
+import com.vaadin.flow.server.osgi.OSGiAccess;
+import com.vaadin.flow.server.startup.EnableOSGiRunner;
+import net.jcip.annotations.NotThreadSafe;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -28,16 +37,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import net.jcip.annotations.NotThreadSafe;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import com.vaadin.flow.server.osgi.OSGiAccess;
-import com.vaadin.flow.server.startup.EnableOSGiRunner;
-
 @NotThreadSafe
 @RunWith(EnableOSGiRunner.class)
 public class OSGiWebComponentConfigurationRegistryTest extends WebComponentConfigurationRegistryTest {
@@ -46,7 +45,7 @@ public class OSGiWebComponentConfigurationRegistryTest extends WebComponentConfi
     @Override
     public void init() {
         registry = WebComponentConfigurationRegistry
-                .getInstance(OSGiAccess.getInstance().getOsgiServletContext());
+                .getInstance(); // OSGiAccess.getInstance().getOsgiServletContext()
     }
 
     @After
@@ -65,7 +64,7 @@ public class OSGiWebComponentConfigurationRegistryTest extends WebComponentConfi
     @Test
     public void assertOsgiRegistryIsServedAsASingleton() {
         Assert.assertEquals(registry, WebComponentConfigurationRegistry
-                .getInstance(OSGiAccess.getInstance().getOsgiServletContext()));
+                .getInstance()); // OSGiAccess.getInstance().getOsgiServletContext())
     }
 
     @Override

--- a/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/OSGiWebComponentConfigurationRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/OSGiWebComponentConfigurationRegistryTest.java
@@ -44,6 +44,7 @@ public class OSGiWebComponentConfigurationRegistryTest extends WebComponentConfi
     @Before
     @Override
     public void init() {
+
         registry = WebComponentConfigurationRegistry
                 .getInstance(); // OSGiAccess.getInstance().getOsgiServletContext()
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/WebComponentConfigurationRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/WebComponentConfigurationRegistryTest.java
@@ -16,7 +16,15 @@
 
 package com.vaadin.flow.server.webcomponent;
 
-import javax.servlet.ServletContext;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.WebComponentExporter;
+import com.vaadin.flow.component.webcomponent.WebComponent;
+import com.vaadin.flow.component.webcomponent.WebComponentConfiguration;
+import net.jcip.annotations.NotThreadSafe;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -32,26 +40,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import net.jcip.annotations.NotThreadSafe;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-
-import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.WebComponentExporter;
-import com.vaadin.flow.component.webcomponent.WebComponent;
-import com.vaadin.flow.component.webcomponent.WebComponentConfiguration;
-import com.vaadin.flow.internal.CurrentInstance;
-import com.vaadin.flow.server.MockInstantiator;
-import com.vaadin.flow.server.VaadinService;
-import com.vaadin.flow.server.VaadinSession;
-
-import static org.mockito.Mockito.mock;
-
 @NotThreadSafe
 public class WebComponentConfigurationRegistryTest {
 
@@ -63,7 +51,7 @@ public class WebComponentConfigurationRegistryTest {
     @Before
     public void init() {
         registry = WebComponentConfigurationRegistry
-                .getInstance(mock(ServletContext.class));
+                .getInstance();
     }
 
     @Test


### PR DESCRIPTION
New methods for storing and obtaining attributes that are dependent on the application context, rather than request or session context.

Previously the code has been assuming that `VaadinRequest` is a `VaadinServletRequest` and stored the information directly. Now there are three methods in `VaadinService`:
* `Object getAttribute(String name, Supplier<?> defaultValueSupplier)`
* `Object getAttribute(String name)`
* `void setAttribute(String name, Object value)`

The middle method is implemented in `VaadinService` by calling the first method with `null` supplier.

Implementation in `VaadinServletService` synchronises on servlet context and delegates storing attributes to there.

As a side effect, `WebComponentConfigurationRegistry.getInstance` no longer needs servlet request as a parameter and just delegates setting itself to current context.

Question remains, should that be stored via `CurrentInstance` instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5510)
<!-- Reviewable:end -->
