### PR TITLE
Explicitly include binary location in PATH

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -23,6 +23,7 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -224,5 +225,39 @@ public class FrontendUtils {
             LoggerFactory.getLogger(FrontendUtils.class).warn("Couldn't close template input stream", exception);
         }
         return ret;
+    }
+
+    /**
+     * Creates a process builder for the given list of program and arguments. If
+     * the program is defined as an absolute path, then the directory that
+     * contains the program is also appended to PATH so that the it can locate
+     * related tools.
+     *
+     * @param command
+     *            a list with the program and arguments
+     * @return a configured process builder
+     */
+    public static ProcessBuilder createProcessBuilder(List<String> command) {
+        ProcessBuilder processBuilder = new ProcessBuilder(command);
+
+        /*
+         * Ensure the location of the command to run is in PATH. This is in some
+         * cases needed by npm to locate a node binary.
+         */
+        File commandFile = new File(command.get(0));
+        if (commandFile.isAbsolute()) {
+            String commandPath = commandFile.getParent();
+
+            Map<String, String> environment = processBuilder.environment();
+            String path = environment.get("PATH");
+            if (path == null || path.isEmpty()) {
+                path = commandPath;
+            } else if (!path.contains(commandPath)) {
+                path += File.pathSeparatorChar + commandPath;
+            }
+            environment.put("PATH", path);
+        }
+
+        return processBuilder;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeNpmInstall.java
@@ -70,16 +70,8 @@ public class NodeNpmInstall implements Command {
         List<String> command = new ArrayList<>(FrontendUtils.getNpmExecutable());
         command.add("install");
 
-        ProcessBuilder builder = new ProcessBuilder(command);
+        ProcessBuilder builder = FrontendUtils.createProcessBuilder(command);
         builder.directory(packageUpdater.npmFolder);
-
-        // For a locally installed Node on windows we need to add the node folder
-        // to the path for it to work as expected with NPM
-        if (FrontendUtils.isWindows() && command.get(0).contains("node.exe")) {
-            String nodeExecutable = command.get(0).replace("\\node.exe", "");
-            builder.environment().put("PATH",
-                    System.getenv().get("PATH") + ";" + nodeExecutable);
-        }
 
         Process process = null;
         try {


### PR DESCRIPTION
npm uses PATH to find node. If npm is used from a custom location, then
we should ensure that location is in PATH so that npm can find node.

Also restructures the logic in tryLocateTool to make it easier to step
through the logic in a debugger.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5641)
<!-- Reviewable:end -->
