### PR TITLE
Allow customizing scroll position restoration

### DIFF
--- a/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtRouterLinkHandlerTest.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtRouterLinkHandlerTest.java
@@ -32,6 +32,8 @@ public class GwtRouterLinkHandlerTest extends ClientEngineTestBase {
     protected void gwtSetUp() throws Exception {
         super.gwtSetUp();
 
+        createDummyWindowVaadinFlow();
+
         invocations = JsCollections.array();
 
         ServerConnector connector = new ServerConnector(null) {
@@ -59,6 +61,16 @@ public class GwtRouterLinkHandlerTest extends ClientEngineTestBase {
         Browser.getDocument().getBody().appendChild(boundElement);
         RouterLinkHandler.bind(registry, boundElement);
     }
+
+    private static native void createDummyWindowVaadinFlow()
+    /*-{
+      if (!$wnd.Vaadin) {
+        $wnd.Vaadin = {};
+      }
+      if (!$wnd.Vaadin.Flow) {
+        $wnd.Vaadin.Flow = {};
+      }
+    }-*/;
 
     public void testRouterLink_anchorWithRouterLink_eventIntercepted() {
         currentEvent = null;

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/scroll/CustomScrollCallbacksView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/scroll/CustomScrollCallbacksView.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.scroll;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Anchor;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.BeforeEvent;
+import com.vaadin.flow.router.HasUrlParameter;
+import com.vaadin.flow.router.OptionalParameter;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouterLink;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+import com.vaadin.flow.uitest.ui.AbstractDivView;
+
+@Route(value = "com.vaadin.flow.uitest.ui.scroll.CustomScrollCallbacksView", layout = ViewTestLayout.class)
+public class CustomScrollCallbacksView extends AbstractDivView
+        implements HasUrlParameter<String> {
+    private final Div viewName = new Div();
+    private final Div log = new Div();
+
+    public CustomScrollCallbacksView() {
+        viewName.setId("view");
+
+        log.setId("log");
+        log.getStyle().set("white-space", "pre");
+
+        UI.getCurrent().getPage().executeJs(
+                "window.Vaadin.Flow.setScrollPosition = function(xAndY) { $0.textContent += JSON.stringify(xAndY) + '\\n' }",
+                log);
+        UI.getCurrent().getPage().executeJs(
+                "window.Vaadin.Flow.getScrollPosition = function() { return [42, -window.pageYOffset] }");
+
+        RouterLink navigate = new RouterLink("Navigate",
+                CustomScrollCallbacksView.class, "navigated");
+        navigate.setId("navigate");
+
+        Anchor back = new Anchor("javascript:history.go(-1)", "Back");
+        back.setId("back");
+
+        add(viewName, log, new Span("Scroll down to see navigation actions"),
+                ScrollView.createSpacerDiv(2000), navigate, back);
+    }
+
+    @Override
+    public void setParameter(BeforeEvent event,
+            @OptionalParameter String parameter) {
+        viewName.setText("Current view: " + parameter);
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/scroll/CustomScrollCallbacksIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/scroll/CustomScrollCallbacksIT.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.scroll;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+public class CustomScrollCallbacksIT extends AbstractScrollIT {
+    @Test
+    public void customCallbacks_customResults() throws InterruptedException {
+        open();
+        assertView("null");
+        assertLog("");
+
+        // Scroll to bottom
+        scrollBy(0, 2000);
+
+        int bottom = getScrollY();
+
+        findElement(By.id("navigate")).click();
+
+        assertView("navigated");
+        assertLog("[0,0]");
+        /*
+         * Scroll position should not be reset, but might have changed slightly
+         * because of more log rows
+         */
+        checkPageScroll(0, bottom, 50);
+
+        findElement(By.id("back")).click();
+
+        assertView("null");
+        assertLog("[0,0]\n[42,-" + bottom + "]");
+        /*
+         * Scroll position should not be reset, but might have changed slightly
+         * because of more log rows
+         */
+        checkPageScroll(0, bottom, 50);
+    }
+
+    private void assertView(String expected) {
+        String text = findElement(By.id("view")).getText();
+        Assert.assertEquals("Current view: " + expected, text);
+    }
+
+    private void assertLog(String expected) {
+        String text = findElement(By.id("log")).getText();
+        Assert.assertEquals(expected, text);
+    }
+}


### PR DESCRIPTION
Enables the application to control how the scroll position restoration
logic reads and writes the browser scroll position. This gives
applications control to e.g. disable the logic altogether, postpone
scroll position updates until animations have finished, or to scroll
some other element instead of window.

The custom callbacks are namespaced to window.Vaadin.Flow since there
can only be one set of callbacks per page. There would thus not be any
benefit from isolating the them inside window.Vaadin.Flow.clients.xyz.

In addition to adding actual feature, this patch also reorders some
unrelated statements to consistently process the x coordinate before the
y coordinate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5594)
<!-- Reviewable:end -->
