### PR TITLE
CCDM: ensure flow.start works with testbench

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
@@ -57,6 +57,8 @@ export class Flow {
   constructor(config?: FlowConfig) {
     this.flowRoot.$ = this.flowRoot.$ || {};
     this.config = config || {};
+    $wnd.Vaadin = $wnd.Vaadin || {};
+    $wnd.Vaadin.Flow = $wnd.Vaadin.Flow || {};
   }
 
   /**

--- a/flow-client/src/test/frontend/FlowTests.ts
+++ b/flow-client/src/test/frontend/FlowTests.ts
@@ -103,9 +103,17 @@ suite("Flow", () => {
   });
 
   test("should accept a configuration object", () => {
+    assert.isUndefined($wnd.Vaadin);
     const flow = new Flow({imports: () => {}});
     assert.isDefined(flow.config);
     assert.isDefined(flow.config.imports);
+  });
+
+  test("should initialize window.Flow object", () => {
+    assert.isUndefined($wnd.Vaadin);
+    const flow = new Flow({imports: () => {}});
+    assert.isDefined($wnd.Vaadin);
+    assert.isDefined($wnd.Vaadin.Flow);
   });
 
   test("should initialize Flow server navigation when calling start()", () => {


### PR DESCRIPTION
This PR is a temporary solution which only ensures that `flow.start` works with TestBench.
If the project uses client-side routing with `flow.route` and runs tests in a pure client-side view, it will be delayed for first 20s. This needs to be improved later.
Connected #6558

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6588)
<!-- Reviewable:end -->
