### PR TITLE
Lock dev dependencies versions, add webcomponentsjs

### DIFF
--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/TestComponents.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/TestComponents.java
@@ -82,7 +82,6 @@ public class TestComponents {
 
     @Route
     @Theme(value = Lumo.class, variant = Lumo.DARK)
-    @NpmPackage(value = "@webcomponents/webcomponentsjs", version = "2.2.9")
     public static class MainView extends Component {
         ButtonComponent buttonComponent;
         IconComponent iconComponent;

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -23,7 +23,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Future;
 
-import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.dnd.DragSource;
 import com.vaadin.flow.component.internal.UIInternals;
 import com.vaadin.flow.component.page.LoadingIndicatorConfiguration;

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Future;
 
+import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.dnd.DragSource;
 import com.vaadin.flow.component.internal.UIInternals;
 import com.vaadin.flow.component.page.LoadingIndicatorConfiguration;
@@ -88,6 +89,7 @@ import org.slf4j.LoggerFactory;
  *
  */
 @Tag("body")
+@NpmPackage(value = "@webcomponents/webcomponentsjs", version = "2.2.10")
 public class UI extends Component
         implements PollNotifier, HasComponents, RouterLayout {
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -89,7 +89,6 @@ import org.slf4j.LoggerFactory;
  *
  */
 @Tag("body")
-@NpmPackage(value = "@webcomponents/webcomponentsjs", version = "2.2.10")
 public class UI extends Component
         implements PollNotifier, HasComponents, RouterLayout {
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdatePackages.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -136,16 +137,16 @@ public class NodeUpdatePackages extends NodeUpdater {
     private boolean updatePackageJsonDevDependencies(JsonObject packageJson) {
         boolean added = false;
         JsonObject json = packageJson.getObject(DEV_DEPENDENCIES);
-        for (String pkg : Arrays.asList(
-                "webpack",
-                "webpack-cli",
-                "webpack-dev-server",
-                "webpack-babel-multi-target-plugin",
-                "copy-webpack-plugin"
-                )) {
-            if (!json.hasKey(pkg)) {
-                json.put(pkg, "latest");
-                log().info("Added {} dependency.", pkg);
+        Map<String, String> devDependencies = new HashMap<>();
+        devDependencies.put("webpack", "4.30.0");
+        devDependencies.put("webpack-cli", "3.3.0");
+        devDependencies.put("webpack-dev-server", "3.3.0");
+        devDependencies.put("webpack-babel-multi-target-plugin", "2.1.0");
+        devDependencies.put("copy-webpack-plugin", "5.0.3");
+        for(Entry<String, String> entry: devDependencies.entrySet()) {
+            if(!json.hasKey(entry.getKey())) {
+                json.put(entry.getKey(), entry.getValue());
+                log().info("Added {} dependency.", entry.getKey());
                 added = true;
             }
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdatePackages.java
@@ -19,7 +19,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URL;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -38,7 +37,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * Updates <code>package.json</code> by visiting {@link NpmPackage} annotations found in
  * the classpath. It also visits classes annotated with {@link NpmPackage}
  */
-@NpmPackage(value = "@webcomponents/webcomponentsjs", version = "2.2.9")
 @NpmPackage(value = "@polymer/polymer", version = "3.1.0")
 public class NodeUpdatePackages extends NodeUpdater {
 
@@ -130,6 +128,9 @@ public class NodeUpdatePackages extends NodeUpdater {
                 log().info("Added {}@{} dependency.", e.getKey(), version);
                 added = true;
             }
+        }
+        if(!json.hasKey("@webcomponents/webcomponentsjs")) {
+            json.put("@webcomponents/webcomponentsjs", "2.2.10");
         }
         return added;
     }


### PR DESCRIPTION
Lock the dev dependencies instead of using latest
as for instance versions after 2.1.0 of webpack-babel-multi-target-plugin
throw errors and exceptions on windows.

Added NpmPackage annotation for webcomponentsjs
as the npm package is used from bootstrap, but never
downloaded to node_modules.

Fixes #5557

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5566)
<!-- Reviewable:end -->
