### PR TITLE
Use a unique CSRF token for every UI instance

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -21,7 +21,11 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.Future;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.internal.UIInternals;
 import com.vaadin.flow.component.page.LoadingIndicatorConfiguration;
@@ -62,8 +66,6 @@ import com.vaadin.flow.theme.NoTheme;
 import com.vaadin.flow.theme.Theme;
 import com.vaadin.flow.theme.ThemeDefinition;
 import com.vaadin.flow.theme.ThemeUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * The topmost component in any component hierarchy. There is one UI for every
@@ -110,6 +112,14 @@ public class UI extends Component
     private final UIInternals internals = new UIInternals(this);
 
     private final Page page = new Page(this);
+
+    /*
+     * Despite section 6 of RFC 4122, this particular use of UUID *is* adequate
+     * for security capabilities. Type 4 UUIDs contain 122 bits of random data,
+     * and UUID.randomUUID() is defined to use a cryptographically secure random
+     * generator.
+     */
+    private final String csrfToken = UUID.randomUUID().toString();
 
     /**
      * Creates a new empty UI.
@@ -1094,7 +1104,7 @@ public class UI extends Component
      * <p>
      * <em>NOTE: the generic drag and drop feature for Flow is available in
      * another artifact, {@code flow-dnd} for now.</em>
-     * 
+     *
      * @return Extension of the drag source component if the drag event is
      *         active and originated from this UI, {@literal null} otherwise.
      * @since 2.0
@@ -1102,4 +1112,16 @@ public class UI extends Component
     public Component getActiveDragSourceComponent() {
         return getInternals().getActiveDragSourceComponent();
     }
+
+    /**
+     * Gets the CSRF token (aka double submit cookie) that is used to protect
+     * against Cross Site Request Forgery attacks.
+     *
+     * @return the csrf token string
+     * @since 2.0
+     */
+    public String getCsrfToken() {
+        return csrfToken;
+    }
+
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -1221,7 +1221,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
 
         VaadinSession session = ui.getSession();
         if (session.getConfiguration().isXsrfProtectionEnabled()) {
-            writeSecurityKeyUIDL(json, session);
+            writeSecurityKeyUIDL(json, ui);
         }
         writePushIdUIDL(json, session);
         if (getLogger().isDebugEnabled()) {
@@ -1236,12 +1236,11 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
      *
      * @param response
      *            the response JSON object to write security key into
-     * @param session
-     *            the vaadin session to which the security key belongs
+     * @param ui
+     *            the UI to which the security key belongs
      */
-    private static void writeSecurityKeyUIDL(JsonObject response,
-            VaadinSession session) {
-        String seckey = session.getCsrfToken();
+    private static void writeSecurityKeyUIDL(JsonObject response, UI ui) {
+        String seckey = ui.getCsrfToken();
         response.put(ApplicationConstants.UIDL_SECURITY_TOKEN_ID, seckey);
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -1848,7 +1848,7 @@ public abstract class VaadinService implements Serializable {
 
     /**
      * Verifies that the given CSRF token (aka double submit cookie) is valid
-     * for the given session. This is used to protect against Cross Site Request
+     * for the given UI. This is used to protect against Cross Site Request
      * Forgery attacks.
      * <p>
      * This protection is enabled by default, but it might need to be disabled
@@ -1856,8 +1856,8 @@ public abstract class VaadinService implements Serializable {
      * disabled by setting the init parameter
      * <code>disable-xsrf-protection</code> to <code>true</code>.
      *
-     * @param session
-     *            the vaadin session for which the check should be done
+     * @param ui
+     *            the UI for which the check should be done
      * @param requestToken
      *            the CSRF token provided in the request
      * @return <code>true</code> if the token is valid or if the protection is
@@ -1865,14 +1865,13 @@ public abstract class VaadinService implements Serializable {
      *         token is invalid
      * @see DeploymentConfiguration#isXsrfProtectionEnabled()
      */
-    public static boolean isCsrfTokenValid(VaadinSession session,
-            String requestToken) {
+    public static boolean isCsrfTokenValid(UI ui, String requestToken) {
 
-        if (session.getService().getDeploymentConfiguration()
+        if (ui.getSession().getService().getDeploymentConfiguration()
                 .isXsrfProtectionEnabled()) {
-            String sessionToken = session.getCsrfToken();
+            String uiToken = ui.getCsrfToken();
 
-            if (sessionToken == null || !sessionToken.equals(requestToken)) {
+            if (uiToken == null || !uiToken.equals(requestToken)) {
                 return false;
             }
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
@@ -119,14 +119,6 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      */
     private transient ConcurrentLinkedQueue<FutureAccess> pendingAccessQueue = new ConcurrentLinkedQueue<>();
 
-    /*
-     * Despite section 6 of RFC 4122, this particular use of UUID *is* adequate
-     * for security capabilities. Type 4 UUIDs contain 122 bits of random data,
-     * and UUID.randomUUID() is defined to use a cryptographically secure random
-     * generator.
-     */
-    private final String csrfToken = UUID.randomUUID().toString();
-
     private final String pushId = UUID.randomUUID().toString();
 
     private final Attributes attributes = new Attributes();
@@ -953,17 +945,6 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      */
     public Queue<FutureAccess> getPendingAccessQueue() {
         return pendingAccessQueue;
-    }
-
-    /**
-     * Gets the CSRF token (aka double submit cookie) that is used to protect
-     * against Cross Site Request Forgery attacks.
-     *
-     * @return the csrf token string
-     */
-    public String getCsrfToken() {
-        checkHasLock();
-        return csrfToken;
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
@@ -239,8 +239,7 @@ public class ServerRpcHandler implements Serializable {
 
         // Security: double cookie submission pattern unless disabled by
         // property
-        if (!VaadinService.isCsrfTokenValid(ui.getSession(),
-                rpcRequest.getCsrfToken())) {
+        if (!VaadinService.isCsrfTokenValid(ui, rpcRequest.getCsrfToken())) {
             throw new InvalidUIDLSecurityKeyException();
         }
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/UITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/UITest.java
@@ -2,10 +2,10 @@ package com.vaadin.flow.component;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -789,4 +789,23 @@ public class UITest {
         assertEquals("Handler should have run once", 1, runCount.get());
     }
 
+    @Test
+    public void csrfToken_differentUIs_shouldBeUnique() {
+        String token1 = new UI().getCsrfToken();
+        String token2 = new UI().getCsrfToken();
+
+        Assert.assertNotEquals("Each UI should have a unique CSRF token",
+                token1, token2);
+    }
+
+    @Test
+    public void csrfToken_sameUI_shouldBeSame() {
+        UI ui = new UI();
+        String token1 = ui.getCsrfToken();
+        String token2 = ui.getCsrfToken();
+
+        Assert.assertEquals(
+                "getCsrfToken() should always return the same value for the same UI",
+                token1, token2);
+    }
 }


### PR DESCRIPTION
Using the same CSRF token for all UIs in a session is no longer feasible
with the way the token is included in web-component-bootstrap.js. This
is fixed by giving each UI instance a unique token so that the token
from web-component-bootstrap.js will not be valid for any other context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5765)
<!-- Reviewable:end -->
