### PR TITLE
Support for portlet resource targets

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ElementAttributeMap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ElementAttributeMap.java
@@ -17,6 +17,7 @@
 package com.vaadin.flow.internal.nodefeature;
 
 import java.io.Serializable;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -123,7 +124,15 @@ public class ElementAttributeMap extends NodeMap {
      *            the value
      */
     public void setResource(String attribute, AbstractStreamResource resource) {
-        set(attribute, StreamResourceRegistry.getURI(resource).toASCIIString());
+        final URI targetUri;
+        if (VaadinSession.getCurrent() != null) {
+            final StreamResourceRegistry resourceRegistry =
+                    VaadinSession.getCurrent().getResourceRegistry();
+            targetUri = resourceRegistry.getTargetURI(resource);
+        } else {
+            targetUri = StreamResourceRegistry.getURI(resource);
+        }
+        set(attribute, targetUri.toASCIIString());
         if (getNode().isAttached()) {
             registerResource(attribute, resource);
         } else {

--- a/flow-server/src/main/java/com/vaadin/flow/server/StreamResourceRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StreamResourceRegistry.java
@@ -127,6 +127,18 @@ public class StreamResourceRegistry implements Serializable {
         return getURI(resource.getName(), resource.getId());
     }
 
+    /**
+     * Returns the URI path to the given resource in the context of this
+     * registry (relevant in portlet context).
+     *
+     * @param resource
+     *              stream resource
+     * @return resource URI
+     */
+    public URI getTargetURI(AbstractStreamResource resource) {
+        return StreamResourceRegistry.getURI(resource);
+    }
+
     private static URI getURI(String name, String id) {
         try {
             return new URI(StreamRequestHandler.generateURI(name, id));

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
@@ -34,6 +34,8 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Future;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import javax.servlet.http.HttpSession;
 import javax.servlet.http.HttpSessionBindingEvent;
@@ -133,7 +135,16 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      */
     public VaadinSession(VaadinService service) {
         this.service = service;
-        resourceRegistry = new StreamResourceRegistry(this);
+        resourceRegistry = createStreamResourceRegistry();
+    }
+
+    /**
+     * Creates the StreamResourceRegistry for this session.
+     *
+     * @return A StreamResourceRegistry instance
+     */
+    protected StreamResourceRegistry createStreamResourceRegistry() {
+        return new StreamResourceRegistry(this);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
@@ -34,8 +34,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Future;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.function.Function;
-import java.util.function.Supplier;
 
 import javax.servlet.http.HttpSession;
 import javax.servlet.http.HttpSessionBindingEvent;

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
@@ -182,6 +182,8 @@ public class StreamReceiverHandler implements Serializable {
     private boolean hasParts(VaadinRequest request) throws IOException {
         try {
             return !getParts(request).isEmpty();
+        } catch (IOException ioe) {
+            throw ioe;
         } catch (Exception e) {
             getLogger().trace(
                     "Pretending the request did not contain any parts because of exception",

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.server.communication;
 
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.Part;
 import java.io.BufferedWriter;
@@ -25,6 +24,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.Iterator;
 
 import org.apache.commons.fileupload.FileItemIterator;
@@ -130,8 +130,7 @@ public class StreamReceiverHandler implements Serializable {
         }
 
         try {
-            if (ServletFileUpload
-                    .isMultipartContent((HttpServletRequest) request)) {
+            if (isMultipartUpload(request)) {
                 doHandleMultipartFileUpload(session, request, response,
                         streamReceiver, source);
             } else {
@@ -182,8 +181,8 @@ public class StreamReceiverHandler implements Serializable {
 
     private boolean hasParts(VaadinRequest request) throws IOException {
         try {
-            return !((HttpServletRequest) request).getParts().isEmpty();
-        } catch (ServletException | IllegalStateException e) {
+            return !getParts(request).isEmpty();
+        } catch (Exception e) {
             getLogger().trace(
                     "Pretending the request did not contain any parts because of exception",
                     e);
@@ -197,13 +196,12 @@ public class StreamReceiverHandler implements Serializable {
         // If we try to parse the request now, we will get an exception
         // since it has already been parsed and turned into Parts.
         try {
-            Iterator<Part> iter = ((HttpServletRequest) request).getParts()
-                    .iterator();
+            Iterator<Part> iter = getParts(request).iterator();
             while (iter.hasNext()) {
                 Part part = iter.next();
                 handleStream(session, streamReceiver, owner, part);
             }
-        } catch (ServletException e) {
+        } catch (Exception e) {
             // This should only happen if the request is not a multipart
             // request and this we have already checked in hasParts().
             getLogger().warn("File upload failed.", e);
@@ -213,14 +211,11 @@ public class StreamReceiverHandler implements Serializable {
     private void handleMultipartFileUploadFromInputStream(VaadinSession session,
             VaadinRequest request, StreamReceiver streamReceiver,
             StateNode owner) throws IOException {
-        // Create a new file upload handler
-        ServletFileUpload upload = new ServletFileUpload();
-
-        long contentLength = getContentLength(request);
+        long contentLength = request.getContentLength();
         // Parse the request
         FileItemIterator iter;
         try {
-            iter = upload.getItemIterator((HttpServletRequest) request);
+            iter = getItemIterator(request);
             while (iter.hasNext()) {
                 FileItemStream item = iter.next();
                 handleStream(session, streamReceiver, owner, contentLength,
@@ -515,12 +510,28 @@ public class StreamReceiverHandler implements Serializable {
      * specification. To support larger file uploads manually evaluate the
      * Content-Length header which can contain long values.
      */
-    private long getContentLength(VaadinRequest request) {
+    protected long getContentLength(VaadinRequest request) {
         try {
             return Long.parseLong(request.getHeader("Content-Length"));
         } catch (NumberFormatException e) {
             return -1l;
         }
+    }
+
+    protected boolean isMultipartUpload(VaadinRequest request) {
+        return request instanceof HttpServletRequest && ServletFileUpload
+                .isMultipartContent((HttpServletRequest) request);
+    }
+
+    protected Collection<Part> getParts(VaadinRequest request)
+            throws Exception {
+        return ((HttpServletRequest) request).getParts();
+    }
+
+    protected FileItemIterator getItemIterator(VaadinRequest request)
+            throws FileUploadException, IOException {
+        ServletFileUpload upload = new ServletFileUpload();
+        return upload.getItemIterator((HttpServletRequest) request);
     }
 
     private static Logger getLogger() {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamRequestHandler.java
@@ -51,8 +51,21 @@ public class StreamRequestHandler implements RequestHandler {
      */
     static final String DYN_RES_PREFIX = "VAADIN/dynamic/resource/";
 
-    private StreamResourceHandler resourceHandler = new StreamResourceHandler();
-    private StreamReceiverHandler receiverHandler = new StreamReceiverHandler();
+    private final StreamResourceHandler resourceHandler =
+            new StreamResourceHandler();
+    private final StreamReceiverHandler receiverHandler;
+
+    /**
+     * Create a new stream request handler with the default
+     * StreamReceiverHandler.
+     */
+    public StreamRequestHandler() {
+        this(new StreamReceiverHandler());
+    }
+
+    protected StreamRequestHandler(StreamReceiverHandler receiverHandler) {
+        this.receiverHandler = receiverHandler;
+    }
 
     @Override
     public boolean handleRequest(VaadinSession session, VaadinRequest request,


### PR DESCRIPTION
Makes it possible for portlet support to add prefix to resource target by overriding `StreamResourceRegistry.getTargetURI`. Required for #6374.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6421)
<!-- Reviewable:end -->
