### PR TITLE
Reverse the reversed error message #6290

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import com.vaadin.flow.server.Constants;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.LoggerFactory;
 
@@ -265,16 +266,17 @@ public class TaskUpdateImports extends NodeUpdater {
         }
 
         if (!resourceNotFound.isEmpty()) {
-            String prefix = String.format(
-                    "Failed to resolve the following files either:"
-                            + "%n   · in the `%s` sources folder"
-                            + "%n   · or as a `META-INF/resources/frontend` resource in some JAR.",
-                    frontendDirectory.getPath());
+            String prefix =  "Failed to find the following files: ";
             String suffix = String.format(
-                    "Please, double check that those files exist. If you use a custom directory "
+                    "%n  Locations searched were:"
+                            + "%n      - `%s` in this project"
+                            + "%n      - `%s` in included JARs"
+                            + "%n%n  Please, double check that those files exist. If you use a custom directory "
                             + "for your resource files instead of default "
                             + "`frontend` folder then make sure you it's correctly configured "
                             + "(e.g. set '%s' property)",
+                    frontendDirectory.getPath(),
+                    Constants.RESOURCES_FRONTEND_DEFAULT,
                     FrontendUtils.PARAM_FRONTEND_DIR);
             throw new IllegalStateException(
                     notFoundMessage(resourceNotFound, prefix, suffix));
@@ -313,7 +315,7 @@ public class TaskUpdateImports extends NodeUpdater {
         } catch (IOException exception) {
             LoggerFactory.getLogger(TaskUpdateImports.class)
                     .warn("Could not read file {}. Skipping "
-                            + "applyig theme for its imports", file.getPath(),
+                            + "applying theme for its imports", file.getPath(),
                             exception);
         }
     }


### PR DESCRIPTION
Reverse the reversed error message #6290 

Shows list of files not found first before listing the directories searched.
At the same time I referenced the constant for RESOURCES_FRONTEND_DEFAULT
instead of hard-coding that path.

Added two new test cases to cover single- and multi-file exception messages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6368)
<!-- Reviewable:end -->