### PR TITLE
Make it possible to implement cross site support

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/gwt/elemental/js/util/Xhr.java
+++ b/flow-client/src/main/java/com/vaadin/client/gwt/elemental/js/util/Xhr.java
@@ -202,6 +202,7 @@ public class Xhr {
             xhr.setOnReadyStateChange(new Handler(callback));
             xhr.open(method, url);
             xhr.setRequestHeader("Content-type", contentType);
+            xhr.setWithCredentials(true);
             xhr.send(requestData);
         } catch (JavaScriptException e) {
             // Just fail.


### PR DESCRIPTION
Setting withCredentials=true causes cookies to be included in cross
site requests, making it possible to do UIDL request cross sites. This
is required to be able to do cross site embedding.

"Setting withCredentials has no effect on same-site requests."
See https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials
for more information

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5616)
<!-- Reviewable:end -->
