### PR TITLE
Only hash for dependencies

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -200,7 +200,8 @@ public class NodeTasks implements FallibleCommand {
 
         /**
          * Sets whether to enable imports file update. Default is
-         * <code>true</code>.
+         * <code>false</code>. This will also enable creation of missing package
+         * files if set to true.
          *
          * @param enableImportsUpdate
          *            <code>true</code> to enable imports file update, otherwise
@@ -209,6 +210,7 @@ public class NodeTasks implements FallibleCommand {
          */
         public Builder enableImportsUpdate(boolean enableImportsUpdate) {
             this.enableImportsUpdate = enableImportsUpdate;
+            this.createMissingPackageJson = enableImportsUpdate || createMissingPackageJson;
             return this;
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -27,7 +27,6 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -105,7 +105,8 @@ public class TaskUpdatePackages extends NodeUpdater {
             boolean isModified = updatePackageJsonDependencies(packageJson,
                     deps);
             if (isModified) {
-                String content = writeAppPackageFile(packageJson);
+                writeAppPackageFile(packageJson);
+                String content = "";
                 // If we have dependencies generate hash on ordered content.
                 if(packageJson.hasKey("dependencies")) {
                     JsonObject dependencies = packageJson.getObject("dependencies");

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdatePackagesTest.java
@@ -21,6 +21,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
@@ -28,11 +30,13 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
 
 import elemental.json.Json;
 import elemental.json.JsonObject;
 import elemental.json.JsonValue;
-
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
 import static elemental.json.impl.JsonUtil.stringify;
@@ -245,7 +249,7 @@ public class NodeUpdatePackagesTest extends NodeUpdateTestUtil {
     }
 
     @Test
-    public void generateAppPackageJsonFromScratch_updaterIsModified()
+    public void generateAppPackageJsonFromScratch_hashCalculated_updaterIsModified()
             throws IOException {
         packageCreator.execute();
         packageUpdater.execute();
@@ -257,8 +261,7 @@ public class NodeUpdatePackagesTest extends NodeUpdateTestUtil {
     }
 
     @Test
-    public void regenerateAppPackageJson_sameContent_updaterIsNotModified()
-            throws IOException {
+    public void regenerateAppPackageJson_sameContent_updaterIsNotModified() {
         packageCreator.execute();
         packageUpdater.execute();
 
@@ -277,8 +280,21 @@ public class NodeUpdatePackagesTest extends NodeUpdateTestUtil {
     }
 
     @Test
-    public void generateAppPackageJson_changedContent_updaterIsModified()
-            throws IOException {
+    public void generateAppPackageJson_sameDependencies_updaterIsNotModified() {
+        FrontendDependencies frontendDependencies = Mockito.mock(FrontendDependencies.class);
+
+        Map<String, String> packages = new HashMap<>();
+        packages.put("@polymer/iron-list", "3.0.2");
+        packages.put("@vaadin/vaadin-confirm-dialog", "1.1.4");
+        packages.put("@vaadin/vaadin-checkbox", "2.2.10");
+        packages.put("@polymer/iron-icon", "3.0.1");
+        packages.put("@vaadin/vaadin-time-picker", "2.0.2");
+
+        Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
+
+        packageUpdater = new TaskUpdatePackages(null, frontendDependencies, baseDir,
+                generatedDir, false);
+
         packageCreator.execute();
         packageUpdater.execute();
 
@@ -289,7 +305,75 @@ public class NodeUpdatePackagesTest extends NodeUpdateTestUtil {
         // packageCreator has not added its content
         packageUpdater.execute();
 
-        Assert.assertTrue(packageUpdater.modified);
+        Assert.assertFalse(
+                "Modification flag should be false when no dependencies changed.",
+                packageUpdater.modified);
+    }
+
+    @Test
+    public void generateAppPackageJson_removedDependencies_updaterIsModified() {
+        FrontendDependencies frontendDependencies = Mockito.mock(FrontendDependencies.class);
+
+        Map<String, String> packages = new HashMap<>();
+        packages.put("@polymer/iron-list", "3.0.2");
+        packages.put("@vaadin/vaadin-confirm-dialog", "1.1.4");
+        packages.put("@vaadin/vaadin-checkbox", "2.2.10");
+        packages.put("@polymer/iron-icon", "3.0.1");
+        packages.put("@vaadin/vaadin-time-picker", "2.0.2");
+
+        Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
+
+        packageUpdater = new TaskUpdatePackages(null, frontendDependencies, baseDir,
+                generatedDir, false);
+
+        packageCreator.execute();
+        packageUpdater.execute();
+
+        // delete generated file
+        appPackageJson.delete();
+
+        packages.remove("@vaadin/vaadin-checkbox");
+
+        // generate it one more time, the content will be different since
+        // packageCreator has not added its content
+        packageUpdater.execute();
+
+        Assert.assertTrue(
+                "Modification flag should be true when dependency removed.",
+                packageUpdater.modified);
+    }
+
+    @Test
+    public void generateAppPackageJson_addedDependencies_updaterIsModified() {
+        FrontendDependencies frontendDependencies = Mockito.mock(FrontendDependencies.class);
+
+        Map<String, String> packages = new HashMap<>();
+        packages.put("@polymer/iron-list", "3.0.2");
+        packages.put("@vaadin/vaadin-confirm-dialog", "1.1.4");
+        packages.put("@vaadin/vaadin-checkbox", "2.2.10");
+        packages.put("@polymer/iron-icon", "3.0.1");
+        packages.put("@vaadin/vaadin-time-picker", "2.0.2");
+
+        Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
+
+        packageUpdater = new TaskUpdatePackages(null, frontendDependencies, baseDir,
+                generatedDir, false);
+
+        packageCreator.execute();
+        packageUpdater.execute();
+
+        // delete generated file
+        appPackageJson.delete();
+
+        packages.put("@vaadin/vaadin-list-box", "1.1.1");
+
+        // generate it one more time, the content will be different since
+        // packageCreator has not added its content
+        packageUpdater.execute();
+
+        Assert.assertTrue(
+                "Modification flag should be true when dependency added.",
+                packageUpdater.modified);
     }
 
     private void makeNodeModulesAndPackageLock() throws IOException {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdatePackagesTest.java
@@ -375,6 +375,34 @@ public class NodeUpdatePackagesTest extends NodeUpdateTestUtil {
                 "Modification flag should be true when dependency added.",
                 packageUpdater.modified);
     }
+    @Test
+    public void generateAppPackageJson_noDependencies_updaterIsNotModified() {
+        FrontendDependencies frontendDependencies = Mockito.mock(FrontendDependencies.class);
+
+        Map<String, String> packages = new HashMap<>();
+        Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
+
+        packageUpdater = new TaskUpdatePackages(null, frontendDependencies, baseDir,
+                generatedDir, false);
+
+        packageCreator.execute();
+        packageUpdater.execute();
+
+        Assert.assertFalse(
+                "Modification flag should be false when there was no dependencies.",
+                packageUpdater.modified);
+
+        // delete generated file
+        appPackageJson.delete();
+
+        // generate it one more time, the content will be different since
+        // packageCreator has not added its content
+        packageUpdater.execute();
+
+        Assert.assertFalse(
+                "Modification flag should be false when there has never been dependencies.",
+                packageUpdater.modified);
+    }
 
     private void makeNodeModulesAndPackageLock() throws IOException {
         // Make two node_modules folders and package lock


### PR DESCRIPTION
When hashing sort dependencies
so we only flag modified if
dependencies have changed.

Closes #6151

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6422)
<!-- Reviewable:end -->
