### PR TITLE
fix JS linter issues in the autogenerated webpack config

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateWebpack.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateWebpack.java
@@ -115,22 +115,22 @@ public class TaskUpdateWebpack implements Command {
         List<String> lines = FileUtils.readLines(generatedFile, "UTF-8");
 
         String outputLine =
-                "mavenOutputFolderForFlowBundledFiles = require('path').resolve(__dirname, '"
+                "const mavenOutputFolderForFlowBundledFiles = require('path').resolve(__dirname, '"
                         + getEscapedRelativeWebpackPath(webpackOutputPath)
                         + "');";
         String mainLine =
-                "fileNameOfTheFlowGeneratedMainEntryPoint = require('path').resolve(__dirname, '"
+                "const fileNameOfTheFlowGeneratedMainEntryPoint = require('path').resolve(__dirname, '"
                         + getEscapedRelativeWebpackPath(flowImportsFilePath)
                         + "');";
 
         for (int i = 0; i < lines.size(); i++) {
             String line = lines.get(i).trim();
             if (lines.get(i)
-                    .startsWith("fileNameOfTheFlowGeneratedMainEntryPoint")
+                    .startsWith("const fileNameOfTheFlowGeneratedMainEntryPoint")
                     && !line.equals(mainLine)) {
                 lines.set(i, mainLine);
             }
-            if (lines.get(i).startsWith("mavenOutputFolderForFlowBundledFiles")
+            if (lines.get(i).startsWith("const mavenOutputFolderForFlowBundledFiles")
                     && !line.equals(outputLine)) {
                 lines.set(i, outputLine);
             }

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -6,20 +6,20 @@
  */
 const fs = require('fs');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
-const { BabelMultiTargetPlugin } = require('webpack-babel-multi-target-plugin');
+const {BabelMultiTargetPlugin} = require('webpack-babel-multi-target-plugin');
 
 const path = require('path');
 const baseDir = path.resolve(__dirname);
 // the folder of app resources (main.js and flow templates)
 const frontendFolder = `${baseDir}/frontend`;
 
-fileNameOfTheFlowGeneratedMainEntryPoint;
-mavenOutputFolderForFlowBundledFiles;
+const fileNameOfTheFlowGeneratedMainEntryPoint = '[to-be-generated-by-flow]';
+const mavenOutputFolderForFlowBundledFiles = '[to-be-generated-by-flow]';
 
 // public path for resources, must match Flow VAADIN_BUILD
 const build = 'build';
 // public path for resources, must match the request used in flow to get the /build/stats.json file
-const config = 'config'
+const config = 'config';
 // folder for outputting index.js bundle, etc.
 const buildFolder = `${mavenOutputFolderForFlowBundledFiles}/${build}`;
 // folder for outputting stats.js
@@ -36,7 +36,7 @@ exports = {
   frontendFolder: `${frontendFolder}`,
   buildFolder: `${buildFolder}`,
   confFolder: `${confFolder}`
-}
+};
 
 module.exports = {
   mode: 'production',
@@ -100,9 +100,10 @@ module.exports = {
     }),
 
     // Generates the stats file for flow `@Id` binding.
-    function (compiler) {
-      compiler.hooks.afterEmit.tapAsync("FlowIdPlugin", (compilation, done) => {
-        console.log("Emitted " + statsFile)
+    function(compiler) {
+      compiler.hooks.afterEmit.tapAsync('FlowIdPlugin', (compilation, done) => {
+        // eslint-disable-next-line no-console
+        console.log('Emitted ' + statsFile);
         fs.writeFile(statsFile, JSON.stringify(compilation.getStats().toJson(), null, 1), done);
       });
     },

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateWebpackTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateWebpackTest.java
@@ -145,11 +145,11 @@ public class TaskUpdateWebpackTest extends NodeUpdateTestUtil {
     private void verifyUpdate(List<String> webpackContents, String entryPoint, String outputFolder) {
         Assert.assertTrue(
                 "webpack config should update fileNameOfTheFlowGeneratedMainEntryPoint",
-                webpackContents.contains("fileNameOfTheFlowGeneratedMainEntryPoint = require('path').resolve(__dirname, '" + entryPoint + "');"));
+                webpackContents.contains("const fileNameOfTheFlowGeneratedMainEntryPoint = require('path').resolve(__dirname, '" + entryPoint + "');"));
 
         Assert.assertTrue(
                 "webpack config should update fileNameOfTheFlowGeneratedMainEntryPoint",
-                webpackContents.contains("mavenOutputFolderForFlowBundledFiles = require('path').resolve(__dirname, '" + outputFolder + "');"));
+                webpackContents.contains("const mavenOutputFolderForFlowBundledFiles = require('path').resolve(__dirname, '" + outputFolder + "');"));
 
     }
 


### PR DESCRIPTION
Apply the Vaadin JS linter config from https://github.com/vaadin/vaadin-element-skeleton/blob/wip/next/.eslintrc.json
 - add missing semi-colons
 - declare local variables before using
 - use single quotes for strings

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5956)
<!-- Reviewable:end -->
