### PR TITLE
CCDM: connect client and server UIs from javascript

### DIFF
--- a/flow-client/.eslintrc.js
+++ b/flow-client/.eslintrc.js
@@ -13,5 +13,40 @@ module.exports = {
         "sourceType": "module"
     },
     "rules": {
-    }
+    },
+    "overrides": [{
+        "files": ["FlowClient.js"],
+
+        "rules": {
+            "brace-style": "off",
+            "camelcase": "off",
+            "comma-spacing": "off",
+            "curly": "off",
+            "indent": "off",
+            "key-spacing": "off",
+            "keyword-spacing": "off",
+            "max-len": "off",
+            "no-caller": "off",
+            "no-constant-condition": "off",
+            "no-control-regex": "off",
+            "no-debugger": "off",
+            "no-empty": "off",
+            "no-ex-assign": "off",
+            "no-extra-semi": "off",
+            "no-func-assign": "off",
+            "no-invalid-this": "off",
+            "no-redeclare": "off",
+            "no-self-assign": "off",
+            "no-throw-literal": "off",
+            "no-unused-vars": "off",
+            "quotes": "off",
+            "semi": "off",
+            "semi-spacing": "off",
+            "space-before-blocks": "off",
+            "space-before-function-paren": "off",
+            "space-infix-ops": "off",
+            "no-trailing-spaces": "off",
+            "func-call-spacing": "off"
+        }
+    }]
 };

--- a/flow-client/package.json
+++ b/flow-client/package.json
@@ -9,14 +9,14 @@
     "url": "https://github.com/vaadin/flow/issues"
   },
   "scripts": {
-    "lint": "eslint 'src/main/resources/META-INF/resources/frontend/FlowBootstrap.js' && tslint 'src/main/resources/META-INF/resources/frontend/**/*.ts'",
+    "lint": "eslint 'src/main/resources/META-INF/resources/frontend/*.js' && tslint 'src/main/resources/META-INF/resources/frontend/*.ts'",
     "_cp_to_src": "ncp target/classes/META-INF/resources/VAADIN/static/client/client-*.cache.js src/main/resources/META-INF/resources/frontend/FlowClient.js",
     "_wrap_fnc": "replace-in-files --regex '(.+[\\s\\S]*)' --replacement 'const init = function(){\\n$1\\n};\\nexport {init};\\n' src/main/resources/META-INF/resources/frontend/FlowClient.js",
     "_cp_to_tgt": "ncp src/main/resources/META-INF/resources/frontend/FlowClient.js target/classes/META-INF/resources/frontend/FlowClient.js",
     "client": "npm run _cp_to_src && npm run _wrap_fnc && npm run _cp_to_tgt",
     "webpack": "webpack --config=webpack.tests.config.js",
     "build": "npm run client && tsc",
-    "compile": "npm run lint && npm run build",
+    "compile": "npm run build && npm run lint",
     "test": "npm run build && npm run webpack && intern",
     "debug": "npm run build && npm run webpack && intern serveOnly"
   },

