### PR TITLE
5500: adding attribute getter and setter to VaadinService

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -16,6 +16,40 @@
 
 package com.vaadin.flow.server;
 
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.internal.DependencyTreeCache;
+import com.vaadin.flow.component.internal.HtmlImportParser;
+import com.vaadin.flow.di.DefaultInstantiator;
+import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.i18n.I18NProvider;
+import com.vaadin.flow.internal.CurrentInstance;
+import com.vaadin.flow.internal.LocaleUtil;
+import com.vaadin.flow.internal.ReflectionCache;
+import com.vaadin.flow.router.Router;
+import com.vaadin.flow.server.ServletHelper.RequestType;
+import com.vaadin.flow.server.communication.AtmospherePushConnection;
+import com.vaadin.flow.server.communication.HeartbeatHandler;
+import com.vaadin.flow.server.communication.PwaHandler;
+import com.vaadin.flow.server.communication.SessionRequestHandler;
+import com.vaadin.flow.server.communication.StreamRequestHandler;
+import com.vaadin.flow.server.communication.UidlRequestHandler;
+import com.vaadin.flow.server.communication.WebComponentBootstrapHandler;
+import com.vaadin.flow.server.communication.WebComponentProvider;
+import com.vaadin.flow.server.startup.BundleFilterFactory;
+import com.vaadin.flow.server.startup.FakeBrowser;
+import com.vaadin.flow.shared.ApplicationConstants;
+import com.vaadin.flow.shared.JsonConstants;
+import com.vaadin.flow.shared.Registration;
+import com.vaadin.flow.shared.communication.PushMode;
+import com.vaadin.flow.theme.AbstractTheme;
+import elemental.json.Json;
+import elemental.json.JsonException;
+import elemental.json.JsonObject;
+import elemental.json.impl.JsonUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.servlet.Servlet;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletResponse;
@@ -44,45 +78,11 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.vaadin.flow.component.UI;
-import com.vaadin.flow.component.internal.DependencyTreeCache;
-import com.vaadin.flow.component.internal.HtmlImportParser;
-import com.vaadin.flow.di.DefaultInstantiator;
-import com.vaadin.flow.di.Instantiator;
-import com.vaadin.flow.function.DeploymentConfiguration;
-import com.vaadin.flow.i18n.I18NProvider;
-import com.vaadin.flow.internal.CurrentInstance;
-import com.vaadin.flow.internal.LocaleUtil;
-import com.vaadin.flow.internal.ReflectionCache;
-import com.vaadin.flow.router.Router;
-import com.vaadin.flow.server.ServletHelper.RequestType;
-import com.vaadin.flow.server.communication.AtmospherePushConnection;
-import com.vaadin.flow.server.communication.HeartbeatHandler;
-import com.vaadin.flow.server.communication.PwaHandler;
-import com.vaadin.flow.server.communication.SessionRequestHandler;
-import com.vaadin.flow.server.communication.StreamRequestHandler;
-import com.vaadin.flow.server.communication.UidlRequestHandler;
-import com.vaadin.flow.server.communication.WebComponentBootstrapHandler;
-import com.vaadin.flow.server.communication.WebComponentProvider;
-import com.vaadin.flow.server.startup.BundleFilterFactory;
-import com.vaadin.flow.server.startup.FakeBrowser;
-import com.vaadin.flow.shared.ApplicationConstants;
-import com.vaadin.flow.shared.JsonConstants;
-import com.vaadin.flow.shared.Registration;
-import com.vaadin.flow.shared.communication.PushMode;
-import com.vaadin.flow.theme.AbstractTheme;
-
-import elemental.json.Json;
-import elemental.json.JsonException;
-import elemental.json.JsonObject;
-import elemental.json.impl.JsonUtil;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
@@ -2249,4 +2249,38 @@ public abstract class VaadinService implements Serializable {
     public DependencyTreeCache<String> getHtmlImportDependencyCache() {
         return htmlImportDependencyCache;
     }
+
+    /**
+     * Returns value of the specified attribute, creating a default value if not present.
+
+     * @param type
+     *          Type of the attribute.
+     * @param defaultValueSupplier
+     *          {@link Supplier} of the default value, called when there is
+     *                                            no value already present. May be {@code null}.
+     * @return Value of the specified attribute.
+     */
+    public abstract <T> T getAttribute(Class<T> type, Supplier<T> defaultValueSupplier);
+
+    /**
+     * Returns value of the specified attribute.
+
+     * @param type
+     *          Type of the attribute.
+     * @return Value of the specified attribute.
+     */
+    public <T> T getAttribute(Class<T> type) {
+        return this.getAttribute(type, null);
+    }
+
+    /**
+     * Sets the attribute value, overriding previously existing one.
+     * Values are based on exact type, meaning only one attribute of given type is possible at any
+     * given time.
+     *
+     * @param value
+     *          Value of the attribute. May not be {@code null}.
+     */
+    public abstract <T> void setAttribute(T value);
+
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -2270,7 +2270,7 @@ public abstract class VaadinService implements Serializable {
      * @return Value of the specified attribute.
      */
     public <T> T getAttribute(Class<T> type) {
-        return this.getAttribute(type, null);
+        return getAttribute(type, null);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
@@ -238,8 +238,8 @@ public class VaadinServletService extends VaadinService {
 
     @Override
     public <T> T getAttribute(Class<T> type, Supplier<T> defaultValueSupplier) {
-        ServletContext context;
-        synchronized (context = getServlet().getServletContext()) {
+        synchronized (getServlet().getServletContext()) {
+            final ServletContext context = getServlet().getServletContext();
             Object result = context.getAttribute(type.getName());
             if (result == null && defaultValueSupplier != null) {
                 result = defaultValueSupplier.get();

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
@@ -239,7 +239,7 @@ public class VaadinServletService extends VaadinService {
     @Override
     public <T> T getAttribute(Class<T> type, Supplier<T> defaultValueSupplier) {
         ServletContext context;
-        synchronized (context = this.getServlet().getServletContext()) {
+        synchronized (context = getServlet().getServletContext()) {
             Object result = context.getAttribute(type.getName());
             if (result == null && defaultValueSupplier != null) {
                 result = defaultValueSupplier.get();
@@ -253,7 +253,7 @@ public class VaadinServletService extends VaadinService {
     @Override
     public <T> void setAttribute(T value) {
         assert value != null;
-        this.getServlet().getServletContext()
+        getServlet().getServletContext()
             .setAttribute(value.getClass().getName(), value);
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
@@ -16,26 +16,25 @@
 
 package com.vaadin.flow.server;
 
-import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-
-import javax.servlet.GenericServlet;
-import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServletRequest;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.server.communication.FaviconHandler;
 import com.vaadin.flow.server.communication.PushRequestHandler;
 import com.vaadin.flow.server.startup.ApplicationRouteRegistry;
 import com.vaadin.flow.shared.ApplicationConstants;
 import com.vaadin.flow.theme.AbstractTheme;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.GenericServlet;
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Supplier;
 
 /**
  * A service implementation connected to a {@link VaadinServlet}.
@@ -237,6 +236,25 @@ public class VaadinServletService extends VaadinService {
         return Optional.empty();
     }
 
+    @Override
+    public <T> T getAttribute(Class<T> type, Supplier<T> defaultValueSupplier) {
+        ServletContext context = this.getServlet().getServletContext();
+        Object result = context.getAttribute(type.getName());
+        if(result == null && defaultValueSupplier != null) {
+            result = defaultValueSupplier.get();
+            context.setAttribute(type.getName(), result);
+            return type.cast(result);
+        }
+        else return null;
+    }
+
+    @Override
+    public <T> void setAttribute(T value) {
+        assert value != null;
+        this.getServlet().getServletContext()
+            .setAttribute(value.getClass().getName(), value);
+    }
+
     /**
      * Resolves the given {@code url} resource and tries to find a themed or raw
      * version.
@@ -356,5 +374,7 @@ public class VaadinServletService extends VaadinService {
         return getServlet().getWebJarServer()
                 .flatMap(server -> server.getWebJarResourcePath(path));
     }
+
+
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
@@ -238,14 +238,16 @@ public class VaadinServletService extends VaadinService {
 
     @Override
     public <T> T getAttribute(Class<T> type, Supplier<T> defaultValueSupplier) {
-        ServletContext context = this.getServlet().getServletContext();
-        Object result = context.getAttribute(type.getName());
-        if(result == null && defaultValueSupplier != null) {
-            result = defaultValueSupplier.get();
-            context.setAttribute(type.getName(), result);
-            return type.cast(result);
+        ServletContext context;
+        synchronized (context = this.getServlet().getServletContext()) {
+            Object result = context.getAttribute(type.getName());
+            if (result == null && defaultValueSupplier != null) {
+                result = defaultValueSupplier.get();
+                context.setAttribute(type.getName(), result);
+                return type.cast(result);
+            } else
+                return null;
         }
-        else return null;
     }
 
     @Override

--- a/flow-server/src/test/java/com/vaadin/flow/server/MockServletServiceSessionSetup.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/MockServletServiceSessionSetup.java
@@ -24,10 +24,8 @@ import java.net.URLConnection;
 import java.net.URLStreamHandler;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.function.Supplier;
 
@@ -213,9 +211,6 @@ public class MockServletServiceSessionSetup {
     private TestVaadinServletService service;
     private MockDeploymentConfiguration deploymentConfiguration = new MockDeploymentConfiguration();
 
-    // needed to store servlet context attributes
-    private final Map<String, Object> servletAttributesMap = new HashMap<>();
-
     public MockServletServiceSessionSetup() throws Exception {
         this(true);
     }
@@ -228,13 +223,6 @@ public class MockServletServiceSessionSetup {
         deploymentConfiguration.setXsrfProtectionEnabled(false);
         Mockito.when(servletConfig.getServletContext())
                 .thenReturn(servletContext);
-
-        // mock servlet context attributes
-        Mockito.when(servletContext.getAttribute(Mockito.anyString()))
-            .thenAnswer(invocationOnMock -> servletAttributesMap.get(invocationOnMock.getArguments()[0].toString()));
-        Mockito.doAnswer(invocationOnMock -> servletAttributesMap.put(invocationOnMock.getArguments()[0].toString(),
-            invocationOnMock.getArguments()[1]))
-            .when(servletContext).setAttribute(Mockito.anyString(), Mockito.any());
 
         servlet.init(servletConfig);
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/MockServletServiceSessionSetup.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/MockServletServiceSessionSetup.java
@@ -24,8 +24,10 @@ import java.net.URLConnection;
 import java.net.URLStreamHandler;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.function.Supplier;
 
@@ -37,6 +39,7 @@ public class MockServletServiceSessionSetup {
         private TestRouteRegistry routeRegistry;
         private Router router;
         private List<BootstrapListener> bootstrapListeners = new ArrayList<>();
+        private final Map<String, Object> attributes = new HashMap<>();
 
         public TestVaadinServletService(TestVaadinServlet testVaadinServlet,
                 DeploymentConfiguration deploymentConfiguration) {
@@ -92,6 +95,16 @@ public class MockServletServiceSessionSetup {
             super.modifyBootstrapPage(response);
         }
 
+        @Override
+        public <T> T getAttribute(Class<T> type, Supplier<T> defaultValueSupplier) {
+            return type.cast(attributes.computeIfAbsent(type.getName(), key -> defaultValueSupplier.get()));
+        }
+
+        @Override
+        public <T> void setAttribute(T value) {
+            assert value != null;
+            attributes.put(value.getClass().getName(), value);
+        }
     }
 
     public class TestVaadinServlet extends VaadinServlet {

--- a/flow-server/src/test/java/com/vaadin/flow/server/MockServletServiceSessionSetup.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/MockServletServiceSessionSetup.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.function.Supplier;
 
@@ -97,7 +98,13 @@ public class MockServletServiceSessionSetup {
 
         @Override
         public <T> T getAttribute(Class<T> type, Supplier<T> defaultValueSupplier) {
-            return type.cast(attributes.computeIfAbsent(type.getName(), key -> defaultValueSupplier.get()));
+            return
+                type.cast(attributes.computeIfAbsent(
+                    type.getName(),
+                    key -> Optional.ofNullable(defaultValueSupplier)
+                               .map(Supplier::get)
+                               .orElse(null))
+                );
         }
 
         @Override

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletServiceTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletServiceTest.java
@@ -1,19 +1,22 @@
 package com.vaadin.flow.server;
 
-import java.io.IOException;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-
+import com.vaadin.flow.server.MockServletServiceSessionSetup.TestVaadinServletService;
+import com.vaadin.flow.theme.AbstractTheme;
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.vaadin.flow.server.MockServletServiceSessionSetup.TestVaadinServletService;
-import com.vaadin.flow.theme.AbstractTheme;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 public class VaadinServletServiceTest {
+
+    private static String testAttributeProvider() {
+        return "RELAX_THIS_IS_A_TEST";
+    }
 
     private final class TestTheme implements AbstractTheme {
         @Override
@@ -253,6 +256,39 @@ public class VaadinServletServiceTest {
                             "frontend://theme/has-theme-variant.txt", browser,
                             null)); // No theme -> raw version
         }
+    }
+
+    @Test
+    public void testGetAttributeWithProvider() {
+        String value = service.getAttribute(String.class, VaadinServletServiceTest::testAttributeProvider);
+        Assert.assertEquals(testAttributeProvider(), value);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testSetNullAttribute() {
+        service.setAttribute(null);
+    }
+
+    @Test
+    public void testGetAttributeWithoutProvider() {
+        String value = service.getAttribute(String.class);
+        Assert.assertNull(value);
+    }
+
+    @Test
+    public void testSetGetAttributes() {
+        String value = testAttributeProvider();
+        service.setAttribute(value);
+        String result = service.getAttribute(String.class);
+        Assert.assertEquals(value, result);
+        // overwrite
+        String newValue = "this is a new value";
+        service.setAttribute(newValue);
+        result = service.getAttribute(String.class);
+        Assert.assertEquals(newValue, result);
+        // now the provider should not be called, so value should be still there
+        result = service.getAttribute(String.class, VaadinServletServiceTest::testAttributeProvider);
+        Assert.assertEquals(newValue, result);
     }
 
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletServiceTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletServiceTest.java
@@ -259,24 +259,24 @@ public class VaadinServletServiceTest {
     }
 
     @Test
-    public void testGetAttributeWithProvider() {
+    public void getAttributeWithProvider() {
         String value = service.getAttribute(String.class, VaadinServletServiceTest::testAttributeProvider);
         Assert.assertEquals(testAttributeProvider(), value);
     }
 
     @Test(expected = AssertionError.class)
-    public void testSetNullAttribute() {
+    public void setNullAttributeNotAllowed() {
         service.setAttribute(null);
     }
 
     @Test
-    public void testGetAttributeWithoutProvider() {
+    public void getAttributeWithoutProvider() {
         String value = service.getAttribute(String.class);
         Assert.assertNull(value);
     }
 
     @Test
-    public void testSetGetAttributes() {
+    public void setAndGetAttribute() {
         String value = testAttributeProvider();
         service.setAttribute(value);
         String result = service.getAttribute(String.class);


### PR DESCRIPTION
the methods are abstract in VaadinService, VaadinServletService delegates attribute setting to servlet context

attributes are type-based, meaning that only one attribute of a given type can be set (internally, FQN of value class is used to store the attribute)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5545)
<!-- Reviewable:end -->
