### PR TITLE
Mark the production mode web fragment as distributable

### DIFF
--- a/flow-server-production-mode/src/main/resources/META-INF/web-fragment.xml
+++ b/flow-server-production-mode/src/main/resources/META-INF/web-fragment.xml
@@ -11,5 +11,7 @@
         <param-name>productionMode</param-name> 
         <param-value>true</param-value>
     </context-param>
+    
+    <distributable/>
 
 </web-fragment>


### PR DESCRIPTION
A distributable web application only adds serializable values to the
servlet session, which means that sessions can be distsributed between
multiple nodes in a cluster. An application cannot be distributable if
any web fragment that it uses isn't also marked as distributable. The
marker has no effect if the application itself isn't also marked as
distributable.

Fixes #6129

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6145)
<!-- Reviewable:end -->
