### PR TITLE
Use VaadinContext instead of ServletContext

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteConfiguration.java
@@ -35,7 +35,6 @@ import com.vaadin.flow.server.RouteRegistry;
 import com.vaadin.flow.server.SessionRouteRegistry;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServlet;
-import com.vaadin.flow.server.VaadinServletService;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.startup.ApplicationRouteRegistry;
 import com.vaadin.flow.shared.Registration;
@@ -505,19 +504,9 @@ public class RouteConfiguration implements Serializable {
     /* Private methods */
 
     private static RouteRegistry getApplicationRegistry() {
-        VaadinService service = VaadinService.getCurrent();
-        if (service instanceof VaadinServletService) {
-            return ApplicationRouteRegistry
-                    .getInstance(((VaadinServletService) service).getServlet()
-                            .getServletContext());
-        } else {
-            // TODO Once we have PortletService, this will explode
-            // we will need route registry for portlet context
-            throw new IllegalStateException("Cannot access "
-                    + ApplicationRouteRegistry.class.getName() + ", because no "
-                    + "VaadinServletService available for " +
-                    "fetching ServletContext");
-        }    }
+        return ApplicationRouteRegistry
+                .getInstance(VaadinService.getCurrent().getContext());
+    }
 
     private static RouteRegistry getSessionRegistry() {
         return SessionRouteRegistry

--- a/flow-server/src/main/java/com/vaadin/flow/server/PwaRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PwaRegistry.java
@@ -15,9 +15,9 @@
  */
 package com.vaadin.flow.server;
 
-import java.awt.Color;
-import java.awt.Graphics2D;
-import java.awt.Image;
+import javax.imageio.ImageIO;
+import javax.servlet.ServletContext;
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -31,9 +31,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import javax.imageio.ImageIO;
-import javax.servlet.ServletContext;
 
 import com.vaadin.flow.server.startup.ApplicationRouteRegistry;
 
@@ -264,7 +261,8 @@ public class PwaRegistry implements Serializable {
                     .getAttribute(PwaRegistry.class.getName());
 
             if (attribute == null) {
-                ApplicationRouteRegistry reg = ApplicationRouteRegistry.getInstance(servletContext);
+                ApplicationRouteRegistry reg = ApplicationRouteRegistry
+                        .getInstance(new VaadinServletContext(servletContext));
 
                 // Initialize PwaRegistry with found PWA settings
                 PWA pwa = reg.getPwaConfigurationClass() != null ? reg

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinContext.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinContext.java
@@ -53,6 +53,15 @@ public interface VaadinContext extends Serializable {
     }
 
     /**
+     * Returns value of the specified attribute.
+     *
+     * @param name
+     *         name of the attribute.
+     * @return Value of the specified attribute.
+     */
+    Object getAttribute(String name);
+
+    /**
      * Sets the attribute value, overriding previously existing one. Values are
      * based on exact type, meaning only one attribute of given type is possible
      * at any given time.
@@ -62,6 +71,17 @@ public interface VaadinContext extends Serializable {
      * @see #removeAttribute(Class) for removing attributes.
      */
     <T> void setAttribute(T value);
+
+    /**
+     * Sets the attribute value, overriding previously existing one.
+     *
+     * @param name
+     *         attribute name to store value under
+     * @param value
+     *         value of the attribute. May not be {@code null}.
+     * @see #removeAttribute(Class) for removing attributes.
+     */
+    <T> void setAttribute(String name, T value);
 
     /**
      * Removes an attribute identified by the given type. If the attribute does

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -16,42 +16,6 @@
 
 package com.vaadin.flow.server;
 
-import com.vaadin.flow.component.UI;
-import com.vaadin.flow.component.internal.DependencyTreeCache;
-import com.vaadin.flow.component.internal.HtmlImportParser;
-import com.vaadin.flow.di.DefaultInstantiator;
-import com.vaadin.flow.di.Instantiator;
-import com.vaadin.flow.function.DeploymentConfiguration;
-import com.vaadin.flow.i18n.I18NProvider;
-import com.vaadin.flow.internal.CurrentInstance;
-import com.vaadin.flow.internal.LocaleUtil;
-import com.vaadin.flow.internal.ReflectionCache;
-import com.vaadin.flow.internal.UsageStatistics;
-import com.vaadin.flow.router.Router;
-import com.vaadin.flow.server.ServletHelper.RequestType;
-import com.vaadin.flow.server.communication.AtmospherePushConnection;
-import com.vaadin.flow.server.communication.HeartbeatHandler;
-import com.vaadin.flow.server.communication.PwaHandler;
-import com.vaadin.flow.server.communication.SessionRequestHandler;
-import com.vaadin.flow.server.communication.StreamRequestHandler;
-import com.vaadin.flow.server.communication.UidlRequestHandler;
-import com.vaadin.flow.server.communication.WebComponentBootstrapHandler;
-import com.vaadin.flow.server.communication.WebComponentProvider;
-import com.vaadin.flow.server.startup.BundleFilterFactory;
-import com.vaadin.flow.server.startup.FakeBrowser;
-import com.vaadin.flow.server.webcomponent.WebComponentConfigurationRegistry;
-import com.vaadin.flow.shared.ApplicationConstants;
-import com.vaadin.flow.shared.JsonConstants;
-import com.vaadin.flow.shared.Registration;
-import com.vaadin.flow.shared.communication.PushMode;
-import com.vaadin.flow.theme.AbstractTheme;
-import elemental.json.Json;
-import elemental.json.JsonException;
-import elemental.json.JsonObject;
-import elemental.json.impl.JsonUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.servlet.Servlet;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletResponse;
@@ -84,6 +48,44 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.internal.DependencyTreeCache;
+import com.vaadin.flow.component.internal.HtmlImportParser;
+import com.vaadin.flow.di.DefaultInstantiator;
+import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.i18n.I18NProvider;
+import com.vaadin.flow.internal.CurrentInstance;
+import com.vaadin.flow.internal.LocaleUtil;
+import com.vaadin.flow.internal.ReflectionCache;
+import com.vaadin.flow.internal.UsageStatistics;
+import com.vaadin.flow.router.Router;
+import com.vaadin.flow.server.ServletHelper.RequestType;
+import com.vaadin.flow.server.communication.AtmospherePushConnection;
+import com.vaadin.flow.server.communication.HeartbeatHandler;
+import com.vaadin.flow.server.communication.PwaHandler;
+import com.vaadin.flow.server.communication.SessionRequestHandler;
+import com.vaadin.flow.server.communication.StreamRequestHandler;
+import com.vaadin.flow.server.communication.UidlRequestHandler;
+import com.vaadin.flow.server.communication.WebComponentBootstrapHandler;
+import com.vaadin.flow.server.communication.WebComponentProvider;
+import com.vaadin.flow.server.startup.ApplicationRouteRegistry;
+import com.vaadin.flow.server.startup.BundleFilterFactory;
+import com.vaadin.flow.server.startup.FakeBrowser;
+import com.vaadin.flow.server.webcomponent.WebComponentConfigurationRegistry;
+import com.vaadin.flow.shared.ApplicationConstants;
+import com.vaadin.flow.shared.JsonConstants;
+import com.vaadin.flow.shared.Registration;
+import com.vaadin.flow.shared.communication.PushMode;
+import com.vaadin.flow.theme.AbstractTheme;
+
+import elemental.json.Json;
+import elemental.json.JsonException;
+import elemental.json.JsonObject;
+import elemental.json.impl.JsonUtil;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
@@ -332,7 +334,9 @@ public abstract class VaadinService implements Serializable {
      *
      * @return the route registry to use, not <code>null</code>
      */
-    protected abstract RouteRegistry getRouteRegistry();
+    protected RouteRegistry getRouteRegistry() {
+        return ApplicationRouteRegistry.getInstance(getContext());
+    }
 
     protected abstract PwaRegistry getPwaRegistry();
 
@@ -379,9 +383,9 @@ public abstract class VaadinService implements Serializable {
     }
 
     private boolean hasWebComponentConfigurations() {
-            WebComponentConfigurationRegistry registry = WebComponentConfigurationRegistry
-                    .getInstance(this.getContext());
-            return registry.hasConfigurations();
+        WebComponentConfigurationRegistry registry = WebComponentConfigurationRegistry
+                .getInstance(getContext());
+        return registry.hasConfigurations();
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletContext.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletContext.java
@@ -68,10 +68,23 @@ public class VaadinServletContext implements VaadinContext {
     }
 
     @Override
+    public Object getAttribute(String name) {
+        ensureServletContext();
+        return context.getAttribute(name);
+    }
+
+    @Override
     public <T> void setAttribute(T value) {
         assert value != null;
         ensureServletContext();
         context.setAttribute(value.getClass().getName(), value);
+    }
+
+    @Override
+    public <T> void setAttribute(String name, T value) {
+        assert value != null;
+        ensureServletContext();
+        context.setAttribute(name, value);
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
@@ -176,11 +176,6 @@ public class VaadinServletService extends VaadinService {
     }
 
     @Override
-    protected RouteRegistry getRouteRegistry() {
-        return ApplicationRouteRegistry.getInstance(getServlet().getServletContext());
-    }
-
-    @Override
     protected PwaRegistry getPwaRegistry() {
         return Optional.ofNullable(getServlet())
                 .map(GenericServlet::getServletContext)

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
@@ -33,11 +33,8 @@ import org.slf4j.LoggerFactory;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.server.communication.FaviconHandler;
 import com.vaadin.flow.server.communication.PushRequestHandler;
-import com.vaadin.flow.server.startup.ApplicationRouteRegistry;
 import com.vaadin.flow.shared.ApplicationConstants;
 import com.vaadin.flow.theme.AbstractTheme;
-
-import static com.vaadin.flow.server.Constants.META_INF;
 
 /**
  * A service implementation connected to a {@link VaadinServlet}.

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ApplicationRouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ApplicationRouteRegistry.java
@@ -207,11 +207,11 @@ public class ApplicationRouteRegistry extends AbstractRouteRegistry {
 
         Object attribute;
         synchronized (context) {
-            attribute = context.getAttribute(RouteRegistry.class);
+            attribute = context.getAttribute(RouteRegistry.class.getName());
 
             if (attribute == null) {
                 attribute = createRegistry(context);
-                context.setAttribute(attribute);
+                context.setAttribute(RouteRegistry.class.getName(), attribute);
             }
         }
 
@@ -359,7 +359,7 @@ public class ApplicationRouteRegistry extends AbstractRouteRegistry {
 
     private static ApplicationRouteRegistry createRegistry(
             VaadinContext context) {
-        if (context != null && context == OSGiAccess.getInstance()
+        if (context != null && ((VaadinServletContext)context).getContext() == OSGiAccess.getInstance()
                 .getOsgiServletContext()) {
             return new OSGiDataCollector();
         } else if (OSGiAccess.getInstance().getOsgiServletContext() == null) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ApplicationRouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ApplicationRouteRegistry.java
@@ -30,6 +30,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.slf4j.LoggerFactory;
+
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.router.InternalServerError;
 import com.vaadin.flow.router.NotFoundException;
@@ -42,9 +44,10 @@ import com.vaadin.flow.router.internal.AbstractRouteRegistry;
 import com.vaadin.flow.router.internal.ErrorTargetEntry;
 import com.vaadin.flow.server.PWA;
 import com.vaadin.flow.server.RouteRegistry;
+import com.vaadin.flow.server.VaadinContext;
+import com.vaadin.flow.server.VaadinServletContext;
 import com.vaadin.flow.server.osgi.OSGiAccess;
 import com.vaadin.flow.shared.Registration;
-import org.slf4j.LoggerFactory;
 
 /**
  * Registry for holding navigation target components found on servlet
@@ -80,7 +83,7 @@ public class ApplicationRouteRegistry extends AbstractRouteRegistry {
                 return;
             }
             OSGiDataCollector registry = (OSGiDataCollector) getInstance(
-                    osgiServletContext);
+                    new VaadinServletContext(osgiServletContext));
             if (registry.errorNavigationTargets.get() != null) {
                 setErrorNavigationTargets(
                         registry.errorNavigationTargets.get());
@@ -93,7 +96,8 @@ public class ApplicationRouteRegistry extends AbstractRouteRegistry {
             }
             if (OSGiAccess.getInstance().hasInitializers()) {
                 OSGiDataCollector registry = (OSGiDataCollector) getInstance(
-                        OSGiAccess.getInstance().getOsgiServletContext());
+                        new VaadinServletContext(OSGiAccess.getInstance()
+                                .getOsgiServletContext()));
                 setPwaConfigurationClass(registry.getPwaConfigurationClass());
             }
         }
@@ -192,25 +196,22 @@ public class ApplicationRouteRegistry extends AbstractRouteRegistry {
      * context has no route registry, a new instance is created and assigned to
      * the context.
      *
-     * @param servletContext
-     *            the servlet context for which to get a route registry, not
-     *            <code>null</code>
-     * @return a registry instance for the given servlet context, not
+     * @param context
+     *         the vaadin context for which to get a route registry, not
      *         <code>null</code>
+     * @return a registry instance for the given servlet context, not
+     * <code>null</code>
      */
-    public static ApplicationRouteRegistry getInstance(
-            ServletContext servletContext) {
-        assert servletContext != null;
+    public static ApplicationRouteRegistry getInstance(VaadinContext context) {
+        assert context != null;
 
         Object attribute;
-        synchronized (servletContext) {
-            attribute = servletContext
-                    .getAttribute(RouteRegistry.class.getName());
+        synchronized (context) {
+            attribute = context.getAttribute(RouteRegistry.class);
 
             if (attribute == null) {
-                attribute = createRegistry(servletContext);
-                servletContext.setAttribute(RouteRegistry.class.getName(),
-                        attribute);
+                attribute = createRegistry(context);
+                context.setAttribute(attribute);
             }
         }
 
@@ -218,7 +219,7 @@ public class ApplicationRouteRegistry extends AbstractRouteRegistry {
             return (ApplicationRouteRegistry) attribute;
         } else {
             throw new IllegalStateException(
-                    "Unknown servlet context attribute value: " + attribute);
+                    "Unknown context attribute value: " + attribute);
         }
     }
 
@@ -357,7 +358,7 @@ public class ApplicationRouteRegistry extends AbstractRouteRegistry {
     }
 
     private static ApplicationRouteRegistry createRegistry(
-            ServletContext context) {
+            VaadinContext context) {
         if (context != null && context == OSGiAccess.getInstance()
                 .getOsgiServletContext()) {
             return new OSGiDataCollector();
@@ -367,7 +368,8 @@ public class ApplicationRouteRegistry extends AbstractRouteRegistry {
 
         OSGiRouteRegistry osgiRouteRegistry = new OSGiRouteRegistry();
         OSGiDataCollector osgiDataCollector = (OSGiDataCollector) getInstance(
-                OSGiAccess.getInstance().getOsgiServletContext());
+                new VaadinServletContext(
+                        OSGiAccess.getInstance().getOsgiServletContext()));
         osgiRouteRegistry.setRoutes(osgiDataCollector.getRegisteredRoutes());
         osgiRouteRegistry.subscribeToChanges(osgiDataCollector);
         return osgiRouteRegistry;

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ErrorNavigationTargetInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ErrorNavigationTargetInitializer.java
@@ -15,17 +15,17 @@
  */
 package com.vaadin.flow.server.startup;
 
-import java.util.HashSet;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import javax.servlet.ServletContainerInitializer;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.HandlesTypes;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.router.HasErrorParameter;
+import com.vaadin.flow.server.VaadinServletContext;
 
 /**
  * Servlet initializer for collecting all available error handler navigation
@@ -48,7 +48,8 @@ public class ErrorNavigationTargetInitializer
                 .map(clazz -> (Class<? extends Component>) clazz)
                 .collect(Collectors.toSet());
 
-        ApplicationRouteRegistry.getInstance(servletContext)
+        ApplicationRouteRegistry
+                .getInstance(new VaadinServletContext(servletContext))
                 .setErrorNavigationTargets(routes);
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/RouteRegistryInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/RouteRegistryInitializer.java
@@ -29,6 +29,7 @@ import com.vaadin.flow.router.RouteAlias;
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.flow.server.AmbiguousRouteConfigurationException;
 import com.vaadin.flow.server.InvalidRouteConfigurationException;
+import com.vaadin.flow.server.VaadinServletContext;
 
 /**
  * Servlet initializer for collecting all available {@link Route}s on startup.
@@ -40,10 +41,11 @@ public class RouteRegistryInitializer extends AbstractRouteRegistryInitializer
     @Override
     public void onStartup(Set<Class<?>> classSet, ServletContext servletContext)
             throws ServletException {
+        VaadinServletContext context = new VaadinServletContext(servletContext);
         try {
             if (classSet == null) {
                 ApplicationRouteRegistry routeRegistry = ApplicationRouteRegistry
-                        .getInstance(servletContext);
+                        .getInstance(context);
                 routeRegistry.clean();
                 return;
             }
@@ -52,7 +54,7 @@ public class RouteRegistryInitializer extends AbstractRouteRegistryInitializer
                     classSet.stream());
 
             ApplicationRouteRegistry routeRegistry = ApplicationRouteRegistry
-                    .getInstance(servletContext);
+                    .getInstance(context);
 
             RouteConfiguration routeConfiguration = RouteConfiguration
                     .forRegistry(routeRegistry);

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletDeployer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletDeployer.java
@@ -22,7 +22,6 @@ import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRegistration;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -202,13 +201,13 @@ public class ServletDeployer implements ServletContextListener {
         return result;
     }
 
-    private VaadinServletCreation createAppServlet(ServletContext context) {
+    private VaadinServletCreation createAppServlet(ServletContext servletContext) {
+        VaadinServletContext context = new VaadinServletContext(servletContext);
         boolean createServlet = ApplicationRouteRegistry.getInstance(context)
                 .hasNavigationTargets();
 
         createServlet = createServlet || WebComponentConfigurationRegistry
-                .getInstance(new VaadinServletContext(context))
-                .hasConfigurations();
+                .getInstance(context).hasConfigurations();
 
         if (!createServlet) {
             getLogger().info(
@@ -218,7 +217,7 @@ public class ServletDeployer implements ServletContextListener {
             return VaadinServletCreation.NO_CREATION;
         }
 
-        ServletRegistration vaadinServlet = findVaadinServlet(context);
+        ServletRegistration vaadinServlet = findVaadinServlet(servletContext);
         if (vaadinServlet != null) {
             getLogger().info(
                     "{} there is already a Vaadin servlet with the name {}",
@@ -227,7 +226,7 @@ public class ServletDeployer implements ServletContextListener {
             return VaadinServletCreation.SERVLET_EXISTS;
         }
 
-        return createServletIfNotExists(context, getClass().getName(),
+        return createServletIfNotExists(servletContext, getClass().getName(),
                 VaadinServlet.class, "/*");
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouteConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouteConfigurationTest.java
@@ -1,5 +1,6 @@
 package com.vaadin.flow.router;
 
+import javax.servlet.ServletContext;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -7,8 +8,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 
-import javax.servlet.ServletContext;
-
+import net.jcip.annotations.NotThreadSafe;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -23,11 +23,10 @@ import com.vaadin.flow.server.RouteRegistry;
 import com.vaadin.flow.server.SessionRouteRegistry;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServlet;
+import com.vaadin.flow.server.VaadinServletContext;
 import com.vaadin.flow.server.VaadinServletService;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.startup.ApplicationRouteRegistry;
-
-import net.jcip.annotations.NotThreadSafe;
 
 @NotThreadSafe
 public class RouteConfigurationTest {
@@ -40,7 +39,8 @@ public class RouteConfigurationTest {
     @Before
     public void init() {
         servletContext = Mockito.mock(ServletContext.class);
-        registry = ApplicationRouteRegistry.getInstance(servletContext);
+        registry = ApplicationRouteRegistry
+                .getInstance(new VaadinServletContext(servletContext));
 
         Mockito.when(servletContext.getAttribute(RouteRegistry.class.getName()))
                 .thenReturn(registry);

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouteConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouteConfigurationTest.java
@@ -35,18 +35,21 @@ public class RouteConfigurationTest {
     private MockService vaadinService;
     private VaadinSession session;
     private ServletContext servletContext;
+    private VaadinServletContext vaadinContext;
 
     @Before
     public void init() {
         servletContext = Mockito.mock(ServletContext.class);
+        vaadinContext = new VaadinServletContext(servletContext);
         registry = ApplicationRouteRegistry
-                .getInstance(new VaadinServletContext(servletContext));
+                .getInstance(vaadinContext);
 
         Mockito.when(servletContext.getAttribute(RouteRegistry.class.getName()))
                 .thenReturn(registry);
 
         vaadinService = Mockito.mock(MockService.class);
         Mockito.when(vaadinService.getRouteRegistry()).thenReturn(registry);
+        Mockito.when(vaadinService.getContext()).thenReturn(vaadinContext);
 
         VaadinService.setCurrent(vaadinService);
 

--- a/flow-server/src/test/java/com/vaadin/flow/router/SessionRouteRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/SessionRouteRegistryTest.java
@@ -1,5 +1,6 @@
 package com.vaadin.flow.router;
 
+import javax.servlet.ServletContext;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -14,8 +15,6 @@ import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import javax.servlet.ServletContext;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,6 +26,7 @@ import com.vaadin.flow.server.MockVaadinSession;
 import com.vaadin.flow.server.RouteRegistry;
 import com.vaadin.flow.server.SessionRouteRegistry;
 import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinServletContext;
 import com.vaadin.flow.server.VaadinServletService;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.startup.ApplicationRouteRegistry;
@@ -40,8 +40,8 @@ public class SessionRouteRegistryTest {
 
     @Before
     public void init() {
-        registry = ApplicationRouteRegistry
-                .getInstance(Mockito.mock(ServletContext.class));
+        registry = ApplicationRouteRegistry.getInstance(
+                new VaadinServletContext(Mockito.mock(ServletContext.class)));
 
         vaadinService = Mockito.mock(MockService.class);
         Mockito.when(vaadinService.getRouteRegistry()).thenReturn(registry);

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.router.internal;
 
+import javax.servlet.ServletContext;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -23,8 +24,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
-import javax.servlet.ServletContext;
-
+import net.jcip.annotations.NotThreadSafe;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,12 +56,11 @@ import com.vaadin.flow.server.MockVaadinServletService;
 import com.vaadin.flow.server.MockVaadinSession;
 import com.vaadin.flow.server.RouteRegistry;
 import com.vaadin.flow.server.ServiceException;
+import com.vaadin.flow.server.VaadinServletContext;
 import com.vaadin.flow.server.startup.ApplicationRouteRegistry;
 import com.vaadin.tests.util.AlwaysLockedVaadinSession;
 import com.vaadin.tests.util.MockDeploymentConfiguration;
 import com.vaadin.tests.util.MockUI;
-
-import net.jcip.annotations.NotThreadSafe;
 
 @NotThreadSafe
 public class NavigationStateRendererTest {
@@ -70,8 +69,8 @@ public class NavigationStateRendererTest {
 
     @Before
     public void init() {
-        RouteRegistry registry = ApplicationRouteRegistry
-                .getInstance(Mockito.mock(ServletContext.class));
+        RouteRegistry registry = ApplicationRouteRegistry.getInstance(
+                new VaadinServletContext(Mockito.mock(ServletContext.class)));
         router = new Router(registry);
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/ApplicationRouteRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/ApplicationRouteRegistryTest.java
@@ -1,5 +1,6 @@
 package com.vaadin.flow.server.startup;
 
+import javax.servlet.ServletContext;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -10,8 +11,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import javax.servlet.ServletContext;
-
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,6 +18,7 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.router.RouteBaseData;
 import com.vaadin.flow.server.RouteRegistry;
+import com.vaadin.flow.server.VaadinServletContext;
 
 /**
  * Tests for {@link ApplicationRouteRegistry} instance inside OSGi container.
@@ -29,8 +29,8 @@ public class ApplicationRouteRegistryTest extends RouteRegistryTestBase {
 
     @Before
     public void init() {
-        registry = ApplicationRouteRegistry
-                .getInstance(Mockito.mock(ServletContext.class));
+        registry = ApplicationRouteRegistry.getInstance(
+                new VaadinServletContext(Mockito.mock(ServletContext.class)));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/OSGiApplicationRouteRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/OSGiApplicationRouteRegistryTest.java
@@ -20,6 +20,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import com.vaadin.flow.server.VaadinServletContext;
 import com.vaadin.flow.server.osgi.OSGiAccess;
 
 @RunWith(EnableOSGiRunner.class)
@@ -29,10 +30,8 @@ public class OSGiApplicationRouteRegistryTest
     @After
     public void cleanUp() {
         if (OSGiAccess.getInstance().getOsgiServletContext() != null) {
-            ApplicationRouteRegistry
-                    .getInstance(
-                            OSGiAccess.getInstance().getOsgiServletContext())
-                    .clean();
+            ApplicationRouteRegistry.getInstance(new VaadinServletContext(
+                    OSGiAccess.getInstance().getOsgiServletContext())).clean();
         }
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/OSGiInitApplicationRouteRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/OSGiInitApplicationRouteRegistryTest.java
@@ -15,12 +15,12 @@
  */
 package com.vaadin.flow.server.startup;
 
+import javax.servlet.ServletContext;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import javax.servlet.ServletContext;
-
+import net.jcip.annotations.NotThreadSafe;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,9 +31,8 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.router.RouteData;
 import com.vaadin.flow.server.RouteRegistry;
+import com.vaadin.flow.server.VaadinServletContext;
 import com.vaadin.flow.server.osgi.OSGiAccess;
-
-import net.jcip.annotations.NotThreadSafe;
 
 /**
  * Tests for {@link ApplicationRouteRegistry} instance which is initialized via
@@ -58,11 +57,12 @@ public class OSGiInitApplicationRouteRegistryTest
         OSGiAccess.getInstance().getOsgiServletContext()
                 .setAttribute(RouteRegistry.class.getName(), null);
 
-        registry = ApplicationRouteRegistry
-                .getInstance(Mockito.mock(ServletContext.class));
+        registry = ApplicationRouteRegistry.getInstance(
+                new VaadinServletContext(Mockito.mock(ServletContext.class)));
 
-        osgiCollectorRegistry = ApplicationRouteRegistry
-                .getInstance(OSGiAccess.getInstance().getOsgiServletContext());
+        osgiCollectorRegistry = ApplicationRouteRegistry.getInstance(
+                new VaadinServletContext(
+                        OSGiAccess.getInstance().getOsgiServletContext()));
     }
 
     @Test
@@ -283,7 +283,8 @@ public class OSGiInitApplicationRouteRegistryTest
                 Collections.singletonList(MainLayout.class));
 
         ApplicationRouteRegistry anotherRegistry = ApplicationRouteRegistry
-                .getInstance(Mockito.mock(ServletContext.class));
+                .getInstance(new VaadinServletContext(
+                        Mockito.mock(ServletContext.class)));
 
         List<RouteData> routes = anotherRegistry.getRegisteredRoutes();
         Assert.assertEquals(2, routes.size());


### PR DESCRIPTION
Move away from ServletContext to VaadinContext so that
we enable using the application route registry in environments
that have another context than ServletContext.

Note! this is a breaking change for anyone using the
application route registry not though the RouteConfiguration util.

Fixes #6294

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6304)
<!-- Reviewable:end -->
