### PR TITLE
Terminate webpack dev server process only on connection error

### DIFF
--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -43,37 +43,27 @@ if (watchDogPort){
 
 const net = require('net');
 
-function setupWatchDog(firstRun){
+function setupWatchDog(){
     var client = new net.Socket();
     client.connect(watchDogPort, 'localhost', function() {
-        if (firstRun){
-            console.debug('Watchdog connected.');
-        } else {
-            console.log('Watchdog connected.');
-        }
+        console.debug('Watchdog connected.');
     });
 
     client.on('error', function(){
-        console.error("Watchdog connection error. Terminating webpack process...");
+        console.log("Watchdog connection error. Terminating webpack process...");
         client.destroy();
         process.exit(0);
     });
 
     client.on('close', function() {
         client.destroy();
-        if (firstRun){
-            console.debug('Watchdog connection closed. Trying to re-run watchdog.');
-            setupWatchDog(false);
-        }
-        else {
-            console.log('Watchdog connection closed. Terminating webpack process...');
-            process.exit(0);
-        }
+        console.debug('Watchdog connection closed. Trying to re-run watchdog.');
+        setupWatchDog();
     });  
 }
 
 if (watchDogPort){
-    setupWatchDog(true);
+    setupWatchDog();
 }
 
 


### PR DESCRIPTION
Try to reconnect always on connection close. So the process is
terminated only if there is a connection error (which happens if there
is no network port available which is listen by Java process).

Fixes vaadin/spring#494

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6520)
<!-- Reviewable:end -->
