### PR TITLE
Update Javadocs for `JsModule`, `JavaScript`, and `CssImport`

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/dependency/CssImport.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/dependency/CssImport.java
@@ -115,6 +115,22 @@ import java.lang.annotation.Target;
  *
  *
  * </ul>
+ * <p>
+ * It is guaranteed that dependencies will be loaded only once. The files
+ * loaded will be in the same order as the annotations were on the class.
+ * However, loading order is only guaranteed on a class level; Annotations
+ * from different classes may appear in different order, grouped by the
+ * annotated class. Also, files identified by {@code @CssImport} will be
+ * loaded after {@link com.vaadin.flow.component.dependency.JsModule} and
+ * {@link com.vaadin.flow.component.dependency.JavaScript}.
+ * <p>
+ * NOTE: Currently all frontend resources are bundled together into one big
+ * bundle. This means, that CSS files loaded by one class will be
+ * present on a view constructed by another class. For example, if there are
+ * two classes {@code RootRoute} annotated with {@code @Route("")}, and
+ * another class {@code RouteA} annotated with {@code @Route("route-a")} and
+ * {@code @CssImport("./styles/custom-style.css")}, the {@code custom-style.css}
+ * will be present on the root route as well.
  *
  * @since 2.0
  *

--- a/flow-server/src/main/java/com/vaadin/flow/component/dependency/JavaScript.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/dependency/JavaScript.java
@@ -31,12 +31,26 @@ import com.vaadin.flow.shared.ui.LoadMode;
  * multiple JavaScript files for a single component, you can use this annotation
  * multiple times.
  * <p>
- * It is guaranteed that dependencies will be loaded only once.
+ * It is guaranteed that dependencies will be loaded only once. The files
+ * loaded will be in the same order as the annotations were on the class.
+ * However, loading order is only guaranteed on a class level; Annotations
+ * from different classes may appear in different order. Also, files identified
+ * by {@code @JavaScript} will be loaded after
+ * {@link com.vaadin.flow.component.dependency.JsModule} and before
+ * {@link com.vaadin.flow.component.dependency.CssImport}.
  * <p>
  * NOTE: while this annotation is not inherited using the
  * {@link Inherited @Inherited} annotation, the annotations of the possible
  * parent components or implemented interfaces are read when sending the
  * dependencies to the browser.
+ * <p>
+ * NOTE: Currently all frontend resources are bundled together into one big
+ * bundle. This means, that JavaScript files loaded by one class will be
+ * present on a view constructed by another class. For example, if there are
+ * two classes {@code RootRoute} annotated with {@code @Route("")}, and
+ * another class {@code RouteA} annotated with {@code @Route("route-a")} and
+ * {@code @JavaScript("./src/javascript.js")}, the {@code javascript.js} will be
+ * run on the root route as well.
  *
  * @author Vaadin Ltd
  * @since 1.0

--- a/flow-server/src/main/java/com/vaadin/flow/component/dependency/JavaScript.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/dependency/JavaScript.java
@@ -34,9 +34,9 @@ import com.vaadin.flow.shared.ui.LoadMode;
  * It is guaranteed that dependencies will be loaded only once. The files
  * loaded will be in the same order as the annotations were on the class.
  * However, loading order is only guaranteed on a class level; Annotations
- * from different classes may appear in different order. Also, files identified
- * by {@code @JavaScript} will be loaded after
- * {@link com.vaadin.flow.component.dependency.JsModule} and before
+ * from different classes may appear in different order, grouped by the
+ * annotated class. Also, files identified by {@code @JavaScript} will be
+ * loaded after {@link com.vaadin.flow.component.dependency.JsModule} and before
  * {@link com.vaadin.flow.component.dependency.CssImport}.
  * <p>
  * NOTE: while this annotation is not inherited using the

--- a/flow-server/src/main/java/com/vaadin/flow/component/dependency/JsModule.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/dependency/JsModule.java
@@ -43,9 +43,9 @@ import com.vaadin.flow.shared.ui.LoadMode;
  * It is guaranteed that dependencies will be loaded only once. The files
  * loaded will be in the same order as the annotations were on the class.
  * However, loading order is only guaranteed on a class level; Annotations
