### PR TITLE
CCDM: deprecate server-side bootstrap related APIs

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/di/Instantiator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/di/Instantiator.java
@@ -95,7 +95,12 @@ public interface Instantiator extends Serializable {
      *            listeners, not <code>null</code>
      *
      * @return a stream of all bootstrap listeners to use, not <code>null</code>
+     * 
+     * @deprecated This API is deprecated in favor of
+     *             {@link Instantiator#getClientIndexBootstrapListeners(Stream)}
+     *             when using client-side bootstrapping
      */
+    @Deprecated
     default Stream<BootstrapListener> getBootstrapListeners(
             Stream<BootstrapListener> serviceInitListeners) {
         return serviceInitListeners;

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapListener.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapListener.java
@@ -30,7 +30,9 @@ import java.util.EventListener;
  * 
  * @see ServiceInitEvent#addBootstrapListener(BootstrapListener)
  *
- * @deprecated Use {@link ClientIndexBootstrapListener} instead
+ * @deprecated This API is deprecated in favor of
+ *             {@link ClientIndexBootstrapListener} when using client-side
+ *             bootstrapping
  *
  * @author Vaadin Ltd
  * @since 1.0

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapListener.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapListener.java
@@ -30,10 +30,13 @@ import java.util.EventListener;
  * 
  * @see ServiceInitEvent#addBootstrapListener(BootstrapListener)
  *
+ * @deprecated Use {@link ClientIndexBootstrapListener} instead
+ *
  * @author Vaadin Ltd
  * @since 1.0
  */
 @FunctionalInterface
+@Deprecated
 public interface BootstrapListener extends EventListener, Serializable {
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapPageResponse.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapPageResponse.java
@@ -26,7 +26,9 @@ import com.vaadin.flow.shared.VaadinUriResolver;
  * page contains of the full DOM of the HTML document as well as the HTTP
  * headers that will be included in the corresponding HTTP response.
  *
- * @deprecated use {@link ClientIndexBootstrapPage} instead
+ * @deprecated This API is deprecated in favor of
+ *             {@link ClientIndexBootstrapPage} when using client-side
+ *             bootstrapping
  *
  * @author Vaadin Ltd
  * @since 1.0

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapPageResponse.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapPageResponse.java
@@ -26,9 +26,12 @@ import com.vaadin.flow.shared.VaadinUriResolver;
  * page contains of the full DOM of the HTML document as well as the HTTP
  * headers that will be included in the corresponding HTTP response.
  *
+ * @deprecated use {@link ClientIndexBootstrapPage} instead
+ *
  * @author Vaadin Ltd
  * @since 1.0
  */
+@Deprecated
 public class BootstrapPageResponse {
 
     private final VaadinRequest request;

--- a/flow-server/src/main/java/com/vaadin/flow/server/ServiceInitEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/ServiceInitEvent.java
@@ -73,7 +73,11 @@ public class ServiceInitEvent extends EventObject {
      *
      * @param bootstrapListener
      *            the bootstrap listener to add, not <code>null</code>
+     * @deprecated This API is deprecated in favor of
+     *             {@link ServiceInitEvent#addClientIndexBootstrapListener} when
+     *             using client-side bootstrapping
      */
+    @Deprecated
     public void addBootstrapListener(BootstrapListener bootstrapListener) {
         Objects.requireNonNull(bootstrapListener,
                 "Bootstrap listener cannot be null");
@@ -124,7 +128,11 @@ public class ServiceInitEvent extends EventObject {
      * service.
      *
      * @return the stream of added bootstrap listeners
+     * @deprecated This API is deprecated in favor of
+     *             {@link ServiceInitEvent#getAddedClientIndexBootstrapListeners()}
+     *             when using client-side bootstrapping
      */
+    @Deprecated
     public Stream<BootstrapListener> getAddedBootstrapListeners() {
         return addedBootstrapListeners.stream();
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -628,7 +628,12 @@ public abstract class VaadinService implements Serializable {
      * @param response
      *            The object containing all relevant info needed by listeners to
      *            change the bootstrap page.
+     * 
+     * @deprecated use
+     *             {@link VaadinService#modifyClientIndexBootstrapPage(ClientIndexBootstrapPage)}
+     *             instead
      */
+    @Deprecated
     public void modifyBootstrapPage(BootstrapPageResponse response) {
         bootstrapListeners
                 .forEach(listener -> listener.modifyBootstrapPage(response));

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -629,9 +629,9 @@ public abstract class VaadinService implements Serializable {
      *            The object containing all relevant info needed by listeners to
      *            change the bootstrap page.
      * 
-     * @deprecated use
+     * @deprecated This API is deprecated in favor of
      *             {@link VaadinService#modifyClientIndexBootstrapPage(ClientIndexBootstrapPage)}
-     *             instead
+     *             when using client-side bootstrapping
      */
     @Deprecated
     public void modifyBootstrapPage(BootstrapPageResponse response) {


### PR DESCRIPTION
Fixes #6484
This PR deprecates `BootstrapListener` related APIs in favor of `ClientIndexBootstrapListener`.

For other APIs which were used to modify/add content to the bootstrap page (e.g. `@PWA`, `PageConfigurator`, `@Inline`,....) need to be considered separately.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6517)
<!-- Reviewable:end -->
