### PR TITLE
Update vaadin-material-styles version to 1.2.3

### DIFF
--- a/flow-theme-integrations/material/pom.xml
+++ b/flow-theme-integrations/material/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>
             <artifactId>vaadin-material-styles</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.3</version>
         </dependency>
     </dependencies>
     <build>

--- a/flow-theme-integrations/material/src/main/java/com/vaadin/flow/theme/material/Material.java
+++ b/flow-theme-integrations/material/src/main/java/com/vaadin/flow/theme/material/Material.java
@@ -29,7 +29,7 @@ import com.vaadin.flow.theme.AbstractTheme;
 /**
  * Material component theme class implementation.
  */
-@NpmPackage(value = "@vaadin/vaadin-material-styles", version = "1.2.2")
+@NpmPackage(value = "@vaadin/vaadin-material-styles", version = "1.2.3")
 @HtmlImport("frontend://bower_components/vaadin-material-styles/color.html")
 @HtmlImport("frontend://bower_components/vaadin-material-styles/typography.html")
 @JsModule("@vaadin/vaadin-material-styles/color.js")


### PR DESCRIPTION
This is important to land before stable release to pick up BFP workaround in IE11
vaadin/vaadin-material-styles#85

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5894)
<!-- Reviewable:end -->
