### PR TITLE
Increase asset size limit so Bakery can be compiled without warnings

### DIFF
--- a/flow-server/src/main/resources/webpack.config.js
+++ b/flow-server/src/main/resources/webpack.config.js
@@ -60,7 +60,10 @@ module.exports = {
       }
     ]
   },
-
+  performance: {
+    maxEntrypointSize: 2097152, // 2MB
+    maxAssetSize: 2097152 // 2MB
+  },
   plugins: [
     // Transpile with babel, and produce different bundles per browser
     new BabelMultiTargetPlugin({


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5813)
<!-- Reviewable:end -->
