### PR TITLE
Fixed incorrect file upload status

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
@@ -237,7 +237,7 @@ public class StreamReceiverHandler implements Serializable {
         // Create a new file upload handler
         ServletFileUpload upload = new ServletFileUpload();
 
-        boolean success = false;
+        boolean success = true;
         long contentLength = getContentLength(request);
         // Parse the request
         FileItemIterator iter;


### PR DESCRIPTION
It looks like I missed an error in the Boolean logic when reviewing #6381. This caused a regression where the upload component reported error also for successful uploads.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6399)
<!-- Reviewable:end -->
