### PR TITLE
CCDM: Use html-webpack-plugin to add webpack bundles to index.html

### DIFF
--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
@@ -172,7 +172,8 @@ public class PrepareFrontendMojoTest {
 
         assertContainsPackage(packageJsonObject.getObject("devDependencies"),
                 "webpack", "webpack-cli", "webpack-dev-server",
-                "webpack-babel-multi-target-plugin", "copy-webpack-plugin");
+                "webpack-babel-multi-target-plugin", "copy-webpack-plugin",
+                "html-webpack-plugin");
     }
 
     private List<File> gatherFiles(File root) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/ClientIndexHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/ClientIndexHandler.java
@@ -45,9 +45,6 @@ public class ClientIndexHandler extends SynchronizedRequestHandler {
             VaadinRequest request, VaadinResponse response) throws IOException {
         Document indexDocument = getIndexHtmlDocument(request);
         prependBaseHref(request, indexDocument);
-        BootstrapHandler.BootstrapPageBuilder
-                .appendNpmBundle(indexDocument.head(),
-                request.getService());
         response.setContentType(CONTENT_TYPE_TEXT_HTML_UTF_8);
         request.getService().modifyClientIndexBootstrapPage(
                 new ClientIndexBootstrapPage(request, response, session,

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -239,6 +239,8 @@ public abstract class NodeUpdater implements FallibleCommand {
                 "webpack-babel-multi-target-plugin", "2.1.0") || added;
         added = addDependency(packageJson, DEV_DEPENDENCIES,
                 "copy-webpack-plugin", "5.0.3") || added;
+        added = addDependency(packageJson, DEV_DEPENDENCIES,
+                "html-webpack-plugin", "3.2.0") || added;
         added = addDependency(packageJson, DEV_DEPENDENCIES, "webpack-merge",
                 "4.2.1") || added;
         added = addDependency(packageJson, DEV_DEPENDENCIES, "raw-loader",

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -6,6 +6,7 @@
  */
 const fs = require('fs');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 const {BabelMultiTargetPlugin} = require('webpack-babel-multi-target-plugin');
 
 const path = require('path');
@@ -47,7 +48,7 @@ module.exports = {
   mode: 'production',
   context: frontendFolder,
   entry: {
-    bundle: useClientSideIndexFileForBootstrapping ? `${frontendFolder}/index` : fileNameOfTheFlowGeneratedMainEntryPoint
+    bundle: useClientSideIndexFileForBootstrapping ? './index' : fileNameOfTheFlowGeneratedMainEntryPoint
   },
 
   output: {
@@ -155,10 +156,10 @@ module.exports = {
       to: `${build}/webcomponentsjs/`
     }]),
 
-    useClientSideIndexFileForBootstrapping && new CopyWebpackPlugin([{
-     from: `${frontendFolder}/index.html`,
-     to: `${mavenOutputFolderForFlowBundledFiles}/index.html`
-    }]),
+    // Includes JS output bundles into "index.html"
+    useClientSideIndexFileForBootstrapping && new HtmlWebpackPlugin({
+      template: './index.html'
+    }),
   ].filter(Boolean)
 };
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/ClientIndexHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/ClientIndexHandlerTest.java
@@ -93,26 +93,6 @@ public class ClientIndexHandlerTest {
     }
 
     @Test
-    public void serveIndexHtml_requestWithRootPath_hasInjectedBundles()
-            throws IOException {
-        clientIndexBootstrapHandler
-                .synchronizedHandleRequest(session, createVaadinRequest(""),
-                        response);
-        String indexHtml = responseOutput
-                .toString(StandardCharsets.UTF_8.name());
-        Assert.assertTrue(
-                "Response should have ES6 bundle script based on "
-                        + "information in 'META-INF/VAADIN/config/stats.json'",
-                indexHtml.contains(
-                "<script type=\"module\" defer src=\"./VAADIN/build/index-1111.cache.js\"></script>"));
-        Assert.assertTrue(
-                "Response should have ES5 bundle script based on "
-                        + "information in 'META-INF/VAADIN/config/stats.json'",
-                indexHtml.contains(
-                "<script type=\"text/javascript\" defer src=\"./VAADIN/build/index.es5-2222.cache.js\" nomodule></script>"));
-    }
-
-    @Test
     public void canHandleRequest_requestWithRootPath_handleRequest() {
         boolean canHandleRequest = clientIndexBootstrapHandler
                 .canHandleRequest(createVaadinRequest(""));

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdatePackagesTest.java
@@ -494,6 +494,8 @@ public class NodeUpdatePackagesTest extends NodeUpdateTestUtil {
                 devDependencies.hasKey("webpack-babel-multi-target-plugin"));
         Assert.assertTrue("Missing copy-webpack-plugin dev package",
                 devDependencies.hasKey("copy-webpack-plugin"));
+        Assert.assertTrue("Missing html-webpack-plugin dev package",
+                devDependencies.hasKey("html-webpack-plugin"));
     }
 
     private void assertAppPackageJsonContent() throws IOException {

--- a/flow-tests/test-ccdm/package.json
+++ b/flow-tests/test-ccdm/package.json
@@ -16,6 +16,7 @@
     "webpack-merge": "4.2.1",
     "raw-loader": "3.0.0",
     "typescript": "3.5.3",
-    "awesome-typescript-loader": "5.2.1"
+    "awesome-typescript-loader": "5.2.1",
+    "html-webpack-plugin": "3.2.0"
   }
 }


### PR DESCRIPTION
Fixes #6443

All bundles produced by webpack were eagerly added into `index.html` by
Flow. That did not allow to postpone loading dynamically imported JS parts.

This change makes only the initial bundles be included into the page, so that
the JS code imported dynamically is loaded upon import request.

This behaviour is achieved by processing the `frontend/index.html` file
through `html-webpack-plugin`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6465)
<!-- Reviewable:end -->
