### PR TITLE
Initialize embedded web components once, with correct value

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentConfiguration.java
@@ -26,17 +26,20 @@ import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.server.webcomponent.PropertyData;
 import com.vaadin.flow.server.webcomponent.WebComponentBinding;
 
+import elemental.json.JsonObject;
+
 /**
- * Result of defining an embeddable web component using {@link
- * WebComponentExporter}. Provides all the necessary information to generate the
- * web component resources and constructs new {@link WebComponentBinding}
- * instances with {@link #createWebComponentBinding(Instantiator, Element)};
+ * Result of defining an embeddable web component using
+ * {@link WebComponentExporter}. Provides all the necessary information to
+ * generate the web component resources and constructs new
+ * {@link WebComponentBinding} instances with
+ * {@link #createWebComponentBinding(com.vaadin.flow.di.Instantiator, com.vaadin.flow.dom.Element, elemental.json.JsonObject)};
  *
  * @param <C>
- *         type of the component being exported
+ *            type of the component being exported
  * @author Vaadin Ltd.
  * @see com.vaadin.flow.component.WebComponentExporter.WebComponentConfigurationFactory
- *         for constructing new instances
+ *      for constructing new instances
  */
 public interface WebComponentConfiguration<C extends Component>
         extends Serializable {
@@ -46,7 +49,7 @@ public interface WebComponentConfiguration<C extends Component>
      * propertyName}.
      *
      * @param propertyName
-     *         name of the property, not null
+     *            name of the property, not null
      * @return has property
      */
     boolean hasProperty(String propertyName);
@@ -56,7 +59,7 @@ public interface WebComponentConfiguration<C extends Component>
      * returns {@code null}
      *
      * @param propertyName
-     *         name of the property, not null
+     *            name of the property, not null
      * @return property type or null
      */
     Class<? extends Serializable> getPropertyType(String propertyName);
@@ -80,15 +83,20 @@ public interface WebComponentConfiguration<C extends Component>
      * Creates a new {@link WebComponentBinding} instance.
      *
      * @param instantiator
-     *         {@link Instantiator} used to construct instances
+     *            {@link com.vaadin.flow.di.Instantiator} used to construct
+     *            instances
      * @param element
-     *         element which acts as the root element for the exported
-     *         {@code component} instance
+     *            element which acts as the root element for the exported
+     *            {@code component} instance
+     * @param newAttributeDefaults
+     *            {@link JsonObject} containing default overrides set by the
+     *            user defining the component on a web page. These defaults are
+     *            set using the web component's attributes.
      * @return web component binding which can be used by the web component host
      *         to communicate with the component it is hosting
      */
     WebComponentBinding<C> createWebComponentBinding(Instantiator instantiator,
-                                                     Element element);
+            Element element, JsonObject newAttributeDefaults);
 
     /**
      * Retrieves the tag name configured by the web component exporter.

--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentUI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentUI.java
@@ -15,11 +15,9 @@
  */
 package com.vaadin.flow.component.webcomponent;
 
-import java.io.Serializable;
 import java.util.Map;
 import java.util.Optional;
 
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.ClientCallable;
@@ -28,7 +26,6 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.DeploymentConfiguration;
-import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.internal.nodefeature.NodeProperties;
 import com.vaadin.flow.router.HasUrlParameter;
 import com.vaadin.flow.router.QueryParameters;
@@ -42,11 +39,7 @@ import com.vaadin.flow.theme.Theme;
 import com.vaadin.flow.theme.ThemeDefinition;
 import com.vaadin.flow.theme.ThemeUtil;
 
-import elemental.json.Json;
-import elemental.json.JsonException;
 import elemental.json.JsonObject;
-import elemental.json.JsonString;
-import elemental.json.JsonValue;
 
 /**
  * Custom UI for use with WebComponents served from the server.

--- a/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/PropertyConfigurationImpl.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/PropertyConfigurationImpl.java
@@ -77,7 +77,7 @@ public final class PropertyConfigurationImpl<C extends Component,
 
     @Override
     public PropertyConfiguration<C, P> readOnly() {
-        data = new PropertyData<>(data, true);
+        data = data.updateReadOnly(true);
         return this;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/PropertyData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/PropertyData.java
@@ -22,10 +22,11 @@ import java.util.Objects;
  * Value object containing information of a web component's property field.
  *
  * @param <P>
- *         type of the property's value
+ *            type of the property's value
  * @author Vaadin Ltd.
  */
