### PR TITLE
Move node build-frontend to process_classes

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/NodeBuildFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/NodeBuildFrontendMojo.java
@@ -63,7 +63,7 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
  * <li>Update {@link FrontendUtils#WEBPACK_CONFIG} file.</li>
  * </ul>
  */
-@Mojo(name = "build-frontend", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, defaultPhase = LifecyclePhase.PREPARE_PACKAGE)
+@Mojo(name = "build-frontend", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, defaultPhase = LifecyclePhase.PROCESS_CLASSES)
 public class NodeBuildFrontendMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}", readonly = true, required = true)


### PR DESCRIPTION
Moved node build-frontend from prepare_package to process_classes
so that it is executed also for spring-boot:run

Fixes #5677

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5691)
<!-- Reviewable:end -->
