### PR TITLE
Register a DevModeServlet to handle .js files

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
@@ -275,8 +275,7 @@ public class DevModeHandler implements Serializable {
         int responseCode = connection.getResponseCode();
         if (responseCode == HTTP_NOT_FOUND) {
             getLogger().debug("Resource not served by webpack {}", requestFilename);
-            // webpack cannot access the resource, return false so as flow can
-            // handle it
+            // Webpack cannot access the resource.
             response.sendError(HTTP_NOT_FOUND);
 
         } else {

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
@@ -51,7 +51,6 @@ import com.vaadin.flow.shared.JsonConstants;
 public class VaadinServlet extends HttpServlet {
     private VaadinServletService servletService;
     private StaticFileHandler staticFileHandler;
-    private DevModeHandler devmodeHandler;
     private WebJarServer webJarServer;
 
     /**
@@ -82,7 +81,6 @@ public class VaadinServlet extends HttpServlet {
         if (deploymentConfiguration.areWebJarsEnabled()) {
             webJarServer = new WebJarServer(deploymentConfiguration);
         }
-        devmodeHandler = DevModeHandler.getDevModeHandler();
 
         // Sets current service even though there are no request and response
         servletService.setCurrentInstances(null, null);
@@ -277,11 +275,6 @@ public class VaadinServlet extends HttpServlet {
      */
     protected boolean serveStaticOrWebJarRequest(HttpServletRequest request,
             HttpServletResponse response) throws ServletException, IOException {
-
-        if (devmodeHandler != null && devmodeHandler.isDevModeRequest(request)
-                && devmodeHandler.serveDevModeRequest(request, response)) {
-            return true;
-        }
 
         if (staticFileHandler.isStaticResourceRequest(request)) {
             staticFileHandler.serveStaticResource(request, response);

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -140,7 +140,7 @@ public class DevModeInitializer
      * @param config
      *         deployment configuration
      */
-    private static void initDevModeHandler(Set<Class<?>> classes,
+    public static void initDevModeHandler(Set<Class<?>> classes,
                                            ServletContext context, DeploymentConfiguration config) {
         if (config.isProductionMode()) {
             log().debug("Skipping DEV MODE because PRODUCTION MODE is set.");
@@ -199,14 +199,14 @@ public class DevModeInitializer
 
     private static Set<String> getDevModeMapping(DeploymentConfiguration config) {
         List<String> polyfills = config.getPolyfills();
-        Set<String> buildScripts = new HashSet<>(polyfills.size() + 2);
+        Set<String> buildScripts = new HashSet<>();
         buildScripts.addAll(polyfills);
         buildScripts.add(config.getJsModuleBundle());
         buildScripts.add(config.getJsModuleBundleEs5());
 
         Pattern pattern = Pattern.compile(DEV_MODE_MAPPING_REGEX);
 
-        Set<String> mappings = new HashSet<>(1);
+        Set<String> mappings = new HashSet<>();
         for (String buildScript : buildScripts) {
 
             Matcher matcher = pattern.matcher(buildScript);

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -165,9 +165,9 @@ public class DevModeInitializer
             }
         }
 
-        Set<String> mappings = getDevModeMappings(config);
+        Set<String> mapping = getDevModeMapping(config);
 
-        if (mappings == null || mappings.isEmpty()) {
+        if (mapping == null || mapping.isEmpty()) {
             log().warn(
                     "Skipping DEV MODE because DevModeServlet mapping can't be determined. Please make sure "
                             + SERVLET_PARAMETER_JSBUNDLE + " and "
@@ -192,14 +192,12 @@ public class DevModeInitializer
         // Register DevModeServlet.
         ServletRegistration.Dynamic registration = context.addServlet(DevModeServlet.class.getName(), DevModeServlet.class);
         registration.setAsyncSupported(true);
-        for (String mapping : mappings) {
-            registration.addMapping("/" + mapping + "/*");
-        }
+        registration.addMapping(mapping.toArray(new String[mapping.size()]));
 
-        log().info("DevModeServlet registered to {}.", mappings);
+        log().info("DevModeServlet mapped to {}.", mapping);
     }
 
-    private static Set<String> getDevModeMappings(DeploymentConfiguration config) {
+    private static Set<String> getDevModeMapping(DeploymentConfiguration config) {
         List<String> polyfills = config.getPolyfills();
         Set<String> buildScripts = new HashSet<>(polyfills.size() + 2);
         buildScripts.addAll(polyfills);
@@ -214,7 +212,7 @@ public class DevModeInitializer
             Matcher matcher = pattern.matcher(buildScript);
 
             if (matcher.find()) {
-                mappings.add(matcher.group(1));
+                mappings.add("/" + matcher.group(1) + "/*");
             } else {
                 log().error("Script path " + buildScript + " doesn't match " + DEV_MODE_MAPPING_REGEX + " regex.");
                 return null;

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -216,7 +216,7 @@ public class DevModeInitializer
             } else {
                 log().error("Script path {} doesn't match {} regex.",
                         buildScript, DEV_MODE_MAPPING_REGEX);
-                return Collections.EMPTY_SET;
+                return Collections.emptySet();
             }
         }
         return mappings;

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -167,12 +168,10 @@ public class DevModeInitializer
 
         Set<String> mapping = getDevModeMapping(config);
 
-        if (mapping == null || mapping.isEmpty()) {
+        if (mapping.isEmpty()) {
             log().warn(
-                    "Skipping DEV MODE because DevModeServlet mapping can't be determined. Please make sure "
-                            + SERVLET_PARAMETER_JSBUNDLE + " and "
-                            + SERVLET_PARAMETER_POLYFILLS
-                            + " servlet parameters are correctly configured.");
+                    "Skipping DEV MODE because DevModeServlet mapping can't be determined. Please make sure {} and {} servlet parameters are correctly configured.",
+                    SERVLET_PARAMETER_JSBUNDLE, SERVLET_PARAMETER_POLYFILLS);
             return;
         }
 
@@ -190,7 +189,8 @@ public class DevModeInitializer
         DevModeHandler.start(config, builder.npmFolder);
 
         // Register DevModeServlet.
-        ServletRegistration.Dynamic registration = context.addServlet(DevModeServlet.class.getName(), DevModeServlet.class);
+        ServletRegistration.Dynamic registration = context.addServlet(
+                DevModeServlet.class.getName(), DevModeServlet.class);
         registration.setAsyncSupported(true);
         registration.addMapping(mapping.toArray(new String[mapping.size()]));
 
@@ -214,8 +214,9 @@ public class DevModeInitializer
             if (matcher.find()) {
                 mappings.add("/" + matcher.group(1) + "/*");
             } else {
-                log().error("Script path " + buildScript + " doesn't match " + DEV_MODE_MAPPING_REGEX + " regex.");
-                return null;
+                log().error("Script path {} doesn't match {} regex.",
+                        buildScript, DEV_MODE_MAPPING_REGEX);
+                return Collections.EMPTY_SET;
             }
         }
         return mappings;

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeServlet.java
@@ -28,10 +28,14 @@ public class DevModeServlet extends HttpServlet {
     @Override
     protected void service(HttpServletRequest request,
                            HttpServletResponse response) throws IOException {
-        if (!(devmodeHandler != null && devmodeHandler.isDevModeRequest(request)
-                && devmodeHandler.serveDevModeRequest(request, response))) {
+        if (devmodeHandler != null && devmodeHandler.isDevModeRequest(request)) {
+            devmodeHandler.serveDevModeRequest(request, response);
 
+        } else {
             response.sendError(SC_NOT_FOUND);
+
+            // Close request to avoid issues in CI and Chrome
+            response.getOutputStream().close();
         }
 
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeServlet.java
@@ -9,6 +9,8 @@ import java.io.IOException;
 
 import com.vaadin.flow.server.DevModeHandler;
 
+import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+
 /**
  * Serves js bundle files and polyfills during development mode.
  */
@@ -25,10 +27,13 @@ public class DevModeServlet extends HttpServlet {
 
     @Override
     protected void service(HttpServletRequest request,
-            HttpServletResponse response) throws IOException {
-        if (devmodeHandler != null && devmodeHandler.isDevModeRequest(request)) {
-            devmodeHandler.serveDevModeRequest(request, response);
+                           HttpServletResponse response) throws IOException {
+        if (!(devmodeHandler != null && devmodeHandler.isDevModeRequest(request)
+                && devmodeHandler.serveDevModeRequest(request, response))) {
+
+            response.sendError(SC_NOT_FOUND);
         }
+
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeServlet.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.flow.server.startup;
 
 import javax.servlet.ServletConfig;
@@ -37,7 +52,6 @@ public class DevModeServlet extends HttpServlet {
             // Close request to avoid issues in CI and Chrome
             response.getOutputStream().close();
         }
-
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeServlet.java
@@ -2,17 +2,17 @@ package com.vaadin.flow.server.startup;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 import com.vaadin.flow.server.DevModeHandler;
-import com.vaadin.flow.server.VaadinServlet;
 
 /**
  * Serves js bundle files and polyfills during development mode.
  */
-public class DevModeServlet extends VaadinServlet {
+public class DevModeServlet extends HttpServlet {
 
     private DevModeHandler devmodeHandler;
 
@@ -24,13 +24,12 @@ public class DevModeServlet extends VaadinServlet {
     }
 
     @Override
-    protected boolean serveStaticOrWebJarRequest(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-
+    protected void service(HttpServletRequest request,
+            HttpServletResponse response) throws IOException {
         if (devmodeHandler != null && devmodeHandler.isDevModeRequest(request)
                 && devmodeHandler.serveDevModeRequest(request, response)) {
-            return true;
         }
 
-        return super.serveStaticOrWebJarRequest(request, response);
     }
+
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeServlet.java
@@ -1,0 +1,36 @@
+package com.vaadin.flow.server.startup;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import com.vaadin.flow.server.DevModeHandler;
+import com.vaadin.flow.server.VaadinServlet;
+
+/**
+ * Serves js bundle files and polyfills during development mode.
+ */
+public class DevModeServlet extends VaadinServlet {
+
+    private DevModeHandler devmodeHandler;
+
+    @Override
+    public void init(ServletConfig servletConfig) throws ServletException {
+        devmodeHandler = DevModeHandler.getDevModeHandler();
+
+        super.init(servletConfig);
+    }
+
+    @Override
+    protected boolean serveStaticOrWebJarRequest(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+
+        if (devmodeHandler != null && devmodeHandler.isDevModeRequest(request)
+                && devmodeHandler.serveDevModeRequest(request, response)) {
+            return true;
+        }
+
+        return super.serveStaticOrWebJarRequest(request, response);
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeServlet.java
@@ -26,10 +26,9 @@ public class DevModeServlet extends HttpServlet {
     @Override
     protected void service(HttpServletRequest request,
             HttpServletResponse response) throws IOException {
-        if (devmodeHandler != null && devmodeHandler.isDevModeRequest(request)
-                && devmodeHandler.serveDevModeRequest(request, response)) {
+        if (devmodeHandler != null && devmodeHandler.isDevModeRequest(request)) {
+            devmodeHandler.serveDevModeRequest(request, response);
         }
-
     }
 
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.sun.net.httpserver.HttpServer;
+import com.vaadin.flow.server.startup.DevModeServlet;
 import net.jcip.annotations.NotThreadSafe;
 import org.junit.After;
 import org.junit.Before;
@@ -239,10 +240,10 @@ public class DevModeHandlerTest {
 
     @Test(expected = ConnectException.class)
     public void servlet_should_ThrowAnException_When_WebpackNotListening() throws Exception {
-        VaadinServlet servlet = prepareServlet();
         HttpServletRequest request = prepareRequest("/foo.js");
         HttpServletResponse response = prepareResponse();
-        servlet.service(request, response);
+
+        prepareServlet().service(request, response);
         Thread.sleep(150); //NOSONAR
     }
 
@@ -256,9 +257,9 @@ public class DevModeHandlerTest {
         assertEquals(HTTP_OK, responseStatus);
     }
 
-    private VaadinServlet prepareServlet() throws ServletException {
+    private DevModeServlet prepareServlet() throws ServletException {
         DevModeHandler.start(configuration, npmFolder);
-        VaadinServlet servlet = new VaadinServlet();
+        DevModeServlet servlet = new DevModeServlet();
         ServletConfig cfg = mock(ServletConfig.class);
         ServletContext ctx = mock(ServletContext.class);
         Mockito.doAnswer(invocation -> ctx).when(cfg).getServletContext();

--- a/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
@@ -225,7 +225,7 @@ public class DevModeHandlerTest {
         int port = prepareHttpServer(HTTP_NOT_FOUND, "");
 
         assertFalse(new DevModeHandler(port).serveDevModeRequest(request, response));
-        assertEquals(200, responseStatus);
+        assertEquals(HTTP_NOT_FOUND, responseStatus);
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/vaadin/flow/issues/5740

Following is the extreme case when a user would map `/build/*` to their own servlet. However, without changing the parameters, the code is mapping `DevModeServlet` to `/build/*`, which is defined in the default parameters.

Add a custom servlet.
```
import javax.servlet.annotation.WebServlet;

import com.vaadin.flow.server.VaadinServlet;

@WebServlet("/build/*")
public class MyServlet extends VaadinServlet {

}
```

Setup dev-mode to serve from different location, change these 3 parameters to a different path (it works with system properties) and the `build` field in `webpack.config`:
```
            <plugin>
                <groupId>org.codehaus.mojo</groupId>
                <artifactId>properties-maven-plugin</artifactId>
                <version>1.0.0</version>
                <executions>
                    <execution>
                        <goals>
                            <goal>set-system-properties</goal>
                        </goals>
                        <configuration>
                            <properties>
                                <property>
                                    <name>vaadin.module.bundle</name>
                                    <value>context://web-pack/index.js</value>
                                </property>
                                <property>
                                    <name>vaadin.module.polyfills</name>
                                    <value>context://web-pack/webcomponentsjs/webcomponents-loader.js</value>
                                </property>
                                <property>
                                    <name>vaadin.statistics.file.path</name>
                                    <value>/web-pack/stats.json</value>
                                </property>
                            </properties>
                        </configuration>
                    </execution>
                </executions>
            </plugin>
```
```
// public path for resources, must match flow that requests /build/index.js /build/stats.json
const build = 'web-pack';
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5779)
<!-- Reviewable:end -->
