### PR TITLE
Mark the compatibility mode web fragment as distributable

### DIFF
--- a/flow-server-compatibility-mode/src/main/resources/META-INF/web-fragment.xml
+++ b/flow-server-compatibility-mode/src/main/resources/META-INF/web-fragment.xml
@@ -12,4 +12,6 @@
         <param-value>true</param-value>
     </context-param>
 
+    <distributable/>
+
 </web-fragment>


### PR DESCRIPTION
Same as #6145, but for the fragment that didn't exist when that one was merged

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6147)
<!-- Reviewable:end -->
