### PR TITLE
flow-maven-plugin unit tests: check copied files modulo order to avoid flakiness

### DIFF
--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/migration/CopyResourcesStepTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/migration/CopyResourcesStepTest.java
@@ -219,7 +219,8 @@ public class CopyResourcesStepTest {
         List<String> list = copied.get(source.getPath());
         Assert.assertEquals(path.length, list.size());
         for (int i = 0; i < path.length; i++) {
-            Assert.assertEquals(path[i], list.get(i));
+            Assert.assertTrue(String.format("copied files %s did not contain expected file '%s'", list.toString(), path[i]),
+                    list.contains(path[i]));
         }
     }
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6166)
<!-- Reviewable:end -->
