### PR TITLE
Check location's query parameters in addition to path in server round-trip triggering logic in PopStateHandler

### DIFF
--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/BackButtonServerRoundTripView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/BackButtonServerRoundTripView.java
@@ -1,0 +1,41 @@
+package com.vaadin.flow.uitest.ui;
+
+import java.util.Collections;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.BeforeEvent;
+import com.vaadin.flow.router.HasUrlParameter;
+import com.vaadin.flow.router.QueryParameters;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.WildcardParameter;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+@Route(value = "com.vaadin.flow.uitest.ui.BackButtonServerRoundTripView", layout = ViewTestLayout.class)
+public class BackButtonServerRoundTripView extends Div implements HasUrlParameter<String> {
+
+    static final String BUTTON_ID = "button";
+    static final String QUERY_LABEL_ID = "query";
+
+    private final Label queryLabel;
+
+    public BackButtonServerRoundTripView() {
+        queryLabel = new Label();
+        queryLabel.setId(QUERY_LABEL_ID);
+        add(queryLabel);
+
+        NativeButton button = new NativeButton("Change query parameter",
+                e -> UI.getCurrent().navigate(
+                        "com.vaadin.flow.uitest.ui.BackButtonServerRoundTripView/1",
+                        QueryParameters.simple(Collections.singletonMap("query", "bar"))));
+        button.setId(BUTTON_ID);
+        add(button);
+    }
+
+    @Override
+    public void setParameter(BeforeEvent beforeEvent, @WildcardParameter String param) {
+        queryLabel.setText(beforeEvent.getLocation().getQueryParameters().getQueryString());
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/BackButtonServerRoundTripIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/BackButtonServerRoundTripIT.java
@@ -1,0 +1,34 @@
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class BackButtonServerRoundTripIT extends ChromeBrowserTest {
+    @Test
+    public void testForwardingToViewInSetParameter() {
+        final String baseLoc =
+                "/view/com.vaadin.flow.uitest.ui.BackButtonServerRoundTripView";
+        getDriver().get(getRootURL() + baseLoc + "/1?query=foo");
+
+        WebElement button = findElement(By.id(BackButtonServerRoundTripView.BUTTON_ID));
+        button.click();
+
+        final String queryValue0 = findElement(
+                By.id(BackButtonServerRoundTripView.QUERY_LABEL_ID)).getText();
+        Assert.assertTrue("should have received query parameter value 'bar'",
+                queryValue0.equals("query=bar"));
+
+        getDriver().navigate().back();
+
+        final String queryValue1 = findElement(
+                By.id(BackButtonServerRoundTripView.QUERY_LABEL_ID)).getText();
+        Assert.assertTrue("should have received query parameter value 'foo'",
+                queryValue1.equals("query=foo"));
+    }
+}
+
+


### PR DESCRIPTION
Cherry-pick #6148

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6159)
<!-- Reviewable:end -->
