### PR TITLE
Warn for missing generated in webpack.config.js

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateWebpack.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateWebpack.java
@@ -88,10 +88,14 @@ public class TaskUpdateWebpack implements Command {
 
         // If we have an old config file we remove it and create the new one using the webpack.generated.js
         if (configFile.exists()) {
-            if (!FileUtils.readFileToString(configFile, "UTF-8").contains(
-                    "const flowDefaults = require('./webpack.generated.js');")) {
-                log().info("Webpack configuration was outdated, removing file: " + configFile);
-                configFile.delete();
+            if (!FileUtils.readFileToString(configFile, "UTF-8")
+                    .contains("./webpack.generated.js")) {
+                log().warn(
+                        "Flow generated webpack configuration was not mentioned "
+                                + "in the configuration file: {}."
+                                + "Please verify that './webpack.generated.js' is used "
+                                + "in the merge or remove the file to generate a new one.",
+                        configFile);
             }
         }
 

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -31,6 +31,13 @@ const mkdirp = require('mkdirp');
 mkdirp(buildFolder);
 mkdirp(confFolder);
 
+
+exports = {
+  frontendFolder: `${frontendFolder}`,
+  buildFolder: `${buildFolder}`,
+  confFolder: `${confFolder}`
+}
+
 module.exports = {
   mode: 'production',
   context: frontendFolder,


### PR DESCRIPTION
Export flow configuration paths
Now the webpack.config.js is not automatically removed
and there will only be a warning in the logs that it seems
like you don't import the flow webpack configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5918)
<!-- Reviewable:end -->