- * from different classes may appear in different order. Also, files identified
- * by {@code @JsModule} will be loaded before
- * {@link com.vaadin.flow.component.dependency.JavaScript} and
+ * from different classes may appear in different order, grouped by the
+ * annotated class. Also, files identified by {@code @JsModule} will be
+ * loaded before {@link com.vaadin.flow.component.dependency.JavaScript} and
  * {@link com.vaadin.flow.component.dependency.CssImport}.
  * <p>
  * NOTE: while this annotation is not inherited using the

--- a/flow-server/src/main/java/com/vaadin/flow/component/dependency/JsModule.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/dependency/JsModule.java
@@ -40,12 +40,26 @@ import com.vaadin.flow.shared.ui.LoadMode;
  * {@code src/main/resources/META-INF/resources/frontend} directory).
  * </ul>
  * <p>
- * It is guaranteed that dependencies will be loaded only once.
+ * It is guaranteed that dependencies will be loaded only once. The files
+ * loaded will be in the same order as the annotations were on the class.
+ * However, loading order is only guaranteed on a class level; Annotations
+ * from different classes may appear in different order. Also, files identified
+ * by {@code @JsModule} will be loaded before
+ * {@link com.vaadin.flow.component.dependency.JavaScript} and
+ * {@link com.vaadin.flow.component.dependency.CssImport}.
  * <p>
  * NOTE: while this annotation is not inherited using the
  * {@link Inherited @Inherited} annotation, the annotations of the possible
  * parent components or implemented interfaces are read when sending the
  * dependencies to the browser.
+ * <p>
+ * NOTE: Currently all frontend resources are bundled together into one big
+ * bundle. This means, that JavaScript files loaded by one class will be
+ * present on a view constructed by another class. For example, if there are
+ * two classes {@code RootRoute} annotated with {@code @Route("")}, and
+ * another class {@code RouteA} annotated with {@code @Route("route-a")} and
+ * {@code @JsModule("./src/jsmodule.js")}, the {@code jsmodule.js} will be
+ * run on the root route as well.
  *
  * @author Vaadin Ltd
  * @since 2.0

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -266,31 +266,32 @@ public class Page implements Serializable {
     }
 
     /**
-     * Adds the given JavaScript module to the page and ensures that it is
-     * loaded successfully.
+     * Adds the given external JavaScript module to the page and ensures that it
+     * is loaded successfully.
      * <p>
-     * For component related JsModule dependencies, you should use the
-     * {@link JsModule @JsModule} annotation.
-     * <p>
-     * Is is guaranteed that script will be loaded before the first page load.
-     * For more options, refer to {@link #addJsModule(String, LoadMode)}
+     * If the JavaScript modules are local or do not need to be added
+     * dynamically, you should use the {@link JsModule @JsModule} annotation
+     * instead.
      *
      * @param url
-     *            the URL to load the JavaScript from, not <code>null</code>
+     *            the URL to load the JavaScript module from, not
+     *            <code>null</code>
      */
     public void addJsModule(String url) {
         addJsModule(url, LoadMode.EAGER);
     }
 
     /**
-     * Adds the given JavaScript module to the page and ensures that it is
-     * loaded successfully.
+     * Adds the given external JavaScript module to the page and ensures that it
+     * is loaded successfully.
      * <p>
-     * For component related JavaScript dependencies, you should use the
-     * {@link JsModule @JsModule} annotation.
+     * If the JavaScript modules are local or do not need to be added
+     * dynamically, you should use the {@link JsModule @JsModule} annotation
+     * instead.
      *
      * @param url
-     *            the URL to load the JavaScript from, not <code>null</code>
+     *            the URL to load the JavaScript module from, not
+     *            <code>null</code>
      * @param loadMode
      *            determines dependency load mode, refer to {@link LoadMode} for
      *            details


### PR DESCRIPTION
Addresses Javadoc documentation needs of #5945. Flow documentation still needs to be updated. Also, adds some Javadoc for [documentation#706](https://github.com/vaadin/flow-and-components-documentation/issues/706).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6532)
<!-- Reviewable:end -->
