### PR TITLE
CCDM: consider query string in flow navigate

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
@@ -29,6 +29,7 @@ interface FlowRoot {
 
 export interface NavigationParameters {
   pathname: string;
+  search: string;
 }
 
 export interface NavigationCommands {
@@ -114,9 +115,9 @@ export class Flow {
       // The callback to run from server side once the view is ready
       this.container.serverConnected = cancel =>
         resolve(cmd && cancel ? cmd.prevent() : this.container);
-
+      const flowRoute: string = ctx.pathname + (ctx.search ? ctx.search : '');
       // Call server side to navigate to the given route
-      this.flowRoot.$server.connectClient(this.container.localName, this.container.id, ctx.pathname);
+      this.flowRoot.$server.connectClient(this.container.localName, this.container.id, flowRoute);
     });
   }
 

--- a/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/ViewWithParameter.java
+++ b/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/ViewWithParameter.java
@@ -25,6 +25,12 @@ public class ViewWithParameter extends Div implements HasUrlParameter<String> {
 
     @Override
     public void setParameter(BeforeEvent event, String parameter) {
-        setText("Parameter: " + parameter);
+        String textContent = "Parameter: " + parameter;
+        String queryString = event.getLocation().getQueryParameters()
+                .getQueryString();
+        if (queryString.length() > 0) {
+            textContent += " - Query string: " + queryString;
+        }
+        setText(textContent);
     }
 }

--- a/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/ClientIndexHandlerIT.java
+++ b/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/ClientIndexHandlerIT.java
@@ -189,6 +189,24 @@ public class ClientIndexHandlerIT extends ChromeBrowserTest {
     }
 
     @Test
+    public void should_executeSetParameter_WhenRouteHasParameterAndQueryString() {
+        openTestUrl("/");
+        waitForElementPresent(By.id("button3"));
+        String inputParam = "123";
+        String queryString = "query1=123&query2=456";
+        findElement(By.id("pathname"))
+                .sendKeys("paramview/" + inputParam + "?" + queryString);
+        findElement(By.id("button3")).click();
+        waitForElementPresent(By.id("result"));
+
+        String content = findElement(By.id("result")).getText();
+        Assert.assertEquals("Should execute set parameter method",
+                "Main layout\nParameter: " + inputParam + " - Query string: "
+                        + queryString,
+                content);
+    }
+
+    @Test
     public void should_rerouteToOtherView_WhenViewRerouteInOnBeforeEnter() {
         openTestUrl("/");
         waitForElementPresent(By.id("button3"));


### PR DESCRIPTION
Fixes #6446 

This PR sends  the query string (if available) together with pathname to the server when navigating using `flow.navigate`, so that the server view will be able to get the query string from Location object.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6450)
<!-- Reviewable:end -->
