### PR TITLE
Deploy web component request handlers only when necessary

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -78,6 +78,7 @@ import com.vaadin.flow.server.communication.WebComponentBootstrapHandler;
 import com.vaadin.flow.server.communication.WebComponentProvider;
 import com.vaadin.flow.server.startup.BundleFilterFactory;
 import com.vaadin.flow.server.startup.FakeBrowser;
+import com.vaadin.flow.server.webcomponent.WebComponentConfigurationRegistry;
 import com.vaadin.flow.shared.ApplicationConstants;
 import com.vaadin.flow.shared.JsonConstants;
 import com.vaadin.flow.shared.Registration;
@@ -360,9 +361,31 @@ public abstract class VaadinService implements Serializable {
                 && pwaRegistry.getPwaConfiguration().isEnabled()) {
             handlers.add(new PwaHandler(pwaRegistry));
         }
-        handlers.add(new WebComponentProvider());
-        handlers.add(new WebComponentBootstrapHandler());
+
+        if (hasWebComponentConfigurations()) {
+            handlers.add(new WebComponentProvider());
+            handlers.add(new WebComponentBootstrapHandler());
+        }
+
         return handlers;
+    }
+
+    private boolean hasWebComponentConfigurations() {
+        /*
+         * Should be updated to use
+         * WebComponentConfigurationRegistry.getInstance(VaadinService) once
+         * https://github.com/vaadin/flow/pull/5657 has been merged
+         */
+        if (this instanceof VaadinServletService) {
+            ServletContext servletContext = ((VaadinServletService) this)
+                    .getServlet().getServletContext();
+            WebComponentConfigurationRegistry registry = WebComponentConfigurationRegistry
+                    .getInstance(servletContext);
+
+            return registry.hasConfigurations();
+        } else {
+            return false;
+        }
     }
 
     /**
@@ -1349,8 +1372,7 @@ public abstract class VaadinService implements Serializable {
      */
     private int getUidlRequestTimeout(VaadinSession session) {
         return getDeploymentConfiguration().isCloseIdleSessions()
-                ? session.getSession().getMaxInactiveInterval()
-                : -1;
+                ? session.getSession().getMaxInactiveInterval() : -1;
     }
 
     /**


### PR DESCRIPTION
The web component endpoints expose some internal information that can in
theory be exploitable, even though no specific case is know after #5765.
To reduce the attack surface, the request handlers are only activated
when there's at least one exported web component in the application.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5768)
<!-- Reviewable:end -->
