### PR TITLE
skip compressing bundles when in dev-mode

### DIFF
--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -128,7 +128,7 @@ module.exports = {
   },
   plugins: [
     // Generate compressed bundles
-    new CompressionPlugin(),
+    !devMode && new CompressionPlugin(),
 
     // Transpile with babel, and produce different bundles per browser
     new BabelMultiTargetPlugin({

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -127,8 +127,8 @@ module.exports = {
     maxAssetSize: 2097152 // 2MB
   },
   plugins: [
-    // Generate compressed bundles
-    !devMode && new CompressionPlugin(),
+    // Generate compressed bundles when not devMode
+    ...(devMode ? [] : [new CompressionPlugin()]),
 
     // Transpile with babel, and produce different bundles per browser
     new BabelMultiTargetPlugin({


### PR DESCRIPTION
This reduces dev-mode start-up time in bakery about 1sec

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6662)
<!-- Reviewable:end -->
