### PR TITLE
Picks from 1.4 to 1.0

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -26,13 +26,6 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.vaadin.flow.router.AfterNavigationListener;
-import com.vaadin.flow.router.BeforeEnterListener;
-import com.vaadin.flow.router.BeforeLeaveListener;
-import com.vaadin.flow.router.ListenerPriority;
-import com.vaadin.flow.router.Location;
-import com.vaadin.flow.router.Router;
-import com.vaadin.flow.router.RouterLayout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,7 +51,14 @@ import com.vaadin.flow.internal.nodefeature.NodeFeature;
 import com.vaadin.flow.internal.nodefeature.PollConfigurationMap;
 import com.vaadin.flow.internal.nodefeature.PushConfigurationMap;
 import com.vaadin.flow.internal.nodefeature.ReconnectDialogConfigurationMap;
+import com.vaadin.flow.router.AfterNavigationListener;
+import com.vaadin.flow.router.BeforeEnterListener;
 import com.vaadin.flow.router.BeforeLeaveEvent.ContinueNavigationAction;
+import com.vaadin.flow.router.BeforeLeaveListener;
+import com.vaadin.flow.router.ListenerPriority;
+import com.vaadin.flow.router.Location;
+import com.vaadin.flow.router.Router;
+import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.router.internal.AfterNavigationHandler;
 import com.vaadin.flow.router.internal.BeforeEnterHandler;
 import com.vaadin.flow.router.internal.BeforeLeaveHandler;
