### PR TITLE
Update RoutePrefix to fix Javadoc typo

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/Route.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/Route.java
@@ -80,7 +80,7 @@ public @interface Route {
     Class<? extends RouterLayout> layout() default UI.class;
 
     /**
-     * Have the rout chain break on defined class and not take into notice any
+     * Have the route chain break on defined class and not take into notice any
      * more parent layout route prefixes.
      *
      * @return route up to here should be absolute

--- a/flow-server/src/main/java/com/vaadin/flow/router/RoutePrefix.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RoutePrefix.java
@@ -40,7 +40,7 @@ public @interface RoutePrefix {
     String value();
 
     /**
-     * Have the rout chain break on defined class and not take into notice any
+     * Have the route chain break on defined class and not take into notice any
      * more parent layout route prefixes.
      * 
      * @return route up to here should be absolute


### PR DESCRIPTION
Fix spelling typo in Javadoc from "rout" to "route".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6350)
<!-- Reviewable:end -->
