### PR TITLE
Allow custom `frontend` and `target/frontend` locations.

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/NodeBuildFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/NodeBuildFrontendMojo.java
@@ -40,25 +40,27 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.plugin.common.AnnotationValuesExtractor;
 import com.vaadin.flow.plugin.common.FlowPluginFrontendUtils;
 import com.vaadin.flow.plugin.common.WebComponentModulesGenerator;
+import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.frontend.FrontendUtils;
 import com.vaadin.flow.server.frontend.NodeTasks;
 import com.vaadin.flow.theme.Theme;
 
 import static com.vaadin.flow.plugin.common.FlowPluginFrontendUtils.getClassFinder;
-import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_IMPORTS_FILE;
+import static com.vaadin.flow.server.frontend.FrontendUtils.FRONTEND;
 import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
 
 /**
- * Goal that builds frontend bundle by:
+ * Goal that builds the frontend bundle.
+ *
+ * It performs the following actions:
  * <ul>
- * <li>Updating <code>package.json</code> file with the {@link NpmPackage}
+ * <li>Update {@link Constants#PACKAGE_JSON} file with the {@link NpmPackage}
  * annotations defined in the classpath,</li>
- * <li>Installing dependencies by running <code>npm install</code></li>
- * <li>Updating the {@link FrontendUtils#FLOW_IMPORTS_FILE} file imports with
+ * <li>Install dependencies by running <code>npm install</code></li>
+ * <li>Update the {@link FrontendUtils#IMPORTS_NAME} file imports with
  * the {@link JsModule} {@link Theme} and {@link JavaScript} annotations defined
  * in the classpath,</li>
- * <li>creating <code>webpack.config.js</code> if it does not exist yet, or
- * updating it otherwise</li>
+ * <li>Update {@link FrontendUtils#WEBPACK_CONFIG} file.</li>
  * </ul>
  */
 @Mojo(name = "build-frontend", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, defaultPhase = LifecyclePhase.PREPARE_PACKAGE)
