### PR TITLE
Fix style overrides when placing imports on RouterLayouts

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -89,6 +89,9 @@ public class TaskUpdateImports extends NodeUpdater {
     private static final Pattern NEW_LINE_TRIM = Pattern
             .compile("(?m)(^\\s+|\\s?\n)");
 
+    private static final Pattern FRONTEND_IMPORT_LINE = Pattern.compile(
+            String.format(IMPORT_TEMPLATE, WEBPACK_PREFIX_ALIAS + "\\S*"));
+
     /**
      * Create an instance of the updater given all configurable parameters.
      *
@@ -141,9 +144,8 @@ public class TaskUpdateImports extends NodeUpdater {
         ArrayList<String> externals = new ArrayList<>();
         ArrayList<String> internals = new ArrayList<>();
 
-        final String importPrefix = getLocalImportPrefix();
         for (String module : getModuleLines(modules)) {
-            if (module.startsWith(importPrefix)) {
+            if (FRONTEND_IMPORT_LINE.matcher(module).matches()) {
                 internals.add(module);
             } else {
                 externals.add(module);
@@ -489,11 +491,5 @@ public class TaskUpdateImports extends NodeUpdater {
 
     private static String generatedResourcePathIntoRelativePath(String path) {
         return path.replace(GENERATED_PREFIX, "./");
-    }
-
-    private static String getLocalImportPrefix() {
-        return String.format(
-                IMPORT_TEMPLATE.substring(0, IMPORT_TEMPLATE.length() - 2),
-                WEBPACK_PREFIX_ALIAS);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -137,7 +137,21 @@ public class TaskUpdateImports extends NodeUpdater {
 
         lines.addAll(getThemeLines());
         lines.addAll(getCssLines());
-        lines.addAll(getModuleLines(modules));
+
+        ArrayList<String> externals = new ArrayList<>();
+        ArrayList<String> internals = new ArrayList<>();
+
+        final String importPrefix = getLocalImportPrefix();
+        for (String module : getModuleLines(modules)) {
+            if (module.startsWith(importPrefix)) {
+                internals.add(module);
+            } else {
+                externals.add(module);
+            }
+        }
+
+        lines.addAll(externals);
+        lines.addAll(internals);
 
         return lines;
     }
@@ -475,5 +489,11 @@ public class TaskUpdateImports extends NodeUpdater {
 
     private static String generatedResourcePathIntoRelativePath(String path) {
         return path.replace(GENERATED_PREFIX, "./");
+    }
+
+    private static String getLocalImportPrefix() {
+        return String.format(
+                IMPORT_TEMPLATE.substring(0, IMPORT_TEMPLATE.length() - 2),
+                WEBPACK_PREFIX_ALIAS);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -89,6 +89,8 @@ public class TaskUpdateImports extends NodeUpdater {
     private static final Pattern NEW_LINE_TRIM = Pattern
             .compile("(?m)(^\\s+|\\s?\n)");
 
+    // Used to recognize and sort FRONTEND/ imports in the final
+    // generated-flow-imports.js
     private static final Pattern FRONTEND_IMPORT_LINE = Pattern.compile(
             String.format(IMPORT_TEMPLATE, WEBPACK_PREFIX_ALIAS + "\\S*"));
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
@@ -306,7 +306,7 @@ public class FrontendDependencies implements Serializable {
         // entry-point visits
         for (EndPointData endPoint : endPoints.values()) {
             if (endPoint.getLayout() != null) {
-                visitClass(endPoint.getLayout(), endPoint, true);
+                visitClass(endPoint.getLayout(), endPoint, false);
             }
             if (endPoint.getTheme() != null) {
                 visitClass(endPoint.getTheme().getName(), endPoint, true);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTestComponents.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTestComponents.java
@@ -29,7 +29,9 @@ import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.theme.AbstractTheme;
 import com.vaadin.flow.theme.Theme;
 
@@ -101,8 +103,18 @@ public class NodeTestComponents {
 
     }
 
+    @JsModule("./common-js-file.js")
     @Theme(value = LumoTest.class, variant = LumoTest.DARK)
     @Route
+    public static class MainLayout implements RouterLayout {
+        @Override
+        public Element getElement() {
+            return null;
+        }
+    }
+
+
+    @Route(value = "", layout = MainLayout.class)
     public static class MainView extends Component {
         ButtonComponent buttonComponent;
         IconComponent iconComponent;

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateImportsTest.java
@@ -375,6 +375,19 @@ public class NodeUpdateImportsTest extends NodeUpdateTestUtil {
                 "styles/styles.js");
     }
 
+    // flow #6408
+    @Test
+    public void jsModuleOnRouterLayout_shouldBe_addedAfterLumoStyles() throws Exception {
+        updater.execute();
+
+        assertContainsImports(true, "Frontend/common-js-file.js");
+
+        assertImportOrder("@vaadin/vaadin-lumo-styles/color.js",
+                "Frontend/common-js-file.js");
+        assertImportOrder("@vaadin/vaadin-mixed-component/theme/lumo/vaadin-something-else.js",
+                "Frontend/common-js-file.js");
+    }
+
     @Test
     public void jsModulesOrderIsPreservedAnsAfterJsModules() throws Exception {
         updater.execute();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateTestUtil.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateTestUtil.java
@@ -153,7 +153,8 @@ public class NodeUpdateTestUtil {
                 "./local-template.js",
                 "./foo-dir/vaadin-npm-component.js",
                 "./foo.css",
-                "@vaadin/vaadin-mixed-component/bar.css");
+                "@vaadin/vaadin-mixed-component/bar.css",
+                "./common-js-file.js");
     }
 
     void createExpectedImports(File directoryWithImportsJs,

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
@@ -34,6 +34,9 @@ import com.vaadin.flow.server.frontend.scanner.samples.JsOrderComponent;
 import com.vaadin.flow.server.frontend.scanner.samples.MyServiceListener;
 import com.vaadin.flow.server.frontend.scanner.samples.MyUIInitListener;
 import com.vaadin.flow.server.frontend.scanner.samples.RouteComponent;
+import com.vaadin.flow.server.frontend.scanner.samples.RouteComponentWithLayout;
+
+import static org.hamcrest.CoreMatchers.is;
 
 public class FrontendDependenciesTest {
 
@@ -118,6 +121,20 @@ public class FrontendDependenciesTest {
 
         Assert.assertEquals(new ArrayList<>(dependencies.getScripts()),
                 Arrays.asList("a.js", "b.js", "c.js"));
+    }
+
+    // flow #6408
+    @Test
+    public void annotationsInRouterLayoutWontBeFlaggedAsBelongingToTheme() {
+        Mockito.when(classFinder.getAnnotatedClasses(Route.class))
+                .thenReturn(Collections.singleton(RouteComponentWithLayout.class));
+        FrontendDependencies dependencies = new FrontendDependencies(
+                classFinder, false);
+
+        List<String> expectedOrder = Arrays.asList("theme-foo.js", "foo.js");
+        Assert.assertThat("Theme's annotations should come first",
+                    dependencies.getModules(), is(expectedOrder)
+                );
     }
 
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/samples/CustomTheme.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/samples/CustomTheme.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.server.frontend.scanner.samples;
+
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.theme.AbstractTheme;
+
+@JsModule("theme-foo.js")
+public class CustomTheme implements AbstractTheme {
+    @Override
+    public String getBaseUrl() {
+        return null;
+    }
+
+    @Override
+    public String getThemeUrl() {
+        return null;
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/samples/RouteComponentWithLayout.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/samples/RouteComponentWithLayout.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.frontend.scanner.samples;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.dependency.JavaScript;
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "layout", layout = RouteLayoutComponent.class)
+public class RouteComponentWithLayout extends Component {
+
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/samples/RouteLayoutComponent.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/samples/RouteLayoutComponent.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.server.frontend.scanner.samples;
+
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.router.RouterLayout;
+import com.vaadin.flow.theme.Theme;
+
+@JsModule("foo.js")
+@Theme(CustomTheme.class)
+public class RouteLayoutComponent implements RouterLayout {
+    @Override
+    public Element getElement() {
+        return null;
+    }
+}


### PR DESCRIPTION
Two changes:
- `@JsModule` annotations on the same class as the `@Theme` annotation are no longer put into the "theme scope". Belonging to theme scope forces the annotations to the top of the list.
- Imports in `generated-flow-imports.js` starting with `FRONTEND/` are moved to the end of the file. This allows local files to override styles in theme related files.

Now, am not 100% sure I did not miss some implementation detail in regards to the `generated-flow-imports,js` file ordering. Who would have insight on the matter?

I had another implementation, which ordered the import based on their package domain name; `com.vaadin` would be on the top and imports whose domain matches that of the EndPointData's class would be on the bottom. But that did not seem to provide enough value to warrant the complexity. It did place imports in addons always under Vaadin stuff

Fixes #6408

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6423)
<!-- Reviewable:end -->
