### PR TITLE
Avoid redundant locking in WebComponentProvider

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentProvider.java
@@ -15,7 +15,9 @@
  */
 package com.vaadin.flow.server.communication;
 
-import javax.servlet.http.HttpServletResponse;
+import static com.vaadin.flow.shared.ApplicationConstants.CONTENT_TYPE_TEXT_HTML_UTF_8;
+import static com.vaadin.flow.shared.ApplicationConstants.CONTENT_TYPE_TEXT_JAVASCRIPT_UTF_8;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
@@ -24,6 +26,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.io.IOUtils;
 import org.slf4j.LoggerFactory;
@@ -40,9 +44,6 @@ import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.webcomponent.WebComponentConfigurationRegistry;
 import com.vaadin.flow.server.webcomponent.WebComponentGenerator;
-
-import static com.vaadin.flow.shared.ApplicationConstants.CONTENT_TYPE_TEXT_HTML_UTF_8;
-import static com.vaadin.flow.shared.ApplicationConstants.CONTENT_TYPE_TEXT_JAVASCRIPT_UTF_8;
 
 /**
  * Request handler that supplies the script/html of the web component matching
@@ -71,8 +72,7 @@ public class WebComponentProvider extends SynchronizedRequestHandler {
     private Map<String, String> cache;
 
     @Override
-    public boolean synchronizedHandleRequest(
-            VaadinSession session, VaadinRequest request, VaadinResponse response) throws IOException {
+    protected boolean canHandleRequest(VaadinRequest request) {
         VaadinServletRequest servletRequest = (VaadinServletRequest) request;
         String pathInfo = servletRequest.getPathInfo();
 
@@ -83,6 +83,15 @@ public class WebComponentProvider extends SynchronizedRequestHandler {
         if (!pathInfo.startsWith(PATH_PREFIX)) {
             return false;
         }
+
+        return true;
+    }
+
+    @Override
+    public boolean synchronizedHandleRequest(VaadinSession session,
+            VaadinRequest request, VaadinResponse response) throws IOException {
+        VaadinServletRequest servletRequest = (VaadinServletRequest) request;
+        String pathInfo = servletRequest.getPathInfo();
 
         final boolean bowerMode =
                 session.getService().getDeploymentConfiguration().isBowerMode();


### PR DESCRIPTION
Implement canHandleRequest so that the session only needs to be locked
for requests that are actually targeted to this request handler.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5766)
<!-- Reviewable:end -->
