### PR TITLE
vaadin/vaadin-grid-flow#687 Fix for ComponentRenderer enabled state setting

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/renderer/ComponentRenderer.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/renderer/ComponentRenderer.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.data.provider.ComponentDataGenerator;
 import com.vaadin.flow.data.provider.DataGenerator;
@@ -189,7 +190,8 @@ public class ComponentRenderer<COMPONENT extends Component, SOURCE>
         Element templateElement = rendering.getTemplateElement();
         owner.appendChild(templateElement);
 
-        Element container = new Element("div");
+        ContainerComponent containerComponent = new ContainerComponent();
+        Element container = containerComponent.getElement();
         owner.appendVirtualChild(container);
         rendering.setContainer(container);
         String templateInnerHtml;
@@ -219,6 +221,10 @@ public class ComponentRenderer<COMPONENT extends Component, SOURCE>
         }
 
         templateElement.setProperty("innerHTML", templateInnerHtml);
+    }
+
+    @Tag(Tag.DIV)
+    private static class ContainerComponent extends Component {
     }
 
     /**

--- a/flow-data/src/test/java/com/vaadin/flow/data/renderer/ComponentRendererTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/renderer/ComponentRendererTest.java
@@ -123,11 +123,12 @@ public class ComponentRendererTest {
         Element child = Element.get(stateNode);
         Assert.assertFalse("After attach child should be disabled",
                 child.isEnabled());
-        Assert.assertTrue(child.getComponent().isPresent());
+        Assert.assertTrue("The child should have a component", child.getComponent().isPresent());
         // Fetch the actual MyCheckbox component
         Component checkboxComponent = child.getChildren().findFirst().get()
                 .getComponent().get();
-        Assert.assertTrue(checkboxComponent instanceof MyCheckbox);
+        Assert.assertTrue("Component is of wrong type", checkboxComponent instanceof MyCheckbox);
+        Assert.assertFalse("The component should be disabled", checkboxComponent.getElement().isEnabled());
     }
 
     @Tag("div")


### PR DESCRIPTION
Required for fixing vaadin/vaadin-grid-flow#687

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6257)
<!-- Reviewable:end -->
