### PR TITLE
Reactivate drop target after detach/attach

### DIFF
--- a/flow-dnd/src/main/java/com/vaadin/flow/component/dnd/DragSource.java
+++ b/flow-dnd/src/main/java/com/vaadin/flow/component/dnd/DragSource.java
@@ -180,11 +180,8 @@ public interface DragSource<T extends Component> extends HasElement {
             // The attribute is an enumerated one and not a Boolean one.
             getDraggableElement().setProperty("draggable",
                     Boolean.TRUE.toString());
-            getDraggableElement()
-                    .executeJavaScript(
-                            "window.Vaadin.Flow.dndConnector"
-                                    + ".activateDragSource($0)",
-                            getDraggableElement());
+            DndUtil.updateDragSourceActivation(this);
+
             // store & clear the component as active drag source for the UI
             Registration startListenerRegistration = addDragStartListener(
                     event -> getDragSourceComponent().getUI()
@@ -204,10 +201,7 @@ public interface DragSource<T extends Component> extends HasElement {
                     endListenerRegistration);
         } else {
             getDraggableElement().removeProperty("draggable");
-            getDraggableElement().executeJavaScript(
-                    "window.Vaadin.Flow.dndConnector"
-                            + ".deactivateDragSource($0)",
-                    getDraggableElement());
+            DndUtil.updateDragSourceActivation(this);
             // clear listeners for setting active data source
             Object startListenerRegistration = ComponentUtil.getData(
                     getDragSourceComponent(),

--- a/flow-dnd/src/main/java/com/vaadin/flow/component/dnd/DropTarget.java
+++ b/flow-dnd/src/main/java/com/vaadin/flow/component/dnd/DropTarget.java
@@ -152,17 +152,7 @@ public interface DropTarget<T extends Component> extends HasElement {
         if (isActive() != active) {
             getElement().setProperty(DndUtil.DROP_TARGET_ACTIVE_PROPERTY,
                     active);
-            if (active) {
-                getElement().executeJs(
-                        "window.Vaadin.Flow"
-                                + ".dndConnector.activateDropTarget($0)",
-                        getElement());
-            } else {
-                getElement().executeJavaScript(
-                        "window.Vaadin.Flow"
-                                + ".dndConnector.deactivateDropTarget($0)",
-                        getElement());
-            }
+            DndUtil.updateDropTargetActivation(this);
         }
     }
 

--- a/flow-dnd/src/main/java/com/vaadin/flow/component/dnd/internal/DndUtil.java
+++ b/flow-dnd/src/main/java/com/vaadin/flow/component/dnd/internal/DndUtil.java
@@ -17,6 +17,11 @@
 package com.vaadin.flow.component.dnd.internal;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.dnd.DragSource;
+import com.vaadin.flow.component.dnd.DropTarget;
+import com.vaadin.flow.server.Command;
+import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.shared.ui.LoadMode;
 
 /**
@@ -67,6 +72,11 @@ public class DndUtil {
      */
     public static final String DROP_EFFECT_ELEMENT_PROPERTY = "__dropEffect";
 
+    /**
+     * Key for storing detach listener for a drop target to component data.
+     */
+    private static final String DETACH_LISTENER_FOR_DROP_TARGET = "_detachListenerForDropTarget";
+
     private DndUtil() {
         // no instances from this class
     }
@@ -82,4 +92,59 @@ public class DndUtil {
         component.getElement().getNode().runWhenAttached(ui -> ui.getPage()
                 .addJavaScript(DND_CONNECTOR, LoadMode.EAGER));
     }
+
+    /**
+     * Triggers drag source activation method in JS connector once when the
+     * component has been attached.
+     * 
+     * @param dragSource
+     *            the drag source to update active status on
+     * @param <T>
+     *            the type of the drag source component
+     */
+    public static <T extends Component> void updateDragSourceActivation(
+            DragSource<T> dragSource) {
+        Command command = () -> dragSource.getDraggableElement().executeJs(
+                "window.Vaadin.Flow.dndConnector.updateDragSource($0)",
+                dragSource.getDraggableElement());
+        runOnAttachBeforeResponse(dragSource.getDragSourceComponent(), command);
+    }
+
+    /**
+     * Triggers drop target activation method in JS connector once when the
+     * component has been attached. Will make sure the activation in JS is done
+     * again when the component is detached and attached again, because
+     * otherwise the element will not be a drop target again.
+     * 
+     * @param dropTarget
+     *            the drop target to update active status on
+     * @param <T>
+     *            the type of the drop target component
+     */
+    public static <T extends Component> void updateDropTargetActivation(
+            DropTarget<T> dropTarget) {
+        Command command = () -> dropTarget.getElement().executeJs(
+                "window.Vaadin.Flow.dndConnector.updateDropTarget($0)",
+                dropTarget.getElement());
+
+        runOnAttachBeforeResponse(dropTarget.getDropTargetComponent(), command);
+
+        // add a detach listener which will make sure the activation is done
+        // again on the client side if the component is removed and added again
+        if (ComponentUtil.getData(dropTarget.getDropTargetComponent(),
+                DETACH_LISTENER_FOR_DROP_TARGET) == null) {
+            Registration detachRegistration = dropTarget.getElement()
+                    .addDetachListener(event -> runOnAttachBeforeResponse(
+                            dropTarget.getDropTargetComponent(), command));
+            ComponentUtil.setData(dropTarget.getDropTargetComponent(),
+                    DETACH_LISTENER_FOR_DROP_TARGET, detachRegistration);
+        }
+    }
+
+    private static void runOnAttachBeforeResponse(Component component,
+            Command command) {
+        component.getElement().getNode().runWhenAttached(ui -> ui
+                .beforeClientResponse(component, context -> command.execute()));
+    }
+
 }

--- a/flow-dnd/src/main/resources/META-INF/resources/frontend/dndConnector.js
+++ b/flow-dnd/src/main/resources/META-INF/resources/frontend/dndConnector.js
@@ -44,19 +44,19 @@ window.Vaadin.Flow.dndConnector = {
     event.stopPropagation();
   },
 
-  activateDropTarget: function (element) {
-    element.addEventListener('dragenter', this.__ondragenterListener, false);
-    element.addEventListener('dragover', this.__ondragoverListener, false);
-    element.addEventListener('dragleave', this.__ondragleaveListener, false);
-    element.addEventListener('drop', this.__ondropListener, false);
-  },
-
-  deactivateDropTarget: function (element) {
-    element.removeEventListener('dragenter', this.__ondragenterListener, false);
-    element.removeEventListener('dragover', this.__ondragoverListener, false);
-    element.removeEventListener('dragleave', this.__ondragleaveListener, false);
-    element.removeEventListener('drop', this.__ondropListener, false);
-    element.classList.remove("v-drag-over-target");
+  updateDropTarget : function(element) {
+    if (element['__active']) {
+      element.addEventListener('dragenter', this.__ondragenterListener, false);
+      element.addEventListener('dragover', this.__ondragoverListener, false);
+      element.addEventListener('dragleave', this.__ondragleaveListener, false);
+      element.addEventListener('drop', this.__ondropListener, false);
+    } else {
+      element.removeEventListener('dragenter', this.__ondragenterListener, false);
+      element.removeEventListener('dragover', this.__ondragoverListener, false);
+      element.removeEventListener('dragleave', this.__ondragleaveListener, false);
+      element.removeEventListener('drop', this.__ondropListener, false);
+      element.classList.remove("v-drag-over-target");
+    }
   },
 
   /** DRAG SOURCE METHODS: */
@@ -73,15 +73,11 @@ window.Vaadin.Flow.dndConnector = {
     event.currentTarget.classList.remove('v-dragged');
   },
 
-  activateDragSource: function (element) {
+  updateDragSource: function (element) {
     if (element['draggable']) {
       element.addEventListener('dragstart', this.__dragstartListener, false);
       element.addEventListener('dragend', this.__dragendListener, false);
-    }
-  },
-
-  deactivateDragSource: function (element) {
-    if (!element['draggable']) {
+    } else {
       element.removeEventListener('dragstart', this.__dragstartListener, false);
       element.removeEventListener('dragend', this.__dragendListener, false);
     }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DnDAttachDetachView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DnDAttachDetachView.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.dnd.DragSource;
+import com.vaadin.flow.component.dnd.DropEffect;
+import com.vaadin.flow.component.dnd.DropEvent;
+import com.vaadin.flow.component.dnd.DropTarget;
+import com.vaadin.flow.component.dnd.EffectAllowed;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.Route;
+
+/* https://github.com/vaadin/flow/issues/6054 */
+@Route(value = "com.vaadin.flow.uitest.ui.DnDAttachDetachView")
+public class DnDAttachDetachView extends Div {
+
+    public static final String DRAGGABLE_ID = "draggable";
+    public static final String VIEW_1_ID = "view1";
+    public static final String VIEW_2_ID = "view2";
+    public static final String SWAP_BUTTON_ID = "swap-button";
+    public static final String MOVE_BUTTON_ID = "move-button";
+    private Div buttonSwitchViews = new Div();
+    private Div buttonRemoveAdd = new Div();
+    private Div view1 = new Div();
+    private Div view2 = new Div();
+    private int counter = 0;
+
+    public DnDAttachDetachView() {
+        setSizeFull();
+
+        buttonSwitchViews.setText("Click to detach OR attach");
+        buttonSwitchViews.setId(SWAP_BUTTON_ID);
+        buttonSwitchViews.getStyle().set("border", "1px solid black");
+        buttonSwitchViews.setHeight("20px");
+        buttonSwitchViews.setWidth("200px");
+
+        buttonRemoveAdd.setText("Click to detach AND attach");
+        buttonRemoveAdd.setId(MOVE_BUTTON_ID);
+        buttonRemoveAdd.getStyle().set("border", "1px solid black");
+        buttonRemoveAdd.setHeight("20px");
+        buttonRemoveAdd.setWidth("200px");
+
+        add(buttonSwitchViews, buttonRemoveAdd);
+
+        Div div = new Div();
+        div.setText("Text To Drag");
+        div.setId(DRAGGABLE_ID);
+        div.getStyle().set("background-color", "grey");
+        add(div);
+
+        add(view1);
+        view1.setWidth("500px");
+        view1.setHeight("500px");
+        view1.getStyle().set("background-color", "pink");
+        view1.setId(VIEW_1_ID);
+
+        view2.setWidth("500px");
+        view2.setHeight("500px");
+        view2.setId(VIEW_2_ID);
+
+        // need to set the effect allowed and drop effect for the simulation
+        DragSource<Div> dragSource = DragSource.create(div);
+        dragSource.addDragStartListener(
+                event -> add(new Span("Start: " + counter)));
+        dragSource.setEffectAllowed(EffectAllowed.COPY);
+
+        DropTarget<Div> dt = DropTarget.create(view1);
+        dt.setDropEffect(DropEffect.COPY);
+
+        buttonSwitchViews.addClickListener(event -> {
+            if (getChildren().anyMatch(component -> component == view1)) {
+                remove(div, view1);
+                add(view2);
+            } else {
+                remove(view2);
+                add(div, view1);
+            }
+        });
+        buttonRemoveAdd.addClickListener(event -> {
+            remove(div, view1);
+            add(div, view1);
+        });
+        DropTarget.configure(view1).addDropListener(this::onDrop);
+    }
+
+    private void onDrop(DropEvent<Div> divDropEvent) {
+        Span span = new Span("Drop: " + counter);
+        span.setId("drop-" + counter);
+        add(span);
+        counter++;
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DnDAttachDetachIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DnDAttachDetachIT.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+import com.vaadin.testbench.TestBenchElement;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import static com.vaadin.flow.uitest.ui.DnDAttachDetachView.DRAGGABLE_ID;
+import static com.vaadin.flow.uitest.ui.DnDAttachDetachView.MOVE_BUTTON_ID;
+import static com.vaadin.flow.uitest.ui.DnDAttachDetachView.SWAP_BUTTON_ID;
+import static com.vaadin.flow.uitest.ui.DnDAttachDetachView.VIEW_1_ID;
+import static com.vaadin.flow.uitest.ui.DnDAttachDetachView.VIEW_2_ID;
+
+public class DnDAttachDetachIT extends ChromeBrowserTest {
+
+    /* https://github.com/vaadin/flow/issues/6054 */
+    @Test
+    public void testDnD_attachDetachAttachSourceAndTarget_dndOperationWorks() {
+        open();
+
+        dragAndDrop(getDraggableText(), getDropTarget());
+
+        TestBenchElement eventElement = getEvent(0);
+        Assert.assertEquals("Drop: 0", eventElement.getText());
+
+        clickElementWithJs(SWAP_BUTTON_ID);
+
+        // just verify that the component was removed
+        waitForElementNotPresent(By.id(VIEW_1_ID));
+        waitForElementPresent(By.id(VIEW_2_ID));
+
+        clickElementWithJs(SWAP_BUTTON_ID);
+
+        dragAndDrop(getDraggableText(), getDropTarget());
+
+        // without proper reactivation of the drop target, the following event
+        // is not discoved
+        eventElement = getEvent(1);
+        Assert.assertEquals("Drop: 1", eventElement.getText());
+
+        Assert.assertFalse("No second event should have occurred",
+                isElementPresent(By.id("drop-" + 2)));
+    }
+
+    @Test
+    public void testDnD_moveComponents_dndOperationWorks() {
+        open();
+
+        dragAndDrop(getDraggableText(), getDropTarget());
+
+        TestBenchElement eventElement = getEvent(0);
+        Assert.assertEquals("Drop: 0", eventElement.getText());
+
+        clickElementWithJs(MOVE_BUTTON_ID);
+
+        dragAndDrop(getDraggableText(), getDropTarget());
+
+        eventElement = getEvent(1);
+        Assert.assertEquals("Drop: 1", eventElement.getText());
+
+        Assert.assertFalse("No second event should have occurred",
+                isElementPresent(By.id("drop-" + 2)));
+    }
+
+    private TestBenchElement getEvent(int i) {
+        waitForElementPresent(By.id("drop-" + i));
+        return $(TestBenchElement.class).id("drop-" + i);
+    }
+
+    private TestBenchElement getDraggableText() {
+        return id(DRAGGABLE_ID);
+    }
+
+    private TestBenchElement getDropTarget() {
+        return id(VIEW_1_ID);
+    }
+
+    private TestBenchElement id(String id) {
+        return $(TestBenchElement.class).id(id);
+    }
+}


### PR DESCRIPTION
Unless the listeners are set again for the element when it is detached
and later on attached again, it will not work as a drop target.

Fixes #6054

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6654)
<!-- Reviewable:end -->
