### PR TITLE
Support for incorrect webjar paths #4601 

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
@@ -46,7 +46,7 @@ import static com.vaadin.flow.shared.ApplicationConstants.VAADIN_STATIC_FILES_PA
  * @since 1.0
  */
 public class StaticFileServer implements StaticFileHandler {
-    private static final String PROPERTY_FIX_INCORRECT_WEBJAR_PATHS = Constants.VAADIN_PREFIX
+    static final String PROPERTY_FIX_INCORRECT_WEBJAR_PATHS = Constants.VAADIN_PREFIX
             + "fixIncorrectWebjarPaths";
     private static final Pattern INCORRECT_WEBJAR_PATH_REGEX = Pattern
             .compile("^/frontend[-\\w/]*/webjars/");

--- a/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
@@ -697,4 +697,23 @@ public class StaticFileServerTest implements Serializable {
         Assert.assertTrue(fileServer.serveStaticResource(request, response));
         Assert.assertArrayEquals(fileData, out.getOutput());
     }
+
+    @Test
+    public void serveStaticResourceFromWebjarWithIncorrectPathAndFixingDisabled()
+            throws IOException {
+        Mockito.when(configuration.getBooleanProperty(
+                StaticFileServer.PROPERTY_FIX_INCORRECT_WEBJAR_PATHS, false))
+                .thenReturn(false);
+
+        Mockito.when(servletService
+                .getStaticResource("/frontend/src/webjars/foo/bar.js"))
+                .thenReturn(null);
+
+        setupRequestURI("", "", "/frontend/src/webjars/foo/bar.js");
+
+        Assert.assertFalse(fileServer.isStaticResourceRequest(request));
+        Assert.assertTrue(fileServer.serveStaticResource(request, response));
+        Assert.assertEquals(HttpServletResponse.SC_NOT_FOUND,
+                responseCode.get());
+    }
 }


### PR DESCRIPTION
As I have described in #4601, stylesheets (either CSS or custom style HTML files) that refer to webjar content (such as webfonts) using relative paths will stop working in production mode. This is because the production build changes the relative paths when the files are bundled into one.

Instead of fixing the polymer build chain, I thought it was easier to add support to the `StaticFileServer` to detect and fix the invalid webjar paths instead. I also made this fix configurable so that it has to be explicitly enabled with the `vaadin.fixIncorrectWebjarPaths` property. By default, it is disabled, meaning static files will be served as before.

This pull request does not yet contain any tests since I want some feedback on this design decision before moving on.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5951)
<!-- Reviewable:end -->
