### PR TITLE
CCDM: routing in JavaScriptBootstrapUI

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUI.java
@@ -45,7 +45,8 @@ import com.vaadin.flow.theme.ThemeDefinition;
  * Custom UI for {@link JavaScriptBootstrapHandler}. This class is intended for
  * internal use in clientSideMode.
  */
-public final class JavaScriptBootstrapUI extends UI {
+public
+class JavaScriptBootstrapUI extends UI {
     private static final String NO_NAVIGATION = "Classic flow navigation is not supported for clien-side projects";
 
     private Element wrapperElement;

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUI.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.internal;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import com.vaadin.flow.component.ClientCallable;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.internal.nodefeature.NodeProperties;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.ErrorParameter;
+import com.vaadin.flow.router.HasErrorParameter;
+import com.vaadin.flow.router.HasUrlParameter;
+import com.vaadin.flow.router.Location;
+import com.vaadin.flow.router.NavigationState;
+import com.vaadin.flow.router.NavigationTrigger;
+import com.vaadin.flow.router.NotFoundException;
+import com.vaadin.flow.router.QueryParameters;
+import com.vaadin.flow.router.RouteNotFoundError;
+import com.vaadin.flow.router.RouterLayout;
+import com.vaadin.flow.server.communication.JavaScriptBootstrapHandler;
+import com.vaadin.flow.theme.ThemeDefinition;
+
+/**
+ * Custom UI for {@link JavaScriptBootstrapHandler}. This class is intended for
+ * internal use in clientSideMode.
+ */
+public final class JavaScriptBootstrapUI extends UI {
+    private static final String NO_NAVIGATION = "Classic flow navigation is not supported for clien-side projects";
+
+    private Element wrapperElement;
+
+    /**
+     * Connect a client with the server side UI.
+     *
+     * @param clientElementTag
+     *            client side element tag
+     * @param clientElementId
+     *            client side element id
+     * @param flowRoute
+     *            flow route that should be attached to the client element
+     */
+    @ClientCallable
+    public void connectClient(String clientElementTag, String clientElementId, String flowRoute) {
+
+        // Get the flow view that the user wants to navigate to.
+        final Element viewElement = getViewForRoute(flowRoute).getElement();
+
+        if (wrapperElement == null) {
+            // Create flow reference for the client outlet element
+            wrapperElement = new Element(clientElementTag);
+
+            // Connect server with client
+            getElement().getStateProvider().appendVirtualChild(
+                    getElement().getNode(), wrapperElement,
+                    NodeProperties.INJECT_BY_ID, clientElementId);
+        }
+
+        // Remove previous view
+        wrapperElement.removeAllChildren();
+        // attach this view
+        wrapperElement.appendChild(viewElement);
+
+        // Inform the client, that everything went fine.
+        wrapperElement.executeJs("$0.serverConnected()");
+    }
+
+    private HasElement getViewForRoute(String route) {
+        if (route.startsWith("/")) {
+            route = route.replaceFirst("/+", "");
+        }
+        Location location = new Location(route);
+        Optional<NavigationState> navigationState = this.getRouter()
+                .resolveNavigationTarget(location);
+        if (navigationState.isPresent()) {
+            NavigationState currentState = navigationState.get();
+            Class<? extends Component> routeTargetType = currentState
+                    .getNavigationTarget();
+            List<RouterLayout> layouts = getRouterLayouts(currentState,
+                    routeTargetType);
+            return getInternals().constructComponentWithLayouts(
+                    getInstanceOf(routeTargetType), layouts);
+        }
+
+        return getFlowErrorComponent(location);
+    }
+
+    private List<RouterLayout> getRouterLayouts(NavigationState navigationState,
+            Class<? extends Component> routeTargetType) {
+        List<Class<? extends RouterLayout>> routeLayouts = this.getRouter()
+                .getRegistry().getRouteLayouts(
+                        navigationState.getResolvedPath(), routeTargetType);
+        List<RouterLayout> layouts = new ArrayList<>();
+        for (Class<? extends RouterLayout> routeLayout : routeLayouts) {
+            layouts.add(getInstanceOf(routeLayout));
+        }
+        return layouts;
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private HasElement getFlowErrorComponent(Location location) {
+        HasElement errorComponent = createErrorComponentInstance();
+        if (errorComponent instanceof HasErrorParameter) {
+            // Create a dummy event to set error message
+            BeforeEnterEvent beforeEnterEvent = new BeforeEnterEvent(
+                    this.getRouter(), NavigationTrigger.PROGRAMMATIC, location,
+                    errorComponent.getClass(), this, Collections.emptyList());
+            String message = String.format("Route not found: '%s'",
+                    location.getPath());
+            ((HasErrorParameter) errorComponent).setErrorParameter(
+                    beforeEnterEvent, new ErrorParameter<>(Exception.class,
+                            new NotFoundException(message)));
+        }
+        return errorComponent;
+    }
+
+    private HasElement createErrorComponentInstance() {
+        Optional<NavigationState> errorNavigationState = this.getRouter()
+                .resolveRouteNotFoundNavigationTarget();
+        if (!errorNavigationState.isPresent()) {
+            // Default built-in RouteNotFoundError component
+            return new RouteNotFoundError();
+        } else {
+            Class<? extends Component> errorNavigationTarget = errorNavigationState
+                    .get().getNavigationTarget();
+            return getInstanceOf(errorNavigationTarget);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends HasElement> T getInstanceOf(Class<T> routeTargetType) {
+        Optional<HasElement> currentInstance = this.getInternals()
+                .getActiveRouterTargetsChain().stream()
+                .filter(component -> component.getClass()
+                        .equals(routeTargetType))
+                .findAny();
+        return (T) currentInstance.orElseGet(
+                () -> Instantiator.get(this).getOrCreate(routeTargetType));
+    }
+
+    @Override
+    public Optional<ThemeDefinition> getThemeFor(Class<?> navigationTarget,
+            String path) {
+        return Optional.empty();
+    }
+
+    @Override
+    public void navigate(String location) {
+        throw new UnsupportedOperationException(NO_NAVIGATION);
+    }
+
+    @Override
+    public void navigate(Class<? extends Component> navigationTarget) {
+        throw new UnsupportedOperationException(NO_NAVIGATION);
+    }
+
+    @Override
+    public <T, C extends Component & HasUrlParameter<T>> void navigate(
+            Class<? extends C> navigationTarget, T parameter) {
+        throw new UnsupportedOperationException(NO_NAVIGATION);
+    }
+
+    @Override
+    public void navigate(String location, QueryParameters queryParameters) {
+        throw new UnsupportedOperationException(NO_NAVIGATION);
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -655,8 +655,39 @@ public class UIInternals implements Serializable {
         }
 
         this.viewLocation = viewLocation;
+        HasElement root = constructComponentWithLayouts(target, layouts);
 
         Element uiElement = ui.getElement();
+        Element rootElement = root.getElement();
+
+        if (!uiElement.equals(rootElement.getParent())) {
+            if (oldRoot != null) {
+                oldRoot.getElement().removeFromParent();
+            }
+            rootElement.removeFromParent();
+            uiElement.appendChild(rootElement);
+        }
+    }
+
+    /**
+     * Construct a new root component based on the given target component and
+     * its layouts.
+     * <p>
+     * <b>NOTE:</b> This method is intended for internal use only, e.g. by
+     * {@link UIInternals#showRouteTarget(Location, String, Component, List)}
+     * and JavaScriptBootstrapUI#getViewForRoute(String) in CCDM. The method
+     * also accesses and modifies the {@link UIInternals#routerTargetChain}
+     * field as well so please use it with caution.
+     * 
+     * @param target
+     *            the target component.
+     * @param layouts
+     *            Layouts of the component.
+     * @return the new root component.
+     * 
+     */
+    public HasElement constructComponentWithLayouts(HasElement target,
+            List<RouterLayout> layouts) {
 
         // Assemble previous parent-child relationships to enable detecting
         // changes
@@ -711,15 +742,7 @@ public class UIInternals implements Serializable {
                     "Root can't be null here since we know there's at least one item in the chain");
         }
 
-        Element rootElement = root.getElement();
-
-        if (!uiElement.equals(rootElement.getParent())) {
-            if (oldRoot != null) {
-                oldRoot.getElement().removeFromParent();
-            }
-            rootElement.removeFromParent();
-            uiElement.appendChild(rootElement);
-        }
+        return root;
     }
 
     private void updateTheme(Component target, String path) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -1365,11 +1365,15 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
         // After init and adding UI to session fire init listeners.
         session.getService().fireUIInitListeners(ui);
 
+        initializeUIWithRouter(request, ui);
+
+        return context;
+    }
+
+    protected void initializeUIWithRouter(VaadinRequest request, UI ui) {
         if (ui.getRouter() != null) {
             ui.getRouter().initializeUI(ui, request);
         }
-
-        return context;
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
@@ -20,21 +20,33 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
 import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.HtmlContainer;
+import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.PushConfiguration;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.internal.nodefeature.NodeProperties;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.ErrorParameter;
+import com.vaadin.flow.router.HasErrorParameter;
 import com.vaadin.flow.router.HasUrlParameter;
+import com.vaadin.flow.router.Location;
+import com.vaadin.flow.router.NavigationState;
+import com.vaadin.flow.router.NavigationTrigger;
+import com.vaadin.flow.router.NotFoundException;
 import com.vaadin.flow.router.QueryParameters;
-import com.vaadin.flow.router.Router;
+import com.vaadin.flow.router.RouteNotFoundError;
+import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.server.BootstrapHandler;
 import com.vaadin.flow.server.DevModeHandler;
 import com.vaadin.flow.server.ServletHelper;
@@ -125,36 +137,101 @@ public class JavaScriptBootstrapHandler extends BootstrapHandler {
             wrapperElement.executeJs("$0.serverConnected()");
         }
 
-        private Component getViewForRoute(String route) {
-            // Create a temporary view until navigation is implemented
-            HtmlContainer view = new HtmlContainer("div");
-            view.setText(String.format(
-                    "Navigation not implemented yet. cannot show '%s'", route));
-            return view;
+        private HasElement getViewForRoute(String route) {
+            Location location = new Location(route);
+            Optional<NavigationState> navigationState = this.getRouter()
+                    .resolveNavigationTarget(location);
+            if (navigationState.isPresent()) {
+                NavigationState currentState = navigationState.get();
+                Class<? extends Component> routeTargetType = currentState
+                        .getNavigationTarget();
+                List<RouterLayout> layouts = getRouterLayouts(currentState,
+                        routeTargetType);
+                return getInternals().constructComponentWithLayouts(
+                        getInstanceOf(routeTargetType), layouts);
+            }
+
+            return getFlowErrorComponent(location);
         }
 
-        @Override
-        public Router getRouter() {
-            return null;
+        private List<RouterLayout> getRouterLayouts(
+                NavigationState navigationState,
+                Class<? extends Component> routeTargetType) {
+            List<Class<? extends RouterLayout>> routeLayouts = this.getRouter()
+                    .getRegistry()
+                    .getRouteLayouts(navigationState.getResolvedPath(),
+                            routeTargetType);
+            List<RouterLayout> layouts = new ArrayList<>();
+            for (Class<? extends RouterLayout> routeLayout : routeLayouts) {
+                layouts.add(getInstanceOf(routeLayout));
+            }
+            return layouts;
         }
+
+        private HasElement getFlowErrorComponent(Location location) {
+            HasElement errorComponent = createErrorComponentInstance();
+            if (errorComponent instanceof HasErrorParameter) {
+                // Create a dummy event to set error message
+                BeforeEnterEvent beforeEnterEvent = new BeforeEnterEvent(
+                        this.getRouter(), NavigationTrigger.PROGRAMMATIC,
+                        location, errorComponent.getClass(), this,
+                        Collections.emptyList());
+                String message = String.format("Route not found: '%s'",
+                        location.getPath());
+                ((HasErrorParameter) errorComponent).setErrorParameter(
+                        beforeEnterEvent,
+                        new ErrorParameter<>(Exception.class,
+                                new NotFoundException(message)));
+            }
+            return errorComponent;
+        }
+
+        private HasElement createErrorComponentInstance() {
+            Optional<NavigationState> errorNavigationState = this.getRouter()
+                    .resolveRouteNotFoundNavigationTarget();
+            if (!errorNavigationState.isPresent()) {
+                // Default built-in RouteNotFoundError component
+                return new RouteNotFoundError();
+            } else {
+                Class<? extends Component> errorNavigationTarget = errorNavigationState
+                        .get().getNavigationTarget();
+                return getInstanceOf(errorNavigationTarget);
+            }
+        }
+
+        private <T extends HasElement> T getInstanceOf(
+                Class<T> routeTargetType) {
+            Optional<HasElement> currentInstance = this.getInternals()
+                    .getActiveRouterTargetsChain().stream()
+                    .filter(component -> component.getClass()
+                            .equals(routeTargetType))
+                    .findAny();
+            return (T) currentInstance.orElseGet(
+                    () -> Instantiator.get(this).getOrCreate(routeTargetType));
+        }
+
         @Override
         public Optional<ThemeDefinition> getThemeFor(Class<?> navigationTarget,
                 String path) {
             return Optional.empty();
         }
+
         @Override
         public void navigate(String location) {
             throw new UnsupportedOperationException(NO_NAVIGATION);
         }
+
         @Override
         public void navigate(Class<? extends Component> navigationTarget) {
             throw new UnsupportedOperationException(NO_NAVIGATION);
         }
+
         @Override
         public <T, C extends Component & HasUrlParameter<T>> void navigate(
                 Class<? extends C> navigationTarget, T parameter) {
             throw new UnsupportedOperationException(NO_NAVIGATION);
         }
+
         @Override
         public void navigate(String location, QueryParameters queryParameters) {
             throw new UnsupportedOperationException(NO_NAVIGATION);
@@ -221,6 +298,12 @@ public class JavaScriptBootstrapHandler extends BootstrapHandler {
         config.put("requestURL", requestURL);
 
         return context;
+    }
+
+    @Override
+    protected void initializeUIWithRouter(VaadinRequest request, UI ui) {
+        // We don't need to initialize UI with Router in CCDM.
+        // Showing view is handled by client-side.
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
@@ -138,6 +138,9 @@ public class JavaScriptBootstrapHandler extends BootstrapHandler {
         }
 
         private HasElement getViewForRoute(String route) {
+            if (route.startsWith("/")) {
+                route = route.replaceFirst("/+", "");
+            }
             Location location = new Location(route);
             Optional<NavigationState> navigationState = this.getRouter()
                     .resolveNavigationTarget(location);

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandlerTest.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.server.communication;
 import java.util.regex.Pattern;
 
 import net.jcip.annotations.NotThreadSafe;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -33,7 +34,6 @@ import com.vaadin.flow.server.MockServletServiceSessionSetup.TestVaadinServletRe
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.communication.JavaScriptBootstrapHandler.JavaScriptBootstrapUI;
-import com.vaadin.flow.shared.ApplicationConstants;
 
 import elemental.json.Json;
 import elemental.json.JsonObject;
@@ -124,7 +124,9 @@ public class JavaScriptBootstrapHandlerTest {
         Assert.assertTrue(hasNodeTag(visitor, "^<body>.*", ElementType.REGULAR));
         Assert.assertTrue(hasNodeTag(visitor, "^<a-tag>.*", ElementType.VIRTUAL_ATTACHED));
         Assert.assertTrue(hasNodeTag(visitor, "^<div>.*", ElementType.REGULAR));
-        Assert.assertTrue(hasNodeTag(visitor, "^<div>.*Navigation not implemented yet.*", ElementType.REGULAR));
+        Assert.assertTrue(
+                hasNodeTag(visitor, "^<div>.*Could not navigate to 'a-route'.*",
+                        ElementType.REGULAR));
 
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandlerTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.internal.JavaScriptBootstrapUI;
 import com.vaadin.flow.dom.NodeVisitor.ElementType;
 import com.vaadin.flow.dom.TestNodeVisitor;
 import com.vaadin.flow.dom.impl.BasicElementStateProvider;
@@ -33,7 +34,7 @@ import com.vaadin.flow.server.MockServletServiceSessionSetup;
 import com.vaadin.flow.server.MockServletServiceSessionSetup.TestVaadinServletResponse;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinSession;
-import com.vaadin.flow.server.communication.JavaScriptBootstrapHandler.JavaScriptBootstrapUI;
+
 
 import elemental.json.Json;
 import elemental.json.JsonObject;

--- a/flow-tests/test-ccdm/frontend/index.html
+++ b/flow-tests/test-ccdm/frontend/index.html
@@ -17,7 +17,12 @@
 
 <button id="button1">Load content from other bundle</button>
 <button id="button2">Load flow</button>
-<button id="button3">Navigate flow</button>
+<p>
+    <input type="text" id="routeValue" placeholder="route">
+    <button id="button3">Navigate flow</button>
+    <div id="div3"></div>
+</p>
+
 
 <div id="div0">index.html content</div>
 

--- a/flow-tests/test-ccdm/frontend/index.js
+++ b/flow-tests/test-ccdm/frontend/index.js
@@ -23,11 +23,15 @@ document.getElementById("button2").addEventListener('click', async e => {
     document.body.appendChild(div);
 });
 
-document.getElementById("button3").addEventListener('click', async e => {
-    const view = await flow.navigate({path: 'my/foo view'});
-    const div = document.createElement('div');
-    div.id = 'div3';
-    div.appendChild(view);
-    document.body.appendChild(div);
+document.getElementById('button3').addEventListener('click', async e => {
+    const route = document.getElementById('routeValue').value;
+    const view = await flow.navigate({path: route});
+    const div = document.getElementById('div3');
+    div.innerHTML = '';
+
+    const result = document.createElement('result');
+    result.id = 'result';
+    result.appendChild(view);
+    div.appendChild(result);
 });
 

--- a/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/MainLayout.java
+++ b/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/MainLayout.java
@@ -17,11 +17,10 @@ package com.vaadin.flow.ccdmtest;
 
 import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouterLayout;
 
-@Route("")
-public class EmptyUI extends Div {
-    public EmptyUI() {
-        add(new Text("Empty view"));
+public class MainLayout extends Div implements RouterLayout {
+    public MainLayout() {
+        add(new Text("Main layout"));
     }
 }

--- a/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/ServerSideView.java
+++ b/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/ServerSideView.java
@@ -19,9 +19,9 @@ import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
 
-@Route("")
-public class EmptyUI extends Div {
-    public EmptyUI() {
-        add(new Text("Empty view"));
+@Route(value = "serverview", layout = MainLayout.class)
+public class ServerSideView extends Div {
+    public ServerSideView() {
+        add(new Text("Server view"));
     }
 }

--- a/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/ViewWithParameter.java
+++ b/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/ViewWithParameter.java
@@ -17,11 +17,19 @@ package com.vaadin.flow.ccdmtest;
 
 import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.BeforeEvent;
+import com.vaadin.flow.router.HasUrlParameter;
 import com.vaadin.flow.router.Route;
 
-@Route("")
-public class EmptyUI extends Div {
-    public EmptyUI() {
-        add(new Text("Empty view"));
+@Route(value = "paramview", layout = MainLayout.class)
+public class ViewWithParameter extends Div implements HasUrlParameter<String> {
+
+    public ViewWithParameter() {
+        add(new Text("Route with parameter"));
+    }
+
+    @Override
+    public void setParameter(BeforeEvent event, String parameter) {
+
     }
 }

--- a/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/ClientIndexHandlerIT.java
+++ b/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/ClientIndexHandlerIT.java
@@ -144,6 +144,20 @@ public class ClientIndexHandlerIT extends ChromeBrowserTest {
     }
 
     @Test
+    public void should_removeFirstSlash_whenRouteStartsWithSlash() {
+        openTestUrl("/");
+        waitForElementPresent(By.id("button3"));
+
+        findElement(By.id("routeValue")).sendKeys("/");
+        findElement(By.id("button3")).click();
+        waitForElementPresent(By.id("result"));
+
+        String content = findElement(By.id("result")).getText();
+        Assert.assertTrue("It should ignore the first slash in route path",
+                content.contains("Empty view"));
+    }
+
+    @Test
     public void should_getViewByRoute_WhenNavigate() {
         openTestUrl("/");
         waitForElementPresent(By.id("button3"));
@@ -189,5 +203,4 @@ public class ClientIndexHandlerIT extends ChromeBrowserTest {
         Assert.assertTrue("Flow.navigate should return not found view",
                 content.contains("Could not navigate"));
     }
-
 }

--- a/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/ClientIndexHandlerIT.java
+++ b/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/ClientIndexHandlerIT.java
@@ -136,12 +136,58 @@ public class ClientIndexHandlerIT extends ChromeBrowserTest {
         openTestUrl("/");
         waitForElementPresent(By.id("button3"));
 
-
         findElement(By.id("button3")).click();
-        waitForElementPresent(By.id("div3"));
+        waitForElementPresent(By.id("result"));
 
-        String content = findElement(By.id("div3")).getText();
-        Assert.assertTrue(content.length() > 0);
+        String content = findElement(By.id("result")).getText();
+        Assert.assertTrue(content.contains("Empty view"));
+    }
+
+    @Test
+    public void should_getViewByRoute_WhenNavigate() {
+        openTestUrl("/");
+        waitForElementPresent(By.id("button3"));
+
+        findElement(By.id("routeValue")).sendKeys("serverview");
+        findElement(By.id("button3")).click();
+        waitForElementPresent(By.id("result"));
+
+        String content = findElement(By.id("result")).getText();
+        Assert.assertTrue("Flow.navigate should return view by route from "
+                + "server views", content.contains("Server view"));
+
+        Assert.assertTrue("Flow.navigate should include router layout",
+                content.contains("Main layout"));
+    }
+
+    @Test
+    public void should_getViewByRoute_WhenRouteHasParameter() {
+        openTestUrl("/");
+        waitForElementPresent(By.id("button3"));
+
+        findElement(By.id("routeValue")).sendKeys("paramview/123");
+        findElement(By.id("button3")).click();
+        waitForElementPresent(By.id("result"));
+
+        String content = findElement(By.id("result")).getText();
+        Assert.assertTrue("Flow.navigate should return view with parameter",
+                content.contains("Route with parameter"));
+        Assert.assertTrue("Flow.navigate should include router layout",
+                content.contains("Main layout"));
+    }
+
+    @Test
+    public void should_returnNotFoundView_WhenRouteNotFound() {
+        openTestUrl("/");
+        waitForElementPresent(By.id("button3"));
+
+        findElement(By.id("routeValue")).sendKeys("not-existing-view");
+        findElement(By.id("button3")).click();
+        waitForElementPresent(By.id("result"));
+
+        String content = findElement(By.id("result")).getText();
+        Assert.assertTrue("Flow.navigate should return not found view",
+                content.contains("Could not navigate"));
     }
 
 }


### PR DESCRIPTION
- JavaScriptBootstrapUI responds to `flow.navigate` (from client-side) by using the `@Route` resolution on the server side.
- The result element contains the server-side layouts as well. 
- A server view which implements `HasUrlParameter` can only be provided when the request has required parameters.
- If a route is not found, an error view of `NotFoundException` will be returned.

- This PR does NOT implement `ui.navigate` method in `JavaScriptBootstrapUI`
Fixes #6221
- The server-side navigation events are not considered in this PR
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6273)
<!-- Reviewable:end -->
