### PR TITLE
Allow user to switch between complete bundle mode and bytecode scan mode in development mode (devmode.optimizeBundle, false by default)

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -132,7 +132,7 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo {
      * components.
      */
     @Parameter(defaultValue = "true")
-    private boolean useByteCodeScanner;
+    private boolean optimizeBundle;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -177,7 +177,7 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo {
         new NodeTasks.Builder(getClassFinder(project), npmFolder,
                 generatedFolder, frontendDirectory).runNpmInstall(runNpmInstall)
                         .enablePackagesUpdate(true)
-                        .useByteCodeScanner(useByteCodeScanner)
+                        .useByteCodeScanner(optimizeBundle)
                         .copyResources(jarFiles)
                         .copyLocalResources(frontendResourcesDirectory)
                         .enableImportsUpdate(true)

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
@@ -134,7 +134,7 @@ public class BuildFrontendMojoTest {
         ReflectionUtils.setVariableValueInObject(mojo, "runNpmInstall", false);
         ReflectionUtils.setVariableValueInObject(mojo, "compatibilityMode",
                 "false");
-        ReflectionUtils.setVariableValueInObject(mojo, "useByteCodeScanner",
+        ReflectionUtils.setVariableValueInObject(mojo, "optimizeBundle",
                 true);
 
         flowPackagPath.mkdirs();

--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -207,6 +207,14 @@ public final class Constants implements Serializable {
     public static final String SERVLET_PARAMETER_DEVMODE_WEBPACK_OPTIONS = "devmode.webpack.options";
 
     /**
+     * Boolean parameter for enabling/disabling bytecode scanning in dev mode.
+     * If enabled, entry points are scanned for reachable frontend resources.
+     * If disabled, all classes on the classpath are scanned.
+     */
+    public static final String SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE = "devmode.optimizeBundle";
+
+
+    /**
      * The path used in the vaadin servlet for handling static resources.
      */
     public static final String META_INF = "META-INF/";

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -152,6 +152,13 @@ public class FrontendUtils {
      */
     public static final String PARAM_TOKEN_FILE = "vaadin.frontend.token.file";
 
+    /**
+     * Boolean parameter for enabling/disabling bytecode scanning in dev mode.
+     * If enabled, entry points are scanned for reachable frontend resources.
+     * If disabled, all classes on the classpath are scanned.
+     */
+    public static final String PARAM_USE_BYTECODE_SCANNER = "vaadin.useByteCodeScanner";
+
     private static final String NOT_FOUND = "%n%n======================================================================================================"
             + "%nFailed to determine '%s' tool." + "%nPlease install it either:"
             + "%n  - by following the https://nodejs.org/en/download/ guide to install it globally"

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -152,13 +152,6 @@ public class FrontendUtils {
      */
     public static final String PARAM_TOKEN_FILE = "vaadin.frontend.token.file";
 
-    /**
-     * Boolean parameter for enabling/disabling bytecode scanning in dev mode.
-     * If enabled, entry points are scanned for reachable frontend resources.
-     * If disabled, all classes on the classpath are scanned.
-     */
-    public static final String PARAM_USE_BYTECODE_SCANNER = "vaadin.useByteCodeScanner";
-
     private static final String NOT_FOUND = "%n%n======================================================================================================"
             + "%nFailed to determine '%s' tool." + "%nPlease install it either:"
             + "%n  - by following the https://nodejs.org/en/download/ guide to install it globally"

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -52,10 +52,13 @@ import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.DevModeHandler;
 import com.vaadin.flow.server.ExecutionFailedException;
+import com.vaadin.flow.server.UIInitListener;
 import com.vaadin.flow.server.VaadinContext;
+import com.vaadin.flow.server.VaadinServiceInitListener;
 import com.vaadin.flow.server.VaadinServlet;
 import com.vaadin.flow.server.VaadinServletContext;
 import com.vaadin.flow.server.frontend.FrontendUtils;
@@ -67,6 +70,7 @@ import com.vaadin.flow.theme.NoTheme;
 import com.vaadin.flow.theme.Theme;
 
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
+import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_USE_BYTECODE_SCANNER;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_FRONTEND_DIR;
@@ -79,10 +83,11 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_GENERATED;
  *
  * @since 2.0
  */
-@HandlesTypes({ WebComponentExporter.class, NpmPackage.class,
-        NpmPackage.Container.class, JsModule.class, JsModule.Container.class,
-        CssImport.class, CssImport.Container.class, JavaScript.class,
-        JavaScript.Container.class, Theme.class, NoTheme.class })
+@HandlesTypes({Route.class, UIInitListener.class,
+        VaadinServiceInitListener.class, WebComponentExporter.class,
+        NpmPackage.class, NpmPackage.Container.class, JsModule.class,
+        JsModule.Container.class, CssImport.class, CssImport.Container.class,
+        JavaScript.class, JavaScript.Container.class, Theme.class, NoTheme.class})
 @WebListener
 public class DevModeInitializer implements ServletContainerInitializer,
         Serializable, ServletContextListener {
@@ -297,8 +302,13 @@ public class DevModeInitializer implements ServletContainerInitializer,
         Set<String> visitedClassNames = new HashSet<>();
         Set<File> frontendLocations = getFrontendLocationsFromClassloader(
                 DevModeInitializer.class.getClassLoader());
+
+        boolean useByteCodeScanner = config.getBooleanProperty(
+                PARAM_USE_BYTECODE_SCANNER, Boolean.parseBoolean(
+                        System.getProperty(PARAM_USE_BYTECODE_SCANNER, "false")));
         try {
-            builder.enablePackagesUpdate(true).useByteCodeScanner(false)
+            builder.enablePackagesUpdate(true)
+                    .useByteCodeScanner(useByteCodeScanner)
                     .copyResources(frontendLocations)
                     .copyLocalResources(new File(baseDir,
                             Constants.LOCAL_FRONTEND_RESOURCES_PATH))

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -307,7 +307,7 @@ public class DevModeInitializer implements ServletContainerInitializer,
                 SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE,
                 Boolean.parseBoolean(
                         System.getProperty(SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE,
-                                "false")));
+                                Boolean.FALSE.toString())));
         try {
             builder.enablePackagesUpdate(true)
                     .useByteCodeScanner(useByteCodeScanner)

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -70,7 +70,7 @@ import com.vaadin.flow.theme.NoTheme;
 import com.vaadin.flow.theme.Theme;
 
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
-import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_USE_BYTECODE_SCANNER;
+import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_FRONTEND_DIR;
@@ -304,8 +304,10 @@ public class DevModeInitializer implements ServletContainerInitializer,
                 DevModeInitializer.class.getClassLoader());
 
         boolean useByteCodeScanner = config.getBooleanProperty(
-                PARAM_USE_BYTECODE_SCANNER, Boolean.parseBoolean(
-                        System.getProperty(PARAM_USE_BYTECODE_SCANNER, "false")));
+                SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE,
+                Boolean.parseBoolean(
+                        System.getProperty(SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE,
+                                "false")));
         try {
             builder.enablePackagesUpdate(true)
                     .useByteCodeScanner(useByteCodeScanner)

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeClassFinderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeClassFinderTest.java
@@ -30,7 +30,10 @@ import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.SessionInitListener;
+import com.vaadin.flow.server.UIInitListener;
+import com.vaadin.flow.server.VaadinServiceInitListener;
 import com.vaadin.flow.server.startup.DevModeInitializer.DevModeClassFinder;
 import com.vaadin.flow.theme.NoTheme;
 import com.vaadin.flow.theme.Theme;
@@ -44,6 +47,9 @@ public class DevModeClassFinderTest {
     @Test
     public void applicableClasses_knownClasses() {
         Collection<Class<?>> classes = getApplicableClasses();
+        Assert.assertTrue(classes.contains(Route.class));
+        Assert.assertTrue(classes.contains(UIInitListener.class));
+        Assert.assertTrue(classes.contains(VaadinServiceInitListener.class));
         Assert.assertTrue(classes.contains(WebComponentExporter.class));
         Assert.assertTrue(classes.contains(NpmPackage.class));
         Assert.assertTrue(classes.contains(NpmPackage.Container.class));
@@ -56,7 +62,7 @@ public class DevModeClassFinderTest {
         Assert.assertTrue(classes.contains(Theme.class));
         Assert.assertTrue(classes.contains(NoTheme.class));
 
-        Assert.assertEquals(11, classes.size());
+        Assert.assertEquals(14, classes.size());
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
@@ -23,7 +23,6 @@ import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.DevModeHandler;
-import com.vaadin.flow.server.frontend.FrontendUtils;
 import com.vaadin.flow.server.startup.DevModeInitializer.VisitedClasses;
 
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE;
@@ -197,8 +196,8 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
     }
 
     @Test
-    public void shouldUseByteCodeScannerIfSystemPropertySet() throws Exception {
-        System.setProperty(FrontendUtils.PARAM_USE_BYTECODE_SCANNER, "true");
+    public void shouldUseByteCodeScannerIfPropertySet() throws Exception {
+        System.setProperty(Constants.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE, "true");
         DevModeInitializer devModeInitializer = new DevModeInitializer();
         final Set<Class<?>> classes = new HashSet<>();
         classes.add(NotVisitedWithDeps.class);
@@ -216,8 +215,7 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
     }
 
     @Test
-    public void shouldUseFullPathScannerIfSystemPropertySet() throws Exception {
-        System.setProperty(FrontendUtils.PARAM_USE_BYTECODE_SCANNER, "false");
+    public void shouldUseFullPathScannerByDefault() throws Exception {
         DevModeInitializer devModeInitializer = new DevModeInitializer();
         final Set<Class<?>> classes = new HashSet<>();
         classes.add(NotVisitedWithDeps.class);

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
@@ -9,8 +9,10 @@ import java.util.Collections;
 import java.util.EventListener;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import net.jcip.annotations.NotThreadSafe;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -18,8 +20,10 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.DevModeHandler;
+import com.vaadin.flow.server.frontend.FrontendUtils;
 import com.vaadin.flow.server.startup.DevModeInitializer.VisitedClasses;
 
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE;
@@ -52,6 +56,11 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
     }
 
     public static class VisitedSubclass extends Visited {
+    }
+
+    @Route
+    public static class RoutedWithReferenceToVisited {
+        Visited b;
     }
 
     @Rule
@@ -187,12 +196,50 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
                 visited.allDependenciesVisited(WithDepsSubclass.class));
     }
 
+    @Test
+    public void shouldUseByteCodeScannerIfSystemPropertySet() throws Exception {
+        System.setProperty(FrontendUtils.PARAM_USE_BYTECODE_SCANNER, "true");
+        DevModeInitializer devModeInitializer = new DevModeInitializer();
+        final Set<Class<?>> classes = new HashSet<>();
+        classes.add(NotVisitedWithDeps.class);
+        classes.add(Visited.class);
+        classes.add(RoutedWithReferenceToVisited.class);
+        devModeInitializer.onStartup(classes, servletContext);
+        ArgumentCaptor<? extends VisitedClasses> arg = ArgumentCaptor
+                .forClass(VisitedClasses.class);
+        Mockito.verify(servletContext, Mockito.atLeastOnce())
+                .setAttribute(Mockito.eq(VisitedClasses.class.getName()), arg.capture());
+        VisitedClasses visitedClasses = arg.getValue();
+        Assert.assertTrue(visitedClasses.allDependenciesVisited(RoutedWithReferenceToVisited.class));
+        Assert.assertTrue(visitedClasses.allDependenciesVisited(Visited.class));
+        Assert.assertFalse(visitedClasses.allDependenciesVisited(NotVisitedWithDeps.class));
+    }
+
+    @Test
+    public void shouldUseFullPathScannerIfSystemPropertySet() throws Exception {
+        System.setProperty(FrontendUtils.PARAM_USE_BYTECODE_SCANNER, "false");
+        DevModeInitializer devModeInitializer = new DevModeInitializer();
+        final Set<Class<?>> classes = new HashSet<>();
+        classes.add(NotVisitedWithDeps.class);
+        classes.add(Visited.class);
+        classes.add(RoutedWithReferenceToVisited.class);
+        devModeInitializer.onStartup(classes, servletContext);
+        ArgumentCaptor<? extends VisitedClasses> arg = ArgumentCaptor
+                .forClass(VisitedClasses.class);
+        Mockito.verify(servletContext, Mockito.atLeastOnce())
+                .setAttribute(Mockito.eq(VisitedClasses.class.getName()), arg.capture());
+        VisitedClasses visitedClasses = arg.getValue();
+        Assert.assertTrue(visitedClasses.allDependenciesVisited(RoutedWithReferenceToVisited.class));
+        Assert.assertTrue(visitedClasses.allDependenciesVisited(Visited.class));
+        Assert.assertTrue(visitedClasses.allDependenciesVisited(NotVisitedWithDeps.class));
+    }
+
     private void loadingJars_allFilesExist(String resourcesFolder)
             throws IOException {
         // Create jar urls for test
         URL jar = new URL("jar:"
                 + this.getClass().getResource("/").toString()
-                        .replace("target/test-classes/", "")
+                .replace("target/test-classes/", "")
                 + "src/test/resources/with%20space/jar-with-frontend-resources.jar!/META-INF/resources/frontend");
         List<URL> urls = new ArrayList<>();
         urls.add(jar);
@@ -216,7 +263,7 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
     }
 
     private void loadingFsResources_allFilesExist(String resourcesRoot,
-            String resourcesFolder) throws IOException {
+                                                  String resourcesFolder) throws IOException {
         List<URL> urls = Collections.singletonList(
                 getClass().getResource(resourcesRoot + resourcesFolder));
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTestBase.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTestBase.java
@@ -31,6 +31,7 @@ import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_PRODUCTION_MODE
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_REUSE_DEV_SERVER;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_CONFIG;
+import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_USE_BYTECODE_SCANNER;
 import static com.vaadin.flow.server.frontend.NodeUpdateTestUtil.createStubNode;
 import static com.vaadin.flow.server.frontend.NodeUpdateTestUtil.createStubWebpackServer;
 
@@ -105,6 +106,7 @@ public class DevModeInitializerTestBase {
         System.clearProperty("vaadin." + SERVLET_PARAMETER_COMPATIBILITY_MODE);
         System.clearProperty("vaadin." + SERVLET_PARAMETER_PRODUCTION_MODE);
         System.clearProperty("vaadin." + SERVLET_PARAMETER_REUSE_DEV_SERVER);
+        System.clearProperty(PARAM_USE_BYTECODE_SCANNER);
 
         webpackFile.delete();
         mainPackageFile.delete();

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTestBase.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTestBase.java
@@ -29,9 +29,9 @@ import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_PRODUCTION_MODE;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_REUSE_DEV_SERVER;
+import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_CONFIG;
-import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_USE_BYTECODE_SCANNER;
 import static com.vaadin.flow.server.frontend.NodeUpdateTestUtil.createStubNode;
 import static com.vaadin.flow.server.frontend.NodeUpdateTestUtil.createStubWebpackServer;
 
@@ -106,7 +106,7 @@ public class DevModeInitializerTestBase {
         System.clearProperty("vaadin." + SERVLET_PARAMETER_COMPATIBILITY_MODE);
         System.clearProperty("vaadin." + SERVLET_PARAMETER_PRODUCTION_MODE);
         System.clearProperty("vaadin." + SERVLET_PARAMETER_REUSE_DEV_SERVER);
-        System.clearProperty(PARAM_USE_BYTECODE_SCANNER);
+        System.clearProperty("vaadin." + SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE);
 
         webpackFile.delete();
         mainPackageFile.delete();

--- a/flow-tests/test-npm-only-features/pom.xml
+++ b/flow-tests/test-npm-only-features/pom.xml
@@ -33,6 +33,8 @@
         <module>test-npm-general</module>
         <module>test-npm-no-buildmojo</module>
         <module>test-npm-custom-frontend-directory</module>
+        <module>test-npm-bytecode-scanning/pom-devmode.xml</module>
+        <module>test-npm-bytecode-scanning/pom-production.xml</module>
     </modules>
 
     <build>

--- a/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/frontend/my-button.js
+++ b/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/frontend/my-button.js
@@ -1,0 +1,14 @@
+import {PolymerElement,html} from '@polymer/polymer/polymer-element.js';
+
+class MyButton extends PolymerElement {
+
+    static get template() {
+        return html`<button>Click me</button>`;
+    }
+
+    static get is() {
+          return 'my-button';
+    }
+}
+
+customElements.define(MyButton.is, MyButton);

--- a/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-devmode.xml
+++ b/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-devmode.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2000-2019 Vaadin Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>flow-test-npm-only-features</artifactId>
+        <groupId>com.vaadin</groupId>
+        <version>2.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>flow-test-npm-bytecode-scanning-devmode</artifactId>
+
+    <name>Flow test of bytecode scanner in dev mode</name>
+    <packaging>war</packaging>
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-html-components-testbench</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-test-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- This module is mapped to default web context -->
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>${jetty.version}</version>
+                <executions>
+                    <!-- start and stop jetty (running our app) when running
+                        integration tests -->
+                    <execution>
+                        <id>start-jetty</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>stop-jetty</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>flow-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-frontend</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>local-run</id>
+            <activation>
+                <property>
+                    <name>!test.use.hub</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.lazerycode.selenium</groupId>
+                        <artifactId>driver-binary-downloader-maven-plugin
+                        </artifactId>
+                        <version>
+                            ${driver.binary.downloader.maven.plugin.version}
+                        </version>
+                        <configuration>
+                            <onlyGetDriversForHostOperatingSystem>true
+                            </onlyGetDriversForHostOperatingSystem>
+                            <rootStandaloneServerDirectory>
+                                ${project.rootdir}/driver
+                            </rootStandaloneServerDirectory>
+                            <downloadedZipFileDirectory>
+                                ${project.rootdir}/driver_zips
+                            </downloadedZipFileDirectory>
+                            <customRepositoryMap>
+                                ${project.rootdir}/drivers.xml
+                            </customRepositoryMap>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>selenium</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-devmode.xml
+++ b/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-devmode.xml
@@ -27,7 +27,7 @@
 
     <artifactId>flow-test-npm-bytecode-scanning-devmode</artifactId>
 
-    <name>Flow test of bytecode scanner in dev mode</name>
+    <name>Flow test of full class scanning in dev mode</name>
     <packaging>war</packaging>
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>

--- a/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-production.xml
+++ b/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-production.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2000-2019 Vaadin Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>flow-test-npm-only-features</artifactId>
+        <groupId>com.vaadin</groupId>
+        <version>2.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>flow-test-npm-bytecode-scanning-production</artifactId>
+
+    <name>Flow test of bytecode scanner in production mode</name>
+    <packaging>war</packaging>
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <vaadin.productionMode>true</vaadin.productionMode>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-html-components-testbench</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-test-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-server-production-mode</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- This module is mapped to default web context -->
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>${jetty.version}</version>
+                <executions>
+                    <!-- start and stop jetty (running our app) when running
+                        integration tests -->
+                    <execution>
+                        <id>start-jetty</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>stop-jetty</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>flow-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-frontend</goal>
+                            <goal>build-frontend</goal>
+                        </goals>
+                        <phase>compile</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>local-run</id>
+            <activation>
+                <property>
+                    <name>!test.use.hub</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.lazerycode.selenium</groupId>
+                        <artifactId>driver-binary-downloader-maven-plugin
+                        </artifactId>
+                        <version>
+                            ${driver.binary.downloader.maven.plugin.version}
+                        </version>
+                        <configuration>
+                            <onlyGetDriversForHostOperatingSystem>true
+                            </onlyGetDriversForHostOperatingSystem>
+                            <rootStandaloneServerDirectory>
+                                ${project.rootdir}/driver
+                            </rootStandaloneServerDirectory>
+                            <downloadedZipFileDirectory>
+                                ${project.rootdir}/driver_zips
+                            </downloadedZipFileDirectory>
+                            <customRepositoryMap>
+                                ${project.rootdir}/drivers.xml
+                            </customRepositoryMap>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>selenium</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/src/main/java/com/vaadin/flow/testnpmonlyfeatures/bytecodescanning/ByteCodeScanningView.java
+++ b/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/src/main/java/com/vaadin/flow/testnpmonlyfeatures/bytecodescanning/ByteCodeScanningView.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.testnpmonlyfeatures.bytecodescanning;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.VaadinService;
+
+@Route("com.vaadin.flow.testnpmonlyfeatures.bytecodescanning.ByteCodeScanningView")
+public class ByteCodeScanningView extends Div {
+
+    public static final String MODE_LABEL_ID = "modeLabel";
+    public static final String COMPONENT_ID = "myButton";
+    public static final String COMPONENT_MISSING_LABEL_ID = "componentMissingLabel";
+
+    public ByteCodeScanningView() throws Exception {
+        /*
+         * Add a label so that the IT can read the current mode.
+         */
+        boolean production = VaadinService.getCurrent()
+                .getDeploymentConfiguration().isProductionMode();
+        Label modeLabel = new Label(Boolean.toString(production));
+        modeLabel.setId(MODE_LABEL_ID);
+        add(modeLabel);
+
+        try {
+            /*
+             * Create component using reflection, so that use will not be
+             * detected by the bytecode scanner.
+             */
+            Class<?> clazz = Class.forName("com.vaadin.flow.testnpmonlyfeatures.bytecodescanning.MyButton");
+            Component button = (Component) clazz.newInstance();
+            button.setId(COMPONENT_ID);
+            add(button);
+        } catch (IllegalStateException e) {
+            /*
+             * IllegalStateException will be thrown by NpmTemplateParser::getTemplateContent
+             * if bytecode scanning is enabled (since MyButton is not reachable).
+             * Add a simple label that can be verified in the IT. If bytecode
+             * scanning is disabled, we should never get here.
+             */
+            Label componentMissingLabel = new Label(e.getMessage());
+            componentMissingLabel.setId(COMPONENT_MISSING_LABEL_ID);
+            add(componentMissingLabel);
+        }
+    }
+}

--- a/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/src/main/java/com/vaadin/flow/testnpmonlyfeatures/bytecodescanning/MyButton.java
+++ b/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/src/main/java/com/vaadin/flow/testnpmonlyfeatures/bytecodescanning/MyButton.java
@@ -1,0 +1,15 @@
+package com.vaadin.flow.testnpmonlyfeatures.bytecodescanning;
+
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.polymertemplate.PolymerTemplate;
+import com.vaadin.flow.templatemodel.TemplateModel;
+
+@Tag("my-button")
+@JsModule("./my-button.js")
+public class MyButton extends PolymerTemplate<MyButton.MyButtonModel> {
+
+    public interface MyButtonModel extends TemplateModel {
+
+    }
+}

--- a/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/src/main/java/com/vaadin/flow/testnpmonlyfeatures/bytecodescanning/MyButton.java
+++ b/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/src/main/java/com/vaadin/flow/testnpmonlyfeatures/bytecodescanning/MyButton.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.flow.testnpmonlyfeatures.bytecodescanning;
 
 import com.vaadin.flow.component.Tag;

--- a/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/src/test/java/com/vaadin/flow/testnpmonlyfeatures/bytecodescanning/ByteCodeScanningIT.java
+++ b/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/src/test/java/com/vaadin/flow/testnpmonlyfeatures/bytecodescanning/ByteCodeScanningIT.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.testnpmonlyfeatures.bytecodescanning;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.html.testbench.LabelElement;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+import com.vaadin.testbench.ElementQuery;
+import com.vaadin.testbench.TestBenchElement;
+
+
+public class ByteCodeScanningIT extends ChromeBrowserTest {
+
+    @Test
+    public void buttonIsShownIffInDevMode() {
+        open();
+
+        LabelElement modeLabel = $(LabelElement.class).id(ByteCodeScanningView.MODE_LABEL_ID);
+
+        ElementQuery<TestBenchElement> component = $(TestBenchElement.class)
+                .attribute("id", ByteCodeScanningView.COMPONENT_ID);
+        ElementQuery<LabelElement> componentMissing = $(LabelElement.class)
+                .attribute("id", ByteCodeScanningView.COMPONENT_MISSING_LABEL_ID);
+        boolean productionMode = Boolean.parseBoolean(modeLabel.getText());
+        if (productionMode) {
+            // in production mode we use optimized bundle by default, so component should be missing
+            Assert.assertFalse("component expected missing in production mode",
+                    component.exists());
+            Assert.assertTrue("label about missing component expected present in production mode",
+                    componentMissing.exists());
+        } else {
+            // in dev mode we use complete bundle by default, so component should be present
+            Assert.assertTrue("component expected present in dev mode", component.exists());
+            Assert.assertFalse("label about missing component expected missing in dev mode",
+                    componentMissing.exists());
+        }
+    }
+
+}


### PR DESCRIPTION
Closes #6481

The IT main view creates a custom component (`MyButton`) instance using reflection in order to fly under the radar of the bytecode scanner, and asserts that it is visible in dev mode (since everything is bundled) but not in production mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6549)
<!-- Reviewable:end -->
