### PR TITLE
Throw immediately on unexpected ClassFinder usage

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -23,19 +23,24 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRegistration;
 import javax.servlet.annotation.HandlesTypes;
 import javax.servlet.annotation.WebListener;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.UncheckedIOException;
+import java.lang.annotation.Annotation;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -76,6 +81,50 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_GENERATED;
 @WebListener
 public class DevModeInitializer implements ServletContainerInitializer,
         Serializable, ServletContextListener {
+
+    static class DevModeClassFinder extends DefaultClassFinder {
+
+        private static final Set<String> APPLICABLE_CLASS_NAME = Collections
+                .unmodifiableSet(calculateApplicableClassNames());
+
+        public DevModeClassFinder(Set<Class<?>> classes) {
+            super(classes);
+        }
+
+        @Override
+        public Set<Class<?>> getAnnotatedClasses(
+                Class<? extends Annotation> annotation) {
+            ensureImplementation(annotation);
+            return super.getAnnotatedClasses(annotation);
+        }
+
+        @Override
+        public <T> Set<Class<? extends T>> getSubTypesOf(Class<T> type) {
+            ensureImplementation(type);
+            return super.getSubTypesOf(type);
+        }
+
+        private void ensureImplementation(Class<?> clazz) {
+            if (!getApplicableClassNames().contains(clazz.getName())) {
+                throw new IllegalArgumentException("Unexpected class name "
+                        + clazz + ". Implementation error: the class finder "
+                        + "instance is not aware of this class. "
+                        + "Fix @HandlesTypes annotation value for"
+                        + DevModeInitializer.class.getName());
+            }
+        }
+
+        private Set<String> getApplicableClassNames() {
+            return APPLICABLE_CLASS_NAME;
+        }
+
+        private static Set<String> calculateApplicableClassNames() {
+            HandlesTypes handlesTypes = DevModeInitializer.class
+                    .getAnnotation(HandlesTypes.class);
+            return Stream.of(handlesTypes.value()).map(Class::getName)
+                    .collect(Collectors.toSet());
+        }
+    }
 
     /**
      * The classes that were visited when determining which frontend resources
@@ -197,12 +246,12 @@ public class DevModeInitializer implements ServletContainerInitializer,
 
         String baseDir = config.getStringProperty(FrontendUtils.PROJECT_BASEDIR,
                 System.getProperty("user.dir", "."));
-        String generatedDir = System
-                .getProperty(PARAM_GENERATED_DIR, DEFAULT_GENERATED_DIR);
+        String generatedDir = System.getProperty(PARAM_GENERATED_DIR,
+                DEFAULT_GENERATED_DIR);
         String frontendFolder = config.getStringProperty(PARAM_FRONTEND_DIR,
                 System.getProperty(PARAM_FRONTEND_DIR, DEFAULT_FRONTEND_DIR));
 
-        Builder builder = new NodeTasks.Builder(new DefaultClassFinder(classes),
+        Builder builder = new NodeTasks.Builder(new DevModeClassFinder(classes),
                 new File(baseDir), new File(generatedDir),
                 new File(frontendFolder));
 
@@ -238,7 +287,8 @@ public class DevModeInitializer implements ServletContainerInitializer,
         }
 
         Set<String> visitedClassNames = new HashSet<>();
-        Set<File> jarFiles = getJarFilesFromClassloader(DevModeInitializer.class.getClassLoader());
+        Set<File> jarFiles = getJarFilesFromClassloader(
+                DevModeInitializer.class.getClassLoader());
         try {
             builder.enablePackagesUpdate(true).copyResources(jarFiles)
                     .copyLocalResources(new File(baseDir,

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -84,7 +84,7 @@ public class DevModeInitializer implements ServletContainerInitializer,
 
     static class DevModeClassFinder extends DefaultClassFinder {
 
-        private static final Set<String> APPLICABLE_CLASS_NAME = Collections
+        private static final Set<String> APPLICABLE_CLASS_NAMES = Collections
                 .unmodifiableSet(calculateApplicableClassNames());
 
         public DevModeClassFinder(Set<Class<?>> classes) {
@@ -105,17 +105,13 @@ public class DevModeInitializer implements ServletContainerInitializer,
         }
 
         private void ensureImplementation(Class<?> clazz) {
-            if (!getApplicableClassNames().contains(clazz.getName())) {
+            if (!APPLICABLE_CLASS_NAMES.contains(clazz.getName())) {
                 throw new IllegalArgumentException("Unexpected class name "
                         + clazz + ". Implementation error: the class finder "
                         + "instance is not aware of this class. "
-                        + "Fix @HandlesTypes annotation value for"
+                        + "Fix @HandlesTypes annotation value for "
                         + DevModeInitializer.class.getName());
             }
-        }
-
-        private Set<String> getApplicableClassNames() {
-            return APPLICABLE_CLASS_NAME;
         }
 
         private static Set<String> calculateApplicableClassNames() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeClassFinderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeClassFinderTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.startup;
+
+import javax.servlet.annotation.HandlesTypes;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.WebComponentExporter;
+import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.VaadinServiceInitListener;
+import com.vaadin.flow.server.startup.DevModeInitializer.DevModeClassFinder;
+import com.vaadin.flow.theme.Theme;
+
+public class DevModeClassFinderTest {
+
+    @Test
+    public void applicableClasses_knownClasses() {
+        Collection<Class<?>> classes = getApplicableClasses();
+        classes.contains(Route.class);
+        classes.contains(NpmPackage.class);
+        classes.contains(NpmPackage.Container.class);
+        classes.contains(WebComponentExporter.class);
+
+        Assert.assertEquals(4, classes.size());
+    }
+
+    @Test
+    public void callGetSubTypesOfByClass_expectedType_doesNotThrow() {
+        DevModeClassFinder classFinder = new DevModeClassFinder(
+                Collections.emptySet());
+        for (Class<?> clazz : getApplicableClasses()) {
+            classFinder.getSubTypesOf(clazz);
+        }
+    }
+
+    @Test
+    public void callGetSubTypesOfByName_expectedType_doesNotThrow()
+            throws ClassNotFoundException {
+        DevModeClassFinder classFinder = new DevModeClassFinder(
+                Collections.emptySet());
+        for (Class<?> clazz : getApplicableClasses()) {
+            classFinder.getSubTypesOf(clazz.getName());
+        }
+    }
+
+    @Test
+    public void callGetgetAnnotatedClassesByName_expectedType_doesNotThrow()
+            throws ClassNotFoundException {
+        DevModeClassFinder classFinder = new DevModeClassFinder(
+                Collections.emptySet());
+        for (Class<?> clazz : getApplicableClasses()) {
+            classFinder.getAnnotatedClasses(clazz.getName());
+        }
+    }
+
+    @Test
+    public void callGetgetAnnotatedClassesByClass_expectedType_doesNotThrow()
+            throws ClassNotFoundException {
+        DevModeClassFinder classFinder = new DevModeClassFinder(
+                Collections.emptySet());
+        for (Class<?> clazz : getApplicableClasses()) {
+            if (clazz.isAnnotation()) {
+                classFinder.getAnnotatedClasses((Class) clazz);
+            }
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void callGetgetAnnotatedClassesByClass_unexpectedType_throw() {
+        DevModeClassFinder classFinder = new DevModeClassFinder(
+                Collections.emptySet());
+        classFinder.getAnnotatedClasses(Test.class);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void callGetgetAnnotatedClassesByName_unexpectedType_throw()
+            throws ClassNotFoundException {
+        DevModeClassFinder classFinder = new DevModeClassFinder(
+                Collections.emptySet());
+        classFinder.getAnnotatedClasses(Theme.class.getName());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void callGetSubTypesOfByClass_unexpectedType_throw() {
+        DevModeClassFinder classFinder = new DevModeClassFinder(
+                Collections.emptySet());
+        classFinder.getSubTypesOf(Object.class);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void callGetSubTypesOfByName_unexpectedType_throw()
+            throws ClassNotFoundException {
+        DevModeClassFinder classFinder = new DevModeClassFinder(
+                Collections.emptySet());
+        classFinder.getSubTypesOf(VaadinServiceInitListener.class.getName());
+    }
+
+    private Collection<Class<?>> getApplicableClasses() {
+        HandlesTypes handlesTypes = DevModeInitializer.class
+                .getAnnotation(HandlesTypes.class);
+        return Stream.of(handlesTypes.value()).collect(Collectors.toList());
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeClassFinderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeClassFinderTest.java
@@ -35,6 +35,9 @@ import com.vaadin.flow.theme.Theme;
 
 public class DevModeClassFinderTest {
 
+    private DevModeClassFinder classFinder = new DevModeClassFinder(
+            Collections.emptySet());
+
     @Test
     public void applicableClasses_knownClasses() {
         Collection<Class<?>> classes = getApplicableClasses();
@@ -49,8 +52,6 @@ public class DevModeClassFinderTest {
 
     @Test
     public void callGetSubTypesOfByClass_expectedType_doesNotThrow() {
-        DevModeClassFinder classFinder = new DevModeClassFinder(
-                Collections.emptySet());
         for (Class<?> clazz : getApplicableClasses()) {
             classFinder.getSubTypesOf(clazz);
         }
@@ -59,8 +60,6 @@ public class DevModeClassFinderTest {
     @Test
     public void callGetSubTypesOfByName_expectedType_doesNotThrow()
             throws ClassNotFoundException {
-        DevModeClassFinder classFinder = new DevModeClassFinder(
-                Collections.emptySet());
         for (Class<?> clazz : getApplicableClasses()) {
             classFinder.getSubTypesOf(clazz.getName());
         }
@@ -69,8 +68,6 @@ public class DevModeClassFinderTest {
     @Test
     public void callGetgetAnnotatedClassesByName_expectedType_doesNotThrow()
             throws ClassNotFoundException {
-        DevModeClassFinder classFinder = new DevModeClassFinder(
-                Collections.emptySet());
         for (Class<?> clazz : getApplicableClasses()) {
             classFinder.getAnnotatedClasses(clazz.getName());
         }
@@ -79,8 +76,6 @@ public class DevModeClassFinderTest {
     @Test
     public void callGetgetAnnotatedClassesByClass_expectedType_doesNotThrow()
             throws ClassNotFoundException {
-        DevModeClassFinder classFinder = new DevModeClassFinder(
-                Collections.emptySet());
         for (Class<?> clazz : getApplicableClasses()) {
             if (clazz.isAnnotation()) {
                 classFinder.getAnnotatedClasses((Class) clazz);
@@ -90,16 +85,12 @@ public class DevModeClassFinderTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void callGetgetAnnotatedClassesByClass_unexpectedType_throw() {
-        DevModeClassFinder classFinder = new DevModeClassFinder(
-                Collections.emptySet());
         classFinder.getAnnotatedClasses(Test.class);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void callGetgetAnnotatedClassesByName_unexpectedType_throw()
             throws ClassNotFoundException {
-        DevModeClassFinder classFinder = new DevModeClassFinder(
-                Collections.emptySet());
         classFinder.getAnnotatedClasses(Theme.class.getName());
     }
 
@@ -113,8 +104,6 @@ public class DevModeClassFinderTest {
     @Test(expected = IllegalArgumentException.class)
     public void callGetSubTypesOfByName_unexpectedType_throw()
             throws ClassNotFoundException {
-        DevModeClassFinder classFinder = new DevModeClassFinder(
-                Collections.emptySet());
         classFinder.getSubTypesOf(VaadinServiceInitListener.class.getName());
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeClassFinderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeClassFinderTest.java
@@ -41,11 +41,11 @@ public class DevModeClassFinderTest {
     @Test
     public void applicableClasses_knownClasses() {
         Collection<Class<?>> classes = getApplicableClasses();
-        classes.contains(Route.class);
-        classes.contains(NpmPackage.class);
-        classes.contains(NpmPackage.Container.class);
-        classes.contains(WebComponentExporter.class);
-        classes.contains(UIInitListener.class);
+        Assert.assertTrue(classes.contains(Route.class));
+        Assert.assertTrue(classes.contains(NpmPackage.class));
+        Assert.assertTrue(classes.contains(NpmPackage.Container.class));
+        Assert.assertTrue(classes.contains(WebComponentExporter.class));
+        Assert.assertTrue(classes.contains(UIInitListener.class));
 
         Assert.assertEquals(5, classes.size());
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeClassFinderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeClassFinderTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import com.vaadin.flow.component.WebComponentExporter;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.UIInitListener;
 import com.vaadin.flow.server.VaadinServiceInitListener;
 import com.vaadin.flow.server.startup.DevModeInitializer.DevModeClassFinder;
 import com.vaadin.flow.theme.Theme;
@@ -41,8 +42,9 @@ public class DevModeClassFinderTest {
         classes.contains(NpmPackage.class);
         classes.contains(NpmPackage.Container.class);
         classes.contains(WebComponentExporter.class);
+        classes.contains(UIInitListener.class);
 
-        Assert.assertEquals(4, classes.size());
+        Assert.assertEquals(5, classes.size());
     }
 
     @Test


### PR DESCRIPTION
This PR may be considered as a fix for #6163. Or may be not. There is a
way to collect all classes in the classpath via
ServletContainerInitializer but I assume it may be very inefficient.
Wold be good to check whether it's feasible to collect all classes and
make the DefautClassFinder instance work as it should work in all
possible cases instead of limiting the useceses.

Related to #6163

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6172)
<!-- Reviewable:end -->
