### PR TITLE
CCDM: Add ITs for Flow client API

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -230,6 +230,10 @@ public abstract class NodeUpdater implements FallibleCommand {
                 "4.2.1") || added;
         added = addDependency(packageJson, DEV_DEPENDENCIES, "raw-loader",
                 "3.0.0") || added;
+        added = addDependency(packageJson, DEV_DEPENDENCIES, "typescript",
+                "3.5.3") || added;
+        added = addDependency(packageJson, DEV_DEPENDENCIES, "awesome-typescript-loader",
+                "5.2.1") || added;
         return added;
     }
 

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -55,6 +55,7 @@ module.exports = {
   },
 
   resolve: {
+    extensions: ['.ts', '.js'],
     alias: {
       Frontend: frontendFolder
     }
@@ -80,6 +81,10 @@ module.exports = {
       { // Files that Babel has to transpile
         test: /\.js$/,
         use: [BabelMultiTargetPlugin.loader()]
+      },
+      {
+        test: /\.ts$/,
+        loader: 'awesome-typescript-loader'
       },
       {
         test: /\.css$/i,
@@ -148,3 +153,4 @@ module.exports = {
     }]),
   ].filter(Boolean)
 };
+

--- a/flow-tests/test-ccdm/frontend/index.html
+++ b/flow-tests/test-ccdm/frontend/index.html
@@ -15,9 +15,12 @@
      in the browsers that do not support these APIs natively (e.g. IE11) -->
 <script src="./VAADIN/build/webcomponentsjs/webcomponents-loader.js"></script>
 
-<div id="content">index.html content</div>
-<button onclick="loadContent()">Load content from other bundle</button>
-<div id="contentFromOtherBundle"></div>
+<button id="button1">Load content from other bundle</button>
+<button id="button2">Load flow</button>
+<button id="button3">Navigate flow</button>
+
+<div id="div0">index.html content</div>
+
 <!-- index.ts is included here automatically (either by the dev server or during the build) -->
 </body>
 </html>

--- a/flow-tests/test-ccdm/frontend/index.js
+++ b/flow-tests/test-ccdm/frontend/index.js
@@ -1,6 +1,33 @@
-window.loadContent = async function() {
+import { Flow } from '@vaadin/flow-frontend/Flow';
+
+document.getElementById("button1").addEventListener('click', async e => {
     await import('./another-bundle.js');
-    const label = document.createElement('label');
-    label.textContent = window.anotherBundle;
-    document.getElementById('contentFromOtherBundle').appendChild(label);
-}
+    const div = document.createElement('div');
+    div.id = 'div1';
+    div.textContent = window.anotherBundle;
+    document.body.appendChild(div);
+});
+
+const flow = new Flow({
+    imports: () => import('../target/frontend/generated-flow-imports')
+});
+
+document.getElementById("button2").addEventListener('click', async e => {
+    await flow.start();
+    const bootstrapLoaded = !!window.Vaadin.Flow.initApplication;
+    const clientLoaded = !!window.Vaadin.Flow.resolveUri;
+    const remoteMethod = !!document.body.$server.connectClient;
+    const div = document.createElement('div');
+    div.id = 'div2';
+    div.textContent = bootstrapLoaded + " " + clientLoaded + " " + remoteMethod;
+    document.body.appendChild(div);
+});
+
+document.getElementById("button3").addEventListener('click', async e => {
+    const view = await flow.navigate({path: 'my/foo view'});
+    const div = document.createElement('div');
+    div.id = 'div3';
+    div.appendChild(view);
+    document.body.appendChild(div);
+});
+

