### PR TITLE
Better parsing of node/npm version output

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -489,12 +489,29 @@ public class FrontendUtils {
                         "Using command " + String.join(" ", versionCommand));
             }
             String output = streamToString(process.getInputStream());
-            return output.replaceFirst("^v", "").replaceAll("\n", "")
-                    .split("\\.", 3);
+            return parseVersion(output);
         } catch (InterruptedException | IOException e) {
             throw new UnknownVersionException(tool,
                     "Using command " + String.join(" ", versionCommand), e);
         }
+    }
+
+    /**
+     * Parse the version number of node/npm from the given output.
+     *
+     * @param output
+     *            The output, typically produced by <code>tool --version</code>
+     * @return the parsed version as an array with 3 elements
+     * @throws IOException
+     *             if parsing fails
+     */
+    static String[] parseVersion(String output) throws IOException {
+        Optional<String> lastOuput = Stream.of(output.split("\n"))
+                .filter(line -> !line.matches("^[ ]*$"))
+                .reduce((first, second) -> second);
+        return lastOuput
+                .map(line -> line.replaceFirst("^v", "").split("\\.", 3))
+                .orElseThrow(() -> new IOException("No output"));
     }
 
     private static Logger getLogger() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.util.stream.Collectors;
@@ -195,4 +196,22 @@ public class FrontendUtilsTest {
             System.clearProperty("vaadin.ignoreVersionChecks");
         }
     }
+
+    @Test
+    public void parseValidToolVersions() throws IOException {
+        Assert.assertArrayEquals(new String[] { "10", "11", "12" },
+                FrontendUtils.parseVersion("v10.11.12"));
+        Assert.assertArrayEquals(new String[] { "8", "0", "0" },
+                FrontendUtils.parseVersion("v8.0.0"));
+        Assert.assertArrayEquals(new String[] { "8", "0", "0" },
+                FrontendUtils.parseVersion("8.0.0"));
+        Assert.assertArrayEquals(new String[] { "6", "9", "0" }, FrontendUtils
+                .parseVersion("Aktive Codepage: 1252\n" + "6.9.0\n" + ""));
+    }
+
+    @Test(expected = IOException.class)
+    public void parseEmptyToolVersions() throws IOException {
+        FrontendUtils.parseVersion(" \n");
+    }
+
 }


### PR DESCRIPTION
Related to #5988

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6014)
<!-- Reviewable:end -->
