### PR TITLE
CCDM: implement `flow.route` API in client (#6338)

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
@@ -1,184 +1,194 @@
 export interface FlowConfig {
-    imports ?: () => void;
+  imports ?: () => void;
 }
 
 interface AppConfig {
-    productionMode: boolean,
-    appId: string,
-    uidl: object
+  productionMode: boolean,
+  appId: string,
+  uidl: object
 }
 
 interface AppInitResponse {
-    appConfig: AppConfig;
+  appConfig: AppConfig;
 }
 
 interface HTMLRouterContainer extends HTMLElement {
-    onBeforeEnter ?: (ctx: NavigationParameters, cmd: NavigationCommands) => Promise<any>;
-    serverConnected ?: (cancel: boolean) => void;
+  onBeforeEnter ?: (ctx: NavigationParameters, cmd: NavigationCommands) => Promise<any>;
+  serverConnected ?: (cancel: boolean) => void;
+}
+
+interface FlowRoute {
+  action : (params: NavigationParameters) => Promise<HTMLRouterContainer>;
+  path: string;
 }
 
 interface FlowRoot {
-    $: any ;
-    $server: any;
+  $: any ;
+  $server: any;
 }
 
 export interface NavigationParameters {
-    pathname: string;
+  pathname: string;
 }
 
 export interface NavigationCommands {
-    prevent: () => any;
+  prevent: () => any;
 }
 
 /**
  * Client API for flow UI operations.
  */
 export class Flow {
-    config ?: FlowConfig;
-    response ?: AppInitResponse;
+  config: FlowConfig;
+  response ?: AppInitResponse;
 
-    // flow uses body for keeping references
-    flowRoot : FlowRoot = document.body as any;
+  // flow uses body for keeping references
+  flowRoot : FlowRoot = document.body as any;
 
+  // @ts-ignore
+  container : HTMLRouterContainer;
+
+  constructor(config?: FlowConfig) {
+    this.flowRoot.$ = this.flowRoot.$ || {};
+    this.config = config || {};
+  }
+
+  /**
+   * This should initialize flow in full page mode when implementing
+   * https://github.com/vaadin/flow/issues/6256
+   * @deprecated
+   */
+  async start(): Promise<AppInitResponse> {
+    return this.flowInit();
+  }
+
+  /**
+   * Go to a route defined in server.
+   *
+   * This is a generic API for non `vaadin-router` applications.
+   */
+  get navigate(): (params: NavigationParameters) => Promise<HTMLElement> {
+    // Return a function which is bound to the flow instance
+    return async (params: NavigationParameters) => {
+      await this.flowInit();
+      delete this.container.onBeforeEnter;
+      return this.flowNavigate(params);
+    }
+  }
+
+  /**
+   * Return a `route` object for vaadin-router
+   *
+   * It returns a `FlowRoute` object whose `path` property handles any route,
+   * and the `action` returns the flow container without updating the content,
+   * delaying the actual Flow server call to the `onBeforeEnter` phase.
+   *
+   * This is a `vaadin-router` specific API.
+   */
+  get route(): FlowRoute {
+    return {
+      path: '(.*)',
+      action: this.action
+    }
+  }
+
+  private get action(): (params: NavigationParameters) => Promise<HTMLRouterContainer> {
+    // Return a function which is bound to the flow instance, thus we can use
+    // the syntax `flow.route` in vaadin-router.
     // @ts-ignore
-    container : HTMLRouterContainer;
+    return async (params: NavigationParameters) => {
+      await this.flowInit();
+      this.container.onBeforeEnter = (ctx, cmd) => this.onBeforeEnter(ctx, cmd);
+      return this.container;
+    }
+  }
 
-    constructor(config?: FlowConfig) {
-        this.flowRoot.$ = {};
-        if (config) {
-            this.config = config;
+  private onBeforeEnter(ctx: NavigationParameters, cmd: NavigationCommands) {
+    return this.flowNavigate(ctx, cmd);
+  }
+
+  // Send the remote call to `JavaScriptBootstrapUI` to render the flow
+  // route specified by `routePath`
+  private async flowNavigate(ctx: NavigationParameters, cmd?: NavigationCommands): Promise<HTMLElement> {
+    return new Promise(resolve => {
+      // The callback to run from server side once the view is ready
+      this.container.serverConnected = cancel =>
+        resolve(cmd && cancel ? cmd.prevent() : this.container);
+
+      // Call server side to navigate to the given route
+      this.flowRoot.$server.connectClient(this.container.localName, this.container.id, ctx.pathname);
+    });
+  }
+
+  // import flow client modules and initialize UI in server side.
+  private async flowInit(): Promise<AppInitResponse> {
+    // Do not start flow twice
+    if (!this.response) {
+      // Initialize server side UI
+      this.response = await this.flowInitUi();
+
+      // Load bootstrap script with server side parameters
+      const bootstrapMod = await import('./FlowBootstrap');
+      await bootstrapMod.init(this.response);
+
+      // Load flow-client module
+      const clientMod = await import('./FlowClient');
+      await this.flowInitClient(clientMod);
+
+      // Load custom modules defined by user
+      if (this.config.imports) {
+        await this.config.imports();
+      }
+
+      const id = this.response.appConfig.appId;
+      // we use a custom tag for the flow app container
+      const tag = `flow-container-${id.toLowerCase()}`;
+
+      this.container = this.flowRoot.$[id] = document.createElement(tag);
+      this.container.id = id;
+      window.console.log("Created container for the flow UI with " + tag);
+    }
+    return this.response;
+  }
+
+  // After the flow-client javascript module has been loaded, this initializes flow UI
+  // in the browser.
+  private async flowInitClient(clientMod: any): Promise<void> {
+    clientMod.init();
+    // client init is async, we need to loop until initialized
+    return new Promise(resolve => {
+      const $wnd = window as any;
+      const intervalId = setInterval(() => {
+        // client `isActive() == true` while initializing
+        const initializing = Object.keys($wnd.Vaadin.Flow.clients)
+          .reduce((prev, id) => prev || $wnd.Vaadin.Flow.clients[id].isActive(), false);
+        if (!initializing) {
+          clearInterval(intervalId);
+          resolve();
         }
-    }
+      }, 5);
+    });
+  }
 
-    /**
-     * This should initialize flow in full page mode when implementing
-     * https://github.com/vaadin/flow/issues/6256
-     * @deprecated
-     */
-    async start(): Promise<AppInitResponse> {
-        return this.flowInit();
-    }
-
-    /**
-     * Configure flow container for going to a route defined in server.
-     * It returns immediately the flow container without updating the content.
-     * Then Iit waits for the `container.onBeforeEnter` to be called in order
-     * to either: prevent navigation or update the content.
-     *
-     * This is a `vaadin-router` specific API.
-     */
-    get route(): (params: NavigationParameters) => Promise<HTMLRouterContainer> {
-        // Return a function which is bound to the flow instance, thus we can use
-        // the syntax `action: flow.route` in vaadin-router.
-        // @ts-ignore
-        return async (params: NavigationParameters) => {
-            await this.flowInit();
-            this.container.onBeforeEnter = (ctx, cmd) => this.onBeforeEnter(ctx, cmd);
-            return this.container;
+  // Send the remote call to `JavaScriptBootstrapHandler` in order to init
+  // server session and UI, and get the `appConfig` and `uidl`
+  private async flowInitUi(): Promise<AppInitResponse> {
+    return new Promise((resolve, reject) => {
+      const httpRequest = new (window as any).XMLHttpRequest();
+      httpRequest.open('GET', 'VAADIN/?v-r=init');
+      httpRequest.onload = () => {
+        if (httpRequest.getResponseHeader('content-type') === 'application/json') {
+          resolve(JSON.parse(httpRequest.responseText));
+        } else {
+          reject(new Error(
+            `Invalid server response when initializing Flow UI.
+            ${httpRequest.status}
+            ${httpRequest.responseText}`));
         }
-    }
-
-    /**
-     * Go to a route defined in server.
-     *
-     * This is a generic API for non `vaadin-router` applications.
-     */
-    get navigate(): (params: NavigationParameters) => Promise<HTMLElement> {
-        // Return a function which is bound to the flow instance
-        return async (params: NavigationParameters) => {
-            await this.flowInit();
-            delete this.container.onBeforeEnter;
-            return this.flowNavigate(params);
-        }
-    }
-
-    private onBeforeEnter(ctx: NavigationParameters, cmd: NavigationCommands) {
-        return this.flowNavigate(ctx, cmd);
-    }
-
-    // Send the remote call to `JavaScriptBootstrapUI` to render the flow
-    // route specified by `routePath`
-    private async flowNavigate(ctx: NavigationParameters, cmd?: NavigationCommands): Promise<HTMLElement> {
-        const routePath = ctx.pathname.replace(/^\//, '');
-        return new Promise(resolve => {
-            // The callback to run from server side once the view is ready
-            this.container.serverConnected = cancel =>
-                resolve(cmd && cancel ? cmd.prevent() : this.container);
-
-            // Call server side to navigate to the given route
-            this.flowRoot.$server.connectClient(this.container.localName, this.container.id, routePath);
-        });
-    }
-
-    // import flow client modules and initialize UI in server side.
-    private async flowInit(): Promise<AppInitResponse> {
-        // Do not start flow twice
-        if (!this.response) {
-            // Initialize server side UI
-            this.response = await this.flowInitUi();
-
-            // Load bootstrap script with server side parameters
-            const bootstrapMod = await import('./FlowBootstrap');
-            await bootstrapMod.init(this.response);
-
-            // Load flow-client module
-            const clientMod = await import('./FlowClient');
-            await this.flowInitClient(clientMod);
-
-            // Load custom modules defined by user
-            if (this.config && this.config.imports) {
-                await this.config.imports();
-            }
-
-            const id = this.response.appConfig.appId;
-            // we use a custom tag for the flow app container
-            const tag = `flow-container-${id.toLowerCase()}`;
-
-            this.container = this.flowRoot.$[id] = document.createElement(tag);
-            this.container.id = id;
-            window.console.log(">>>> Created container for the flow UI with " + tag);
-        }
-        return this.response;
-    }
-
-    // After the flow-client javascript module has been loaded, this initializes flow UI
-    // in the browser.
-    private async flowInitClient(clientMod: any): Promise<void> {
-        clientMod.init();
-        // client init is async, we need to loop until initialized
-        return new Promise(resolve => {
-            const $wnd = window as any;
-            const intervalId = setInterval(() => {
-                // client `isActive() == true` while initializing
-                const initializing = Object.keys($wnd.Vaadin.Flow.clients)
-                  .reduce((prev, id) => prev || $wnd.Vaadin.Flow.clients[id].isActive(), false);
-                if (!initializing) {
-                    clearInterval(intervalId);
-                    resolve();
-                }
-            }, 5);
-        });
-    }
-
-    // Send the remote call to `JavaScriptBootstrapHandler` in order to init
-    // server session and UI, and get the `appConfig` and `uidl`
-    private async flowInitUi(): Promise<AppInitResponse> {
-        return new Promise((resolve, reject) => {
-            const httpRequest = new (window as any).XMLHttpRequest();
-            httpRequest.open('GET', 'VAADIN/?v-r=init');
-            httpRequest.onload = () => {
-                if (httpRequest.getResponseHeader('content-type') === 'application/json') {
-                    resolve(JSON.parse(httpRequest.responseText));
-                } else {
-                    reject(new Error(
-                        `Invalid server response when initializing Flow UI.
-                        ${httpRequest.status}
-                        ${httpRequest.responseText}`));
-                }
-            };
-            httpRequest.send();
-        });
-    }
+      };
+      httpRequest.send();
+    });
+  }
 
 }
 

--- a/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
@@ -12,8 +12,22 @@ interface AppInitResponse {
     appConfig: AppConfig;
 }
 
+interface HTMLRouterContainer extends HTMLElement {
+    onBeforeEnter ?: (ctx: NavigationParameters, cmd: NavigationCommands) => Promise<any>;
+    serverConnected ?: (cancel: boolean) => void;
+}
+
+interface FlowRoot {
+    $: any ;
+    $server: any;
+}
+
 export interface NavigationParameters {
-    path: string;
+    pathname: string;
+}
+
+export interface NavigationCommands {
+    prevent: () => any;
 }
 
 /**
@@ -23,20 +37,85 @@ export class Flow {
     config ?: FlowConfig;
     response ?: AppInitResponse;
 
+    // flow uses body for keeping references
+    flowRoot : FlowRoot = document.body as any;
+
+    // @ts-ignore
+    container : HTMLRouterContainer;
+
     constructor(config?: FlowConfig) {
+        this.flowRoot.$ = {};
         if (config) {
             this.config = config;
         }
     }
 
     /**
-     * Load flow client module and initialize UI in server side.
+     * This should initialize flow in full page mode when implementing
+     * https://github.com/vaadin/flow/issues/6256
+     * @deprecated
      */
     async start(): Promise<AppInitResponse> {
+        return this.flowInit();
+    }
+
+    /**
+     * Configure flow container for going to a route defined in server.
+     * It returns immediately the flow container without updating the content.
+     * Then Iit waits for the `container.onBeforeEnter` to be called in order
+     * to either: prevent navigation or update the content.
+     *
+     * This is a `vaadin-router` specific API.
+     */
+    get route(): (params: NavigationParameters) => Promise<HTMLRouterContainer> {
+        // Return a function which is bound to the flow instance, thus we can use
+        // the syntax `action: flow.route` in vaadin-router.
+        // @ts-ignore
+        return async (params: NavigationParameters) => {
+            await this.flowInit();
+            this.container.onBeforeEnter = (ctx, cmd) => this.onBeforeEnter(ctx, cmd);
+            return this.container;
+        }
+    }
+
+    /**
+     * Go to a route defined in server.
+     *
+     * This is a generic API for non `vaadin-router` applications.
+     */
+    get navigate(): (params: NavigationParameters) => Promise<HTMLElement> {
+        // Return a function which is bound to the flow instance
+        return async (params: NavigationParameters) => {
+            await this.flowInit();
+            delete this.container.onBeforeEnter;
+            return this.flowNavigate(params);
+        }
+    }
+
+    private onBeforeEnter(ctx: NavigationParameters, cmd: NavigationCommands) {
+        return this.flowNavigate(ctx, cmd);
+    }
+
+    // Send the remote call to `JavaScriptBootstrapUI` to render the flow
+    // route specified by `routePath`
+    private async flowNavigate(ctx: NavigationParameters, cmd?: NavigationCommands): Promise<HTMLElement> {
+        const routePath = ctx.pathname.replace(/^\//, '');
+        return new Promise(resolve => {
+            // The callback to run from server side once the view is ready
+            this.container.serverConnected = cancel =>
+                resolve(cmd && cancel ? cmd.prevent() : this.container);
+
+            // Call server side to navigate to the given route
+            this.flowRoot.$server.connectClient(this.container.localName, this.container.id, routePath);
+        });
+    }
+
+    // import flow client modules and initialize UI in server side.
+    private async flowInit(): Promise<AppInitResponse> {
         // Do not start flow twice
         if (!this.response) {
             // Initialize server side UI
-            this.response = await this.initFlowUi();
+            this.response = await this.flowInitUi();
 
             // Load bootstrap script with server side parameters
             const bootstrapMod = await import('./FlowBootstrap');
@@ -44,60 +123,27 @@ export class Flow {
 
             // Load flow-client module
             const clientMod = await import('./FlowClient');
-            await this.initFlowClient(clientMod);
+            await this.flowInitClient(clientMod);
 
-            // // Load custom modules defined by user
+            // Load custom modules defined by user
             if (this.config && this.config.imports) {
                 await this.config.imports();
             }
+
+            const id = this.response.appConfig.appId;
+            // we use a custom tag for the flow app container
+            const tag = `flow-container-${id.toLowerCase()}`;
+
+            this.container = this.flowRoot.$[id] = document.createElement(tag);
+            this.container.id = id;
+            window.console.log(">>>> Created container for the flow UI with " + tag);
         }
         return this.response;
     }
 
-    /**
-     * Go to a route defined in server.
-     */
-    get navigate(): (params: NavigationParameters) => Promise<HTMLElement> {
-        return (params: NavigationParameters) => this.doFlowNavigation(params);
-    }
-
-    private async doFlowNavigation(params : NavigationParameters): Promise<HTMLElement> {
-        await this.start();
-        return this.getFlowElement(params.path);
-    }
-
-    private async getFlowElement(routePath : string): Promise<HTMLElement> {
-        return new Promise(resolve => {
-            if (!this.response) {
-                return;
-            }
-            const id = this.response.appConfig.appId;
-
-            // we use a custom tag for the flow app container
-            const tag = `flow-container-${id.toLowerCase()}`;
-
-            // flow use body for keep references
-            const flowRoot = document.body as any;
-            flowRoot.$ = flowRoot.$ || {};
-
-            // Only the first navigation creates the container element
-            let element = flowRoot.$[id]
-            if (!element) {
-                element = flowRoot.$[id] = document.createElement(tag);
-                // Flow UI needs the id of the element to connect to
-                element.id = id;
-                window.console.log("Created new element for the flow UI with " + tag);
-            }
-
-            // The callback to run from server side once the view is ready
-            (element as any).serverConnected = () => resolve(element);
-
-            // Call server side to navigate to the given route
-            flowRoot.$server.connectClient(tag, element.id, routePath);
-        });
-    }
-
-    private async initFlowClient(clientMod: any): Promise<void> {
+    // After the flow-client javascript module has been loaded, this initializes flow UI
+    // in the browser.
+    private async flowInitClient(clientMod: any): Promise<void> {
         clientMod.init();
         // client init is async, we need to loop until initialized
         return new Promise(resolve => {
@@ -114,7 +160,9 @@ export class Flow {
         });
     }
 
-    private async initFlowUi(): Promise<AppInitResponse> {
+    // Send the remote call to `JavaScriptBootstrapHandler` in order to init
+    // server session and UI, and get the `appConfig` and `uidl`
+    private async flowInitUi(): Promise<AppInitResponse> {
         return new Promise((resolve, reject) => {
             const httpRequest = new (window as any).XMLHttpRequest();
             httpRequest.open('GET', 'VAADIN/?v-r=init');
@@ -131,5 +179,6 @@ export class Flow {
             httpRequest.send();
         });
     }
+
 }
 

--- a/flow-client/src/test/frontend/FlowTests.ts
+++ b/flow-client/src/test/frontend/FlowTests.ts
@@ -72,9 +72,9 @@ suite("Flow", () => {
     mockInitResponse('foobar-1111111');
 
     return new Flow()
-      .navigate({path: "Foo/Bar.baz"})
+      .navigate({pathname: "Foo/Bar.baz"})
       .then(() => {
-        // Check that start() was called
+        // Check that flowInit() was called
         assert.isDefined((window as any).Vaadin.Flow.resolveUri);
 
         // Assert that element was created amd put in flowRoot so as server can find it
@@ -107,7 +107,7 @@ suite("Flow", () => {
     });
 
     return router
-      .navigate({path: 'another-route'})
+      .navigate({pathname: 'another-route'})
       .then(elem => {
         assert.isDefined(elem);
       });
@@ -119,10 +119,10 @@ suite("Flow", () => {
 
     const flow = new Flow();
     return flow
-      .navigate({path: "Foo"})
+      .navigate({pathname: "Foo"})
       .then(e1 => {
         return flow
-        .navigate({path: "Bar"})
+        .navigate({pathname: "Bar"})
         .then(e2 => {
           assert.equal(1, Object.keys(flowRoot.$).length);
           assert.equal(e1, e2);
@@ -130,14 +130,53 @@ suite("Flow", () => {
         });
       });
   });
+
+  test("navigation should be delayed to onBeforeEnter when using router API", () => {
+    stubServerRemoteFunction('foobar-12345');
+    mockInitResponse('foobar-12345');
+
+    return new Flow()
+      .route({pathname: 'Foo/Bar.baz'})
+      .then(async(elem) => {
+
+        // Check that flowInit() was called
+        assert.isDefined((window as any).Vaadin.Flow.resolveUri);
+        // Assert that flowRoot namespace was created
+        assert.isDefined(flowRoot.$);
+        // Assert that container was created and put in the flowRoot
+        assert.isDefined(flowRoot.$['foobar-12345']);
+
+        // Assert server side has not put anything in the container
+        assert.equal(0, elem.children.length);
+
+        // When using router API, it should expose the onBeforeEnter handler
+        assert.isDefined(elem.onBeforeEnter);
+        elem.onBeforeEnter && elem.onBeforeEnter({pathname: 'Foo/Bar.baz'}, {prevent: () => {}})
+
+        // Assert server side has put content in the container
+        assert.equal(1, elem.children.length);
+      });
+  });
 });
 
 function stubServerRemoteFunction(id: string) {
   // Stub remote function exported in JavaScriptBootstrapUI.
   flowRoot.$server = {
-    connectClient: () => {
+    connectClient: (localName: string, elemId: string, route: string) => {
+      assert.isDefined(localName);
+      assert.isDefined(elemId);
+      assert.isDefined(route);
+
+      assert.equal(elemId, id);
+      assert.equal(localName, `flow-container-${elemId.toLowerCase()}`);
+
+      assert.isDefined(flowRoot.$[elemId]);
+      assert.isDefined(flowRoot.$[elemId].serverConnected);
+
+      flowRoot.$[elemId].appendChild(document.createElement('div'));
+
       // Resolve the promise
-      flowRoot.$[id].serverConnected();
+      flowRoot.$[elemId].serverConnected();
     }
   };
 }

--- a/flow-tests/test-ccdm/frontend/index.html
+++ b/flow-tests/test-ccdm/frontend/index.html
@@ -18,7 +18,7 @@
 <button id="button1">Load content from other bundle</button>
 <button id="button2">Load flow</button>
 <p>
-    <input type="text" id="routeValue" placeholder="route">
+    <input type="text" id="pathname" placeholder="route">
     <button id="button3">Navigate flow</button>
     <div id="div3"></div>
 </p>

--- a/flow-tests/test-ccdm/frontend/index.js
+++ b/flow-tests/test-ccdm/frontend/index.js
@@ -25,9 +25,11 @@ document.getElementById("button2").addEventListener('click', async e => {
 
 document.getElementById('button3').addEventListener('click', async e => {
     const route = document.getElementById('routeValue').value;
-    const view = await flow.navigate({path: route});
+    const view = await flow.route({pathname: route});
     const div = document.getElementById('div3');
     div.innerHTML = '';
+
+    await view.onBeforeEnter({pathname: route}, {prevent: () => {}});
 
     const result = document.createElement('result');
     result.id = 'result';

--- a/flow-tests/test-ccdm/frontend/index.js
+++ b/flow-tests/test-ccdm/frontend/index.js
@@ -24,16 +24,19 @@ document.getElementById("button2").addEventListener('click', async e => {
 });
 
 document.getElementById('button3').addEventListener('click', async e => {
-    const route = document.getElementById('routeValue').value;
-    const view = await flow.route({pathname: route});
-    const div = document.getElementById('div3');
-    div.innerHTML = '';
-
-    await view.onBeforeEnter({pathname: route}, {prevent: () => {}});
-
+    const pathname = document.getElementById('pathname').value;
+    // We don't want to depend on `vaadin-router`, thus we do its work here
+    // 1. Call action to get the container
+    const view = await flow.route.action({pathname: pathname});
+    // 2. Call event to ask server to put content in the container
+    await view.onBeforeEnter({pathname: pathname}, {prevent: () => {}});
+    // 3. Take the router outlet in the page and empty it
+    const outlet = document.getElementById('div3');
+    outlet.innerHTML = '';
+    // 4. Append server side response to the outlet
     const result = document.createElement('result');
     result.id = 'result';
     result.appendChild(view);
-    div.appendChild(result);
+    outlet.appendChild(result);
 });
 

--- a/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/ClientIndexHandlerIT.java
+++ b/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/ClientIndexHandlerIT.java
@@ -148,7 +148,7 @@ public class ClientIndexHandlerIT extends ChromeBrowserTest {
         openTestUrl("/");
         waitForElementPresent(By.id("button3"));
 
-        findElement(By.id("routeValue")).sendKeys("/");
+        findElement(By.id("pathname")).sendKeys("/");
         findElement(By.id("button3")).click();
         waitForElementPresent(By.id("result"));
 
@@ -162,7 +162,7 @@ public class ClientIndexHandlerIT extends ChromeBrowserTest {
         openTestUrl("/");
         waitForElementPresent(By.id("button3"));
 
-        findElement(By.id("routeValue")).sendKeys("serverview");
+        findElement(By.id("pathname")).sendKeys("serverview");
         findElement(By.id("button3")).click();
         waitForElementPresent(By.id("result"));
 
@@ -179,7 +179,7 @@ public class ClientIndexHandlerIT extends ChromeBrowserTest {
         openTestUrl("/");
         waitForElementPresent(By.id("button3"));
 
-        findElement(By.id("routeValue")).sendKeys("paramview/123");
+        findElement(By.id("pathname")).sendKeys("paramview/123");
         findElement(By.id("button3")).click();
         waitForElementPresent(By.id("result"));
 
@@ -195,7 +195,7 @@ public class ClientIndexHandlerIT extends ChromeBrowserTest {
         openTestUrl("/");
         waitForElementPresent(By.id("button3"));
 
-        findElement(By.id("routeValue")).sendKeys("not-existing-view");
+        findElement(By.id("pathname")).sendKeys("not-existing-view");
         findElement(By.id("button3")).click();
         waitForElementPresent(By.id("result"));
 


### PR DESCRIPTION

Add `route()` API to flow-client:
  - Prepares the server UI on the first call
  - Creates a container for the flow UI
  - In `route.action` it returns the container but does not call server
  - in `onBeforeEnter` it calls server side, and prevents navigation if server cancels.

This PR:
  - does not modifies server side in order to send the `cancel` flag
  - does not consider the `onBeforeLeave` callback

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6361)
<!-- Reviewable:end -->
