### PR TITLE
5582 lost context path

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/Location.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/Location.java
@@ -181,7 +181,7 @@ public class Location implements Serializable {
 
         String params = queryParameters.getQueryString();
         if (params.isEmpty()) {
-            return !basePath.isEmpty() ? basePath : "/";
+            return !basePath.isEmpty() ? basePath : ".";
         }
         return basePath + QUERY_SEPARATOR + params;
     }

--- a/flow-server/src/test/java/com/vaadin/flow/router/LocationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/LocationTest.java
@@ -266,6 +266,6 @@ public class LocationTest {
 
     @Test
     public void pathShouldNotBeEmpty() {
-        assertEquals("/", new Location("").getPathWithQueryParameters());
+        assertEquals(".", new Location("").getPathWithQueryParameters());
     }
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HistoryIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HistoryIT.java
@@ -82,6 +82,13 @@ public class HistoryIT extends ChromeBrowserTest {
         Assert.assertEquals(baseUrl.resolve("qwerty"), getCurrentUrl());
         Assert.assertEquals(Arrays.asList("New location: qwerty"),
                 getStatusMessages());
+
+        // Navigate to empty string should go to the context path root
+        stateField.clear();
+        locationField.clear();
+        pushButton.click();
+
+        Assert.assertEquals(baseUrl.resolve("."), getCurrentUrl());
     }
 
     private URI getCurrentUrl() throws URISyntaxException {


### PR DESCRIPTION
When navigating to the default view (""), a single period (`.`) should be pushed to the browser history instead of a slash (`/`).

Closes #5582

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/5996)
<!-- Reviewable:end -->
