### PR TITLE
CCDM: Flow.navigate must be executed in the flow ctx

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
@@ -57,7 +57,11 @@ export class Flow {
     /**
      * Go to a route defined in server.
      */
-    async navigate(params : NavigationParameters): Promise<HTMLElement> {
+    get navigate(): (params: NavigationParameters) => Promise<HTMLElement> {
+        return (params: NavigationParameters) => this.doFlowNavigation(params);
+    }
+
+    private async doFlowNavigation(params : NavigationParameters): Promise<HTMLElement> {
         await this.start();
         return this.getFlowElement(params.path);
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
@@ -202,6 +202,9 @@ public class JavaScriptBootstrapHandler extends BootstrapHandler {
 
         config.put(ApplicationConstants.SERVICE_URL, serviceUrl);
 
+        // Do not listen to pushState and routerLink events.
+        config.put(ApplicationConstants.APP_WC_MODE, true);
+
         // TODO(manolo) this comment is left intentionally because we
         // need to revise whether the info passed to client is valid
         // when initialising push. Right now ccdm is not doing

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandlerTest.java
@@ -33,6 +33,7 @@ import com.vaadin.flow.server.MockServletServiceSessionSetup.TestVaadinServletRe
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.communication.JavaScriptBootstrapHandler.JavaScriptBootstrapUI;
+import com.vaadin.flow.shared.ApplicationConstants;
 
 import elemental.json.Json;
 import elemental.json.JsonObject;
@@ -88,6 +89,7 @@ public class JavaScriptBootstrapHandlerTest {
         Assert.assertTrue(json.getObject("appConfig").hasKey("appId"));
         Assert.assertTrue(json.getObject("appConfig").getObject("uidl").hasKey("changes"));
         Assert.assertTrue(json.getObject("appConfig").getBoolean("debug"));
+        Assert.assertTrue(json.getObject("appConfig").getBoolean("webComponentMode"));
 
         Assert.assertEquals("./", json.getObject("appConfig").getString("contextRootUrl"));
         Assert.assertEquals("//localhost:8888/foo/", json.getObject("appConfig").getString("serviceUrl"));


### PR DESCRIPTION
Fixes part of #6219:

- Bind `navigate` method to it original flow context so as it 
  can be assigned to the `action` property in router
- Prevent `window` and `body` listening to `pushstate` and
  `click` events

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6232)
<!-- Reviewable:end -->
