### PR TITLE
Picks from master to 1.4

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -120,7 +120,6 @@ public class UIInternals implements Serializable {
         public List<Object> getParameters() {
             return Collections.unmodifiableList(parameters);
         }
-
     }
 
     /**
@@ -361,13 +360,7 @@ public class UIInternals implements Serializable {
                             + ".");
         } else {
             if (session == null) {
-                try {
-                    ComponentUtil.onComponentDetach(ui);
-                    ui.getChildren().forEach(ComponentUtil::onComponentDetach);
-                } catch (Exception e) {
-                    getLogger().warn("Error while detaching UI from session",
-                            e);
-                }
+                ui.getElement().getNode().setParent(null);
                 // Disable push when the UI is detached. Otherwise the
                 // push connection and possibly VaadinSession will live on.
                 ui.getPushConfiguration().setPushMode(PushMode.DISABLED);
@@ -478,9 +471,11 @@ public class UIInternals implements Serializable {
                     .getAnnotation(ListenerPriority.class);
 
             final int priority1 = listenerPriority1 != null
-                    ? listenerPriority1.value() : 0;
+                    ? listenerPriority1.value()
+                    : 0;
             final int priority2 = listenerPriority2 != null
-                    ? listenerPriority2.value() : 0;
+                    ? listenerPriority2.value()
+                    : 0;
 
             // we want to have a descending order
             return Integer.compare(priority2, priority1);

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateTree.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateTree.java
@@ -45,6 +45,7 @@ import com.vaadin.flow.shared.Registration;
 public class StateTree implements NodeOwner {
 
     private final class RootNode extends StateNode {
+
         private RootNode(Class<? extends NodeFeature>[] features) {
             super(features);
 
@@ -57,14 +58,22 @@ public class StateTree implements NodeOwner {
 
         @Override
         public void setParent(StateNode parent) {
-            throw new IllegalStateException(
-                    "Can't set the parent of the tree root");
+            if (parent == null) {
+                super.setParent(null);
+                isRootAttached = false;
+            } else {
+                throw new IllegalStateException(
+                        "Can't set the parent of the tree root");
+            }
         }
 
         @Override
         public boolean isAttached() {
-            // Root is always attached
-            return true;
+            // the method is called from the super class (which is bad: call
+            // overridden method at the class init phase), so there the field
+            // from enclosing class is used because it's already initialized at
+            // the class constructor call.
+            return isRootAttached;
         }
 
     }
@@ -134,6 +143,11 @@ public class StateTree implements NodeOwner {
     private final StateNode rootNode;
 
     private final UIInternals uiInternals;
+
+    // This field actually belongs to RootNode class but it can'be moved there
+    // because its method isAttached() is called before the RootNode class is
+    // initialization is done.
+    private boolean isRootAttached = true;
 
     /**
      * Creates a new state tree with a set of features defined for the root

--- a/flow-server/src/test/java/com/vaadin/flow/internal/StateTreeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/StateTreeTest.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 import org.apache.commons.lang3.SerializationUtils;
@@ -93,7 +94,7 @@ public class StateTreeTest {
     }
 
     @Test
-    public void testRootNodeState() {
+    public void rootNodeState() {
         StateNode rootNode = tree.getRootNode();
 
         Assert.assertNull("Root node should have no parent",
@@ -109,8 +110,21 @@ public class StateTreeTest {
     }
 
     @Test(expected = IllegalStateException.class)
-    public void testRootNode_setParent_throws() {
+    public void rootNode_setStateNodeAsParent_throws() {
         tree.getRootNode().setParent(new StateNode());
+    }
+
+    @Test
+    public void rootNode_setNullAsParent_nodeIsDetached() {
+        AtomicInteger detachCount = new AtomicInteger();
+        Assert.assertTrue(tree.hasNode(tree.getRootNode()));
+        tree.getRootNode()
+                .addDetachListener(() -> detachCount.incrementAndGet());
+        tree.getRootNode().setParent(null);
+        Assert.assertEquals(1, detachCount.get());
+        Assert.assertFalse(tree.getRootNode().isAttached());
+
+        Assert.assertFalse(tree.hasNode(tree.getRootNode()));
     }
 
     @Test


### PR DESCRIPTION
* Allow to set parent to null for root node (UI element).

Fixes #6092

* Move the field into enclosing class to be able to initialize it before
class construction

(cherry picked from commit 233b24ddc70cf1329bcda78a594349da9ff8af1d)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6126)
<!-- Reviewable:end -->
