### PR TITLE
Lock polymer version to 3.2.0

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -194,7 +194,7 @@ public abstract class NodeUpdater implements Command {
         added = addDependency(packageJson, null, DEP_LICENSE_KEY, DEP_LICENSE_DEFAULT) || added;
 
 
-        added = addDependency(packageJson, DEPENDENCIES, "@polymer/polymer", "^3.1.0") || added;
+        added = addDependency(packageJson, DEPENDENCIES, "@polymer/polymer", "3.2.0") || added;
         added = addDependency(packageJson, DEPENDENCIES, "@webcomponents/webcomponentsjs", "^2.2.10") || added;
         // dependency for the custom package.json placed in the generated folder.
         String customPkg = "./" + npmFolder.getAbsoluteFile().toPath()


### PR DESCRIPTION
Polymer 3.3.0 broke views in starter
applications.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5962)
<!-- Reviewable:end -->
