### PR TITLE
Exclude unused dependencies from the pom file

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -91,6 +91,12 @@
             <groupId>com.helger</groupId>
             <artifactId>ph-commons</artifactId>
             <version>9.1.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Byte code generation -->
@@ -116,6 +122,16 @@
             <groupId>com.google.javascript</groupId>
             <artifactId>closure-compiler-unshaded</artifactId>
             <version>v20190325</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.code.findbugs</groupId>
+                    <artifactId>jsr305</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.errorprone</groupId>
+                    <artifactId>error_prone_annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- TESTING DEPENDENCIES -->


### PR DESCRIPTION
The excluded dependencies are not used in our code but they are transitively
included with different versions. Since we don't need them it's easier to exclude
them completely to reduce dependencies list.

Fixes #5507

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5544)
<!-- Reviewable:end -->
