### PR TITLE
Support @ClientCallable return values

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/ResourceLoader.java
+++ b/flow-client/src/main/java/com/vaadin/client/ResourceLoader.java
@@ -771,7 +771,7 @@ public class ResourceLoader {
     /*-{
           try {
             var promise = promiseSupplier.@java.util.function.Supplier::get(*)();
-            if ( !(promise instanceof Promise )){
+            if ( !(promise instanceof $wnd.Promise )){
                 throw new Error('The expression "'+expression+'" result is not a Promise.');
             }
             promise.then( function(result) { onSuccess.@java.lang.Runnable::run(*)(); } ,

--- a/flow-client/src/main/java/com/vaadin/client/communication/ServerConnector.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/ServerConnector.java
@@ -122,15 +122,21 @@ public class ServerConnector {
      *            the event handler method name to execute on the server side
      * @param argsArray
      *            the arguments array for the method
+     * @param promiseId
+     *            the promise id to use for getting the result back, or -1 if no
+     *            result is expected
      */
     public void sendTemplateEventMessage(StateNode node, String methodName,
-            JsonArray argsArray) {
+            JsonArray argsArray, int promiseId) {
         JsonObject message = Json.createObject();
         message.put(JsonConstants.RPC_TYPE,
                 JsonConstants.RPC_PUBLISHED_SERVER_EVENT_HANDLER);
         message.put(JsonConstants.RPC_NODE, node.getId());
         message.put(JsonConstants.RPC_TEMPLATE_EVENT_METHOD_NAME, methodName);
         message.put(JsonConstants.RPC_TEMPLATE_EVENT_ARGS, argsArray);
+        if (promiseId != -1) {
+            message.put(JsonConstants.RPC_TEMPLATE_EVENT_PROMISE, promiseId);
+        }
         sendMessage(message);
     }
 

--- a/flow-client/src/main/java/com/vaadin/client/flow/StateTree.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/StateTree.java
@@ -245,13 +245,16 @@ public class StateTree {
      *            the method name
      * @param argsArray
      *            the arguments array for the method
+     * @param promiseId
+     *            the promise id to use for getting the result back, or -1 if no
+     *            result is expected
      */
     public void sendTemplateEventToServer(StateNode node, String methodName,
-            JsArray<?> argsArray) {
+            JsArray<?> argsArray, int promiseId) {
         if (isValidNode(node)) {
             JsonArray array = WidgetUtil.crazyJsCast(argsArray);
             registry.getServerConnector().sendTemplateEventMessage(node,
-                    methodName, array);
+                    methodName, array, promiseId);
         }
     }
 

--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/ServerEventHandlerBinder.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/ServerEventHandlerBinder.java
@@ -52,7 +52,7 @@ public class ServerEventHandlerBinder {
     public static EventRemover bindServerEventHandlerNames(Element element,
             StateNode node) {
         return bindServerEventHandlerNames(() -> ServerEventObject.get(element),
-                node, NodeFeatures.CLIENT_DELEGATE_HANDLERS);
+                node, NodeFeatures.CLIENT_DELEGATE_HANDLERS, true);
     }
 
     /**
@@ -67,11 +67,15 @@ public class ServerEventHandlerBinder {
      *            the state node containing the feature
      * @param featureId
      *            the feature id which contains event handler methods
+     * @param returnValue
+     *            <code>true</code> if the handler should return a promise that
+     *            will reflect the server-side result; <code>false</code> to not
+     *            return any value
      * @return a handle which can be used to remove the listener for the feature
      */
     public static EventRemover bindServerEventHandlerNames(
             Supplier<ServerEventObject> objectProvider, StateNode node,
-            int featureId) {
+            int featureId, boolean returnValue) {
         NodeList serverEventHandlerNamesList = node.getList(featureId);
 
         if (serverEventHandlerNamesList.length() > 0) {
@@ -80,7 +84,7 @@ public class ServerEventHandlerBinder {
             for (int i = 0; i < serverEventHandlerNamesList.length(); i++) {
                 String serverEventHandlerName = (String) serverEventHandlerNamesList
                         .get(i);
-                object.defineMethod(serverEventHandlerName, node);
+                object.defineMethod(serverEventHandlerName, node, returnValue);
             }
         }
 
@@ -94,7 +98,8 @@ public class ServerEventHandlerBinder {
 
             JsArray<?> add = e.getAdd();
             for (int i = 0; i < add.length(); i++) {
-                serverObject.defineMethod((String) add.get(i), node);
+                serverObject.defineMethod((String) add.get(i), node,
+                        returnValue);
             }
         });
     }

--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/ServerEventObject.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/ServerEventObject.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.client.flow.binding;
 
-
 import jsinterop.annotations.JsFunction;
 
 import com.google.gwt.core.client.JavaScriptObject;
@@ -28,6 +27,7 @@ import com.vaadin.client.flow.collection.JsCollections;
 import com.vaadin.client.flow.collection.JsMap;
 import com.vaadin.client.flow.util.NativeFunction;
 import com.vaadin.flow.internal.nodefeature.NodeFeatures;
+import com.vaadin.flow.shared.JsonConstants;
 
 import elemental.dom.Element;
 import elemental.dom.Node;
@@ -45,6 +45,8 @@ import elemental.json.JsonObject;
 public final class ServerEventObject extends JavaScriptObject {
     private static final String NODE_ID = "nodeId";
     private static final String EVENT_PREFIX = "event";
+
+    private static final String PROMISE_CALLBACK_NAME = JsonConstants.RPC_PROMISE_CALLBACK_NAME;
 
     /**
      * Callback interface for an event data expression parsed using new
@@ -76,6 +78,31 @@ public final class ServerEventObject extends JavaScriptObject {
     protected ServerEventObject() {
     }
 
+    private native void initPromiseHandler()
+    /*-{
+        var name = @ServerEventObject::PROMISE_CALLBACK_NAME
+        // Use defineProperty to make it non-enumerable
+        Object.defineProperty(this, name, {
+            value: function(promiseId, success, value) {
+                var promise = this[name].promises[promiseId];
+
+                // undefined if client-side node was recreated after execution was scheduled
+                if (promise !== undefined) {
+                    delete this[name].promises[promiseId];
+
+                    if (success) {
+                        // Resolve
+                        promise[0](value);
+                    } else {
+                        // Reject
+                        promise[1](Error("Something went wrong. Check server-side logs for more information."));
+                    }
+                }
+            }
+        });
+        this[name].promises = [];
+    }-*/;
+
     /**
      * Defines a method with the given name to be a callback to the server for
      * the given state node.
@@ -88,8 +115,13 @@ public final class ServerEventObject extends JavaScriptObject {
      * @param node
      *            the node to use as an identifier when sending an event to the
      *            server
+     * @param returnPromise
+     *            <code>true</code> if the handler should return a promise that
+     *            will reflect the server-side result; <code>false</code> to not
+     *            return any value
      */
-    public native void defineMethod(String methodName, StateNode node)
+    public native void defineMethod(String methodName, StateNode node,
+            boolean returnPromise)
     /*-{
         this[methodName] = $entry(function(eventParameter) {
             var prototype = Object.getPrototypeOf(this);
@@ -102,7 +134,24 @@ public final class ServerEventObject extends JavaScriptObject {
             if(args === null) {
                 args = Array.prototype.slice.call(arguments);
             }
-            tree.@com.vaadin.client.flow.StateTree::sendTemplateEventToServer(*)(node, methodName, args);
+    
+            var returnValue;
+            var promiseId = -1;
+    
+            if (returnPromise) {
+                var promises = this[@ServerEventObject::PROMISE_CALLBACK_NAME].promises;
+    
+                promiseId = promises.length;
+    
+                returnValue = new Promise(function(resolve, reject) {
+                    // Store each callback for later use
+                    promises[promiseId] = [resolve, reject];
+                });
+            }
+    
+            tree.@com.vaadin.client.flow.StateTree::sendTemplateEventToServer(*)(node, methodName, args, promiseId);
+    
+            return returnValue;
         });
     }-*/;
 
@@ -230,6 +279,7 @@ public final class ServerEventObject extends JavaScriptObject {
                 .crazyJsoCast(WidgetUtil.getJsProperty(element, "$server"));
         if (serverObject == null) {
             serverObject = (ServerEventObject) JavaScriptObject.createObject();
+            serverObject.initPromiseHandler();
             WidgetUtil.setJsProperty(element, "$server", serverObject);
         }
         return serverObject;

--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
@@ -19,8 +19,11 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import jsinterop.annotations.JsFunction;
+
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.Scheduler;
+
 import com.vaadin.client.Command;
 import com.vaadin.client.Console;
 import com.vaadin.client.ExistingElementMap;
@@ -62,7 +65,6 @@ import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 import elemental.json.JsonType;
 import elemental.json.JsonValue;
-import jsinterop.annotations.JsFunction;
 
 /**
  * Binding strategy for a simple (not template) {@link Element} node.
@@ -257,8 +259,14 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
          * command execution
          */
         Reactive.addPostFlushListener(
-                () -> Scheduler.get().scheduleDeferred(() -> stateNode
-                        .getNodeData(InitialPropertyUpdate.class).execute()));
+                () -> Scheduler.get().scheduleDeferred(() -> {
+                    InitialPropertyUpdate propertyUpdate = stateNode
+                            .getNodeData(InitialPropertyUpdate.class);
+                    // cleared if handlePropertiesChanged has already happened
+                    if (propertyUpdate != null) {
+                        propertyUpdate.execute();
+                    }
+                }));
     }
 
     private native void bindPolymerModelProperties(StateNode node,
@@ -284,9 +292,9 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
     private native void hookUpPolymerElement(StateNode node, Element element)
     /*-{
         var self = this;
-    
+
         var originalPropertiesChanged = element._propertiesChanged;
-    
+
         if (originalPropertiesChanged) {
             element._propertiesChanged = function (currentProps, changedProps, oldProps) {
                 $entry(function () {
@@ -295,16 +303,16 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
                 originalPropertiesChanged.apply(this, arguments);
             };
         }
-    
-    
+
+
         var tree = node.@com.vaadin.client.flow.StateNode::getTree()();
-    
+
         var originalReady = element.ready;
-    
+
         element.ready = function (){
             originalReady.apply(this, arguments);
             @com.vaadin.client.PolymerUtils::fireReadyEvent(*)(element);
-    
+
             // The  _propertiesChanged method which is replaced above for the element
             // doesn't do anything for items in dom-repeat.
             // Instead it's called with some meaningful info for the <code>dom-repeat</code> element.
@@ -313,7 +321,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
             // which changes this method for any dom-repeat instance.
             var replaceDomRepeatPropertyChange = function(){
                 var domRepeat = element.root.querySelector('dom-repeat');
-    
+
                 if ( domRepeat ){
                  // If the <code>dom-repeat</code> element is in the DOM then
                  // this method should not be executed anymore. The logic below will replace
@@ -327,12 +335,12 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
                 // if dom-repeat is found => replace _propertiesChanged method in the prototype and mark it as replaced.
                 if ( !domRepeat.constructor.prototype.$propChangedModified){
                     domRepeat.constructor.prototype.$propChangedModified = true;
-    
+
                     var changed = domRepeat.constructor.prototype._propertiesChanged;
-    
+
                     domRepeat.constructor.prototype._propertiesChanged = function(currentProps, changedProps, oldProps){
                         changed.apply(this, arguments);
-    
+
                         var props = Object.getOwnPropertyNames(changedProps);
                         var items = "items.";
                         for(i=0; i<props.length; i++){
@@ -352,7 +360,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
                                     if( currentPropsItem && currentPropsItem.nodeId ){
                                         var nodeId = currentPropsItem.nodeId;
                                         var value = currentPropsItem[propertyName];
-    
+
                                         // this is an attempt to find the template element
                                         // which is not available as a context in the protype method
                                         var host = this.__dataHost;
@@ -363,7 +371,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
                                         while( !host.localName || host.__dataHost ){
                                             host = host.__dataHost;
                                         }
-    
+
                                         $entry(function () {
                                             @SimpleElementBindingStrategy::handleListItemPropertyChange(*)(nodeId, host, propertyName, value, tree);
                                         })();
@@ -374,7 +382,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
                     };
                 }
             };
-    
+
             // dom-repeat doesn't have to be in DOM even if template has it
             //  such situation happens if there is dom-if e.g. which evaluates to <code>false</code> initially.
             // in this case dom-repeat is not yet in the DOM tree until dom-if becomes <code>true</code>
@@ -389,7 +397,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
                 element.addEventListener('dom-change',replaceDomRepeatPropertyChange);
             }
         }
-    
+
     }-*/;
 
     private static void handleListItemPropertyChange(double nodeId,
@@ -1378,7 +1386,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
     private EventRemover bindPolymerEventHandlerNames(BindingContext context) {
         return ServerEventHandlerBinder.bindServerEventHandlerNames(
                 () -> WidgetUtil.crazyJsoCast(context.htmlNode), context.node,
-                NodeFeatures.POLYMER_SERVER_EVENT_HANDLERS);
+                NodeFeatures.POLYMER_SERVER_EVENT_HANDLERS, false);
     }
 
     private EventRemover bindClientCallableMethods(BindingContext context) {

--- a/flow-client/src/test-gwt/java/com/vaadin/client/ClientEngineTestBase.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/ClientEngineTestBase.java
@@ -10,7 +10,7 @@ import com.google.gwt.junit.client.GWTTestCase;
 public abstract class ClientEngineTestBase extends GWTTestCase {
     @Override
     protected void gwtSetUp() throws Exception {
-        installCollectionsPolyfill();
+        installPolyfills();
         super.gwtSetUp();
     }
 
@@ -19,7 +19,7 @@ public abstract class ClientEngineTestBase extends GWTTestCase {
         return "com.vaadin.ClientEngineXSI";
     }
 
-    private static native void installCollectionsPolyfill()
+    private static native void installPolyfills()
     /*-{
         // Remove broken HtmlUnit versions (polyfill checks window, but installs to $wnd)
         delete window.Set;
@@ -34,6 +34,13 @@ public abstract class ClientEngineTestBase extends GWTTestCase {
         0}function z(){return k(this._itp,this._keys)}function l(){return k(this._itp,this._values)}function A(){return k(this._itp,this._keys,this._values)}function B(){return k(this._itp,this._values,this._values)}function k(a,c,b){var g=[0],e=!1;a.push(g);return{next:function(){var f,d=g[0];!e&&d<c.length?(f=b?[c[d],b[d]]:c[d],g[0]++):(e=!0,a.splice(a.indexOf(g),1));return{done:e,value:f}}}}function x(){return this._values.length}function u(a,c){for(var b=this.entries();;){var d=b.next();if(d.done)break;
         a.call(c,d.value[1],d.value[0],this)}}var b,w=Object.defineProperty,y=function(a,b){return isNaN(a)?isNaN(b):a===b};"undefined"==typeof WeakMap&&(e.WeakMap=f({"delete":d,clear:h,get:m,has:q,set:r},!0));"undefined"!=typeof Map&&"function"===typeof(new Map).values&&(new Map).values().next||(e.Map=f({"delete":d,has:q,get:m,set:r,keys:z,values:l,entries:A,forEach:u,clear:h}));"undefined"!=typeof Set&&"function"===typeof(new Set).values&&(new Set).values().next||(e.Set=f({has:p,add:t,"delete":d,clear:h,
         keys:l,values:l,entries:B,forEach:u}));"undefined"==typeof WeakSet&&(e.WeakSet=f({"delete":d,add:t,clear:h,has:p},!0))})("undefined"!=typeof exports&&"undefined"!=typeof global?global:$wnd);
+
+        // Remove broken HtmlUnit implementation
+        delete window.Promise;
+
+        // promise-polyfill 8.1.3
+
+        !function(e,n){"object"==typeof exports&&"undefined"!=typeof module?n():"function"==typeof define&&define.amd?define(n):n()}(0,function(){"use strict";function e(e){var n=this.constructor;return this.then(function(t){return n.resolve(e()).then(function(){return t})},function(t){return n.resolve(e()).then(function(){return n.reject(t)})})}function n(e){return!(!e||"undefined"==typeof e.length)}function t(){}function o(e){if(!(this instanceof o))throw new TypeError("Promises must be constructed via new");if("function"!=typeof e)throw new TypeError("not a function");this._state=0,this._handled=!1,this._value=undefined,this._deferreds=[],c(e,this)}function r(e,n){for(;3===e._state;)e=e._value;0!==e._state?(e._handled=!0,o._immediateFn(function(){var t=1===e._state?n.onFulfilled:n.onRejected;if(null!==t){var o;try{o=t(e._value)}catch(r){return void f(n.promise,r)}i(n.promise,o)}else(1===e._state?i:f)(n.promise,e._value)})):e._deferreds.push(n)}function i(e,n){try{if(n===e)throw new TypeError("A promise cannot be resolved with itself.");if(n&&("object"==typeof n||"function"==typeof n)){var t=n.then;if(n instanceof o)return e._state=3,e._value=n,void u(e);if("function"==typeof t)return void c(function(e,n){return function(){e.apply(n,arguments)}}(t,n),e)}e._state=1,e._value=n,u(e)}catch(r){f(e,r)}}function f(e,n){e._state=2,e._value=n,u(e)}function u(e){2===e._state&&0===e._deferreds.length&&o._immediateFn(function(){e._handled||o._unhandledRejectionFn(e._value)});for(var n=0,t=e._deferreds.length;t>n;n++)r(e,e._deferreds[n]);e._deferreds=null}function c(e,n){var t=!1;try{e(function(e){t||(t=!0,i(n,e))},function(e){t||(t=!0,f(n,e))})}catch(o){if(t)return;t=!0,f(n,o)}}var a=setTimeout;o.prototype["catch"]=function(e){return this.then(null,e)},o.prototype.then=function(e,n){var o=new this.constructor(t);return r(this,new function(e,n,t){this.onFulfilled="function"==typeof e?e:null,this.onRejected="function"==typeof n?n:null,this.promise=t}(e,n,o)),o},o.prototype["finally"]=e,o.all=function(e){return new o(function(t,o){function r(e,n){try{if(n&&("object"==typeof n||"function"==typeof n)){var u=n.then;if("function"==typeof u)return void u.call(n,function(n){r(e,n)},o)}i[e]=n,0==--f&&t(i)}catch(c){o(c)}}if(!n(e))return o(new TypeError("Promise.all accepts an array"));var i=Array.prototype.slice.call(e);if(0===i.length)return t([]);for(var f=i.length,u=0;i.length>u;u++)r(u,i[u])})},o.resolve=function(e){return e&&"object"==typeof e&&e.constructor===o?e:new o(function(n){n(e)})},o.reject=function(e){return new o(function(n,t){t(e)})},o.race=function(e){return new o(function(t,r){if(!n(e))return r(new TypeError("Promise.race accepts an array"));for(var i=0,f=e.length;f>i;i++)o.resolve(e[i]).then(t,r)})},o._immediateFn="function"==typeof setImmediate&&function(e){setImmediate(e)}||function(e){a(e,0)},o._unhandledRejectionFn=function(e){void 0!==console&&console&&console.warn("Possible Unhandled Promise Rejection:",e)};var l=function(){if("undefined"!=typeof self)return self;if("undefined"!=typeof window)return window;if("undefined"!=typeof global)return global;throw Error("unable to locate global object")}();"Promise"in l?l.Promise.prototype["finally"]||(l.Promise.prototype["finally"]=e):l.Promise=o});
     }-*/;
 
 }

--- a/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtMultipleBindingTest.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtMultipleBindingTest.java
@@ -97,7 +97,7 @@ public class GwtMultipleBindingTest extends ClientEngineTestBase {
         tree = new StateTree(registry) {
             @Override
             public void sendTemplateEventToServer(StateNode node,
-                    String methodName, JsArray<?> argValues) {
+                    String methodName, JsArray<?> argValues, int promiseId) {
             }
         };
 

--- a/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtStateTreeTest.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtStateTreeTest.java
@@ -16,6 +16,7 @@
 package com.vaadin.client.flow;
 
 import com.google.gwt.core.client.JavaScriptObject;
+
 import com.vaadin.client.ClientEngineTestBase;
 import com.vaadin.client.InitialPropertiesHandler;
 import com.vaadin.client.Registry;
@@ -50,7 +51,7 @@ public class GwtStateTreeTest extends ClientEngineTestBase {
 
         @Override
         public void sendTemplateEventMessage(StateNode node, String methodName,
-                JsonArray array) {
+                JsonArray array, int promiseId) {
             this.node = node;
             this.methodName = methodName;
             args = array;
@@ -79,7 +80,7 @@ public class GwtStateTreeTest extends ClientEngineTestBase {
         StateNode node = new StateNode(0, tree);
         tree.registerNode(node);
         JsArray array = getArgArray();
-        tree.sendTemplateEventToServer(node, "foo", array);
+        tree.sendTemplateEventToServer(node, "foo", array, -1);
 
         JsonObject object = Json.createObject();
         object.put("key", "value");
@@ -104,7 +105,7 @@ public class GwtStateTreeTest extends ClientEngineTestBase {
         tree.registerNode(node);
 
         Reactive.addPostFlushListener(() -> {
-            tree.sendTemplateEventToServer(node, "click", null);
+            tree.sendTemplateEventToServer(node, "click", null, -1);
             TestServerConnector serverConnector = (TestServerConnector) registry
                     .getServerConnector();
             assertNull(

--- a/flow-server/src/main/java/com/vaadin/flow/component/ClientCallable.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ClientCallable.java
@@ -25,7 +25,9 @@ import com.vaadin.flow.dom.DisabledUpdateMode;
 
 /**
  * Publishes the annotated method so it can be invoked from the client side
- * using the notation <code>this.$server.method()</code> in template methods.
+ * using the notation <code>this.$server.method()</code>. The method will return
+ * a Promise which will be resolved with either the return value from the server
+ * or a generic rejection if the server-side method throws an exception.
  *
  * @author Vaadin Ltd
  * @since 1.0

--- a/flow-server/src/main/java/com/vaadin/flow/internal/JsonCodec.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/JsonCodec.java
@@ -80,6 +80,8 @@ public class JsonCodec {
      * @return the value encoded as JSON
      */
     public static JsonValue encodeWithTypeInfo(Object value) {
+        assert value == null || canEncodeWithTypeInfo(value.getClass());
+
         if (value instanceof Component) {
             return encodeNode(((Component) value).getElement());
         } else if (value instanceof Node<?>) {
@@ -119,7 +121,7 @@ public class JsonCodec {
 
     /**
      * Helper for checking whether the type is supported by
-     * {@link #encodeWithoutTypeInfo(Object)}. Supported values types are
+     * {@link #encodeWithoutTypeInfo(Object)}. Supported value types are
      * {@link String}, {@link Integer}, {@link Double}, {@link Boolean},
      * {@link JsonValue}.
      *
@@ -132,6 +134,23 @@ public class JsonCodec {
         return String.class.equals(type) || Integer.class.equals(type)
                 || Double.class.equals(type) || Boolean.class.equals(type)
                 || JsonValue.class.isAssignableFrom(type);
+    }
+
+    /**
+     * Helper for checking whether the type is supported by
+     * {@link #encodeWithTypeInfo(Object)}. Supported values types are
+     * {@link Node}, {@link Component}, {@link ReturnChannelRegistration} and
+     * anything accepted by {@link #canEncodeWithoutTypeInfo(Class)}.
+     *
+     * @param type
+     *            the type to check
+     * @return whether the type can be encoded
+     */
+    public static boolean canEncodeWithTypeInfo(Class<?> type) {
+        return canEncodeWithoutTypeInfo(type)
+                || Node.class.isAssignableFrom(type)
+                || Component.class.isAssignableFrom(type)
+                || ReturnChannelRegistration.class.isAssignableFrom(type);
     }
 
     /**
@@ -168,6 +187,9 @@ public class JsonCodec {
         if (value == null) {
             return Json.createNull();
         }
+
+        assert canEncodeWithoutTypeInfo(value.getClass());
+
         Class<?> type = value.getClass();
         if (String.class.equals(value.getClass())) {
             return Json.create((String) value);

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/AbstractServerHandlers.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/AbstractServerHandlers.java
@@ -166,15 +166,7 @@ public abstract class AbstractServerHandlers<T>
      */
     protected void addHandlerMethod(Method method, Collection<Method> methods) {
         ensureSupportedParameterTypes(method);
-        if (!void.class.equals(method.getReturnType())) {
-            String msg = String.format(Locale.ENGLISH,
-                    "Only void handler methods are supported. "
-                            + "Component '%s' has method '%s' annotated with '%s' whose return type is not void but %s",
-                    method.getDeclaringClass().getName(), method.getName(),
-                    getHandlerAnnotation().getName(),
-                    method.getReturnType().getSimpleName());
-            throw new IllegalStateException(msg);
-        }
+        ensureSupportedReturnType(method);
         Optional<Class<?>> checkedException = Stream
                 .of(method.getExceptionTypes())
                 .filter(ReflectTools::isCheckedException).findFirst();
@@ -189,6 +181,24 @@ public abstract class AbstractServerHandlers<T>
             throw new IllegalStateException(msg);
         }
         methods.add(method);
+    }
+
+    /**
+     * Validate return type support for given method.
+     *
+     * @param method
+     *            method to check return type for
+     */
+    protected void ensureSupportedReturnType(Method method) {
+        if (!void.class.equals(method.getReturnType())) {
+            String msg = String.format(Locale.ENGLISH,
+                    "Only void handler methods are supported. "
+                            + "Component '%s' has method '%s' annotated with '%s' whose return type is not void but \"%s\"",
+                    method.getDeclaringClass().getName(), method.getName(),
+                    getHandlerAnnotation().getName(),
+                    method.getReturnType().getSimpleName());
+            throw new IllegalStateException(msg);
+        }
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ClientCallableHandlers.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ClientCallableHandlers.java
@@ -16,10 +16,13 @@
 package com.vaadin.flow.internal.nodefeature;
 
 import java.lang.reflect.Method;
+import java.util.Locale;
 
 import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.dom.DisabledUpdateMode;
+import com.vaadin.flow.internal.JsonCodec;
+import com.vaadin.flow.internal.ReflectTools;
 import com.vaadin.flow.internal.StateNode;
 
 /**
@@ -51,6 +54,25 @@ public class ClientCallableHandlers extends AbstractServerHandlers<Component> {
     protected void ensureSupportedParameterTypes(Method method) {
         // decoder may be able to convert any value to any type so no need to
         // limit supported types
+    }
+
+    @Override
+    protected void ensureSupportedReturnType(Method method) {
+        Class<?> returnType = method.getReturnType();
+        if (returnType.isPrimitive()) {
+            returnType = ReflectTools.convertPrimitiveType(returnType);
+        }
+
+        if (!void.class.equals(returnType)
+                && !JsonCodec.canEncodeWithTypeInfo(returnType)) {
+            String msg = String.format(Locale.ENGLISH,
+                    "Only return types that can be used as Element.executeJs parameters are supported. "
+                            + "Component '%s' has method '%s' annotated with '%s' whose return type is \"%s\"",
+                    method.getDeclaringClass().getName(), method.getName(),
+                    getHandlerAnnotation().getName(),
+                    method.getReturnType().getSimpleName());
+            throw new IllegalStateException(msg);
+        }
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/shared/JsonConstants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/JsonConstants.java
@@ -216,6 +216,17 @@ public class JsonConstants implements Serializable {
     public static final String RPC_TEMPLATE_EVENT_ARGS = "templateEventMethodArgs";
 
     /**
+     * Key used to hold the promise id for a server side method call.
+     */
+    public static final String RPC_TEMPLATE_EVENT_PROMISE = "promise";
+
+    /**
+     * Name of the $server property that is used to track pending promises. The
+     * name is chosen to avoid conflicts with genuine $server method names.
+     */
+    public static final String RPC_PROMISE_CALLBACK_NAME = "}p";
+
+    /**
      * Type value for attach existing element server callback.
      *
      * @see #RPC_ATTACH_ASSIGNED_ID

--- a/flow-server/src/test/java/com/vaadin/flow/component/FocusableTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/FocusableTest.java
@@ -30,7 +30,7 @@ public class FocusableTest {
 
     }
 
-    private final UI ui = new MockUI();
+    private final MockUI ui = new MockUI();
     private final FocusableTestComponent component = new FocusableTestComponent();
 
     @Test
@@ -74,9 +74,8 @@ public class FocusableTest {
     }
 
     private void assertPendingInvocationCount(String message, int expected) {
-        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
-        List<PendingJavaScriptInvocation> invocations = ui.getInternals()
-                .dumpPendingJavaScriptInvocations();
+        List<PendingJavaScriptInvocation> invocations = ui
+                .dumpPendingJsInvocations();
         Assert.assertEquals(message, expected, invocations.size());
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/JsonCodecTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/JsonCodecTest.java
@@ -78,7 +78,7 @@ public class JsonCodecTest {
                 JsonCodec.encodeWithoutTypeInfo(value);
 
                 Assert.fail("Should throw for " + value.getClass());
-            } catch (IllegalArgumentException expected) {
+            } catch (AssertionError expected) {
             }
         }
     }
@@ -134,7 +134,7 @@ public class JsonCodecTest {
                 JsonCodec.encodeWithTypeInfo(value);
 
                 Assert.fail("Should throw for " + value.getClass());
-            } catch (IllegalArgumentException expected) {
+            } catch (AssertionError expected) {
             }
         }
     }

--- a/flow-server/src/test/java/com/vaadin/tests/util/MockUI.java
+++ b/flow-server/src/test/java/com/vaadin/tests/util/MockUI.java
@@ -15,9 +15,12 @@
  */
 package com.vaadin.tests.util;
 
+import java.util.List;
+
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinService;
@@ -37,6 +40,13 @@ public class MockUI extends UI {
     @Override
     protected void init(VaadinRequest request) {
         // Do nothing
+    }
+
+    public List<PendingJavaScriptInvocation> dumpPendingJsInvocations() {
+        // Ensure element invocations are also flushed
+        getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        return getInternals().dumpPendingJavaScriptInvocations();
     }
 
     private static VaadinSession findOrCreateSession() {

--- a/flow-tests/test-root-context/frontend/EventHandler.js
+++ b/flow-tests/test-root-context/frontend/EventHandler.js
@@ -12,6 +12,8 @@ class EventHandler extends PolymerElement {
        <button on-click="sendData" id="send">Send event data to the server</button>
        <button on-click="overriddenClick" id="overridden">Client and server event</button>
        <button on-click="clientHandler" id="client">Delegate via the $server</button>
+       <button on-click="clientHandlerError" id="clientError">Delegate via the $server and throw</button>
+       <span id="status">[[status]]</span>
     `;
   }
 
@@ -20,10 +22,25 @@ class EventHandler extends PolymerElement {
     event.result = "ClientSide handler";
   }
 
-  clientHandler() {
-    const msg = "foo";
-    const enabled = true;
-    this.$server.handleClientCall(msg, enabled);
+  async clientHandler() {
+      this.status = "Waiting"
+  	
+      const msg = "foo";
+      const enabled = true;
+      let result = await this.$server.handleClientCall(msg, enabled);
+      this.status = result;
   }
+  
+  async clientHandlerError() {
+      this.status = "Waiting"
+          
+      const msg = "foo";
+      const enabled = false;
+      try {
+          await this.$server.handleClientCall(msg, enabled);
+      } catch (error) {
+      	  this.status = error;
+      }
+  } 
 }
 customElements.define(EventHandler.is, EventHandler);

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/EventHandlerView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/EventHandlerView.java
@@ -70,10 +70,15 @@ public class EventHandlerView extends PolymerTemplate<TemplateModel> {
     }
 
     @ClientCallable
-    private void handleClientCall(String msg, boolean enabled) {
+    private String handleClientCall(String msg, boolean enabled) {
+        if (!enabled) {
+            throw new RuntimeException("Method is not enabled");
+        }
         Element div = ElementFactory.createDiv(
                 "Call from client, message: " + msg + ", " + enabled);
         div.setAttribute("id", "client-call");
         getParent().get().getElement().appendChild(div);
+
+        return msg.toUpperCase();
     }
 }

--- a/flow-tests/test-root-context/src/main/webapp/frontend/com/vaadin/flow/uitest/ui/template/EventHandler.html
+++ b/flow-tests/test-root-context/src/main/webapp/frontend/com/vaadin/flow/uitest/ui/template/EventHandler.html
@@ -7,6 +7,8 @@
         <button on-click="sendData" id="send">Send event data to the server</button>
         <button on-click="overriddenClick" id="overridden">Client and server event</button>
         <button on-click="clientHandler" id="client">Delegate via the $server</button>
+        <button on-click="clientHandlerError" id="clientError">Delegate via the $server and throw</button>
+        <span id="status">[[status]]</span>
     </template>
     <script>
         class EventHandler extends Polymer.Element {
@@ -19,11 +21,26 @@
                 event.result = "ClientSide handler";
             }
 
-            clientHandler() {
+            async clientHandler() {
+                this.status = "Waiting"
+            	
                 const msg = "foo";
                 const enabled = true;
-                this.$server.handleClientCall(msg, enabled);
+                let result = await this.$server.handleClientCall(msg, enabled);
+                this.status = result;
             }
+            
+            async clientHandlerError() {
+                this.status = "Waiting"
+                    
+                const msg = "foo";
+                const enabled = false;
+                try {
+                    await this.$server.handleClientCall(msg, enabled);
+                } catch (error) {
+                    this.status = error;
+                }
+            }            
         }
         customElements.define(EventHandler.is, EventHandler);
     </script>

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/EventHandlerIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/EventHandlerIT.java
@@ -63,5 +63,20 @@ public class EventHandlerIT extends ChromeBrowserTest {
                 "Overridden server event was invoked with result: ClientSide handler",
                 findElement(By.id("overridden-event-handler-result"))
                         .getText());
+
+        // @ClientCallable return value
+        template.$("button").id("client").click();
+        Assert.assertEquals("Server-side message should be present",
+                "Call from client, message: foo, true",
+                $("div").id("client-call").getText());
+        Assert.assertEquals(
+                "Message from awaiting return value should be present", "FOO",
+                template.$("span").id("status").getText());
+
+        template.$("button").id("clientError").click();
+        Assert.assertEquals(
+                "Message from awaiting exception should be present",
+                "Error: Something went wrong. Check server-side logs for more information.",
+                template.$("span").id("status").getText());
     }
 }


### PR DESCRIPTION
Methods in $server will return a promise that is completed with the
result of the client-side invocation.

When such a method is invoked, an incremental promise id is generated
and a promise is created. The resolve and reject callbacks of the
promise are stored using the promise id as the key. The promise id is
passed to the server with the invocation.

After running the target method on the server, the promise id and the
invocation result is passed back to the client using executeJs. The
executed function finds the appropriate promise callback based on the
promise id and invokes it to complete the cycle.

Fixes #4050
Documented by vaadin/flow-and-components-documentation#848

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6597)
<!-- Reviewable:end -->