--- a/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/ClientIndexHandlerIT.java
+++ b/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/ClientIndexHandlerIT.java
@@ -33,8 +33,8 @@ public class ClientIndexHandlerIT extends ChromeBrowserTest {
     @Test
     public void indexHtmlRequestHandler_openRootURL_shouldResponseIndexHtml() {
         openTestUrl("/");
-        waitForElementPresent(By.tagName("div"));
-        String content = findElement(By.id("content")).getText();
+        waitForElementPresent(By.id("div0"));
+        String content = findElement(By.id("div0")).getText();
         Assert.assertEquals("index.html content", content);
     }
 
@@ -66,16 +66,16 @@ public class ClientIndexHandlerIT extends ChromeBrowserTest {
     @Test
     public void indexHtmlRequestHandler_openRandomRoute_shouldResponseIndexHtml() {
         openTestUrl("/abc");
-        waitForElementPresent(By.tagName("div"));
-        String content = findElement(By.id("content")).getText();
+        waitForElementPresent(By.id("div0"));
+        String content = findElement(By.id("div0")).getText();
         Assert.assertEquals("index.html content", content);
     }
 
     @Test
     public void indexHtmlRequestHandler_openURLHasParameterWithExtension_shouldResponseIndexHtml() {
         openTestUrl("/someroute?myparam=picture.png");
-        waitForElementPresent(By.tagName("div"));
-        String content = findElement(By.id("content")).getText();
+        waitForElementPresent(By.id("div0"));
+        String content = findElement(By.id("div0")).getText();
         Assert.assertEquals("index.html content", content);
     }
 
@@ -89,16 +89,19 @@ public class ClientIndexHandlerIT extends ChromeBrowserTest {
     @Test
     public void indexHtmlRequestHandler_importDynamically_shouldLoadBundleCorrectly() {
         openTestUrl("/");
-        findElement(By.tagName("button")).click();
-        WebElement contentFromJs = findElement(By.id("contentFromOtherBundle"));
-        Assert.assertEquals("Content from other bundle",
-                contentFromJs.getText());
+        waitForElementPresent(By.id("button1"));
+
+        findElement(By.id("button1")).click();
+        waitForElementPresent(By.id("div1"));
+
+        String content = findElement(By.id("div1")).getText();
+        Assert.assertEquals("Content from other bundle", content);
     }
 
     @Test
     public void indexHtmlRequestHandler_openRootURL_shouldAddBaseHref() {
         openTestUrl("/");
-        waitForElementPresent(By.tagName("div"));
+        waitForElementPresent(By.id("div0"));
         // In Selenium, getAttribute('href') won't return the exact value of
         // 'href'.
         // https://stackoverflow.com/questions/35494519/how-to-get-the-exact-text-of-href-attribute-of-tag-a
@@ -110,9 +113,35 @@ public class ClientIndexHandlerIT extends ChromeBrowserTest {
     @Test
     public void indexHtmlRequestHandler_openTwoSlashesURL_shouldAddBaseHrefCorrectly() {
         openTestUrl("/abc/xyz");
-        waitForElementPresent(By.tagName("div"));
+        waitForElementPresent(By.id("div0"));
         String outerHTML = findElement(By.tagName("head"))
                 .findElement(By.tagName("base")).getAttribute("outerHTML");
         Assert.assertTrue(outerHTML.contains("href=\"./..\""));
     }
+
+    @Test
+    public void should_startFlow() {
+        openTestUrl("/");
+        waitForElementPresent(By.id("button2"));
+
+        findElement(By.id("button2")).click();
+        waitForElementPresent(By.id("div2"));
+
+        String content = findElement(By.id("div2")).getText();
+        Assert.assertEquals("true true true", content);
+    }
+
+    @Test
+    public void should_connectFlowServerSide() {
+        openTestUrl("/");
+        waitForElementPresent(By.id("button3"));
+
+
+        findElement(By.id("button3")).click();
+        waitForElementPresent(By.id("div3"));
+
+        String content = findElement(By.id("div3")).getText();
+        Assert.assertTrue(content.length() > 0);
+    }
+
 }

--- a/flow-tests/test-ccdm/tsconfig.json
+++ b/flow-tests/test-ccdm/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "sourceMap": true,
+    "inlineSources": true,
+    "module": "esNext",
+    "target": "es2017",
+    "moduleResolution": "node",
+    "strict": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "experimentalDecorators": true
+  },
+  "include": [
+    "frontend/**/*.ts", "frontend/index.js"
+  ],
+  "exclude": []
+}


### PR DESCRIPTION
Fixes #6143

- Added couple of tests to the test-ccdm module that tests asyncronous bootstraping of flow from javascript and connection of client and server UI.
- Added support for typescript in webpack generated file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6215)
<!-- Reviewable:end -->
