### PR TITLE
Fix #5454: shourcut gets activated twice

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -596,15 +596,18 @@ public class ShortcutRegistration implements Registration, Serializable {
     private static String generateEventModifierFilter(
             Collection<Key> modifiers) {
 
-        if (modifiers.isEmpty()) {
-            return "true";
-        }
+        final List<Key> realMods = modifiers.stream().filter(Key::isModifier)
+                .collect(Collectors.toList());
 
-        return modifiers.stream().filter(Key::isModifier)
-                .map(modifier ->
-                        "event.getModifierState('" +
-                                modifier.getKeys().get(0) + "')")
-                .collect(Collectors.joining(" && "));
+        // build a filter based on all the modifier keys. if modifier is not
+        // in the parameter collection, require it to be passive to match the
+        // shortcut
+        return Arrays.stream(KeyModifier.values()).map(modifier -> {
+            boolean modifierRequired = realMods.stream()
+                    .anyMatch(mod -> mod.matches(modifier.getKeys().get(0)));
+            return (modifierRequired ? "" : "!") + "event.getModifierState('"
+                    + modifier.getKeys().get(0) + "')";
+        }).collect(Collectors.joining(" && "));
     }
 
     private static String generateEventKeyFilter(Key key) {

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsView.java
@@ -30,7 +30,6 @@ import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.server.Command;
 import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 
 @Route(value = "com.vaadin.flow.uitest.ui.ShortcutsView",
@@ -174,12 +173,21 @@ public class ShortcutsView extends Div {
         add(removalInput);
 
         // bindingShortcutToSameKeyWithDifferentModifiers_shouldNot_triggerTwice
-        AtomicInteger integer = new AtomicInteger(0);
-        Command command = () -> actual.setValue("" + integer.incrementAndGet());
-        UI.getCurrent().addShortcutListener(command, Key.KEY_O);
-        UI.getCurrent().addShortcutListener(command, Key.KEY_O,
-                KeyModifier.ALT);
-        UI.getCurrent().addShortcutListener(command, Key.KEY_O,
-                KeyModifier.SHIFT);
+        AtomicInteger oCounter = new AtomicInteger(0);
+        AtomicInteger oShiftCounter = new AtomicInteger(0);
+        AtomicInteger oAltCounter = new AtomicInteger(0);
+        UI.getCurrent()
+                .addShortcutListener(
+                        () -> actual.setValue("" + oCounter.incrementAndGet()
+                                + oShiftCounter.get() + oAltCounter.get()),
+                        Key.KEY_O);
+        UI.getCurrent()
+                .addShortcutListener(() -> actual.setValue("" + oCounter.get()
+                        + oShiftCounter.incrementAndGet() + oAltCounter.get()),
+                        Key.KEY_O, KeyModifier.SHIFT);
+        UI.getCurrent().addShortcutListener(
+                () -> actual.setValue("" + oCounter.get() + oShiftCounter.get()
+                        + oAltCounter.incrementAndGet()),
+                Key.KEY_O, KeyModifier.ALT);
     }
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ShortcutsView.java
@@ -16,6 +16,7 @@
 
 package com.vaadin.flow.uitest.ui;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import com.vaadin.flow.component.Key;
@@ -29,6 +30,7 @@ import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.data.value.ValueChangeMode;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.Command;
 import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 
 @Route(value = "com.vaadin.flow.uitest.ui.ShortcutsView",
@@ -170,5 +172,14 @@ public class ShortcutsView extends Div {
                 }, Key.KEY_D);
         removalAtomicReference.set(removalRegistration);
         add(removalInput);
+
+        // bindingShortcutToSameKeyWithDifferentModifiers_shouldNot_triggerTwice
+        AtomicInteger integer = new AtomicInteger(0);
+        Command command = () -> actual.setValue("" + integer.incrementAndGet());
+        UI.getCurrent().addShortcutListener(command, Key.KEY_O);
+        UI.getCurrent().addShortcutListener(command, Key.KEY_O,
+                KeyModifier.ALT);
+        UI.getCurrent().addShortcutListener(command, Key.KEY_O,
+                KeyModifier.SHIFT);
     }
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ShortcutsIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ShortcutsIT.java
@@ -35,6 +35,8 @@ public class ShortcutsIT extends ChromeBrowserTest {
             .of(Keys.SHIFT, Keys.ALT, Keys.CONTROL, Keys.META)
             .collect(Collectors.toSet());
 
+    private static final String DEFAULT_VALUE = "testing...";
+
     @Before
     public void before() {
         open();
@@ -86,16 +88,16 @@ public class ShortcutsIT extends ChromeBrowserTest {
         assertActualEquals("DISABLED CLICKED");
 
         resetActual();
-        assertActualEquals("testing...");
+        assertActualEquals(DEFAULT_VALUE);
 
         sendKeys(Keys.CONTROL, "U"); // ctrl+shift+u
-        assertActualEquals("testing...");
+        assertActualEquals(DEFAULT_VALUE);
     }
 
     @Test
     public void listenOnScopesTheShortcut() {
         sendKeys(Keys.ALT, "s");
-        assertActualEquals("testing..."); // nothing happened
+        assertActualEquals(DEFAULT_VALUE); // nothing happened
 
         WebElement innerInput = findElement(By.id("focusTarget"));
         innerInput.sendKeys(Keys.ALT, "s");
@@ -108,7 +110,7 @@ public class ShortcutsIT extends ChromeBrowserTest {
     @Test
     public void shortcutsOnlyWorkWhenComponentIsAttached() {
         sendKeys(Keys.ALT, "a");
-        assertActualEquals("testing..."); // nothing happens
+        assertActualEquals(DEFAULT_VALUE); // nothing happens
 
         // attaches the component
         sendKeys(Keys.ALT, "y");
@@ -181,6 +183,25 @@ public class ShortcutsIT extends ChromeBrowserTest {
                 "removalInput 'ABCabcd'. Since shortcut was removed, 'd' can "
                         + "be typed.",
                 "ABCabcd", removalInput.getAttribute("value"));
+    }
+
+    @Test
+    public void bindingShortcutToSameKeyWithDifferentModifiers_shouldNot_triggerTwice() {
+        // they bindings are "o", "shift+o", and "alt+o"
+
+        assertActualEquals(DEFAULT_VALUE);
+
+        // bug #5454:
+        // if the shortcut is without modifiers, bindings on that
+        // key with modifiers also trigger
+        sendKeys("o");
+        assertActualEquals("1");
+
+        sendKeys("O"); // shift+o
+        assertActualEquals("2");
+
+        sendKeys(Keys.ALT, "o");
+        assertActualEquals("3");
     }
 
     private void assertActualEquals(String expected) {

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ShortcutsIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ShortcutsIT.java
@@ -194,14 +194,20 @@ public class ShortcutsIT extends ChromeBrowserTest {
         // bug #5454:
         // if the shortcut is without modifiers, bindings on that
         // key with modifiers also trigger
+
+        // each shortcut has its own counter. each shortcut increments its
+        // respective counter and then all the counters are concatenated into
+        // "actual" text field. Should shortcuts cross-trigger, number two
+        // will be part of the string
+        // string order: [o][shift+o][alt+o]
         sendKeys("o");
-        assertActualEquals("1");
+        assertActualEquals("100");
 
         sendKeys("O"); // shift+o
-        assertActualEquals("2");
+        assertActualEquals("110");
 
         sendKeys(Keys.ALT, "o");
-        assertActualEquals("3");
+        assertActualEquals("111");
     }
 
     private void assertActualEquals(String expected) {


### PR DESCRIPTION
Fix #5454. 

Build a stricter key filter for a particular shortcut. Shortcuts without modifier keys could trigger shortcuts that were bound to the same key but had modifiers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6474)
<!-- Reviewable:end -->
