### PR TITLE
Sanitize input used in error template (#5498)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteNotFoundError.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteNotFoundError.java
@@ -23,7 +23,9 @@ import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.io.IOUtils;
+import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
+import org.jsoup.safety.Whitelist;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.Component;
@@ -47,6 +49,8 @@ public class RouteNotFoundError extends Component
         if (parameter.hasCustomMessage()) {
             additionalInfo = "Reason: " + parameter.getCustomMessage();
         }
+        path = Jsoup.clean(path, Whitelist.none());
+        additionalInfo = Jsoup.clean(additionalInfo, Whitelist.none());
 
         boolean productionMode = event.getUI().getSession().getConfiguration()
                 .isProductionMode();


### PR DESCRIPTION
As error template is html, and the input used in it is taken from the path, which can be anything, the input needs to be sanitized before added to the template to avoid possible XSS injection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5517)
<!-- Reviewable:end -->
