### PR TITLE
Mark LoadMode as deprecated for JsModule annotation and add-method

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/dependency/JsModule.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/dependency/JsModule.java
@@ -85,7 +85,13 @@ public @interface JsModule {
      * details.
      *
      * @return load mode for the dependency
+     * @deprecated {@link com.vaadin.flow.shared.ui.LoadMode} does not function
+     *             with JavaScript modules. If the module is local, it is
+     *             included into the frontend resource bundle. If the module is
+     *             external, it is loaded as deferred due to {@code type=module}
+     *             in {@code scrip} tag.
      */
+    @Deprecated
     LoadMode loadMode() default LoadMode.EAGER;
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/dependency/JsModule.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/dependency/JsModule.java
@@ -85,11 +85,10 @@ public @interface JsModule {
      * details.
      *
      * @return load mode for the dependency
-     * @deprecated {@link com.vaadin.flow.shared.ui.LoadMode} does not function
-     *             with JavaScript modules. If the module is local, it is
-     *             included into the frontend resource bundle. If the module is
-     *             external, it is loaded as deferred due to {@code type=module}
-     *             in {@code scrip} tag.
+     * @deprecated {@code LoadMode} does not function with JavaScript modules.
+     *             If the module is local, it is included into the frontend
+     *             resource bundle. If the module is external, it is loaded as
+     *             deferred due to {@code type=module} in {@code scrip} tag.
      */
     @Deprecated
     LoadMode loadMode() default LoadMode.EAGER;

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -295,7 +295,12 @@ public class Page implements Serializable {
      * @param loadMode
      *            determines dependency load mode, refer to {@link LoadMode} for
      *            details
+     * @deprecated {@link com.vaadin.flow.shared.ui.LoadMode} is not functional
+     *             with external JavaScript modules, as those are loaded as
+     *             deferred due to {@code type=module} in {@code scrip} tag. Use
+     *             {@link #addJsModule(String)} instead.
      */
+    @Deprecated
     public void addJsModule(String url, LoadMode loadMode) {
         addDependency(new Dependency(Type.JS_MODULE, url, loadMode));
     }

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -295,9 +295,9 @@ public class Page implements Serializable {
      * @param loadMode
      *            determines dependency load mode, refer to {@link LoadMode} for
      *            details
-     * @deprecated {@link com.vaadin.flow.shared.ui.LoadMode} is not functional
-     *             with external JavaScript modules, as those are loaded as
-     *             deferred due to {@code type=module} in {@code scrip} tag. Use
+     * @deprecated {@code LoadMode} is not functional with external JavaScript
+     *             modules, as those are loaded as deferred due to
+     *             {@code type=module} in {@code scrip} tag. Use
      *             {@link #addJsModule(String)} instead.
      */
     @Deprecated


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6543)
<!-- Reviewable:end -->
