### PR TITLE
Use readLine != null instead of lines

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -22,6 +22,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -223,9 +225,14 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo {
 
     private String readFullyAndClose(String readErrorMessage,
             Supplier<InputStream> inputStreamSupplier) {
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(
                 inputStreamSupplier.get(), StandardCharsets.UTF_8))) {
-            return br.lines().collect(Collectors.joining("\n"));
+            List<String> lines = new ArrayList<>();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                lines.add(line);
+            }
+            return lines.stream().collect(Collectors.joining("\n"));
         } catch (IOException e) {
             throw new UncheckedIOException(readErrorMessage, e);
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsLocator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsLocator.java
@@ -21,10 +21,10 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -151,20 +151,26 @@ public class FrontendToolsLocator implements Serializable {
             return Optional.empty();
         }
 
-        List<String> stdout;
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(
+        List<String> stdout = new ArrayList<>();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(
                 process.getInputStream(), StandardCharsets.UTF_8))) {
-            stdout = br.lines().collect(Collectors.toList());
+            String line;
+            while ((line = reader.readLine()) != null) {
+                stdout.add(line);
+            }
         } catch (IOException e) {
             log().error("Failed to read the command '{}' stdout", commandString,
                     e);
             return Optional.empty();
         }
 
-        List<String> stderr;
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(
+        List<String> stderr = new ArrayList<>();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(
                 process.getErrorStream(), StandardCharsets.UTF_8))) {
-            stderr = br.lines().collect(Collectors.toList());
+            String line;
+            while ((line = reader.readLine()) != null) {
+                stdout.add(line);
+            }
         } catch (IOException e) {
             log().error("Failed to read the command '{}' stderr", commandString,
                     e);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -303,10 +303,14 @@ public class FrontendUtils {
      */
     public static String streamToString(InputStream inputStream) {
         String ret = "";
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(
                 inputStream, StandardCharsets.UTF_8.name()))) {
-
-            ret = br.lines()
+            List<String> lines = new ArrayList<>();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                lines.add(line);
+            }
+            ret = lines.stream()
                     .collect(Collectors.joining(System.lineSeparator()));
         } catch (IOException exception) {
             // ignore exception on close()


### PR DESCRIPTION
For process streams use readLine
instead of lines as lines may block.

Might fix #6181
Fixes #6483