### PR TITLE
Always recreate migration tool's temporary folder between runs

### DIFF
--- a/flow-migration/src/main/java/com/vaadin/flow/migration/Migration.java
+++ b/flow-migration/src/main/java/com/vaadin/flow/migration/Migration.java
@@ -265,34 +265,24 @@ public class Migration {
      * Prepare migration by cleaning everything, except if only node_modules
      * exists in the target directory.
      */
-    private void prepareMigrationDirectory() {
+    protected void prepareMigrationDirectory() {
         if (getTempMigrationFolder().exists()) {
-            String[] list = getTempMigrationFolder().list();
-            if (list.length == 1 && list[0].equals("node_modules")) {
-                return;
-            } else if (list.length == 2 &&
-                    Stream.of(list).filter(file -> file.startsWith("node"))
-                            .count() == 2) {
-                return;
-            }
             try {
                 FileUtils.forceDelete(getTempMigrationFolder());
-                FileUtils.forceMkdir(getTempMigrationFolder());
             } catch (IOException exception) {
                 String message = String
-                        .format("Unable to clean up directory '%s'",
+                        .format("Unable to delete directory '%s'",
                                 getTempMigrationFolder());
                 throw new UncheckedIOException(message, exception);
             }
-        } else {
-            try {
-                FileUtils.forceMkdir(getTempMigrationFolder());
-            } catch (IOException exception) {
-                String message = String
-                        .format("Failed in creating migration folder '%s'",
-                                getTempMigrationFolder());
-                throw new UncheckedIOException(message, exception);
-            }
+        }
+        try {
+            FileUtils.forceMkdir(getTempMigrationFolder());
+        } catch (IOException exception) {
+            String message = String
+                    .format("Failed in creating migration folder '%s'",
+                            getTempMigrationFolder());
+            throw new UncheckedIOException(message, exception);
         }
     }
 


### PR DESCRIPTION
Seems that CI issues with 13-14 migration test may be due to the fact that the temporary folder was not cleaned if it contained `node_modules`. When run for the first time on an agent, the test passed. On subsequent runs on the same agent, `npm` because of not having write access to some folders inside `node_modules`. The temporary directory was the same.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6259)
<!-- Reviewable:end -->