@@ -85,8 +87,8 @@ public class NodeBuildFrontendMojo extends AbstractMojo {
      * The JavaScript file used as entry point of the application, and which is
      * automatically updated by flow by reading java annotations.
      */
-    @Parameter(defaultValue = "${project.build.directory}/" + FLOW_IMPORTS_FILE)
-    private File generatedFlowImports;
+    @Parameter(defaultValue = "${project.build.directory}/" + FRONTEND)
+    private File generatedFolder;
 
     /**
      * A directory with project's frontend source files.
@@ -141,7 +143,7 @@ public class NodeBuildFrontendMojo extends AbstractMojo {
      * {@link com.vaadin.flow.plugin.common.WebComponentModulesGenerator} to
      * generate JavaScript files from the {@code WebComponentExporters}
      * present in the code base. The generated JavaScript files are placed in
-     * the same folder as the {@link FrontendUtils#FLOW_IMPORTS_FILE}.
+     * the same folder as the {@link FrontendUtils#FLOW_IMPORTS_NAME}.
      */
     private void generateExportedWebComponents() {
         if (!generateEmbeddableWebComponents) {
@@ -152,10 +154,9 @@ public class NodeBuildFrontendMojo extends AbstractMojo {
                         getClassFinder(project)), false);
 
         try {
-            File generatedFrontendDirectory = generatedFlowImports.getParentFile();
-            FileUtils.forceMkdir(generatedFrontendDirectory);
+            FileUtils.forceMkdir(generatedFolder);
             generator.getExporters().forEach(exporter ->
-                    generator.generateModuleFile(exporter, generatedFrontendDirectory));
+                    generator.generateModuleFile(exporter, generatedFolder));
         } catch (IOException e) {
             getLog().error("Failed to create a directory for generated web " +
                     "components", e);
@@ -163,9 +164,8 @@ public class NodeBuildFrontendMojo extends AbstractMojo {
     }
 
     private void runNodeUpdater() {
-        new NodeTasks.Builder(getClassFinder(project), frontendDirectory,
-                generatedFlowImports, npmFolder,
-                convertHtml)
+        new NodeTasks.Builder(getClassFinder(project),
+                npmFolder, generatedFolder, frontendDirectory, convertHtml)
                 .runNpmInstall(runNpmInstall)
                 .enablePackagesUpdate(true)
                 .enableImportsUpdate(true)

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/NodeValidateMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/NodeValidateMojo.java
@@ -40,8 +40,8 @@ import com.vaadin.flow.server.frontend.NodeTasks;
 
 import static com.vaadin.flow.plugin.common.FlowPluginFrontendUtils.getClassFinder;
 import static com.vaadin.flow.server.Constants.RESOURCES_FRONTEND_DEFAULT;
-import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_IMPORTS_FILE;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
+import static com.vaadin.flow.server.frontend.FrontendUtils.FRONTEND;
 import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
 
 /**
@@ -89,11 +89,10 @@ public class NodeValidateMojo extends AbstractMojo {
     private String webpackTemplate;
 
     /**
-     * The JavaScript file used as entry point of the application, and which is
-     * automatically updated by flow by reading java annotations.
+     * The folder where flow will put generated files that will be used by webpack.
      */
-    @Parameter(defaultValue = "${project.build.directory}/" + FLOW_IMPORTS_FILE)
-    private File generatedFlowImports;
+    @Parameter(defaultValue = "${project.build.directory}/" + FRONTEND)
+    private File generatedPath;
 
     @Override
     public void execute() {
@@ -108,7 +107,7 @@ public class NodeValidateMojo extends AbstractMojo {
         FrontendUtils.getNodeExecutable();
         FrontendUtils.getNpmExecutable();
 
-        new NodeTasks.Builder(getClassFinder(project), npmFolder, generatedFlowImports)
+        new NodeTasks.Builder(getClassFinder(project), npmFolder, generatedPath)
                 .withWebpack(getWebpackOutputDirectory(), webpackTemplate)
                 .createMissingPackageJson(true)
                 .enableImportsUpdate(false)

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/NodeBuildFrontendMojoTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/NodeBuildFrontendMojoTest.java
@@ -50,11 +50,11 @@ import elemental.json.Json;
 import elemental.json.JsonObject;
 
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
-import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_FRONTEND;
-import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_IMPORTS_FILE;
-import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
-import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.TARGET;
+import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
+import static com.vaadin.flow.server.frontend.FrontendUtils.IMPORTS_NAME;
+import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
 import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_CONFIG;
 import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_PREFIX_ALIAS;
 import static org.mockito.Mockito.mock;
@@ -65,6 +65,7 @@ public class NodeBuildFrontendMojoTest {
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     private File importsFile;
+    private File generatedFolder;
     private File nodeModulesPath;
     private File flowPackagPath;
     private String packageJson;
@@ -78,16 +79,17 @@ public class NodeBuildFrontendMojoTest {
         Mockito.when(project.getRuntimeClasspathElements()).thenReturn(getClassPath());
 
         File tmpRoot = temporaryFolder.getRoot();
-        importsFile = new File(tmpRoot, TARGET + FLOW_IMPORTS_FILE);
+        generatedFolder = new File(tmpRoot, TARGET);
+        importsFile = new File(generatedFolder, IMPORTS_NAME);
         nodeModulesPath = new File(tmpRoot, NODE_MODULES);
         flowPackagPath = new File(nodeModulesPath, FLOW_NPM_PACKAGE_NAME);
-        File frontendDirectory = new File(tmpRoot, FLOW_FRONTEND);
+        File frontendDirectory = new File(tmpRoot, DEFAULT_FRONTEND_DIR);
 
         packageJson = new File(tmpRoot, PACKAGE_JSON).getAbsolutePath();
         webpackConfig = new File(tmpRoot, WEBPACK_CONFIG).getAbsolutePath();
 
         ReflectionUtils.setVariableValueInObject(mojo, "project", project);
-        ReflectionUtils.setVariableValueInObject(mojo, "generatedFlowImports", importsFile);
+        ReflectionUtils.setVariableValueInObject(mojo, "generatedFolder", generatedFolder);
         ReflectionUtils.setVariableValueInObject(mojo, "frontendDirectory", frontendDirectory);
         ReflectionUtils.setVariableValueInObject(mojo, "generateEmbeddableWebComponents", false);
         ReflectionUtils.setVariableValueInObject(mojo, "convertHtml", true);

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/NodeValidateMojoTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/NodeValidateMojoTest.java
@@ -45,8 +45,6 @@ public class NodeValidateMojoTest {
     private File flowPackagePath;
     private String webpackConfig;
     private String packageJson;
-    private File importsFile;
-
 
     @Before
     public void setup() throws Exception {
@@ -66,7 +64,6 @@ public class NodeValidateMojoTest {
 
         nodeModulesPath = new File(projectBase, NODE_MODULES);
         flowPackagePath = new File(nodeModulesPath, FLOW_NPM_PACKAGE_NAME);
-        importsFile = new File(projectBase, "flow-imports.js");
         webpackConfig = new File(projectBase, WEBPACK_CONFIG).getAbsolutePath();
         packageJson = new File(projectBase, PACKAGE_JSON).getAbsolutePath();
 
@@ -76,7 +73,7 @@ public class NodeValidateMojoTest {
         ReflectionUtils.setVariableValueInObject(mojo, "includes", "**/*.js,**/*.css");
         ReflectionUtils.setVariableValueInObject(mojo, "npmFolder", projectBase);
         ReflectionUtils.setVariableValueInObject(mojo, "webpackTemplate", WEBPACK_CONFIG);
-        ReflectionUtils.setVariableValueInObject(mojo, "generatedFlowImports", importsFile);
+        ReflectionUtils.setVariableValueInObject(mojo, "generatedPath", projectBase);
 
         Assert.assertTrue(flowPackagePath.mkdirs());
         setProject(mojo, "war", "war_output");

--- a/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
@@ -203,7 +203,7 @@ public class DevModeHandler implements Serializable {
             return null;
         }
 
-        File directory = new File(getBaseDir(), FrontendUtils.WEBAPP_FOLDER).getAbsoluteFile();
+        File directory = new File(getBaseDir(), FrontendUtils.DEFAULT_NODE_DIR).getAbsoluteFile();
         if (!directory.exists()) {
             getLogger().warn("Instance not created because cannot change to '{}'", directory);
             return null;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -29,6 +29,8 @@ import java.util.stream.Collectors;
 
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.flow.server.Constants;
+
 /**
  * A class for static methods and definitions that might be
  * used in different locations.
@@ -36,12 +38,33 @@ import org.slf4j.LoggerFactory;
 public class FrontendUtils {
 
     /**
-     * Folder with frontend content. In regular java web projects it is
-     * `src/main/webapp` but in flow we prefer the project root directory so as
-     * we don't pollute sources folders with generated or installed stuff.
+     * Default folder for the node related content. It's the base directory for
+     * {@link Constants#PACKAGE_JSON}, {@link FrontendUtils#WEBPACK_CONFIG},
+     * {@link FrontendUtils#NODE_MODULES}.
      *
+     * By default it's the project root folder.
      */
-    public static final String WEBAPP_FOLDER = "./";
+    public static final String DEFAULT_NODE_DIR = "./";
+
+    /**
+     * Location for the installed node packages. This folder is always
+     * considered by node, even though we define extra folders with the
+     * <code>NODE_PATH</code>.
+     */
+    public static final String NODE_MODULES = "node_modules/";
+
+    /**
+     * Default folder used for source and generated folders.
+     */
+    public static final String FRONTEND = "frontend/";
+
+    /**
+     * Path of the folder containing application frontend source files, it needs
+     * to be relative to the {@link FrontendUtils#DEFAULT_NODE_DIR}
+     *
+     * By default it is <code>/frontend</code> in the project folder.
+     */
+    public static final String DEFAULT_FRONTEND_DIR = DEFAULT_NODE_DIR + FRONTEND;
 
     /**
      * The name of the webpack configuration file.
@@ -49,48 +72,45 @@ public class FrontendUtils {
     public static final String WEBPACK_CONFIG ="webpack.config.js";
 
     /**
-     * NPM package name that will be used for the javascript files present in
-     * jar resources that will to be copied to the npm folder so as they are
+     * The NPM package name that will be used for the javascript files present
+     * in jar resources that will to be copied to the npm folder so as they are
      * accessible to webpack.
      */
     public static final String FLOW_NPM_PACKAGE_NAME = "@vaadin/flow-frontend/";
 
-
     /**
-     * Default location for the installed node packages.
-     */
-    public static final String NODE_MODULES = "node_modules/";
-
-    /**
-     * Relative path to the folder containing application frontend source files.
-     * By default should be <code>/frontend</code> relative to the project
-     * folder.
-     */
-    public static final String FLOW_FRONTEND = "frontend/";
-
-    /**
-     * Target folder.
+     * Default target folder for the java project.
      */
     public static final String TARGET = "target/";
 
     /**
-     * File that contains Flow application imports, javascript, and theme annotations.
+     * Default folder name for flow generated stuff relative to the
+     * {@link FrontendUtils#TARGET}.
+     */
+    public static final String DEFAULT_GENERATED_DIR = TARGET + FRONTEND;
+
+    /**
+     * Name of the file that contains application imports, javascript, theme and style annotations.
      * It is also the entry-point for webpack.
-     * It should be relative to the {@link FrontendUtils#TARGET} folder.
+     * It is always generated in the {@link FrontendUtils#DEFAULT_GENERATED_DIR} folder.
      */
-    public static final String FLOW_IMPORTS_FILE = "frontend/generated-flow-imports.js";
+    public static final String IMPORTS_NAME = "generated-flow-imports.js";
 
     /**
-     *
      * A parameter for overriding the
-     * {@link FrontendUtils#FLOW_IMPORTS_FILE} default value for the file
-     * with all Flow project imports.
+     * {@link FrontendUtils#DEFAULT_GENERATED_DIR} folder.
      */
-    public static final String MAIN_JS_PARAM = "vaadin.frontend.jsFile";
+    public static final String PARAM_GENERATED_DIR = "vaadin.frontend.generated.folder";
 
     /**
-     * A special prefix to use in the webpack config to tell webpack to look for
-     * the import starting with a prefix in the Flow project frontend directory.
+     * A parameter for overriding the
+     * {@link FrontendUtils#DEFAULT_FRONTEND_DIR} folder.
+     */
+    public static final String PARAM_FRONTEND_DIR = "vaadin.frontend.frontend.folder";
+
+    /**
+     * A special prefix used by webpack to map imports placed in the {@link FrontendUtils#DEFAULT_FRONTEND_DIR}.
+     * e.g. <code>import 'Frontend/foo.js';</code> references the file<code>frontend/foo.js</code>.
      */
     public static final String WEBPACK_PREFIX_ALIAS = "Frontend/";
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -24,10 +24,11 @@ import java.util.Set;
 
 import com.vaadin.flow.server.Command;
 
-import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_FRONTEND;
-import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_IMPORTS_FILE;
-import static com.vaadin.flow.server.frontend.FrontendUtils.MAIN_JS_PARAM;
-import static com.vaadin.flow.server.frontend.FrontendUtils.TARGET;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
+import static com.vaadin.flow.server.frontend.FrontendUtils.IMPORTS_NAME;
+import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_FRONTEND_DIR;
+import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.getBaseDir;
 
 /**
@@ -41,15 +42,15 @@ public class NodeTasks implements Command {
      */
     public static class Builder implements Serializable {
 
-        private ClassFinder classFinder;
+        private final ClassFinder classFinder;
 
-        private File npmFolder;
+        private final File npmFolder;
 
-        private File frontendDirectory;
+        private final File generatedPath;
 
-        private File generatedFlowImports;
+        private final File frontendDirectory;
 
-        private boolean convertHtml;
+        private final boolean convertHtml;
 
         private File webpackOutputDirectory;
 
@@ -68,55 +69,66 @@ public class NodeTasks implements Command {
         private Set<String> visitedClasses;
 
         /**
-         * Create a builder instance.
+         * Create a builder instance, with everything set as default.
          *
          * @param classFinder
          *         a class finder
          */
         public Builder(ClassFinder classFinder) {
-            this(classFinder, new File(getBaseDir()),
-                    new File(getBaseDir(), System.getProperty(MAIN_JS_PARAM, TARGET + FLOW_IMPORTS_FILE)));
+            this(classFinder, new File(getBaseDir()));
         }
 
         /**
-         * Create a builder instance.
+         * Create a builder instance given an specific npm folder.
          *
          * @param classFinder
          *         a class finder
-         * @param frontendDirectory
-         *         a directory with project's frontend files
-         * @param generatedFlowImports
-         *         name of the JS file to update with the imports
          * @param npmFolder
          *         folder with the `package.json` file
-         * @param convertHtml
-         *         <code>true</code> to enable polymer-2 annotated classes to
-         *         be considered. Default is <code>true</code>.
          */
-        public Builder(ClassFinder classFinder, File frontendDirectory,
-                       File generatedFlowImports, File npmFolder,
-                       boolean convertHtml) {
+        public Builder(ClassFinder classFinder, File npmFolder) {
+            this(classFinder, npmFolder,
+                    new File(npmFolder, System.getProperty(PARAM_GENERATED_DIR, DEFAULT_GENERATED_DIR)));
+        }
+
+        /**
+         * Create a builder instance with custom npmFolder and generatedPath
+         *
+         * @param classFinder
+         *         a class finder
+         * @param npmFolder
+         *         folder with the `package.json` file
+         * @param generatedPath
+         *            folder where flow generated files will be placed.
+         */
+        public Builder(ClassFinder classFinder, File npmFolder, File generatedPath) {
+            this(classFinder, npmFolder, generatedPath,
+                    new File(npmFolder, System.getProperty(PARAM_FRONTEND_DIR, DEFAULT_FRONTEND_DIR)), true);
+        }
+
+        /**
+         * Create a builder instance with all parameters.
+         *
+         * @param classFinder
+         *            a class finder
+         * @param npmFolder
+         *            folder with the `package.json` file
+         * @param generatedPath
+         *            folder where flow generated files will be placed.
+         * @param frontendDirectory
+         *            a directory with project's frontend files
+         * @param convertHtml
+         *            <code>true</code> to enable polymer-2 annotated classes to
+         *            be considered. Default is <code>true</code>.
+         */
+        public Builder(ClassFinder classFinder, File npmFolder,
+                File generatedPath, File frontendDirectory, boolean convertHtml) {
             this.classFinder = classFinder;
-            this.frontendDirectory = frontendDirectory;
-            this.generatedFlowImports = generatedFlowImports;
             this.npmFolder = npmFolder;
             this.convertHtml = convertHtml;
             this.generateEmbeddableWebComponents = true;
-        }
-
-        /**
-         * Create a builder instance.
-         *
-         * @param classFinder
-         *         a class finder
-         * @param npmFolder
-         *         folder with the `package.json` file
-         * @param generatedFlowImports
-         *         name of the JS file to update with the imports
-         */
-        public Builder(ClassFinder classFinder, File npmFolder, File generatedFlowImports) {
-            this(classFinder, new File(getBaseDir(), FLOW_FRONTEND),
-                    generatedFlowImports, npmFolder, true);
+            this.generatedPath = generatedPath.isAbsolute() ? generatedPath : new File(npmFolder, generatedPath.getPath());
+            this.frontendDirectory = frontendDirectory.isAbsolute() ? frontendDirectory : new File(npmFolder, frontendDirectory.getPath());
         }
 
         /**
@@ -215,7 +227,7 @@ public class NodeTasks implements Command {
         /**
          * Sets a set to which the names of classes visited when finding
          * dependencies will be collected.
-         * 
+         *
          * @param visitedClasses a set to collect class name to, or <code>null</code> to not collect visited classes
          * @return the builder, for chaining
          */
@@ -240,32 +252,31 @@ public class NodeTasks implements Command {
         }
 
         if (builder.createMissingPackageJson) {
-            TaskCreatePackageJson packageCreator = new TaskCreatePackageJson(builder.npmFolder);
+            TaskCreatePackageJson packageCreator = new TaskCreatePackageJson(builder.npmFolder, builder.generatedPath);
             commands.add(packageCreator);
         }
 
         if (builder.enablePackagesUpdate) {
             TaskUpdatePackages packageUpdater = new TaskUpdatePackages(classFinder,
-                    frontendDependencies, builder.npmFolder, builder.convertHtml);
+                    frontendDependencies, builder.npmFolder, builder.generatedPath, builder.convertHtml);
             commands.add(packageUpdater);
 
             if (builder.runNpmInstall) {
                 commands.add(new TaskRunNpmInstall(packageUpdater));
             }
-
         }
 
         if (builder.webpackTemplate != null && !builder.webpackTemplate.isEmpty()) {
             commands.add(new TaskUpdateWebpack(builder.npmFolder,
                     builder.webpackOutputDirectory, builder.webpackTemplate,
-                    builder.generatedFlowImports));
+                    new File(builder.generatedPath, IMPORTS_NAME)));
         }
 
         if (builder.enableImportsUpdate) {
             commands.add(new TaskUpdateImports(classFinder,
-                    frontendDependencies, builder.frontendDirectory,
-                    builder.generatedFlowImports, builder.npmFolder,
-                    builder.convertHtml));
+                frontendDependencies,
+                builder.npmFolder, builder.generatedPath,
+                builder.frontendDirectory, builder.convertHtml));
 
             if (builder.visitedClasses != null) {
                 builder.visitedClasses

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.server.Command;
+import com.vaadin.flow.server.Constants;
 
 import elemental.json.Json;
 import elemental.json.JsonObject;
@@ -58,14 +59,21 @@ public abstract class NodeUpdater implements Command {
     private static final String DEV_DEPENDENCIES = "devDependencies";
 
     /**
-     * Folder with the <code>package.json</code> file.
+     * Base directory for {@link Constants#PACKAGE_JSON},
+     * {@link FrontendUtils#WEBPACK_CONFIG}, {@link FrontendUtils#NODE_MODULES}.
      */
     protected final File npmFolder;
 
     /**
-     * The path to the {@literal node_modules} directory of the project.
+     * The path to the {@link FrontendUtils#NODE_MODULES} directory.
      */
     protected final File nodeModulesPath;
+    
+    
+    /**
+     * Base directory for flow generated files. 
+     */
+    protected final File generatedPath;
 
     /**
      * Enable or disable legacy components annotated only with
@@ -94,17 +102,20 @@ public abstract class NodeUpdater implements Command {
      *            a reusable frontend dependencies
      * @param npmFolder
      *            folder with the `package.json` file
+     * @param generatedPath
+     *            folder where flow generated files will be placed.
      * @param convertHtml
      *            true to enable polymer-2 annotated classes to be considered
      */
     protected NodeUpdater(ClassFinder finder, FrontendDependencies frontendDependencies, File npmFolder,
-            boolean convertHtml) {
+            File generatedPath, boolean convertHtml) {
         this.frontDeps = finder != null && frontendDependencies == null
                 ? new FrontendDependencies(finder)
                 : frontendDependencies;
         this.finder = finder;
         this.npmFolder = npmFolder;
         this.nodeModulesPath = new File(npmFolder, NODE_MODULES);
+        this.generatedPath = generatedPath;
         this.convertHtml = convertHtml;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCreatePackageJson.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCreatePackageJson.java
@@ -31,9 +31,11 @@ public class TaskCreatePackageJson extends NodeUpdater {
      *
      * @param npmFolder
      *            folder with the `package.json` file.
+     * @param generatedPath
+     *            folder where flow generated files will be placed.
      */
-    public TaskCreatePackageJson(File npmFolder) {
-        super(null, null, npmFolder, false);
+    TaskCreatePackageJson(File npmFolder, File generatedPath) {
+        super(null, null, npmFolder, generatedPath, false);
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -39,7 +39,7 @@ public class TaskRunNpmInstall implements Command {
      *            package-updater instance used for checking if previous
      *            execution modified the package.json file
      */
-    public TaskRunNpmInstall(NodeUpdater packageUpdater) {
+    TaskRunNpmInstall(NodeUpdater packageUpdater) {
         this.packageUpdater = packageUpdater;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -38,6 +38,7 @@ import com.vaadin.flow.theme.Theme;
 import com.vaadin.flow.theme.ThemeDefinition;
 
 import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
+import static com.vaadin.flow.server.frontend.FrontendUtils.IMPORTS_NAME;
 import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_PREFIX_ALIAS;
 
 /**
@@ -51,31 +52,29 @@ public class TaskUpdateImports extends NodeUpdater {
 
     private final File generatedFlowImports;
     private final File frontendDirectory;
-    private final File generatedFrontendDirectory;
 
     /**
      * Create an instance of the updater given all configurable parameters.
      *
      * @param finder
-     *         a reusable class finder
+     *            a reusable class finder
      * @param frontendDependencies
-     *         a reusable frontend dependencies
-     * @param frontendDirectory
-     *         a directory with project's frontend files
-     * @param generatedFlowImports
-     *         name of the JS file to update with the imports
+     *            a reusable frontend dependencies
      * @param npmFolder
-     *         folder with the `package.json` file
+     *            folder with the `package.json` file
+     * @param generatedPath
+     *            folder where flow generated files will be placed.
+     * @param frontendDirectory
+     *            a directory with project's frontend files
      * @param convertHtml
-     *         true to enable polymer-2 annotated classes to be considered
+     *            true to enable polymer-2 annotated classes to be considered
      */
-    public TaskUpdateImports(ClassFinder finder,
-            FrontendDependencies frontendDependencies, File frontendDirectory,
-            File generatedFlowImports, File npmFolder, boolean convertHtml) {
-        super(finder, frontendDependencies, npmFolder, convertHtml);
-        this.generatedFlowImports = generatedFlowImports;
+    TaskUpdateImports(ClassFinder finder,
+            FrontendDependencies frontendDependencies, File npmFolder,
+            File generatedPath, File frontendDirectory, boolean convertHtml) {
+        super(finder, frontendDependencies, npmFolder, generatedPath, convertHtml);
         this.frontendDirectory = frontendDirectory;
-        this.generatedFrontendDirectory = generatedFlowImports.getParentFile();
+        this.generatedFlowImports = new File(generatedPath, IMPORTS_NAME);
     }
 
     @Override
@@ -86,7 +85,7 @@ public class TaskUpdateImports extends NodeUpdater {
         }
         modules.addAll(getJavascriptJsModules(frontDeps.getScripts()));
 
-        modules.addAll(getGeneratedModules(generatedFrontendDirectory,
+        modules.addAll(getGeneratedModules(generatedPath,
                 Collections.singleton(generatedFlowImports.getName())));
 
         modules = sortModules(modules);
@@ -174,7 +173,7 @@ public class TaskUpdateImports extends NodeUpdater {
         return new File(frontendDirectory, jsImport).isFile()
                 || new File(nodeModulesPath, jsImport).isFile()
                 || new File(new File(nodeModulesPath, FLOW_NPM_PACKAGE_NAME), jsImport).isFile()
-                || new File(generatedFrontendDirectory,
+                || new File(generatedPath,
                 generatedResourcePathIntoRelativePath(jsImport)).isFile();
     }
 
@@ -191,7 +190,8 @@ public class TaskUpdateImports extends NodeUpdater {
     }
 
     private void updateMainJsFile(List<String> newContent) throws IOException {
-        List<String> oldContent = generatedFlowImports.exists() ? FileUtils.readLines(generatedFlowImports, "UTF-8") : null;
+        List<String> oldContent = generatedFlowImports.exists()
+                ? FileUtils.readLines(generatedFlowImports, "UTF-8") : null;
         if (newContent.equals(oldContent)) {
             log().info("No js modules to update");
         } else {
@@ -200,7 +200,6 @@ public class TaskUpdateImports extends NodeUpdater {
             log().info("Updated {}", generatedFlowImports);
         }
     }
-
 
     private static String generatedResourcePathIntoRelativePath(String path) {
         return path.replace(GENERATED_PREFIX, "./");

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -44,14 +44,16 @@ public class TaskUpdatePackages extends NodeUpdater {
      *            a reusable frontend dependencies
      * @param npmFolder
      *            folder with the `package.json` file
+     * @param generatedPath
+     *            folder where flow generated files will be placed.
      * @param convertHtml
      *            whether to convert html imports or not during the package
      *            updates
      */
-    public TaskUpdatePackages(ClassFinder finder,
+    TaskUpdatePackages(ClassFinder finder,
             FrontendDependencies frontendDependencies, File npmFolder,
-            boolean convertHtml) {
-        super(finder, frontendDependencies, npmFolder, convertHtml);
+            File generatedPath, boolean convertHtml) {
+        super(finder, frontendDependencies, npmFolder, generatedPath, convertHtml);
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateWebpack.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateWebpack.java
@@ -55,7 +55,7 @@ public class TaskUpdateWebpack implements Command {
      * @param generatedFlowImports
      *            name of the JS file to update with the Flow project imports
      */
-    public TaskUpdateWebpack(File webpackConfigFolder, File webpackOutputDirectory,
+    TaskUpdateWebpack(File webpackConfigFolder, File webpackOutputDirectory,
             String webpackTemplate, File generatedFlowImports) {
         this.webpackTemplate = webpackTemplate;
         this.webpackOutputDirectory = webpackOutputDirectory.toPath();

--- a/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
@@ -107,7 +107,7 @@ public class DevModeHandlerTest {
     @Test
     public void should_CreateInstanceAndRunWebPack_When_DevModeAndNpmInstalled() throws Exception {
         assertNotNull(DevModeHandler.start(configuration));
-        assertTrue(new File(getBaseDir(), FrontendUtils.WEBAPP_FOLDER + WEBPACK_TEST_OUT_FILE).canRead());
+        assertTrue(new File(getBaseDir(), FrontendUtils.DEFAULT_NODE_DIR + WEBPACK_TEST_OUT_FILE).canRead());
         assertNull(DevModeHandler.getDevModeHandler().getFailedOutput());
         Thread.sleep(150); //NOSONAR
     }
@@ -156,7 +156,7 @@ public class DevModeHandlerTest {
     @Test
     public void should_RunWebpack_When_WebpackNotListening() throws Exception {
         DevModeHandler.start(configuration);
-        assertTrue(new File(getBaseDir(), FrontendUtils.WEBAPP_FOLDER + WEBPACK_TEST_OUT_FILE).canRead());
+        assertTrue(new File(getBaseDir(), FrontendUtils.DEFAULT_NODE_DIR + WEBPACK_TEST_OUT_FILE).canRead());
         Thread.sleep(150); //NOSONAR
     }
 
@@ -164,7 +164,7 @@ public class DevModeHandlerTest {
     public void shouldNot_RunWebpack_When_WebpackRunning() throws Exception {
         prepareHttpServer(HTTP_OK, "bar");
         DevModeHandler.start(configuration);
-        assertFalse(new File(getBaseDir(), FrontendUtils.WEBAPP_FOLDER + WEBPACK_TEST_OUT_FILE).canRead());
+        assertFalse(new File(getBaseDir(), FrontendUtils.DEFAULT_NODE_DIR + WEBPACK_TEST_OUT_FILE).canRead());
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksTest.java
@@ -1,0 +1,79 @@
+package com.vaadin.flow.server.frontend;
+
+import java.io.File;
+import java.lang.reflect.Field;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.vaadin.flow.server.frontend.ClassFinder.DefaultClassFinder;
+import com.vaadin.flow.server.frontend.NodeTasks.Builder;
+
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
+import static com.vaadin.flow.server.frontend.FrontendUtils.IMPORTS_NAME;
+import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_FRONTEND_DIR;
+import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_GENERATED_DIR;
+
+public class NodeTasksTest {
+
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    String userDir;
+
+    @Before
+    public void setup() {
+        userDir = temporaryFolder.getRoot().getAbsolutePath();
+        System.setProperty("user.dir", userDir);
+        System.clearProperty(PARAM_FRONTEND_DIR);
+        System.clearProperty(PARAM_GENERATED_DIR);
+    }
+
+    @Test
+    public void should_UseDefaultFolders()throws Exception {
+        Builder builder = new Builder(new DefaultClassFinder(this.getClass().getClassLoader()))
+            .enablePackagesUpdate(false)
+            .enableImportsUpdate(true)
+            .runNpmInstall(false)
+            .withEmbeddableWebComponents(false);
+
+
+        Assert.assertEquals(new File(userDir, DEFAULT_FRONTEND_DIR).getAbsolutePath(),
+                ((File)getFieldValue(builder, "frontendDirectory")).getAbsolutePath());
+        Assert.assertEquals(new File(userDir, DEFAULT_GENERATED_DIR).getAbsolutePath(),
+                ((File)getFieldValue(builder, "generatedPath")).getAbsolutePath());
+
+        builder.build().execute();
+        Assert.assertTrue(new File(userDir, DEFAULT_GENERATED_DIR + IMPORTS_NAME).exists());
+    }
+
+    @Test
+    public void should_BeAbleToCustomizeFolders() throws Exception {
+        System.setProperty(PARAM_FRONTEND_DIR, "my_custom_sources_folder");
+        System.setProperty(PARAM_GENERATED_DIR, "my/custom/generated/folder");
+
+        Builder builder = new Builder(new DefaultClassFinder(this.getClass().getClassLoader()))
+            .enablePackagesUpdate(false)
+            .enableImportsUpdate(true)
+            .runNpmInstall(false)
+            .withEmbeddableWebComponents(false);
+
+        Assert.assertEquals(new File(userDir, "my_custom_sources_folder").getAbsolutePath(),
+                ((File)getFieldValue(builder, "frontendDirectory")).getAbsolutePath());
+        Assert.assertEquals(new File(userDir, "my/custom/generated/folder").getAbsolutePath(),
+                ((File)getFieldValue(builder, "generatedPath")).getAbsolutePath());
+
+        builder.build().execute();
+        Assert.assertTrue(new File(userDir, "my/custom/generated/folder/" + IMPORTS_NAME).exists());
+    }
+
+    private Object getFieldValue(Object obj, String name) throws Exception {
+        Field field = obj.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        return field.get(obj);
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdatePackagesTest.java
@@ -29,6 +29,7 @@ import org.junit.rules.TemporaryFolder;
 import elemental.json.JsonObject;
 
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.getBaseDir;
 
 public class NodeUpdatePackagesTest extends NodeUpdateTestUtil {
@@ -45,12 +46,13 @@ public class NodeUpdatePackagesTest extends NodeUpdateTestUtil {
         System.setProperty("user.dir", temporaryFolder.getRoot().getPath());
 
         File baseDir = new File(getBaseDir());
+        File generatedDir = new File(baseDir, DEFAULT_GENERATED_DIR); 
 
         NodeUpdateTestUtil.createStubNode(true, true);
 
-        packageCreator = new TaskCreatePackageJson(baseDir);
+        packageCreator = new TaskCreatePackageJson(baseDir, generatedDir);
 
-        packageUpdater = new TaskUpdatePackages(getClassFinder(), null, baseDir, true);
+        packageUpdater = new TaskUpdatePackages(getClassFinder(), null, baseDir, generatedDir, true);
 
         packageJson = new File(baseDir, PACKAGE_JSON);
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateWebpackTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateWebpackTest.java
@@ -31,7 +31,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_IMPORTS_FILE;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
+import static com.vaadin.flow.server.frontend.FrontendUtils.IMPORTS_NAME;
+import static com.vaadin.flow.server.frontend.FrontendUtils.TARGET;
 import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_CONFIG;
 import static com.vaadin.flow.server.frontend.FrontendUtils.getBaseDir;
 
@@ -52,13 +54,16 @@ public class TaskUpdateWebpackTest extends NodeUpdateTestUtil {
 
         NodeUpdateTestUtil.createStubNode(true, true);
 
-        webpackUpdater = new TaskUpdateWebpack(baseDir, new File(baseDir, "target/classes"), WEBPACK_CONFIG,
-                new File(baseDir, FLOW_IMPORTS_FILE));
+        webpackUpdater = new TaskUpdateWebpack(
+                baseDir,
+                new File(baseDir, TARGET + "classes"),
+                WEBPACK_CONFIG,
+                new File(baseDir, DEFAULT_GENERATED_DIR + IMPORTS_NAME));
 
         webpackConfig = new File(baseDir, WEBPACK_CONFIG);
     }
-    
-    
+
+
     @After
     public void teardown() {
         webpackConfig.delete();
@@ -70,23 +75,23 @@ public class TaskUpdateWebpackTest extends NodeUpdateTestUtil {
         webpackUpdater.execute();
 
         Assert.assertTrue(webpackConfig.exists());
-        assertWebpackConfigContent("frontend/generated-flow-imports.js", "target/classes");
+        assertWebpackConfigContent("target/frontend/generated-flow-imports.js", "target/classes");
     }
 
     @Test
     public void should_update_Webpack() throws Exception {
         webpackUpdater.execute();
         Assert.assertTrue(webpackConfig.exists());
-        
+
         TaskUpdateWebpack newUpdater = new TaskUpdateWebpack(baseDir, new File(baseDir, "foo"), WEBPACK_CONFIG,
                 new File(baseDir, "bar"));
         newUpdater.execute();
-        
+
         assertWebpackConfigContent("bar", "foo");
     }
 
     private void assertWebpackConfigContent(String entryPoint, String outputFolder) throws IOException {
-        
+
         List<String> webpackContents = Files.lines(webpackConfig.toPath()).collect(Collectors.toList());
 
         Assert.assertFalse(
@@ -94,20 +99,20 @@ public class TaskUpdateWebpackTest extends NodeUpdateTestUtil {
                 webpackContents.contains("\\\\"));
 
         verifyNoAbsolutePathsPresent(webpackContents);
-        
+
         verifyUpdate(webpackContents, entryPoint, outputFolder);
     }
-    
-    
+
+
     private void verifyUpdate(List<String> webpackContents, String entryPoint, String outputFolder) {
         Assert.assertTrue(
                 "webpack config should update fileNameOfTheFlowGeneratedMainEntryPoint",
                 webpackContents.contains("fileNameOfTheFlowGeneratedMainEntryPoint = require('path').resolve(__dirname, '" + entryPoint + "');"));
-        
+
         Assert.assertTrue(
                 "webpack config should update fileNameOfTheFlowGeneratedMainEntryPoint",
                 webpackContents.contains("mavenOutputFolderForFlowBundledFiles = require('path').resolve(__dirname, '" + outputFolder + "');"));
-        
+
     }
 
     private void verifyNoAbsolutePathsPresent(List<String> webpackContents) {


### PR DESCRIPTION
- refactor constructors to align parameters order
- improve javadocs of constants and parameters
- change visibility of task commands so as they need to be executed through
  the task executor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5665)
<!-- Reviewable:end -->
