### PR TITLE
CCDM: keep view in `JavaScriptBootstrapUI` on postpone

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
@@ -43,6 +43,7 @@ export interface NavigationCommands {
 export class Flow {
   config: FlowConfig;
   response ?: AppInitResponse;
+  actionPending = false;
 
   // flow uses body for keeping references
   flowRoot : FlowRoot = document.body as any;
@@ -99,6 +100,7 @@ export class Flow {
     // the syntax `flow.route` in vaadin-router.
     // @ts-ignore
     return async (params: NavigationParameters) => {
+      this.actionPending = true;
       await this.flowInit();
       this.container.onBeforeEnter = (ctx, cmd) => this.onBefore(ctx, cmd);
       this.container.onBeforeLeave = (ctx, cmd) => this.onBefore(ctx, cmd);
@@ -107,7 +109,9 @@ export class Flow {
   }
 
   private onBefore(ctx: NavigationParameters, cmd: NavigationCommands) {
-    return this.flowNavigate(ctx, cmd);
+    return this.actionPending
+      ? this.flowNavigate(ctx, cmd).then(() => this.actionPending = false)
+      : Promise.resolve();
   }
 
   // Send the remote call to `JavaScriptBootstrapUI` to render the flow

--- a/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
@@ -14,6 +14,7 @@ interface AppInitResponse {
 
 interface HTMLRouterContainer extends HTMLElement {
   onBeforeEnter ?: (ctx: NavigationParameters, cmd: NavigationCommands) => Promise<any>;
+  onBeforeLeave ?: (ctx: NavigationParameters, cmd: NavigationCommands) => Promise<any>;
   serverConnected ?: (cancel: boolean) => void;
 }
 
@@ -99,12 +100,13 @@ export class Flow {
     // @ts-ignore
     return async (params: NavigationParameters) => {
       await this.flowInit();
-      this.container.onBeforeEnter = (ctx, cmd) => this.onBeforeEnter(ctx, cmd);
+      this.container.onBeforeEnter = (ctx, cmd) => this.onBefore(ctx, cmd);
+      this.container.onBeforeLeave = (ctx, cmd) => this.onBefore(ctx, cmd);
       return this.container;
     }
   }
 
-  private onBeforeEnter(ctx: NavigationParameters, cmd: NavigationCommands) {
+  private onBefore(ctx: NavigationParameters, cmd: NavigationCommands) {
     return this.flowNavigate(ctx, cmd);
   }
 

--- a/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
@@ -120,7 +120,10 @@ export class Flow {
 
   // Send a remote call to `JavaScriptBootstrapUI` to check
   // whether navigation has to be cancelled.
-  private async flowLeave(ctx: NavigationParameters, cmd?: NavigationCommands): Promise<any> {
+  private async flowLeave(
+    // @ts-ignore
+    ctx: NavigationParameters,
+    cmd?: NavigationCommands): Promise<any> {
     return new Promise(resolve => {
       // The callback to run from server side to cancel navigation
       this.container.serverConnected = cancel => {
@@ -128,7 +131,7 @@ export class Flow {
       }
 
       // Call server side to check whether we can leave the view
-      this.flowRoot.$server.leaveNavigation(ctx.pathname);
+      this.flowRoot.$server.leaveNavigation();
     });
   }
 

--- a/flow-client/src/test/frontend/FlowTests.ts
+++ b/flow-client/src/test/frontend/FlowTests.ts
@@ -159,7 +159,7 @@ suite("Flow", () => {
       });
   });
 
-  test("should be possible to cancel navigation when using router API", () => {
+  test("should be possible to cancel navigation when using router onBeforeEnter API", () => {
     stubServerRemoteFunction('foobar-12345', true);
     mockInitResponse('foobar-12345');
 
@@ -183,6 +183,27 @@ suite("Flow", () => {
 
         // @ts-ignore
         const promise = elem.onBeforeEnter({pathname: 'Foo/Bar.baz'}, {prevent: () => {
+          return {cancel: true};
+        }});
+
+        promise.then(obj => assert.isTrue(obj.cancel));
+      });
+  });
+
+  test("should be possible to cancel navigation when using router onBeforeLeave API", () => {
+    stubServerRemoteFunction('foobar-12345', true);
+    mockInitResponse('foobar-12345');
+
+    const route = new Flow().route;
+
+    return route.action({pathname: 'Foo/Bar.baz'})
+      .then(async(elem) => {
+
+        // When using router API, it should expose the onBeforeEnter handler
+        assert.isDefined(elem.onBeforeLeave);
+
+        // @ts-ignore
+        const promise = elem.onBeforeLeave({pathname: 'Foo/Bar.baz'}, {prevent: () => {
           return {cancel: true};
         }});
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUI.java
@@ -86,8 +86,14 @@ public class JavaScriptBootstrapUI extends UI {
         wrapperElement.executeJs("this.serverConnected($0)", postponed);
     }
 
+    /**
+     * Check that the view can be leave.
+     *
+     * This is only called when client route navigates from a server to a client
+     * view.
+     */
     @ClientCallable
-    public void leaveNavigation(String newRoute) {
+    public void leaveNavigation() {
         boolean postponed = postponedNavigation();
         if (!postponed) {
             wrapperElement.removeAllChildren();

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
@@ -95,7 +95,7 @@ public class JavaScriptBootstrapUITest  {
         assertEquals(Tag.HEADER, ui.wrapperElement.getChild(0).getTag());
         assertEquals(Tag.H2, ui.wrapperElement.getChild(0).getChild(0).getTag());
 
-        ui.leaveNavigation("/client-view");
+        ui.leaveNavigation();
 
         assertEquals(0, ui.wrapperElement.getChildCount());
     }
@@ -106,7 +106,7 @@ public class JavaScriptBootstrapUITest  {
         assertEquals(Tag.SPAN, ui.wrapperElement.getChild(0).getTag());
         assertEquals(Tag.H1, ui.wrapperElement.getChild(0).getChild(0).getTag());
 
-        ui.leaveNavigation("/client-view");
+        ui.leaveNavigation();
         assertEquals(Tag.SPAN, ui.wrapperElement.getChild(0).getTag());
         assertEquals(Tag.H1, ui.wrapperElement.getChild(0).getChild(0).getTag());
     }

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
@@ -1,0 +1,98 @@
+package com.vaadin.flow.component.internal;
+
+import java.util.Collections;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.internal.CurrentInstance;
+import com.vaadin.flow.router.BeforeLeaveEvent;
+import com.vaadin.flow.router.BeforeLeaveObserver;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.MockServletServiceSessionSetup;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class JavaScriptBootstrapUITest  {
+    private MockServletServiceSessionSetup mocks;
+    private JavaScriptBootstrapUI ui;
+
+    @Tag(Tag.H2)
+    public static class CleanChild extends Component implements BeforeLeaveObserver {
+        @Override
+        public void beforeLeave(BeforeLeaveEvent event) {
+        }
+    }
+
+    @Route("clean")
+    @Tag(Tag.HEADER)
+    public static class Clean extends Component implements HasComponents{
+        public Clean() {
+            add(new CleanChild());
+        }
+    }
+
+    @Tag(Tag.H1)
+    public static class DirtyChild extends Component implements BeforeLeaveObserver {
+        @Override
+        public void beforeLeave(BeforeLeaveEvent event) {
+            event.postpone();
+        }
+    }
+
+    @Route("dirty")
+    @Tag(Tag.SPAN)
+    public static class Dirty extends Component implements HasComponents {
+        public Dirty() {
+            add(new DirtyChild());
+        }
+    }
+
+    @Before
+    public void setup() throws Exception {
+        mocks = new MockServletServiceSessionSetup();
+        mocks.getService().getRouter().getRegistry().setRoute("clean", Clean.class, Collections.emptyList());
+        mocks.getService().getRouter().getRegistry().setRoute("dirty", Dirty.class, Collections.emptyList());
+        ui = new JavaScriptBootstrapUI();
+        ui.getInternals().setSession(mocks.getSession());
+        CurrentInstance.setCurrent(ui);
+    }
+
+    @Test
+    public void should_allow_navigation() {
+        ui.connectClient("foo", "bar", "/clean");
+        assertEquals(Tag.HEADER, ui.wrapperElement.getChild(0).getTag());
+        assertEquals(Tag.H2, ui.wrapperElement.getChild(0).getChild(0).getTag());
+
+        // Dirty view is allowed after clean view
+        ui.connectClient("foo", "bar", "/dirty");
+        assertEquals(Tag.SPAN, ui.wrapperElement.getChild(0).getTag());
+        assertEquals(Tag.H1, ui.wrapperElement.getChild(0).getChild(0).getTag());
+    }
+
+    @Test
+    public void should_prevent_navigation_on_dirty() {
+        ui.connectClient("foo", "bar", "/dirty");
+        assertEquals(Tag.SPAN, ui.wrapperElement.getChild(0).getTag());
+        assertEquals(Tag.H1, ui.wrapperElement.getChild(0).getChild(0).getTag());
+
+        // clean view cannot be rendered after dirty
+        ui.connectClient("foo", "bar", "/clean");
+        assertEquals(Tag.H1, ui.wrapperElement.getChild(0).getChild(0).getTag());
+        
+        // an error route cannot be rendered after dirty
+        ui.connectClient("foo", "bar", "/errr");
+        assertEquals(Tag.H1, ui.wrapperElement.getChild(0).getChild(0).getTag());
+    }
+
+    @Test
+    public void should_show_error_page() {
+        ui.connectClient("foo", "bar", "/err");
+        assertEquals(Tag.DIV, ui.wrapperElement.getChild(0).getTag());
+        assertTrue(ui.wrapperElement.toString().contains("Available routes:"));
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
@@ -83,9 +83,31 @@ public class JavaScriptBootstrapUITest  {
         // clean view cannot be rendered after dirty
         ui.connectClient("foo", "bar", "/clean");
         assertEquals(Tag.H1, ui.wrapperElement.getChild(0).getChild(0).getTag());
-        
+
         // an error route cannot be rendered after dirty
         ui.connectClient("foo", "bar", "/errr");
+        assertEquals(Tag.H1, ui.wrapperElement.getChild(0).getChild(0).getTag());
+    }
+
+    @Test
+    public void should_remove_content_on_leaveNavigation() {
+        ui.connectClient("foo", "bar", "/clean");
+        assertEquals(Tag.HEADER, ui.wrapperElement.getChild(0).getTag());
+        assertEquals(Tag.H2, ui.wrapperElement.getChild(0).getChild(0).getTag());
+
+        ui.leaveNavigation("/client-view");
+
+        assertEquals(0, ui.wrapperElement.getChildCount());
+    }
+
+    @Test
+    public void should_keep_content_on_leaveNavigation_postpone() {
+        ui.connectClient("foo", "bar", "/dirty");
+        assertEquals(Tag.SPAN, ui.wrapperElement.getChild(0).getTag());
+        assertEquals(Tag.H1, ui.wrapperElement.getChild(0).getChild(0).getTag());
+
+        ui.leaveNavigation("/client-view");
+        assertEquals(Tag.SPAN, ui.wrapperElement.getChild(0).getTag());
         assertEquals(Tag.H1, ui.wrapperElement.getChild(0).getChild(0).getTag());
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandlerTest.java
@@ -18,12 +18,10 @@ package com.vaadin.flow.server.communication;
 import java.util.regex.Pattern;
 
 import net.jcip.annotations.NotThreadSafe;
-
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.internal.JavaScriptBootstrapUI;
@@ -34,7 +32,6 @@ import com.vaadin.flow.server.MockServletServiceSessionSetup;
 import com.vaadin.flow.server.MockServletServiceSessionSetup.TestVaadinServletResponse;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinSession;
-
 
 import elemental.json.Json;
 import elemental.json.JsonObject;


### PR DESCRIPTION
This PR visits all components in the current view before rendering the new one.
- It only considers components with the `BeforeLeaveHandler`
- If postponed it keeps the previous view DOM
- It executes client side callback with a parameter that cancels navigation in flow-client

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6380)
<!-- Reviewable:end -->
