### PR TITLE
CCDM: implement Flow.start() API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ package-lock.json
 flow-tests/**/package.json
 flow-tests/**/webpack*.js
 yarn.lock
+
+flow-client/src/main/resources/META-INF/resources/frontend/FlowClient.js

--- a/flow-client/intern.json
+++ b/flow-client/intern.json
@@ -10,23 +10,13 @@
         ]
       },
       "fixSessionCapabilities": "no-detect"
-    },
-    {
-      "browserName": "firefox",
-      "moz:firefoxOptions": {
-        "args": [
-          "-headless",
-          "--window-size=1024,768"
-        ]
-      }
     }
   ],
   "suites": "target/frontend-tests/tests.js",
   "tunnelOptions": {
     "version": "3.141.59",
     "drivers": [
-      {"name": "chrome", "version": "76.0.3809.68"},
-      {"name": "firefox", "version": "0.24.0"}
+      {"name": "chrome", "version": "76.0.3809.68"}
     ]
   }
 }

--- a/flow-client/intern.json
+++ b/flow-client/intern.json
@@ -1,9 +1,6 @@
 {
   "environments": [
     {
-      "browserName": "node"
-    },
-    {
       "browserName": "chrome",
       "chromeOptions": {
         "args": [

--- a/flow-client/intern.json
+++ b/flow-client/intern.json
@@ -5,11 +5,28 @@
       "chromeOptions": {
         "args": [
           "headless",
-          "disable-gpu"
+          "disable-gpu",
+          "window-size=1024x768"
         ]
       },
       "fixSessionCapabilities": "no-detect"
+    },
+    {
+      "browserName": "firefox",
+      "moz:firefoxOptions": {
+        "args": [
+          "-headless",
+          "--window-size=1024,768"
+        ]
+      }
     }
   ],
-  "suites": "target/frontend-tests/tests.js"
+  "suites": "target/frontend-tests/tests.js",
+  "tunnelOptions": {
+    "version": "3.141.59",
+    "drivers": [
+      {"name": "chrome", "version": "76.0.3809.68"},
+      {"name": "firefox", "version": "0.24.0"}
+    ]
+  }
 }

--- a/flow-client/package.json
+++ b/flow-client/package.json
@@ -9,11 +9,15 @@
     "url": "https://github.com/vaadin/flow/issues"
   },
   "scripts": {
-    "lint": "eslint 'src/main/resources/META-INF/resources/frontend/**/*.js' && tslint 'src/main/resources/META-INF/resources/frontend/**/*.ts'",
-    "compile": "tsc",
-    "build": "npm run lint && npm run compile",
-    "test": "webpack --config=webpack.tests.config.js && intern",
-    "debug": "webpack --config=webpack.tests.config.js && intern serveOnly"
+    "lint": "eslint 'src/main/resources/META-INF/resources/frontend/FlowBootstrap.js' && tslint 'src/main/resources/META-INF/resources/frontend/**/*.ts'",
+    "_copy": "ncp target/classes/META-INF/resources/VAADIN/static/client/client-*.cache.js src/main/resources/META-INF/resources/frontend/FlowClient.js",
+    "_replace": "replace-in-files --regex '(.+[\\s\\S]*)' --replacement 'const init = function(){\\n$1\\n};\\nexport {init};\\n' src/main/resources/META-INF/resources/frontend/FlowClient.js",
+    "client": "npm run _copy && npm run _replace",
+    "webpack": "webpack --config=webpack.tests.config.js",
+    "build": "npm run client && tsc",
+    "compile": "npm run lint && npm run build",
+    "test": "npm run build && npm run webpack && intern",
+    "debug": "npm run build && npm run webpack && intern serveOnly"
   },
   "homepage": "https://vaadin.com",
   "repository": {
@@ -27,13 +31,18 @@
     "eslint": "^5.8.0",
     "eslint-config-vaadin": "^0.2.7",
     "tslint": "^5.12.1",
-    "fetch-mock": "^7.3.0",
     "intern": "^4.4.3",
     "ts-loader": "^6.0.4",
     "typescript": "^3.5.3",
     "tslint-config-prettier": "^1.18.0",
     "tslint-eslint-rules": "^5.4.0",
     "webpack": "^4.39.1",
-    "webpack-cli": "^3.3.6"
+    "webpack-cli": "^3.3.6",
+    "ncp": "^2.0.0",
+    "replace-in-files-cli": "^0.2.0",
+    "xhr-mock": "^2.5.0"
+  },
+  "dependencies": {
+    "child_process": "^1.0.2"
   }
 }

