### PR TITLE
CCDM: use current url for flow.start initialization

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
@@ -222,8 +222,10 @@ export class Flow {
     // send a request to the `JavaScriptBootstrapHandler`
     return new Promise((resolve, reject) => {
       const httpRequest = new (window as any).XMLHttpRequest();
-      httpRequest.open('GET', 'VAADIN/?v-r=init' +
-        (serverSideRouting ? `&location=${encodeURI(this.getFlowRoute(location))}` : ''));
+      const currentPath = location.pathname || '/';
+      const requestPath = `${currentPath}?v-r=init` +
+                                  (serverSideRouting ? `&location=${encodeURI(this.getFlowRoute(location))}` : '');
+      httpRequest.open('GET', requestPath);
       httpRequest.onload = () => {
         if (httpRequest.getResponseHeader('content-type') === 'application/json') {
           resolve(JSON.parse(httpRequest.responseText));

--- a/flow-client/src/test/frontend/FlowTests.ts
+++ b/flow-client/src/test/frontend/FlowTests.ts
@@ -190,7 +190,7 @@ suite("Flow", () => {
 
   test("should throw when an incorrect server response is received", () => {
     // Configure an invalid server response
-    mock.get(/^VAADIN\/\?v-r=init&location=.+/, (req, res) => {
+    mock.get(/^.*\?v-r=init&location=.+/, (req, res) => {
       assert.equal('GET', req.method());
       return res
         .status(500)
@@ -437,7 +437,7 @@ function stubServerRemoteFunction(id: string, cancel: boolean = false) {
 
 function mockInitResponse(appId: string, changes = '[]') {
   // Configure a valid server initialization response
-  mock.get(/^VAADIN\/\?v-r=init.*/, (req, res) => {
+  mock.get(/^.*\?v-r=init.*/, (req, res) => {
     assert.equal('GET', req.method());
     return res
       .status(200)


### PR DESCRIPTION
This PR changes the `flow.start` to use the current URL when requesting server to initialize the session.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6615)
<!-- Reviewable:end -->
