### PR TITLE
Avoid trying to focus a detached element

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/Focusable.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Focusable.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component;
 
+import com.vaadin.flow.dom.Element;
+
 /**
  * Represents a component that can gain and lose focus.
  *
@@ -104,13 +106,13 @@ public interface Focusable<T extends Component>
      */
     default void focus() {
         /*
-         * Make sure to call the focus function only after the element is
+         * Use setTimeout to call the focus function only after the element is
          * attached, and after the initial rendering cycle, so webcomponents can
          * be ready by the time when the function is called.
          */
-        getElement().getNode()
-                .runWhenAttached(ui -> ui.getPage().executeJs(
-                        "setTimeout(function(){$0.focus();},0)", getElement()));
+        Element element = getElement();
+        // Using $0 since "this" won't work inside the function
+        element.executeJs("setTimeout(function(){$0.focus()},0)", element);
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/component/FocusableTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/FocusableTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
+import com.vaadin.tests.util.MockUI;
+
+public class FocusableTest {
+    @Tag("div")
+    private static class FocusableTestComponent extends Component
+            implements Focusable {
+
+    }
+
+    private final UI ui = new MockUI();
+    private final FocusableTestComponent component = new FocusableTestComponent();
+
+    @Test
+    public void focusUnattached_nothingScheduled() {
+        component.focus();
+
+        assertPendingInvocationCount(
+                "Nothing should be scheduled when component is not attached",
+                0);
+    }
+
+    @Test
+    public void focusBeforeAttach_executionScheduled() {
+        component.focus();
+        ui.add(component);
+
+        assertPendingInvocationCount(
+                "An focus() inovocation should be pending for the attached component",
+                1);
+    }
+
+    @Test
+    public void focusAfterAttach_executionScheduled() {
+        ui.add(component);
+        component.focus();
+
+        assertPendingInvocationCount(
+                "An focus() inovocation should be pending for the attached component",
+                1);
+    }
+
+    @Test
+    public void detachAfterFocus_nothingScheduled() {
+        ui.add(component);
+        component.focus();
+        ui.remove(component);
+
+        assertPendingInvocationCount(
+                "Nothing should be scheduled when component is not attached",
+                0);
+    }
+
+    private void assertPendingInvocationCount(String message, int expected) {
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+        List<PendingJavaScriptInvocation> invocations = ui.getInternals()
+                .dumpPendingJavaScriptInvocations();
+        Assert.assertEquals(message, expected, invocations.size());
+    }
+}


### PR DESCRIPTION
All new tests except detachAfterFocus_nothingScheduled were passing also
before this fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6090)
<!-- Reviewable:end -->