--- a/flow-client/package.json
+++ b/flow-client/package.json
@@ -10,9 +10,10 @@
   },
   "scripts": {
     "lint": "eslint 'src/main/resources/META-INF/resources/frontend/FlowBootstrap.js' && tslint 'src/main/resources/META-INF/resources/frontend/**/*.ts'",
-    "_copy": "ncp target/classes/META-INF/resources/VAADIN/static/client/client-*.cache.js src/main/resources/META-INF/resources/frontend/FlowClient.js",
-    "_replace": "replace-in-files --regex '(.+[\\s\\S]*)' --replacement 'const init = function(){\\n$1\\n};\\nexport {init};\\n' src/main/resources/META-INF/resources/frontend/FlowClient.js",
-    "client": "npm run _copy && npm run _replace",
+    "_cp_to_src": "ncp target/classes/META-INF/resources/VAADIN/static/client/client-*.cache.js src/main/resources/META-INF/resources/frontend/FlowClient.js",
+    "_wrap_fnc": "replace-in-files --regex '(.+[\\s\\S]*)' --replacement 'const init = function(){\\n$1\\n};\\nexport {init};\\n' src/main/resources/META-INF/resources/frontend/FlowClient.js",
+    "_cp_to_tgt": "ncp src/main/resources/META-INF/resources/frontend/FlowClient.js target/classes/META-INF/resources/frontend/FlowClient.js",
+    "client": "npm run _cp_to_src && npm run _wrap_fnc && npm run _cp_to_tgt",
     "webpack": "webpack --config=webpack.tests.config.js",
     "build": "npm run client && tsc",
     "compile": "npm run lint && npm run build",
@@ -41,8 +42,5 @@
     "ncp": "^2.0.0",
     "replace-in-files-cli": "^0.2.0",
     "xhr-mock": "^2.5.0"
-  },
-  "dependencies": {
-    "child_process": "^1.0.2"
   }
 }

--- a/flow-client/pom.xml
+++ b/flow-client/pom.xml
@@ -162,10 +162,17 @@
 
                 <executions>
                     <execution>
+                        <phase>compile</phase>
                         <goals>
                             <goal>compile</goal>
-                            <goal>test</goal>
                             <goal>generateAsync</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>gwt-test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -243,20 +250,6 @@
                             <executable>npm</executable>
                             <arguments>
                                 <argument>install</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>npm-lint</id>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <executable>npm</executable>
-                            <arguments>
-                                <argument>run</argument>
-                                <argument>lint</argument>
                             </arguments>
                         </configuration>
                     </execution>

