### PR TITLE
Connect web components to the correct servlet/UI

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/ApplicationConfiguration.java
+++ b/flow-client/src/main/java/com/vaadin/client/ApplicationConfiguration.java
@@ -42,6 +42,7 @@ public class ApplicationConfiguration {
     private String servletVersion;
     private String atmosphereVersion;
     private String atmosphereJSVersion;
+    private String[] exportedWebComponents;
 
     /**
      * Gets the id generated for the application.
@@ -314,4 +315,22 @@ public class ApplicationConfiguration {
         this.frontendRootUrl = frontendRootUrl;
     }
 
+    /**
+     * Sets the exported web components.
+     *
+     * @param exportedWebComponents
+     *            the exported web components
+     */
+    public void setExportedWebComponents(String[] exportedWebComponents) {
+        this.exportedWebComponents = exportedWebComponents;
+    }
+
+    /**
+     * Gets the exported web components.
+     *
+     * @return the exported web components
+     */
+    public String[] getExportedWebComponents() {
+        return exportedWebComponents;
+    }
 }

--- a/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
@@ -81,7 +81,8 @@ public class ApplicationConnection {
         boolean productionMode = applicationConfiguration.isProductionMode();
         boolean requestTiming = applicationConfiguration.isRequestTiming();
         publishProductionModeJavascriptMethods(appRootPanelName, productionMode,
-                requestTiming);
+                requestTiming,
+                applicationConfiguration.getExportedWebComponents());
         if (!productionMode) {
             String servletVersion = applicationConfiguration
                     .getServletVersion();
@@ -138,9 +139,12 @@ public class ApplicationConnection {
      * @param requestTiming
      *            <code>true</code> if request timing info should be made
      *            available, <code>false</code> otherwise
+     * @param exportedWebComponents
+     *            a list of web component tags exported by this UI
      */
     private native void publishProductionModeJavascriptMethods(
-            String applicationId, boolean productionMode, boolean requestTiming)
+            String applicationId, boolean productionMode, boolean requestTiming,
+            String[] exportedWebComponents)
     /*-{
         var ap = this;
         var client = {};
@@ -154,6 +158,13 @@ public class ApplicationConnection {
         client.poll = $entry(function() {
                 var poller = ap.@ApplicationConnection::registry.@com.vaadin.client.Registry::getPoller()();
                 poller.@com.vaadin.client.communication.Poller::poll()();
+        });
+        client.connectWebComponent = $entry(function(eventData) {
+            // Connects the web component described by eventData with the server
+            var registry = ap.@ApplicationConnection::registry;
+            var sc = registry.@com.vaadin.client.Registry::getServerConnector()();
+            var nodeId = registry.@com.vaadin.client.Registry::getStateTree()().@com.vaadin.client.flow.StateTree::getRootNode()().@com.vaadin.client.flow.StateNode::id;
+            sc.@com.vaadin.client.communication.ServerConnector::sendEventMessage(ILjava/lang/String;Lelemental/json/JsonObject;)(nodeId, 'connect-web-component', eventData);
         });
         if (requestTiming) {
            client.getProfilingData = $entry(function() {
@@ -182,7 +193,7 @@ public class ApplicationConnection {
         });
 
         client.initializing = false;
-
+        client.exportedWebComponents = exportedWebComponents;
         $wnd.Vaadin.Flow.clients[applicationId] = client;
     }-*/;
 

--- a/flow-client/src/main/java/com/vaadin/client/bootstrap/Bootstrapper.java
+++ b/flow-client/src/main/java/com/vaadin/client/bootstrap/Bootstrapper.java
@@ -167,7 +167,8 @@ public class Bootstrapper implements EntryPoint {
         conf.setProductionMode(!jsoConfiguration.getConfigBoolean("debug"));
         conf.setRequestTiming(
                 jsoConfiguration.getConfigBoolean("requestTiming"));
-
+        conf.setExportedWebComponents(
+                jsoConfiguration.getConfigStringArray("webcomponents"));
     }
 
     private static void doStartApplication(final String applicationId) {

--- a/flow-client/src/main/java/com/vaadin/client/bootstrap/JsoConfiguration.java
+++ b/flow-client/src/main/java/com/vaadin/client/bootstrap/JsoConfiguration.java
@@ -19,7 +19,7 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.vaadin.client.ValueMap;
 
 /**
- * Helper class for reading configuration options from the bootstrap javascript
+ * Helper class for reading configuration options from the bootstrap javascript.
  *
  */
 public final class JsoConfiguration extends JavaScriptObject {
@@ -58,6 +58,19 @@ public final class JsoConfiguration extends JavaScriptObject {
      *         defined
      */
     public native ValueMap getConfigValueMap(String name)
+    /*-{
+        return this.getConfig(name);
+    }-*/;
+
+    /**
+     * Reads a configuration parameter as a String array.
+     *
+     * @param name
+     *            name of the configuration parameter
+     * @return value of the configuration parameter, or <code>null</code>if not
+     *         defined
+     */
+    public native String[] getConfigStringArray(String name)
     /*-{
         return this.getConfig(name);
     }-*/;

--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentUI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentUI.java
@@ -20,8 +20,10 @@ import java.util.Optional;
 
 import org.slf4j.LoggerFactory;
 
-import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.DomEvent;
+import com.vaadin.flow.component.EventData;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.Element;
@@ -72,48 +74,110 @@ public class WebComponentUI extends UI {
              * components will be contained within index.js
              */
             getConfigurationRegistry().getConfigurations()
-                    .forEach(config -> getPage()
-                            .addHtmlImport(getWebComponentHtmlPath(config)));
+            .forEach(config -> getPage()
+                    .addHtmlImport(getWebComponentHtmlPath(config)));
+        }
+
+        getEventBus().addListener(WebComponentConnectEvent.class,
+                this::connectWebComponent);
+    }
+
+    /**
+     * Event used for sending the activation event for an exported web component
+     * from the client to the server.
+     */
+    @DomEvent("connect-web-component")
+    public static class WebComponentConnectEvent extends ComponentEvent<UI> {
+
+        private String tag;
+        private String webComponentElementId;
+        private JsonObject attributeValues;
+
+        /**
+         * Creates a new web component connection event.
+         *
+         * @param source
+         *            the component that was attached
+         * @param fromClient
+         *            <code>true</code> if the event was originally fired on the
+         *            client, <code>false</code> if the event originates from
+         *            server-side logic
+         * @param tag
+         *            the tag of the element to connect
+         * @param webComponentElementId
+         *            the id of the web component
+         * @param attributeValues
+         *            initial attribute values as a JsonObject. If present,
+         *            these will override the default value designated by the
+         *            {@code WebComponentExporter} but only for this instance.
+         */
+        public WebComponentConnectEvent(UI source, boolean fromClient,
+                @EventData("tag") String tag,
+                @EventData("id") String webComponentElementId,
+                @EventData("attributeValues") JsonObject attributeValues) {
+            super(source, true);
+            this.tag = tag;
+            this.webComponentElementId = webComponentElementId;
+            this.attributeValues = attributeValues;
+        }
+
+        /**
+         * Gets the tag of the element to connect.
+         *
+         * @return the tag of the element
+         */
+        public String getTag() {
+            return tag;
+        }
+
+        /**
+         * Gets the id of the web component.
+         *
+         * @return the id of the web component
+         */
+        public String getWebComponentElementId() {
+            return webComponentElementId;
+        }
+
+        /**
+         * Gets the initial attribute values.
+         *
+         * @return the initial attribute values
+         */
+        public JsonObject getAttributeJson() {
+            return attributeValues;
         }
     }
 
     /**
-     * Connect a client side web component element with a server side
-     * {@link Component} that's added as a virtual child to the UI as the actual
-     * relation of the elements is unknown.
+     * Connects a client side web component element with a server side
+     * {@link Component} that's added as a virtual child to this UI.
      *
-     * @param tag
-     *            web component tag
-     * @param webComponentElementId
-     *            client side id of the element
-     * @param attributeJson
-     *            initial attribute values as a JsonObject. If present, these
-     *            will override the default value designated by the
-     *            {@code WebComponentExporter} but only for this instance.
+     * @param event
+     *            an event describing the tag, element id and initial property
+     *            values of the web component
      */
-    @ClientCallable
-    public void connectWebComponent(String tag, String webComponentElementId,
-            JsonObject attributeJson) {
+    private void connectWebComponent(WebComponentConnectEvent event) {
         Optional<WebComponentConfiguration<? extends Component>> webComponentConfiguration = getConfigurationRegistry()
-                .getConfiguration(tag);
+                .getConfiguration(event.getTag());
 
         if (!webComponentConfiguration.isPresent()) {
             LoggerFactory.getLogger(WebComponentUI.class).warn(
                     "Received connect request for non existing WebComponent '{}'",
-                    tag);
+                    event.getTag());
             return;
         }
 
-        final Element rootElement = new Element(tag);
+        Element rootElement = new Element(event.getTag());
         WebComponentBinding binding = webComponentConfiguration.get()
                 .createWebComponentBinding(Instantiator.get(this), rootElement,
-                        attributeJson);
+                        event.getAttributeJson());
         WebComponentWrapper wrapper = new WebComponentWrapper(rootElement,
                 binding);
 
         getElement().getStateProvider().appendVirtualChild(
                 getElement().getNode(), wrapper.getElement(),
-                NodeProperties.INJECT_BY_ID, webComponentElementId);
+                NodeProperties.INJECT_BY_ID, event.getWebComponentElementId());
         wrapper.getElement().executeJs("$0.serverConnected()");
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.server.communication;
 import com.vaadin.flow.component.PushConfiguration;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.webcomponent.WebComponentUI;
+import com.vaadin.flow.internal.JsonUtils;
 import com.vaadin.flow.server.BootstrapHandler;
 import com.vaadin.flow.server.ServletHelper;
 import com.vaadin.flow.server.VaadinRequest;
@@ -28,6 +29,9 @@ import com.vaadin.flow.server.webcomponent.WebComponentConfigurationRegistry;
 import com.vaadin.flow.shared.ApplicationConstants;
 import com.vaadin.flow.theme.Theme;
 import com.vaadin.flow.theme.ThemeDefinition;
+
+import elemental.json.Json;
+import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 import org.jsoup.nodes.Attribute;
 import org.jsoup.nodes.Document;
@@ -154,6 +158,13 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
         assert serviceUrl.endsWith("/");
         config.put(ApplicationConstants.SERVICE_URL, serviceUrl);
         config.put(ApplicationConstants.APP_WC_MODE, true);
+        WebComponentConfigurationRegistry registry = WebComponentConfigurationRegistry
+                .getInstance(request.getService().getContext());
+
+        JsonArray tags = registry.getConfigurations().stream()
+                .map(conf -> Json.create(conf.getTag()))
+                .collect(JsonUtils.asArray());
+        config.put("webcomponents", tags);
         return context;
     }
 

--- a/flow-server/src/main/resources/com/vaadin/flow/server/BootstrapHandler.js
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/BootstrapHandler.js
@@ -1,7 +1,5 @@
 (function() {
   var apps = {};
-  var widgetsets = {};
-
 
   var log;
   if (typeof console === undefined || !window.location.search.match(/[&?]debug(&|$)/)) {
@@ -47,6 +45,7 @@
   if (!window.Vaadin.Flow.clients) {
     window.Vaadin.Flow.clients = {};
 
+    window.Vaadin.Flow.pendingStartup = {};
     window.Vaadin.Flow.initApplication = function(appId, config) {
       var testbenchId = appId.replace(/-\d+$/, '');
       
@@ -85,17 +84,19 @@
       }
   
       var widgetset = "client";
-      widgetsets[widgetset] = {
+      if (!window.Vaadin.Flow.pendingStartup[widgetset]) {
+        window.Vaadin.Flow.pendingStartup[widgetset] = {
           pendingApps: []
         };
-      if (widgetsets[widgetset].callback) {
-        log("Starting from bootstrap", appId);
-        widgetsets[widgetset].callback(appId);
-      }  else {
-        log("Setting pending startup", appId);
-        widgetsets[widgetset].pendingApps.push(appId);
       }
-  
+      if (window.Vaadin.Flow.pendingStartup[widgetset].callback) {
+        log("Starting from bootstrap", appId);
+        window.Vaadin.Flow.pendingStartup[widgetset].callback(appId);
+      } else {
+        log("Setting pending startup", appId);
+        window.Vaadin.Flow.pendingStartup[widgetset].pendingApps.push(appId);
+      }
+
       return app;
     };
     window.Vaadin.Flow.getAppIds = function() {
@@ -112,10 +113,18 @@
     };
     window.Vaadin.Flow.registerWidgetset = function(widgetset, callback) {
       log("Widgetset registered", widgetset);
-      var ws = widgetsets[widgetset];
-      if (ws && ws.pendingApps) {
+      if (!window.Vaadin.Flow.pendingStartup[widgetset]) {
+        window.Vaadin.Flow.pendingStartup[widgetset] = {
+          pendingApps: [],
+          callback: callback
+        };
+        /* Callback will be invoked when initApp is called */
+        return;
+      }
+      var ws = window.Vaadin.Flow.pendingStartup[widgetset];
+      if (ws.pendingApps) {
         ws.callback = callback;
-        for(var i = 0; i < ws.pendingApps.length; i++) {
+        for (var i = 0; i < ws.pendingApps.length; i++) {
           var appId = ws.pendingApps[i];
           log("Starting from register widgetset", appId);
           callback(appId);

--- a/flow-server/src/main/resources/com/vaadin/flow/server/webcomponent/webcomponent-script-template.js
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/webcomponent/webcomponent-script-template.js
@@ -78,21 +78,29 @@ class _TagCamel_ extends HTMLElement {
       if (!this.$.id) {
         this._registerElement();
       } else {
+        console.debug('reconnecting',this,'using id',this.$.id);
         this.$server.reconnect();
       }
-      console.debug('connected', this);
-
   }
 
   _registerElement() {
     this.$.id = "_TagCamel_-" + _TagCamel_.id++;
-    const flowRoot = document.body;
+    console.debug('registering',this,'using id',this.$.id);
+
     // Needed to make Flow do lookup correctly
     const poller = () => {
-      if (flowRoot && flowRoot.$server) {
-        flowRoot.$ = flowRoot.$ || {};
-        flowRoot.$[this.$.id] = this;
-        flowRoot.$server.connectWebComponent('_TagDash_', this.$.id, _PropertyValues_);
+      var flowClient = this._getClient();
+      if (flowClient && flowClient.connectWebComponent) {
+        document.body.$ = document.body.$ || {};
+        document.body.$[this.$.id] = this;
+        const properties = {};
+        for (var prop in _TagCamel_.properties) {
+          if (prop === "_propertyUpdatedFromServer") {
+            continue;
+          }
+          properties[prop] = this[prop];
+        }
+        flowClient.connectWebComponent({tag: '_TagDash_', id: this.$.id, attributeValues: _PropertyValues_});
       } else {
         setTimeout(poller, 10);
       }
@@ -100,7 +108,12 @@ class _TagCamel_ extends HTMLElement {
 
     poller();
   }
+  _getClient() {
+    if (!window.Vaadin || !window.Vaadin.Flow || !window.Vaadin.Flow.clients)
+      return undefined;
 
+    return Object.values(window.Vaadin.Flow.clients).find(c => c.exportedWebComponents && c.exportedWebComponents.indexOf('_TagDash_') != -1)
+  }
   disconnectedCallback() {
     this.$server.disconnected();
 

--- a/flow-tests/test-multi-war/deployment/src/main/webapp/both.html
+++ b/flow-tests/test-multi-war/deployment/src/main/webapp/both.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Web components from /test-war1 and /test-war2</title>
+    <script
+      type="text/javascript"
+      src="/test-war1/web-component/hello-war1.js"
+    ></script>
+    <script
+      type="text/javascript"
+      src="/test-war2/web-component/hello-war2.js"
+    ></script>
+  </head>
+  <body>
+    <p>Hello-war1: <hello-war1 id="hello1"></hello-war1></p>
+    <p>Hello-war2: <hello-war2 id="hello2"></hello-war2></p>
+  </body>
+</html>

--- a/flow-tests/test-multi-war/deployment/src/main/webapp/index.html
+++ b/flow-tests/test-multi-war/deployment/src/main/webapp/index.html
@@ -11,3 +11,11 @@ Hello Deployment:
     com.vaadin.flow.multiwar.war2.MainView"
   </li>
 </ul>
+
+Exported web components:
+
+<ul>
+        <li>The first app exports <pre>&lt;hello-war1&gt;</pre></li>
+        <li>The second app exports <pre>&lt;hello-war2&gt;</pre></li>
+        <li><a href="/both.html">/both.html</a> uses both exported components on the same page</a></li>
+</ul>

--- a/flow-tests/test-multi-war/deployment/src/test/java/com/vaadin/flow/multiwar/deployment/TwoAppsIT.java
+++ b/flow-tests/test-multi-war/deployment/src/test/java/com/vaadin/flow/multiwar/deployment/TwoAppsIT.java
@@ -10,7 +10,7 @@ import com.vaadin.flow.testutil.ChromeBrowserTest;
 public class TwoAppsIT extends ChromeBrowserTest {
     @Override
     protected String getTestPath() {
-        return "/";
+        return "/both.html";
     }
 
     @Test
@@ -34,6 +34,16 @@ public class TwoAppsIT extends ChromeBrowserTest {
         Assert.assertEquals("Hello Hello from com.vaadin.flow.multiwar." + warId
                 + ".MainView", helloText.getText());
 
+    }
+
+    @Test
+    public void bothWebComponentsEmbedded() {
+        open();
+        WebElement hello1 = findElement(By.id("hello1"));
+        WebElement hello2 = findElement(By.id("hello2"));
+
+        Assert.assertEquals("Hello from com.vaadin.flow.multiwar.war1.HelloComponent", hello1.getText());
+        Assert.assertEquals("Hello from com.vaadin.flow.multiwar.war2.HelloComponent", hello2.getText());
     }
 
 }

--- a/flow-tests/test-multi-war/test-war1/src/main/java/com/vaadin/flow/multiwar/war1/HelloComponentExporter.java
+++ b/flow-tests/test-multi-war/test-war1/src/main/java/com/vaadin/flow/multiwar/war1/HelloComponentExporter.java
@@ -1,0 +1,16 @@
+package com.vaadin.flow.multiwar.war1;
+
+import com.vaadin.flow.component.WebComponentExporter;
+import com.vaadin.flow.component.webcomponent.WebComponent;
+
+public class HelloComponentExporter extends WebComponentExporter<HelloComponent> {
+
+    public HelloComponentExporter() {
+        super("hello-war1");
+    }
+
+    @Override
+    public void configureInstance(WebComponent<HelloComponent> webComponent, HelloComponent component) {
+    }
+
+}

--- a/flow-tests/test-multi-war/test-war2/src/main/java/com/vaadin/flow/multiwar/war2/HelloComponentExporter.java
+++ b/flow-tests/test-multi-war/test-war2/src/main/java/com/vaadin/flow/multiwar/war2/HelloComponentExporter.java
@@ -1,0 +1,16 @@
+package com.vaadin.flow.multiwar.war2;
+
+import com.vaadin.flow.component.WebComponentExporter;
+import com.vaadin.flow.component.webcomponent.WebComponent;
+
+public class HelloComponentExporter extends WebComponentExporter<HelloComponent> {
+
+    public HelloComponentExporter() {
+        super("hello-war2");
+    }
+
+    @Override
+    public void configureInstance(WebComponent<HelloComponent> webComponent, HelloComponent component) {
+    }
+
+}


### PR DESCRIPTION
Exports a list of web component tags for each UI and uses ApplicationConnection to
connect to the correct instance instead of a shared DOM element (body).

Fixes #5808

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5897)
<!-- Reviewable:end -->
