### PR TITLE
Enable manually defining the webpackoutput directory

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/NodeValidateMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/NodeValidateMojo.java
@@ -94,6 +94,13 @@ public class NodeValidateMojo extends AbstractMojo {
     @Parameter(defaultValue = "${project.build.directory}/" + FRONTEND)
     private File generatedPath;
 
+    /**
+     * The folder where webpack should output index.js and other generated files.
+     * By default the output folder is decided depending on project package type.
+     */
+    @Parameter
+    private File webpackOutputDirectory;
+
     @Override
     public void execute() {
 
@@ -164,6 +171,10 @@ public class NodeValidateMojo extends AbstractMojo {
     }
 
     private File getWebpackOutputDirectory() {
+        if(webpackOutputDirectory != null) {
+            return webpackOutputDirectory;
+        }
+
         Build buildInformation = project.getBuild();
         switch (project.getPackaging()) {
             case "jar":


### PR DESCRIPTION
Partial fix for vaadin/spring#5676

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5685)
<!-- Reviewable:end -->
