### PR TITLE
CCDM: fix lifecycle events when leaving server view

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
@@ -12,10 +12,16 @@ interface AppInitResponse {
   appConfig: AppConfig;
 }
 
+interface RouterLocation {
+  pathname: string;
+  search: string;
+}
+
 interface HTMLRouterContainer extends HTMLElement {
   onBeforeEnter ?: (ctx: NavigationParameters, cmd: NavigationCommands) => Promise<any>;
   onBeforeLeave ?: (ctx: NavigationParameters, cmd: NavigationCommands) => Promise<any>;
   serverConnected ?: (cancel: boolean) => void;
+  location ?: RouterLocation;
 }
 
 interface FlowRoute {
@@ -132,7 +138,7 @@ export class Flow {
       }
 
       // Call server side to check whether we can leave the view
-      this.flowRoot.$server.leaveNavigation();
+      this.flowRoot.$server.leaveNavigation(this.getFlowRoute(ctx));
     });
   }
 
@@ -146,8 +152,12 @@ export class Flow {
 
       // Call server side to navigate to the given route
       this.flowRoot.$server
-        .connectClient(this.container.localName, this.container.id, ctx.pathname + (ctx.search || ''));
+        .connectClient(this.container.localName, this.container.id, this.getFlowRoute(ctx));
     });
+  }
+
+  private getFlowRoute(context: NavigationParameters): string {
+    return context.pathname + (context.search || '');
   }
 
   // import flow client modules and initialize UI in server side.

--- a/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
@@ -12,16 +12,10 @@ interface AppInitResponse {
   appConfig: AppConfig;
 }
 