--- a/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
@@ -1,25 +1,91 @@
-export interface FlowSettings {
+export interface FlowConfig {
     imports ?: () => void;
 }
 
-class Flow {
+interface AppConfig {
+    productionMode: boolean,
+    appId: string,
+    uidl: object
+}
 
-    config ?: FlowSettings;
+interface AppInitResponse {
+    appConfig: AppConfig;
+}
 
-    constructor(config?: FlowSettings) {
+/**
+ * Client API for flow UI operations.
+ */
+export class Flow {
+    config ?: FlowConfig;
+    response ?: AppInitResponse;
+
+    constructor(config?: FlowConfig) {
         if (config) {
             this.config = config;
         }
     }
 
-    start(): Promise<void> {
-        return Promise.resolve();
+    /**
+     * Load flow client module and initialize UI in server side.
+     */
+    async start(): Promise<AppInitResponse> {
+        // Do not start flow twice
+        if (!this.response) {
+            // Initialize server side UI
+            this.response = await this.__initFlowUi();
+
+            // Load bootstrap script with server side parameters
+            const bootstrapMod = await import('./FlowBootstrap');
+            await bootstrapMod.init(this.response);
+
+            // Load flow-client module
+            const clientMod = await import('./FlowClient');
+            await this.__initFlowClient(clientMod);
+
+            // // Load custom modules defined by user
+            if (this.config && this.config.imports) {
+                await this.config.imports();
+            }
+        }
+        return this.response;
     }
 
+    /**
+     * Go to a route defined in server.
+     */
     navigate(): Promise<void> {
         return Promise.resolve();
     }
-} 
 
-export { Flow };
+    async __initFlowClient(clientMod: any): Promise<void> {
+        clientMod.init();
+        // client init is async, we need to loop until initialized
+        return new Promise((resolve) => {
+            const $wnd = (window as any);
+            const intervalId = setInterval(() => {
+                // client `isActive() == true` while initializing
+                const initializing = Object.keys($wnd.Vaadin.Flow.clients)
+                  .reduce((prev, id) => prev || $wnd.Vaadin.Flow.clients[id].isActive(), false);
+                if (!initializing) {
+                    clearInterval(intervalId);
+                    resolve();
+                }
+            }, 5);
+        });
+    }
 
+    async __initFlowUi(): Promise<AppInitResponse> {
+        return new Promise((resolve, reject) => {
+            const httpRequest = new (window as any).XMLHttpRequest();
+            httpRequest.open('GET', 'VAADIN/?v-r=init');
+            httpRequest.onload = () => {
+                if (httpRequest.getResponseHeader('content-type') === 'application/json') {
+                    resolve(JSON.parse(httpRequest.responseText));
+                } else {
+                    reject(httpRequest);
+                }
+            };
+            httpRequest.send();
+        });
+    }
+}

--- a/flow-client/src/main/resources/META-INF/resources/frontend/FlowBootstrap.d.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/FlowBootstrap.d.ts
@@ -1,0 +1,1 @@
+export const init: (appInitResponse: any) => void;

--- a/flow-client/src/main/resources/META-INF/resources/frontend/FlowBootstrap.js
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/FlowBootstrap.js
@@ -1,0 +1,238 @@
+/* This is a copy of the regular `BootstrapHandler.js` in the flow-server
+   module, but with the following modifications:
+   - The main function is exported as an ES module for lazy initialization.
+   - Application configuration is passed as a parameter instead of using
+     replacement placeholders as in the regular bootstrapping.
+   - Fixed lint errors.
+ */
+const init = function(appInitResponse) {
+  window.Vaadin = window.Vaadin || {};
+  window.Vaadin.Flow = window.Vaadin.Flow || {};
+
+  var apps = {};
+  var widgetsets = {};
+
+  var log;
+  if (typeof window.console === undefined || !window.location.search.match(/[&?]debug(&|$)/)) {
+    /* If no console.log present, just use a no-op */
+    log = function() {};
+  } else if (typeof window.console.log === 'function') {
+    /* If it's a function, use it with apply */
+    log = function() {
+      window.console.log.apply(window.console, arguments);
+    };
+  } else {
+    /* In IE, its a native function for which apply is not defined, but it works
+     without a proper 'this' reference */
+    log = window.console.log;
+  }
+
+  var isInitializedInDom = function(appId) {
+    var appDiv = document.getElementById(appId);
+    if (!appDiv) {
+      return false;
+    }
+    for (var i = 0; i < appDiv.childElementCount; i++) {
+      var className = appDiv.childNodes[i].className;
+      /* If the app div contains a child with the class
+      'v-app-loading' we have only received the HTML
+      but not yet started the widget set
+      (UIConnector removes the v-app-loading div). */
+      if (className && className.indexOf('v-app-loading') != -1) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  /*
+   * Needed for Testbench compatibility, but prevents any Vaadin 7 app from
+   * bootstrapping unless the legacy vaadinBootstrap.js file is loaded before
+   * this script.
+   */
+  window.Vaadin = window.Vaadin || {};
+  window.Vaadin.Flow = window.Vaadin.Flow || {};
+
+  if (!window.Vaadin.Flow.clients) {
+    window.Vaadin.Flow.clients = {};
+
+    window.Vaadin.Flow.initApplication = function(appId, config) {
+      var testbenchId = appId.replace(/-\d+$/, '');
+
+      if (apps[appId]) {
+        if (window.Vaadin
+            && window.Vaadin.Flow
+            && window.Vaadin.Flow.clients
+            && window.Vaadin.Flow.clients[testbenchId]
+            && window.Vaadin.Flow.clients[testbenchId].initializing) {
+          throw new Error('Application ' + appId + ' is already being initialized');
+        }
+        if (isInitializedInDom(appId)) {
+          throw new Error('Application ' + appId + ' already initialized');
+        }
+      }
+
+      log('init application', appId, config);
+
+      window.Vaadin.Flow.clients[testbenchId] = {
+        isActive: function() {
+          return true;
+        },
+        initializing: true,
+        productionMode: mode
+      };
+
+      var getConfig = function(name) {
+        var value = config[name];
+        return value;
+      };
+
+      /* Export public data */
+      var app = {
+        getConfig: getConfig
+      };
+      apps[appId] = app;
+
+      if (!window.name) {
+        window.name = appId + '-' + Math.random();
+      }
+
+      var widgetset = 'client';
+      widgetsets[widgetset] = {
+        pendingApps: []
+      };
+      if (widgetsets[widgetset].callback) {
+        log('Starting from bootstrap', appId);
+        widgetsets[widgetset].callback(appId);
+      } else {
+        log('Setting pending startup', appId);
+        widgetsets[widgetset].pendingApps.push(appId);
+      }
+
+      return app;
+    };
+    window.Vaadin.Flow.getAppIds = function() {
+      var ids = [];
+      for (var id in apps) {
+        if (apps.hasOwnProperty(id)) {
+          ids.push(id);
+        }
+      }
+      return ids;
+    };
+    window.Vaadin.Flow.getApp = function(appId) {
+      return apps[appId];
+    };
+    window.Vaadin.Flow.registerWidgetset = function(widgetset, callback) {
+      log('Widgetset registered', widgetset);
+      var ws = widgetsets[widgetset];
+      if (ws && ws.pendingApps) {
+        ws.callback = callback;
+        for (var i = 0; i < ws.pendingApps.length; i++) {
+          var appId = ws.pendingApps[i];
+          log('Starting from register widgetset', appId);
+          callback(appId);
+        }
+        ws.pendingApps = null;
+      }
+    };
+    window.Vaadin.Flow.getBrowserDetailsParameters = function() {
+      var params = {};
+
+      /* Screen height and width */
+      params['v-sh'] = window.screen.height;
+      params['v-sw'] = window.screen.width;
+      /* Browser window dimensions */
+      params['v-wh'] = window.innerHeight;
+      params['v-ww'] = window.innerWidth;
+      /* Body element dimensions */
+      params['v-bh'] = document.body.clientHeight;
+      params['v-bw'] = document.body.clientWidth;
+
+      /* Current time */
+      var date = new Date();
+      params['v-curdate'] = date.getTime();
+
+      /* Current timezone offset (including DST shift) */
+      var tzo1 = date.getTimezoneOffset();
+
+      /* Compare the current tz offset with the first offset from the end
+         of the year that differs --- if less that, we are in DST, otherwise
+         we are in normal time */
+      var dstDiff = 0;
+      var rawTzo = tzo1;
+      for (var m = 12; m > 0; m--) {
+        date.setUTCMonth(m);
+        var tzo2 = date.getTimezoneOffset();
+        if (tzo1 != tzo2) {
+          dstDiff = (tzo1 > tzo2 ? tzo1 - tzo2 : tzo2 - tzo1);
+          rawTzo = (tzo1 > tzo2 ? tzo1 : tzo2);
+          break;
+        }
+      }
+
+      /* Time zone offset */
+      params['v-tzo'] = tzo1;
+
+      /* DST difference */
+      params['v-dstd'] = dstDiff;
+
+      /* Time zone offset without DST */
+      params['v-rtzo'] = rawTzo;
+
+      /* DST in effect? */
+      params['v-dston'] = (tzo1 != rawTzo);
+
+      /* Time zone id (if available) */
+      try {
+        params['v-tzid'] = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      } catch (err) {
+        params['v-tzid'] = '';
+      }
+
+      /* Window name */
+      if (window.name) {
+        params['v-wn'] = window.name;
+      }
+
+      /* Detect touch device support */
+      var supportsTouch = false;
+      try {
+        document.createEvent('TouchEvent');
+        supportsTouch = true;
+      } catch (e) {
+        /* Chrome and IE10 touch detection */
+        supportsTouch = 'ontouchstart' in window
+          || (typeof navigator.msMaxTouchPoints !== 'undefined');
+      }
+      params['v-td'] = supportsTouch;
+
+      /* Device Pixel Ratio */
+      params['v-pr'] = window.devicePixelRatio;
+
+      /* Stringify each value (they are parsed on the server side) */
+      Object.keys(params).forEach(function(key) {
+        var value = params[key];
+        if (typeof value !== 'undefined') {
+          params[key] = value.toString();
+        }
+      });
+      return params;
+    };
+  }
+
+  log('Flow bootstrap loaded');
+  if (appInitResponse.appConfig.productionMode && typeof window.__gwtStatsEvent != 'function') {
+    window.Vaadin.Flow.gwtStatsEvents = [];
+    window.__gwtStatsEvent = function(event) {
+      window.Vaadin.Flow.gwtStatsEvents.push(event);
+      return true;
+    };
+  }
+  var config = appInitResponse.appConfig;
+  var mode = appInitResponse.appConfig.productionMode;
+  window.Vaadin.Flow.initApplication(config.appId, config);
+};
+
+export {init};
+

--- a/flow-client/src/main/resources/META-INF/resources/frontend/FlowClient.d.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/FlowClient.d.ts
@@ -1,0 +1,1 @@
+export const init: () => void;

--- a/flow-client/src/main/resources/META-INF/resources/frontend/flow-bootstrap.js
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/flow-bootstrap.js
@@ -1,4 +1,0 @@
-
-// Intentionally empty for now.
-// Will have the content of flow BootstrapHandler.js
-(function() {})();

--- a/flow-client/src/test/frontend/FlowTests.ts
+++ b/flow-client/src/test/frontend/FlowTests.ts
@@ -1,21 +1,76 @@
-const { suite, test } = intern.getInterface("tdd");
+const { suite, test, beforeEach, afterEach } = intern.getInterface("tdd");
 const { assert } = intern.getPlugin("chai");
 
+// API to test
 import { Flow } from "../../main/resources/META-INF/resources/frontend/Flow";
+// Intern does not serve webpack chunks, adding deps here in order to
+// produce one chunk, because dynamic imports in Flow.ts  will not work.
+import "../../main/resources/META-INF/resources/frontend/FlowBootstrap";
+import "../../main/resources/META-INF/resources/frontend/FlowClient";
+// Mock XMLHttpRequest so as we don't need flow-server running for tests.
+import mock from 'xhr-mock';
 
 suite("Flow", () => {
 
-    test("should accept a configuration object", () => {
-        const flow = new Flow({imports: () => {}});
-        assert.isDefined(flow.config);
-        assert.isDefined(flow.config.imports);
+  beforeEach(() => {
+    mock.setup();
+    mock.get('VAADIN/?v-r=init', (req, res) => {
+      assert.equal('GET', req.method());
+      return res
+        .status(200)
+        .header("content-type","application/json")
+        .body(`
+        {
+          "appConfig": {
+            "heartbeatInterval" : 300,
+            "contextRootUrl" : "../",
+            "debug" : true,
+            "v-uiId" : 0,
+            "serviceUrl" : "//localhost:8080/flow/",
+            "webComponentMode" : false,
+            "productionMode": false,
+            "appId": "foobar-1111111",
+            "uidl": {
+              "syncId": 0,
+              "clientId": 0,
+              "changes": [],
+              "timings": [],
+              "Vaadin-Security-Key": "119a6005-e663-4a4c-a882-bbfa8bd0c304",
+              "Vaadin-Push-ID": "4b915ffb-4e0a-484c-9995-09500fe9fa3a"
+            }
+          }
+        }
+      `);
     });
+  });
 
-    test("should have the start() method in the API", () => {
-        return new Flow().start();
-    });
+  afterEach(() => {
+    mock.teardown();
+  });
 
-    test("should have the navigate() method in the API", () => {
-        return new Flow().navigate();
-    });
+  test("should accept a configuration object", () => {
+    const flow = new Flow({imports: () => {}});
+    assert.isDefined(flow.config);
+    assert.isDefined(flow.config.imports);
+  });
+
+  test("should have the start() method in the API", () => {
+    return new Flow()
+      .start()
+      .then(response => {
+        assert.isDefined(response);
+        assert.isDefined(response.appConfig);
+        const $wnd = window as any;
+        // Check that bootstrap was initialized
+        assert.isDefined($wnd.Vaadin.Flow.initApplication);
+        assert.isDefined($wnd.Vaadin.Flow.registerWidgetset);
+        // Check that flowClient was initialized
+        assert.isDefined($wnd.Vaadin.Flow.resolveUri);
+        assert.isFalse($wnd.Vaadin.Flow.clients.foobar.isActive());
+      });
+  });
+
+  test("should have the navigate() method in the API", () => {
+    return new Flow().navigate();
+  });
 });


### PR DESCRIPTION
This fixes #6133 

- Adding the `FlowBootstrap.js` file that is distributed in `flow-client.jar`. It is based in `BootstrapHandler.js` but with small modifications to be an ES module.
- Copying the flow-client file as `FlowClient.js` to be distributed in the client jar file. It needs to be wrapped in a function so as it can be lazily executed.
- Adding definition files for `FlowBootstrap.js` and `FlowClient.js` files so as they can be used from typescript.
- Implemented the `Flow.start()` method with the following  steps
   -  Send a XHR request to flow `JavaScriptBoostrapHandler` in order to get create session 
      and get the application configuration
   - Load `FlowBootstrap.js` chunk and initialize it with the response from the previous step
   - Load `FlowClient.js` chunk and run it.
- Added tasks to maven and npm to correctly build the Flow client library and test it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6194)
<!-- Reviewable:end -->
