### PR TITLE
CCDM: fix bug navigate server to server

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
@@ -115,8 +115,8 @@ export class Flow {
     // @ts-ignore
     return async (params: NavigationParameters) => {
       const response = await this.flowInit();
-      const id = response.appConfig.appId;
-      this.flowRouterContainer = document.createElement(`flow-router-container-${id}`);
+      const id = `flow-router-container-${response.appConfig.appId.toLowerCase()}`;
+      this.flowRouterContainer = document.createElement(id);
       this.flowRouterContainer.id = id;
       this.flowRouterContainer.onBeforeEnter = (ctx, cmd) => this.onBeforeEnter(ctx, cmd);
       return this.flowRouterContainer;
@@ -125,7 +125,7 @@ export class Flow {
 
   private async onBeforeEnter(ctx: NavigationParameters, cmd: NavigationCommands) {
     const result = await this.flowNavigate(ctx, cmd)
-    if (this.flowRouterContainer) {
+    if (this.flowRouterContainer && result instanceof HTMLElement) {
       this.flowRouterContainer.appendChild(result);
     }
     return result;
@@ -163,9 +163,9 @@ export class Flow {
       if (this.config.imports) {
         await this.config.imports();
       }
-      const appId: string = this.response.appConfig.appId;
-      const tag: string = `flow-virtual-child-${appId.toLowerCase()}`;
-      const id: string = tag;
+
+      const id: string = this.response.appConfig.appId;
+      const tag: string = `flow-virtual-child-${id.toLowerCase()}`;
 
       // we use a custom tag for the flow app container
       this.flowVirtualChild = this.flowRoot.$[id] = document.createElement(tag);

--- a/flow-client/src/test/frontend/FlowTests.ts
+++ b/flow-client/src/test/frontend/FlowTests.ts
@@ -152,10 +152,13 @@ suite("Flow", () => {
 
         // When using router API, it should expose the onBeforeEnter handler
         assert.isDefined(elem.onBeforeEnter);
-        elem.onBeforeEnter && elem.onBeforeEnter({pathname: 'Foo/Bar.baz'}, {prevent: () => {}})
+        elem.onBeforeEnter && await elem.onBeforeEnter({pathname: 'Foo/Bar.baz'}, {prevent: () => {}})
 
-        // Assert server side has put content in the container
+        // Assert Flow has put flowVirtualChild in the container
         assert.equal(1, elem.children.length);
+
+        // Assert Flow server has put content in the flowVirtualChild
+        assert.equal(1, elem.children[0].children.length);
       });
   });
 
@@ -187,6 +190,8 @@ suite("Flow", () => {
         }});
 
         promise.then(obj => assert.isTrue(obj.cancel));
+        // should not put the result into flowRouterContainer if the result is not a HTMLElement
+        assert.equal(0, elem.children.length);
       });
   });
 });
