### PR TITLE
Fix faulty  path separator for imports

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -289,7 +289,7 @@ public class TaskUpdateImports extends NodeUpdater {
             return;
         }
         Path filePath = file.toPath();
-        visitedImports.add(filePath.normalize().toString());
+        visitedImports.add(filePath.normalize().toString().replace("\\", "/"));
         try {
             visitImportsRecursively(filePath, path, theme, imports,
                     visitedImports);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -337,7 +337,7 @@ public class TaskUpdateImports extends NodeUpdater {
     private String normalizeImportPath(String path) {
         String importPath = toValidBrowserImport(path);
         File file = new File(importPath);
-        return file.toPath().normalize().toString();
+        return file.toPath().normalize().toString().replace("\\", "/");
     }
 
     /**


### PR DESCRIPTION
When collecting imports on windows the
windows path separator is used when
it should be / instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6193)
<!-- Reviewable:end -->
