### PR TITLE
CCDM: enable webpack babel bundle targeting for .ts files

### DIFF
--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -89,7 +89,10 @@ module.exports = {
       },
       {
         test: /\.ts$/,
-        loader: 'awesome-typescript-loader'
+        use: [
+          BabelMultiTargetPlugin.loader(),
+          'awesome-typescript-loader'
+        ]
       },
       {
         test: /\.css$/i,


### PR DESCRIPTION
Fixes #6295

Any JS chunks emitted by webpack for dynamic imports of `.ts` files were missing the target for the Babel multi-target build. This made webpack emit and load duplicate JS code for same dependencies appearing with the target path suffix in the index chunk (e. g., 'lit-element.js?babel-target=es6') and without the suffix in the dynamically imported chunk (e. g., just 'lit-element.js'), which resulted in obscure component template rendering issues.

This fix adjusts the generated webpack config in order to feed the `.ts` files though the same target-assigning loader as regular `.js` files, which makes all the chunks correctly retain the target, and resolves the duplicate dependency code issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6391)
<!-- Reviewable:end -->
