### PR TITLE
Use VaadinServiceInitListener as an entry point for collecting endpoints

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
@@ -43,6 +43,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.internal.ReflectTools;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.UIInitListener;
+import com.vaadin.flow.server.VaadinServiceInitListener;
 import com.vaadin.flow.theme.AbstractTheme;
 import com.vaadin.flow.theme.NoTheme;
 import com.vaadin.flow.theme.ThemeDefinition;
@@ -275,6 +276,11 @@ public class FrontendDependencies implements Serializable {
 
         for (Class<?> initListener : finder.getSubTypesOf(
                 finder.loadClass(UIInitListener.class.getName()))) {
+            collectEndpoints(initListener);
+        }
+
+        for (Class<?> initListener : finder.getSubTypesOf(
+                finder.loadClass(VaadinServiceInitListener.class.getName()))) {
             collectEndpoints(initListener);
         }
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -56,6 +56,7 @@ import com.vaadin.flow.server.DevModeHandler;
 import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.UIInitListener;
 import com.vaadin.flow.server.VaadinContext;
+import com.vaadin.flow.server.VaadinServiceInitListener;
 import com.vaadin.flow.server.VaadinServlet;
 import com.vaadin.flow.server.VaadinServletContext;
 import com.vaadin.flow.server.frontend.FrontendUtils;
@@ -77,7 +78,8 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_GENERATED;
  * server.
  */
 @HandlesTypes({ Route.class, NpmPackage.class, NpmPackage.Container.class,
-        WebComponentExporter.class, UIInitListener.class })
+        WebComponentExporter.class, UIInitListener.class,
+        VaadinServiceInitListener.class })
 @WebListener
 public class DevModeInitializer implements ServletContainerInitializer,
         Serializable, ServletContextListener {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
@@ -26,6 +26,8 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.UIInitListener;
+import com.vaadin.flow.server.VaadinServiceInitListener;
+import com.vaadin.flow.server.frontend.scanner.samples.MyServiceListener;
 import com.vaadin.flow.server.frontend.scanner.samples.MyUIInitListener;
 import com.vaadin.flow.server.frontend.scanner.samples.RouteComponent;
 
@@ -40,6 +42,10 @@ public class FrontendDependenciesTest {
 
         Mockito.when(classFinder.loadClass(UIInitListener.class.getName()))
                 .thenReturn((Class) UIInitListener.class);
+
+        Mockito.when(classFinder
+                .loadClass(VaadinServiceInitListener.class.getName()))
+                .thenReturn((Class) VaadinServiceInitListener.class);
 
         Mockito.doAnswer(invocation -> {
             return FrontendDependenciesTest.class.getClassLoader()
@@ -69,6 +75,22 @@ public class FrontendDependenciesTest {
             throws ClassNotFoundException {
         Mockito.when(classFinder.getSubTypesOf(UIInitListener.class))
                 .thenReturn(Collections.singleton(MyUIInitListener.class));
+        FrontendDependencies dependencies = new FrontendDependencies(
+                classFinder, false);
+        List<String> modules = dependencies.getModules();
+        Assert.assertEquals(1, modules.size());
+        Assert.assertEquals("baz.js", modules.get(0));
+
+        Set<String> scripts = dependencies.getScripts();
+        Assert.assertEquals(1, scripts.size());
+        Assert.assertEquals("foobar.js", scripts.iterator().next());
+    }
+
+    @Test
+    public void componentInsideUiInitListenerInsideServiceInitListener_endpointsAreCollected()
+            throws ClassNotFoundException {
+        Mockito.when(classFinder.getSubTypesOf(VaadinServiceInitListener.class))
+                .thenReturn(Collections.singleton(MyServiceListener.class));
         FrontendDependencies dependencies = new FrontendDependencies(
                 classFinder, false);
         List<String> modules = dependencies.getModules();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/samples/MyServiceListener.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/samples/MyServiceListener.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.frontend.scanner.samples;
+
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinServiceInitListener;
+
+public class MyServiceListener implements VaadinServiceInitListener {
+
+    @Override
+    public void serviceInit(ServiceInitEvent event) {
+        event.getSource().addUIInitListener(new MyUIInitListener());
+    }
+
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeClassFinderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeClassFinderTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import com.vaadin.flow.component.WebComponentExporter;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.SessionInitListener;
 import com.vaadin.flow.server.UIInitListener;
 import com.vaadin.flow.server.VaadinServiceInitListener;
 import com.vaadin.flow.server.startup.DevModeInitializer.DevModeClassFinder;
@@ -46,8 +47,9 @@ public class DevModeClassFinderTest {
         Assert.assertTrue(classes.contains(NpmPackage.Container.class));
         Assert.assertTrue(classes.contains(WebComponentExporter.class));
         Assert.assertTrue(classes.contains(UIInitListener.class));
+        Assert.assertTrue(classes.contains(VaadinServiceInitListener.class));
 
-        Assert.assertEquals(5, classes.size());
+        Assert.assertEquals(6, classes.size());
     }
 
     @Test
@@ -104,7 +106,7 @@ public class DevModeClassFinderTest {
     @Test(expected = IllegalArgumentException.class)
     public void callGetSubTypesOfByName_unexpectedType_throw()
             throws ClassNotFoundException {
-        classFinder.getSubTypesOf(VaadinServiceInitListener.class.getName());
+        classFinder.getSubTypesOf(SessionInitListener.class.getName());
     }
 
     private Collection<Class<?>> getApplicableClasses() {


### PR DESCRIPTION
Spring classes search by subtype is not able to find lambdas, so
VaadinServiceInitListener is used as an entry point to search endpoints
instead of UIInitListener as it's the only proper way to add a ui init
listener

Part of vaadin/spring#475

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6326)
<!-- Reviewable:end -->
