### PR TITLE
Fallback import is excluded by name

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -146,14 +146,9 @@ public class TaskUpdateImports extends NodeUpdater {
 
         @Override
         protected Collection<String> getGeneratedModules() {
-            Set<String> exclude = null;
-            if (fallBackImports == null) {
-                exclude = Collections.singleton(generatedFlowImports.getName());
-            } else {
-                exclude = new HashSet<>(
-                        Arrays.asList(generatedFlowImports.getName(),
-                                fallBackImports.getName()));
-            }
+            final Set<String> exclude = new HashSet<>(
+                    Arrays.asList(generatedFlowImports.getName(),
+                            FrontendUtils.FALLBACK_IMPORTS_NAME));
             return NodeUpdater.getGeneratedModules(generatedFolder, exclude);
         }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -18,6 +18,10 @@ package com.vaadin.flow.server.frontend;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -85,6 +89,24 @@ public class NodeUpdaterTest {
     @Test
     public void resolveResource_doesNotHaveModernResourcesFolder() {
         resolveResource_unhappyPath(RESOURCES_FRONTEND_DEFAULT);
+    }
+
+    @Test
+    public void getGeneratedModules_should_excludeByFileName() throws IOException {
+        File generated = temporaryFolder.newFolder();
+        File fileA = new File(generated, "a.js");
+        File fileB = new File(generated, "b.js");
+        File fileC = new File(generated, "c.js");
+        fileA.createNewFile();
+        fileB.createNewFile();
+        fileC.createNewFile();
+        
+        Set<String> modules = NodeUpdater.getGeneratedModules(generated, Stream
+                .of("a.js", "/b.js").collect(Collectors.toSet()));
+
+        Assert.assertEquals(1, modules.size());
+        // GENERATED/ is an added prefix for files from this method
+        Assert.assertTrue(modules.contains("GENERATED/c.js"));
     }
 
     private void resolveResource_happyPath(String resourceFolder) {


### PR DESCRIPTION
Even if fallback import is not in use, it is still excluded from imports file in case the user has an unclean environment.

Fixes #6634

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6640)
<!-- Reviewable:end -->
