### PR TITLE
Remove extra call of getMetaTargets()

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -847,10 +847,9 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             head.appendElement(META_TAG).attr("name", VIEWPORT)
                 .attr(CONTENT_ATTRIBUTE, BootstrapUtils.getViewportContent(context).orElse(Viewport.DEFAULT));
 
-            if (!BootstrapUtils.getMetaTargets(context).isEmpty()) {
-                BootstrapUtils.getMetaTargets(context)
-                    .forEach((name, content) -> head.appendElement(META_TAG).attr("name", name).attr(CONTENT_ATTRIBUTE, content));
-            }
+            BootstrapUtils.getMetaTargets(context)
+                .forEach((name, content) -> head.appendElement(META_TAG).attr("name", name).attr(CONTENT_ATTRIBUTE, content));
+
             resolvePageTitle(context).ifPresent(title -> {
                 if (!title.isEmpty()) {
                     head.appendElement("title").appendText(title);


### PR DESCRIPTION
This fix is removing extra call to `BootstrapUtils.getMetaTargets(context)`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5848)
<!-- Reviewable:end -->
