### PR TITLE
simpler code by making node_modules a static

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/NodeBuildFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/NodeBuildFrontendMojo.java
@@ -45,8 +45,8 @@ import com.vaadin.flow.server.frontend.NodeTasks;
 import com.vaadin.flow.theme.Theme;
 
 import static com.vaadin.flow.plugin.common.FlowPluginFrontendUtils.getClassFinder;
-import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_GENERATED_FOLDER;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_IMPORTS_FILE;
+import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
 
 /**
  * Goal that builds frontend bundle by:
@@ -82,23 +82,11 @@ public class NodeBuildFrontendMojo extends AbstractMojo {
     private File npmFolder;
 
     /**
-     * The path to the {@literal node_modules} directory of the project.
-     */
-    @Parameter(defaultValue = "${project.basedir}/node_modules/")
-    private File nodeModulesPath;
-
-    /**
      * The JavaScript file used as entry point of the application, and which is
      * automatically updated by flow by reading java annotations.
      */
     @Parameter(defaultValue = "${project.build.directory}/" + FLOW_IMPORTS_FILE)
     private File generatedFlowImports;
-
-    /**
-     * A directory for generated frontend source files.
-     */
-    @Parameter(defaultValue = "${project.build.directory}/" + FLOW_GENERATED_FOLDER)
-    private File generatedFrontendDirectory;
 
     /**
      * A directory with project's frontend source files.
@@ -143,7 +131,7 @@ public class NodeBuildFrontendMojo extends AbstractMojo {
             runWebpack();
         }
 
-        long ms = (System.nanoTime() - start) / 1000;
+        long ms = (System.nanoTime() - start) / 1000000;
         getLog().info("update-frontend took " + ms + "ms.");
     }
 
@@ -153,7 +141,7 @@ public class NodeBuildFrontendMojo extends AbstractMojo {
      * {@link com.vaadin.flow.plugin.common.WebComponentModulesGenerator} to
      * generate JavaScript files from the {@code WebComponentExporters}
      * present in the code base. The generated JavaScript files are placed in
-     * {@code ./target/frontend}.
+     * the same folder as the {@link FrontendUtils#FLOW_IMPORTS_FILE}.
      */
     private void generateExportedWebComponents() {
         if (!generateEmbeddableWebComponents) {
@@ -164,6 +152,7 @@ public class NodeBuildFrontendMojo extends AbstractMojo {
                         getClassFinder(project)), false);
 
         try {
+            File generatedFrontendDirectory = generatedFlowImports.getParentFile();
             FileUtils.forceMkdir(generatedFrontendDirectory);
             generator.getExporters().forEach(exporter ->
                     generator.generateModuleFile(exporter, generatedFrontendDirectory));
@@ -175,8 +164,8 @@ public class NodeBuildFrontendMojo extends AbstractMojo {
 
     private void runNodeUpdater() {
         new NodeTasks.Builder(getClassFinder(project), frontendDirectory,
-                generatedFrontendDirectory, generatedFlowImports, npmFolder,
-                nodeModulesPath, convertHtml)
+                generatedFlowImports, npmFolder,
+                convertHtml)
                 .runNpmInstall(runNpmInstall)
                 .enablePackagesUpdate(true)
                 .enableImportsUpdate(true)
@@ -186,7 +175,7 @@ public class NodeBuildFrontendMojo extends AbstractMojo {
 
     private void runWebpack() {
         String webpackCommand = "webpack/bin/webpack.js";
-        File webpackExecutable = new File(nodeModulesPath, webpackCommand);
+        File webpackExecutable = new File(npmFolder, NODE_MODULES + webpackCommand);
         if (!webpackExecutable.isFile()) {
             throw new IllegalStateException(String.format(
                     "Unable to locate webpack executable by path '%s'. Double" +

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/NodeValidateMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/NodeValidateMojo.java
@@ -42,6 +42,7 @@ import static com.vaadin.flow.plugin.common.FlowPluginFrontendUtils.getClassFind
 import static com.vaadin.flow.server.Constants.RESOURCES_FRONTEND_DEFAULT;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_IMPORTS_FILE;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
+import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
 
 /**
  * Goal checks that node and npm tools are installed, and copies frontend
@@ -52,12 +53,6 @@ public class NodeValidateMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private MavenProject project;
-
-    /**
-     * The path to the {@literal node_modules} directory of the project.
-     */
-    @Parameter(defaultValue = "${project.basedir}/node_modules/")
-    private File nodeModulesPath;
 
     @Parameter(defaultValue = "${project.basedir}/src/main/resources/META-INF/resources/frontend")
     private File frontendResourcesDirectory;
@@ -113,7 +108,7 @@ public class NodeValidateMojo extends AbstractMojo {
         FrontendUtils.getNodeExecutable();
         FrontendUtils.getNpmExecutable();
 
-        new NodeTasks.Builder(getClassFinder(project), npmFolder, nodeModulesPath, generatedFlowImports)
+        new NodeTasks.Builder(getClassFinder(project), npmFolder, generatedFlowImports)
                 .withWebpack(getWebpackOutputDirectory(), webpackTemplate)
                 .createMissingPackageJson(true)
                 .enableImportsUpdate(false)
@@ -121,8 +116,8 @@ public class NodeValidateMojo extends AbstractMojo {
                 .runNpmInstall(false)
                 .build().execute();
 
-        File flowNodeDirectory = new File(nodeModulesPath,
-                FLOW_NPM_PACKAGE_NAME);
+        File flowNodeDirectory = new File(npmFolder,
+                NODE_MODULES + FLOW_NPM_PACKAGE_NAME);
         copyFlowModuleDependencies(flowNodeDirectory);
         copyProjectFrontendResources(flowNodeDirectory);
 

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/NodeBuildFrontendMojoTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/NodeBuildFrontendMojoTest.java
@@ -50,9 +50,13 @@ import elemental.json.Json;
 import elemental.json.JsonObject;
 
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
+import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_FRONTEND;
+import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_IMPORTS_FILE;
+import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
+import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
+import static com.vaadin.flow.server.frontend.FrontendUtils.TARGET;
 import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_CONFIG;
 import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_PREFIX_ALIAS;
-import static com.vaadin.flow.server.frontend.FrontendUtils.getFlowPackage;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -62,7 +66,7 @@ public class NodeBuildFrontendMojoTest {
 
     private File importsFile;
     private File nodeModulesPath;
-
+    private File flowPackagPath;
     private String packageJson;
     private String webpackConfig;
 
@@ -74,10 +78,10 @@ public class NodeBuildFrontendMojoTest {
         Mockito.when(project.getRuntimeClasspathElements()).thenReturn(getClassPath());
 
         File tmpRoot = temporaryFolder.getRoot();
-        importsFile = new File(tmpRoot, "flow-imports.js");
-        nodeModulesPath = new File(tmpRoot, "node_modules");
-        File frontendDirectory = new File(tmpRoot, "frontend");
-        File generatedFrontendDirectory = new File(tmpRoot, "target/frontend");
+        importsFile = new File(tmpRoot, TARGET + FLOW_IMPORTS_FILE);
+        nodeModulesPath = new File(tmpRoot, NODE_MODULES);
+        flowPackagPath = new File(nodeModulesPath, FLOW_NPM_PACKAGE_NAME);
+        File frontendDirectory = new File(tmpRoot, FLOW_FRONTEND);
 
         packageJson = new File(tmpRoot, PACKAGE_JSON).getAbsolutePath();
         webpackConfig = new File(tmpRoot, WEBPACK_CONFIG).getAbsolutePath();
@@ -85,15 +89,13 @@ public class NodeBuildFrontendMojoTest {
         ReflectionUtils.setVariableValueInObject(mojo, "project", project);
         ReflectionUtils.setVariableValueInObject(mojo, "generatedFlowImports", importsFile);
         ReflectionUtils.setVariableValueInObject(mojo, "frontendDirectory", frontendDirectory);
-        ReflectionUtils.setVariableValueInObject(mojo, "generatedFrontendDirectory", generatedFrontendDirectory);
         ReflectionUtils.setVariableValueInObject(mojo, "generateEmbeddableWebComponents", false);
         ReflectionUtils.setVariableValueInObject(mojo, "convertHtml", true);
         ReflectionUtils.setVariableValueInObject(mojo, "npmFolder", tmpRoot);
-        ReflectionUtils.setVariableValueInObject(mojo, "nodeModulesPath", nodeModulesPath);
         ReflectionUtils.setVariableValueInObject(mojo, "generateBundle", false);
         ReflectionUtils.setVariableValueInObject(mojo, "runNpmInstall", false);
 
-        Assert.assertTrue(getFlowPackage(nodeModulesPath).mkdirs());
+        Assert.assertTrue(flowPackagPath.mkdirs());
 
         setProject(mojo, "war", "war_output");
 
@@ -138,12 +140,12 @@ public class NodeBuildFrontendMojoTest {
 
         assertContainsImports(true, expectedLines.toArray(new String[0]));
 
-        Assert.assertTrue(getFlowPackage(nodeModulesPath).exists());
-        Assert.assertTrue(new File(getFlowPackage(nodeModulesPath), "ExampleConnector.js").exists());
+        Assert.assertTrue(new File(flowPackagPath, "ExampleConnector.js").exists());
     }
 
     @Test
     public void shouldNot_UpdateJsFile_when_NoChanges() throws Exception {
+
         mojo.execute();
         long timestamp1 = importsFile.lastModified();
 

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/NodeValidateMojoTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/NodeValidateMojoTest.java
@@ -28,8 +28,9 @@ import static com.vaadin.flow.plugin.maven.NodeBuildFrontendMojoTest.getPackageJ
 import static com.vaadin.flow.plugin.maven.NodeBuildFrontendMojoTest.setProject;
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 import static com.vaadin.flow.server.Constants.RESOURCES_FRONTEND_DEFAULT;
+import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
+import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
 import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_CONFIG;
-import static com.vaadin.flow.server.frontend.FrontendUtils.getFlowPackage;
 
 public class NodeValidateMojoTest {
     @Rule
@@ -41,6 +42,7 @@ public class NodeValidateMojoTest {
     private final NodeValidateMojo mojo = new NodeValidateMojo();
     private File projectFrontendResourcesDirectory;
     private File nodeModulesPath;
+    private File flowPackagePath;
     private String webpackConfig;
     private String packageJson;
     private File importsFile;
@@ -62,23 +64,21 @@ public class NodeValidateMojoTest {
                 new File(projectFrontendResourcesDirectory,
                         "test_project_resource.js").createNewFile());
 
-        nodeModulesPath = new File(projectBase, "node_modules");
+        nodeModulesPath = new File(projectBase, NODE_MODULES);
+        flowPackagePath = new File(nodeModulesPath, FLOW_NPM_PACKAGE_NAME);
         importsFile = new File(projectBase, "flow-imports.js");
         webpackConfig = new File(projectBase, WEBPACK_CONFIG).getAbsolutePath();
         packageJson = new File(projectBase, PACKAGE_JSON).getAbsolutePath();
 
         ReflectionUtils.setVariableValueInObject(mojo, "project", project);
-        ReflectionUtils.setVariableValueInObject(mojo, "nodeModulesPath", nodeModulesPath);
         ReflectionUtils.setVariableValueInObject(mojo, "frontendResourcesDirectory", projectFrontendResourcesDirectory);
         ReflectionUtils.setVariableValueInObject(mojo, "jarResourcePathsToCopy", RESOURCES_FRONTEND_DEFAULT);
         ReflectionUtils.setVariableValueInObject(mojo, "includes", "**/*.js,**/*.css");
         ReflectionUtils.setVariableValueInObject(mojo, "npmFolder", projectBase);
-        ReflectionUtils.setVariableValueInObject(mojo, "nodeModulesPath", nodeModulesPath);
         ReflectionUtils.setVariableValueInObject(mojo, "webpackTemplate", WEBPACK_CONFIG);
         ReflectionUtils.setVariableValueInObject(mojo, "generatedFlowImports", importsFile);
 
-
-        Assert.assertTrue(getFlowPackage(nodeModulesPath).mkdirs());
+        Assert.assertTrue(flowPackagePath.mkdirs());
         setProject(mojo, "war", "war_output");
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentMetaData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/ComponentMetaData.java
@@ -333,11 +333,8 @@ public class ComponentMetaData {
                 ApplicationConstants.FRONTEND_PROTOCOL_PREFIX);
 
         String module = value
-                .replaceFirst("^.*bower_components/(vaadin-.*)\\.html",
-                        "/node_modules/@vaadin/$1.js")
-                .replaceFirst("^.*bower_components/((iron|paper)-.*)\\.html",
-                        "/node_modules/@polymer/$1.js")
-                .replaceFirst("^frontend://(.+)\\.html$", "/frontend/$1.js");
+                .replaceFirst("^.*bower_components/(vaadin-.*)\\.html", "@vaadin/$1.js")
+                .replaceFirst("^.*bower_components/((iron|paper)-.*)\\.html", "@polymer/$1.js");
 
         return jsModule(module, htmlImport.loadMode());
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentProvider.java
@@ -176,8 +176,8 @@ public class WebComponentProvider extends SynchronizedRequestHandler {
                 contextRootRelativePath, session);
         String polyFillsUri = resolver
                 .resolveVaadinUri(BootstrapHandler.POLYFILLS_JS);
-        // <code>thisScript</code> below allows to refer the currently executing
-        // script
+
+        // `thisScript` below allows to refer the currently executing script
         return getThisScript(tagName)
                 + generateAddPolyfillsScript(polyFillsUri, "thisScript")
                 + generateUiImport("thisScript");
@@ -264,8 +264,8 @@ public class WebComponentProvider extends SynchronizedRequestHandler {
     }
 
     private static class ComponentInfo implements Serializable {
-        public final String tag;
-        public final String extension;
+        final String tag;
+        final String extension;
 
         private ComponentInfo(String pathInfo) {
             Matcher matcher = TAG_PATTERN.matcher(pathInfo);
@@ -282,19 +282,19 @@ public class WebComponentProvider extends SynchronizedRequestHandler {
             }
         }
 
-        public String getTag() {
+        String getTag() {
             return tag;
         }
 
-        public boolean hasExtension() {
+        boolean hasExtension() {
             return extension != null;
         }
 
-        public boolean isHTML() {
+        boolean isHTML() {
             return HTML_EXTENSION.equals(extension);
         }
 
-        public boolean isJS() {
+        boolean isJS() {
             return JS_EXTENSION.equals(extension);
         }
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -55,18 +55,30 @@ public class FrontendUtils {
      */
     public static final String FLOW_NPM_PACKAGE_NAME = "@vaadin/flow-frontend/";
 
+
     /**
-     * Folder that contains generated javascript files used to build the
-     * application.
+     * Default location for the installed node packages.
      */
-    public static final String FLOW_GENERATED_FOLDER = "frontend/";
+    public static final String NODE_MODULES = "node_modules/";
+
+    /**
+     * Relative path to the folder containing application frontend source files.
+     * By default should be <code>/frontend</code> relative to the project
+     * folder.
+     */
+    public static final String FLOW_FRONTEND = "frontend/";
+
+    /**
+     * Target folder.
+     */
+    public static final String TARGET = "target/";
 
     /**
      * File that contains Flow application imports, javascript, and theme annotations.
      * It is also the entry-point for webpack.
+     * It should be relative to the {@link FrontendUtils#TARGET} folder.
      */
-    public static final String FLOW_IMPORTS_FILE =
-            FLOW_GENERATED_FOLDER + "generated-flow-imports.js";
+    public static final String FLOW_IMPORTS_FILE = "frontend/generated-flow-imports.js";
 
     /**
      *
@@ -131,17 +143,6 @@ public class FrontendUtils {
      */
     public static String getBaseDir() {
         return System.getProperty("project.basedir", System.getProperty("user.dir", "."));
-    }
-
-    /**
-     * Gets the flow package inside node_modules.
-     *
-     * @param nodeModulesPath
-     *            path to node_modules.
-     * @return the flow package folder.
-     */
-    public static File getFlowPackage(File nodeModulesPath) {
-        return new File(nodeModulesPath, FLOW_NPM_PACKAGE_NAME);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -39,10 +39,10 @@ import elemental.json.JsonObject;
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 import static com.vaadin.flow.server.Constants.RESOURCES_FRONTEND_DEFAULT;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
+import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
 import static com.vaadin.flow.shared.ApplicationConstants.FRONTEND_PROTOCOL_PREFIX;
+import static elemental.json.impl.JsonUtil.stringify;
 import static java.nio.charset.StandardCharsets.UTF_8;
-
-
 /**
  * Base abstract class for frontend updaters that needs to be run when in
  * dev-mode or from the flow maven plugin.
@@ -90,40 +90,21 @@ public abstract class NodeUpdater implements Command {
      *
      * @param finder
      *            a reusable class finder
-     * @param npmFolder
-     *            folder with the `package.json` file
-     * @param nodeModulesPath
-     *            the path to the {@literal node_modules} directory of the
-     *            project
-     * @param convertHtml
-     *            true to enable polymer-2 annotated classes to be considered
-     */
-    protected NodeUpdater(ClassFinder finder, File npmFolder, File nodeModulesPath, boolean convertHtml) {
-        this(finder, null, npmFolder, nodeModulesPath, convertHtml);
-    }
-
-    /**
-     * Constructor.
-     *
-     * @param finder
-     *            a reusable class finder
      * @param frontendDependencies
      *            a reusable frontend dependencies
      * @param npmFolder
      *            folder with the `package.json` file
-     * @param nodeModulesPath
-     *            the path to the {@literal node_modules} directory of the
-     *            project
      * @param convertHtml
      *            true to enable polymer-2 annotated classes to be considered
      */
-    protected NodeUpdater(ClassFinder finder, FrontendDependencies frontendDependencies, File npmFolder, File nodeModulesPath, boolean convertHtml) {
+    protected NodeUpdater(ClassFinder finder, FrontendDependencies frontendDependencies, File npmFolder,
+            boolean convertHtml) {
         this.frontDeps = finder != null && frontendDependencies == null
                 ? new FrontendDependencies(finder)
                 : frontendDependencies;
         this.finder = finder;
         this.npmFolder = npmFolder;
-        this.nodeModulesPath = nodeModulesPath;
+        this.nodeModulesPath = new File(npmFolder, NODE_MODULES);
         this.convertHtml = convertHtml;
     }
 
@@ -142,7 +123,7 @@ public abstract class NodeUpdater implements Command {
                 .collect(Collectors.toSet());
     }
 
-    Set<String> getTargetFrontendModules(File directory, Set<String> excludes) {
+    Set<String> getGeneratedModules(File directory, Set<String> excludes) {
         if (!directory.exists()) {
             return Collections.emptySet();
         }
@@ -246,7 +227,7 @@ public abstract class NodeUpdater implements Command {
 
     void writePackageFile(JsonObject packageJson) throws IOException {
         File packageFile = new File(npmFolder, PACKAGE_JSON);
-        FileUtils.writeStringToFile(packageFile, packageJson.toJson(), UTF_8.name());
+        FileUtils.writeStringToFile(packageFile, stringify(packageJson, 2), UTF_8.name());
     }
 
     static Logger log() {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCreatePackageJson.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCreatePackageJson.java
@@ -31,11 +31,9 @@ public class TaskCreatePackageJson extends NodeUpdater {
      *
      * @param npmFolder
      *            folder with the `package.json` file.
-     * @param nodeModulesPath
-     *            `node_modules` folder.
      */
-    public TaskCreatePackageJson(File npmFolder, File nodeModulesPath) {
-        super(null, null, npmFolder, nodeModulesPath, false);
+    public TaskCreatePackageJson(File npmFolder) {
+        super(null, null, npmFolder, false);
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -58,57 +58,24 @@ public class TaskUpdateImports extends NodeUpdater {
      *
      * @param finder
      *         a reusable class finder
-     * @param frontendDirectory
-     *         a directory with project's frontend files
-     * @param generatedFrontendDirectory
-     *         a directory with project's generated frontend files
-     * @param generatedFlowImports
-     *         name of the JS file to update with the Flow project imports
-     * @param npmFolder
-     *         folder with the `package.json` file
-     * @param nodeModulesPath
-     *         the path to the {@literal node_modules} directory of the project
-     * @param convertHtml
-     *         true to enable polymer-2 annotated classes to be considered
-     */
-    public TaskUpdateImports(
-            ClassFinder finder, File frontendDirectory,
-            File generatedFrontendDirectory, File generatedFlowImports,
-            File npmFolder, File nodeModulesPath, boolean convertHtml) {
-        this(finder, null, frontendDirectory, generatedFrontendDirectory,
-                generatedFlowImports, npmFolder, nodeModulesPath, convertHtml);
-    }
-
-
-    /**
-     * Create an instance of the updater given all configurable parameters.
-     *
-     * @param finder
-     *         a reusable class finder
      * @param frontendDependencies
      *         a reusable frontend dependencies
      * @param frontendDirectory
      *         a directory with project's frontend files
-     * @param generatedFrontendDirectory
-     *         a directory with project's generated frontend files
      * @param generatedFlowImports
      *         name of the JS file to update with the imports
      * @param npmFolder
      *         folder with the `package.json` file
-     * @param nodeModulesPath
-     *         the path to the {@literal node_modules} directory of the project
      * @param convertHtml
      *         true to enable polymer-2 annotated classes to be considered
      */
-    public TaskUpdateImports(
-            ClassFinder finder, FrontendDependencies frontendDependencies,
-            File frontendDirectory, File generatedFrontendDirectory,
-            File generatedFlowImports, File npmFolder, File nodeModulesPath,
-            boolean convertHtml) {
-        super(finder, frontendDependencies, npmFolder, nodeModulesPath, convertHtml);
+    public TaskUpdateImports(ClassFinder finder,
+            FrontendDependencies frontendDependencies, File frontendDirectory,
+            File generatedFlowImports, File npmFolder, boolean convertHtml) {
+        super(finder, frontendDependencies, npmFolder, convertHtml);
         this.generatedFlowImports = generatedFlowImports;
         this.frontendDirectory = frontendDirectory;
-        this.generatedFrontendDirectory = generatedFrontendDirectory;
+        this.generatedFrontendDirectory = generatedFlowImports.getParentFile();
     }
 
     @Override
@@ -119,8 +86,8 @@ public class TaskUpdateImports extends NodeUpdater {
         }
         modules.addAll(getJavascriptJsModules(frontDeps.getScripts()));
 
-        modules.addAll(getTargetFrontendModules(generatedFrontendDirectory,
-                Collections.singleton(FrontendUtils.FLOW_IMPORTS_FILE)));
+        modules.addAll(getGeneratedModules(generatedFrontendDirectory,
+                Collections.singleton(generatedFlowImports.getName())));
 
         modules = sortModules(modules);
         try {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -40,40 +40,18 @@ public class TaskUpdatePackages extends NodeUpdater {
      *
      * @param finder
      *            a reusable class finder
-     * @param npmFolder
-     *            folder with the `package.json` file
-     * @param nodeModulesPath
-     *            the path to the {@literal node_modules} directory of the
-     *            project
-     * @param convertHtml
-     *            whether to convert html imports or not during the package
-     *            updates
-     */
-    public TaskUpdatePackages(ClassFinder finder, File npmFolder,
-                              File nodeModulesPath, boolean convertHtml) {
-        this(finder, null, npmFolder, nodeModulesPath, convertHtml);
-    }
-
-    /**
-     * Create an instance of the updater given all configurable parameters.
-     *
-     * @param finder
-     *            a reusable class finder
      * @param frontendDependencies
      *            a reusable frontend dependencies
      * @param npmFolder
      *            folder with the `package.json` file
-     * @param nodeModulesPath
-     *            the path to the {@literal node_modules} directory of the
-     *            project
      * @param convertHtml
      *            whether to convert html imports or not during the package
      *            updates
      */
     public TaskUpdatePackages(ClassFinder finder,
             FrontendDependencies frontendDependencies, File npmFolder,
-            File nodeModulesPath, boolean convertHtml) {
-        super(finder, frontendDependencies, npmFolder, nodeModulesPath, convertHtml);
+            boolean convertHtml) {
+        super(finder, frontendDependencies, npmFolder, convertHtml);
     }
 
     @Override

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateImportsTest.java
@@ -38,6 +38,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
+import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
 import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_PREFIX_ALIAS;
 
 public class NodeUpdateImportsTest extends NodeUpdateTestUtil {
@@ -46,9 +48,8 @@ public class NodeUpdateImportsTest extends NodeUpdateTestUtil {
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     private File importsFile;
-    private File nodeModulesPath;
     private File frontendDirectory;
-    private File generatedFrontendDirectory;
+    private File nodeModulesPath;
     private TaskUpdateImports node;
 
     @Before
@@ -56,15 +57,13 @@ public class NodeUpdateImportsTest extends NodeUpdateTestUtil {
 
         File tmpRoot = temporaryFolder.getRoot();
         importsFile = new File(tmpRoot, "flow-imports.js");
-        nodeModulesPath = new File(tmpRoot, "node_modules");
         frontendDirectory = new File(tmpRoot, "frontend");
-        generatedFrontendDirectory = new File(tmpRoot, "target/frontend");
+        nodeModulesPath = new File(tmpRoot, NODE_MODULES);
 
-        node = new TaskUpdateImports(getClassFinder(), frontendDirectory,
-                generatedFrontendDirectory, importsFile, tmpRoot,
-                nodeModulesPath, true);
+        node = new TaskUpdateImports(getClassFinder(), null, frontendDirectory,
+                importsFile, tmpRoot, true);
 
-        Assert.assertTrue(getFlowPackage().mkdirs());
+        Assert.assertTrue(nodeModulesPath.mkdirs());
 
         createExpectedImports(frontendDirectory, nodeModulesPath);
     }
@@ -132,8 +131,10 @@ public class NodeUpdateImportsTest extends NodeUpdateTestUtil {
 
         assertContainsImports(true, expectedLines.toArray(new String[0]));
 
-        Assert.assertTrue(getFlowPackage().exists());
-        Assert.assertTrue(new File(getFlowPackage(), "ExampleConnector.js")
+        File flowPackage = new File(nodeModulesPath, FLOW_NPM_PACKAGE_NAME);
+
+        Assert.assertTrue(flowPackage.exists());
+        Assert.assertTrue(new File(flowPackage, "ExampleConnector.js")
                 .exists());
     }
 
@@ -258,9 +259,4 @@ public class NodeUpdateImportsTest extends NodeUpdateTestUtil {
         Files.write(Paths.get(importsFile.toURI()),
                 content.getBytes(StandardCharsets.UTF_8), options);
     }
-
-    File getFlowPackage() {
-        return FrontendUtils.getFlowPackage(nodeModulesPath);
-    }
-
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdatePackagesTest.java
@@ -48,11 +48,9 @@ public class NodeUpdatePackagesTest extends NodeUpdateTestUtil {
 
         NodeUpdateTestUtil.createStubNode(true, true);
 
-        packageCreator = new TaskCreatePackageJson(baseDir,
-                new File(baseDir, "node_modules"));
+        packageCreator = new TaskCreatePackageJson(baseDir);
 
-        packageUpdater = new TaskUpdatePackages(getClassFinder(), baseDir,
-                new File(baseDir, "node_modules"), true);
+        packageUpdater = new TaskUpdatePackages(getClassFinder(), null, baseDir, true);
 
         packageJson = new File(baseDir, PACKAGE_JSON);
     }


### PR DESCRIPTION
`node_modules` is a standard location that is always considered by node even though the user declares a `NODE_PATH` variable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5661)
<!-- Reviewable:end -->
