### PR TITLE
Remove Maven specific warning message

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
@@ -44,17 +44,13 @@ public class DefaultDeploymentConfiguration
 
     public static final String WARNING_BOWER_MODE = SEPARATOR
             + "\nVaadin is running in BOWER mode.\n"
-            + "This mode will be unsuported in future Vaadin versions."
+            + "This mode will be unsupported in future Vaadin versions."
             + SEPARATOR;
 
      public static final String WARNING_BOWER_LEGACY = SEPARATOR
-            + "\n** WARNING **  Vaadin is running in BOWER MODE.\n"
-            + "\nBy default Vaadin should run in npm mode but this project is not"
-            + "\nproperly configured.\n"
-            + "\nTo disable this message, migrate your project to 'npm' or set the"
-            + "\nproperty" + " 'vaadin." + SERVLET_PARAMETER_BOWER_MODE + "' to 'true'"
+            + "\nVaadin is running in BOWER MODE.\n"
             + SEPARATOR;
-
+             
     public static final String WARNING_XSRF_PROTECTION_DISABLED = SEPARATOR
             + "\nWARNING: Cross-site request forgery protection is disabled!"
             + SEPARATOR;


### PR DESCRIPTION
The error message is only specific to the Vaadin Maven plugin. 

For Gradle users this should not be shown as it is a call to action which a user cannot do anything about right now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5711)
<!-- Reviewable:end -->
