### PR TITLE
`converHtml` was not fully removed, removing it from imports updater

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/NodeBuildFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/NodeBuildFrontendMojo.java
@@ -33,7 +33,6 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 
-import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
@@ -68,13 +67,6 @@ public class NodeBuildFrontendMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private MavenProject project;
-
-    /**
-     * Enable or disable legacy components annotated only with
-     * {@link HtmlImport}.
-     */
-    @Parameter(defaultValue = "true")
-    private boolean convertHtml;
 
     /**
      * The folder where `package.json` file is located. Default is project root
@@ -165,7 +157,7 @@ public class NodeBuildFrontendMojo extends AbstractMojo {
 
     private void runNodeUpdater() {
         new NodeTasks.Builder(getClassFinder(project),
-                npmFolder, generatedFolder, frontendDirectory, convertHtml)
+                npmFolder, generatedFolder, frontendDirectory)
                 .runNpmInstall(runNpmInstall)
                 .enablePackagesUpdate(true)
                 .enableImportsUpdate(true)

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/NodeBuildFrontendMojoTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/NodeBuildFrontendMojoTest.java
@@ -98,7 +98,6 @@ public class NodeBuildFrontendMojoTest {
                 frontendDirectory);
         ReflectionUtils.setVariableValueInObject(mojo,
                 "generateEmbeddableWebComponents", false);
-        ReflectionUtils.setVariableValueInObject(mojo, "convertHtml", true);
         ReflectionUtils.setVariableValueInObject(mojo, "npmFolder", npmFolder);
         ReflectionUtils.setVariableValueInObject(mojo, "generateBundle", false);
         ReflectionUtils.setVariableValueInObject(mojo, "runNpmInstall", false);

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/TestComponents.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/TestComponents.java
@@ -34,12 +34,12 @@ public class TestComponents {
     class ButtonComponent extends Component {
     }
 
-    @HtmlImport("frontend://bower_components/iron-icon/iron-icon.html")
+    @JsModule("@polymer/iron-icon/iron-icon.js")
     class IconComponent extends Component {
     }
 
-    @HtmlImport("frontend://bower_components/vaadin-date-picker/src/vaadin-date-picker.html")
-    @HtmlImport("frontend://bower_components/vaadin-date-picker/src/vaadin-month-calendar.html")
+    @JsModule("@vaadin/vaadin-date-picker/src/vaadin-date-picker.js")
+    @JsModule("@vaadin/vaadin-date-picker/src/vaadin-month-calendar.js")
     @JavaScript("frontend://ExampleConnector.js")
     public static class VaadinBowerComponent extends Component {
     }
@@ -58,7 +58,7 @@ public class TestComponents {
     public static class VaadinMixedComponent extends Component {
     }
 
-    @HtmlImport("frontend://local-p2-template.html")
+    @JsModule("./local-p2-template.js")
     public static class LocalP2Template extends Component {
     }
 
@@ -70,7 +70,7 @@ public class TestComponents {
     public static class FrontendP3Template extends Component {
     }
 
-    @HtmlImport("foo.html")
+    @JsModule("./foo.js")
     public static class FlatImport extends Component {
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendDependencies.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -36,7 +35,6 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.WebComponentExporter;
-import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.internal.ReflectTools;
 import com.vaadin.flow.router.Route;
@@ -191,25 +189,6 @@ public class FrontendDependencies implements Serializable {
         Set<String> all = new HashSet<>();
         for (FrontendClassVisitor.EndPointData r : endPoints.values()) {
             all.addAll(r.classes);
-        }
-        return all;
-    }
-
-    /**
-     * get all HTML imports used in the application. It excludes imports from
-     * classes that are already annotated with {@link NpmPackage} or {@link
-     * JsModule}
-     *
-     * @return the set of HTML imports
-     */
-    public Set<String> getImports() {
-        Set<String> all = new HashSet<>();
-        for (FrontendClassVisitor.EndPointData r : endPoints.values()) {
-            for (Entry<String, Set<String>> e : r.imports.entrySet()) {
-                if (!r.npmDone.contains(e.getKey())) {
-                    all.addAll(e.getValue());
-                }
-            }
         }
         return all;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -16,13 +16,6 @@
 
 package com.vaadin.flow.server.frontend;
 
-import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
-import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
-import static com.vaadin.flow.server.frontend.FrontendUtils.IMPORTS_NAME;
-import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_FRONTEND_DIR;
-import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_GENERATED_DIR;
-import static com.vaadin.flow.server.frontend.FrontendUtils.getBaseDir;
-
 import java.io.File;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -30,6 +23,13 @@ import java.util.Collection;
 import java.util.Set;
 
 import com.vaadin.flow.server.Command;
+
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
+import static com.vaadin.flow.server.frontend.FrontendUtils.IMPORTS_NAME;
+import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_FRONTEND_DIR;
+import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_GENERATED_DIR;
+import static com.vaadin.flow.server.frontend.FrontendUtils.getBaseDir;
 
 /**
  * An executor that it's run when the servlet context is initialised in dev-mode
@@ -45,8 +45,6 @@ public class NodeTasks implements Command {
         private final ClassFinder classFinder;
 
         private final File frontendDirectory;
-
-        private final boolean convertHtml;
 
         private File webpackOutputDirectory;
 
@@ -111,8 +109,7 @@ public class NodeTasks implements Command {
                 File generatedPath) {
             this(classFinder, npmFolder, generatedPath,
                     new File(npmFolder, System.getProperty(PARAM_FRONTEND_DIR,
-                            DEFAULT_FRONTEND_DIR)),
-                    true);
+                            DEFAULT_FRONTEND_DIR)));
         }
 
         /**
@@ -126,16 +123,11 @@ public class NodeTasks implements Command {
          *            folder where flow generated files will be placed.
          * @param frontendDirectory
          *            a directory with project's frontend files
-         * @param convertHtml
-         *            <code>true</code> to enable polymer-2 annotated classes to
-         *            be considered. Default is <code>true</code>.
          */
         public Builder(ClassFinder classFinder, File npmFolder,
-                File generatedPath, File frontendDirectory,
-                boolean convertHtml) {
+                File generatedPath, File frontendDirectory) {
             this.classFinder = classFinder;
             this.npmFolder = npmFolder;
-            this.convertHtml = convertHtml;
             this.generateEmbeddableWebComponents = true;
             this.generatedFolder = generatedPath.isAbsolute() ? generatedPath
                     : new File(npmFolder, generatedPath.getPath());
@@ -295,7 +287,7 @@ public class NodeTasks implements Command {
             commands.add(
                     new TaskUpdateImports(classFinder, frontendDependencies,
                             builder.npmFolder, builder.generatedFolder,
-                            builder.frontendDirectory, builder.convertHtml));
+                            builder.frontendDirectory));
 
             if (builder.visitedClasses != null) {
                 builder.visitedClasses

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -21,7 +21,6 @@ import java.net.URI;
 import java.net.URL;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -30,7 +29,6 @@ import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.server.Command;
 import com.vaadin.flow.server.Constants;
 
@@ -82,12 +80,6 @@ public abstract class NodeUpdater implements Command {
     protected final File generatedFolder;
 
     /**
-     * Enable or disable legacy components annotated only with
-     * {@link HtmlImport}.
-     */
-    protected final boolean convertHtml;
-
-    /**
      * The {@link FrontendDependencies} object representing the application
      * dependencies.
      */
@@ -110,11 +102,9 @@ public abstract class NodeUpdater implements Command {
      *            folder with the `package.json` file
      * @param generatedPath
      *            folder where flow generated files will be placed.
-     * @param convertHtml
-     *            true to enable polymer-2 annotated classes to be considered
      */
     protected NodeUpdater(ClassFinder finder, FrontendDependencies frontendDependencies, File npmFolder,
-            File generatedPath, boolean convertHtml) {
+            File generatedPath) {
         this.frontDeps = finder != null && frontendDependencies == null
                 ? new FrontendDependencies(finder)
                 : frontendDependencies;
@@ -122,17 +112,6 @@ public abstract class NodeUpdater implements Command {
         this.npmFolder = npmFolder;
         this.nodeModulesFolder = new File(npmFolder, NODE_MODULES);
         this.generatedFolder = generatedPath;
-        this.convertHtml = convertHtml;
-    }
-
-    Set<String> getHtmlImportJsModules(Set<String> htmlImports) {
-        return htmlImports.stream().map(this::htmlImportToJsModule).filter(Objects::nonNull)
-                .collect(Collectors.toSet());
-    }
-
-    Set<String> getHtmlImportNpmPackages(Set<String> htmlImports) {
-        return htmlImports.stream().map(this::htmlImportToNpmPackage).filter(Objects::nonNull)
-                .collect(Collectors.toSet());
     }
 
     Set<String> getJavascriptJsModules(Set<String> javascripts) {
@@ -177,26 +156,6 @@ public abstract class NodeUpdater implements Command {
     private URL getResourceUrl(String resource) {
         resource = RESOURCES_FRONTEND_DEFAULT + "/" + resource.replaceFirst(FLOW_NPM_PACKAGE_NAME, "");
         return finder.getResource(resource);
-    }
-
-    private String htmlImportToJsModule(String htmlImport) {
-        String module = resolveInFlowFrontendDirectory( // @formatter:off
-        htmlImport
-          .replaceFirst("^.*bower_components/(vaadin-[^/]*/.*)\\.html$", "@vaadin/$1.js")
-          .replaceFirst("^.*bower_components/((iron|paper)-[^/]*/.*)\\.html$", "@polymer/$1.js")
-          .replaceFirst("\\.html$", ".js")
-        ); // @formatter:on
-        return Objects.equals(module, htmlImport) ? null : module;
-    }
-
-    private String htmlImportToNpmPackage(String htmlImport) {
-        String module = resolveInFlowFrontendDirectory( // @formatter:off
-        htmlImport
-          .replaceFirst("^.*bower_components/(vaadin-[^/]*)/.*\\.html$", "@vaadin/$1")
-          .replaceFirst("^.*bower_components/((iron|paper)-[^/]*)/.*\\.html$", "@polymer/$1")
-          .replaceFirst("\\.html$", ".js")
-        ); // @formatter:on
-        return Objects.equals(module, htmlImport) ? null : module;
     }
 
     JsonObject getMainPackageJson() throws IOException {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCreatePackageJson.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCreatePackageJson.java
@@ -36,7 +36,7 @@ public class TaskCreatePackageJson extends NodeUpdater {
      *            folder where flow generated files will be placed.
      */
     TaskCreatePackageJson(File npmFolder, File generatedPath) {
-        super(null, null, npmFolder, generatedPath, false);
+        super(null, null, npmFolder, generatedPath);
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -66,13 +66,11 @@ public class TaskUpdateImports extends NodeUpdater {
      *            folder where flow generated files will be placed.
      * @param frontendDirectory
      *            a directory with project's frontend files
-     * @param convertHtml
-     *            true to enable polymer-2 annotated classes to be considered
      */
     TaskUpdateImports(ClassFinder finder,
             FrontendDependencies frontendDependencies, File npmFolder,
-            File generatedPath, File frontendDirectory, boolean convertHtml) {
-        super(finder, frontendDependencies, npmFolder, generatedPath, convertHtml);
+            File generatedPath, File frontendDirectory) {
+        super(finder, frontendDependencies, npmFolder, generatedPath);
         this.frontendDirectory = frontendDirectory;
         this.generatedFlowImports = new File(generatedPath, IMPORTS_NAME);
     }
@@ -80,9 +78,6 @@ public class TaskUpdateImports extends NodeUpdater {
     @Override
     public void execute() {
         Set<String> modules = new HashSet<>(getJavascriptJsModules(frontDeps.getModules()));
-        if (convertHtml) {
-            modules.addAll(getHtmlImportJsModules(frontDeps.getImports()));
-        }
         modules.addAll(getJavascriptJsModules(frontDeps.getScripts()));
 
         modules.addAll(getGeneratedModules(generatedFolder,

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -59,7 +59,7 @@ public class TaskUpdatePackages extends NodeUpdater {
     TaskUpdatePackages(ClassFinder finder,
             FrontendDependencies frontendDependencies, File npmFolder,
             File generatedPath) {
-        super(finder, frontendDependencies, npmFolder, generatedPath, false);
+        super(finder, frontendDependencies, npmFolder, generatedPath);
     }
 
     @Override

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendDependenciesTest.java
@@ -113,8 +113,6 @@ public class FrontendDependenciesTest {
 
         assertEquals(Theme4.class, deps.getThemeDefinition().getTheme());
 
-        assertEquals(0, deps.getImports().size());
-
         assertEquals(1, deps.getModules().size());
         assertTrue(deps.getModules().contains("./theme-4.js"));
 
@@ -130,7 +128,6 @@ public class FrontendDependenciesTest {
 
         assertNull(deps.getThemeDefinition());
 
-        assertEquals(0, deps.getImports().size());
         assertEquals(2, deps.getModules().size());
         assertEquals(0, deps.getPackages().size());
         assertEquals(1, deps.getScripts().size());
@@ -141,7 +138,6 @@ public class FrontendDependenciesTest {
         FrontendDependencies deps = create(RootViewWithLayoutTheme.class);
         assertEquals(Theme1.class, deps.getThemeDefinition().getTheme());
 
-        assertEquals(2, deps.getImports().size());
         assertEquals(8, deps.getModules().size());
         assertEquals(0, deps.getPackages().size());
         assertEquals(6, deps.getScripts().size());
@@ -155,7 +151,6 @@ public class FrontendDependenciesTest {
         assertEquals(Theme2.class, deps.getThemeDefinition().getTheme());
         assertEquals("foo", deps.getThemeDefinition().getVariant());
 
-        assertEquals(2, deps.getImports().size());
         assertEquals(4, deps.getModules().size());
         assertEquals(0, deps.getPackages().size());
         assertEquals(2, deps.getScripts().size());
@@ -167,7 +162,6 @@ public class FrontendDependenciesTest {
 
         assertNull(deps.getThemeDefinition());
 
-        assertEquals(1, deps.getImports().size());
         assertEquals(4, deps.getModules().size());
         assertEquals(0, deps.getPackages().size());
         assertEquals(2, deps.getScripts().size());
@@ -180,7 +174,6 @@ public class FrontendDependenciesTest {
 
         assertEquals(Theme1.class, deps.getThemeDefinition().getTheme());
 
-        assertEquals(2, deps.getImports().size());
         assertEquals(8, deps.getModules().size());
         assertEquals(1, deps.getPackages().size());
         assertEquals(6, deps.getScripts().size());
@@ -190,7 +183,6 @@ public class FrontendDependenciesTest {
     public void should_resolveComponentFactories() throws Exception {
         FrontendDependencies deps = create(ThirdView.class);
 
-         assertEquals(0, deps.getImports().size());
          assertEquals(3, deps.getModules().size());
          assertEquals(0, deps.getPackages().size());
          assertEquals(0, deps.getScripts().size());

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendDependenciesTestComponents.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendDependenciesTestComponents.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.server.frontend;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
@@ -50,10 +49,8 @@ public class FrontendDependenciesTestComponents {
         }
     }
 
-    @HtmlImport("frontend://theme-1.html")
     static class Theme1 extends Theme0 {
     }
-    @HtmlImport("frontend://theme-2.html")
     static class Theme2 extends Theme0 {
     }
     @JsModule("./theme-4.js")
@@ -66,7 +63,6 @@ public class FrontendDependenciesTestComponents {
 
     @NpmPackage(value = "@vaadin/component-0", version = "=2.1.0")
     @JsModule("./component-0.js")
-    @HtmlImport("frontend://component-0.html")
     @JavaScript("frontend://component-0.js")
     @Tag("component-0")
     @NpmPackage(value = "@vaadin/component-0", version = "^1.1.0")
@@ -75,7 +71,6 @@ public class FrontendDependenciesTestComponents {
     }
 
     @JsModule("./component-1.js")
-    @HtmlImport("frontend://component-1.html")
     @JavaScript("frontend://component-1.js")
     @Tag("component-1")
     @NpmPackage(value = "@vaadin/component-1", version = "1.1.1")
@@ -83,7 +78,6 @@ public class FrontendDependenciesTestComponents {
     }
 
     @JsModule("./component-2.js")
-    @HtmlImport("frontend://component-2.html")
     @JavaScript("frontend://component-2.js")
     @Tag("component-2")
     @NpmPackage(value = "@vaadin/component-2", version = "222.222.222")
@@ -91,7 +85,6 @@ public class FrontendDependenciesTestComponents {
     }
 
     @JsModule("./component-3.js")
-    @HtmlImport("frontend://component-3.html")
     @JavaScript("frontend://component-3.js")
     @Tag("component-3")
     @NpmPackage(value = "@vaadin/component-3", version = "~2.1.0")

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTestComponents.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTestComponents.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
@@ -42,12 +41,12 @@ public class NodeTestComponents {
     class ButtonComponent extends Component {
     }
 
-    @HtmlImport("frontend://bower_components/iron-icon/iron-icon.html")
+    @JsModule("@polymer/iron-icon/iron-icon.js")
     class IconComponent extends Component {
     }
 
-    @HtmlImport("frontend://bower_components/vaadin-date-picker/src/vaadin-date-picker.html")
-    @HtmlImport("frontend://bower_components/vaadin-date-picker/src/vaadin-month-calendar.html")
+    @JsModule("@vaadin/vaadin-date-picker/src/vaadin-date-picker.js")
+    @JsModule("@vaadin/vaadin-date-picker/src/vaadin-month-calendar.js")
     @JavaScript("frontend://ExampleConnector.js")
     public static class VaadinBowerComponent extends Component {
     }
@@ -61,12 +60,11 @@ public class NodeTestComponents {
     public static class VaadinNpmComponent extends Component {
     }
 
-    @HtmlImport("frontend://bower_components/vaadin-date-picker/vaadin-date-picker-light.html")
     @JsModule("vaadin-mixed-component/src/vaadin-mixed-component.js")
     public static class VaadinMixedComponent extends Component {
     }
 
-    @HtmlImport("frontend://local-p2-template.html")
+    @JsModule("./local-p2-template.js")
     public static class LocalP2Template extends Component {
     }
 
@@ -79,7 +77,7 @@ public class NodeTestComponents {
     public static class FrontendP3Template extends Component {
     }
 
-    @HtmlImport("foo.html")
+    @JsModule("./foo.js")
     public static class FlatImport extends Component {
     }
 
@@ -108,12 +106,12 @@ public class NodeTestComponents {
     /**
      * Lumo component theme class implementation.
      */
-    @HtmlImport("frontend://bower_components/vaadin-lumo-styles/color.html")
-    @HtmlImport("frontend://bower_components/vaadin-lumo-styles/typography.html")
-    @HtmlImport("frontend://bower_components/vaadin-lumo-styles/sizing.html")
-    @HtmlImport("frontend://bower_components/vaadin-lumo-styles/spacing.html")
-    @HtmlImport("frontend://bower_components/vaadin-lumo-styles/style.html")
-    @HtmlImport("frontend://bower_components/vaadin-lumo-styles/icons.html")
+    @JsModule("@vaadin/vaadin-lumo-styles/color.js")
+    @JsModule("@vaadin/vaadin-lumo-styles/typography.js")
+    @JsModule("@vaadin/vaadin-lumo-styles/sizing.js")
+    @JsModule("@vaadin/vaadin-lumo-styles/spacing.js")
+    @JsModule("@vaadin/vaadin-lumo-styles/style.js")
+    @JsModule("@vaadin/vaadin-lumo-styles/icons.js")
     public static class LumoTest implements AbstractTheme {
 
         public static final String LIGHT = "light";

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateImportsTest.java
@@ -64,7 +64,7 @@ public class NodeUpdateImportsTest extends NodeUpdateTestUtil {
         importsFile = new File(generatedPath, IMPORTS_NAME);
 
         updater = new TaskUpdateImports(getClassFinder(), null,
-                tmpRoot, generatedPath, frontendDirectory, true);
+                tmpRoot, generatedPath, frontendDirectory);
 
         Assert.assertTrue(nodeModulesPath.mkdirs());
         createExpectedImports(frontendDirectory, nodeModulesPath);
@@ -157,7 +157,8 @@ public class NodeUpdateImportsTest extends NodeUpdateTestUtil {
     public void should_ContainLumoThemeFiles() throws Exception {
         updater.execute();
 
-        assertContainsImports(true, "@vaadin/vaadin-lumo-styles/color.js",
+        assertContainsImports(true,
+                "@vaadin/vaadin-lumo-styles/color.js",
                 "@vaadin/vaadin-lumo-styles/typography.js",
                 "@vaadin/vaadin-lumo-styles/sizing.js",
                 "@vaadin/vaadin-lumo-styles/spacing.js",
@@ -202,8 +203,6 @@ public class NodeUpdateImportsTest extends NodeUpdateTestUtil {
 
         updater.execute();
 
-        assertContainsImports(true, "@vaadin/vaadin-lumo-styles/sizing.js",
-                "./local-p2-template.js");
         assertContainsImports(false, "./added-import.js");
     }
 


### PR DESCRIPTION
Related with https://github.com/vaadin/flow/issues/5535 and https://github.com/vaadin/flow/pull/5678

Fixes https://github.com/vaadin/flow/issues/5679 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5704)
<!-- Reviewable:end -->
