### PR TITLE
Make call to Reactive.flush() deferred

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
@@ -907,7 +907,9 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
             // Correct binding requires reactive involvement which doesn't
             // happen automatically when we are out of the phase. So we should
             // call <code>flush()</code> explicitly.
-            Reactive.flush();
+            // Defer the call to avoid issues due recursion. 
+            // See also https://github.com/vaadin/flow/issues/5806 
+            Scheduler.get().scheduleDeferred(()-> Reactive.flush());
         }
     }
 


### PR DESCRIPTION
Should fix https://github.com/vaadin/flow/issues/5806

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6544)
<!-- Reviewable:end -->
