### PR TITLE
Cache visit to irrelevant classes per class instead or per entryPoint

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendClassVisitor.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendClassVisitor.java
@@ -105,12 +105,8 @@ class FrontendClassVisitor extends ClassVisitor {
             return classes;
         }
 
-        boolean hasData() {
-            boolean hasTheme = theme.name != null || theme.notheme;
-            boolean hasScriptsOrModules = modules.size() > 0
-                    || scripts.size() > 0;
-
-            return hasTheme || layout != null || hasScriptsOrModules;
+        int dataHash() {
+            return Objects.hash(theme.name, theme.notheme, modules, scripts, layout);
         }
 
         ThemeData getTheme() {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendClassVisitor.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendClassVisitor.java
@@ -44,7 +44,6 @@ class FrontendClassVisitor extends ClassVisitor {
     private static final String LAYOUT = "layout";
     static final String VALUE = "value";
     static final String VERSION = "version";
-    static final Set<String> invalidClasses = new HashSet<>();
 
     /**
      * An annotation visitor implementation that enables repeated annotations.
@@ -105,16 +104,16 @@ class FrontendClassVisitor extends ClassVisitor {
             return classes;
         }
 
-        int dataHash() {
-            return Objects.hash(theme.name, theme.notheme, modules, scripts, layout);
-        }
-
         ThemeData getTheme() {
             return theme;
         }
 
         String getRoute() {
             return route;
+        }
+
+        String getLayout() {
+            return layout;
         }
 
         String getName() {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendDependencies.java
@@ -272,10 +272,6 @@ public class FrontendDependencies implements Serializable {
             if (endPoint.getLayout() != null) {
                 visitClass(endPoint.getLayout(), endPoint);
             }
-
-            if (!endPoint.getTheme().isNotheme() && endPoint.getTheme().getName() != null) {
-                visitClass(endPoint.getTheme().getName(), endPoint);
-            }
         }
 
         Set<ThemeData> themes = endPoints.values().stream()

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendDependencies.java
@@ -111,11 +111,11 @@ public class FrontendDependencies implements Serializable {
     }
 
     private final ClassFinder finder;
-    final HashMap<String, EndPointData> endPoints = new HashMap<>();
+    private final HashMap<String, EndPointData> endPoints = new HashMap<>();
     private ThemeDefinition themeDefinition;
     private AbstractTheme themeInstance;
     private final HashMap<String, String> packages = new HashMap<>();
-    final Set<String> irrelevantClasses = new HashSet<>();
+    private final Set<String> irrelevantClasses = new HashSet<>();
 
     /**
      * Default Constructor.
@@ -151,7 +151,8 @@ public class FrontendDependencies implements Serializable {
             if (generateEmbeddableWebComponents) {
                 computeExporters();
             }
-            log().info("took " + (System.nanoTime() - start) / 1000000 + "ms.");
+            long ms = (System.nanoTime() - start) / 1000000;
+            log().info("took {} ms.", ms);
         } catch (ClassNotFoundException | InstantiationException
                 | IllegalAccessException | IOException e) {
             throw new IllegalStateException(

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendDependencies.java
@@ -111,11 +111,11 @@ public class FrontendDependencies implements Serializable {
     }
 
     private final ClassFinder finder;
-    private final HashMap<String, EndPointData> endPoints = new HashMap<>();
+    final HashMap<String, EndPointData> endPoints = new HashMap<>();
     private ThemeDefinition themeDefinition;
     private AbstractTheme themeInstance;
     private final HashMap<String, String> packages = new HashMap<>();
-    private final Set<String> irrelevantClasses = new HashSet<>();
+    final Set<String> irrelevantClasses = new HashSet<>();
 
     /**
      * Default Constructor.
@@ -143,6 +143,7 @@ public class FrontendDependencies implements Serializable {
             boolean generateEmbeddableWebComponents) {
         log().info(
                 "Scanning classes to find frontend configurations and dependencies...");
+        long start = System.nanoTime();
         this.finder = finder;
         try {
             computeEndpoints();
@@ -150,6 +151,7 @@ public class FrontendDependencies implements Serializable {
             if (generateEmbeddableWebComponents) {
                 computeExporters();
             }
+            log().info("took " + (System.nanoTime() - start) / 1000000 + "ms.");
         } catch (ClassNotFoundException | InstantiationException
                 | IllegalAccessException | IOException e) {
             throw new IllegalStateException(
@@ -437,6 +439,8 @@ public class FrontendDependencies implements Serializable {
             return endPoint;
         }
 
+        int previousDataHash = endPoint.dataHash();
+
         FrontendClassVisitor visitor = new FrontendClassVisitor(className,
                 endPoint);
         ClassReader cr = new ClassReader(url.openStream());
@@ -454,7 +458,7 @@ public class FrontendDependencies implements Serializable {
             visitClass(endPoint.getTheme().getName(), endPoint);
         }
 
-        if (!endPoint.hasData()) {
+        if (previousDataHash == endPoint.dataHash()) {
             irrelevantClasses.add(className);
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendDependencies.java
@@ -22,6 +22,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.net.URL;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -115,7 +116,7 @@ public class FrontendDependencies implements Serializable {
     private ThemeDefinition themeDefinition;
     private AbstractTheme themeInstance;
     private final HashMap<String, String> packages = new HashMap<>();
-    private final Set<String> irrelevantClasses = new HashSet<>();
+    private final Set<String> visited = new HashSet<>();
 
     /**
      * Default Constructor.
@@ -147,6 +148,7 @@ public class FrontendDependencies implements Serializable {
         this.finder = finder;
         try {
             computeEndpoints();
+            computeApplicationTheme(endPoints);
             computePackages();
             if (generateEmbeddableWebComponents) {
                 computeExporters();
@@ -161,7 +163,7 @@ public class FrontendDependencies implements Serializable {
     }
 
     /**
-     * get all npm packages the application depends on.
+     * Get all npm packages the application depends on.
      *
      * @return the set of npm packages
      */
@@ -170,7 +172,7 @@ public class FrontendDependencies implements Serializable {
     }
 
     /**
-     * get all ES6 modules needed for run the application.
+     * Get all ES6 modules needed for run the application.
      *
      * @return the set of JS modules
      */
@@ -183,7 +185,7 @@ public class FrontendDependencies implements Serializable {
     }
 
     /**
-     * get all JS files used by the application.
+     * Get all the JS files used by the application.
      *
      * @return the set of JS files
      */
@@ -196,20 +198,25 @@ public class FrontendDependencies implements Serializable {
     }
 
     /**
-     * get all Java classes considered when looking for used dependencies.
+     * Get all Java classes considered when looking for used dependencies.
      *
      * @return the set of JS files
      */
     public Set<String> getClasses() {
-        Set<String> all = new HashSet<>();
-        for (FrontendClassVisitor.EndPointData data : endPoints.values()) {
-            all.addAll(data.getClasses());
-        }
-        return all;
+        return visited;
     }
 
     /**
-     * get the {@link ThemeDefinition} of the application.
+     * Get all entryPoints in the application.
+     *
+     * @return the set of JS files
+     */
+    public Collection<EndPointData> getEndPoints() {
+        return endPoints.values();
+    }
+
+    /**
+     * Get the {@link ThemeDefinition} of the application.
      *
      * @return the theme definition
      */
@@ -218,7 +225,7 @@ public class FrontendDependencies implements Serializable {
     }
 
     /**
-     * get the {@link AbstractTheme} instance used in the application.
+     * Get the {@link AbstractTheme} instance used in the application.
      *
      * @return the theme instance
      */
@@ -235,11 +242,8 @@ public class FrontendDependencies implements Serializable {
      *
      * @throws ClassNotFoundException
      * @throws IOException
-     * @throws InstantiationException
-     * @throws IllegalAccessException
      */
-    private void computeEndpoints() throws ClassNotFoundException, IOException,
-            InstantiationException, IllegalAccessException {
+    private void computeEndpoints() throws ClassNotFoundException, IOException {
         // Because of different classLoaders we need compare against class
         // references loaded by the specific class finder loader
         Class<? extends Annotation> routeClass = finder
@@ -249,7 +253,6 @@ public class FrontendDependencies implements Serializable {
             EndPointData data = new EndPointData(route);
             endPoints.put(className, visitClass(className, data));
         }
-        computeApplicationTheme(endPoints);
     }
 
     // Visit all end-points and compute the theme for the application.
@@ -261,6 +264,19 @@ public class FrontendDependencies implements Serializable {
             HashMap<String, EndPointData> endPoints)
             throws ClassNotFoundException, InstantiationException,
             IllegalAccessException, IOException {
+
+        // Re-visit theme related classes, because they might be skipped
+        // when they where already added to the visited list during other
+        // entry-point visits
+        for (EndPointData endPoint : endPoints.values()) {
+            if (endPoint.getLayout() != null) {
+                visitClass(endPoint.getLayout(), endPoint);
+            }
+
+            if (!endPoint.getTheme().isNotheme() && endPoint.getTheme().getName() != null) {
+                visitClass(endPoint.getTheme().getName(), endPoint);
+            }
+        }
 
         Set<ThemeData> themes = endPoints.values().stream()
                 // consider only endPoints with theme information
@@ -427,40 +443,32 @@ public class FrontendDependencies implements Serializable {
     private EndPointData visitClass(String className,
             FrontendClassVisitor.EndPointData endPoint) throws IOException {
 
-        if (!isVisitable(className)
-                || endPoint.getClasses().contains(className)) {
+        if (!isVisitable(className) || endPoint.getClasses().contains(className)) {
             return endPoint;
         }
-
         endPoint.getClasses().add(className);
 
         URL url = getUrl(className);
         if (url == null) {
-            irrelevantClasses.add(className);
             return endPoint;
         }
-
-        int previousDataHash = endPoint.dataHash();
 
         FrontendClassVisitor visitor = new FrontendClassVisitor(className,
                 endPoint);
         ClassReader cr = new ClassReader(url.openStream());
         cr.accept(visitor, ClassReader.EXPAND_FRAMES);
 
+        // all classes visited by the scanner, used for performance (#5933)
+        visited.add(className);
+
         for (String clazz : visitor.getChildren()) {
-            visitClass(clazz, endPoint);
-        }
-
-        boolean isRootLevel = className.equals(endPoint.getName())
-                && endPoint.getRoute().isEmpty();
-        boolean hasTheme = !endPoint.getTheme().isNotheme()
-                && endPoint.getTheme().getName() != null;
-        if (isRootLevel && hasTheme) {
-            visitClass(endPoint.getTheme().getName(), endPoint);
-        }
-
-        if (previousDataHash == endPoint.dataHash()) {
-            irrelevantClasses.add(className);
+            // Since we only have an entry point for the app, it is all right to
+            // skip the visit to the the same class in other end-points, because
+            // we output all dependencies at once. When we implement
+            // chunks, this will need to be considered.
+            if (!visited.contains(clazz)) {
+                visitClass(clazz, endPoint);
+            }
         }
 
         return endPoint;
@@ -477,11 +485,10 @@ public class FrontendDependencies implements Serializable {
     private boolean isVisitable(String className) {
         // We should visit only those classes that might have NpmPackage,
         // JsImport, JavaScript and HtmlImport annotations, basically
-        // HasElement, and AbstractTheme classes, but that excludes some
-        // syntaxes like using factories. This is the reason of having just a
-        // blacklist of some common name-spaces that would not have components.
+        // HasElement, and AbstractTheme classes, but that prevents the usage of
+        // factories. This is the reason of having just a blacklist of some
+        // common name-spaces that would not have components.
         return className != null && // @formatter:off
-                !irrelevantClasses.contains(className) &&
                 !className.matches(
                     "(^$|"
                     + ".*(slf4j).*|"

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendDependenciesTest.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -17,7 +18,7 @@ import org.mockito.Mockito;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.frontend.ClassFinder.DefaultClassFinder;
-import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.BridgeClass;
+import com.vaadin.flow.server.frontend.FrontendClassVisitor.EndPointData;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.Component0;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.Component1;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.Component2;
@@ -29,7 +30,6 @@ import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.RootVi
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.RootViewWithoutTheme;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.RootViewWithoutThemeAnnotation;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.RoutedClass;
-import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.RoutedClassWithAnnotations;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.RoutedClassWithoutAnnotations;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.SecondView;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.Theme1;
@@ -305,28 +305,42 @@ public class FrontendDependenciesTest {
     @Test
     public void should_notVisitNonAnnotatredClasses() throws Exception {
         FrontendDependencies deps = create(UnAnnotatedClass.class);
-        assertEquals(0, deps.irrelevantClasses.size());
-        assertEquals(0, deps.endPoints.size());
+        Set<String> irrelevantClasses = getFieldValue(deps, "irrelevantClasses");
+        HashMap<String, EndPointData> endPoints = getFieldValue(deps, "endPoints");
+        assertEquals(0, irrelevantClasses.size());
+        assertEquals(0, endPoints.size());
     }
 
     @Test
     public void should_cacheIrrelevantClasses() throws Exception {
         FrontendDependencies deps = create(RoutedClassWithoutAnnotations.class);
-        assertEquals(1, deps.endPoints.size());
-        assertEquals(2, deps.irrelevantClasses.size());
-        assertTrue(deps.irrelevantClasses.contains(Route.class.getName()));
-        assertTrue(deps.irrelevantClasses.contains(RoutedClassWithoutAnnotations.class.getName()));
+        Set<String> irrelevantClasses = getFieldValue(deps, "irrelevantClasses");
+        HashMap<String, EndPointData> endPoints = getFieldValue(deps, "endPoints");
+        assertEquals(1, endPoints.size());
+        assertEquals(2, irrelevantClasses.size());
+        assertTrue(irrelevantClasses.contains(Route.class.getName()));
+        assertTrue(irrelevantClasses.contains(RoutedClassWithoutAnnotations.class.getName()));
     }
 
     @Test
     public void should_cacheSuperIrrelevantClasses() throws Exception {
         FrontendDependencies deps = create(RoutedClass.class);
-        assertEquals(1, deps.endPoints.size());
-        assertEquals(6, deps.irrelevantClasses.size());
-        assertTrue(deps.irrelevantClasses.contains(Route.class.getName()));
-        assertTrue(deps.irrelevantClasses.contains(NoTheme.class.getName()));
-        assertTrue(deps.irrelevantClasses.contains(RoutedClassWithoutAnnotations.class.getName()));
-        assertTrue(deps.irrelevantClasses.contains(LoadMode.class.getName()));
-        assertTrue(deps.irrelevantClasses.contains(JsModule.class.getName()));
+        Set<String> irrelevantClasses = getFieldValue(deps, "irrelevantClasses");
+        HashMap<String, EndPointData> endPoints = getFieldValue(deps, "endPoints");
+        assertEquals(1, endPoints.size());
+        assertEquals(6, irrelevantClasses.size());
+        assertTrue(irrelevantClasses.contains(Route.class.getName()));
+        assertTrue(irrelevantClasses.contains(NoTheme.class.getName()));
+        assertTrue(irrelevantClasses.contains(RoutedClassWithoutAnnotations.class.getName()));
+        assertTrue(irrelevantClasses.contains(LoadMode.class.getName()));
+        assertTrue(irrelevantClasses.contains(JsModule.class.getName()));
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T getFieldValue(Object obj, String name) throws Exception {
+        // awful, slow, and non-type-safe, but here to keep private FrotendDependencies fields
+        Field field = obj.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        return (T) field.get(obj);
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendDependenciesTest.java
@@ -14,7 +14,10 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.frontend.ClassFinder.DefaultClassFinder;
+import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.BridgeClass;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.Component0;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.Component1;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.Component2;
@@ -25,13 +28,18 @@ import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.RootVi
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.RootViewWithTheme;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.RootViewWithoutTheme;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.RootViewWithoutThemeAnnotation;
+import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.RoutedClass;
+import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.RoutedClassWithAnnotations;
+import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.RoutedClassWithoutAnnotations;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.SecondView;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.Theme1;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.Theme2;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.Theme4;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.ThemeExporter;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.ThirdView;
-import com.vaadin.flow.theme.AbstractTheme;
+import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.UnAnnotatedClass;
+import com.vaadin.flow.shared.ui.LoadMode;
+import com.vaadin.flow.theme.NoTheme;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -40,7 +48,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class FrontendDependenciesTest {
 
@@ -293,5 +300,33 @@ public class FrontendDependenciesTest {
 
         new FrontendDependencies(finder);
         verify(finder, times(0)).loadClass(FrontendDependencies.LUMO);
+    }
+
+    @Test
+    public void should_notVisitNonAnnotatredClasses() throws Exception {
+        FrontendDependencies deps = create(UnAnnotatedClass.class);
+        assertEquals(0, deps.irrelevantClasses.size());
+        assertEquals(0, deps.endPoints.size());
+    }
+
+    @Test
+    public void should_cacheIrrelevantClasses() throws Exception {
+        FrontendDependencies deps = create(RoutedClassWithoutAnnotations.class);
+        assertEquals(1, deps.endPoints.size());
+        assertEquals(2, deps.irrelevantClasses.size());
+        assertTrue(deps.irrelevantClasses.contains(Route.class.getName()));
+        assertTrue(deps.irrelevantClasses.contains(RoutedClassWithoutAnnotations.class.getName()));
+    }
+
+    @Test
+    public void should_cacheSuperIrrelevantClasses() throws Exception {
+        FrontendDependencies deps = create(RoutedClass.class);
+        assertEquals(1, deps.endPoints.size());
+        assertEquals(6, deps.irrelevantClasses.size());
+        assertTrue(deps.irrelevantClasses.contains(Route.class.getName()));
+        assertTrue(deps.irrelevantClasses.contains(NoTheme.class.getName()));
+        assertTrue(deps.irrelevantClasses.contains(RoutedClassWithoutAnnotations.class.getName()));
+        assertTrue(deps.irrelevantClasses.contains(LoadMode.class.getName()));
+        assertTrue(deps.irrelevantClasses.contains(JsModule.class.getName()));
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendDependenciesTest.java
@@ -1,15 +1,12 @@
 package com.vaadin.flow.server.frontend;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
-import org.apache.commons.lang3.reflect.FieldUtils;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -18,7 +15,7 @@ import org.mockito.Mockito;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.frontend.ClassFinder.DefaultClassFinder;
-import com.vaadin.flow.server.frontend.FrontendClassVisitor.EndPointData;
+import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.BridgeClass;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.Component0;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.Component1;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.Component2;
@@ -30,6 +27,7 @@ import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.RootVi
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.RootViewWithoutTheme;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.RootViewWithoutThemeAnnotation;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.RoutedClass;
+import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.RoutedClassWithAnnotations;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.RoutedClassWithoutAnnotations;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.SecondView;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.Theme1;
@@ -53,19 +51,6 @@ public class FrontendDependenciesTest {
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
-
-    @Before
-    public void setup() throws NoSuchFieldException, IllegalAccessException {
-
-        // TODO: This is not working yet, need to be fixed and adjust the test
-        // //NOSONAR
-        Field field = FieldUtils.getDeclaredField(FrontendDependencies.class,
-                "LUMO", true);
-        FieldUtils.removeFinalModifier(field, true);
-        FieldUtils.writeStaticField(field,
-                "com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.ThemeDefault",
-                true);
-    }
 
     private FrontendDependencies create(Class<?>... classes) throws Exception {
         FrontendDependencies frontendDependencies = new FrontendDependencies(
@@ -305,42 +290,40 @@ public class FrontendDependenciesTest {
     @Test
     public void should_notVisitNonAnnotatredClasses() throws Exception {
         FrontendDependencies deps = create(UnAnnotatedClass.class);
-        Set<String> irrelevantClasses = getFieldValue(deps, "irrelevantClasses");
-        HashMap<String, EndPointData> endPoints = getFieldValue(deps, "endPoints");
-        assertEquals(0, irrelevantClasses.size());
-        assertEquals(0, endPoints.size());
+        assertEquals(0, deps.getEndPoints().size());
+        assertEquals(0, deps.getClasses().size());
     }
 
     @Test
-    public void should_cacheIrrelevantClasses() throws Exception {
+    public void should_cacheVisitedClasses() throws Exception {
         FrontendDependencies deps = create(RoutedClassWithoutAnnotations.class);
-        Set<String> irrelevantClasses = getFieldValue(deps, "irrelevantClasses");
-        HashMap<String, EndPointData> endPoints = getFieldValue(deps, "endPoints");
-        assertEquals(1, endPoints.size());
-        assertEquals(2, irrelevantClasses.size());
-        assertTrue(irrelevantClasses.contains(Route.class.getName()));
-        assertTrue(irrelevantClasses.contains(RoutedClassWithoutAnnotations.class.getName()));
+        assertEquals(1, deps.getEndPoints().size());
+        assertEquals(2, deps.getClasses().size());
+        assertTrue(deps.getClasses().contains(Route.class.getName()));
+        assertTrue(deps.getClasses().contains(RoutedClassWithoutAnnotations.class.getName()));
     }
 
     @Test
-    public void should_cacheSuperIrrelevantClasses() throws Exception {
-        FrontendDependencies deps = create(RoutedClass.class);
-        Set<String> irrelevantClasses = getFieldValue(deps, "irrelevantClasses");
-        HashMap<String, EndPointData> endPoints = getFieldValue(deps, "endPoints");
-        assertEquals(1, endPoints.size());
-        assertEquals(6, irrelevantClasses.size());
-        assertTrue(irrelevantClasses.contains(Route.class.getName()));
-        assertTrue(irrelevantClasses.contains(NoTheme.class.getName()));
-        assertTrue(irrelevantClasses.contains(RoutedClassWithoutAnnotations.class.getName()));
-        assertTrue(irrelevantClasses.contains(LoadMode.class.getName()));
-        assertTrue(irrelevantClasses.contains(JsModule.class.getName()));
-    }
+    public void should_cacheSuperVisitedClasses() throws Exception {
+        List<Class<?>> visited = Arrays.asList(Route.class, NoTheme.class, JsModule.class, LoadMode.class,
+                RoutedClassWithAnnotations.class, RoutedClassWithoutAnnotations.class, RoutedClass.class,
+                BridgeClass.class);
 
-    @SuppressWarnings("unchecked")
-    private <T> T getFieldValue(Object obj, String name) throws Exception {
-        // awful, slow, and non-type-safe, but here to keep private FrotendDependencies fields
-        Field field = obj.getClass().getDeclaredField(name);
-        field.setAccessible(true);
-        return (T) field.get(obj);
+        // Visit a route that extends an extra routed class
+        FrontendDependencies deps = create(RoutedClass.class);
+        assertEquals(1, deps.getEndPoints().size());
+        assertEquals(9, deps.getClasses().size());
+        for (Class<?> clz : visited) {
+            assertTrue("should cache " + clz.getName(), deps.getClasses().contains(clz.getName()));
+        }
+
+        // Visit the same route but also the super routed class, the number of visited classes should
+        // be the same, but number of entry points increases
+        deps = create(RoutedClassWithoutAnnotations.class, RoutedClass.class);
+        assertEquals(2, deps.getEndPoints().size());
+        assertEquals(9, deps.getClasses().size());
+        for (Class<?> clz : visited) {
+            assertTrue("should cache " + clz.getName(), deps.getClasses().contains(clz.getName()));
+        }
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendDependenciesTest.java
@@ -21,6 +21,7 @@ import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.Compon
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.Component2;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.FirstView;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.NoThemeExporter;
+import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.RootView2WithLayoutTheme;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.RootViewWithLayoutTheme;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.RootViewWithMultipleTheme;
 import com.vaadin.flow.server.frontend.FrontendDependenciesTestComponents.RootViewWithTheme;
@@ -169,6 +170,7 @@ public class FrontendDependenciesTest {
         assertTrue(deps.getPackages().containsKey("@foo/first-view"));
         assertEquals("0.0.1", deps.getPackages().get("@foo/first-view"));
     }
+
 
     @Test
     public void should_takeThemeWhenMultipleTheme() throws Exception {
@@ -325,5 +327,15 @@ public class FrontendDependenciesTest {
         for (Class<?> clz : visited) {
             assertTrue("should cache " + clz.getName(), deps.getClasses().contains(clz.getName()));
         }
+    }
+
+    @Test
+    public void should_takeThemeFromLayout_ifLayoutAlreadyVisited() throws Exception {
+        // Make sure that all entry-points sharing layouts are correctly theming-configured
+        FrontendDependencies deps = create(RootViewWithLayoutTheme.class, RootView2WithLayoutTheme.class);
+        assertEquals(Theme1.class, deps.getThemeDefinition().getTheme());
+        deps.getEndPoints().forEach(endPoint -> {
+            assertEquals(Theme1.class.getName(), endPoint.getTheme().getName());
+        });
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendDependenciesTestComponents.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendDependenciesTestComponents.java
@@ -16,8 +16,6 @@
  */
 package com.vaadin.flow.server.frontend;
 
-import java.io.Serializable;
-
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.WebComponentExporter;

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendDependenciesTestComponents.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendDependenciesTestComponents.java
@@ -142,6 +142,10 @@ public class FrontendDependenciesTestComponents {
     public static class RootViewWithLayoutTheme extends FirstView {
     }
 
+    @Route(value = "2", layout = RouterLayout1.class)
+    public static class RootView2WithLayoutTheme {
+    }
+
     @Route(value = "", layout = RouterLayout2.class)
     @Theme(value = Theme2.class, variant = "foo")
     @JsModule("./view-2.js")

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendDependenciesTestComponents.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendDependenciesTestComponents.java
@@ -16,6 +16,8 @@
  */
 package com.vaadin.flow.server.frontend;
 
+import java.io.Serializable;
+
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.WebComponentExporter;
@@ -241,4 +243,26 @@ public class FrontendDependenciesTestComponents {
 
         }
     }
+
+
+    public static class UnAnnotatedClass {
+    }
+
+    @Route
+    public static class RoutedClassWithoutAnnotations {
+    }
+
+    @Route("route-1")
+    @NoTheme
+    @JsModule("./foo")
+    public static class RoutedClassWithAnnotations extends RoutedClassWithoutAnnotations {
+    }
+
+    public static class BridgeClass extends RoutedClassWithAnnotations {
+    }
+
+    @Route("route-2")
+    public static class RoutedClass extends BridgeClass {
+    }
+
 }


### PR DESCRIPTION
This reduces scanning time from `7578ms` to `1350ms` in the `flow-tests/test-root-context`
module when in npm mode.

Fixes #5803

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5932)
<!-- Reviewable:end -->
