### PR TITLE
added note about error messages to AbstractCompositeField JavaDoc

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/AbstractCompositeField.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/AbstractCompositeField.java
@@ -24,6 +24,9 @@ import com.vaadin.flow.shared.Registration;
 /**
  * An abstract field class that is backed by a composite component.
  * <p>
+ * Note that composite fields do not automatically show client side
+ * validation error messages or required indicators.
+ * <p>
  * See the detailed documentation for {@link AbstractField} and
  * {@link Composite} for detailed information.
  *


### PR DESCRIPTION
added a note to JavaDoc about AbstractCompositeField not supporting validation error messages or required indicators

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6600)
<!-- Reviewable:end -->
