### PR TITLE
Additions to generic DnD support

### DIFF
--- a/flow-dnd/src/main/java/com/vaadin/flow/component/dnd/DragEndEvent.java
+++ b/flow-dnd/src/main/java/com/vaadin/flow/component/dnd/DragEndEvent.java
@@ -76,11 +76,30 @@ public class DragEndEvent<T extends Component> extends ComponentEvent<T> {
     /**
      * Returns whether the drop event succesful or was it cancelled or didn't
      * succeed. This is a shorthand for {@code dropEffect != NONE}.
-     *
+     * <em>NOTE:</em> For Edge, Safari and IE11 this method will <b>always
+     * report <code>false</code></b> due to bugs in the browsers!
+     * 
+     * @deprecated replaced with {@link #isSuccessful()} since 2.1 (v14.1), this
+     *             method will be removed later.
      * @return {@code true} if the drop event succeeded, {@code false}
      *         otherwise.
      */
+    @Deprecated
     public boolean isSuccesful() {
+        return isSuccessful();
+    }
+
+    /**
+     * Returns whether the drop event succesful or was it cancelled or didn't
+     * succeed. This is a shorthand for {@code dropEffect != NONE}.
+     * <em>NOTE:</em> For Edge, Safari and IE11 this method will <b>always
+     * report <code>false</code></b> due to bugs in the browsers!
+     * 
+     * @return {@code true} if the drop event succeeded, {@code false}
+     *         otherwise.
+     * @since 2.1
+     */
+    public boolean isSuccessful() {
         return getDropEffect() != DropEffect.NONE;
     }
 

--- a/flow-dnd/src/main/java/com/vaadin/flow/component/dnd/DropTarget.java
+++ b/flow-dnd/src/main/java/com/vaadin/flow/component/dnd/DropTarget.java
@@ -184,7 +184,7 @@ public interface DropTarget<T extends Component> extends HasElement {
      * <p>
      * <em>NOTE: If the drop effect that doesn't match the effectAllowed of the
      * drag source, it DOES NOT prevent drop on IE11 and Safari! For FireFox and
-     * Chrome the drop is prevented if there they don't match.</em>
+     * Chrome the drop is prevented if the properties don't match.</em>
      *
      * @param dropEffect
      *            the drop effect to be set or {@code null} to not modify

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DnDCustomComponentView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DnDCustomComponentView.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.uitest.ui;
+
+import java.util.stream.Stream;
+
+import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.dnd.DragEndEvent;
+import com.vaadin.flow.component.dnd.DragSource;
+import com.vaadin.flow.component.dnd.DragStartEvent;
+import com.vaadin.flow.component.dnd.DropTarget;
+import com.vaadin.flow.component.dnd.EffectAllowed;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+@Route(value = "com.vaadin.flow.uitest.ui.DnDCustomComponentView", layout = ViewTestLayout.class)
+public class DnDCustomComponentView extends Div {
+
+    private final Div dropTarget;
+
+    public class DraggableItem extends Div
+            implements DragSource<DraggableItem> {
+
+        private final Div dragHandle;
+
+        public DraggableItem(EffectAllowed effectAllowed) {
+            dragHandle = new Div();
+            dragHandle.setHeight("50px");
+            dragHandle.setWidth("80px");
+            dragHandle.getStyle().set("background", "#000 ");
+            dragHandle.getStyle().set("margin", "5 10px");
+            dragHandle.getStyle().set("display", "inline-block");
+
+            setDraggable(true);
+            setDragData(effectAllowed);
+            addDragStartListener(DnDCustomComponentView.this::onDragStart);
+            addDragEndListener(DnDCustomComponentView.this::onDragEnd);
+
+            setHeight("50px");
+            setWidth("200px");
+            getStyle().set("border", "1px solid black");
+            getStyle().set("display", "inline-block");
+
+            add(dragHandle, new Span(effectAllowed.toString()));
+        }
+
+        @Override
+        public Element getDraggableElement() {
+            return dragHandle.getElement();
+        }
+    }
+
+    public DnDCustomComponentView() {
+        Stream.of(EffectAllowed.values()).map(DraggableItem::new)
+                .forEach(this::add);
+
+        dropTarget = new Div();
+        dropTarget.add(new Text("Drop Here"));
+        dropTarget.setWidth("200px");
+        dropTarget.setHeight("200px");
+        dropTarget.getStyle().set("border", "solid 1px pink");
+        add(dropTarget);
+
+        DropTarget.create(dropTarget).addDropListener(event -> event.getSource()
+                .add(new Span(event.getDragData().get().toString())));
+    }
+
+    private void onDragStart(DragStartEvent<DraggableItem> event) {
+        dropTarget.getStyle().set("background-color", "lightgreen");
+    }
+
+    private void onDragEnd(DragEndEvent<DraggableItem> event) {
+        dropTarget.getStyle().remove("background-color");
+    }
+
+}


### PR DESCRIPTION
Adds missing method for customizing draggable element.
Adds unit test for customizing draggable element.
Adds test UI for manually testing customized draggable element.
Fixes typo in API and deprecates typoed method.

Part of #3978

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6612)
<!-- Reviewable:end -->
