### PR TITLE
Update FrontendToolsLocator.java

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsLocator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsLocator.java
@@ -121,7 +121,7 @@ public class FrontendToolsLocator implements Serializable {
 
         boolean commandExited = false;
         try {
-            commandExited = process.waitFor(3, TimeUnit.SECONDS);
+            commandExited = process.waitFor(10, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             log().error(
                     "Unexpected interruption happened during '{}' command execution",


### PR DESCRIPTION
Behind a company proxy, npm -v is too slow to respond in a 3 seconds timeout.
This timeout should be configurable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6165)
<!-- Reviewable:end -->
