### PR TITLE
Fixed test module exclusions under -DskipTests

### DIFF
--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -203,6 +203,12 @@
         </pluginManagement>
     </build>
 
+    <!-- these modules should be build, regardless of `skipTests` -->
+    <modules>
+        <module>test-resources</module>
+        <module>test-common</module>
+    </modules>
+
     <profiles>
         <profile>
             <id>run-tests</id>
@@ -213,8 +219,6 @@
             </activation>
 
             <modules>
-                <module>test-resources</module>
-                <module>test-common</module>
                 <module>test-pwa</module>
                 
                 <module>test-mixed</module>


### PR DESCRIPTION
Running `mvn install -DskipTests` for a clean or old project would skip install for some of the resource modules for tests. Then attempting to run a specific IT would fail because the dependencies were not available locally (nor in remote, since those deps are not deployed).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6388)
<!-- Reviewable:end -->
