### PR TITLE
Fix Vaadin Spring issue #381

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
@@ -26,7 +26,6 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.util.Iterator;
-import java.util.List;
 
 import org.apache.commons.fileupload.FileItemIterator;
 import org.apache.commons.fileupload.FileItemStream;
@@ -175,7 +174,8 @@ public class StreamReceiverHandler implements Serializable {
             // If we try to parse the request now, we will get an exception
             // since it has already been parsed and turned into Parts.
             try {
-                Iterator<Part> iter = ((HttpServletRequest) request).getParts().iterator();
+                Iterator<Part> iter = ((HttpServletRequest) request).getParts()
+                        .iterator();
                 while (iter.hasNext()) {
                     Part part = iter.next();
                     handleStream(session, streamReceiver, owner, part);
@@ -208,15 +208,18 @@ public class StreamReceiverHandler implements Serializable {
 
     private boolean hasParts(VaadinRequest request) {
         try {
-            return ((HttpServletRequest) request).getParts().size() > 0;
+            return !((HttpServletRequest) request).getParts().isEmpty();
         } catch (Exception e) {
+            getLogger().trace(
+                    "Pretending the request did not contain any parts because of exception",
+                    e);
             return false;
         }
     }
 
     private void handleStream(VaadinSession session,
-                            StreamReceiver streamReceiver, StateNode owner,
-                            Part part) throws IOException {
+            StreamReceiver streamReceiver, StateNode owner, Part part)
+            throws IOException {
         String name = part.getName();
         InputStream stream = part.getInputStream();
         try {


### PR DESCRIPTION
For reference: https://github.com/vaadin/spring/issues/381

The problem turned out to be that if multipart uploads are enabled in Spring Boot, as they are by default, they are also enabled in the underlying servlet container (such as Tomcat). When this happens, the servlet container will already parse the multipart request into `Part`s even before the request reaches Spring or Flow. If Flow now tries to parse the request, it will fail since the input stream has already been read once by the servlet container.

This pull request will check if there are `Part`s in the request already and use them directly if present. Otherwise, it will fallback to the default behavior, i.e. parsing the request manually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5902)
<!-- Reviewable:end -->
