### PR TITLE
Rename goal 'validate' -> 'prepare-package'

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -63,7 +63,7 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
  * </ul>
  */
 @Mojo(name = "build-frontend", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, defaultPhase = LifecyclePhase.PREPARE_PACKAGE)
-public class NodeBuildFrontendMojo extends AbstractMojo {
+public class BuildFrontendMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private MavenProject project;

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
@@ -45,11 +45,29 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.FRONTEND;
 import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
 
 /**
- * Goal checks that node and npm tools are installed, and copies frontend
- * resources available inside `.jar` files of the project dependencies.
+ * This goal checks that node and npm tools are installed, copies frontend
+ * resources available inside `.jar` dependencies to `node_modules`, and creates
+ * or updates `package.json` and `webpack.config.json` files.
  */
-@Mojo(name = "validate", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, defaultPhase = LifecyclePhase.PROCESS_RESOURCES)
-public class NodeValidateMojo extends AbstractMojo {
+@Mojo(name = "prepare-frontend", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, defaultPhase = LifecyclePhase.PROCESS_RESOURCES)
+public class PrepareFrontendMojo extends AbstractMojo {
+
+    /**
+     * This goal checks that node and npm tools are installed, copies frontend
+     * resources available inside `.jar` dependencies to `node_modules`, and creates
+     * or updates `package.json` and `webpack.config.json` files.
+     * 
+     * @deprecated use {@link PrepareFrontendMojo} instead
+     */
+    @Deprecated
+    @Mojo(name = "validate", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, defaultPhase = LifecyclePhase.PROCESS_RESOURCES)
+    public static class VaildateMojo extends PrepareFrontendMojo {
+        @Override
+        public void execute() {
+            getLog().warn("\n\n   You are using the 'validate' goal which has been renamed to 'prepare-frontend', please update your 'pom.xml'.\n");
+            super.execute();
+        }
+    }
 
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private MavenProject project;

--- a/flow-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/flow-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -8,6 +8,7 @@
           <goal>copy-production-files</goal>
           <goal>package-for-production</goal>
           <goal>validate</goal>
+          <goal>prepare-frontend</goal>
           <goal>build-frontend</goal>
         </goals>
       </pluginExecutionFilter>

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
@@ -60,7 +60,7 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_PREFIX_ALIAS
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class NodeBuildFrontendMojoTest {
+public class BuildFrontendMojoTest {
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -72,7 +72,7 @@ public class NodeBuildFrontendMojoTest {
     private String appPackage;
     private String webpackConfig;
 
-    private final NodeBuildFrontendMojo mojo = new NodeBuildFrontendMojo();
+    private final BuildFrontendMojo mojo = new BuildFrontendMojo();
 
     @Before
     public void setup() throws Exception {

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
@@ -24,23 +24,23 @@ import org.mockito.Mockito;
 
 import elemental.json.JsonObject;
 
-import static com.vaadin.flow.plugin.maven.NodeBuildFrontendMojoTest.assertContainsPackage;
-import static com.vaadin.flow.plugin.maven.NodeBuildFrontendMojoTest.getPackageJson;
-import static com.vaadin.flow.plugin.maven.NodeBuildFrontendMojoTest.setProject;
+import static com.vaadin.flow.plugin.maven.BuildFrontendMojoTest.assertContainsPackage;
+import static com.vaadin.flow.plugin.maven.BuildFrontendMojoTest.getPackageJson;
+import static com.vaadin.flow.plugin.maven.BuildFrontendMojoTest.setProject;
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 import static com.vaadin.flow.server.Constants.RESOURCES_FRONTEND_DEFAULT;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
 import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
 import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_CONFIG;
 
-public class NodeValidateMojoTest {
+public class PrepareFrontendMojoTest {
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
-    private final NodeValidateMojo mojo = new NodeValidateMojo();
+    private final PrepareFrontendMojo mojo = new PrepareFrontendMojo();
     private File projectFrontendResourcesDirectory;
     private File nodeModulesPath;
     private File flowPackagePath;


### PR DESCRIPTION
keep old goal as deprecated until all elements are migrated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5713)
<!-- Reviewable:end -->