-interface RouterLocation {
-  pathname: string;
-  search: string;
-}
-
 interface HTMLRouterContainer extends HTMLElement {
   onBeforeEnter ?: (ctx: NavigationParameters, cmd: NavigationCommands) => Promise<any>;
   onBeforeLeave ?: (ctx: NavigationParameters, cmd: NavigationCommands) => Promise<any>;
   serverConnected ?: (cancel: boolean) => void;
-  location ?: RouterLocation;
 }
 
 interface FlowRoute {

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUI.java
@@ -52,6 +52,7 @@ public class JavaScriptBootstrapUI extends UI {
             "not supported for client-side projects";
 
     Element wrapperElement;
+    private NavigationState clientViewNavigationState;
 
     /**
      * Create UI for clientSideMode.
@@ -93,10 +94,13 @@ public class JavaScriptBootstrapUI extends UI {
      *
      * This is only called when client route navigates from a server to a client
      * view.
+     * 
+     * @param route
+     *            the route that is navigating to.
      */
     @ClientCallable
-    public void leaveNavigation(String nextLocation) {
-        boolean postponed = navigateToPlaceholder(nextLocation);
+    public void leaveNavigation(String route) {
+        boolean postponed = navigateToPlaceholder(route);
         if (!postponed) {
             wrapperElement.removeAllChildren();
         }
@@ -106,10 +110,16 @@ public class JavaScriptBootstrapUI extends UI {
     }
 
     private boolean navigateToPlaceholder(String nextLocation) {
-        Location activeLocation = new Location(removeFirstSlash(nextLocation));
-        NavigationState build = new NavigationStateBuilder(this.getRouter())
-                .withTarget(ClientViewPlaceholder.class).build();
-        return handleNavigation(activeLocation, build);
+        Location clientViewLocation = new Location(
+                removeFirstSlash(nextLocation));
+        if (clientViewNavigationState == null) {
+            clientViewNavigationState = new NavigationStateBuilder(
+                    this.getRouter()).withTarget(ClientViewPlaceholder.class)
+                            .build();
+        }
+        // Passing the `clientViewLocation` to make sure that the navigation
+        // events contain the correct location that we are navigating to.
+        return handleNavigation(clientViewLocation, clientViewNavigationState);
     }
 
     private boolean renderViewForRoute(String route) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUI.java
@@ -40,7 +40,6 @@ import com.vaadin.flow.router.RouteNotFoundError;
 import com.vaadin.flow.router.internal.ErrorStateRenderer;
 import com.vaadin.flow.router.internal.NavigationStateRenderer;
 import com.vaadin.flow.server.communication.JavaScriptBootstrapHandler;
-import com.vaadin.flow.theme.NoTheme;
 import com.vaadin.flow.theme.ThemeDefinition;
 
 /**
@@ -218,7 +217,11 @@ public class JavaScriptBootstrapUI extends UI {
             JavaScriptBootstrapUI jsUI = castToJavaScriptUI(ui);
             Element wrapperElement = jsUI.wrapperElement;
             Element rootElement = newRoot.getElement();
-            if (!wrapperElement.equals(rootElement.getParent())) {
+            if (newRoot instanceof ClientViewPlaceholder) {
+                // only need to remove all children when newRoot is a
+                // placeholder
+                wrapperElement.removeAllChildren();
+            } else if (!wrapperElement.equals(rootElement.getParent())) {
                 if (oldRoot != null) {
                     oldRoot.getElement().removeFromParent();
                 }
@@ -251,13 +254,6 @@ public class JavaScriptBootstrapUI extends UI {
      * views.
      */
     @Tag(Tag.DIV)
-    @NoTheme
     public static class ClientViewPlaceholder extends Component {
-        /**
-         * Public constructor for creating the instance from reflection.
-         */
-        public ClientViewPlaceholder() {
-            // Empty constructor
-        }
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUI.java
@@ -101,9 +101,6 @@ public class JavaScriptBootstrapUI extends UI {
     @ClientCallable
     public void leaveNavigation(String route) {
         boolean postponed = navigateToPlaceholder(route);
-        if (!postponed) {
-            wrapperElement.removeAllChildren();
-        }
 
         // Inform the client whether the navigation should be postponed
         wrapperElement.executeJs("this.serverConnected($0)", postponed);

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUI.java
@@ -250,6 +250,7 @@ public class JavaScriptBootstrapUI extends UI {
          * Public constructor for creating the instance from reflection.
          */
         public ClientViewPlaceholder() {
+            // Empty constructor
         }
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
@@ -95,7 +95,7 @@ public class JavaScriptBootstrapUITest  {
         assertEquals(Tag.HEADER, ui.wrapperElement.getChild(0).getTag());
         assertEquals(Tag.H2, ui.wrapperElement.getChild(0).getChild(0).getTag());
 
-        ui.leaveNavigation();
+        ui.leaveNavigation("/client-view");
 
         assertEquals(0, ui.wrapperElement.getChildCount());
     }
@@ -106,7 +106,7 @@ public class JavaScriptBootstrapUITest  {
         assertEquals(Tag.SPAN, ui.wrapperElement.getChild(0).getTag());
         assertEquals(Tag.H1, ui.wrapperElement.getChild(0).getChild(0).getTag());
 
-        ui.leaveNavigation();
+        ui.leaveNavigation("/client-view");
         assertEquals(Tag.SPAN, ui.wrapperElement.getChild(0).getTag());
         assertEquals(Tag.H1, ui.wrapperElement.getChild(0).getChild(0).getTag());
     }

--- a/flow-tests/test-ccdm/frontend/client-router.js
+++ b/flow-tests/test-ccdm/frontend/client-router.js
@@ -36,6 +36,7 @@ export function loadRouter(flow) {
   navigationContainer.appendChild(createNavigationLink('Client view', 'client-view'));
   navigationContainer.appendChild(createNavigationLink('Server view', 'serverview'));
   navigationContainer.appendChild(createNavigationLink('View with all events', 'view-with-all-events'));
+  navigationContainer.appendChild(createNavigationLink('Prevent leaving view', 'prevent-leaving'));
   routerContainer.appendChild(navigationContainer);
 
   const outlet = document.createElement('div');

--- a/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/PreventLeavingView.java
+++ b/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/PreventLeavingView.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.ccdmtest;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Input;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Paragraph;
+import com.vaadin.flow.router.BeforeLeaveEvent;
+import com.vaadin.flow.router.BeforeLeaveObserver;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "prevent-leaving", layout = MainLayout.class)
+public class PreventLeavingView extends Div implements BeforeLeaveObserver {
+    private String preventRoute;
+
+    public PreventLeavingView() {
+        Input input = new Input();
+        input.setId("preventRouteInput");
+        add(input);
+        NativeButton submitPreventRoute = new NativeButton(
+                "Submit prevent route");
+        submitPreventRoute
+                .addClickListener(event -> {
+                    preventRoute = input.getValue();
+                    String preventedMessage = String
+                            .format("preventing navigation to '%s'",
+                                    preventRoute);
+                    Paragraph paragraph = new Paragraph(preventedMessage);
+                    paragraph.setClassName("prevented-route");
+                    add(paragraph);
+                });
+        submitPreventRoute.setId("preventRouteButton");
+        add(submitPreventRoute);
+    }
+
+    @Override
+    public void beforeLeave(BeforeLeaveEvent event) {
+        if (preventRoute != null
+                && event.getLocation().getPath().equals(preventRoute)) {
+            event.postpone();
+        }
+    }
+}

--- a/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/ServerSideView.java
+++ b/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/ServerSideView.java
@@ -23,5 +23,6 @@ import com.vaadin.flow.router.Route;
 public class ServerSideView extends Div {
     public ServerSideView() {
         add(new Text("Server view"));
+        setId("serverView");
     }
 }

--- a/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/ClientIndexHandlerIT.java
+++ b/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/ClientIndexHandlerIT.java
@@ -324,6 +324,32 @@ public class ClientIndexHandlerIT extends ChromeBrowserTest {
     }
 
     @Test
+    public void should_navigateFromServerToServer_When_UsingVaadinRouter() {
+        openTestUrl("/");
+        waitForElementPresent(By.id("loadVaadinRouter"));
+        findElement(By.id("loadVaadinRouter")).click();
+        waitForElementPresent(By.id("outlet"));
+
+        findElement(By.linkText("View with all events")).click();
+        waitForElementPresent(By.id("mainLayout"));
+        String mainLayoutContent = findElement(By.id("mainLayout")).getText();
+        String expectedContent = "Main layout\nViewWithAllEvents: 1 "
+                + "setParameter\nViewWithAllEvents: 2 "
+                + "beforeEnter\nViewWithAllEvents: 3 "
+                + "onAttach\nViewWithAllEvents: 4 afterNavigation";
+        Assert.assertEquals("Should load view with all events", expectedContent,
+                mainLayoutContent);
+
+        findElement(By.linkText("Server view")).click();
+        waitForElementPresent(By.id("serverView"));
+        String serverViewContent = findElement(By.id("mainLayout"))
+                .getText();
+        Assert.assertEquals(
+                "Should load server side view content with vaadin-router",
+                "Main layout\nServer view", serverViewContent);
+    }
+
+    @Test
     public void should_returnNotFoundView_WhenRouteNotFound() {
         openTestUrl("/");
         waitForElementPresent(By.id("button3"));
@@ -335,5 +361,79 @@ public class ClientIndexHandlerIT extends ChromeBrowserTest {
         String content = findElement(By.id("result")).getText();
         Assert.assertTrue("Flow.navigate should return not found view",
                 content.contains("Could not navigate"));
+    }
+
+    @Test
+    public void should_notRunExtraEvents_When_NavigatingServerClientServer() {
+        openTestUrl("/");
+        waitForElementPresent(By.id("loadVaadinRouter"));
+        findElement(By.id("loadVaadinRouter")).click();
+        waitForElementPresent(By.id("outlet"));
+
+        findElement(By.linkText("View with all events")).click();
+        waitForElementPresent(By.id("mainLayout"));
+        String mainLayoutContent = findElement(By.id("mainLayout")).getText();
+        String expectedContent = "Main layout\nViewWithAllEvents: 1 "
+                + "setParameter\nViewWithAllEvents: 2 "
+                + "beforeEnter\nViewWithAllEvents: 3 "
+                + "onAttach\nViewWithAllEvents: 4 afterNavigation";
+        Assert.assertEquals("Should load view with all events", expectedContent,
+                mainLayoutContent);
+
+        findElement(By.linkText("Client view")).click();
+        waitForElementPresent(By.id("clientView"));
+        String clientSideViewContent = findElement(By.id("clientView"))
+                .getText();
+        Assert.assertEquals(
+                "Should load client side view content with vaadin-router",
+                "Client view", clientSideViewContent);
+
+        findElement(By.linkText("View with all events")).click();
+        waitForElementPresent(By.id("mainLayout"));
+        mainLayoutContent = findElement(By.id("mainLayout")).getText();
+        expectedContent = "Main layout\nViewWithAllEvents: 1 "
+                + "setParameter\nViewWithAllEvents: 2 "
+                + "beforeEnter\nViewWithAllEvents: 3 "
+                + "onAttach\nViewWithAllEvents: 4 afterNavigation";
+        Assert.assertEquals("Should load a fresh view with all events",
+                expectedContent, mainLayoutContent);
+    }
+
+    @Test
+    public void should_renderServerView_When_ClickSameServerLinkTwiceAndGoToClientView() {
+        openTestUrl("/");
+        waitForElementPresent(By.id("loadVaadinRouter"));
+        findElement(By.id("loadVaadinRouter")).click();
+        waitForElementPresent(By.id("outlet"));
+
+        findElement(By.linkText("View with all events")).click();
+        waitForElementPresent(By.id("mainLayout"));
+        // click the link again to trigger `action` of `flow.route`
+        findElement(By.linkText("View with all events")).click();
+        String mainLayoutContent = findElement(By.id("mainLayout")).getText();
+        String expectedContent = "Main layout\nViewWithAllEvents: 1 "
+                + "setParameter\nViewWithAllEvents: 2 "
+                + "beforeEnter\nViewWithAllEvents: 3 "
+                + "onAttach\nViewWithAllEvents: 4 afterNavigation";
+        Assert.assertEquals("Should load view with all events", expectedContent,
+                mainLayoutContent);
+
+        findElement(By.linkText("Client view")).click();
+        waitForElementPresent(By.id("clientView"));
+        String clientSideViewContent = findElement(By.id("clientView"))
+                .getText();
+        Assert.assertEquals(
+                "Should load client side view content with vaadin-router",
+                "Client view", clientSideViewContent);
+
+        findElement(By.linkText("View with all events")).click();
+        waitForElementPresent(By.id("mainLayout"));
+        mainLayoutContent = findElement(By.id("mainLayout")).getText();
+        expectedContent = "Main layout\nViewWithAllEvents: 1 "
+                + "setParameter\nViewWithAllEvents: 2 "
+                + "beforeEnter\nViewWithAllEvents: 3 "
+                + "onAttach\nViewWithAllEvents: 4 afterNavigation";
+        Assert.assertEquals("Should load a fresh view with all events",
+                expectedContent, mainLayoutContent);
     }
 }

--- a/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/ClientIndexHandlerIT.java
+++ b/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/ClientIndexHandlerIT.java
@@ -436,4 +436,33 @@ public class ClientIndexHandlerIT extends ChromeBrowserTest {
         Assert.assertEquals("Should load a fresh view with all events",
                 expectedContent, mainLayoutContent);
     }
+
+    @Test
+    public void should_passCorrectLocationObject_When_NavigateServerToClient() {
+        openTestUrl("/");
+        waitForElementPresent(By.id("loadVaadinRouter"));
+        findElement(By.id("loadVaadinRouter")).click();
+        waitForElementPresent(By.id("outlet"));
+
+        findElement(By.linkText("Prevent leaving view")).click();
+        waitForElementPresent(By.id("mainLayout"));
+        findElement(By.id("preventRouteInput")).sendKeys("client-view\t");
+        findElement(By.id("preventRouteButton")).click();
+        waitForElementPresent(By.cssSelector("p[class=\"prevented-route\"]"));
+
+        findElement(By.linkText("Client view")).click();
+        String preventedRoute = findElement(
+                By.cssSelector("p[class" + "=\"prevented-route\"]")).getText();
+        Assert.assertEquals(
+                "Should pass correct location object in "
+                        + "navigation events so that the view can prevent the "
+                        + "navigation and stay in the same view",
+                "preventing navigation to 'client-view'", preventedRoute);
+
+        findElement(By.linkText("Server view")).click();
+        waitForElementPresent(By.id("serverView"));
+        String mainLayoutContent = findElement(By.id("mainLayout")).getText();
+        Assert.assertEquals("Should be able to navigate to other view",
+                "Main" + " layout\nServer view", mainLayoutContent);
+    }
 }


### PR DESCRIPTION
Fixes #6458 

- `ServerView` -> `client-view`: this PR helps the server to navigate to a predefined view, called `ClientViewPlaceholder`. So that we only execute `beforeLeave` in `ServerView` but not `beforeEnter` and `afterNavigation` as before the fix. 

- `ServerView` -> `client-view` -> `ServerView`: a new instance of ServerView is used and there is no `beforeLeave` called on `ServerView` in the second navigation. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6477)
<!-- Reviewable:end -->
