### PR TITLE
Delay getting dev mode handler refernce until servlet is initialized

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
@@ -51,7 +51,7 @@ import com.vaadin.flow.shared.JsonConstants;
 public class VaadinServlet extends HttpServlet {
     private VaadinServletService servletService;
     private StaticFileHandler staticFileHandler;
-    private DevModeHandler devmodeHandler = DevModeHandler.getDevModeHandler();
+    private DevModeHandler devmodeHandler;
     private WebJarServer webJarServer;
 
     /**
@@ -82,6 +82,7 @@ public class VaadinServlet extends HttpServlet {
         if (deploymentConfiguration.areWebJarsEnabled()) {
             webJarServer = new WebJarServer(deploymentConfiguration);
         }
+        devmodeHandler = DevModeHandler.getDevModeHandler();
 
         // Sets current service even though there are no request and response
         servletService.setCurrentInstances(null, null);


### PR DESCRIPTION
The Dev Mode Handler is started in a ServletContainerInitializer. This happens
before init() is called for servlets but not necessarily before the servlet
instance is created.

With Spring Boot, before this patch, the reference is always null because of this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5734)
<!-- Reviewable:end -->
