### PR TITLE
Generic DnD: load connector in bundle, add stats

### DIFF
--- a/flow-dnd/pom.xml
+++ b/flow-dnd/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/flow-dnd/src/main/java/com/vaadin/flow/component/dnd/DragSource.java
+++ b/flow-dnd/src/main/java/com/vaadin/flow/component/dnd/DragSource.java
@@ -23,6 +23,7 @@ import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JavaScript;
+import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dnd.internal.DndUtil;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.shared.Registration;
@@ -46,7 +47,8 @@ import com.vaadin.flow.shared.Registration;
  * @author Vaadin Ltd
  * @since 2.0
  */
-@JavaScript(DndUtil.DND_CONNECTOR)
+@JavaScript(DndUtil.DND_CONNECTOR_COMPATIBILITY)
+@JsModule(DndUtil.DND_CONNECTOR)
 public interface DragSource<T extends Component> extends HasElement {
 
     /**
@@ -216,6 +218,8 @@ public interface DragSource<T extends Component> extends HasElement {
                 ((Registration) endListenerRegistration).remove();
             }
         }
+        // only onetime thing when in development mode
+        DndUtil.reportUsage();
     }
 
     /**

--- a/flow-dnd/src/main/java/com/vaadin/flow/component/dnd/DropTarget.java
+++ b/flow-dnd/src/main/java/com/vaadin/flow/component/dnd/DropTarget.java
@@ -23,6 +23,7 @@ import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.dependency.JavaScript;
+import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dnd.internal.DndUtil;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.shared.Registration;
@@ -40,7 +41,8 @@ import com.vaadin.flow.shared.Registration;
  * @author Vaadin Ltd
  * @since 2.0
  */
-@JavaScript(DndUtil.DND_CONNECTOR)
+@JavaScript(DndUtil.DND_CONNECTOR_COMPATIBILITY)
+@JsModule(DndUtil.DND_CONNECTOR)
 public interface DropTarget<T extends Component> extends HasElement {
 
     /**
@@ -153,6 +155,8 @@ public interface DropTarget<T extends Component> extends HasElement {
             getElement().setProperty(DndUtil.DROP_TARGET_ACTIVE_PROPERTY,
                     active);
             DndUtil.updateDropTargetActivation(this);
+            // only onetime thing when in development mode
+            DndUtil.reportUsage();
         }
     }
 

--- a/flow-dnd/src/main/resources/META-INF/resources/frontend/dndConnector-es6.js
+++ b/flow-dnd/src/main/resources/META-INF/resources/frontend/dndConnector-es6.js
@@ -1,0 +1,2 @@
+import './dndConnector.js';
+

--- a/flow-dnd/src/test/java/com/vaadin/flow/component/dnd/AbstractDnDUnitTest.java
+++ b/flow-dnd/src/test/java/com/vaadin/flow/component/dnd/AbstractDnDUnitTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.component.dnd;
+
+import java.util.Collection;
+import java.util.Properties;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.internal.DependencyList;
+import com.vaadin.flow.internal.UsageStatistics;
+import com.vaadin.flow.router.RouterLink;
+import com.vaadin.flow.server.DefaultDeploymentConfiguration;
+import com.vaadin.flow.server.VaadinServlet;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.shared.ui.Dependency;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public abstract class AbstractDnDUnitTest {
+
+    protected MockUI ui;
+    protected boolean compatibilityMode;
+
+    @Before
+    public void setup() {
+        DefaultDeploymentConfiguration configuration = new DefaultDeploymentConfiguration(
+                VaadinServlet.class, new Properties()) {
+            @Override
+            public boolean isCompatibilityMode() {
+                return compatibilityMode;
+            }
+        };
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        Mockito.when(session.getConfiguration()).thenReturn(configuration);
+        ui = new MockUI(session);
+    }
+
+    @Test
+    public void testExtension_activated_usageStatisticsEntryAdded() {
+        runStaticCreateMethodForExtension(new RouterLink());
+
+        Assert.assertTrue("No usage statistics for generic dnd reported",
+                UsageStatistics.getEntries().anyMatch(
+                        entry -> entry.getName().contains("generic-dnd")));
+    }
+
+    @Test
+    public void testExtension_staticApiInCompatibilityMode_connectorDependencyAddedDynamically() {
+        compatibilityMode = true;
+        ui.getInternals().getDependencyList().clearPendingSendToClient();
+
+        RouterLink component = new RouterLink();
+        ui.add(component);
+        runStaticCreateMethodForExtension(component);
+
+        DependencyList dependencyList = ui.getInternals().getDependencyList();
+        Collection<Dependency> pendingSendToClient = dependencyList
+                .getPendingSendToClient();
+
+        Assert.assertEquals("No dependency added", 1,
+                pendingSendToClient.size());
+
+        Dependency dependency = pendingSendToClient.iterator().next();
+        Assert.assertEquals("Wrong dependency loaded",
+                "frontend://dndConnector.js", dependency.getUrl());
+    }
+
+    @Test
+    public void testExtension_staticApi_connectorDependencyNotAddedDynamically() {
+        ui.getInternals().getDependencyList().clearPendingSendToClient();
+
+        RouterLink component = new RouterLink();
+        ui.add(component);
+        runStaticCreateMethodForExtension(component);
+
+        DependencyList dependencyList = ui.getInternals().getDependencyList();
+        Collection<Dependency> pendingSendToClient = dependencyList
+                .getPendingSendToClient();
+
+        Assert.assertEquals("No dependency added", 0,
+                pendingSendToClient.size());
+    }
+
+    protected abstract void runStaticCreateMethodForExtension(
+            Component component);
+}

--- a/flow-dnd/src/test/java/com/vaadin/flow/component/dnd/DragSourceTest.java
+++ b/flow-dnd/src/test/java/com/vaadin/flow/component/dnd/DragSourceTest.java
@@ -27,17 +27,22 @@ import com.vaadin.flow.router.RouterLink;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class DragSourceTest {
+public class DragSourceTest extends AbstractDnDUnitTest {
 
     @Tag("div")
     class TestComponent extends Component implements DragSource<TestComponent> {
 
     }
 
+    @Override
+    protected void runStaticCreateMethodForExtension(Component component) {
+        DragSource.create(component);
+    }
+
     @Test
     public void testDragSource_mixinInterface() {
         TestComponent component = new TestComponent();
-        new MockUI().add(component);
+        ui.add(component);
         component.setDraggable(true);
 
         Assert.assertEquals("component element not set draggable", "true",
@@ -72,7 +77,7 @@ public class DragSourceTest {
     @Test
     public void testDragSource_dragStartEvent_canSetDragData() {
         TestComponent component = new TestComponent();
-        new MockUI().add(component);
+        ui.add(component);
         component.setDraggable(true);
 
         final String dragData = "FOOBAR";
@@ -134,7 +139,7 @@ public class DragSourceTest {
     @Test
     public void testDragSource_serverSideEvents_correctData() {
         RouterLink component = new RouterLink();
-        new MockUI().add(component);
+        ui.add(component);
         DragSource<RouterLink> dragSource = DragSource.create(component);
 
         AtomicReference<DragStartEvent<RouterLink>> startEventCapture = new AtomicReference<>();
@@ -186,23 +191,23 @@ public class DragSourceTest {
     @Test
     public void testDragSource_notAttachedToUIAndCatchesDragEndEvent_doesNotThrow() {
         RouterLink component = new RouterLink();
-        MockUI mockUI = new MockUI();
-        mockUI.add(component);
+        ui.add(component);
         DragSource<RouterLink> dragSource = DragSource.create(component);
 
         DragStartEvent<RouterLink> startEvent = new DragStartEvent<RouterLink>(
                 component, true);
         ComponentUtil.fireEvent(component, startEvent);
-        Assert.assertEquals(component, mockUI.getActiveDragSourceComponent());
+        Assert.assertEquals(component, ui.getActiveDragSourceComponent());
 
         // the drop event could remove the component if in same UI
-        mockUI.remove(component);
+        ui.remove(component);
 
         DragEndEvent<RouterLink> endEvent = new DragEndEvent<>(component, true,
                 "move");
         // should not throw for removing the active drag source
         ComponentUtil.fireEvent(component, endEvent);
 
-        Assert.assertNull(mockUI.getActiveDragSourceComponent());
+        Assert.assertNull(ui.getActiveDragSourceComponent());
     }
+
 }

--- a/flow-dnd/src/test/java/com/vaadin/flow/component/dnd/DropTargetTest.java
+++ b/flow-dnd/src/test/java/com/vaadin/flow/component/dnd/DropTargetTest.java
@@ -26,10 +26,9 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dnd.internal.DndUtil;
 import com.vaadin.flow.router.RouterLink;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
-public class DropTargetTest {
+public class DropTargetTest extends AbstractDnDUnitTest {
 
     @Tag("div")
     class TestComponent extends Component
@@ -37,11 +36,9 @@ public class DropTargetTest {
 
     }
 
-    private MockUI ui;
-
-    @Before
-    public void setup() {
-        ui = new MockUI();
+    @Override
+    protected void runStaticCreateMethodForExtension(Component component) {
+        DropTarget.create(component);
     }
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DnDIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DnDIT.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.uitest.ui;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 


### PR DESCRIPTION
Instead of loading the DnD connector dynamically outside the bundle in
npm mode, it is now loaded as part of the bundle created by webpack for
npm mode.
Added usage statistics reporting for the feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6633)
<!-- Reviewable:end -->
