### PR TITLE
Version table outdated for Safari

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/shared/BrowserDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/BrowserDetails.java
@@ -194,9 +194,6 @@ public class BrowserDetails implements Serializable {
                     } else if (engineVersion >= 6060 && engineVersion < 6070) {
                         browserMajorVersion = 12;
                         browserMinorVersion = 0;
-                    } else if (engineVersion >= 6060 && engineVersion < 6070) {
-                        browserMajorVersion = 12;
-                        browserMinorVersion = 0;
                     } else if (engineVersion >= 6070) {
                         browserMajorVersion = 12;
                         browserMinorVersion = 1;

--- a/flow-server/src/main/java/com/vaadin/flow/shared/BrowserDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/BrowserDetails.java
@@ -176,8 +176,29 @@ public class BrowserDetails implements Serializable {
                     if (engineVersion >= 6010 && engineVersion < 6015) {
                         browserMajorVersion = 9;
                         browserMinorVersion = 0;
-                    } else if (engineVersion >= 6015) {
+                    } else if (engineVersion >= 6015 && engineVersion < 6018) {
                         browserMajorVersion = 9;
+                        browserMinorVersion = 1;
+                    } else if (engineVersion >= 6020 && engineVersion < 6030) {
+                        browserMajorVersion = 10;
+                        browserMinorVersion = 0;
+                    } else if (engineVersion >= 6030 && engineVersion < 6040) {
+                        browserMajorVersion = 10;
+                        browserMinorVersion = 1;
+                    } else if (engineVersion >= 6040 && engineVersion < 6050) {
+                        browserMajorVersion = 11;
+                        browserMinorVersion = 0;
+                    } else if (engineVersion >= 6050 && engineVersion < 6060) {
+                        browserMajorVersion = 11;
+                        browserMinorVersion = 1;
+                    } else if (engineVersion >= 6060 && engineVersion < 6070) {
+                        browserMajorVersion = 12;
+                        browserMinorVersion = 0;
+                    } else if (engineVersion >= 6060 && engineVersion < 6070) {
+                        browserMajorVersion = 12;
+                        browserMinorVersion = 0;
+                    } else if (engineVersion >= 6070) {
+                        browserMajorVersion = 12;
                         browserMinorVersion = 1;
                     }
                 }
@@ -613,7 +634,7 @@ public class BrowserDetails implements Serializable {
             return true;
         }
         // Safari 9+
-        if (isSafari() && getBrowserMajorVersion() < 9) {
+        if (isSafari() && getBrowserMajorVersion() < 10) {
             return true;
         }
         // Firefox 43+ for now


### PR DESCRIPTION
- UPDATED webkit/safari version table as per https://en.wikipedia.org/wiki/Safari_version_history
- Vaadin 14 is saying tooOld is false for Webkit 602.1 but nothing gets displayed on that version of WebKit so CHANGED to be true

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6518)
<!-- Reviewable:end -->
