### PR TITLE
Request only hash from dev-server

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/NpmTemplateParser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/NpmTemplateParser.java
@@ -171,9 +171,11 @@ public class NpmTemplateParser implements TemplateParser {
 
         try {
             lock.lock();
+            // - always load if jsonStats is null.
+            // - always load a new stats if the hash has changed, but we do not have a bundle.
+            // - else never load again when we have a bundle as it never changes.
             if (jsonStats == null || !jsonStats.get("hash").asString()
                     .equals(hash)) {
-                // Only load stats for null jsonStats or if we don't use bundle files.
                 if(jsonStats == null || !usesBundleFile(config)) {
                     String content = FrontendUtils.getStatsContent(service);
                     if (content != null) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/NpmTemplateParser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/NpmTemplateParser.java
@@ -165,8 +165,9 @@ public class NpmTemplateParser implements TemplateParser {
 
     private String getSourcesFromStats(VaadinService service, String url)
             throws IOException {
-        String hash = FrontendUtils.getStatsHash();
-        if(jsonStats == null || !jsonStats.get("hash").asString().equals(hash)) {
+        String hash = FrontendUtils.getStatsHash(service);
+        if (jsonStats == null || !jsonStats.get("hash").asString()
+                .equals(hash)) {
             String content = FrontendUtils.getStatsContent(service);
             if (content != null) {
                 updateCache(url, content);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,14 +27,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Scanner;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.vaadin.flow.component.polymertemplate.BundleParser;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.DevModeHandler;
@@ -377,10 +374,11 @@ public class FrontendUtils {
     }
 
     /**
-     * Get the latest has for the stats file. In development mode it is taken
-     * from the webpack-dev-server, while in production mode and disabled dev
-     * server mode we read it from the stats.json file.
-     * json</code> file produced by webpack.
+     * Get the latest has for the stats file in development mode. This is
+     * requested from the webpack-dev-server.
+     * <p>
+     * In production mode and disabled dev server mode an empty string is
+     * returned.
      *
      * @param service
      *         the vaadin service.
@@ -396,25 +394,6 @@ public class FrontendUtils {
                     handler.prepareConnection("/stats.hash", "GET").getInputStream()).replaceAll("\"", "");
         }
 
-        String stats = service.getDeploymentConfiguration()
-                .getStringProperty(SERVLET_PARAMETER_STATISTICS_JSON,
-                        VAADIN_SERVLET_RESOURCES + STATISTICS_JSON_DEFAULT)
-                // Remove absolute
-                .replaceFirst("^/", "");
-
-        URL statsURL = service.getClassLoader().getResource(stats);
-
-        if(statsURL != null) {
-            File statsFile = new File(statsURL.getFile());
-            try (Scanner scanner = new Scanner(statsFile, StandardCharsets.UTF_8.name())) {
-                while (scanner.hasNextLine()) {
-                    String line = scanner.nextLine();
-                    if (line.trim().startsWith("\"hash\"")) {
-                        return BundleParser.getHashFromStatistics(line);
-                    }
-                }
-            }
-        }
         return "";
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -380,7 +380,10 @@ public class FrontendUtils {
      * Get the latest has for the stats file. In development mode it is taken
      * from the webpack-dev-server, while in production mode and disabled dev
      * server mode we read it from the stats.json file.
+     * json</code> file produced by webpack.
      *
+     * @param service
+     *         the vaadin service.
      * @return hash string for the stats.json file, empty string if none found
      * @throws IOException
      *         if an I/O error occurs while creating the input stream.
@@ -402,11 +405,13 @@ public class FrontendUtils {
         URL statsURL = service.getClassLoader().getResource(stats);
 
         if(statsURL != null) {
-            Scanner scanner = new Scanner(new File(statsURL.getFile()));
-            while (scanner.hasNextLine()) {
-                String line = scanner.nextLine();
-                if (line.trim().startsWith("\"hash\"")) {
-                    return BundleParser.getHashFromStatistics(line);
+            File statsFile = new File(statsURL.getFile());
+            try (Scanner scanner = new Scanner(statsFile, StandardCharsets.UTF_8)) {
+                while (scanner.hasNextLine()) {
+                    String line = scanner.nextLine();
+                    if (line.trim().startsWith("\"hash\"")) {
+                        return BundleParser.getHashFromStatistics(line);
+                    }
                 }
             }
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -381,7 +381,7 @@ public class FrontendUtils {
      * returned.
      *
      * @param service
-     *         the vaadin service.
+     *         the Vaadin service.
      * @return hash string for the stats.json file, empty string if none found
      * @throws IOException
      *         if an I/O error occurs while creating the input stream.

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -406,7 +406,7 @@ public class FrontendUtils {
 
         if(statsURL != null) {
             File statsFile = new File(statsURL.getFile());
-            try (Scanner scanner = new Scanner(statsFile, StandardCharsets.UTF_8)) {
+            try (Scanner scanner = new Scanner(statsFile, StandardCharsets.UTF_8.name())) {
                 while (scanner.hasNextLine()) {
                     String line = scanner.nextLine();
                     if (line.trim().startsWith("\"hash\"")) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -397,12 +398,16 @@ public class FrontendUtils {
                         VAADIN_SERVLET_RESOURCES + STATISTICS_JSON_DEFAULT)
                 // Remove absolute
                 .replaceFirst("^/", "");
-        Scanner scanner = new Scanner(new File(service.getClassLoader()
-                .getResource(stats).getFile()));
-        while (scanner.hasNextLine()) {
-            String line = scanner.nextLine();
-            if(line.trim().startsWith("\"hash\"")) {
-                return BundleParser.getHashFromStatistics(line);
+
+        URL statsURL = service.getClassLoader().getResource(stats);
+
+        if(statsURL != null) {
+            Scanner scanner = new Scanner(new File(statsURL.getFile()));
+            while (scanner.hasNextLine()) {
+                String line = scanner.nextLine();
+                if (line.trim().startsWith("\"hash\"")) {
+                    return BundleParser.getHashFromStatistics(line);
+                }
             }
         }
         return "";

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -373,6 +373,11 @@ public class FrontendUtils {
         return content != null ? streamToString(content) : null;
     }
 
+    public static String getStatsHash() throws IOException{
+        DevModeHandler handler = DevModeHandler.getDevModeHandler();
+        return streamToString(handler.prepareConnection("/stats.hash", "GET").getInputStream()).replaceAll("\"","");
+    }
+
     private static InputStream getStatsFromWebpack() throws IOException {
         DevModeHandler handler = DevModeHandler.getDevModeHandler();
         return handler.prepareConnection("/stats.json", "GET").getInputStream();

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -65,6 +65,9 @@ module.exports = {
       app.get(`/stats.json`, function(req, res) {
         res.json(stats.toJson());
       });
+      app.get(`/stats.hash`, function(req, res) {
+        res.json(stats.toJson().hash.toString());
+      });
       app.get(`/stop`, function(req, res) {
         // eslint-disable-next-line no-console
         console.log("Stopped 'webpack-dev-server'");


### PR DESCRIPTION
In dev mode when parsing the stats file for
template sources only request the latest
stats hash from dev-server.

This instead of requesting the whole
stats file for checking the hash before choosing
if the cache should be updated.

Fixes #6191

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6197)
<!-- Reviewable:end -->
