### PR TITLE
Skip flow-tests module when `-DskipTests` is given

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,6 @@
         <module>flow-theme-integrations</module>
         <module>flow-dnd</module>
         <module>flow-test-util</module>
-        <module>flow-tests</module>
         <module>flow-server-production-mode</module>
         <module>flow-server-compatibility-mode</module>
         <module>flow-components-parent</module>
@@ -693,6 +692,17 @@
                 <module>flow-server-production-mode</module>
                 <module>flow-components-parent</module>
                 <module>build-tools</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>run-tests</id>
+            <activation>
+                <property>
+                    <name>!skipTests</name>
+                </property>
+            </activation>
+            <modules>
+                <module>flow-tests</module>
             </modules>
         </profile>
     </profiles>


### PR DESCRIPTION
This commit avoids that `flow-tests` module is compiled when user wants to skip-tests, reducing the build time in 6 minutes. It makes that TC builds are faster. 

Notice that building flow-tests module without running tests is not worth, in the verification step thought it will catch compilation and other errors.


In my local machine `mvn clean install -DskipTests` reports those times before and after the modification.
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  08:29 min
[INFO] Finished at: 2019-08-05T08:44:59+02:00
[INFO] ------------------------------------------------------------------------
```

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:49 min
[INFO] Finished at: 2019-08-05T08:51:48+02:00
[INFO] ------------------------------------------------------------------------

```

In TC PRs time is reduced by 5 mins like it can be checked by visiting these two builds:

A random PR build before this change took 33m:40s
https://teamcity.vaadin.com/viewLog.html?buildId=51717&buildTypeId=Flow_FlowTests

This PR build took  28m:53s
https://teamcity.vaadin.com/viewLog.html?buildId=52003&buildTypeId=Flow_FlowTests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6175)
<!-- Reviewable:end -->
