### PR TITLE
Update enabled status for virtual children of Element without Component (#6315)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
@@ -234,9 +234,9 @@ public class ComponentUtil {
                 && component.getElement().isEnabled() != component.getElement()
                         .getNode().isEnabledSelf()) {
 
-            Optional<Component> parent = component.getParent();
-            if (parent.isPresent()
-                    && isAttachedToParent(component, parent.get())) {
+            Element parent = component.getElement().getParent();
+            if (parent != null
+                    && isAttachedToParent(component.getElement(), parent)) {
                 component.onEnabledStateChanged(
                         component.getElement().isEnabled());
             }
@@ -265,12 +265,12 @@ public class ComponentUtil {
         if (component instanceof HasEnabled
                 && component.getElement().isEnabled() != component.getElement()
                         .getNode().isEnabledSelf()) {
-            Optional<Component> parent = component.getParent();
-            if (parent.isPresent()) {
-                Component parentComponent = parent.get();
-                boolean state = isAttachedToParent(component, parentComponent)
-                        ? checkParentChainState(parentComponent)
-                        : component.getElement().getNode().isEnabledSelf();
+            Element parent = component.getElement().getParent();
+            if (parent != null) {
+                boolean state = isAttachedToParent(component.getElement(),
+                        parent) ? checkParentChainState(parent)
+                                : component.getElement().getNode()
+                                        .isEnabledSelf();
                 component.onEnabledStateChanged(state);
             } else {
                 component.onEnabledStateChanged(
@@ -279,35 +279,31 @@ public class ComponentUtil {
         }
     }
 
-    private static boolean isAttachedToParent(Component component,
-            Component parentComponent) {
-        return parentComponent.getChildren()
-                .anyMatch(child -> child.equals(component))
-                || isVirtualChild(component, parentComponent);
+    private static boolean isAttachedToParent(Element element, Element parent) {
+        return parent.getChildren().anyMatch(child -> child.equals(element))
+                || isVirtualChild(element, parent);
     }
 
-    private static boolean isVirtualChild(Component component,
-            Component parentComponent) {
-        Iterator<StateNode> iterator = parentComponent.getElement().getNode()
+    private static boolean isVirtualChild(Element element, Element parent) {
+        Iterator<StateNode> iterator = parent.getNode()
                 .getFeature(VirtualChildrenList.class).iterator();
         while (iterator.hasNext()) {
-            if (iterator.next().equals(component.getElement().getNode())) {
+            if (iterator.next().equals(element.getNode())) {
                 return true;
             }
         }
         return false;
     }
 
-    private static boolean checkParentChainState(Component component) {
-        if (!component.getElement().getNode().isEnabledSelf()) {
+    private static boolean checkParentChainState(Element element) {
+        if (!element.getNode().isEnabledSelf()) {
             return false;
         }
 
-        Optional<Component> parent = component.getParent();
-        if (parent.isPresent()) {
-            Component parentComponent = parent.get();
-            if (isAttachedToParent(component, parentComponent)) {
-                return checkParentChainState(parentComponent);
+        Element parent = element.getParent();
+        if (parent != null) {
+            if (isAttachedToParent(element, parent)) {
+                return checkParentChainState(parent);
             }
         }
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
@@ -24,10 +24,12 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import net.jcip.annotations.NotThreadSafe;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -53,7 +55,6 @@ import com.vaadin.tests.util.MockUI;
 import com.vaadin.tests.util.TestUtil;
 
 import elemental.json.Json;
-import net.jcip.annotations.NotThreadSafe;
 
 @NotThreadSafe
 public class ComponentTest {
@@ -1216,33 +1217,17 @@ public class ComponentTest {
 
     @Test // 3818
     public void enabledStateChangeOnAttachCalledForParentState() {
-        UI ui = new UI();
+        enabledStateChangeOnAttachCalledForParentState(
+                (parent, child) -> parent.add(child));
+    }
 
-        EnabledDiv parent = new EnabledDiv();
-        parent.setEnabled(false);
-        ui.add(parent);
-
-        AtomicReference<Boolean> stateChange = new AtomicReference<>();
-        EnabledDiv child = new EnabledDiv() {
-            @Override
-            public void onEnabledStateChanged(boolean enabled) {
-                super.onEnabledStateChanged(enabled);
-                Assert.assertTrue("Expected empty state for enabled change",
-                        stateChange.compareAndSet(null, enabled));
-            }
-        };
-
-        Assert.assertFalse("Parent should be disabled", parent.isEnabled());
-        Assert.assertTrue("Child should be enabled.", child.isEnabled());
-        Assert.assertNull(child.getElement().getAttribute("disabled"));
-
-        parent.add(child);
-
-        Assert.assertFalse("After attach child should be disabled",
-                child.isEnabled());
-        Assert.assertFalse("Disabled event should have triggered",
-                stateChange.get());
-        Assert.assertNotNull(child.getElement().getAttribute("disabled"));
+    @Test
+    public void enabledStateChangeOnAttachCalledForParentOfVirtualChildState() {
+        enabledStateChangeOnAttachCalledForParentState((parent, child) -> {
+            Element wrapper = new Element("div");
+            parent.getElement().appendVirtualChild(wrapper);
+            wrapper.appendChild(child.getElement());
+        });
     }
 
     @Test // 3818
@@ -1282,6 +1267,21 @@ public class ComponentTest {
         Assert.assertTrue("Enable event should have triggered",
                 stateChange.get());
         Assert.assertNull(child.getElement().getAttribute("disabled"));
+    }
+
+    @Test
+    public void enabledStateChangeOnParentDetachReturnsOldState() {
+        enabledStateChangeOnParentDetachReturnsOldState(
+                (parent, child) -> parent.add(child));
+    }
+
+    @Test
+    public void enabledStateChangeOnParentOfVirtualChildDetachReturnsOldState() {
+        enabledStateChangeOnParentDetachReturnsOldState((parent, child) -> {
+            Element wrapper = new Element("div");
+            parent.getElement().appendVirtualChild(wrapper);
+            wrapper.appendChild(child.getElement());
+        });
     }
 
     @Test // 3818
@@ -1565,5 +1565,91 @@ public class ComponentTest {
         Assert.assertNotNull("Disabled attribute should exist for subSubChild",
                 subSubChild.getElement().getAttribute("disabled"));
 
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void add_componentIsAttachedToAnotherUI_throwsIllegalStateException() {
+        // given
+        TestComponent child = new TestComponent();
+        UI ui1 = new UI();
+        ui1.add(child);
+        UI ui2 = new UI();
+
+        // then
+        ui2.add(child);
+    }
+
+    private void enabledStateChangeOnAttachCalledForParentState(
+            BiConsumer<EnabledDiv, Component> modificationStartegy) {
+        UI ui = new UI();
+
+        EnabledDiv parent = new EnabledDiv();
+        parent.setEnabled(false);
+        ui.add(parent);
+
+        AtomicReference<Boolean> stateChange = new AtomicReference<>();
+        EnabledDiv child = new EnabledDiv() {
+            @Override
+            public void onEnabledStateChanged(boolean enabled) {
+                super.onEnabledStateChanged(enabled);
+                Assert.assertTrue("Expected empty state for enabled change",
+                        stateChange.compareAndSet(null, enabled));
+            }
+        };
+
+        Assert.assertFalse("Parent should be disabled", parent.isEnabled());
+        Assert.assertTrue("Child should be enabled.", child.isEnabled());
+        Assert.assertNull(child.getElement().getAttribute("disabled"));
+
+        modificationStartegy.accept(parent, child);
+
+        Assert.assertFalse("After attach child should be disabled",
+                child.isEnabled());
+        Assert.assertFalse("Disabled event should have triggered",
+                stateChange.get());
+        Assert.assertNotNull(child.getElement().getAttribute("disabled"));
+    }
+
+    private void enabledStateChangeOnParentDetachReturnsOldState(
+            BiConsumer<EnabledDiv, Component> modificationStartegy) {
+        UI ui = new UI();
+
+        EnabledDiv grandParent = new EnabledDiv();
+        grandParent.setEnabled(false);
+        ui.add(grandParent);
+
+        EnabledDiv parent = new EnabledDiv();
+
+        AtomicReference<Boolean> stateChange = new AtomicReference<>();
+        EnabledDiv child = new EnabledDiv() {
+            @Override
+            public void onEnabledStateChanged(boolean enabled) {
+                super.onEnabledStateChanged(enabled);
+
+                stateChange.set(enabled);
+            }
+        };
+
+        Assert.assertTrue("Parent should be enabled", parent.isEnabled());
+        Assert.assertTrue("Child should be enabled.", child.isEnabled());
+        Assert.assertNull(child.getElement().getAttribute("disabled"));
+
+        modificationStartegy.accept(parent, child);
+
+        grandParent.add(parent);
+
+        Assert.assertFalse("After attach child should be disabled",
+                child.isEnabled());
+        Assert.assertFalse("Disabled event should have triggered",
+                stateChange.get());
+        Assert.assertNotNull(child.getElement().getAttribute("disabled"));
+
+        grandParent.remove(parent);
+
+        Assert.assertTrue("After detach child should be enabled",
+                child.isEnabled());
+        Assert.assertTrue("Enable event should have triggered",
+                stateChange.get());
+        Assert.assertNull(child.getElement().getAttribute("disabled"));
     }
 }


### PR DESCRIPTION
ComponentUtil::onComponentAttach/ComponentUtil::onComponentDetach should
use Element API parent to decide whether to call
Component::onEnabledStateChanged.
That allows to use correct parent in case there is no Component mapped
to Element.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6331)
<!-- Reviewable:end -->
