### PR TITLE
Cherry-pick: Clarify Javadocs for UI and session locale settings (#5412)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -33,6 +33,7 @@ import com.vaadin.flow.component.page.Page;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableRunnable;
+import com.vaadin.flow.i18n.I18NProvider;
 import com.vaadin.flow.internal.CurrentInstance;
 import com.vaadin.flow.internal.ExecutionContext;
 import com.vaadin.flow.internal.StateNode;
@@ -682,9 +683,22 @@ public class UI extends Component
     }
 
     /**
-     * * Gets the locale for this UI.
+     * Gets the locale for this UI. The default locale is based on the session's
+     * locale, which is in turn determined in different ways depending on
+     * whether a {@link I18NProvider} is available.
+     * <p>
+     * If a i18n provider is available, the locale is determined by selecting
+     * the locale from {@link I18NProvider#getProvidedLocales()} that best
+     * matches the user agent preferences (i.e. the <code>Accept-Language</code>
+     * header). If an exact match is found, then that locale is used. Otherwise,
+     * the matching logic looks for the first provided locale that uses the same
+     * language regardless of the country. If no other match is found, then the
+     * first item from {@link I18NProvider#getProvidedLocales()} is used.
+     * <p>
+     * If no i18n provider is available, then the {@link Locale#getDefault()
+     * default JVM locale} is used as the default locale.
      *
-     * @return the locale in use
+     * @return the locale in use, not <code>null</code>
      */
     @Override
     public Locale getLocale() {
@@ -693,6 +707,10 @@ public class UI extends Component
 
     /**
      * Sets the locale for this UI.
+     * <p>
+     * Note that {@link VaadinSession#setLocale(Locale)} will set the locale for
+     * all UI instances in that session, and might thus override any custom
+     * locale previous set for a specific UI.
      *
      * @param locale
      *            the locale to use, not null
@@ -1009,24 +1027,21 @@ public class UI extends Component
      * {@link ShortcutRegistration#remove()} is called.
      *
      * @param command
-     *              code to execute when the shortcut is invoked. Cannot be
-     *              null
+     *            code to execute when the shortcut is invoked. Cannot be null
      * @param key
-     *              primary {@link Key} used to trigger the shortcut. Cannot
-     *              be null
+     *            primary {@link Key} used to trigger the shortcut. Cannot be
+     *            null
      * @param keyModifiers
-     *              {@link KeyModifier KeyModifiers} which also need to be
-     *              pressed for the shortcut to trigger
-     * @return      {@link ShortcutRegistration} for configuring the shortcut
-     *              and removing
-     * @see #addShortcutListener(ShortcutEventListener, Key, KeyModifier...)
-     *              for registering a listener which receives a {@link
-     *              ShortcutEvent}
-     * @see Shortcuts
-     *              for a more generic way to add a shortcut
+     *            {@link KeyModifier KeyModifiers} which also need to be pressed
+     *            for the shortcut to trigger
+     * @return {@link ShortcutRegistration} for configuring the shortcut and
+     *         removing
+     * @see #addShortcutListener(ShortcutEventListener, Key, KeyModifier...) for
+     *      registering a listener which receives a {@link ShortcutEvent}
+     * @see Shortcuts for a more generic way to add a shortcut
      */
-    public ShortcutRegistration addShortcutListener(
-            Command command, Key key, KeyModifier... keyModifiers) {
+    public ShortcutRegistration addShortcutListener(Command command, Key key,
+            KeyModifier... keyModifiers) {
         if (command == null) {
             throw new InvalidParameterException(String.format(Shortcuts.NULL,
                     "command"));
@@ -1048,17 +1063,16 @@ public class UI extends Component
      * {@link ShortcutRegistration#remove()} is called.
      *
      * @param listener
-     *                  listener to execute when the shortcut is invoked.
-     *                  Receives a {@link ShortcutEvent}. Cannot be null
+     *            listener to execute when the shortcut is invoked. Receives a
+     *            {@link ShortcutEvent}. Cannot be null
      * @param key
-     *                  primary {@link Key} used to trigger the shortcut
+     *            primary {@link Key} used to trigger the shortcut
      * @param keyModifiers
-     *                  {@link KeyModifier KeyModifiers} which also need to be
-     *                  pressed for the shortcut to trigger
-     * @return          {@link ShortcutRegistration} for configuring the
-     *                  shortcut and removing
-     * @see Shortcuts
-     *                  for a more generic way to add a shortcut
+     *            {@link KeyModifier KeyModifiers} which also need to be pressed
+     *            for the shortcut to trigger
+     * @return {@link ShortcutRegistration} for configuring the shortcut and
+     *         removing
+     * @see Shortcuts for a more generic way to add a shortcut
      */
     public ShortcutRegistration addShortcutListener(
             ShortcutEventListener listener, Key key,
@@ -1071,7 +1085,7 @@ public class UI extends Component
             throw new InvalidParameterException(String.format(Shortcuts.NULL,
                     "key"));
         }
-        return new ShortcutRegistration(this, () -> this,
-                listener, key).withModifiers(keyModifiers);
+        return new ShortcutRegistration(this, () -> this, listener, key)
+                .withModifiers(keyModifiers);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
@@ -16,9 +16,6 @@
 
 package com.vaadin.flow.server;
 
-import javax.servlet.http.HttpSession;
-import javax.servlet.http.HttpSessionBindingEvent;
-import javax.servlet.http.HttpSessionBindingListener;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
@@ -38,11 +35,16 @@ import java.util.concurrent.Future;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpSessionBindingEvent;
+import javax.servlet.http.HttpSessionBindingListener;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.i18n.I18NProvider;
 import com.vaadin.flow.internal.CurrentInstance;
 import com.vaadin.flow.shared.communication.PushMode;
 
@@ -135,7 +137,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * Creates a new VaadinSession tied to a VaadinService.
      *
      * @param service
-     *         the Vaadin service for the new session
+     *            the Vaadin service for the new session
      */
     public VaadinSession(VaadinService service) {
         this.service = service;
@@ -168,8 +170,8 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
             checkHasLock();
             // Ignore if the session is being moved to a different backing
             // session or if GAEVaadinServlet is doing its normal cleanup.
-            if (getAttribute(VaadinService.PRESERVE_UNBOUND_SESSION_ATTRIBUTE)
-                    == Boolean.TRUE) {
+            if (getAttribute(
+                    VaadinService.PRESERVE_UNBOUND_SESSION_ATTRIBUTE) == Boolean.TRUE) {
                 return;
             }
 
@@ -198,7 +200,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
 
     /**
      * @return The total time spent servicing requests in this session, in
-     * milliseconds.
+     *         milliseconds.
      */
     public long getCumulativeRequestDuration() {
         checkHasLock();
@@ -210,7 +212,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * the total time spent servicing requests in this session.
      *
      * @param time
-     *         The time spent in the last request, in milliseconds.
+     *            The time spent in the last request, in milliseconds.
      */
     public void setLastRequestDuration(long time) {
         checkHasLock();
@@ -220,7 +222,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
 
     /**
      * @return The time spent servicing the last request in this session, in
-     * milliseconds.
+     *         milliseconds.
      */
     public long getLastRequestDuration() {
         checkHasLock();
@@ -231,8 +233,8 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * Sets the time when the last UIDL request was serviced in this session.
      *
      * @param timestamp
-     *         The time when the last request was handled, in milliseconds
-     *         since the epoch.
+     *            The time when the last request was handled, in milliseconds
+     *            since the epoch.
      */
     public void setLastRequestTimestamp(long timestamp) {
         checkHasLock();
@@ -243,7 +245,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * Returns the time when the last request was serviced in this session.
      *
      * @return The time when the last request was handled, in milliseconds since
-     * the epoch.
+     *         the epoch.
      */
     public long getLastRequestTimestamp() {
         checkHasLock();
@@ -270,7 +272,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * session.
      *
      * @param httpSession
-     *         the HTTP session
+     *            the HTTP session
      * @return the found VaadinSessions
      */
     public static Collection<VaadinSession> getAllSessions(
@@ -305,8 +307,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
         if (configuration == null) {
             throw new IllegalArgumentException("Can not set to null");
         }
-        assert this.configuration
-                == null : "Configuration can only be set once";
+        assert this.configuration == null : "Configuration can only be set once";
         this.configuration = configuration;
     }
 
@@ -321,10 +322,21 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
     }
 
     /**
-     * Gets the default locale for this session.
-     *
-     * By default this is the preferred locale of the user using the session. In
-     * most cases it is read from the browser defaults.
+     * Gets the locale for this session.
+     * <p>
+     * The default locale is determined in different ways depending on whether a
+     * {@link I18NProvider} is available.
+     * <p>
+     * If a i18n provider is available, the locale is determined by selecting
+     * the locale from {@link I18NProvider#getProvidedLocales()} that best
+     * matches the user agent preferences (i.e. the <code>Accept-Language</code>
+     * header). If an exact match is found, then that locale is used. Otherwise,
+     * the matching logic looks for the first provided locale that uses the same
+     * language regardless of the country. If no other match is found, then the
+     * first item from {@link I18NProvider#getProvidedLocales()} is used.
+     * <p>
+     * If no i18n provider is available, then the {@link Locale#getDefault()
+     * default JVM locale} is used as the default locale.
      *
      * @return the locale of this session.
      */
@@ -335,14 +347,16 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
 
     /**
      * Sets the default locale for this session.
-     *
-     * By default this is the preferred locale of the user using the
-     * application. In most cases it is read from the browser defaults.
+     * <p>
+     * Setting the locale of a session will also override any custom locale
+     * configured for all UIs in this session.
      *
      * @param locale
-     *         the Locale object.
+     *            the locale to set, not <code>null</code>
      */
     public void setLocale(Locale locale) {
+        assert locale != null : "Null locale is not supported!";
+
         checkHasLock();
         this.locale = locale;
 
@@ -363,7 +377,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * Sets the session error handler.
      *
      * @param errorHandler
-     *         the new error handler
+     *            the new error handler
      */
     public void setErrorHandler(ErrorHandler errorHandler) {
         checkHasLock();
@@ -379,7 +393,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * added handler will be called first.
      *
      * @param handler
-     *         the request handler to add
+     *            the request handler to add
      * @see #removeRequestHandler(RequestHandler)
      */
     public void addRequestHandler(RequestHandler handler) {
@@ -391,7 +405,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * Removes a request handler from the session.
      *
      * @param handler
-     *         the request handler to remove
+     *            the request handler to remove
      */
     public void removeRequestHandler(RequestHandler handler) {
         checkHasLock();
@@ -404,7 +418,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * which the request handlers will be invoked when a request is handled.
      *
      * @return a collection of request handlers, with the iteration order
-     * according to the order they would be invoked
+     *         according to the order they would be invoked
      * @see #addRequestHandler(RequestHandler)
      * @see #removeRequestHandler(RequestHandler)
      */
@@ -424,7 +438,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * case it is not explicitly cleared.
      *
      * @return the current session instance if available, otherwise
-     * <code>null</code>
+     *         <code>null</code>
      * @see #setCurrent(VaadinSession)
      */
     public static VaadinSession getCurrent() {
@@ -444,7 +458,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * case it is not explicitly cleared.
      *
      * @param session
-     *         the session to set as current
+     *            the session to set as current
      * @see #getCurrent()
      * @see ThreadLocal
      */
@@ -470,7 +484,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * This is meant for framework internal use.
      *
      * @param uiId
-     *         The UI id
+     *            The UI id
      * @return The UI with the given id or null if not found
      */
     public UI getUIById(int uiId) {
@@ -499,8 +513,8 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * production mode is not enabled.
      *
      * @param message
-     *         the error message to include when failing if the check is done
-     *         and the session is not locked
+     *            the error message to include when failing if the check is done
+     *            and the session is not locked
      */
     public void checkHasLock(String message) {
         if (configuration == null || configuration.isProductionMode()) {
@@ -528,9 +542,9 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * WrappedSession.
      *
      * @param service
-     *         the service to check
+     *            the service to check
      * @param session
-     *         the session to use for checking
+     *            the session to use for checking
      * @return true if this thread has exclusive access, false otherwise
      */
     protected static boolean hasLock(VaadinService service,
@@ -544,7 +558,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * it has been closed.
      *
      * @param ui
-     *         the UI to remove
+     *            the UI to remove
      */
     public void removeUI(UI ui) {
         checkHasLock();
@@ -566,7 +580,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * {@link Lock#unlock()}.
      *
      * @return the <code>Lock</code> that is used for synchronization, never
-     * <code>null</code>
+     *         <code>null</code>
      * @see #lock()
      * @see Lock
      */
@@ -642,8 +656,8 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
                 getService().runPendingAccessTasks(this);
 
                 for (UI ui : getUIs()) {
-                    if (ui.getPushConfiguration().getPushMode()
-                            == PushMode.AUTOMATIC) {
+                    if (ui.getPushConfiguration()
+                            .getPushMode() == PushMode.AUTOMATIC) {
                         Map<Class<?>, CurrentInstance> oldCurrent = CurrentInstance
                                 .setCurrent(ui);
                         try {
@@ -678,11 +692,11 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * <code>null</code> clears the stored value.
      *
      * @param name
-     *         the name to associate the value with, can not be
-     *         <code>null</code>
+     *            the name to associate the value with, can not be
+     *            <code>null</code>
      * @param value
-     *         the value to associate with the name, or <code>null</code> to
-     *         remove a previous association.
+     *            the value to associate with the name, or <code>null</code> to
+     *            remove a previous association.
      * @see #getAttribute(String)
      */
     public void setAttribute(String name, Object value) {
@@ -702,12 +716,12 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * <code>setAttribute(type.getName(), value);</code>
      *
      * @param type
-     *         the type that the stored value represents, can not be null
+     *            the type that the stored value represents, can not be null
      * @param value
-     *         the value to associate with the type, or <code>null</code> to
-     *         remove a previous association.
+     *            the value to associate with the type, or <code>null</code> to
+     *            remove a previous association.
      * @param <T>
-     *         the type of the stored value
+     *            the type of the stored value
      * @see #getAttribute(Class)
      * @see #setAttribute(String, Object)
      */
@@ -722,9 +736,9 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * <code>null</code> is returned.
      *
      * @param name
-     *         the name of the value to get, can not be <code>null</code>.
+     *            the name of the value to get, can not be <code>null</code>.
      * @return the value, or <code>null</code> if no value has been stored or if
-     * it has been set to null.
+     *         it has been set to null.
      * @see #setAttribute(String, Object)
      */
     public Object getAttribute(String name) {
@@ -744,11 +758,11 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * <code>getAttribute(type.getName());</code>
      *
      * @param type
-     *         the type of the value to get, can not be <code>null</code>.
+     *            the type of the value to get, can not be <code>null</code>.
      * @param <T>
-     *         the type of the value to get
+     *            the type of the value to get
      * @return the value, or <code>null</code> if no value has been stored or if
-     * it has been set to null.
+     *         it has been set to null.
      * @see #setAttribute(Class, Object)
      * @see #getAttribute(String)
      */
@@ -771,7 +785,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * Adds an initialized UI to this session.
      *
      * @param ui
-     *         the initialized UI to add.
+     *            the initialized UI to add.
      */
     public void addUI(UI ui) {
         checkHasLock();
@@ -822,20 +836,20 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * OPEN to CLOSING and CLOSING to CLOSED.
      *
      * @param state
-     *         the new state
+     *            the new state
      */
     protected void setState(VaadinSessionState state) {
         checkHasLock();
-        assert isValidChange(state) :
-                "Invalid session state change " + this.state + "->" + state;
+        assert isValidChange(state) : "Invalid session state change "
+                + this.state + "->" + state;
 
         this.state = state;
     }
 
     private boolean isValidChange(VaadinSessionState newState) {
         return (state == VaadinSessionState.OPEN
-                && newState == VaadinSessionState.CLOSING) || (
-                state == VaadinSessionState.CLOSING
+                && newState == VaadinSessionState.CLOSING)
+                || (state == VaadinSessionState.CLOSING
                         && newState == VaadinSessionState.CLOSED);
     }
 
@@ -865,9 +879,9 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * </ul>
      *
      * @param command
-     *         the command which accesses the session
+     *            the command which accesses the session
      * @throws IllegalStateException
-     *         if the current thread holds the lock for another session
+     *             if the current thread holds the lock for another session
      * @see #lock()
      * @see #getCurrent()
      * @see #access(Command)
@@ -918,9 +932,9 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * some other session.
      *
      * @param command
-     *         the command which accesses the session
+     *            the command which accesses the session
      * @return a future that can be used to check for task completion and to
-     * cancel the task
+     *         cancel the task
      * @see #lock()
      * @see #getCurrent()
      * @see #accessSynchronously(Command)
@@ -968,11 +982,11 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * {@link #pendingAccessQueue}.
      *
      * @param stream
-     *         the object to read
+     *            the object to read
      * @throws IOException
-     *         if an IO error occurred
+     *             if an IO error occurred
      * @throws ClassNotFoundException
-     *         if the class of the stream object could not be found
+     *             if the class of the stream object could not be found
      */
     private void readObject(ObjectInputStream stream)
             throws IOException, ClassNotFoundException {
@@ -992,9 +1006,9 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      * Called internally by the framework.
      *
      * @param wrappedSession
-     *         the session this VaadinSession is stored in
+     *            the session this VaadinSession is stored in
      * @param vaadinService
-     *         the service associated with this VaadinSession
+     *            the service associated with this VaadinSession
      */
     public void refreshTransients(WrappedSession wrappedSession,
             VaadinService vaadinService) {


### PR DESCRIPTION
Also updates an inconsistency in null checking between UI and session
when setting a locale.

(cherry picked from commit cf321a147e39df33d67de442ab028df318017ecd)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5524)
<!-- Reviewable:end -->
