### PR TITLE
Start webpack IO thread as deamon

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
@@ -435,6 +435,7 @@ public final class DevModeHandler implements Serializable {
             // DevModeHandler to continue
             doNotify();
         });
+        thread.setDaemon(true);
         thread.setName("webpack");
         thread.start();
     }


### PR DESCRIPTION
Allows the Java process to terminate with Spring Boot 2.2

Related to vaadin/spring#491