### PR TITLE
Don't use NoTheme for built-in classes.

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/InternalServerError.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/InternalServerError.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.router;
 
 import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -30,7 +31,6 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementFactory;
 import com.vaadin.flow.server.VaadinService;
-import com.vaadin.flow.theme.NoTheme;
 
 /**
  * This is a basic default error view shown on exceptions during navigation.
@@ -38,7 +38,6 @@ import com.vaadin.flow.theme.NoTheme;
  * @since 1.0
  */
 @Tag(Tag.DIV)
-@NoTheme
 public class InternalServerError extends Component
         implements HasErrorParameter<Exception> {
 

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteNotFoundError.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteNotFoundError.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Html;
 import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.theme.NoTheme;
 
 /**
  * This is a basic default error view shown on routing exceptions.
@@ -39,7 +38,6 @@ import com.vaadin.flow.theme.NoTheme;
  * @since 1.0
  */
 @Tag(Tag.DIV)
-@NoTheme
 public class RouteNotFoundError extends Component
         implements HasErrorParameter<NotFoundException> {
 
@@ -110,7 +108,8 @@ public class RouteNotFoundError extends Component
             return elementAsLink(route.getUrl(), text);
         } else {
             Class<? extends Component> target = route.getNavigationTarget();
-            if (ParameterDeserializer.isAnnotatedParameter(target, OptionalParameter.class)) {
+            if (ParameterDeserializer.isAnnotatedParameter(target,
+                    OptionalParameter.class)) {
                 text = text + " (supports optional parameter)";
                 return elementAsLink(route.getUrl(), text);
             } else {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScanner.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScanner.java
@@ -39,7 +39,6 @@ import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.function.SerializableBiFunction;
 import com.vaadin.flow.internal.AnnotationReader;
-import com.vaadin.flow.router.Router;
 import com.vaadin.flow.theme.AbstractTheme;
 import com.vaadin.flow.theme.NoTheme;
 import com.vaadin.flow.theme.Theme;
@@ -293,13 +292,9 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
 
             Class<? extends Annotation> loadedNoThemeAnnotation = getFinder()
                     .loadClass(NoTheme.class.getName());
-            // Filter out build-in classes (which are in the router package)
-            // which
-            // are annotated with @NoTheme (see e.g. InternalServerError).
+
             Set<Class<?>> notThemeClasses = getFinder()
                     .getAnnotatedClasses(loadedNoThemeAnnotation).stream()
-                    .filter(clazz -> !clazz.getName()
-                            .startsWith(Router.class.getPackage().getName()))
                     .collect(Collectors.toSet());
             if (themes.size() > 1) {
                 throw new IllegalStateException(


### PR DESCRIPTION
- Remove NoTheme annotation from flow-server classes.
- Clean up workaround logic which has been introduced to skip those
classes.

Fixes #6522

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6547)
<!-- Reviewable:end -->