--- a/flow-client/src/main/java/com/vaadin/client/communication/XhrConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/XhrConnection.java
@@ -184,17 +184,13 @@ public class XhrConnection {
      * @return The URI to use for server messages.
      */
     protected String getUri() {
-        String uri = registry.getApplicationConfiguration().getServiceUrl();
-        uri = SharedUtil.addGetParameter(uri,
-                ApplicationConstants.REQUEST_TYPE_PARAMETER,
-                ApplicationConstants.REQUEST_TYPE_UIDL);
-
-        uri = SharedUtil.addGetParameter(uri,
-                ApplicationConstants.UI_ID_PARAMETER,
-                registry.getApplicationConfiguration().getUIId());
-
-        return uri;
-
+        return SharedUtil.addGetParameter(
+                    SharedUtil.addGetParameter(
+                        registry.getApplicationConfiguration().getServiceUrl(),
+                        ApplicationConstants.REQUEST_TYPE_PARAMETER,
+                        ApplicationConstants.REQUEST_TYPE_UIDL),
+                    ApplicationConstants.UI_ID_PARAMETER,
+                    registry.getApplicationConfiguration().getUIId());
     }
 
     private static native boolean resendRequest(XMLHttpRequest xhr)

--- a/flow-client/src/main/java/com/vaadin/client/communication/XhrConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/XhrConnection.java
@@ -184,6 +184,11 @@ public class XhrConnection {
      * @return The URI to use for server messages.
      */
     protected String getUri() {
+        // This code is in one line because an odd bug in GWT
+        // compiler inlining this piece of code and not declaring
+        // the variable in JS scope, breaking strict mode which is
+        // needed for ES6 imports.
+        // See https://github.com/vaadin/flow/pull/6227
         return SharedUtil.addGetParameter(
                     SharedUtil.addGetParameter(
                         registry.getApplicationConfiguration().getServiceUrl(),

--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
@@ -335,6 +335,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
     
                         var props = Object.getOwnPropertyNames(changedProps);
                         var items = "items.";
+                        var i;
                         for(i=0; i<props.length; i++){
                             // There should be a property which starts with "items."
                             // and the next token is the index of changed item

--- a/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
@@ -12,6 +12,10 @@ interface AppInitResponse {
     appConfig: AppConfig;
 }
 
+export interface NavigationParameters {
+    path: string;
+}
+
 /**
  * Client API for flow UI operations.
  */
@@ -53,9 +57,9 @@ export class Flow {
     /**
      * Go to a route defined in server.
      */
-    async navigate(path : string): Promise<HTMLElement> {
+    async navigate(params : NavigationParameters): Promise<HTMLElement> {
         await this.start();
-        return this.getFlowElement(path);
+        return this.getFlowElement(params.path);
     }
 
     private async getFlowElement(routePath : string): Promise<HTMLElement> {

--- a/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
@@ -53,8 +53,32 @@ export class Flow {
     /**
      * Go to a route defined in server.
      */
-    navigate(): Promise<void> {
-        return Promise.resolve();
+    async navigate(path : string): Promise<HTMLElement> {
+        await this.start();
+        return this.getFlowElement(path);
+    }
+
+    private async getFlowElement(routePath : string): Promise<HTMLElement> {
+        return new Promise(resolve => {
+            // we create any tag using the route as reference
+            const tag = 'flow-' + routePath.replace(/[^\w]+/g, "-").toLowerCase();
+
+            // flow use body for keep references
+            const flowRoot = document.body as any;
+            flowRoot.$ = flowRoot.$ || {counter: 0};
+
+            // Create the wrapper element with an unique id
+            const id  = `${tag}-${flowRoot.$.counter ++}`;
+            const element = flowRoot.$[id] = document.createElement(tag);
+            element.id = id;
+            window.console.log("Created new element for a flow view: " + id);
+
+            // The callback run from server side once the view is ready
+            (element as any).serverConnected = () => resolve(element);
+
+            // Call server side to navigate to the given route
+            flowRoot.$server.connectClient(tag, id, routePath);
+        });
     }
 
     private async initFlowClient(clientMod: any): Promise<void> {

--- a/flow-client/src/test/frontend/FlowTests.ts
+++ b/flow-client/src/test/frontend/FlowTests.ts
@@ -76,7 +76,7 @@ suite("Flow", () => {
 
     mockInitResponse();
     return new Flow()
-      .navigate("Foo/Bar.baz")
+      .navigate({path: "Foo/Bar.baz"})
       .then(() => {
         // Check that start() was called
         assert.isDefined((window as any).Vaadin.Flow.resolveUri);

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
@@ -25,10 +25,13 @@ import java.util.function.Function;
 
 import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HtmlContainer;
 import com.vaadin.flow.component.PushConfiguration;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.UsageStatistics;
+import com.vaadin.flow.internal.nodefeature.NodeProperties;
 import com.vaadin.flow.router.HasUrlParameter;
 import com.vaadin.flow.router.QueryParameters;
 import com.vaadin.flow.router.Router;
@@ -82,17 +85,44 @@ public class JavaScriptBootstrapHandler extends BootstrapHandler {
      * Custom UI for {@link JavaScriptBootstrapHandler}.
      */
     public static class JavaScriptBootstrapUI extends UI {
-        public static final String NO_NAVIGATION = "Navigation is not implemented yet";
+        public static final String NO_NAVIGATION =
+                "Classic flow navigation is not supported for clien-side projects";
 
         /**
-         * Connect a client side with server side UI.
+         * Connect a client with the server side UI.
          *
-         * @param containerId
-         *            client side id of the element
+         * @param clientElementTag
+         *            client side element tag
+         * @param clientElementId
+         *            client side element id
+         * @param flowRoute
+         *            flow route that should be attached to the client element
          */
         @ClientCallable
-        public void connectClient(String containerId) {
-            // NOT implemented yet
+        public void connectClient(String clientElementTag, String clientElementId, String flowRoute) {
+
+            // Get the flow view that the user wants to navigate to.
+            final Element viewElement = getViewForRoute(flowRoute).getElement();
+
+            // Create flow reference for the client outlet element
+            final Element wrapperElement = new Element(clientElementTag);
+            wrapperElement.appendChild(viewElement);
+
+            // Connect server with client
+            getElement().getStateProvider().appendVirtualChild(
+                    getElement().getNode(), wrapperElement,
+                    NodeProperties.INJECT_BY_ID, clientElementId);
+
+            // Inform the client, that everything went fine.
+            wrapperElement.executeJs("$0.serverConnected()");
+        }
+
+        private Component getViewForRoute(String route) {
+            // Create a temporary view until navigation is implemented
+            HtmlContainer view = new HtmlContainer("div");
+            view.setText(String.format(
+                    "Navigation not implemented yet. cannot show '%s'", route));
+            return view;
         }
 
         @Override

--- a/flow-server/src/test/java/com/vaadin/flow/dom/BasicElementStateProviderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/BasicElementStateProviderTest.java
@@ -81,8 +81,7 @@ public class BasicElementStateProviderTest {
 
     @Test
     public void visitOnlyNode_hasDescendants_nodeVisitedAndNoDescendantsVisited() {
-        TestNodeVisitor visitor = new TestNodeVisitor();
-        visitor.visitDescendants = false;
+        TestNodeVisitor visitor = new TestNodeVisitor(false);
 
         Map<Node<?>, ElementType> map = new HashMap<>();
 
@@ -90,17 +89,16 @@ public class BasicElementStateProviderTest {
 
         BasicElementStateProvider.get().visit(subject.getNode(), visitor);
 
-        Assert.assertEquals(1, visitor.visited.size());
+        Assert.assertEquals(1, visitor.getVisited().size());
         Assert.assertEquals(subject,
-                visitor.visited.keySet().iterator().next());
+                visitor.getVisited().keySet().iterator().next());
         Assert.assertEquals(ElementType.REGULAR,
-                visitor.visited.values().iterator().next());
+                visitor.getVisited().values().iterator().next());
     }
 
     @Test
     public void visitOnlyNode_hasDescendants_nodeAndDescendatnsAreVisited() {
-        TestNodeVisitor visitor = new TestNodeVisitor();
-        visitor.visitDescendants = true;
+        TestNodeVisitor visitor = new TestNodeVisitor(true);
 
         Map<Node<?>, ElementType> map = new HashMap<>();
 
@@ -112,7 +110,7 @@ public class BasicElementStateProviderTest {
 
         Assert.assertEquals(
                 "The collected descendants doesn't match expected descendatns",
-                map, visitor.visited);
+                map, visitor.getVisited());
     }
 
     @Test
@@ -121,7 +119,7 @@ public class BasicElementStateProviderTest {
 
         assertNoChildFeatures(element);
 
-        element.accept(new TestNodeVisitor());
+        element.accept(new TestNodeVisitor(true));
 
         assertNoChildFeatures(element);
     }

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ShadowRootTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ShadowRootTest.java
@@ -290,8 +290,7 @@ public class ShadowRootTest extends AbstractNodeTest {
 
     @Test
     public void visitOnlyNode_hasDescendants_nodeVisitedAndNoDescendantsVisited() {
-        TestNodeVisitor visitor = new TestNodeVisitor();
-        visitor.visitDescendants = false;
+        TestNodeVisitor visitor = new TestNodeVisitor(false);
 
         Map<Node<?>, ElementType> map = new HashMap<>();
 
@@ -299,16 +298,15 @@ public class ShadowRootTest extends AbstractNodeTest {
 
         ShadowRootStateProvider.get().visit(subject.getNode(), visitor);
 
-        Assert.assertEquals(1, visitor.visited.size());
+        Assert.assertEquals(1, visitor.getVisited().size());
         Assert.assertEquals(subject,
-                visitor.visited.keySet().iterator().next());
-        Assert.assertEquals(null, visitor.visited.values().iterator().next());
+                visitor.getVisited().keySet().iterator().next());
+        Assert.assertEquals(null, visitor.getVisited().values().iterator().next());
     }
 
     @Test
     public void visitOnlyNode_hasDescendants_nodeAndDescendatnsAreVisited() {
-        TestNodeVisitor visitor = new TestNodeVisitor();
-        visitor.visitDescendants = true;
+        TestNodeVisitor visitor = new TestNodeVisitor(true);
 
         Map<Node<?>, ElementType> map = new HashMap<>();
 
@@ -320,7 +318,7 @@ public class ShadowRootTest extends AbstractNodeTest {
 
         Assert.assertEquals(
                 "The collected descendants doesn't match expected descendatns",
-                map, visitor.visited);
+                map, visitor.getVisited());
     }
 
     private ShadowRoot createHierarchy(Map<Node<?>, ElementType> map) {

--- a/flow-server/src/test/java/com/vaadin/flow/dom/TestNodeVisitor.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/TestNodeVisitor.java
@@ -18,10 +18,18 @@ package com.vaadin.flow.dom;
 import java.util.HashMap;
 import java.util.Map;
 
-class TestNodeVisitor implements NodeVisitor {
+public class TestNodeVisitor implements NodeVisitor {
 
-    Map<Node<?>, ElementType> visited = new HashMap<>();
-    boolean visitDescendants = true;
+    private final Map<Node<?>, ElementType> visited = new HashMap<>();
+    private final boolean visitDescendants;
+
+    public TestNodeVisitor(boolean visitDescendants) {
+        this.visitDescendants = visitDescendants;
+    }
+
+    public Map<Node<?>, ElementType> getVisited() {
+        return visited;
+    }
 
     @Override
     public boolean visit(ElementType type, Element element) {


### PR DESCRIPTION
Fixes part of #6133.

- This Makes possible to append flow UI to browser without requiring an exported web component.
- After flow-client configures the bootstrap, is it possible to attach UI to any slot in the browser.
- This PR does not resolve client side navigation because server side is not implemented yet (#6221), instead it attaches a static view to the outlet from server
- Fixes a couple of errors in the generated client javascript when importing the file as an ES6 module:
  - There was a JSNI block with non declared variable in a for statement
  - There was a weird function where a variable was not declared when the method was inlined by gwt compiler
- Adding `eslint` rules to early detect whether the produced javascript has declaration errors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6210)
<!-- Reviewable:end -->
