### PR TITLE
Use FrontendUtils to get Node executable

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/NodeBuildFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/NodeBuildFrontendMojo.java
@@ -22,7 +22,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -39,7 +38,6 @@ import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.plugin.common.FlowPluginFrontendUtils;
-import com.vaadin.flow.server.frontend.FrontendToolsLocator;
 import com.vaadin.flow.server.frontend.FrontendUtils;
 import com.vaadin.flow.server.frontend.NodeTasks;
 import com.vaadin.flow.theme.Theme;

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/NodeBuildFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/NodeBuildFrontendMojo.java
@@ -160,17 +160,11 @@ public class NodeBuildFrontendMojo extends AbstractMojo {
                     webpackExecutable.getAbsolutePath()));
         }
 
-        FrontendToolsLocator frontendToolsLocator = new FrontendToolsLocator();
-        File nodePath = Optional.of(new File("./node/node"))
-                .filter(frontendToolsLocator::verifyTool)
-                .orElseGet(() -> frontendToolsLocator.tryLocateTool("node")
-                        .orElseThrow(() -> new IllegalStateException(
-                                "Failed to determine 'node' tool. "
-                                        + "Please install it using the https://nodejs.org/en/download/ guide.")));
+        String nodePath  = FrontendUtils.getNodeExecutable();
 
         Process webpackLaunch = null;
         try {
-            webpackLaunch =  new ProcessBuilder(nodePath.getAbsolutePath(),
+            webpackLaunch =  new ProcessBuilder(nodePath,
                     webpackExecutable.getAbsolutePath()).directory(project.getBasedir())
                     .redirectOutput(ProcessBuilder.Redirect.INHERIT).start();
             int errorCode = webpackLaunch.waitFor();


### PR DESCRIPTION
Changed to use FrontendUtils to get the Node
executable as it takes into account the fact that
windows and *nix need different targets.

Fixes Windows execution of `runWebpack` in the 
build-frontend mojo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5572)
<!-- Reviewable:end -->
