### PR TITLE
Fix IPv6 escaping

### DIFF
--- a/flow-push/src/main/resources/META-INF/resources/VAADIN/static/push/vaadinPush.js
+++ b/flow-push/src/main/resources/META-INF/resources/VAADIN/static/push/vaadinPush.js
@@ -3091,7 +3091,16 @@ window.vaadinPush = window.vaadinPush|| {};
 
             // encodeURI and decodeURI are needed to normalize URL between IE and non-IE,
             // since IE doesn't encode the href property value and return it - http://jsfiddle.net/Yq9M8/1/
-            return encodeURI(decodeURI(div.firstChild.href));
+            var ua = window.navigator.userAgent;
+            if(ua.indexOf('MSIE ')>0 || ua.indexOf('Trident/') > 0 || ua.indexOf('Edge/') > 0){
+                return atmosphere.util.fixedEncodeURI(decodeURI(div.firstChild.href));
+            }
+            return div.firstChild.href;
+        },
+
+        // Fix IPv6 escaping, see: https://github.com/Atmosphere/atmosphere-javascript/pull/243
+        fixedEncodeURI: function (str) {
+            return encodeURI(str).replace(/%5B/g, '[').replace(/%5D/g, ']');
         },
 
         prepareURL: function (url) {


### PR DESCRIPTION
Fix IPv6 escaping, see: https://github.com/Atmosphere/atmosphere-javascript/pull/243

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6536)
<!-- Reviewable:end -->
