### PR TITLE
Make ./ prefix warning message consistent

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -158,7 +158,7 @@ public abstract class NodeUpdater implements Command {
             if (finder.getResource(RESOURCES_FRONTEND_DEFAULT + "/" + resource) != null) {
                 if (!resolved.startsWith("./")) {
                     log().warn(
-                            "Use the './' prefix for resources in JAR files: '{}', please update your component.",
+                            "Use the './' prefix for files in JAR files: '{}', please update your component.",
                             importPath);
                 }
                 resolved = FLOW_NPM_PACKAGE_NAME + resource;

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateImportsTest.java
@@ -138,7 +138,7 @@ public class NodeUpdateImportsTest extends NodeUpdateTestUtil {
         String output = FileUtils.readFileToString(loggerFile, "UTF-8");
         assertContains(output, true,
                 "changing 'frontend://frontend-p3-template.js' to './frontend-p3-template.js'",
-                "Use the './' prefix for resources in JAR files: 'ExampleConnector.js'",
+                "Use the './' prefix for files in JAR files: 'ExampleConnector.js'",
                 "Use the './' prefix for files in the 'frontend' folder: 'vaadin-mixed-component/theme/lumo/vaadin-mixed-component.js'");
 
         // Using regex match because of the ➜ character in TC


### PR DESCRIPTION
Currently warning refers to `file` or `resource` depending on location

>[WARNING] Use the './' prefix for resources in JAR files: 'flow-component-renderer.js', please update your component.
[WARNING] Use the './' prefix for files in the 'frontend' folder: 'styles/shared-styles.js', please update your annotations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5849)
<!-- Reviewable:end -->
