### PR TITLE
Update enabled status for virtual children of Element without Component (#6315)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
@@ -237,9 +237,9 @@ public class ComponentUtil {
                 && component.getElement().isEnabled() != component.getElement()
                         .getNode().isEnabledSelf()) {
 
-            Optional<Component> parent = component.getParent();
-            if (parent.isPresent()
-                    && isAttachedToParent(component, parent.get())) {
+            Element parent = component.getElement().getParent();
+            if (parent != null
+                    && isAttachedToParent(component.getElement(), parent)) {
                 component.onEnabledStateChanged(
                         component.getElement().isEnabled());
             }
@@ -268,12 +268,12 @@ public class ComponentUtil {
         if (component instanceof HasEnabled
                 && component.getElement().isEnabled() != component.getElement()
                         .getNode().isEnabledSelf()) {
-            Optional<Component> parent = component.getParent();
-            if (parent.isPresent()) {
-                Component parentComponent = parent.get();
-                boolean state = isAttachedToParent(component, parentComponent)
-                        ? checkParentChainState(parentComponent)
-                        : component.getElement().getNode().isEnabledSelf();
+            Element parent = component.getElement().getParent();
+            if (parent != null) {
+                boolean state = isAttachedToParent(component.getElement(),
+                        parent) ? checkParentChainState(parent)
+                                : component.getElement().getNode()
+                                        .isEnabledSelf();
                 component.onEnabledStateChanged(state);
             } else {
                 component.onEnabledStateChanged(
@@ -282,37 +282,33 @@ public class ComponentUtil {
         }
     }
 
-    private static boolean isAttachedToParent(Component component,
-            Component parentComponent) {
-        return parentComponent.getChildren()
-                .anyMatch(child -> child.equals(component))
-                || isVirtualChild(component, parentComponent);
+    private static boolean isAttachedToParent(Element element, Element parent) {
+        return parent.getChildren().anyMatch(child -> child.equals(element))
+                || isVirtualChild(element, parent);
     }
 
-    private static boolean isVirtualChild(Component component,
-            Component parentComponent) {
-        Iterator<StateNode> iterator = parentComponent.getElement().getNode()
+    private static boolean isVirtualChild(Element element, Element parent) {
+        Iterator<StateNode> iterator = parent.getNode()
                 .getFeatureIfInitialized(VirtualChildrenList.class)
                 .map(VirtualChildrenList::iterator)
                 .orElse(Collections.emptyIterator());
         while (iterator.hasNext()) {
-            if (iterator.next().equals(component.getElement().getNode())) {
+            if (iterator.next().equals(element.getNode())) {
                 return true;
             }
         }
         return false;
     }
 
-    private static boolean checkParentChainState(Component component) {
-        if (!component.getElement().getNode().isEnabledSelf()) {
+    private static boolean checkParentChainState(Element element) {
+        if (!element.getNode().isEnabledSelf()) {
             return false;
         }
 
-        Optional<Component> parent = component.getParent();
-        if (parent.isPresent()) {
-            Component parentComponent = parent.get();
-            if (isAttachedToParent(component, parentComponent)) {
-                return checkParentChainState(parentComponent);
+        Element parent = element.getParent();
+        if (parent != null) {
+            if (isAttachedToParent(element, parent)) {
+                return checkParentChainState(parent);
             }
         }
 


### PR DESCRIPTION
ComponentUtil::onComponentAttach/ComponentUtil::onComponentDetach should
use Element API parent to decide whether to call
Component::onEnabledStateChanged.
That allows to use correct parent in case there is no Component mapped
to Element.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6330)
<!-- Reviewable:end -->
