### PR TITLE
CCDM: add vaadin-router into CCDM tests

### DIFF
--- a/flow-tests/test-ccdm/.gitignore
+++ b/flow-tests/test-ccdm/.gitignore
@@ -1,0 +1,1 @@
+!package.json

--- a/flow-tests/test-ccdm/frontend/client-router.js
+++ b/flow-tests/test-ccdm/frontend/client-router.js
@@ -1,0 +1,50 @@
+import {Router} from '@vaadin/router';
+
+const createNavigationLink = (text, link) => {
+  const aLink = document.createElement('a');
+  aLink.href = link;
+  aLink.textContent = text;
+  aLink.style.margin = '10px';
+  return aLink;
+}
+
+export function loadRouter(flow) {
+  //------- Configure Router
+  const routes = [
+    {
+      path: '/',
+      component: 'client-layout',
+      children: [
+        {
+          path: 'client-view',
+          action: () => {
+            const div = document.createElement('div');
+            div.textContent = 'Client view';
+            div.id = 'clientView';
+            return div;
+          }
+        },
+        flow.route
+      ]
+    }
+  ];
+
+  const routerContainer = document.createElement('div');
+
+  const navigationContainer = document.createElement('div');
+  navigationContainer.appendChild(createNavigationLink('Empty view', ''));
+  navigationContainer.appendChild(createNavigationLink('Client view', 'client-view'));
+  navigationContainer.appendChild(createNavigationLink('Server view', 'serverview'));
+  navigationContainer.appendChild(createNavigationLink('View with all events', 'view-with-all-events'));
+  routerContainer.appendChild(navigationContainer);
+
+  const outlet = document.createElement('div');
+  outlet.id = 'outlet';
+  routerContainer.appendChild(outlet);
+
+  document.body.appendChild(routerContainer);
+
+  const router = new Router(outlet);
+
+  router.setRoutes(routes, true);
+}

--- a/flow-tests/test-ccdm/frontend/index.html
+++ b/flow-tests/test-ccdm/frontend/index.html
@@ -17,6 +17,7 @@
 
 <button id="button1">Load content from other bundle</button>
 <button id="button2">Load flow</button>
+<button id="loadVaadinRouter">Load Vaadin Router</button>
 <p>
     <input type="text" id="pathname" placeholder="route">
     <button id="button3">Navigate flow</button>

--- a/flow-tests/test-ccdm/frontend/index.js
+++ b/flow-tests/test-ccdm/frontend/index.js
@@ -40,3 +40,8 @@ document.getElementById('button3').addEventListener('click', async e => {
     outlet.appendChild(result);
 });
 
+document.getElementById("loadVaadinRouter").addEventListener('click', async(e) => {
+    const clientRouter = await import('./client-router.js');
+    clientRouter.loadRouter(flow);
+});
+

--- a/flow-tests/test-ccdm/package.json
+++ b/flow-tests/test-ccdm/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "no-name",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "@polymer/polymer": "3.2.0",
+    "@webcomponents/webcomponentsjs": "^2.2.10",
+    "@vaadin/flow-deps": "./target/frontend",
+    "@vaadin/router": "^1.4.1"
+  },
+  "devDependencies": {
+    "webpack": "4.30.0",
+    "webpack-cli": "3.3.0",
+    "webpack-dev-server": "3.3.0",
+    "webpack-babel-multi-target-plugin": "2.1.0",
+    "copy-webpack-plugin": "5.0.3",
+    "webpack-merge": "4.2.1",
+    "raw-loader": "3.0.0",
+    "typescript": "3.5.3",
+    "awesome-typescript-loader": "5.2.1"
+  }
+}

--- a/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/MainLayout.java
+++ b/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/MainLayout.java
@@ -22,5 +22,6 @@ import com.vaadin.flow.router.RouterLayout;
 public class MainLayout extends Div implements RouterLayout {
     public MainLayout() {
         add(new Text("Main layout"));
+        setId("mainLayout");
     }
 }

--- a/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/ClientIndexHandlerIT.java
+++ b/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/ClientIndexHandlerIT.java
@@ -260,6 +260,52 @@ public class ClientIndexHandlerIT extends ChromeBrowserTest {
     }
 
     @Test
+    public void should_navigateFromClientToServer_When_UsingVaadinRouter() {
+        openTestUrl("/");
+        waitForElementPresent(By.id("loadVaadinRouter"));
+        findElement(By.id("loadVaadinRouter")).click();
+        waitForElementPresent(By.id("outlet"));
+
+        findElement(By.linkText("Client view")).click();
+        waitForElementPresent(By.id("clientView"));
+        String clientSideViewContent = findElement(By.id("clientView"))
+                .getText();
+        Assert.assertEquals(
+                "Should load client side view content with vaadin-router",
+                "Client view", clientSideViewContent);
+
+        findElement(By.linkText("Server view")).click();
+        waitForElementPresent(By.id("mainLayout"));
+        String mainLayoutContent = findElement(By.id("mainLayout")).getText();
+        Assert.assertEquals("Should load server view content with " +
+                "vaadin-router", "Main layout\nServer view", mainLayoutContent);
+
+    }
+
+    @Test
+    public void should_navigateFromServerToClient_When_UsingVaadinRouter() {
+        openTestUrl("/");
+        waitForElementPresent(By.id("loadVaadinRouter"));
+        findElement(By.id("loadVaadinRouter")).click();
+        waitForElementPresent(By.id("outlet"));
+
+
+        findElement(By.linkText("Server view")).click();
+        waitForElementPresent(By.id("mainLayout"));
+        String mainLayoutContent = findElement(By.id("mainLayout")).getText();
+        Assert.assertEquals("Should load server view content with " +
+                "vaadin-router", "Main layout\nServer view", mainLayoutContent);
+
+        findElement(By.linkText("Client view")).click();
+        waitForElementPresent(By.id("clientView"));
+        String clientSideViewContent = findElement(By.id("clientView"))
+                .getText();
+        Assert.assertEquals(
+                "Should load client side view content with vaadin-router",
+                "Client view", clientSideViewContent);
+    }
+
+    @Test
     public void should_returnNotFoundView_WhenRouteNotFound() {
         openTestUrl("/");
         waitForElementPresent(By.id("button3"));


### PR DESCRIPTION
This PR adds `vaadin-router` to ccdm tests to test router's integration use cases.
There are only two use cases at the moment, `server -> client` and `client -> server` because other use cases are not working yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6447)
<!-- Reviewable:end -->