@@ -200,7 +205,7 @@ function stubServerRemoteFunction(id: string, cancel: boolean = false) {
       assert.isDefined(route);
 
       assert.equal(elemId, id);
-      assert.equal(localName, `flow-container-${elemId.toLowerCase()}`);
+      assert.equal(localName, `flow-virtual-child-${elemId.toLowerCase()}`);
 
       assert.isDefined(flowRoot.$[elemId]);
       assert.isDefined(flowRoot.$[elemId].serverConnected);

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUI.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.internal;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -24,7 +25,9 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.internal.nodefeature.NodeProperties;
+import com.vaadin.flow.internal.nodefeature.VirtualChildrenList;
 import com.vaadin.flow.router.ErrorNavigationEvent;
 import com.vaadin.flow.router.ErrorParameter;
 import com.vaadin.flow.router.HasUrlParameter;
@@ -74,7 +77,6 @@ public class JavaScriptBootstrapUI extends UI {
         if (wrapperElement == null) {
             // Create flow reference for the client outlet element
             wrapperElement = new Element(clientElementTag);
-
             // Connect server with client
             getElement().getStateProvider().appendVirtualChild(
                     getElement().getNode(), wrapperElement,
@@ -95,6 +97,15 @@ public class JavaScriptBootstrapUI extends UI {
      */
     public Element getWrapperElement() {
         return wrapperElement;
+    }
+
+    private void cleanUpVirtualChildren(UI ui) {
+        Iterator<StateNode> virtualChildrenIterator = ui.getElement().getNode()
+                .getFeature(VirtualChildrenList.class).iterator();
+        while (virtualChildrenIterator.hasNext()) {
+            virtualChildrenIterator.next();
+            virtualChildrenIterator.remove();
+        }
     }
 
     private void renderViewForRoute(String route) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUI.java
@@ -99,15 +99,6 @@ public class JavaScriptBootstrapUI extends UI {
         return wrapperElement;
     }
 
-    private void cleanUpVirtualChildren(UI ui) {
-        Iterator<StateNode> virtualChildrenIterator = ui.getElement().getNode()
-                .getFeature(VirtualChildrenList.class).iterator();
-        while (virtualChildrenIterator.hasNext()) {
-            virtualChildrenIterator.next();
-            virtualChildrenIterator.remove();
-        }
-    }
-
     private void renderViewForRoute(String route) {
         if (route.startsWith("/")) {
             route = route.replaceFirst("/+", "");

--- a/flow-tests/test-ccdm/frontend/client-router.js
+++ b/flow-tests/test-ccdm/frontend/client-router.js
@@ -1,0 +1,43 @@
+import {Flow} from '@vaadin/flow-frontend/Flow';
+import {Router} from '@vaadin/router';
+
+//------- Configure flow
+const flow = new Flow({
+  imports: () => import('../target/frontend/generated-flow-imports')
+});
+const createNavigationLink = (text, link) => {
+  const aLink = document.createElement('a');
+  aLink.href = link;
+  aLink.textContent = text;
+  aLink.setAttribute('router-link', true);
+  return aLink;
+}
+//------- Configure Router
+const routes = [{ path: 'client-view',
+                  action: () => {
+                    const div = document.createElement('div');
+                    div.textContent = 'My clientside text content';
+                    return div;
+                  }
+                },
+                  flow.route
+               ];
+
+const routerContainer = document.createElement('div');
+const navigationContainer = document.createElement('div');
+navigationContainer.id = 'navigationContainer';
+navigationContainer.appendChild(createNavigationLink('Empty view', ''));
+navigationContainer.appendChild(createNavigationLink('Client side view', 'client-view'));
+navigationContainer.appendChild(createNavigationLink('Server view', 'serverview'));
+navigationContainer.appendChild(createNavigationLink('View with all events', 'view-with-all-events'));
+routerContainer.appendChild(navigationContainer);
+
+const outlet = document.createElement('div');
+outlet.id = 'outlet';
+routerContainer.appendChild(outlet);
+document.body.appendChild(routerContainer);
+const router = new Router(document.querySelector('#outlet'));
+
+router.setRoutes(routes);
+
+

--- a/flow-tests/test-ccdm/frontend/client-router.js
+++ b/flow-tests/test-ccdm/frontend/client-router.js
@@ -1,45 +1,43 @@
-import {Flow} from '@vaadin/flow-frontend/Flow';
 import {Router} from '@vaadin/router';
 
-//------- Configure flow
-const flow = new Flow({
-  imports: () => import('../target/frontend/generated-flow-imports')
-});
 const createNavigationLink = (text, link) => {
   const aLink = document.createElement('a');
   aLink.href = link;
   aLink.textContent = text;
   return aLink;
 }
-//------- Configure Router
-const routes = [
-  {
-    path: 'client-view',
-    action: () => {
-      const div = document.createElement('div');
-      div.textContent = 'Client view';
-      div.id = 'clientSideView';
-      return div;
-    }
-  },
-  flow.route
-];
 
-const routerContainer = document.createElement('div');
-const navigationContainer = document.createElement('div');
-navigationContainer.id = 'navigationContainer';
-navigationContainer.appendChild(createNavigationLink('Empty view', ''));
-navigationContainer.appendChild(createNavigationLink('Client side view', 'client-view'));
-navigationContainer.appendChild(createNavigationLink('Server view', 'serverview'));
-navigationContainer.appendChild(createNavigationLink('View with all events', 'view-with-all-events'));
-routerContainer.appendChild(navigationContainer);
+export function loadRouter(flow) {
+  //------- Configure Router
+  const routes = [
+    {
+      path: 'client-view',
+      action: () => {
+        const div = document.createElement('div');
+        div.textContent = 'Client view';
+        div.id = 'clientSideView';
+        return div;
+      }
+    },
+    flow.route
+  ];
 
-const outlet = document.createElement('div');
-outlet.id = 'outlet';
-routerContainer.appendChild(outlet);
-document.body.appendChild(routerContainer);
-const router = new Router(outlet);
+  const routerContainer = document.createElement('div');
+  const navigationContainer = document.createElement('div');
+  navigationContainer.id = 'navigationContainer';
+  navigationContainer.appendChild(createNavigationLink('Empty view', ''));
+  navigationContainer.appendChild(createNavigationLink('Client side view', 'client-view'));
+  navigationContainer.appendChild(createNavigationLink('Server view', 'serverview'));
+  navigationContainer.appendChild(createNavigationLink('View with all events', 'view-with-all-events'));
+  routerContainer.appendChild(navigationContainer);
 
-router.setRoutes(routes);
+  const outlet = document.createElement('div');
+  outlet.id = 'outlet';
+  routerContainer.appendChild(outlet);
+  document.body.appendChild(routerContainer);
+  const router = new Router(outlet);
+
+  router.setRoutes(routes);
+}
 
 

--- a/flow-tests/test-ccdm/frontend/client-router.js
+++ b/flow-tests/test-ccdm/frontend/client-router.js
@@ -9,19 +9,21 @@ const createNavigationLink = (text, link) => {
   const aLink = document.createElement('a');
   aLink.href = link;
   aLink.textContent = text;
-  aLink.setAttribute('router-link', true);
   return aLink;
 }
 //------- Configure Router
-const routes = [{ path: 'client-view',
-                  action: () => {
-                    const div = document.createElement('div');
-                    div.textContent = 'My clientside text content';
-                    return div;
-                  }
-                },
-                  flow.route
-               ];
+const routes = [
+  {
+    path: 'client-view',
+    action: () => {
+      const div = document.createElement('div');
+      div.textContent = 'Client view';
+      div.id = 'clientSideView';
+      return div;
+    }
+  },
+  flow.route
+];
 
 const routerContainer = document.createElement('div');
 const navigationContainer = document.createElement('div');
@@ -36,7 +38,7 @@ const outlet = document.createElement('div');
 outlet.id = 'outlet';
 routerContainer.appendChild(outlet);
 document.body.appendChild(routerContainer);
-const router = new Router(document.querySelector('#outlet'));
+const router = new Router(outlet);
 
 router.setRoutes(routes);
 

--- a/flow-tests/test-ccdm/frontend/index.html
+++ b/flow-tests/test-ccdm/frontend/index.html
@@ -17,6 +17,7 @@
 
 <button id="button1">Load content from other bundle</button>
 <button id="button2">Load flow</button>
+<button id="loadRouter">Load Vaadin Router</button>
 <p>
     <input type="text" id="pathname" placeholder="route">
     <button id="button3">Navigate flow</button>

--- a/flow-tests/test-ccdm/frontend/index.js
+++ b/flow-tests/test-ccdm/frontend/index.js
@@ -40,7 +40,8 @@ document.getElementById('button3').addEventListener('click', async e => {
     outlet.appendChild(result);
 });
 
-document.getElementById("loadRouter").addEventListener('click', async e => {
-    await import('./client-router.js');
+document.getElementById("loadRouter").addEventListener('click', async(e) => {
+    const clientRouter = await import('./client-router.js');
+    clientRouter.loadRouter(flow);
 });
 

--- a/flow-tests/test-ccdm/frontend/index.js
+++ b/flow-tests/test-ccdm/frontend/index.js
@@ -40,3 +40,7 @@ document.getElementById('button3').addEventListener('click', async e => {
     outlet.appendChild(result);
 });
 
+document.getElementById("loadRouter").addEventListener('click', async e => {
+    await import('./client-router.js');
+});
+

--- a/flow-tests/test-ccdm/pom.xml
+++ b/flow-tests/test-ccdm/pom.xml
@@ -53,6 +53,7 @@
                 <configuration>
                     <compatibilityMode>false</compatibilityMode>
                     <productionMode>false</productionMode>
+                    <clientSideMode>true</clientSideMode>
                 </configuration>
             </plugin>
         </plugins>

--- a/flow-tests/test-ccdm/pom.xml
+++ b/flow-tests/test-ccdm/pom.xml
@@ -53,7 +53,6 @@
                 <configuration>
                     <compatibilityMode>false</compatibilityMode>
                     <productionMode>false</productionMode>
-                    <clientSideMode>true</clientSideMode>
                 </configuration>
             </plugin>
         </plugins>

--- a/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/EmptyUI.java
+++ b/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/EmptyUI.java
@@ -23,5 +23,6 @@ import com.vaadin.flow.router.Route;
 public class EmptyUI extends Div {
     public EmptyUI() {
         add(new Text("Empty view"));
+        setId("emptyView");
     }
 }

--- a/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/MainLayout.java
+++ b/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/MainLayout.java
@@ -15,12 +15,34 @@
  */
 package com.vaadin.flow.ccdmtest;
 
+import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.DetachEvent;
 import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.router.RouterLayout;
+import com.vaadin.flow.router.RouterLink;
 
 public class MainLayout extends Div implements RouterLayout {
     public MainLayout() {
         add(new Text("Main layout"));
+        add(new RouterLink("Server view", ServerSideView.class));
+        add(new RouterLink("all events", ViewWithAllEvents.class));
+    }
+
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        super.onAttach(attachEvent);
+        addLog("MainLayout: attach");
+    }
+
+    @Override
+    protected void onDetach(DetachEvent detachEvent) {
+        super.onDetach(detachEvent);
+        addLog("MainLayout: detach");
+    }
+
+    private void addLog(String log) {
+        add(new Paragraph(log));
     }
 }

--- a/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/MainLayout.java
+++ b/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/MainLayout.java
@@ -21,25 +21,23 @@ import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.router.RouterLayout;
-import com.vaadin.flow.router.RouterLink;
 
 public class MainLayout extends Div implements RouterLayout {
     public MainLayout() {
         add(new Text("Main layout"));
-        add(new RouterLink("Server view", ServerSideView.class));
-        add(new RouterLink("all events", ViewWithAllEvents.class));
+        setId("mainLayout");
     }
 
     @Override
     protected void onAttach(AttachEvent attachEvent) {
         super.onAttach(attachEvent);
-        addLog("MainLayout: attach");
+        addLog("MainLayout: onAttach");
     }
 
     @Override
     protected void onDetach(DetachEvent detachEvent) {
         super.onDetach(detachEvent);
-        addLog("MainLayout: detach");
+        addLog("MainLayout: onDetach");
     }
 
     private void addLog(String log) {

--- a/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/ServerSideView.java
+++ b/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/ServerSideView.java
@@ -23,5 +23,6 @@ import com.vaadin.flow.router.Route;
 public class ServerSideView extends Div {
     public ServerSideView() {
         add(new Text("Server view"));
+        setId("serverView");
     }
 }

--- a/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/ViewWithAllEvents.java
+++ b/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/ViewWithAllEvents.java
@@ -35,6 +35,7 @@ public class ViewWithAllEvents extends Div implements BeforeEnterObserver,
     public ViewWithAllEvents() {
         logger = new Div();
         add(logger);
+        setId("viewWithAllEvents");
     }
 
     @Override
@@ -43,10 +44,6 @@ public class ViewWithAllEvents extends Div implements BeforeEnterObserver,
         addLog("1 setParameter");
     }
 
-    @Override
-    public void afterNavigation(AfterNavigationEvent event) {
-        addLog("4 afterNavigation");
-    }
 
     @Override
     public void beforeEnter(BeforeEnterEvent event) {
@@ -56,6 +53,11 @@ public class ViewWithAllEvents extends Div implements BeforeEnterObserver,
     @Override
     protected void onAttach(AttachEvent attachEvent) {
         addLog("3 onAttach");
+    }
+
+    @Override
+    public void afterNavigation(AfterNavigationEvent event) {
+        addLog("4 afterNavigation");
     }
 
     private void addLog(String log) {

--- a/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/ClientIndexHandlerIT.java
+++ b/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/ClientIndexHandlerIT.java
@@ -185,7 +185,7 @@ public class ClientIndexHandlerIT extends ChromeBrowserTest {
 
         String content = findElement(By.id("result")).getText();
         Assert.assertEquals("Should execute set parameter method",
-                "Main layout\nParameter: " + inputParam, content);
+                "Main layout\nParameter: " + inputParam + "\nMainLayout: onAttach", content);
     }
 
     @Test
@@ -199,7 +199,7 @@ public class ClientIndexHandlerIT extends ChromeBrowserTest {
         String content = findElement(By.id("result")).getText();
         Assert.assertEquals(
                 "Should execute onBeforeEnter and reroute to ServerSideView",
-                "Main layout\nServer view", content);
+                "Main layout\nServer view\nMainLayout: onAttach", content);
     }
 
     @Test
@@ -213,7 +213,7 @@ public class ClientIndexHandlerIT extends ChromeBrowserTest {
         String content = findElement(By.id("result")).getText();
         Assert.assertEquals(
                 "Should execute onBeforeEnter and forward to ServerSideView",
-                "Main layout\nServer view", content);
+                "Main layout\nServer view\nMainLayout: onAttach", content);
     }
 
     @Test
@@ -229,7 +229,7 @@ public class ClientIndexHandlerIT extends ChromeBrowserTest {
         String expectedContent = "Main layout\nViewWithAllEvents: 1 "
                 + "setParameter\nViewWithAllEvents: 2 "
                 + "beforeEnter\nViewWithAllEvents: 3 "
-                + "onAttach\nViewWithAllEvents: 4 afterNavigation";
+                + "onAttach\nViewWithAllEvents: 4 afterNavigation\nMainLayout: onAttach";
         Assert.assertEquals("Should execute all lifecycle callbacks",
                 expectedContent, content);
     }
@@ -271,24 +271,26 @@ public class ClientIndexHandlerIT extends ChromeBrowserTest {
         findElement(By.partialLinkText("Server view")).click();
         waitForElementPresent(By.id("serverView"));
         String serverViewContent = findElement(By.id("mainLayout")).getText();
-        Assert.assertTrue("Should load server view",
-                serverViewContent.contains("Server view"));
-        Assert.assertTrue("Should attach MainLayout",
-                serverViewContent.contains("MainLayout: onAttach"));
+        Assert.assertEquals(
+                "Should load server view and execute main layout onAttach",
+                "Main layout\nServer view\nMainLayout: onAttach", serverViewContent);
 
         findElement(By.partialLinkText("View with all events")).click();
         waitForElementPresent(By.id("viewWithAllEvents"));
-        String viewWithAllEventsContent = findElement(By.id("mainLayout")).getText();
-        Assert.assertTrue("Should attach MainLayout",
-                viewWithAllEventsContent.contains("MainLayout: onAttach"));
-        Assert.assertTrue("Should execute setParameter",
-                viewWithAllEventsContent.contains("ViewWithAllEvents: 1 setParameter"));
-        Assert.assertTrue("Should execute onBeforeEnter",
-                viewWithAllEventsContent.contains("ViewWithAllEvents: 2 beforeEnter"));
-        Assert.assertTrue("Should execute onAttach",
-                viewWithAllEventsContent.contains("ViewWithAllEvents: 3 onAttach"));
-        Assert.assertTrue("Should execute afterNavigation",
-                viewWithAllEventsContent.contains("ViewWithAllEvents: 4 afterNavigation"));
+        String viewWithAllEventsContent =
+                findElement(By.id("mainLayout")).getText();
+
+        // because MainLayout stays the same, so that `MainLayout: onAttach`
+        // appears before the view
+        String expectedContent = "Main layout\nMainLayout: " +
+                "onAttach\nViewWithAllEvents: 1 "
+                + "setParameter\nViewWithAllEvents: 2 "
+                + "beforeEnter\nViewWithAllEvents: 3 "
+                + "onAttach\nViewWithAllEvents: 4 afterNavigation";
+
+        Assert.assertEquals("Should load ViewWithAllEvents without detaching " +
+                        "MainLayout",
+                expectedContent, viewWithAllEventsContent);
 
         Assert.assertFalse("Should not detach MainLayout",
                 viewWithAllEventsContent.contains("MainLayout: onDetach"));
@@ -296,8 +298,8 @@ public class ClientIndexHandlerIT extends ChromeBrowserTest {
         findElement(By.partialLinkText("Empty view")).click();
         waitForElementNotPresent(By.id("mainLayout"));
         String emptyViewContent = findElement(By.id("emptyView")).getText();
-        Assert.assertTrue("Should load empty view",
-                emptyViewContent.contains("Empty view"));
+        Assert.assertEquals("Should load empty view", "Empty view",
+                emptyViewContent);
     }
 
     @Test

--- a/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/ClientIndexHandlerIT.java
+++ b/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/ClientIndexHandlerIT.java
@@ -260,6 +260,47 @@ public class ClientIndexHandlerIT extends ChromeBrowserTest {
     }
 
     @Test
+    public void should_navigateFromServerToServer_When_usingVaadinRouter() {
+        openTestUrl("/");
+        waitForElementPresent(By.id("loadRouter"));
+        findElement(By.id("loadRouter")).click();
+        waitForElementPresent(By.id("navigationContainer"));
+        // Wait for the first router load
+        waitForElementPresent(By.id("emptyView"));
+
+        findElement(By.partialLinkText("Server view")).click();
+        waitForElementPresent(By.id("serverView"));
+        String serverViewContent = findElement(By.id("mainLayout")).getText();
+        Assert.assertTrue("Should load server view",
+                serverViewContent.contains("Server view"));
+        Assert.assertTrue("Should attach MainLayout",
+                serverViewContent.contains("MainLayout: onAttach"));
+
+        findElement(By.partialLinkText("View with all events")).click();
+        waitForElementPresent(By.id("viewWithAllEvents"));
+        String viewWithAllEventsContent = findElement(By.id("mainLayout")).getText();
+        Assert.assertTrue("Should attach MainLayout",
+                viewWithAllEventsContent.contains("MainLayout: onAttach"));
+        Assert.assertTrue("Should execute setParameter",
+                viewWithAllEventsContent.contains("ViewWithAllEvents: 1 setParameter"));
+        Assert.assertTrue("Should execute onBeforeEnter",
+                viewWithAllEventsContent.contains("ViewWithAllEvents: 2 beforeEnter"));
+        Assert.assertTrue("Should execute onAttach",
+                viewWithAllEventsContent.contains("ViewWithAllEvents: 3 onAttach"));
+        Assert.assertTrue("Should execute afterNavigation",
+                viewWithAllEventsContent.contains("ViewWithAllEvents: 4 afterNavigation"));
+
+        Assert.assertFalse("Should not detach MainLayout",
+                viewWithAllEventsContent.contains("MainLayout: onDetach"));
+
+        findElement(By.partialLinkText("Empty view")).click();
+        waitForElementNotPresent(By.id("mainLayout"));
+        String emptyViewContent = findElement(By.id("emptyView")).getText();
+        Assert.assertTrue("Should load empty view",
+                emptyViewContent.contains("Empty view"));
+    }
+
+    @Test
     public void should_returnNotFoundView_WhenRouteNotFound() {
         openTestUrl("/");
         waitForElementPresent(By.id("button3"));


### PR DESCRIPTION
Fixes #6406 

This PR fixes the server to server navigation bug when integrating with `vaadin-router`.
I found that `vaadin-router` and Flow server have their own requirements:
  - `vaadin-router` requires us to have a new container instance for every navigation because we are relying on `onBeforeEnter` event to fetch server view. If returning the element instance, `vaadin-router` thinks that the element won't change, so it won't trigger any events for that element. This means the container doesn't have a chance to update its content with the new server component.
  - Flow server requires us to have only one `wrapperElement` to be able to reuse components and layouts. If we have different `wrapperElement` for every navigation, Flow will have to detach the `rootLayout` from the old wrapper, then attach the `rootLayout` to the new wrapper which creates a wrong lifecycle callbacks flow.

With these requirements, I created another container, called `flowRouterContainer`, and renamed the old container to `flowVirtualChild`. So that `flowRouterContainer` is the result for `action` method of the route object which will be instantiated for each `action` call. While `flowVirtualChild` will be created only once in `flow.init` and connect to `wrapperElement` in `JavaScriptBootstrapUI` at the first server view request.

This PR is based on #6400 because of some mutual changes in `JavaScriptBootstrapUI`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6418)
<!-- Reviewable:end -->