-public final class PropertyData<P extends Serializable> implements Serializable {
+public final class PropertyData<P extends Serializable>
+        implements Serializable {
     private final String name;
     private final Class<P> type;
     private final P defaultValue;
@@ -36,34 +37,22 @@ public final class PropertyData<P extends Serializable> implements Serializable 
      * property's value given by {@code type}.
      *
      * @param name
-     *         name of the property
+     *            name of the property
      * @param type
-     *         type of the property value
+     *            type of the property value
      * @param readOnly
-     *         is the property read-only (on the client-side)
+     *            is the property read-only (on the client-side)
      * @param defaultValue
-     *         default value for the property
+     *            default value for the property
      */
     public PropertyData(String name, Class<P> type, boolean readOnly,
-                        P defaultValue) {
+            P defaultValue) {
         Objects.requireNonNull(name, "Parameter 'name' must not be null!");
         Objects.requireNonNull(type, "Parameter 'type' must not be null!");
         this.name = name;
         this.type = type;
         this.readOnly = readOnly;
         this.defaultValue = defaultValue;
-    }
-
-    /**
-     * Copy-constructor, which allows for changing the {@code readOnly} flag.
-     *
-     * @param data
-     *         base property data
-     * @param readOnly
-     *         new read-only value
-     */
-    public PropertyData(PropertyData<P> data, boolean readOnly) {
-        this(data.name, data.type, readOnly, data.defaultValue);
     }
 
     /**
@@ -100,6 +89,39 @@ public final class PropertyData<P extends Serializable> implements Serializable 
      */
     public boolean isReadOnly() {
         return readOnly;
+    }
+
+    /**
+     * Creates a copy of {@code this} with the new {@code readOnly} value.
+     *
+     * @param readOnly
+     *            new {@code readOnly} value
+     * @return copy of {@code this}
+     */
+    public PropertyData<P> updateReadOnly(boolean readOnly) {
+        return new PropertyData<>(this.name, this.type, readOnly,
+                this.defaultValue);
+    }
+
+    /**
+     * Creates a copy of {@code this} with the new {@code defaultValue} value.
+     * 
+     * @param defaultValue
+     *            new {@code defaultValue} value
+     * @return copy of {@code this}
+     * @throws IllegalArgumentException
+     *             if {@code defaultValue} does not share type with the previous
+     *             value
+     */
+    public PropertyData<P> updateDefaultValue(Serializable defaultValue) {
+        if (defaultValue != null && !this.type.isAssignableFrom(defaultValue.getClass())) {
+            throw new IllegalArgumentException(String.format(
+                    "Parameter 'defaultValue' of type '%s' cannot be cast to " +
+                            "%s!", defaultValue.getClass().getName(),
+                    this.type.getName()));
+        }
+        return new PropertyData<>(this.name, this.type, this.readOnly,
+                (P) defaultValue);
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/PropertyData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/PropertyData.java
@@ -103,27 +103,6 @@ public final class PropertyData<P extends Serializable>
                 this.defaultValue);
     }
 
-    /**
-     * Creates a copy of {@code this} with the new {@code defaultValue} value.
-     * 
-     * @param defaultValue
-     *            new {@code defaultValue} value
-     * @return copy of {@code this}
-     * @throws IllegalArgumentException
-     *             if {@code defaultValue} does not share type with the previous
-     *             value
-     */
-    public PropertyData<P> updateDefaultValue(Serializable defaultValue) {
-        if (defaultValue != null && !this.type.isAssignableFrom(defaultValue.getClass())) {
-            throw new IllegalArgumentException(String.format(
-                    "Parameter 'defaultValue' of type '%s' cannot be cast to " +
-                            "%s!", defaultValue.getClass().getName(),
-                    this.type.getName()));
-        }
-        return new PropertyData<>(this.name, this.type, this.readOnly,
-                (P) defaultValue);
-    }
-
     @Override
     public int hashCode() {
         return Objects.hash(name, type);

--- a/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentBinding.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentBinding.java
@@ -24,10 +24,11 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.webcomponent.WebComponentConfiguration;
-import com.vaadin.flow.di.Instantiator;
-import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableBiConsumer;
 import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.internal.JsonCodec;
+
+import elemental.json.JsonValue;
 
 /**
  * Represents a single instance of a exported web component instance embedded
@@ -36,12 +37,14 @@ import com.vaadin.flow.function.SerializableConsumer;
  * updates from the client to the {@code component}.
  *
  * @param <C>
- *         type of the exported component
+ *            type of the exported component
  * @author Vaadin Ltd.
- * @see WebComponentConfiguration#createWebComponentBinding(Instantiator,
- *         Element) to create {@code WebComponentBindings}
+ * @see WebComponentConfiguration#createWebComponentBinding(com.vaadin.flow.di.Instantiator,
+ *      com.vaadin.flow.dom.Element, elemental.json.JsonObject) to create
+ *      {@code WebComponentBindings}
  */
-public final class WebComponentBinding<C extends Component> implements Serializable {
+public final class WebComponentBinding<C extends Component>
+        implements Serializable {
     private C component;
     private HashMap<String, PropertyBinding<? extends Serializable>> properties = new HashMap<>();
 
@@ -51,14 +54,14 @@ public final class WebComponentBinding<C extends Component> implements Serializa
      * are bound by calling {@link #bindProperty(PropertyConfigurationImpl)};
      *
      * @param component
-     *         component which exposes {@code properties} as web component. Not
-     *         {@code null}
+     *            component which exposes {@code properties} as web component.
+     *            Not {@code null}
      * @throws NullPointerException
-     *         if {@code component} is {@code null}
+     *             if {@code component} is {@code null}
      */
     public WebComponentBinding(C component) {
-        Objects.requireNonNull(component, "Parameter 'component' must not be " +
-                "null!");
+        Objects.requireNonNull(component,
+                "Parameter 'component' must not be " + "null!");
 
         this.component = component;
     }
@@ -70,17 +73,17 @@ public final class WebComponentBinding<C extends Component> implements Serializa
      * value (which could be {@code null}).
      *
      * @param propertyName
-     *         name of the property, not {@code null}
+     *            name of the property, not {@code null}
      * @param value
-     *         new value to set for the property
+     *            new value to set for the property
      * @throws NullPointerException
-     *         if {@code propertyName} is {@code null}
+     *             if {@code propertyName} is {@code null}
      * @throws IllegalArgumentException
-     *         if no bound property can be found for {@code propertyName}
+     *             if no bound property can be found for {@code propertyName}
      */
     public void updateProperty(String propertyName, Serializable value) {
-        Objects.requireNonNull(propertyName, "Parameter 'propertyName' must " +
-                "not be null!");
+        Objects.requireNonNull(propertyName,
+                "Parameter 'propertyName' must " + "not be null!");
 
         PropertyBinding<?> propertyBinding = properties.get(propertyName);
 
@@ -91,6 +94,34 @@ public final class WebComponentBinding<C extends Component> implements Serializa
         }
 
         propertyBinding.updateValue(value);
+    }
+
+    /**
+     * Updates a property bound to the {@code component}. Converts the {@code
+     * jsonValue} into the correct type if able and then calls
+     * {@link #updateProperty(String, java.io.Serializable)}.
+     *
+     * @param propertyName
+     *            name of the property, not {@code null}
+     * @param jsonValue
+     *            new value to set for the property
+     * @throws NullPointerException
+     *             if {@code propertyName} is {@code null}
+     * @throws IllegalArgumentException
+     *             if no bound property can be found for {@code propertyName}
+     * @throws IllegalArgumentException
+     *             if the {@code jsonValue} cannot be converted to the type of
+     *             the property identified by {@code propertyName}.
+     */
+    public void updateProperty(String propertyName, JsonValue jsonValue) {
+        Objects.requireNonNull(propertyName,
+                "Parameter 'propertyName' must " + "not be null!");
+
+        Class<? extends Serializable> propertyType = getPropertyType(
+                propertyName);
+
+        Serializable value = jsonValueToConcreteType(jsonValue, propertyType);
+        updateProperty(propertyName, value);
     }
 
     /**
@@ -106,7 +137,7 @@ public final class WebComponentBinding<C extends Component> implements Serializa
      * Retrieve the type of a property's value.
      *
      * @param propertyName
-     *         name of the property
+     *            name of the property
      * @return property type
      */
     public Class<? extends Serializable> getPropertyType(String propertyName) {
@@ -120,7 +151,7 @@ public final class WebComponentBinding<C extends Component> implements Serializa
      * Does the component binding have a property identified by given name.
      *
      * @param propertyName
-     *         name of the property
+     *            name of the property
      * @return has property
      */
     public boolean hasProperty(String propertyName) {
@@ -128,8 +159,8 @@ public final class WebComponentBinding<C extends Component> implements Serializa
     }
 
     /**
-     * Calls the bound change handlers defined via {@link
-     * com.vaadin.flow.component.webcomponent.PropertyConfiguration#onChange(SerializableBiConsumer)}
+     * Calls the bound change handlers defined via
+     * {@link com.vaadin.flow.component.webcomponent.PropertyConfiguration#onChange(SerializableBiConsumer)}
      * for each bound property with the current value of the property.
      */
     public void updatePropertiesToComponent() {
@@ -142,32 +173,71 @@ public final class WebComponentBinding<C extends Component> implements Serializa
      * previous binding is removed.
      *
      * @param propertyConfiguration
-     *         property configuration, not {@code null}
+     *            property configuration, not {@code null}
+     * @param overrideDefault
+     *            set to {@code true} if the default value of the property
+     *            should be replaced with the value given by
+     *            {@code newDefaultValue}
+     * @param newDefaultValue
+     *            new default value for the property. Can be {@code null}.
+     *            {@code overrideDefault} must be {@code true} for this value to
+     *            have any effect
      * @throws NullPointerException
-     *         if {@code propertyConfiguration} is {@code null}
+     *             if {@code propertyConfiguration} is {@code null}
      */
-    public void bindProperty(PropertyConfigurationImpl<C,
-            ? extends Serializable> propertyConfiguration) {
-        Objects.requireNonNull(propertyConfiguration, "Parameter " +
-                "'propertyConfiguration' cannot be null!");
+    public void bindProperty(
+            PropertyConfigurationImpl<C, ? extends Serializable> propertyConfiguration,
+            boolean overrideDefault, JsonValue newDefaultValue) {
+        Objects.requireNonNull(propertyConfiguration,
+                "Parameter 'propertyConfiguration' cannot be null!");
 
-        SerializableBiConsumer<C, Serializable> consumer = propertyConfiguration
+        final SerializableBiConsumer<C, Serializable> consumer =
+                propertyConfiguration
                 .getOnChangeHandler();
-        PropertyBinding<? extends Serializable> binding =
-                new PropertyBinding<>(propertyConfiguration.getPropertyData(),
-                        consumer == null ? null
-                                : value -> consumer.accept(
-                                component, value));
-        properties.put(propertyConfiguration.getPropertyData().getName(), binding);
+
+        final Serializable serializableDefault =
+                jsonValueToConcreteType(newDefaultValue,
+                        propertyConfiguration.getPropertyData().getType());
+        // calculate new PropertyData, we'll need to change the default
+        // value, if the user defined a new value in the component's attributes
+        final PropertyData<? extends Serializable> propertyData = !overrideDefault
+                ? propertyConfiguration.getPropertyData()
+                : propertyConfiguration.getPropertyData()
+                        .updateDefaultValue(serializableDefault);
+
+        final PropertyBinding<? extends Serializable> binding =
+                new PropertyBinding<>(
+                propertyData, consumer == null ? null
+                        : value -> consumer.accept(component, value));
+        properties.put(propertyConfiguration.getPropertyData().getName(),
+                binding);
     }
 
-    private static class PropertyBinding<P extends Serializable> implements Serializable {
+    private Serializable jsonValueToConcreteType(JsonValue jsonValue,
+            Class<? extends Serializable> type) {
+        Objects.requireNonNull(type, "Parameter 'type' must not be null!");
+
+        if (JsonCodec.canEncodeWithoutTypeInfo(type)) {
+            Serializable value = null;
+            if (jsonValue != null) {
+                value = JsonCodec.decodeAs(jsonValue, type);
+            }
+            return value;
+        } else {
+            throw new IllegalArgumentException(String.format(
+                    "Received '%s' was not convertible" + " to '%s'",
+                    JsonValue.class.getName(), type.getName()));
+        }
+    }
+
+    private static class PropertyBinding<P extends Serializable>
+            implements Serializable {
         private PropertyData<P> data;
         private SerializableConsumer<P> listener;
         private P value;
 
         public PropertyBinding(PropertyData<P> data,
-                               SerializableConsumer<P> listener) {
+                SerializableConsumer<P> listener) {
             Objects.requireNonNull(data, "Parameter 'data' must not be null!");
             this.data = data;
             this.listener = listener;
@@ -178,19 +248,18 @@ public final class WebComponentBinding<C extends Component> implements Serializa
         public void updateValue(Serializable newValue) {
             if (isReadOnly()) {
                 LoggerFactory.getLogger(getClass())
-                        .warn(String.format("An attempt was made to write to " +
-                                        "a read-only property '%s' owned by exported " +
-                                        "component %s", getName(),
+                        .warn(String.format("An attempt was made to write to "
+                                + "a read-only property '%s' owned by exported "
+                                + "component %s", getName(),
                                 getType().getCanonicalName()));
                 return;
             }
 
             if (newValue != null && newValue.getClass() != getType()) {
-                throw new IllegalArgumentException(String.format("Parameter " +
-                                "'newValue' is of the wrong type: onChangeHandler" +
-                                " of the property expected to receive %s but " +
-                                "found %s instead.",
-                        getType().getCanonicalName(),
+                throw new IllegalArgumentException(String.format("Parameter "
+                        + "'newValue' is of the wrong type: onChangeHandler"
+                        + " of the property expected to receive %s but "
+                        + "found %s instead.", getType().getCanonicalName(),
                         newValue.getClass().getCanonicalName()));
             }
 
@@ -247,8 +316,8 @@ public final class WebComponentBinding<C extends Component> implements Serializa
             if (obj instanceof PropertyBinding) {
                 PropertyBinding other = (PropertyBinding) obj;
                 boolean valuesAreNull = value == null && other.value == null;
-                boolean valuesAreEqual = valuesAreNull ||
-                        (value != null && value.equals(other.value));
+                boolean valuesAreEqual = valuesAreNull
+                        || (value != null && value.equals(other.value));
                 return data.equals(other.data) && valuesAreEqual;
             }
             return false;

--- a/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentBinding.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentBinding.java
@@ -51,7 +51,8 @@ public final class WebComponentBinding<C extends Component>
     /**
      * Constructs a new {@code WebComponentBinding}. The bound {@link Component}
      * is given via {@code component} parameter. The web component properties
-     * are bound by calling {@link #bindProperty(PropertyConfigurationImpl)};
+     * are bound by calling
+     * {@link #bindProperty(PropertyConfigurationImpl, boolean, elemental.json.JsonValue)};
      *
      * @param component
      *            component which exposes {@code properties} as web component.

--- a/flow-server/src/main/resources/com/vaadin/flow/server/webcomponent/webcomponent-script-template.js
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/webcomponent/webcomponent-script-template.js
@@ -17,7 +17,8 @@
   _PropertyMethods_
 
   _sync(property, newValue) {
-    if (this.$server) {
+    // Don't sync, if the web component has not been registered yet
+    if (this.$server && document.body.$[this.$.id] === this) {
       if (!this._propertyUpdatedFromServer[property]) {
         this.$server.sync(property, newValue);
       } else {
@@ -56,7 +57,14 @@
       if (flowRoot && flowRoot.$server) {
         flowRoot.$ = flowRoot.$ || {};
         flowRoot.$[this.$.id] = this;
-        flowRoot.$server.connectWebComponent('_TagDash_', this.$.id);
+        const properties = {};
+        for (var prop in _TagCamel_.properties) {
+          if (prop === "_propertyUpdatedFromServer") {
+            continue;
+          }
+          properties[prop] = this[prop];
+        }
+        flowRoot.$server.connectWebComponent('_TagDash_', this.$.id, properties);
       } else {
         setTimeout(poller, 10);
       }
@@ -72,11 +80,6 @@
   }
 
   serverConnected() {
-    Object.keys(_TagCamel_.properties).forEach(prop => {
-      if (prop !== "_propertyUpdatedFromServer") {
-        this._sync(prop, this[prop]);
-      }
-    });
   }
 }
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/webcomponent/WebComponentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/webcomponent/WebComponentTest.java
@@ -43,9 +43,10 @@ public class WebComponentTest {
 
     @Before
     public void init() {
-        WebComponentBinding<Component> componentBinding = new WebComponentBinding<>(
-                mock(Component.class));
-        webComponent = new WebComponent<>(componentBinding, new Element("tag"));
+        WebComponentBinding<Component> componentBinding =
+                new WebComponentBinding<>(mock(Component.class));
+        webComponent = new WebComponent<>(componentBinding,
+                new Element("tag"));
     }
 
     @Test
@@ -77,17 +78,18 @@ public class WebComponentTest {
     @Test
     public void setProperty_throwsOnUnknownProperty() {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage(
-                "WebComponent does not have a property identified");
+        exception.expectMessage("WebComponent does not have a property identified");
 
-        WebComponentBinding<Component> binding = new WebComponentBinding<>(
-                mock(Component.class));
+        WebComponentBinding<Component> binding =
+                new WebComponentBinding<>(mock(Component.class));
 
-        WebComponent<Component> webComponent = new WebComponent<>(binding,
+        WebComponent<Component> webComponent =
+                new WebComponent<>(binding,
                 new Element("tag"));
 
-        PropertyConfigurationImpl<Component, String> configuration = new PropertyConfigurationImpl<>(
-                Component.class, "property", String.class, "value");
+        PropertyConfigurationImpl<Component, String> configuration =
+                new PropertyConfigurationImpl<>(
+                        Component.class, "property", String.class, "value");
 
         webComponent.setProperty(configuration, "newValue");
     }
@@ -95,22 +97,24 @@ public class WebComponentTest {
     @Test
     public void setProperty_throwsWhenGivenWrongPropertyTypeAsParameter() {
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Property 'property' of type "
-                + "'java.lang.Integer' cannot be assigned value of type "
-                + "'java.lang.String'!");
+        exception.expectMessage("Property 'property' of type " +
+                "'java.lang.Integer' cannot be assigned value of type " +
+                "'java.lang.String'!");
 
-        PropertyConfigurationImpl<Component, Integer> intConfiguration = new PropertyConfigurationImpl<>(
+        PropertyConfigurationImpl<Component, Integer> intConfiguration =
+        new PropertyConfigurationImpl<>(
                 Component.class, "property", Integer.class, 0);
 
-        WebComponentBinding<Component> binding = new WebComponentBinding<>(
-                mock(Component.class));
-        binding.bindProperty(intConfiguration);
+        WebComponentBinding<Component> binding =
+                new WebComponentBinding<>(mock(Component.class));
+        binding.bindProperty(intConfiguration, false, null);
 
-        WebComponent<Component> webComponent = new WebComponent<>(binding,
-                new Element("tag"));
+        WebComponent<Component> webComponent =
+                new WebComponent<>(binding, new Element("tag"));
 
-        PropertyConfigurationImpl<Component, String> stringConfiguration = new PropertyConfigurationImpl<>(
-                Component.class, "property", String.class, "value");
+        PropertyConfigurationImpl<Component, String> stringConfiguration =
+                new PropertyConfigurationImpl<>(
+                        Component.class, "property", String.class, "value");
 
         webComponent.setProperty(stringConfiguration, "newValue");
     }
@@ -120,25 +124,30 @@ public class WebComponentTest {
         Element element = spy(new Element("tag"));
 
         // configurations
-        PropertyConfigurationImpl<Component, Integer> intConfiguration = new PropertyConfigurationImpl<>(
-                Component.class, "int", Integer.class, 0);
-        PropertyConfigurationImpl<Component, Double> doubleConfiguration = new PropertyConfigurationImpl<>(
-                Component.class, "double", Double.class, 0.0);
-        PropertyConfigurationImpl<Component, String> stringConfiguration = new PropertyConfigurationImpl<>(
-                Component.class, "string", String.class, "");
-        PropertyConfigurationImpl<Component, Boolean> booleanConfiguration = new PropertyConfigurationImpl<>(
-                Component.class, "boolean", Boolean.class, false);
-        PropertyConfigurationImpl<Component, JsonValue> jsonConfiguration = new PropertyConfigurationImpl<>(
-                Component.class, "json", JsonValue.class, Json.createNull());
+        PropertyConfigurationImpl<Component, Integer> intConfiguration =
+                new PropertyConfigurationImpl<>(
+                        Component.class, "int", Integer.class, 0);
+        PropertyConfigurationImpl<Component, Double> doubleConfiguration =
+                new PropertyConfigurationImpl<>(
+                        Component.class, "double", Double.class, 0.0);
+        PropertyConfigurationImpl<Component, String> stringConfiguration =
+                new PropertyConfigurationImpl<>(
+                        Component.class, "string", String.class, "");
+        PropertyConfigurationImpl<Component, Boolean> booleanConfiguration =
+                new PropertyConfigurationImpl<>(
+                        Component.class, "boolean", Boolean.class, false);
+        PropertyConfigurationImpl<Component, JsonValue> jsonConfiguration =
+                new PropertyConfigurationImpl<>(
+                        Component.class, "json", JsonValue.class, Json.createNull());
 
         // binding
-        WebComponentBinding<Component> binding = new WebComponentBinding<>(
-                mock(Component.class));
-        binding.bindProperty(intConfiguration);
-        binding.bindProperty(doubleConfiguration);
-        binding.bindProperty(stringConfiguration);
-        binding.bindProperty(booleanConfiguration);
-        binding.bindProperty(jsonConfiguration);
+        WebComponentBinding<Component> binding =
+                new WebComponentBinding<>(mock(Component.class));
+        binding.bindProperty(intConfiguration, false, null);
+        binding.bindProperty(doubleConfiguration, false, null);
+        binding.bindProperty(stringConfiguration, false, null);
+        binding.bindProperty(booleanConfiguration, false, null);
+        binding.bindProperty(jsonConfiguration, false, null);
 
         // test
         WebComponent<Component> webComponent = new WebComponent<>(binding,

--- a/flow-server/src/test/java/com/vaadin/flow/component/webcomponent/WebComponentWrapperTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/webcomponent/WebComponentWrapperTest.java
@@ -61,7 +61,7 @@ public class WebComponentWrapperTest {
         // make component available and bind properties to it
         binding = (WebComponentBinding<MyComponent>) new WebComponentExporter
                 .WebComponentConfigurationFactory().create(exporter)
-                .createWebComponentBinding(new MockInstantiator(), element);
+                .createWebComponentBinding(new MockInstantiator(), element, Json.createObject());
         wrapper = new WebComponentWrapper(element, binding);
         component = binding.getComponent();
     }
@@ -226,7 +226,7 @@ public class WebComponentWrapperTest {
         }
         WebComponentBinding<C> binding = (WebComponentBinding<C>)
                 new WebComponentExporter.WebComponentConfigurationFactory().create(exporter)
-                        .createWebComponentBinding(new MockInstantiator(), element);
+                        .createWebComponentBinding(new MockInstantiator(), element, Json.createObject());
         wrapper = new WebComponentWrapper(element, binding) {
             @Override
             public Optional<UI> getUI() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/WebComponentBindingTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/WebComponentBindingTest.java
@@ -22,8 +22,10 @@ import org.junit.Test;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.webcomponent.PropertyConfiguration;
 import com.vaadin.flow.server.webcomponent.PropertyConfigurationImpl;
 
+import elemental.json.Json;
 import elemental.json.JsonValue;
 
 public class WebComponentBindingTest {
@@ -34,13 +36,15 @@ public class WebComponentBindingTest {
     @Before
     public void setUp() {
         component = new MyComponent();
-        binding = new WebComponentBinding(component);
+        binding = new WebComponentBinding<>(component);
         binding.bindProperty(
                 new PropertyConfigurationImpl<>(
-                        MyComponent.class, "int", Integer.class, 0));
+                        MyComponent.class, "int", Integer.class, 0), false,
+                null);
         binding.bindProperty(
                 new PropertyConfigurationImpl<>(
-                        MyComponent.class, "json", JsonValue.class, null));
+                        MyComponent.class, "json", JsonValue.class, null),
+                false, null);
     }
 
     @Test
@@ -62,7 +66,6 @@ public class WebComponentBindingTest {
         Assert.assertTrue(binding.hasProperty("json"));
 
         Assert.assertFalse(binding.hasProperty("not-a-property"));
-
     }
 
     @Tag("tag")

--- a/flow-tests/test-npm-web-components/src/main/webapp/defaultValue.html
+++ b/flow-tests/test-npm-web-components/src/main/webapp/defaultValue.html
@@ -1,0 +1,48 @@
+<!--
+  ~ Copyright 2000-2018 Vaadin Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+
+<!doctype html>
+
+<head>
+    <script type='module' src='/vaadin/web-component/default-value-init.js'></script>
+</head>
+
+<body>
+<p>
+    Test default value delivery of embedded Web Components
+</p>
+
+<default-value-init id="init-1"></default-value-init>
+<default-value-init id="init-2" value="2"></default-value-init>
+<default-value-init id="init-3"></default-value-init>
+<input type="button" id="update-properties" onclick="updateValues()">
+
+<script>
+    // initialize via property
+    var init3 = document.getElementById("init-3");
+    init3.value = 3;
+
+    var init1 = document.getElementById("init-1");
+    var init2 = document.getElementById("init-2");
+
+    function updateValues() {
+        init1.value = 4;
+        init2.value = 4;
+        init3.value = 4;
+    }
+  </script>
+
+</body>

--- a/flow-tests/test-npm-web-components/src/test/java/com/vaadin/flow/webcomponent/NpmDefaultValueInitializationIT.java
+++ b/flow-tests/test-npm-web-components/src/test/java/com/vaadin/flow/webcomponent/NpmDefaultValueInitializationIT.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.webcomponent;
+
+import com.vaadin.flow.webcomponent.tests.DefaultValueInitializationIT;
+
+public class NpmDefaultValueInitializationIT extends DefaultValueInitializationIT {
+}

--- a/flow-tests/test-web-components/src/main/webapp/defaultValue.html
+++ b/flow-tests/test-web-components/src/main/webapp/defaultValue.html
@@ -1,0 +1,49 @@
+<!--
+  ~ Copyright 2000-2018 Vaadin Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+
+<!doctype html>
+
+<head>
+    <script type="text/javascript" src="./frontend/bower_components/webcomponentsjs/webcomponents-loader.js"></script>
+    <link rel='import' href='/web-component/default-value-init.html'>
+</head>
+
+<body>
+<p>
+    Test default value delivery of embedded Web Components
+</p>
+
+<default-value-init id="init-1"></default-value-init>
+<default-value-init id="init-2" value="2"></default-value-init>
+<default-value-init id="init-3"></default-value-init>
+<input type="button" id="update-properties" onclick="updateValues()">
+
+<script>
+    // initialize via property
+    var init3 = document.getElementById("init-3");
+    init3.value = 3;
+
+    var init1 = document.getElementById("init-1");
+    var init2 = document.getElementById("init-2");
+
+    function updateValues() {
+        init1.value = 4;
+        init2.value = 4;
+        init3.value = 4;
+    }
+  </script>
+
+</body>

--- a/flow-tests/test-web-components/src/test/java/com/vaadin/flow/webcomponent/BowerDefaultValueInitializationIT.java
+++ b/flow-tests/test-web-components/src/test/java/com/vaadin/flow/webcomponent/BowerDefaultValueInitializationIT.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.webcomponent;
+
+import com.vaadin.flow.webcomponent.tests.DefaultValueInitializationIT;
+
+public class BowerDefaultValueInitializationIT extends DefaultValueInitializationIT {
+}

--- a/flow-tests/web-component-test-assets/src/main/java/com/vaadin/flow/webcomponent/DefaultValueInitializationComponent.java
+++ b/flow-tests/web-component-test-assets/src/main/java/com/vaadin/flow/webcomponent/DefaultValueInitializationComponent.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.webcomponent;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Paragraph;
+
+public class DefaultValueInitializationComponent extends Div {
+    private int value = 0;
+    private int updateCounter = 0;
+    private Paragraph valueParagraph;
+    private Paragraph updateParagraph;
+    public DefaultValueInitializationComponent() {
+        valueParagraph = new Paragraph();
+        valueParagraph.setId("value");
+        updateParagraph = new Paragraph();
+        updateParagraph.setId("counter");
+        updateParagraphs();
+        add(valueParagraph, updateParagraph);
+    }
+
+    public void updateValue(int newValue) {
+        value = newValue;
+        updateCounter++;
+        updateParagraphs();
+    }
+
+    private void updateParagraphs() {
+        valueParagraph.setText(Integer.toString(value));
+        updateParagraph.setText(Integer.toString(updateCounter));
+    }
+}

--- a/flow-tests/web-component-test-assets/src/main/java/com/vaadin/flow/webcomponent/DefaultValueInitializationExporter.java
+++ b/flow-tests/web-component-test-assets/src/main/java/com/vaadin/flow/webcomponent/DefaultValueInitializationExporter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.webcomponent;
+
+import com.vaadin.flow.component.WebComponentExporter;
+import com.vaadin.flow.component.webcomponent.WebComponent;
+
+public class DefaultValueInitializationExporter
+        extends WebComponentExporter<DefaultValueInitializationComponent> {
+
+    public DefaultValueInitializationExporter() {
+        super("default-value-init");
+        addProperty("value", 1)
+                .onChange(DefaultValueInitializationComponent::updateValue);
+    }
+
+    @Override
+    protected void configureInstance(
+            WebComponent<DefaultValueInitializationComponent> webComponent,
+            DefaultValueInitializationComponent component) {
+
+    }
+}

--- a/flow-tests/web-component-test-assets/src/main/java/com/vaadin/flow/webcomponent/tests/DefaultValueInitializationIT.java
+++ b/flow-tests/web-component-test-assets/src/main/java/com/vaadin/flow/webcomponent/tests/DefaultValueInitializationIT.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.webcomponent.tests;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public abstract class DefaultValueInitializationIT extends ChromeBrowserTest {
+
+    @Override
+    protected String getTestPath() {
+        return "/defaultValue.html";
+    }
+
+    @Test
+    public void defaultValues_areSetToCorrectValues_withCorrectUpdateCounts() {
+        open();
+        /*
+         * The page contains three instances of
+         * DefaultValueInitializationComponents (default-value-init). id:init-1
+         * will have the default value set in Java, id:init-2 will have default
+         * value set by an attribute, and id:init-3 will have a value updated by
+         * property change
+         */
+
+        // Java default
+        Assert.assertEquals("Java default value is correct", "1",
+                value("init-1"));
+        Assert.assertEquals("Java default's counter is correct", "1",
+                counter("init-1"));
+
+        // JS default
+        Assert.assertEquals("JS default value is correct", "2",
+                value("init-2"));
+        Assert.assertEquals("JS default's counter is correct", "1",
+                counter("init-2"));
+
+        // Updated property
+        Assert.assertEquals("Property updated default value is correct", "3",
+                value("init-3"));
+        Assert.assertEquals("Property updated default's counter is correct",
+                "1", counter("init-3"));
+
+        // Verify that counters actually update by clicking a button which
+        // updates all the properties
+        findElement(By.id("update-properties")).click();
+
+        // Java default
+        Assert.assertEquals("Java default's value is changed", "4",
+                value("init-1"));
+        Assert.assertEquals("Java default's counter increases", "2",
+                counter("init-1"));
+
+        // JS default
+        Assert.assertEquals("JS default's value is changed", "4",
+                value("init-2"));
+        Assert.assertEquals("JS default's counter increases", "2",
+                counter("init-2"));
+
+        // Updated property
+        Assert.assertEquals("Property updated default's value is changed", "4",
+                value("init-3"));
+        Assert.assertEquals("Property updated default's counter increases", "2",
+                counter("init-3"));
+    }
+
+    private String value(String componentId) {
+        WebElement comp = findElement(By.id(componentId));
+        return comp.findElement(By.id("value")).getText();
+    }
+
+    private String counter(String componentId) {
+        WebElement comp = findElement(By.id(componentId));
+        return comp.findElement(By.id("counter")).getText();
+    }
+}


### PR DESCRIPTION
If the user sets an `attribute` for the embedded web component, that attribute value is delivered to the web component when it is created. The attribute value will act as the new default value for that particular embedded web component, overriding the previously defined default value (java side, `WebComponentExporter::addProperty`).

Fixes: #5794 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5912)
<!-- Reviewable:end -->
