### PR TITLE
fix(material): LoadingIndicator's primary color

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/LoadingIndicator.java
+++ b/flow-client/src/main/java/com/vaadin/client/LoadingIndicator.java
@@ -74,7 +74,7 @@ public class LoadingIndicator {
             "width: 50%;" +
             "opacity: 1;" +
             "height: 4px;" +
-            "background-color: var(--lumo-primary-color, blue);" +
+            "background-color: var(--lumo-primary-color, var(--material-primary-color, blue));" +
             "pointer-events: none;" +
             "transition: none;" +
             "animation: v-progress-start 1000ms 200ms both;}" +


### PR DESCRIPTION
If css var --material-primary-color is changed, it needs to be applied to loading indicator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6591)
<!-- Reviewable:end -->
