### PR TITLE
Ignore KeyUpEvents without a key

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/KeyUpEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/KeyUpEvent.java
@@ -23,7 +23,7 @@ import com.vaadin.flow.component.internal.KeyboardEvent;
  * @author Vaadin Ltd
  * @since 1.0
  */
-@DomEvent("keyup")
+@DomEvent(value = "keyup", filter = "typeof(event.key) === 'string'''k && event.key.length > 0")
 public class KeyUpEvent extends KeyboardEvent {
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/KeyUpEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/KeyUpEvent.java
@@ -23,7 +23,7 @@ import com.vaadin.flow.component.internal.KeyboardEvent;
  * @author Vaadin Ltd
  * @since 1.0
  */
-@DomEvent(value = "keyup", filter = "typeof(event.key) === 'string'''k && event.key.length > 0")
+@DomEvent(value = "keyup", filter = "typeof(event.key) === 'string' && event.key.length > 0")
 public class KeyUpEvent extends KeyboardEvent {
 
     /**

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/KeyboardEventView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/KeyboardEventView.java
@@ -1,17 +1,23 @@
 package com.vaadin.flow.uitest.ui;
 
 import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.DetachEvent;
 import com.vaadin.flow.component.KeyDownEvent;
+import com.vaadin.flow.component.KeyUpEvent;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Input;
+import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.DefaultErrorHandler;
 import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 
 @Route(value = "com.vaadin.flow.uitest.ui.KeyboardEventView",
         layout = ViewTestLayout.class)
 public class KeyboardEventView extends Div {
     private Input input = new Input();
+    private NativeButton sendInvalidKeyUp = new NativeButton();
 
     public KeyboardEventView() {
         input.setId("input");
@@ -30,7 +36,27 @@ public class KeyboardEventView extends Div {
                     "");
             paragraph.setText(keyText + ":" + codeText);
         });
-
         add(input, paragraph);
+
+        Paragraph keyUpParagraph = new Paragraph();
+        keyUpParagraph.setId("keyUpParagraph");
+        ComponentUtil.addListener(input, KeyUpEvent.class,
+                event -> keyUpParagraph
+                        .setText(String.join(",", event.getKey().getKeys())));
+
+        sendInvalidKeyUp.setId("sendInvalidKeyUp");
+        sendInvalidKeyUp.addClickListener(event -> {
+            getUI().ifPresent(ui -> ui.getPage().executeJs(
+                    "$0.dispatchEvent(new KeyboardEvent('keyup', {}))",
+                    input.getElement()));
+        });
+        add(sendInvalidKeyUp, keyUpParagraph);
+        UI.getCurrent().getSession().setErrorHandler(event -> keyUpParagraph
+                .setText(event.getThrowable().getMessage()));
+    }
+
+    @Override
+    protected void onDetach(DetachEvent detachEvent) {
+        UI.getCurrent().getSession().setErrorHandler(new DefaultErrorHandler());
     }
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/KeyboardEventIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/KeyboardEventIT.java
@@ -51,4 +51,20 @@ public class KeyboardEventIT extends ChromeBrowserTest {
                 paragraph.getText()
         );
     }
+
+    @Test // #5989
+    public void verify_that_invalid_keyup_event_is_ignored() {
+        open();
+
+        WebElement input = findElement(By.id("input"));
+        WebElement sendInvalidKeyUp = findElement(By.id("sendInvalidKeyUp"));
+        WebElement paragraph = findElement(By.id("keyUpParagraph"));
+
+        input.sendKeys("q");
+        Assert.assertEquals("q", paragraph.getText());
+
+        sendInvalidKeyUp.click();
+
+        Assert.assertEquals("q", paragraph.getText());
+    }
 }


### PR DESCRIPTION
When Chrome's password manager autofills a username and a password, it also generates a `keyup` event without any additional information. Flow always expected `event.key` to be present and throws an NPE if not. This PR adds a filter to the `KeyUpEvent` class so that DOM events without `event.key` are ignored.

Closes #5092

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5989)
<!-- Reviewable:end -->
