### PR TITLE
find tools in common unix paths when IDE launched from desktop icon

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsLocator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsLocator.java
@@ -22,7 +22,6 @@ import java.io.InputStreamReader;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -72,7 +71,12 @@ public class FrontendToolsLocator implements Serializable {
     public Optional<File> tryLocateTool(String toolName) {
         return executeCommand(isWindows() ? "where" : "which", toolName)
                 .map(this::omitErrorResult).map(CommandResult::getStdout)
-                .orElse(Collections.emptyList()).stream().map(File::new)
+                // Add most common paths in unix #5611
+                .orElse(Arrays.asList(
+                        "/usr/local/bin/" + toolName,
+                        "/opt/local/bin/" + toolName,
+                        "/opt/bin/" + toolName))
+                .stream().map(File::new)
                 .filter(this::verifyTool).findFirst();
     }
 


### PR DESCRIPTION
When Eclipse is run from the Applications menu instead of from the command line
the process does not inherits the PATH configured in the shell.
With this we cover a very common case when the user wants to run `jetty:run` from
IDE's that were started by clicking on the desktop icon.

Fixes #5611

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5613)
<!-- Reviewable:end -->
