### PR TITLE
Fixed bug with component elements added multiple times during @PreserveOnRefresh

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
@@ -322,6 +322,7 @@ public class NavigationStateRendererTest {
         // transferred from the previous UI to the new UI
         final Set<Element> uiChildren = ui1.getElement().getChildren()
                 .collect(Collectors.toSet());
+        Assert.assertEquals(2, uiChildren.size());
         Assert.assertTrue("Component element expected transferred",
                 uiChildren.contains(view.getElement()));
         Assert.assertTrue("Extra element expected transferred",

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PreserveOnRefreshView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PreserveOnRefreshView.java
@@ -2,6 +2,7 @@ package com.vaadin.flow.uitest.ui;
 
 import java.util.Random;
 
+import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.dom.Element;
@@ -12,19 +13,39 @@ import com.vaadin.flow.router.Route;
 @PreserveOnRefresh
 public class PreserveOnRefreshView extends Div {
 
+    final static String COMPONENT_ID = "contents";
+    final static String NOTIFICATION_ID = "notification";
+    final static String ATTACHCOUNTER_ID = "attachcounter";
+
+    private int attached = 0;
+    private final Div attachCounter;
+
     public PreserveOnRefreshView() {
         // create unique content for this instance
         final String uniqueId = Long.toString(new Random().nextInt());
 
-        setText(uniqueId);
-        setId("contents");
+        final Div componentId = new Div();
+        componentId.setId(COMPONENT_ID);
+        componentId.setText(uniqueId);
+        add(componentId);
+
+        // add an element to keep track of number of attach events
+        attachCounter = new Div();
+        attachCounter.setId(ATTACHCOUNTER_ID);
+        attachCounter.setText("0");
+        add(attachCounter);
 
         // also add an element as a separate UI child. This is expected to be
         // transferred on refresh (mimicking dialogs and notifications)
         final Element looseElement = new Element("div");
-        looseElement.setProperty("id", "notification");
+        looseElement.setProperty("id", NOTIFICATION_ID);
         looseElement.setText(uniqueId);
         UI.getCurrent().getElement().insertChild(0, looseElement);
     }
 
+    @Override
+    protected void onAttach(AttachEvent event) {
+        attached += 1;
+        attachCounter.setText(Integer.toString(attached));
+    }
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PreserveOnRefreshIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PreserveOnRefreshIT.java
@@ -7,45 +7,50 @@ import org.openqa.selenium.JavascriptExecutor;
 
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
-public class PreserveOnRefreshIT extends ChromeBrowserTest {
+import static com.vaadin.flow.uitest.ui.PreserveOnRefreshView.*;
 
-    private final static String COMPONENT_ID = "contents";
-    private final static String NOTIFICATION_ID = "notification";
+public class PreserveOnRefreshIT extends ChromeBrowserTest {
 
     @Test
     public void refresh_componentAndUiChildrenReused() {
         open();
-        final String componentId = getContents(COMPONENT_ID);
-        final String notificationId = getContents(NOTIFICATION_ID);
+        final String componentId = getString(COMPONENT_ID);
+        final String notificationId = getString(NOTIFICATION_ID);
 
         open();
-        final String newComponentId = getContents(COMPONENT_ID);
-        final String newNotificationId = getContents(NOTIFICATION_ID);
+        final String newComponentId = getString(COMPONENT_ID);
+        final String newNotificationId = getString(NOTIFICATION_ID);
+        final int attachCount = getInt(ATTACHCOUNTER_ID);
 
         Assert.assertEquals("Component contents expected identical",
                 componentId, newComponentId);
         Assert.assertEquals("Notification contents expected identical",
                 notificationId, newNotificationId);
+        Assert.assertEquals("Expected two attaches",
+                2, attachCount);
     }
 
     @Test
     public void navigateToNonRefreshing_refreshInDifferentWindow_componentIsRecreated() {
         open();
-        final String componentId = getContents(COMPONENT_ID);
-        final String notificationId = getContents(NOTIFICATION_ID);
+        final String componentId = getString(COMPONENT_ID);
+        final String notificationId = getString(NOTIFICATION_ID);
 
         // navigate to some other page in between
         getDriver().get(getRootURL() +
                 "/view/com.vaadin.flow.uitest.ui.PageView");
 
         open();
-        final String newComponentId = getContents(COMPONENT_ID);
-        final String newNotificationId = getContents(NOTIFICATION_ID);
+        final String newComponentId = getString(COMPONENT_ID);
+        final String newNotificationId = getString(NOTIFICATION_ID);
+        final int attachCount = getInt(ATTACHCOUNTER_ID);
 
         Assert.assertNotEquals("Component contents expected different",
                 componentId, newComponentId);
         Assert.assertNotEquals("Notification contents expected different",
                 notificationId, newNotificationId);
+        Assert.assertEquals("Expected one attach",
+                1, attachCount);
     }
 
     @Test
@@ -53,8 +58,8 @@ public class PreserveOnRefreshIT extends ChromeBrowserTest {
         open();
         final String firstWin = getDriver().getWindowHandle();
 
-        final String componentId = getContents(COMPONENT_ID);
-        final String notificationId = getContents(NOTIFICATION_ID);
+        final String componentId = getString(COMPONENT_ID);
+        final String notificationId = getString(NOTIFICATION_ID);
 
         ((JavascriptExecutor) getDriver()).executeScript(
                 "window.open('" + getTestURL() + "','_blank');");
@@ -65,17 +70,25 @@ public class PreserveOnRefreshIT extends ChromeBrowserTest {
                 .get();
         driver.switchTo().window(secondWin);
 
-        final String newComponentId = getContents(COMPONENT_ID);
-        final String newNotificationId = getContents(NOTIFICATION_ID);
+        final String newComponentId = getString(COMPONENT_ID);
+        final String newNotificationId = getString(NOTIFICATION_ID);
+        final int attachCount = getInt(ATTACHCOUNTER_ID);
 
         Assert.assertNotEquals("Component contents expected different",
                 componentId, newComponentId);
         Assert.assertNotEquals("Notification contents expected different",
                 notificationId, newNotificationId);
+        Assert.assertEquals("Expected one attach",
+                1, attachCount);
     }
 
-    private String getContents(String id) {
+    private String getString(String id) {
         waitForElementPresent(By.id(id));
-        return findElement(By.id(COMPONENT_ID)).getText();
+        return findElement(By.id(id)).getText();
+    }
+
+    private int getInt(String id) {
+        return Integer.parseInt(getString(id));
+
     }
 }


### PR DESCRIPTION
Fixed a bug in my previous PR where the preserved component's element was erroneously added twice. This was noticed e.g. by attach listener running multiple times. Corrected and added IT tests for the attach count.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5636)
<!-- Reviewable:end -->
