### PR TITLE
Do not prefix with `Frontend` if file is not in place.

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -178,16 +178,18 @@ public class TaskUpdateImports extends NodeUpdater {
         return new File(base, String.join("/", path)).isFile();
     }
 
-    private String toValidBrowserImport(String s) {
-        if (s.startsWith(GENERATED_PREFIX)) {
-            return generatedResourcePathIntoRelativePath(s);
-        } else if (s.startsWith("./")) {
-            return WEBPACK_PREFIX_ALIAS + s.substring(2);
-        } else if (Character.isAlphabetic(s.charAt(0))
-                && !s.startsWith(WEBPACK_PREFIX_ALIAS)) {
-            return WEBPACK_PREFIX_ALIAS + s;
+    private String toValidBrowserImport(String jsImport) {
+        if (jsImport.startsWith(GENERATED_PREFIX)) {
+            return generatedResourcePathIntoRelativePath(jsImport);
+        } else if (isFile(frontendDirectory, jsImport)) {
+            if (!jsImport.startsWith("./")) {
+                log().warn(
+                        "Use the './' prefix for files in the 'frontend' folder: '{}', please update your annotations.",
+                        jsImport);
+            }
+            return WEBPACK_PREFIX_ALIAS + jsImport.replaceFirst("^\\./", "");
         }
-        return s;
+        return jsImport;
     }
 
     private void updateMainJsFile(List<String> newContent) throws IOException {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTestComponents.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTestComponents.java
@@ -56,7 +56,7 @@ public class NodeTestComponents {
     public static class VaadinElementMixin extends Component {
     }
 
-    @JsModule("foo-dir/vaadin-npm-component.js")
+    @JsModule("./foo-dir/vaadin-npm-component.js")
     public static class VaadinNpmComponent extends Component {
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateImportsTest.java
@@ -96,15 +96,16 @@ public class NodeUpdateImportsTest extends NodeUpdateTestUtil {
                 "document.body.setAttribute('theme', 'dark');"));
         expectedLines.addAll(getExpectedImports());
 
+        // An import without `.js` extension
+        expectedLines.add("import '@vaadin/vaadin-mixed-component/theme/lumo/vaadin-something-else'");
+        // An import not found in node_modules
+        expectedLines.add("import 'unresolved/component';");
+
         Assert.assertFalse(importsFile.exists());
         updater.execute();
         Assert.assertTrue(importsFile.exists());
 
         assertContainsImports(true, expectedLines.toArray(new String[0]));
-        // An import without `.js` extension
-        assertContainsImports(true, "import '@vaadin/vaadin-mixed-component/theme/lumo/vaadin-something-else'");
-        // An import not found in node_modules
-        assertContainsImports(true, "import 'unresolved/component';");
     }
 
     @Test


### PR DESCRIPTION
Warn about `./` missing in local resources

Fixes #5761

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5764)
<!-- Reviewable:end -->
