### PR TITLE
Clarify that "limit" is the number of items to fetch

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/Query.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/Query.java
@@ -101,7 +101,7 @@ public class Query<T, F> implements Serializable {
     }
 
     /**
-     * Gets the limit of items to fetch. The limit is only used when fetching
+     * Gets the number of items to fetch. The limit is only used when fetching
      * items, but not when counting the number of available items.
      * <p>
      * <strong>Note: </strong>It is possible that


### PR DESCRIPTION
With the original phrasing, "limit" could potentially also be understood
as the index of the last item to fetch.

Related to #6072

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6099)
<!-- Reviewable:end -->
