### PR TITLE
Fix multiple NpmPackage annotations for jetty:run

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -66,7 +66,7 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_GENERATED;
  * Servlet initializer starting node updaters as well as the webpack-dev-mode
  * server.
  */
-@HandlesTypes({ Route.class, NpmPackage.class, WebComponentExporter.class })
+@HandlesTypes({ Route.class, NpmPackage.class, NpmPackage.Container.class, WebComponentExporter.class })
 @WebListener
 public class DevModeInitializer
         implements ServletContainerInitializer, Serializable, ServletContextListener {
@@ -137,8 +137,6 @@ public class DevModeInitializer
 
         initDevModeHandler(classes, context, config);
     }
-
-
 
     /**
      * Initialize the devmode server if not in production mode or compatibility

--- a/flow-tests/test-npm-only-features/pom.xml
+++ b/flow-tests/test-npm-only-features/pom.xml
@@ -31,5 +31,6 @@
     <modules>
         <module>test-default-theme</module>
         <module>test-npm-general</module>
+        <module>test-npm-no-buildmojo</module>
     </modules>
 </project>

--- a/flow-tests/test-npm-only-features/test-npm-no-buildmojo/pom.xml
+++ b/flow-tests/test-npm-only-features/test-npm-no-buildmojo/pom.xml
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2000-2019 Vaadin Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>flow-test-npm-only-features</artifactId>
+        <groupId>com.vaadin</groupId>
+        <version>2.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>flow-test-npm-no-buildmojo</artifactId>
+    <version>2.0-SNAPSHOT</version>
+
+    <name>Flow test npm without BuildFrontendMojo</name>
+    <packaging>war</packaging>
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-html-components-testbench</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-test-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!--
+                Clean node_modules and package-lock to make sure that
+                @NpmPackage test works as it should.
+             -->
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <filesets>
+                        <fileset>
+                            <directory>${project.basedir}/node_modules</directory>
+                            <includes>
+                                <include>@polymer/**/*</include>
+                                <include>@vaadin/**/*</include>
+                            </includes>
+                            <followSymlinks>false</followSymlinks>
+                        </fileset>
+                        <fileset>
+                            <directory>${project.basedir}</directory>
+                            <includes>
+                                <include>package-lock.json</include>
+                                <include>/target/**</include>
+                            </includes>
+                        </fileset>
+                    </filesets>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>auto-clean</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- This module is mapped to default web context -->
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>${jetty.version}</version>
+                <executions>
+                    <!-- start and stop jetty (running our app) when running
+                        integration tests -->
+                    <execution>
+                        <id>start-jetty</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>stop-jetty</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>flow-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-frontend</goal>
+                            <!-- removing build simulates pure jetty:run -->
+<!--                            <goal>build-frontend</goal>-->
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>local-run</id>
+            <activation>
+                <property>
+                    <name>!test.use.hub</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.lazerycode.selenium</groupId>
+                        <artifactId>driver-binary-downloader-maven-plugin
+                        </artifactId>
+                        <version>
+                            ${driver.binary.downloader.maven.plugin.version}
+                        </version>
+                        <configuration>
+                            <onlyGetDriversForHostOperatingSystem>true
+                            </onlyGetDriversForHostOperatingSystem>
+                            <rootStandaloneServerDirectory>
+                                ${project.rootdir}/driver
+                            </rootStandaloneServerDirectory>
+                            <downloadedZipFileDirectory>
+                                ${project.rootdir}/driver_zips
+                            </downloadedZipFileDirectory>
+                            <customRepositoryMap>
+                                ${project.rootdir}/drivers.xml
+                            </customRepositoryMap>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>selenium</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>productionMode</id>
+            <activation>
+                <property>
+                    <!-- In BrowserStack tests are run on IE11, and transpilation
+                        is needed -->
+                    <name>test.use.browserstack</name>
+                    <value>true</value>
+                </property>
+            </activation>
+
+            <dependencies>
+                <dependency>
+                    <groupId>com.vaadin</groupId>
+                    <artifactId>flow-server-production-mode</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+</project>

--- a/flow-tests/test-npm-only-features/test-npm-no-buildmojo/pom.xml
+++ b/flow-tests/test-npm-only-features/test-npm-no-buildmojo/pom.xml
@@ -111,6 +111,15 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <systemProperties>
+                        <systemProperty>
+                            <!-- make sure we do not leave webpack-dev-server running after IT -->
+                            <name>vaadin.reuseDevServer</name>
+                            <value>false</value>
+                        </systemProperty>
+                    </systemProperties>
+                </configuration>
             </plugin>
 
             <plugin>

--- a/flow-tests/test-npm-only-features/test-npm-no-buildmojo/src/main/java/com/vaadin/flow/testnpmonlyfeatures/nobuildmojo/MultipleNpmPackageAnnotationsView.java
+++ b/flow-tests/test-npm-only-features/test-npm-no-buildmojo/src/main/java/com/vaadin/flow/testnpmonlyfeatures/nobuildmojo/MultipleNpmPackageAnnotationsView.java
@@ -1,0 +1,29 @@
+package com.vaadin.flow.testnpmonlyfeatures.nobuildmojo;
+
+import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.router.Route;
+
+
+@JsModule("@polymer/paper-input/paper-input.js")
+@JsModule("@polymer/paper-checkbox/paper-checkbox.js")
+@Route(value = "com.vaadin.flow.testnpmonlyfeatures.nobuildmojo" +
+        ".MultipleNpmPackageAnnotationsView", layout = NpmPackageLayout.class)
+public class MultipleNpmPackageAnnotationsView extends Div {
+
+
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        super.onAttach(attachEvent);
+
+        Element paperInput = new Element("paper-input");
+        paperInput.setText("Input");
+        Element paperCheckbox = new Element("paper-checkbox");
+        paperCheckbox.setText("Checkbox");
+
+        getElement().appendChild(paperInput);
+        getElement().appendChild(paperCheckbox);
+    }
+}

--- a/flow-tests/test-npm-only-features/test-npm-no-buildmojo/src/main/java/com/vaadin/flow/testnpmonlyfeatures/nobuildmojo/MultipleNpmPackageAnnotationsView.java
+++ b/flow-tests/test-npm-only-features/test-npm-no-buildmojo/src/main/java/com/vaadin/flow/testnpmonlyfeatures/nobuildmojo/MultipleNpmPackageAnnotationsView.java
@@ -13,7 +13,6 @@ import com.vaadin.flow.router.Route;
         ".MultipleNpmPackageAnnotationsView", layout = NpmPackageLayout.class)
 public class MultipleNpmPackageAnnotationsView extends Div {
 
-
     @Override
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);

--- a/flow-tests/test-npm-only-features/test-npm-no-buildmojo/src/main/java/com/vaadin/flow/testnpmonlyfeatures/nobuildmojo/NpmPackageLayout.java
+++ b/flow-tests/test-npm-only-features/test-npm-no-buildmojo/src/main/java/com/vaadin/flow/testnpmonlyfeatures/nobuildmojo/NpmPackageLayout.java
@@ -1,0 +1,10 @@
+package com.vaadin.flow.testnpmonlyfeatures.nobuildmojo;
+
+import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.RouterLayout;
+
+@NpmPackage(value = "@polymer/paper-input", version = "3.0.2")
+@NpmPackage(value = "@polymer/paper-checkbox", version = "3.0.1")
+public class NpmPackageLayout extends Div implements RouterLayout {
+}

--- a/flow-tests/test-npm-only-features/test-npm-no-buildmojo/src/test/java/com/vaadin/flow/testnpmonlyfeatures/nobuildmojo/MultipleNpmPackageAnnotationsIT.java
+++ b/flow-tests/test-npm-only-features/test-npm-no-buildmojo/src/test/java/com/vaadin/flow/testnpmonlyfeatures/nobuildmojo/MultipleNpmPackageAnnotationsIT.java
@@ -1,0 +1,35 @@
+package com.vaadin.flow.testnpmonlyfeatures.nobuildmojo;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class MultipleNpmPackageAnnotationsIT extends ChromeBrowserTest {
+    @Before
+    public void init() {
+        open();
+    }
+
+    @Test
+    public void pageShouldContainTwoPaperComponents() {
+        WebElement paperInput = findElement(By.tagName("paper-input"));
+        WebElement paperCheckbox = findElement(By.tagName("paper-checkbox"));
+
+        Assert.assertNotNull(paperInput);
+        Assert.assertNotNull(paperCheckbox);
+
+        // check that the elements are upgraded by checking their shadow-roots
+        WebElement paperContainer = getInShadowRoot(paperInput, By.id(
+                "container"));
+
+        WebElement checkboxContainer = getInShadowRoot(paperCheckbox, By.id(
+                "checkboxContainer"));
+
+        Assert.assertNotNull(paperContainer);
+        Assert.assertNotNull(checkboxContainer);
+    }
+}

--- a/flow-tests/test-npm-only-features/test-npm-no-buildmojo/src/test/java/com/vaadin/flow/testnpmonlyfeatures/nobuildmojo/MultipleNpmPackageAnnotationsIT.java
+++ b/flow-tests/test-npm-only-features/test-npm-no-buildmojo/src/test/java/com/vaadin/flow/testnpmonlyfeatures/nobuildmojo/MultipleNpmPackageAnnotationsIT.java
@@ -3,10 +3,9 @@ package com.vaadin.flow.testnpmonlyfeatures.nobuildmojo;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.testutil.ChromeBrowserTest;
+import com.vaadin.testbench.TestBenchElement;
 
 public class MultipleNpmPackageAnnotationsIT extends ChromeBrowserTest {
     @Before
@@ -16,20 +15,15 @@ public class MultipleNpmPackageAnnotationsIT extends ChromeBrowserTest {
 
     @Test
     public void pageShouldContainTwoPaperComponents() {
-        WebElement paperInput = findElement(By.tagName("paper-input"));
-        WebElement paperCheckbox = findElement(By.tagName("paper-checkbox"));
+        TestBenchElement paperInput = $("paper-input").first();
+        TestBenchElement paperCheckbox = $("paper-checkbox").first();
 
+        // check that elements are on the page
         Assert.assertNotNull(paperInput);
         Assert.assertNotNull(paperCheckbox);
 
-        // check that the elements are upgraded by checking their shadow-roots
-        WebElement paperContainer = getInShadowRoot(paperInput, By.id(
-                "container"));
-
-        WebElement checkboxContainer = getInShadowRoot(paperCheckbox, By.id(
-                "checkboxContainer"));
-
-        Assert.assertNotNull(paperContainer);
-        Assert.assertNotNull(checkboxContainer);
+        // verify that the paper components are upgraded
+        Assert.assertNotNull(paperInput.$("paper-input-container"));
+        Assert.assertNotNull(paperCheckbox.$("checkboxContainer"));
     }
 }


### PR DESCRIPTION
`DevModeInitializer`'s `@HandlesTypes(.., NpmPackage.class, ..)` was not enough to catch cases where one class has multiple `@NpmPackage` annotations (and those are not on a `@Route` annotation.

However, those annotations were found by `FrontendBuildMojo`, using maven's class finder.

Fixes #5628

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6037)
<!-- Reviewable:end -->
