### PR TITLE
CCDM: set clientSideMode as the default mode

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -50,7 +50,7 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo {
      * Whether or not we are running in client-side bootstrap mode (CCDM).
      */
     @Parameter(defaultValue = "${vaadin.clientSideMode}")
-    public boolean clientSideMode;
+    private String clientSideMode;
 
     /**
      * Whether or not insert the initial Uidl object in the bootstrap index.html
@@ -80,6 +80,14 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo {
         compatibility = compatibilityMode != null
                 ? Boolean.valueOf(compatibilityMode)
                 : isDefaultCompatibility();
+        // Default bootstrapping mode for V15 is clientSideMode
+    }
+
+    public boolean isClientSideMode() {
+        if (clientSideMode == null || clientSideMode.isEmpty()) {
+            return true;
+        }
+        return Boolean.parseBoolean(clientSideMode);
     }
 
     abstract boolean isDefaultCompatibility();

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -47,7 +47,8 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo {
     public boolean productionMode;
 
     /**
-     * Whether or not we are running in client-side bootstrap mode (CCDM).
+     * Whether or not we are running in client-side bootstrap mode (CCDM). True
+     * if not defined.
      */
     @Parameter(defaultValue = "${vaadin.clientSideMode}")
     private String clientSideMode;
@@ -80,9 +81,13 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo {
         compatibility = compatibilityMode != null
                 ? Boolean.valueOf(compatibilityMode)
                 : isDefaultCompatibility();
-        // Default bootstrapping mode for V15 is clientSideMode
     }
 
+    /**
+     * Check if the plugin is running in `clientSideMode` or not. Default: true.
+     * 
+     * @return true if the `clientSideMode` property is not defined or empty.
+     */
     public boolean isClientSideMode() {
         if (clientSideMode == null || clientSideMode.isEmpty()) {
             return true;

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
@@ -150,7 +150,7 @@ public class PrepareFrontendMojo extends FlowModeAbstractMojo {
                     generatedFolder, frontendDirectory)
                             .withWebpack(webpackOutputDirectory,
                                     webpackTemplate, webpackGeneratedTemplate)
-                            .enableClientSideMode(clientSideMode)
+                            .enableClientSideMode(isClientSideMode())
                             .createMissingPackageJson(true)
                             .enableImportsUpdate(false)
                             .enablePackagesUpdate(false).runNpmInstall(false)
@@ -169,7 +169,7 @@ public class PrepareFrontendMojo extends FlowModeAbstractMojo {
         JsonObject buildInfo = Json.createObject();
         buildInfo.put(SERVLET_PARAMETER_COMPATIBILITY_MODE, compatibility);
         buildInfo.put(SERVLET_PARAMETER_PRODUCTION_MODE, productionMode);
-        buildInfo.put(SERVLET_PARAMETER_CLIENT_SIDE_MODE, clientSideMode);
+        buildInfo.put(SERVLET_PARAMETER_CLIENT_SIDE_MODE, isClientSideMode());
         buildInfo.put(SERVLET_PARAMETER_INITIAL_UIDL, eagerServerLoad);
         buildInfo.put(NPM_TOKEN, npmFolder.getAbsolutePath());
         buildInfo.put(GENERATED_TOKEN, generatedFolder.getAbsolutePath());

--- a/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
@@ -76,7 +76,7 @@ public interface DeploymentConfiguration extends Serializable {
      */
     default boolean isClientSideMode() {
         return getBooleanProperty(SERVLET_PARAMETER_CLIENT_SIDE_MODE,
-                false);
+                true);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
@@ -156,7 +156,7 @@ public class DefaultDeploymentConfiguration
     }
 
     /**
-     * {@inheritDoc} The default is false.
+     * {@inheritDoc} The default is true.
      * 
      */
     @Override
@@ -301,7 +301,7 @@ public class DefaultDeploymentConfiguration
      */
     private void checkClientSideMode(boolean loggWarning) {
         clientSideMode = getBooleanProperty(
-                Constants.SERVLET_PARAMETER_CLIENT_SIDE_MODE, false);
+                Constants.SERVLET_PARAMETER_CLIENT_SIDE_MODE, true);
         if (clientSideMode && loggWarning) {
             String frontendDir = getStringProperty(PARAM_FRONTEND_DIR, System
                     .getProperty(PARAM_FRONTEND_DIR, DEFAULT_FRONTEND_DIR));

--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -22,6 +22,7 @@
             concurrent running of test modules. -->
         <server.port>8888</server.port>
         <server.stop.port>8889</server.stop.port>
+        <vaadin.clientSideMode>false</vaadin.clientSideMode>
     </properties>
 
     <dependencies>
@@ -197,6 +198,12 @@
                         <stopPort>${server.stop.port}</stopPort>
                         <stopKey>foo</stopKey>
                         <stopWait>5</stopWait>
+                        <systemProperties>
+                            <systemProperty>
+                                <name>vaadin.clientSideMode</name>
+                                <value>${vaadin.clientSideMode}</value>
+                            </systemProperty>
+                        </systemProperties>
                     </configuration>
                 </plugin>
             </plugins>

--- a/flow-tests/test-ccdm/pom-production.xml
+++ b/flow-tests/test-ccdm/pom-production.xml
@@ -16,6 +16,7 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <vaadin.clientSideMode>true</vaadin.clientSideMode>
     </properties>
 
     <dependencies>
@@ -61,7 +62,6 @@
                 <configuration>
                     <compatibilityMode>false</compatibilityMode>
                     <productionMode>true</productionMode>
-                    <clientSideMode>true</clientSideMode>
                 </configuration>
             </plugin>
         </plugins>

--- a/flow-tests/test-ccdm/pom.xml
+++ b/flow-tests/test-ccdm/pom.xml
@@ -16,6 +16,7 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <vaadin.clientSideMode>true</vaadin.clientSideMode>
     </properties>
 
     <build>
@@ -30,10 +31,6 @@
                             <!-- make sure we do not leave webpack-dev-server running after IT -->
                             <name>vaadin.reuseDevServer</name>
                             <value>false</value>
-                        </systemProperty>
-                        <systemProperty>
-                            <name>vaadin.clientSideMode</name>
-                            <value>true</value>
                         </systemProperty>
                     </systemProperties>
                 </configuration>
@@ -53,7 +50,6 @@
                 <configuration>
                     <compatibilityMode>false</compatibilityMode>
                     <productionMode>false</productionMode>
-                    <clientSideMode>true</clientSideMode>
                 </configuration>
             </plugin>
         </plugins>

--- a/flow-tests/test-dev-mode/pom.xml
+++ b/flow-tests/test-dev-mode/pom.xml
@@ -62,6 +62,10 @@
                             <name>vaadin.frontend.url.es5</name>
                             <value>context://frontend-es6/</value>
                         </systemProperty>
+                        <systemProperty>
+                            <name>vaadin.clientSideMode</name>
+                            <value>${vaadin.clientSideMode}</value>
+                        </systemProperty>
                     </systemProperties>
                 </configuration>
             </plugin>

--- a/flow-tests/test-npm-only-features/test-npm-no-buildmojo/pom.xml
+++ b/flow-tests/test-npm-only-features/test-npm-no-buildmojo/pom.xml
@@ -123,6 +123,9 @@
                             <!-- removing build simulates pure jetty:run -->
 <!--                            <goal>build-frontend</goal>-->
                         </goals>
+                        <configuration>
+                            <clientSideMode>false</clientSideMode>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
This PR sets the `clientSideMode` as the default mode of the application. 
To be able to use server-side bootstrap (v14), `vaadin.clientSideMode` must be `false`

Connected to #6367

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6557)
<!-- Reviewable:end -->
