### PR TITLE
#3522 preserve on refresh

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -41,6 +41,7 @@ import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.internal.ComponentMetaData.DependencyInfo;
 import com.vaadin.flow.component.internal.ComponentMetaData.HtmlImportDependency;
+import com.vaadin.flow.component.page.ExtendedClientDetails;
 import com.vaadin.flow.component.page.Page;
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.Element;
@@ -196,6 +197,9 @@ public class UIInternals implements Serializable {
     private String appId;
 
     private Component activeDragSourceComponent;
+
+    private ExtendedClientDetails extendedClientDetails = null;
+
 
     /**
      * Creates a new instance for the given UI.
@@ -1041,5 +1045,25 @@ public class UIInternals implements Serializable {
      */
     public UI getUI() {
         return ui;
+    }
+
+    /**
+     * The extended client details, if obtained, are cached in this field.
+     *
+     * @return the extended client details, or {@literal null} if not yet
+     *         received.
+     */
+    public ExtendedClientDetails getExtendedClientDetails() {
+        return extendedClientDetails;
+    }
+
+    /**
+     * Updates the extended client details.
+     *
+     * @param details
+     *              the updated extended client details.
+     */
+    public void setExtendedClientDetails(ExtendedClientDetails details) {
+        this.extendedClientDetails = details;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -148,9 +148,6 @@ public class Page implements Serializable {
     private final UI ui;
     private final History history;
 
-    private ExtendedClientDetails extendedClientDetails = null;
-
-
     /**
      * Creates a page instance for the given UI.
      *
@@ -560,14 +557,17 @@ public class Page implements Serializable {
      */
     public void retrieveExtendedClientDetails(
             ExtendedClientDetailsReceiver receiver) {
-        if (extendedClientDetails != null) {
-            receiver.receiveDetails(extendedClientDetails);
+        final ExtendedClientDetails cachedDetails =
+                ui.getInternals().getExtendedClientDetails();
+        if (cachedDetails != null) {
+            receiver.receiveDetails(cachedDetails);
             return;
         }
         final String js = "return Vaadin.Flow.getBrowserDetailsParameters();";
         final SerializableConsumer<JsonValue> resultHandler = json -> {
             handleExtendedClientDetailsResponse(json);
-            receiver.receiveDetails(extendedClientDetails);
+            receiver.receiveDetails(
+                    ui.getInternals().getExtendedClientDetails());
         };
         final SerializableConsumer<String> errorHandler = err -> {
             throw new RuntimeException("Unable to retrieve extended " +
@@ -593,7 +593,7 @@ public class Page implements Serializable {
                 return null;
             }
         };
-        extendedClientDetails = new ExtendedClientDetails(
+        ui.getInternals().setExtendedClientDetails(new ExtendedClientDetails(
                 getStringElseNull.apply("v-sw"),
                 getStringElseNull.apply("v-sh"),
                 getStringElseNull.apply("v-tzo"),
@@ -603,7 +603,7 @@ public class Page implements Serializable {
                 getStringElseNull.apply("v-tzid"),
                 getStringElseNull.apply("v-curdate"),
                 getStringElseNull.apply("v-td"),
-                getStringElseNull.apply("v-wn"));
+                getStringElseNull.apply("v-wn")));
 
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/Pair.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/Pair.java
@@ -23,22 +23,22 @@ import java.io.Serializable;
  * @author Vaadin Ltd
  *
  */
-class Pair<U extends Serializable, V extends Serializable>
+public class Pair<U extends Serializable, V extends Serializable>
         implements Serializable {
 
     private final U first;
     private final V second;
 
-    Pair(U u, V v) {
+    public Pair(U u, V v) {
         first = u;
         second = v;
     }
 
-    U getFirst() {
+    public U getFirst() {
         return first;
     }
 
-    V getSecond() {
+    public V getSecond() {
         return second;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/internal/Pair.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/Pair.java
@@ -18,7 +18,7 @@ package com.vaadin.flow.internal;
 import java.io.Serializable;
 
 /**
- * Represents a pair of two values.
+ * Generic class representing an immutable pair of values.
  *
  * @author Vaadin Ltd
  *
@@ -29,15 +29,32 @@ public class Pair<U extends Serializable, V extends Serializable>
     private final U first;
     private final V second;
 
+    /**
+     * Creates a new pair.
+     * @param u
+     *      the value of the first component
+     * @param v
+     *      the value of the second component
+     */
     public Pair(U u, V v) {
         first = u;
         second = v;
     }
 
+    /**
+     * Gets the first component of the pair.
+     * @return
+     *      the first component of the pair
+     */
     public U getFirst() {
         return first;
     }
 
+    /**
+     * Gets the second component of the pair.
+     * @return
+     *      the second component of the pair
+     */
     public V getSecond() {
         return second;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/router/PreserveOnRefresh.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/PreserveOnRefresh.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.flow.router;
 
 import java.lang.annotation.Documented;

--- a/flow-server/src/main/java/com/vaadin/flow/router/PreserveOnRefresh.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/PreserveOnRefresh.java
@@ -1,0 +1,19 @@
+package com.vaadin.flow.router;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that a previous view instance should be-reused when reloading a
+ * location in the same browser window/tab.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Inherited
+@Documented
+public @interface PreserveOnRefresh {
+}

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.router.internal;
 
+import java.io.Serializable;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -527,7 +528,7 @@ public abstract class AbstractNavigationStateRenderer
     private static class PreservedComponentCache extends HashMap<String,
             PreservedComponentCache.LocationComponent> {
 
-        private static class LocationComponent {
+        private static class LocationComponent implements Serializable {
             private final String location;
             private final Component component;
 

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PreserveOnRefreshView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PreserveOnRefreshView.java
@@ -1,0 +1,19 @@
+package com.vaadin.flow.uitest.ui;
+
+import java.util.Random;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.PreserveOnRefresh;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "com.vaadin.flow.uitest.ui.PreserveOnRefreshView")
+@PreserveOnRefresh
+public class PreserveOnRefreshView extends Div {
+
+    public PreserveOnRefreshView() {
+        // create unique content for this instance
+        setText(Long.toString(new Random().nextInt()));
+        setId("contents");
+    }
+
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PreserveOnRefreshIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PreserveOnRefreshIT.java
@@ -1,0 +1,67 @@
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class PreserveOnRefreshIT extends ChromeBrowserTest {
+
+    private final static String DIV_ID = "contents";
+
+    @Test
+    public void refresh_componentIsReused() {
+        open();
+        waitForElementPresent((By.id(DIV_ID)));
+        final String initialContents = findElement(By.id(DIV_ID)).getText();
+
+        open();
+        waitForElementPresent((By.id(DIV_ID)));
+        final String newContents = findElement(By.id(DIV_ID)).getText();
+
+        Assert.assertEquals("Component contents expected identical",
+                initialContents, newContents);
+    }
+
+    @Test
+    public void navigateToNonRefreshing_refreshInDifferentWindow_componentIsRecreated() {
+        open();
+        waitForElementPresent((By.id(DIV_ID)));
+        final String initialContents = findElement(By.id(DIV_ID)).getText();
+
+        // navigate to some other page in between
+        getDriver().get(getRootURL() +
+                "/view/com.vaadin.flow.uitest.ui.PageView");
+
+        open();
+        waitForElementPresent((By.id(DIV_ID)));
+        final String newContents = findElement(By.id(DIV_ID)).getText();
+
+        Assert.assertNotEquals("Component contents expected different",
+                initialContents, newContents);
+    }
+
+    @Test
+    public void refreshInDifferentWindow_componentIsRecreated() {
+        open();
+        final String firstWin = getDriver().getWindowHandle();
+        waitForElementPresent((By.id(DIV_ID)));
+        final String initialContents = findElement(By.id(DIV_ID)).getText();
+
+        ((JavascriptExecutor) getDriver()).executeScript(
+                "window.open('" + getTestURL() + "','_blank');");
+
+        final String secondWin = getDriver().getWindowHandles().stream()
+                .filter(windowId -> !windowId.equals(firstWin))
+                .findFirst()
+                .get();
+        driver.switchTo().window(secondWin);
+        waitForElementPresent((By.id(DIV_ID)));
+        final String newContents = findElement(By.id(DIV_ID)).getText();
+
+        Assert.assertNotEquals("Component contents expected different",
+                initialContents, newContents);
+    }
+}


### PR DESCRIPTION
Addresses #3522. If the @PreserveOnRefresh annotation is added to a routable component, then router will detect on refresh in the same browser/window tab whether a component has already been created previously in the session, and if, reuse that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5589)
<!-- Reviewable:end -->
