### PR TITLE
Extended client details

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
@@ -39,6 +39,8 @@ public class ExtendedClientDetails implements Serializable {
      *            the difference between the raw TimeZone and DST in minutes
      * @param dstInEffect
      *            is DST currently active in the region or not?
+     * @param tzId
+     *            time zone id
      * @param curDate
      *            the current date in milliseconds since the epoch
      * @param touchDevice
@@ -47,12 +49,12 @@ public class ExtendedClientDetails implements Serializable {
      *            a unique browser window name which persists on reload
      */
     ExtendedClientDetails(String sw, String sh, String tzo, String rtzo,
-                          String dstSavings, String dstInEffect, String tzId, String curDate,
-                          boolean touchDevice, String windowName) {
+                          String dstSavings, String dstInEffect, String tzId,
+                          String curDate, String touchDevice, String windowName) {
         if (sw != null) {
             try {
-                screenHeight = Integer.parseInt(sh);
                 screenWidth = Integer.parseInt(sw);
+                screenHeight = Integer.parseInt(sh);
             } catch (final NumberFormatException e) {
                 screenHeight = screenWidth = -1;
             }
@@ -99,19 +101,11 @@ public class ExtendedClientDetails implements Serializable {
                 clientServerTimeDelta = 0;
             }
         }
-        this.touchDevice = touchDevice;
+        if (touchDevice != null) {
+            this.touchDevice = Boolean.parseBoolean(touchDevice);
+        }
 
         this.windowName = windowName;
-    }
-
-    /**
-     * Gets the height of the screen in pixels. This is the full screen
-     * resolution and not the height available for the application.
-     *
-     * @return the height of the screen in pixels.
-     */
-    public int getScreenHeight() {
-        return screenHeight;
     }
 
     /**
@@ -122,6 +116,16 @@ public class ExtendedClientDetails implements Serializable {
      */
     public int getScreenWidth() {
         return screenWidth;
+    }
+
+    /**
+     * Gets the height of the screen in pixels. This is the full screen
+     * resolution and not the height available for the application.
+     *
+     * @return the height of the screen in pixels.
+     */
+    public int getScreenHeight() {
+        return screenHeight;
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
@@ -42,15 +42,15 @@ public class ExtendedClientDetails implements Serializable {
      * For internal use only. Updates all properties in the class according to
      * the given information.
      *
-     * @param sw
+     * @param screenWidth
      *            Screen width
-     * @param sh
+     * @param screenHeight
      *            Screen height
-     * @param tzo
+     * @param tzOffset
      *            TimeZone offset in minutes from GMT
-     * @param rtzo
+     * @param rawTzOffset
      *            raw TimeZone offset in minutes from GMT (w/o DST adjustment)
-     * @param dstSavings
+     * @param dstShift
      *            the difference between the raw TimeZone and DST in minutes
      * @param dstInEffect
      *            is DST currently active in the region or not?
@@ -63,37 +63,38 @@ public class ExtendedClientDetails implements Serializable {
      * @param windowName
      *            a unique browser window name which persists on reload
      */
-    ExtendedClientDetails(String sw, String sh, String tzo, String rtzo,
-                          String dstSavings, String dstInEffect, String tzId,
-                          String curDate, String touchDevice, String windowName) {
-        if (sw != null) {
+    ExtendedClientDetails(String screenWidth, String screenHeight,
+                          String tzOffset, String rawTzOffset, String dstShift,
+                          String dstInEffect, String tzId, String curDate,
+                          String touchDevice, String windowName) {
+        if (screenWidth != null) {
             try {
-                screenWidth = Integer.parseInt(sw);
-                screenHeight = Integer.parseInt(sh);
+                this.screenWidth = Integer.parseInt(screenWidth);
+                this.screenHeight = Integer.parseInt(screenHeight);
             } catch (final NumberFormatException e) {
-                screenHeight = screenWidth = -1;
+                this.screenHeight = this.screenWidth = -1;
             }
         }
-        if (tzo != null) {
+        if (tzOffset != null) {
             try {
                 // browser->java conversion: min->ms, reverse sign
-                timezoneOffset = -Integer.parseInt(tzo) * 60 * 1000;
+                timezoneOffset = -Integer.parseInt(tzOffset) * 60 * 1000;
             } catch (final NumberFormatException e) {
                 timezoneOffset = 0; // default gmt+0
             }
         }
-        if (rtzo != null) {
+        if (rawTzOffset != null) {
             try {
                 // browser->java conversion: min->ms, reverse sign
-                rawTimezoneOffset = -Integer.parseInt(rtzo) * 60 * 1000;
+                rawTimezoneOffset = -Integer.parseInt(rawTzOffset) * 60 * 1000;
             } catch (final NumberFormatException e) {
                 rawTimezoneOffset = 0; // default gmt+0
             }
         }
-        if (dstSavings != null) {
+        if (dstShift != null) {
             try {
                 // browser->java conversion: min->ms
-                this.dstSavings = Integer.parseInt(dstSavings) * 60 * 1000;
+                this.dstSavings = Integer.parseInt(dstShift) * 60 * 1000;
             } catch (final NumberFormatException e) {
                 this.dstSavings = 0; // default no savings
             }

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
@@ -1,0 +1,241 @@
+package com.vaadin.flow.component.page;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.TimeZone;
+
+/**
+ * Provides extended information about the web browser, such as screen
+ * resolution and time zone.
+ *
+ * @author Vaadin Ltd
+ * @since 1.0.
+ */
+public class ExtendedClientDetails implements Serializable {
+    private int screenHeight = -1;
+    private int screenWidth = -1;
+    private int timezoneOffset = 0;
+    private int rawTimezoneOffset = 0;
+    private int dstSavings;
+    private boolean dstInEffect;
+    private String timeZoneId;
+    private boolean touchDevice;
+    private long clientServerTimeDelta;
+    private String windowName;
+
+    /**
+     * For internal use only. Updates all properties in the class according to
+     * the given information.
+     *
+     * @param sw
+     *            Screen width
+     * @param sh
+     *            Screen height
+     * @param tzo
+     *            TimeZone offset in minutes from GMT
+     * @param rtzo
+     *            raw TimeZone offset in minutes from GMT (w/o DST adjustment)
+     * @param dstSavings
+     *            the difference between the raw TimeZone and DST in minutes
+     * @param dstInEffect
+     *            is DST currently active in the region or not?
+     * @param curDate
+     *            the current date in milliseconds since the epoch
+     * @param touchDevice
+     *            whether browser responds to touch events
+     * @param windowName
+     *            a unique browser window name which persists on reload
+     */
+    ExtendedClientDetails(String sw, String sh, String tzo, String rtzo,
+                          String dstSavings, String dstInEffect, String tzId, String curDate,
+                          boolean touchDevice, String windowName) {
+        if (sw != null) {
+            try {
+                screenHeight = Integer.parseInt(sh);
+                screenWidth = Integer.parseInt(sw);
+            } catch (final NumberFormatException e) {
+                screenHeight = screenWidth = -1;
+            }
+        }
+        if (tzo != null) {
+            try {
+                // browser->java conversion: min->ms, reverse sign
+                timezoneOffset = -Integer.parseInt(tzo) * 60 * 1000;
+            } catch (final NumberFormatException e) {
+                timezoneOffset = 0; // default gmt+0
+            }
+        }
+        if (rtzo != null) {
+            try {
+                // browser->java conversion: min->ms, reverse sign
+                rawTimezoneOffset = -Integer.parseInt(rtzo) * 60 * 1000;
+            } catch (final NumberFormatException e) {
+                rawTimezoneOffset = 0; // default gmt+0
+            }
+        }
+        if (dstSavings != null) {
+            try {
+                // browser->java conversion: min->ms
+                this.dstSavings = Integer.parseInt(dstSavings) * 60 * 1000;
+            } catch (final NumberFormatException e) {
+                this.dstSavings = 0; // default no savings
+            }
+        }
+        if (dstInEffect != null) {
+            this.dstInEffect = Boolean.parseBoolean(dstInEffect);
+        }
+
+        if (tzId == null || "undefined".equals(tzId)) {
+            this.timeZoneId = null;
+        } else {
+            this.timeZoneId = tzId;
+        }
+
+        if (curDate != null) {
+            try {
+                long curTime = Long.parseLong(curDate);
+                clientServerTimeDelta = curTime - new Date().getTime();
+            } catch (final NumberFormatException e) {
+                clientServerTimeDelta = 0;
+            }
+        }
+        this.touchDevice = touchDevice;
+
+        this.windowName = windowName;
+    }
+
+    /**
+     * Gets the height of the screen in pixels. This is the full screen
+     * resolution and not the height available for the application.
+     *
+     * @return the height of the screen in pixels.
+     */
+    public int getScreenHeight() {
+        return screenHeight;
+    }
+
+    /**
+     * Gets the width of the screen in pixels. This is the full screen
+     * resolution and not the width available for the application.
+     *
+     * @return the width of the screen in pixels.
+     */
+    public int getScreenWidth() {
+        return screenWidth;
+    }
+
+    /**
+     * Returns the browser-reported TimeZone offset in milliseconds from GMT.
+     * This includes possible daylight saving adjustments, to figure out which
+     * TimeZone the user actually might be in, see
+     * {@link #getRawTimezoneOffset()}.
+     *
+     * @see ExtendedClientDetails#getRawTimezoneOffset()
+     * @return timezone offset in milliseconds, 0 if not available
+     */
+    public int getTimezoneOffset() {
+        return timezoneOffset;
+    }
+
+    /**
+     * Returns the TimeZone Id (like "Europe/Helsinki") provided by the browser
+     * (if the browser supports this feature).
+     *
+     * @return the TimeZone Id if provided by the browser, null otherwise.
+     * @see <a href=
+     *      "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/resolvedOptions">Intl.DateTimeFormat.prototype.resolvedOptions()</a>
+     */
+    public String getTimeZoneId() {
+        return timeZoneId;
+    }
+
+    /**
+     * Returns the browser-reported TimeZone offset in milliseconds from GMT
+     * ignoring possible daylight saving adjustments that may be in effect in
+     * the browser.
+     * <p>
+     * You can use this to figure out which TimeZones the user could actually be
+     * in by calling {@link TimeZone#getAvailableIDs(int)}.
+     * </p>
+     * <p>
+     * If {@link #getRawTimezoneOffset()} and {@link #getTimezoneOffset()}
+     * returns the same value, the browser is either in a zone that does not
+     * currently have daylight saving time, or in a zone that never has daylight
+     * saving time.
+     * </p>
+     *
+     * @return timezone offset in milliseconds excluding DST, 0 if not available
+     */
+    public int getRawTimezoneOffset() {
+        return rawTimezoneOffset;
+    }
+
+    /**
+     * Returns the offset in milliseconds between the browser's GMT TimeZone and
+     * DST.
+     *
+     * @return the number of milliseconds that the TimeZone shifts when DST is
+     *         in effect
+     */
+    public int getDSTSavings() {
+        return dstSavings;
+    }
+
+    /**
+     * Returns whether daylight saving time (DST) is currently in effect in the
+     * region of the browser or not.
+     *
+     * @return true if the browser resides at a location that currently is in
+     *         DST
+     */
+    public boolean isDSTInEffect() {
+        return dstInEffect;
+    }
+
+    /**
+     * Returns the current date and time of the browser. This will not be
+     * entirely accurate due to varying network latencies, but should provide a
+     * close-enough value for most cases. Also note that the returned Date
+     * object uses servers default time zone, not the clients.
+     * <p>
+     * To get the actual date and time shown in the end users computer, you can
+     * do something like:
+     *
+     * <pre>
+     * WebBrowser browser = ...;
+     * SimpleTimeZone timeZone = new SimpleTimeZone(browser.getTimezoneOffset(), "Fake client time zone");
+     * DateFormat format = DateFormat.getDateTimeInstance();
+     * format.setTimeZone(timeZone);
+     * myLabel.setValue(format.format(browser.getCurrentDate()));
+     * </pre>
+     *
+     * @return the current date and time of the browser.
+     * @see #isDSTInEffect()
+     * @see #getDSTSavings()
+     * @see #getTimezoneOffset()
+     */
+    public Date getCurrentDate() {
+        return new Date(new Date().getTime() + clientServerTimeDelta);
+    }
+
+    /**
+     * Checks if the browser supports touch events.
+     *
+     * @return true if the browser is detected to support touch events, false
+     *         otherwise
+     */
+    public boolean isTouchDevice() {
+        return touchDevice;
+    }
+
+    /**
+     * Returns a unique browser window identifier. For internal use only.
+     *
+     * @return An id which persists if the UI is reloaded in the same browser
+     * window/tab.
+     */
+    public String getWindowName() {
+        return windowName;
+    }
+
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.flow.component.page;
 
 import java.io.Serializable;

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -532,7 +532,7 @@ public class Page implements Serializable {
      * Callback for receiving extende client-side details.
      */
     @FunctionalInterface
-    public interface ExtendedClientDetailsReceiver {
+    public interface ExtendedClientDetailsReceiver extends Serializable {
         void receiveDetails(ExtendedClientDetails extendedClientDetails);
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -23,7 +23,6 @@ import java.io.Serializable;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Function;
 
 import com.vaadin.flow.component.ClientCallable;
@@ -37,7 +36,6 @@ import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
 import com.vaadin.flow.component.internal.UIInternals.JavaScriptInvocation;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableConsumer;
-import com.vaadin.flow.internal.JsonCodec;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.shared.ui.Dependency;
 import com.vaadin.flow.shared.ui.Dependency.Type;

--- a/flow-server/src/main/java/com/vaadin/flow/server/WebBrowser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/WebBrowser.java
@@ -24,8 +24,8 @@ import java.util.TimeZone;
 import com.vaadin.flow.shared.BrowserDetails;
 
 /**
- * Provides information about the web browser the user is using. Provides
- * information such as browser name and version, screen resolution and IP
+ * Provides information about the web browser the user is using that is directly
+ * available in the request, for instance browser name and version and IP
  * address.
  *
  * @author Vaadin Ltd
@@ -33,41 +33,15 @@ import com.vaadin.flow.shared.BrowserDetails;
  */
 public class WebBrowser implements Serializable {
 
-    private int screenHeight = -1;
-    private int screenWidth = -1;
+
     private String browserApplication = null;
     private Locale locale;
     private String address;
     private boolean secureConnection;
-    private int timezoneOffset = 0;
-    private int rawTimezoneOffset = 0;
-    private int dstSavings;
-    private boolean dstInEffect;
-    private String timeZoneId;
-    private boolean touchDevice;
+
 
     private BrowserDetails browserDetails;
-    private long clientServerTimeDelta;
 
-    /**
-     * Gets the height of the screen in pixels. This is the full screen
-     * resolution and not the height available for the application.
-     *
-     * @return the height of the screen in pixels.
-     */
-    public int getScreenHeight() {
-        return screenHeight;
-    }
-
-    /**
-     * Gets the width of the screen in pixels. This is the full screen
-     * resolution and not the width available for the application.
-     *
-     * @return the width of the screen in pixels.
-     */
-    public int getScreenWidth() {
-        return screenWidth;
-    }
 
     /**
      * Get the browser user-agent string.
@@ -317,186 +291,6 @@ public class WebBrowser implements Serializable {
         return browserDetails.isChromeOS();
     }
 
-    /**
-     * Returns the browser-reported TimeZone offset in milliseconds from GMT.
-     * This includes possible daylight saving adjustments, to figure out which
-     * TimeZone the user actually might be in, see
-     * {@link #getRawTimezoneOffset()}.
-     *
-     * @see WebBrowser#getRawTimezoneOffset()
-     * @return timezone offset in milliseconds, 0 if not available
-     */
-    public int getTimezoneOffset() {
-        return timezoneOffset;
-    }
-
-    /**
-     * Returns the TimeZone Id (like "Europe/Helsinki") provided by the browser
-     * (if the browser supports this feature).
-     *
-     * @return the TimeZone Id if provided by the browser, null otherwise.
-     * @see <a href=
-     *      "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DateTimeFormat/resolvedOptions">Intl.DateTimeFormat.prototype.resolvedOptions()</a>
-     */
-    public String getTimeZoneId() {
-        return timeZoneId;
-    }
-
-    /**
-     * Returns the browser-reported TimeZone offset in milliseconds from GMT
-     * ignoring possible daylight saving adjustments that may be in effect in
-     * the browser.
-     * <p>
-     * You can use this to figure out which TimeZones the user could actually be
-     * in by calling {@link TimeZone#getAvailableIDs(int)}.
-     * </p>
-     * <p>
-     * If {@link #getRawTimezoneOffset()} and {@link #getTimezoneOffset()}
-     * returns the same value, the browser is either in a zone that does not
-     * currently have daylight saving time, or in a zone that never has daylight
-     * saving time.
-     * </p>
-     *
-     * @return timezone offset in milliseconds excluding DST, 0 if not available
-     */
-    public int getRawTimezoneOffset() {
-        return rawTimezoneOffset;
-    }
-
-    /**
-     * Returns the offset in milliseconds between the browser's GMT TimeZone and
-     * DST.
-     *
-     * @return the number of milliseconds that the TimeZone shifts when DST is
-     *         in effect
-     */
-    public int getDSTSavings() {
-        return dstSavings;
-    }
-
-    /**
-     * Returns whether daylight saving time (DST) is currently in effect in the
-     * region of the browser or not.
-     *
-     * @return true if the browser resides at a location that currently is in
-     *         DST
-     */
-    public boolean isDSTInEffect() {
-        return dstInEffect;
-    }
-
-    /**
-     * Returns the current date and time of the browser. This will not be
-     * entirely accurate due to varying network latencies, but should provide a
-     * close-enough value for most cases. Also note that the returned Date
-     * object uses servers default time zone, not the clients.
-     * <p>
-     * To get the actual date and time shown in the end users computer, you can
-     * do something like:
-     *
-     * <pre>
-     * WebBrowser browser = ...;
-     * SimpleTimeZone timeZone = new SimpleTimeZone(browser.getTimezoneOffset(), "Fake client time zone");
-     * DateFormat format = DateFormat.getDateTimeInstance();
-     * format.setTimeZone(timeZone);
-     * myLabel.setValue(format.format(browser.getCurrentDate()));
-     * </pre>
-     *
-     * @return the current date and time of the browser.
-     * @see #isDSTInEffect()
-     * @see #getDSTSavings()
-     * @see #getTimezoneOffset()
-     */
-    public Date getCurrentDate() {
-        return new Date(new Date().getTime() + clientServerTimeDelta);
-    }
-
-    /**
-     * Checks if the browser supports touch events.
-     *
-     * @return true if the browser is detected to support touch events, false
-     *         otherwise
-     */
-    public boolean isTouchDevice() {
-        return touchDevice;
-    }
-
-    /**
-     * For internal use only. Updates all properties in the class according to
-     * the given information.
-     *
-     * @param sw
-     *            Screen width
-     * @param sh
-     *            Screen height
-     * @param tzo
-     *            TimeZone offset in minutes from GMT
-     * @param rtzo
-     *            raw TimeZone offset in minutes from GMT (w/o DST adjustment)
-     * @param dstSavings
-     *            the difference between the raw TimeZone and DST in minutes
-     * @param dstInEffect
-     *            is DST currently active in the region or not?
-     * @param curDate
-     *            the current date in milliseconds since the epoch
-     * @param touchDevice
-     */
-    void updateClientSideDetails(String sw, String sh, String tzo, String rtzo,
-            String dstSavings, String dstInEffect, String tzId, String curDate,
-            boolean touchDevice) {
-        if (sw != null) {
-            try {
-                screenHeight = Integer.parseInt(sh);
-                screenWidth = Integer.parseInt(sw);
-            } catch (final NumberFormatException e) {
-                screenHeight = screenWidth = -1;
-            }
-        }
-        if (tzo != null) {
-            try {
-                // browser->java conversion: min->ms, reverse sign
-                timezoneOffset = -Integer.parseInt(tzo) * 60 * 1000;
-            } catch (final NumberFormatException e) {
-                timezoneOffset = 0; // default gmt+0
-            }
-        }
-        if (rtzo != null) {
-            try {
-                // browser->java conversion: min->ms, reverse sign
-                rawTimezoneOffset = -Integer.parseInt(rtzo) * 60 * 1000;
-            } catch (final NumberFormatException e) {
-                rawTimezoneOffset = 0; // default gmt+0
-            }
-        }
-        if (dstSavings != null) {
-            try {
-                // browser->java conversion: min->ms
-                this.dstSavings = Integer.parseInt(dstSavings) * 60 * 1000;
-            } catch (final NumberFormatException e) {
-                this.dstSavings = 0; // default no savings
-            }
-        }
-        if (dstInEffect != null) {
-            this.dstInEffect = Boolean.parseBoolean(dstInEffect);
-        }
-
-        if (tzId == null || "undefined".equals(tzId)) {
-            this.timeZoneId = null;
-        } else {
-            this.timeZoneId = tzId;
-        }
-
-        if (curDate != null) {
-            try {
-                long curTime = Long.parseLong(curDate);
-                clientServerTimeDelta = curTime - new Date().getTime();
-            } catch (final NumberFormatException e) {
-                clientServerTimeDelta = 0;
-            }
-        }
-        this.touchDevice = touchDevice;
-
-    }
 
     /**
      * For internal use only. Updates all properties in the class according to
@@ -516,17 +310,6 @@ public class WebBrowser implements Serializable {
         if (agent != null) {
             browserApplication = agent;
             browserDetails = new BrowserDetails(agent);
-        }
-
-        if (request.getParameter("v-sw") != null) {
-            updateClientSideDetails(request.getParameter("v-sw"),
-                    request.getParameter("v-sh"), request.getParameter("v-tzo"),
-                    request.getParameter("v-rtzo"),
-                    request.getParameter("v-dstd"),
-                    request.getParameter("v-dston"),
-                    request.getParameter("v-tzid"),
-                    request.getParameter("v-curdate"),
-                    request.getParameter("v-td") != null);
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/WebBrowser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/WebBrowser.java
@@ -17,9 +17,7 @@
 package com.vaadin.flow.server;
 
 import java.io.Serializable;
-import java.util.Date;
 import java.util.Locale;
-import java.util.TimeZone;
 
 import com.vaadin.flow.shared.BrowserDetails;
 

--- a/flow-server/src/main/resources/com/vaadin/flow/server/BootstrapHandler.js
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/BootstrapHandler.js
@@ -151,11 +151,11 @@
            var params = {  };
 
            /* Screen height and width */
-           params['v-sh'] = window.screen.height.toString();
-           params['v-sw'] = window.screen.width.toString();
+           params['v-sh'] = window.screen.height;
+           params['v-sw'] = window.screen.width;
 
            var d = new Date();
-           params['v-curdate'] = d.getTime().toString();
+           params['v-curdate'] = d.getTime();
 
            var tzo1 = d.getTimezoneOffset(); /* current offset */
            var dstDiff = 0;
@@ -172,16 +172,16 @@
            }
 
            /* Time zone offset */
-           params['v-tzo'] = tzo1.toString();
+           params['v-tzo'] = tzo1;
 
            /* DST difference */
-           params['v-dstd'] = dstDiff.toString();
+           params['v-dstd'] = dstDiff;
 
            /* Raw time zone offset */
-           params['v-rtzo'] = rtzo.toString();
+           params['v-rtzo'] = rtzo;
 
            /* DST in effect? */
-           params['v-dston'] = (tzo1 != rtzo).toString();
+           params['v-dston'] = (tzo1 != rtzo);
 
            /* Time zone id (if available) */
            try {
@@ -207,6 +207,13 @@
            }
            params['v-td'] = false;
 
+           /* Stringify each value (they are parsed on the server side) */
+           Object.keys(params).forEach(function(key) {
+                var value = params[key];
+                if (typeof value !== 'undefined') {
+                    params[key] = value.toString();
+                }
+           });
            return params;
         }
 	};

--- a/flow-server/src/main/resources/com/vaadin/flow/server/BootstrapHandler.js
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/BootstrapHandler.js
@@ -146,7 +146,69 @@
 				}
 				ws.pendingApps = null;
 			}
-		}
+		},
+        getBrowserDetailsParameters: function() {
+           var params = {  };
+
+           /* Screen height and width */
+           params['v-sh'] = window.screen.height.toString();
+           params['v-sw'] = window.screen.width.toString();
+
+           var d = new Date();
+           params['v-curdate'] = d.getTime().toString();
+
+           var tzo1 = d.getTimezoneOffset(); /* current offset */
+           var dstDiff = 0;
+           var rtzo = tzo1;
+
+           for (var m = 12; m > 0; m--) {
+               d.setUTCMonth(m);
+               var tzo2 = d.getTimezoneOffset();
+               if (tzo1 != tzo2) {
+                   dstDiff = (tzo1 > tzo2 ? tzo1 - tzo2 : tzo2 - tzo1);
+                   rtzo = (tzo1 > tzo2 ? tzo1 : tzo2);
+                   break;
+               }
+           }
+
+           /* Time zone offset */
+           params['v-tzo'] = tzo1.toString();
+
+           /* DST difference */
+           params['v-dstd'] = dstDiff.toString();
+
+           /* Raw time zone offset */
+           params['v-rtzo'] = rtzo.toString();
+
+           /* DST in effect? */
+           params['v-dston'] = (tzo1 != rtzo).toString();
+
+           /* Time zone id (if available) */
+           try {
+               params['v-tzid'] = Intl.DateTimeFormat().resolvedOptions().timeZone;
+           } catch (err) {
+               params['v-tzid'] = '';
+           }
+
+           /* Window name */
+           if (window.name) {
+               params['v-wn'] = window.name;
+           }
+
+           /* Detect touch device support */
+           var supportsTouch = false;
+           try {
+               document.createEvent("TouchEvent");
+               supportsTouch = true;
+           } catch (e) {
+               /* Chrome and IE10 touch detection */
+               supportsTouch = 'ontouchstart' in window
+                   || (typeof navigator.msMaxTouchPoints !== 'undefined');
+           }
+           params['v-td'] = false;
+
+           return params;
+        }
 	};
 	
 	log('Flow bootstrap loaded');

--- a/flow-server/src/main/resources/com/vaadin/flow/server/BootstrapHandler.js
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/BootstrapHandler.js
@@ -148,73 +148,78 @@
 			}
 		},
         getBrowserDetailsParameters: function() {
-           var params = {  };
+            var params = {  };
 
-           /* Screen height and width */
-           params['v-sh'] = window.screen.height;
-           params['v-sw'] = window.screen.width;
+            /* Screen height and width */
+            params['v-sh'] = window.screen.height;
+            params['v-sw'] = window.screen.width;
 
-           var d = new Date();
-           params['v-curdate'] = d.getTime();
+            /* Current time */
+            var date = new Date();
+            params['v-curdate'] = date.getTime();
 
-           var tzo1 = d.getTimezoneOffset(); /* current offset */
-           var dstDiff = 0;
-           var rtzo = tzo1;
+            /* Current timezone offset (including DST shift) */
+            var tzo1 = date.getTimezoneOffset();
 
-           for (var m = 12; m > 0; m--) {
-               d.setUTCMonth(m);
-               var tzo2 = d.getTimezoneOffset();
-               if (tzo1 != tzo2) {
-                   dstDiff = (tzo1 > tzo2 ? tzo1 - tzo2 : tzo2 - tzo1);
-                   rtzo = (tzo1 > tzo2 ? tzo1 : tzo2);
-                   break;
+            /* Compare the current tz offset with the first offset from the end
+            of the year that differs --- if less that, we are in DST, otherwise
+            we are in normal time */
+            var dstDiff = 0;
+            var rawTzo = tzo1;
+            for(var m = 12; m > 0; m--) {
+                date.setUTCMonth(m);
+                var tzo2 = date.getTimezoneOffset();
+                if (tzo1 != tzo2) {
+                    dstDiff = (tzo1 > tzo2 ? tzo1 - tzo2 : tzo2 - tzo1);
+                    rawTzo = (tzo1 > tzo2 ? tzo1 : tzo2);
+                    break;
                }
-           }
+            }
 
-           /* Time zone offset */
-           params['v-tzo'] = tzo1;
+            /* Time zone offset */
+            params['v-tzo'] = tzo1;
 
-           /* DST difference */
-           params['v-dstd'] = dstDiff;
+            /* DST difference */
+            params['v-dstd'] = dstDiff;
 
-           /* Raw time zone offset */
-           params['v-rtzo'] = rtzo;
+            /* Time zone offset without DST */
+            params['v-rtzo'] = rawTzo;
 
-           /* DST in effect? */
-           params['v-dston'] = (tzo1 != rtzo);
+            /* DST in effect? */
+            params['v-dston'] = (tzo1 != rawTzo);
 
-           /* Time zone id (if available) */
-           try {
-               params['v-tzid'] = Intl.DateTimeFormat().resolvedOptions().timeZone;
-           } catch (err) {
-               params['v-tzid'] = '';
-           }
+            /* Time zone id (if available) */
+            try {
+                params['v-tzid'] = Intl.DateTimeFormat().resolvedOptions().timeZone;
+            } catch (err) {
+                params['v-tzid'] = '';
+            }
 
-           /* Window name */
-           if (window.name) {
-               params['v-wn'] = window.name;
-           }
+            /* Window name */
+            if (window.name) {
+                params['v-wn'] = window.name;
+            }
 
-           /* Detect touch device support */
-           var supportsTouch = false;
-           try {
-               document.createEvent("TouchEvent");
-               supportsTouch = true;
-           } catch (e) {
-               /* Chrome and IE10 touch detection */
-               supportsTouch = 'ontouchstart' in window
+            /* Detect touch device support */
+            var supportsTouch = false;
+            try {
+                document.createEvent("TouchEvent");
+                supportsTouch = true;
+            } catch (e) {
+                /* Chrome and IE10 touch detection */
+                supportsTouch = 'ontouchstart' in window
                    || (typeof navigator.msMaxTouchPoints !== 'undefined');
-           }
-           params['v-td'] = false;
+            }
+            params['v-td'] = false;
 
-           /* Stringify each value (they are parsed on the server side) */
-           Object.keys(params).forEach(function(key) {
+            /* Stringify each value (they are parsed on the server side) */
+            Object.keys(params).forEach(function(key) {
                 var value = params[key];
                 if (typeof value !== 'undefined') {
                     params[key] = value.toString();
                 }
-           });
-           return params;
+            });
+            return params;
         }
 	};
 	

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/ExtendedClientDetailsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/ExtendedClientDetailsTest.java
@@ -1,0 +1,34 @@
+package com.vaadin.flow.component.page;
+
+import org.junit.Test;
+import org.junit.Assert;
+
+public class ExtendedClientDetailsTest {
+
+    @Test
+    public void initializeWithClientValues_gettersReturnExpectedValues() {
+        final ExtendedClientDetails details = new ExtendedClientDetails(
+                "2560",
+                "1450",
+                "-270", // minutes from UTC
+                "-210", // minutes from UTC without DST
+                "60", // dist shift amount
+                "true",
+                "Asia/Tehran",
+                "1555000000000", // Apr 11 2019
+                "false",
+                "ROOT-1234567-0.1234567");
+        Assert.assertEquals(2560, details.getScreenWidth());
+        Assert.assertEquals(1450, details.getScreenHeight());
+        Assert.assertEquals(16200000, details.getTimezoneOffset());
+        Assert.assertEquals("Asia/Tehran", details.getTimeZoneId());
+        Assert.assertEquals(12600000, details.getRawTimezoneOffset());
+        Assert.assertEquals(3600000, details.getDSTSavings());
+        Assert.assertEquals(true, details.isDSTInEffect());
+        Assert.assertEquals(false, details.isTouchDevice());
+        Assert.assertEquals("ROOT-1234567-0.1234567", details.getWindowName());
+
+        // Don't test getCurrentDate() and time delta due to the dependency on
+        // server-side time
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
@@ -16,14 +16,24 @@
 package com.vaadin.flow.component.page;
 
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.internal.JsonUtils;
 import com.vaadin.flow.shared.Registration;
+import com.vaadin.tests.util.MockUI;
+
+import elemental.json.Json;
+import elemental.json.JsonObject;
+import elemental.json.JsonValue;
 
 public class PageTest {
 
@@ -144,5 +154,63 @@ public class PageTest {
                         CoreMatchers.containsString("resize")));
 
         Assert.assertTrue(page.firstParam instanceof Component);
+    }
+
+    @Test
+    public void retrieveExtendedClientDetails_twice_jsOnceAndCallbackTwice() {
+        // given
+        final UI mockUI = new MockUI();
+        final Page page = new Page(mockUI) {
+            @Override
+            public PendingJavaScriptResult executeJs(String expression,
+                                                     Serializable... params) {
+                super.executeJs(expression,params);
+
+                return new PendingJavaScriptResult() {
+
+                    @Override
+                    public boolean cancelExecution() {
+                        return false;
+                    }
+
+                    @Override
+                    public boolean isSentToBrowser() {
+                        return false;
+                    }
+
+                    @Override
+                    public void then(SerializableConsumer<JsonValue> resultHandler,
+                                     SerializableConsumer<String> errorHandler) {
+                        final HashMap<String,String> params = new HashMap<>();
+                        params.put("v-sw","2560");
+                        params.put("v-sh","1450");
+                        params.put("v-tzo","-270");
+                        params.put("v-rtzo","-210");
+                        params.put("v-dstd","60");
+                        params.put("v-dston","true");
+                        params.put("v-tzid","Asia/Tehran");
+                        params.put("v-curdate","1555000000000");
+                        params.put("v-td","false");
+                        params.put("v-wn","ROOT-1234567-0.1234567");
+                        resultHandler.accept(JsonUtils.createObject(
+                                params, Json::create));
+                    }
+                };
+            }
+        };
+        final AtomicInteger callbackInvocations = new AtomicInteger();
+        final Page.ExtendedClientDetailsReceiver receiver = details -> {
+            callbackInvocations.incrementAndGet();
+        };
+
+        // when
+        page.retrieveExtendedClientDetails(receiver);
+        page.retrieveExtendedClientDetails(receiver);
+
+        // then
+        final int jsInvocations =
+                mockUI.getInternals().dumpPendingJavaScriptInvocations().size();
+        Assert.assertEquals(1, jsInvocations);
+        Assert.assertEquals(2, callbackInvocations.get());
     }
 }

--- a/flow-tests/test-dev-mode/src/main/java/com/vaadin/flow/uitest/ui/InfoView.java
+++ b/flow-tests/test-dev-mode/src/main/java/com/vaadin/flow/uitest/ui/InfoView.java
@@ -77,7 +77,6 @@ public class InfoView extends Div {
 
         info("Os", os.stream().collect(Collectors.joining(", ")));
 
-        add(browser, "Touch device", webBrowser.isTouchDevice());
         add(browser, "Chrome", webBrowser.isChrome());
         add(browser, "Edge", webBrowser.isEdge());
         add(browser, "Firefox", webBrowser.isFirefox());
@@ -92,8 +91,6 @@ public class InfoView extends Div {
         info("User-agent", webBrowser.getBrowserApplication());
         info("Browser major", webBrowser.getBrowserMajorVersion());
         info("Browser minor", webBrowser.getBrowserMinorVersion());
-        info("Screen height", webBrowser.getScreenHeight());
-        info("Screen width", webBrowser.getScreenWidth());
         info("Locale", webBrowser.getLocale());
 
         info("Secure connection (https)", webBrowser.isSecureConnection());

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/VerifyBrowserVersionView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/VerifyBrowserVersionView.java
@@ -28,11 +28,5 @@ public class VerifyBrowserVersionView extends Div {
         WebBrowser browser = VaadinSession.getCurrent().getBrowser();
         Span userAgent = new Span(browser.getBrowserApplication());
         userAgent.setId("userAgent");
-
-        Span touchDevice = new Span(
-                "Touch device? " + (browser.isTouchDevice() ? "YES" : "No"));
-        touchDevice.setId("touchDevice");
-
-        add(userAgent, touchDevice);
     }
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/VerifyBrowserVersionView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/VerifyBrowserVersionView.java
@@ -28,5 +28,6 @@ public class VerifyBrowserVersionView extends Div {
         WebBrowser browser = VaadinSession.getCurrent().getBrowser();
         Span userAgent = new Span(browser.getBrowserApplication());
         userAgent.setId("userAgent");
+        add(userAgent);
     }
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/VerifyExtendedClientDetailsView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/VerifyExtendedClientDetailsView.java
@@ -1,0 +1,32 @@
+package com.vaadin.flow;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.Route;
+
+@Route("com.vaadin.flow.VerifyExtendedClientDetailsView")
+public class VerifyExtendedClientDetailsView extends Div {
+
+    public VerifyExtendedClientDetailsView() {
+        UI.getCurrent().getPage().retrieveExtendedClientDetails(details ->{
+            addSpan("screenWidth", details.getScreenWidth());
+            addSpan("screenHeight", details.getScreenHeight());
+            addSpan("timezoneOffset", details.getTimezoneOffset());
+            addSpan("timeZoneId", details.getTimeZoneId());
+            addSpan("rawTimezoneOffset", details.getRawTimezoneOffset());
+            addSpan("DSTSavings", details.getDSTSavings());
+            addSpan("DSTInEffect", details.isDSTInEffect());
+            addSpan("currentDate", details.getCurrentDate());
+            addSpan("touchDevice", details.isTouchDevice());
+            addSpan("windowName", details.getWindowName());
+        });
+    }
+
+    private void addSpan(String name, Object value) {
+        Span span = new Span(value.toString());
+        span.setId(name);
+        add(span);
+
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/VerifyBrowserVersionIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/VerifyBrowserVersionIT.java
@@ -36,9 +36,6 @@ public class VerifyBrowserVersionIT extends ChromeBrowserTest {
         }
 
         assertThat(userAgent, containsString(browserIdentifier));
-
-        assertThat(findElement(By.id("touchDevice")).getText(),
-                is("Touch device? No"));
     }
 
     private String getExpectedUserAgentString(DesiredCapabilities dCap) {

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/VerifyExtendedClientDetailsIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/VerifyExtendedClientDetailsIT.java
@@ -1,0 +1,63 @@
+package com.vaadin.flow;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.Matchers.isOneOf;
+import static org.hamcrest.Matchers.not;
+
+public class VerifyExtendedClientDetailsIT extends ChromeBrowserTest {
+
+    private final TypeSafeMatcher<String> isParseableAsInteger() {
+        return new TypeSafeMatcher<String>() {
+
+            @Override
+            protected boolean matchesSafely(String s) {
+                try {
+                    Integer.parseInt(s);
+                    return true;
+                } catch (NumberFormatException nfe) {
+                    return false;
+                }
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("only digits");
+            }
+        };
+    }
+
+    @Test
+    public void verifyClientDetails() {
+        open();
+
+        Assert.assertThat(findElement(By.id("screenWidth")).getText(),
+                isParseableAsInteger());
+        Assert.assertThat(findElement(By.id("screenHeight")).getText(),
+                isParseableAsInteger());
+        Assert.assertThat(findElement(By.id("timezoneOffset")).getText(),
+                isParseableAsInteger());
+        Assert.assertThat(findElement(By.id("timeZoneId")).getText(),
+                not(isEmptyString()));
+        Assert.assertThat(findElement(By.id("rawTimezoneOffset")).getText(),
+                isParseableAsInteger());
+        Assert.assertThat(findElement(By.id("DSTSavings")).getText(),
+                isParseableAsInteger());
+        Assert.assertThat(findElement(By.id("DSTInEffect")).getText(),
+                isOneOf("true","false"));
+        Assert.assertThat(findElement(By.id("currentDate")).getText(),
+                not(isEmptyString()));
+        Assert.assertThat(findElement(By.id("touchDevice")).getText(),
+                isOneOf("true","false"));
+        Assert.assertThat(findElement(By.id("windowName")).getText(),
+                not(isEmptyString()));
+    }
+
+}


### PR DESCRIPTION
This PR moves currently disused fields in `WebBrowser` (screen width, height, tz fields and touch support flag) into a separate class `ExtendedClientDetails` and makes them user-accessible through `Page#retrieveExtendedClientDetails`. Also exposes the `window.name` JS attribute which is required for upcoming `@PreserveOnRefresh`-like feature. Related to  #3657 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5564)
<!-- Reviewable:end -->
