### PR TITLE
Make removingShortcutCleansJavascriptEventSettingsItUsed more stable

### DIFF
--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ShortcutsIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ShortcutsIT.java
@@ -172,12 +172,15 @@ public class ShortcutsIT extends ChromeBrowserTest {
         // The shortcut is removed at the same time, so another 'd' should be
         // printed out.
 
-        removalInput.sendKeys("abcd abcd");
+        removalInput.sendKeys("abcd");
+        Assert.assertEquals("removalInput should have 'ABC' and no 'd'", "ABC",
+                removalInput.getAttribute("value"));
 
+        removalInput.sendKeys("abcd");
         Assert.assertEquals(
-                "removalInput should have text, with some letters"
-                        + " capitalized and only one 'd' letter",
-                "ABC abcd", removalInput.getAttribute("value"));
+                "removalInput 'ABCabcd'. Since shortcut was removed, 'd' can "
+                        + "be typed.",
+                "ABCabcd", removalInput.getAttribute("value"));
     }
 
     private void assertActualEquals(String expected) {


### PR DESCRIPTION
I could not get the changed test to flake locally. Does not say much about bender tho.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6461)
<!-- Reviewable:end -->