@@ -120,7 +120,6 @@ public class UIInternals implements Serializable {
         public List<Object> getParameters() {
             return Collections.unmodifiableList(parameters);
         }
-
     }
 
     /**
@@ -361,13 +360,7 @@ public class UIInternals implements Serializable {
                             + ".");
         } else {
             if (session == null) {
-                try {
-                    ComponentUtil.onComponentDetach(ui);
-                    ui.getChildren().forEach(ComponentUtil::onComponentDetach);
-                } catch (Exception e) {
-                    getLogger().warn("Error while detaching UI from session",
-                            e);
-                }
+                ui.getElement().getNode().setParent(null);
                 // Disable push when the UI is detached. Otherwise the
                 // push connection and possibly VaadinSession will live on.
                 ui.getPushConfiguration().setPushMode(PushMode.DISABLED);
@@ -472,13 +465,19 @@ public class UIInternals implements Serializable {
             Class<?> o1Class = o1.getClass();
             Class<?> o2Class = o2.getClass();
 
-            final ListenerPriority listenerPriority1 = o1Class.getAnnotation(ListenerPriority.class);
-            final ListenerPriority listenerPriority2 = o2Class.getAnnotation(ListenerPriority.class);
+            final ListenerPriority listenerPriority1 = o1Class
+                    .getAnnotation(ListenerPriority.class);
+            final ListenerPriority listenerPriority2 = o2Class
+                    .getAnnotation(ListenerPriority.class);
 
-            final int priority1 = listenerPriority1 != null ? listenerPriority1.value() : 0;
-            final int priority2 = listenerPriority2 != null ? listenerPriority2.value() : 0;
+            final int priority1 = listenerPriority1 != null
+                    ? listenerPriority1.value()
+                    : 0;
+            final int priority2 = listenerPriority2 != null
+                    ? listenerPriority2.value()
+                    : 0;
 
-            //we want to have a descending order
+            // we want to have a descending order
             return Integer.compare(priority2, priority1);
         });
 
@@ -772,7 +771,7 @@ public class UIInternals implements Serializable {
         Page page = ui.getPage();
         DependencyInfo dependencies = ComponentUtil
                 .getDependencies(session.getService(), componentClass);
-        dependencies.getHtmlImports().stream()
+        dependencies.getHtmlImports()
                 .forEach(html -> addHtmlImport(html, page));
         dependencies.getJavaScripts()
                 .forEach(js -> page.addJavaScript(js.value(), js.loadMode()));
@@ -787,7 +786,7 @@ public class UIInternals implements Serializable {
         // contain versions for which files. They must be translated before
         // added to page though, as whatever is added there is sent without
         // modifications to the client
-        dependency.getUris().stream().forEach(uri -> page
+        dependency.getUris().forEach(uri -> page
                 .addHtmlImport(translateTheme(uri), dependency.getLoadMode()));
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateTree.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateTree.java
@@ -45,6 +45,7 @@ import com.vaadin.flow.shared.Registration;
 public class StateTree implements NodeOwner {
 
     private final class RootNode extends StateNode {
+
         private RootNode(Class<? extends NodeFeature>[] features) {
             super(features);
 
@@ -57,14 +58,22 @@ public class StateTree implements NodeOwner {
 
         @Override
         public void setParent(StateNode parent) {
-            throw new IllegalStateException(
-                    "Can't set the parent of the tree root");
+            if (parent == null) {
+                super.setParent(null);
+                isRootAttached = false;
+            } else {
+                throw new IllegalStateException(
+                        "Can't set the parent of the tree root");
+            }
         }
 
         @Override
         public boolean isAttached() {
-            // Root is always attached
-            return true;
+            // the method is called from the super class (which is bad: call
+            // overridden method at the class init phase), so there the field
+            // from enclosing class is used because it's already initialized at
+            // the class constructor call.
+            return isRootAttached;
         }
 
     }
@@ -134,6 +143,11 @@ public class StateTree implements NodeOwner {
     private final StateNode rootNode;
 
     private final UIInternals uiInternals;
+
+    // This field actually belongs to RootNode class but it can'be moved there
+    // because its method isAttached() is called before the RootNode class is
+    // initialization is done.
+    private boolean isRootAttached = true;
 
     /**
      * Creates a new state tree with a set of features defined for the root

--- a/flow-server/src/test/java/com/vaadin/flow/component/UITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/UITest.java
@@ -2,7 +2,6 @@ package com.vaadin.flow.component;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -22,6 +21,7 @@ import org.mockito.Mockito;
 import com.vaadin.flow.component.page.History;
 import com.vaadin.flow.component.page.History.HistoryStateChangeEvent;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.ElementDetachEvent;
 import com.vaadin.flow.dom.Node;
 import com.vaadin.flow.dom.NodeVisitor;
 import com.vaadin.flow.dom.impl.AbstractTextElementStateProvider;
@@ -129,7 +129,7 @@ public class UITest {
     }
 
     private static void initUI(UI ui, String initialLocation,
-                               ArgumentCaptor<Integer> statusCodeCaptor)
+            ArgumentCaptor<Integer> statusCodeCaptor)
             throws InvalidRouteConfigurationException {
         try {
             VaadinServletRequest request = Mockito
@@ -357,6 +357,30 @@ public class UITest {
     }
 
     @Test
+    public void unserSession_datachEventIsFiredForElements()
+            throws InvalidRouteConfigurationException {
+        UI ui = createTestUI();
+
+        List<ElementDetachEvent> events = new ArrayList<>();
+
+        ui.getElement().addDetachListener(events::add);
+        initUI(ui, "", null);
+
+        Component childComponent = new AttachableComponent();
+        ui.add(childComponent);
+        childComponent.getElement().addDetachListener(events::add);
+
+        ui.getSession().access(() -> ui.getInternals().setSession(null));
+
+        // Unlock to run pending access tasks
+        ui.getSession().unlock();
+
+        assertEquals(2, events.size());
+        assertEquals(childComponent.getElement(), events.get(0).getSource());
+        assertEquals(ui.getElement(), events.get(1).getSource());
+    }
+
+    @Test
     public void beforeClientResponse_regularOrder() {
         UI ui = createTestUI();
         Component rootComponent = new AttachableComponent();
@@ -519,25 +543,28 @@ public class UITest {
     }
 
     @ListenerPriority(5)
-    private static class BeforeEnterListenerFirst implements BeforeEnterListener{
+    private static class BeforeEnterListenerFirst
+            implements BeforeEnterListener {
         @Override
         public void beforeEnter(BeforeEnterEvent event) {
         }
     }
 
-    private static class BeforeEnterListenerSecond implements BeforeEnterListener{
+    private static class BeforeEnterListenerSecond
+            implements BeforeEnterListener {
         @Override
         public void beforeEnter(BeforeEnterEvent event) {
         }
     }
 
     @ListenerPriority(-5)
-    private static class BeforeEnterListenerThird implements BeforeEnterListener{
+    private static class BeforeEnterListenerThird
+            implements BeforeEnterListener {
         @Override
         public void beforeEnter(BeforeEnterEvent event) {
         }
     }
-    
+
     @Test
     public void before_enter_listener_priority_should_dictate_sort_order()
             throws InvalidRouteConfigurationException {
@@ -549,31 +576,39 @@ public class UITest {
         ui.addBeforeEnterListener(new BeforeEnterListenerFirst());
         ui.addBeforeEnterListener(new BeforeEnterListenerSecond());
 
-        final List<BeforeEnterHandler> beforeEnterListeners = ui.getNavigationListeners(BeforeEnterHandler.class);
-        
+        final List<BeforeEnterHandler> beforeEnterListeners = ui
+                .getNavigationListeners(BeforeEnterHandler.class);
+
         assertEquals(4, beforeEnterListeners.size());
-        
-        assertTrue(beforeEnterListeners.get(0) instanceof BeforeEnterListenerFirst);
-        assertTrue(beforeEnterListeners.get(1) instanceof BeforeEnterListenerSecond);
-        assertTrue(beforeEnterListeners.get(2) instanceof BeforeEnterListenerThird);
-        assertTrue(beforeEnterListeners.get(3) instanceof BeforeEnterListenerThird);
+
+        assertTrue(beforeEnterListeners
+                .get(0) instanceof BeforeEnterListenerFirst);
+        assertTrue(beforeEnterListeners
+                .get(1) instanceof BeforeEnterListenerSecond);
+        assertTrue(beforeEnterListeners
+                .get(2) instanceof BeforeEnterListenerThird);
+        assertTrue(beforeEnterListeners
+                .get(3) instanceof BeforeEnterListenerThird);
     }
-    
+
     @ListenerPriority(5)
-    private static class BeforeLeaveListenerFirst implements BeforeLeaveListener{
+    private static class BeforeLeaveListenerFirst
+            implements BeforeLeaveListener {
         @Override
         public void beforeLeave(BeforeLeaveEvent event) {
         }
     }
 
-    private static class BeforeLeaveListenerSecond implements BeforeLeaveListener{
+    private static class BeforeLeaveListenerSecond
+            implements BeforeLeaveListener {
         @Override
         public void beforeLeave(BeforeLeaveEvent event) {
         }
     }
 
     @ListenerPriority(-5)
-    private static class BeforeLeaveListenerThird implements BeforeLeaveListener{
+    private static class BeforeLeaveListenerThird
+            implements BeforeLeaveListener {
         @Override
         public void beforeLeave(BeforeLeaveEvent event) {
         }
@@ -590,32 +625,39 @@ public class UITest {
         ui.addBeforeLeaveListener(new BeforeLeaveListenerSecond());
         ui.addBeforeLeaveListener(new BeforeLeaveListenerThird());
 
-        final List<BeforeLeaveHandler> beforeLeaveListeners = ui.getNavigationListeners(BeforeLeaveHandler.class);
+        final List<BeforeLeaveHandler> beforeLeaveListeners = ui
+                .getNavigationListeners(BeforeLeaveHandler.class);
 
         assertEquals(4, beforeLeaveListeners.size());
 
-        assertTrue(beforeLeaveListeners.get(0) instanceof BeforeLeaveListenerFirst);
-        assertTrue(beforeLeaveListeners.get(1) instanceof BeforeLeaveListenerSecond);
-        assertTrue(beforeLeaveListeners.get(2) instanceof BeforeLeaveListenerThird);
-        assertTrue(beforeLeaveListeners.get(3) instanceof BeforeLeaveListenerThird);
+        assertTrue(beforeLeaveListeners
+                .get(0) instanceof BeforeLeaveListenerFirst);
+        assertTrue(beforeLeaveListeners
+                .get(1) instanceof BeforeLeaveListenerSecond);
+        assertTrue(beforeLeaveListeners
+                .get(2) instanceof BeforeLeaveListenerThird);
+        assertTrue(beforeLeaveListeners
+                .get(3) instanceof BeforeLeaveListenerThird);
     }
 
-
     @ListenerPriority(5)
-    private static class AfterNavigationListenerFirst implements AfterNavigationListener{
+    private static class AfterNavigationListenerFirst
+            implements AfterNavigationListener {
         @Override
         public void afterNavigation(AfterNavigationEvent event) {
         }
     }
 
-    private static class AfterNavigationListenerSecond implements AfterNavigationListener{
+    private static class AfterNavigationListenerSecond
+            implements AfterNavigationListener {
         @Override
         public void afterNavigation(AfterNavigationEvent event) {
         }
     }
 
     @ListenerPriority(-5)
-    private static class AfterNavigationListenerThird implements AfterNavigationListener{
+    private static class AfterNavigationListenerThird
+            implements AfterNavigationListener {
         @Override
         public void afterNavigation(AfterNavigationEvent event) {
         }
@@ -632,13 +674,18 @@ public class UITest {
         ui.addAfterNavigationListener(new AfterNavigationListenerFirst());
         ui.addAfterNavigationListener(new AfterNavigationListenerSecond());
 
-        final List<AfterNavigationHandler> AfterNavigationListeners = ui.getNavigationListeners(AfterNavigationHandler.class);
+        final List<AfterNavigationHandler> AfterNavigationListeners = ui
+                .getNavigationListeners(AfterNavigationHandler.class);
 
         assertEquals(4, AfterNavigationListeners.size());
 
-        assertTrue(AfterNavigationListeners.get(0) instanceof AfterNavigationListenerFirst);
-        assertTrue(AfterNavigationListeners.get(1) instanceof AfterNavigationListenerSecond);
-        assertTrue(AfterNavigationListeners.get(2) instanceof AfterNavigationListenerThird);
-        assertTrue(AfterNavigationListeners.get(3) instanceof AfterNavigationListenerThird);
+        assertTrue(AfterNavigationListeners
+                .get(0) instanceof AfterNavigationListenerFirst);
+        assertTrue(AfterNavigationListeners
+                .get(1) instanceof AfterNavigationListenerSecond);
+        assertTrue(AfterNavigationListeners
+                .get(2) instanceof AfterNavigationListenerThird);
+        assertTrue(AfterNavigationListeners
+                .get(3) instanceof AfterNavigationListenerThird);
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/StateTreeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/StateTreeTest.java
@@ -24,6 +24,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 import org.apache.commons.lang3.SerializationUtils;
@@ -93,7 +94,7 @@ public class StateTreeTest {
     }
 
     @Test
-    public void testRootNodeState() {
+    public void rootNodeState() {
         StateNode rootNode = tree.getRootNode();
 
         Assert.assertNull("Root node should have no parent",
@@ -109,8 +110,21 @@ public class StateTreeTest {
     }
 
     @Test(expected = IllegalStateException.class)
-    public void testRootNode_setParent_throws() {
+    public void rootNode_setStateNodeAsParent_throws() {
         tree.getRootNode().setParent(new StateNode());
+    }
+
+    @Test
+    public void rootNode_setNullAsParent_nodeIsDetached() {
+        AtomicInteger detachCount = new AtomicInteger();
+        Assert.assertTrue(tree.hasNode(tree.getRootNode()));
+        tree.getRootNode()
+                .addDetachListener(() -> detachCount.incrementAndGet());
+        tree.getRootNode().setParent(null);
+        Assert.assertEquals(1, detachCount.get());
+        Assert.assertFalse(tree.getRootNode().isAttached());
+
+        Assert.assertFalse(tree.hasNode(tree.getRootNode()));
     }
 
     @Test


### PR DESCRIPTION
* Allow to set parent to null for root node (UI element).

Fixes #6092

* Move the field into enclosing class to be able to initialize it before
class construction

(cherry picked from commit 233b24ddc70cf1329bcda78a594349da9ff8af1d)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6128)
<!-- Reviewable:end -->
