### PR TITLE
Extracted interface ExportsWebComponent from WebComponentExporter

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/common/FlowPluginFrontendUtils.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/common/FlowPluginFrontendUtils.java
@@ -18,7 +18,7 @@ package com.vaadin.flow.plugin.common;
 
 import java.io.File;
 import java.net.URL;
-import java.util.List;
+import java.util.stream.Stream;
 
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.project.MavenProject;
@@ -34,6 +34,12 @@ import com.vaadin.flow.utils.FlowFileUtils;
  */
 public class FlowPluginFrontendUtils {
 
+    /**
+     * Additionally include compile-time-only dependencies matching the pattern.
+     */
+    private static final String INCLUDE_FROM_COMPILE_DEPS_REGEX =
+            ".*/portlet-api-.+jar$";
+
     private FlowPluginFrontendUtils() {
     }
 
@@ -46,15 +52,18 @@ public class FlowPluginFrontendUtils {
      * @return a <code>ClassFinder</code> instance.
      */
     public static ClassFinder getClassFinder(MavenProject project) {
-        final List<String> runtimeClasspathElements;
+        final Stream<String> classpathElements;
         try {
-            runtimeClasspathElements = project.getRuntimeClasspathElements();
+            classpathElements = Stream.concat(
+                    project.getRuntimeClasspathElements().stream(),
+                    project.getCompileClasspathElements().stream()
+                        .filter(s -> s.matches(INCLUDE_FROM_COMPILE_DEPS_REGEX)));
         } catch (DependencyResolutionRequiredException e) {
             throw new IllegalStateException(String.format(
                     "Failed to retrieve runtime classpath elements from project '%s'",
                     project), e);
         }
-        URL[] urls = runtimeClasspathElements.stream().map(File::new)
+        URL[] urls = classpathElements.distinct().map(File::new)
                 .map(FlowFileUtils::convertToUrl).toArray(URL[]::new);
 
         return new ReflectionsClassFinder(urls);

--- a/flow-server/src/main/java/com/vaadin/flow/component/ExportsWebComponent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ExportsWebComponent.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Map;
+
+import com.vaadin.flow.component.webcomponent.WebComponent;
+import com.vaadin.flow.server.webcomponent.PropertyConfigurationImpl;
+
+/**
+ * Exports a {@link Component} as a web component embeddable in any web page.
+ * To export your own web component, do not use this interface directly,
+ * instead subclass {@link com.vaadin.flow.component.WebComponentExporter}.
+ */
+public interface ExportsWebComponent<C extends Component> extends Serializable {
+
+    /**
+     * The concrete component class object.
+     *
+     * @return component class
+     */
+    Class<C> getComponentClass();
+
+    /**
+     * The tag associated with the exported component.
+     *
+     * @return the tag
+     */
+    String getTag();
+
+    /**
+     * The property configuration map for this exporter.
+     * @return a property configuration map
+     */
+    default Map<String, PropertyConfigurationImpl<C, ? extends Serializable>> getPropertyConfigurationMap() {
+        return Collections.emptyMap();
+    }
+
+    /**
+     * If custom initialization for the created {@link Component} instance is
+     * needed, it can be done here. It is also possible to configure custom
+     * communication between the {@code component} instance and client-side web
+     * component using the {@link WebComponent} instance. The {@code
+     * webComponent} and {@code component} are in 1-to-1 relation.
+     * <p>
+     * Note that it's incorrect to call any {@code addProperty} method within
+     * {@link #configure(WebComponent, Component)} method. All
+     * properties have to be configured inside the exporter's constructor.
+     *
+     * @param webComponent instance representing the client-side web component instance
+     *                     matching the component
+     * @param component    instance of the exported web component
+     */
+    default void configure(WebComponent<C> webComponent, C component) {
+    }
+
+    /**
+     * Always called before {@link #configure(WebComponent, Component)}.
+     */
+    default void preConfigure() {
+    }
+
+    /**
+     * Always called after {@link #configure(WebComponent, Component)}.
+     */
+    default void postConfigure() {
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/ExportsWebComponent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ExportsWebComponent.java
@@ -26,6 +26,12 @@ import com.vaadin.flow.server.webcomponent.PropertyConfigurationImpl;
  * Exports a {@link Component} as a web component embeddable in any web page.
  * To export your own web component, do not use this interface directly,
  * instead subclass {@link com.vaadin.flow.component.WebComponentExporter}.
+ *
+ * @param <C>
+ *            type of the component to export
+ *
+ * @author Vaadin Ltd.
+ * @since 2.1
  */
 public interface ExportsWebComponent<C extends Component> extends Serializable {
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/WebComponentExporter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/WebComponentExporter.java
@@ -291,22 +291,22 @@ public abstract class WebComponentExporter<C extends Component>
 
 
     @Override
-    public void preConfigure() {
+    public final void preConfigure() {
         isConfigureInstanceCall = true;
     }
 
     @Override
-    public void configure(WebComponent<C> webComponent, C component) {
+    public final void configure(WebComponent<C> webComponent, C component) {
         configureInstance(webComponent,component);
     }
 
     @Override
-    public void postConfigure() {
+    public final void postConfigure() {
         isConfigureInstanceCall = false;
     }
 
     @Override
-    public String getTag() {
+    public final String getTag() {
         return tag;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/WebComponentExporter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/WebComponentExporter.java
@@ -526,8 +526,7 @@ public abstract class WebComponentExporter<C extends Component>
         }
 
         /**
-         * Use {@link #create(ExportsWebComponent<? extends Component>)}
-         * instead.
+         * Use {@link #create(ExportsWebComponent)} instead.
          *
          * @param exporter
          *            exporter instance, not {@code null}

--- a/flow-server/src/main/java/com/vaadin/flow/component/WebComponentExporter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/WebComponentExporter.java
@@ -524,6 +524,23 @@ public abstract class WebComponentExporter<C extends Component>
 
             return new WebComponentConfigurationImpl<>(exporter);
         }
+
+        /**
+         * Use {@link #create(ExportsWebComponent<? extends Component>)}
+         * instead.
+         *
+         * @param exporter
+         *            exporter instance, not {@code null}
+         * @return a web component configuration matching the instance of
+         *         received {@code exporter}
+         * @throws NullPointerException
+         *             when {@code exporter} is {@code null}
+         */
+        @Deprecated
+        public WebComponentConfiguration<? extends Component> create(
+                WebComponentExporter<? extends Component> exporter) {
+            return create((ExportsWebComponent<? extends Component>) exporter);
+        }
     }
 
     private static class NullTagException extends NullPointerException {

--- a/flow-server/src/main/java/com/vaadin/flow/component/WebComponentExporter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/WebComponentExporter.java
@@ -94,7 +94,6 @@ public abstract class WebComponentExporter<C extends Component>
                     Integer.class, Double.class, JsonValue.class));
 
     private final String tag;
-    private final Class<C> componentClass;
     private HashMap<String, PropertyConfigurationImpl<C, ? extends Serializable>> propertyConfigurationMap = new HashMap<>();
 
     private boolean isConfigureInstanceCall;
@@ -113,27 +112,14 @@ public abstract class WebComponentExporter<C extends Component>
      */
     @SuppressWarnings("unchecked")
     protected WebComponentExporter(String tag) {
-        this.tag = tag;
-        componentClass = (Class<C>) ReflectTools.getGenericInterfaceType(
-                this.getClass(), WebComponentExporter.class);
-        validateTagAndComponent();
-    }
-
-    protected WebComponentExporter(String tag, Class<C> componentClass) {
-        this.tag = tag;
-        this.componentClass = componentClass;
-        validateTagAndComponent();
-    }
-
-    private void validateTagAndComponent() {
         if (tag == null) {
             throw new NullTagException("Parameter 'tag' must not be null!");
         }
-
-        if (componentClass == null) {
+        this.tag = tag;
+        if (getComponentClass() == null) {
             throw new IllegalStateException(String.format("Failed to "
-                    + "determine component type for '%s'. Please "
-                    + "provide a valid type for %s as a type parameter.",
+                            + "determine component type for '%s'. Please "
+                            + "provide a valid type for %s as a type parameter.",
                     getClass().getName(),
                     WebComponentExporter.class.getSimpleName()));
         }
@@ -162,7 +148,7 @@ public abstract class WebComponentExporter<C extends Component>
         }
 
         PropertyConfigurationImpl<C, P> propertyConfigurationImpl = new PropertyConfigurationImpl<>(
-                componentClass, name, type, defaultValue);
+                getComponentClass(), name, type, defaultValue);
 
         propertyConfigurationMap.put(name, propertyConfigurationImpl);
 
@@ -283,12 +269,6 @@ public abstract class WebComponentExporter<C extends Component>
      */
     protected abstract void configureInstance(WebComponent<C> webComponent,
                                               C component);
-
-    @Override
-    public Class<C> getComponentClass() {
-        return componentClass;
-    }
-
 
     @Override
     public final void preConfigure() {

--- a/flow-server/src/main/java/com/vaadin/flow/component/WebComponentExporter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/WebComponentExporter.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.component.internal.ExportsWebComponent;
 import com.vaadin.flow.component.webcomponent.PropertyConfiguration;
 import com.vaadin.flow.component.webcomponent.WebComponent;
 import com.vaadin.flow.component.webcomponent.WebComponentConfiguration;
@@ -288,10 +289,6 @@ public abstract class WebComponentExporter<C extends Component>
         return componentClass;
     }
 
-    @Override
-    public Map<String, PropertyConfigurationImpl<C, ? extends Serializable>> getPropertyConfigurationMap() {
-        return propertyConfigurationMap;
-    }
 
     @Override
     public void preConfigure() {
@@ -325,8 +322,14 @@ public abstract class WebComponentExporter<C extends Component>
         private WebComponentConfigurationImpl(
                 ExportsWebComponent<C> exporter) {
             this.exporter = exporter;
-            immutablePropertyMap = Collections
-                    .unmodifiableMap(exporter.getPropertyConfigurationMap());
+            if (exporter instanceof WebComponentExporter) {
+                WebComponentExporter wcExporter =
+                        (WebComponentExporter)exporter;
+                immutablePropertyMap = Collections
+                        .unmodifiableMap(wcExporter.propertyConfigurationMap);
+            } else {
+                immutablePropertyMap = Collections.emptyMap();
+            }
         }
 
         @Override

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/ExportsWebComponent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/ExportsWebComponent.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.webcomponent.WebComponent;
+import com.vaadin.flow.internal.ReflectTools;
 
 /**
  * Exports a {@link Component} as a web component embeddable in any web page.
@@ -34,18 +35,22 @@ import com.vaadin.flow.component.webcomponent.WebComponent;
 public interface ExportsWebComponent<C extends Component> extends Serializable {
 
     /**
-     * The concrete component class object.
-     *
-     * @return component class
-     */
-    Class<C> getComponentClass();
-
-    /**
      * The tag associated with the exported component.
      *
      * @return the tag
      */
     String getTag();
+
+    /**
+     * The concrete component class object. By default creates an instance of
+     * the actual type parameter.
+     *
+     * @return component class
+     */
+    default Class<C> getComponentClass() {
+        return (Class<C>) ReflectTools.getGenericInterfaceType(
+                this.getClass(), ExportsWebComponent.class);
+    }
 
     /**
      * If custom initialization for the created {@link Component} instance is

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/ExportsWebComponent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/ExportsWebComponent.java
@@ -16,12 +16,9 @@
 package com.vaadin.flow.component.internal;
 
 import java.io.Serializable;
-import java.util.Collections;
-import java.util.Map;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.webcomponent.WebComponent;
-import com.vaadin.flow.server.webcomponent.PropertyConfigurationImpl;
 
 /**
  * Exports a {@link Component} as a web component embeddable in any web page.

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/ExportsWebComponent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/ExportsWebComponent.java
@@ -13,12 +13,13 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.flow.component;
+package com.vaadin.flow.component.internal;
 
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.webcomponent.WebComponent;
 import com.vaadin.flow.server.webcomponent.PropertyConfigurationImpl;
 
@@ -48,14 +49,6 @@ public interface ExportsWebComponent<C extends Component> extends Serializable {
      * @return the tag
      */
     String getTag();
-
-    /**
-     * The property configuration map for this exporter.
-     * @return a property configuration map
-     */
-    default Map<String, PropertyConfigurationImpl<C, ? extends Serializable>> getPropertyConfigurationMap() {
-        return Collections.emptyMap();
-    }
 
     /**
      * If custom initialization for the created {@link Component} instance is

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendWebComponentGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendWebComponentGenerator.java
@@ -20,7 +20,7 @@ import java.io.File;
 import java.io.Serializable;
 import java.util.Set;
 
-import com.vaadin.flow.component.ExportsWebComponent;
+import com.vaadin.flow.component.internal.ExportsWebComponent;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.webcomponent.WebComponentModulesWriter;
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendWebComponentGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendWebComponentGenerator.java
@@ -20,7 +20,7 @@ import java.io.File;
 import java.io.Serializable;
 import java.util.Set;
 
-import com.vaadin.flow.component.WebComponentExporter;
+import com.vaadin.flow.component.ExportsWebComponent;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.webcomponent.WebComponentModulesWriter;
 
@@ -72,7 +72,7 @@ public class FrontendWebComponentGenerator implements Serializable {
             final Class<?> writerClass = finder
                     .loadClass(WebComponentModulesWriter.class.getName());
             final Set<Class<?>> exporterClasses = finder
-                    .getSubTypesOf(WebComponentExporter.class.getName());
+                    .getSubTypesOf(ExportsWebComponent.class.getName());
             return WebComponentModulesWriter.DirectoryWriter
                     .generateWebComponentsToDirectory(writerClass,
                             exporterClasses, outputDirectory, false);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
@@ -35,7 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.WebComponentExporter;
+import com.vaadin.flow.component.ExportsWebComponent;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.internal.ReflectTools;
 import com.vaadin.flow.router.Route;
@@ -391,9 +391,9 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
         // references loaded by the specific class finder loader
         Class<? extends Annotation> routeClass = getFinder()
                 .loadClass(Route.class.getName());
-        Class<WebComponentExporter<? extends Component>> exporterClass = getFinder()
-                .loadClass(WebComponentExporter.class.getName());
-        Set<? extends Class<? extends WebComponentExporter<? extends Component>>> exporterClasses = getFinder()
+        Class<ExportsWebComponent<? extends Component>> exporterClass = getFinder()
+                .loadClass(ExportsWebComponent.class.getName());
+        Set<? extends Class<? extends ExportsWebComponent<? extends Component>>> exporterClasses = getFinder()
                 .getSubTypesOf(exporterClass);
 
         // if no exporters in the project, return

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
@@ -35,7 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.ExportsWebComponent;
+import com.vaadin.flow.component.internal.ExportsWebComponent;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.internal.ReflectTools;
 import com.vaadin.flow.router.Route;

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -55,7 +55,7 @@ import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.vaadin.flow.component.WebComponentExporter;
+import com.vaadin.flow.component.ExportsWebComponent;
 import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.JsModule;
@@ -97,7 +97,7 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_GENERATED;
  * @since 2.0
  */
 @HandlesTypes({ Route.class, UIInitListener.class,
-        VaadinServiceInitListener.class, WebComponentExporter.class,
+        VaadinServiceInitListener.class, ExportsWebComponent.class,
         NpmPackage.class, NpmPackage.Container.class, JsModule.class,
         JsModule.Container.class, CssImport.class, CssImport.Container.class,
         JavaScript.class, JavaScript.Container.class, Theme.class,

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -55,7 +55,7 @@ import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.vaadin.flow.component.ExportsWebComponent;
+import com.vaadin.flow.component.internal.ExportsWebComponent;
 import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.JsModule;

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/WebComponentConfigurationRegistryInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/WebComponentConfigurationRegistryInitializer.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.server.startup;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ExportsWebComponent;
 import com.vaadin.flow.component.WebComponentExporter;
 import com.vaadin.flow.component.webcomponent.WebComponentConfiguration;
 import com.vaadin.flow.internal.CustomElementNameValidator;
@@ -44,7 +45,7 @@ import java.util.stream.Collectors;
  * @author Vaadin Ltd.
  * @since 2.0
  */
-@HandlesTypes({WebComponentExporter.class})
+@HandlesTypes({ExportsWebComponent.class})
 public class WebComponentConfigurationRegistryInitializer
         implements ServletContainerInitializer {
 
@@ -61,8 +62,8 @@ public class WebComponentConfigurationRegistryInitializer
         }
 
         try {
-            Set<Class<? extends WebComponentExporter<? extends Component>>> exporterClasses = set
-                    .stream().filter(WebComponentExporter.class::isAssignableFrom)
+            Set<Class<? extends ExportsWebComponent<? extends Component>>> exporterClasses = set
+                    .stream().filter(ExportsWebComponent.class::isAssignableFrom)
                     .filter(clazz -> !clazz.isInterface()
                             && !Modifier.isAbstract(clazz.getModifiers()))
                     .map(aClass -> (Class<? extends WebComponentExporter<? extends Component>>) aClass)
@@ -85,7 +86,7 @@ public class WebComponentConfigurationRegistryInitializer
     }
 
     private static Set<WebComponentConfiguration<? extends Component>> constructConfigurations(
-            Set<Class<? extends WebComponentExporter<? extends Component>>> exporterClasses) {
+            Set<Class<? extends ExportsWebComponent<? extends Component>>> exporterClasses) {
         Objects.requireNonNull(exporterClasses, "Parameter 'exporterClasses' " +
                 "cannot be null!");
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/WebComponentConfigurationRegistryInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/WebComponentConfigurationRegistryInitializer.java
@@ -16,7 +16,7 @@
 package com.vaadin.flow.server.startup;
 
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.ExportsWebComponent;
+import com.vaadin.flow.component.internal.ExportsWebComponent;
 import com.vaadin.flow.component.WebComponentExporter;
 import com.vaadin.flow.component.webcomponent.WebComponentConfiguration;
 import com.vaadin.flow.internal.CustomElementNameValidator;

--- a/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentExporterTagExtractor.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentExporterTagExtractor.java
@@ -17,6 +17,7 @@
 package com.vaadin.flow.server.webcomponent;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ExportsWebComponent;
 import com.vaadin.flow.component.WebComponentExporter;
 import com.vaadin.flow.function.SerializableFunction;
 
@@ -28,11 +29,11 @@ import com.vaadin.flow.function.SerializableFunction;
  * @since 2.0
  */
 public final class WebComponentExporterTagExtractor
-        implements SerializableFunction<Class<? extends WebComponentExporter<? extends Component>>, String> {
+        implements SerializableFunction<Class<? extends ExportsWebComponent<? extends Component>>, String> {
 
     @Override
     public String apply(Class<?
-            extends WebComponentExporter<? extends Component>> exporterClass) {
+            extends ExportsWebComponent<? extends Component>> exporterClass) {
         return new WebComponentExporter.WebComponentConfigurationFactory()
                 .create(exporterClass)
                 .getTag();

--- a/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentExporterTagExtractor.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentExporterTagExtractor.java
@@ -17,7 +17,7 @@
 package com.vaadin.flow.server.webcomponent;
 
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.ExportsWebComponent;
+import com.vaadin.flow.component.internal.ExportsWebComponent;
 import com.vaadin.flow.component.WebComponentExporter;
 import com.vaadin.flow.function.SerializableFunction;
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentGenerator.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import org.apache.commons.io.IOUtils;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ExportsWebComponent;
 import com.vaadin.flow.component.WebComponentExporter;
 import com.vaadin.flow.component.webcomponent.WebComponentConfiguration;
 import com.vaadin.flow.shared.util.SharedUtil;
@@ -94,7 +95,7 @@ public class WebComponentGenerator {
      * @return generated web component html/JS to be served to the client
      */
     public static String generateModule(
-            Class<? extends WebComponentExporter<? extends Component>> exporterClass,
+            Class<? extends ExportsWebComponent<? extends Component>> exporterClass,
                     String frontendURI, boolean compatibilityMode) {
         Objects.requireNonNull(exporterClass);
         Objects.requireNonNull(frontendURI);

--- a/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentGenerator.java
@@ -26,7 +26,7 @@ import java.util.Set;
 import org.apache.commons.io.IOUtils;
 
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.ExportsWebComponent;
+import com.vaadin.flow.component.internal.ExportsWebComponent;
 import com.vaadin.flow.component.WebComponentExporter;
 import com.vaadin.flow.component.webcomponent.WebComponentConfiguration;
 import com.vaadin.flow.shared.util.SharedUtil;

--- a/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentModulesWriter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentModulesWriter.java
@@ -35,7 +35,7 @@ import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
 
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.WebComponentExporter;
+import com.vaadin.flow.component.ExportsWebComponent;
 import com.vaadin.flow.internal.ReflectTools;
 
 /**
@@ -58,7 +58,7 @@ public final class WebComponentModulesWriter implements Serializable {
      * file is {@code [web component's tag].js}.
      *
      * @param exporterClasses
-     *            set of {@link com.vaadin.flow.component.WebComponentExporter}
+     *            set of {@link ExportsWebComponent}
      *            classes
      * @param outputDirectory
      *            target directory for the generated web component module files
@@ -72,7 +72,7 @@ public final class WebComponentModulesWriter implements Serializable {
      *             if {@code outputDirectory} is not a directory
      */
     private static Set<File> writeWebComponentsToDirectory( // NOSONAR
-            Set<Class<? extends WebComponentExporter<? extends Component>>> exporterClasses,
+            Set<Class<? extends ExportsWebComponent<? extends Component>>> exporterClasses,
             File outputDirectory, boolean compatibilityMode) {
         // this method is used via reflection by DirectoryWriter
         Objects.requireNonNull(exporterClasses,
@@ -92,10 +92,10 @@ public final class WebComponentModulesWriter implements Serializable {
                 .collect(Collectors.toSet());
     }
 
-    private static Stream<Class<? extends WebComponentExporter<? extends Component>>> filterConcreteExporters(
-            Set<Class<? extends WebComponentExporter<? extends Component>>> exporterClasses) {
+    private static Stream<Class<? extends ExportsWebComponent<? extends Component>>> filterConcreteExporters(
+            Set<Class<? extends ExportsWebComponent<? extends Component>>> exporterClasses) {
         return exporterClasses.stream()
-                .filter(clazz -> WebComponentExporter.class
+                .filter(clazz -> ExportsWebComponent.class
                         .isAssignableFrom(clazz) && !clazz.isInterface()
                         && !Modifier.isAbstract(clazz.getModifiers()));
     }
@@ -111,7 +111,7 @@ public final class WebComponentModulesWriter implements Serializable {
      * @return the generated module content
      */
     private static File writeWebComponentToDirectory(
-            Class<? extends WebComponentExporter<? extends Component>> clazz,
+            Class<? extends ExportsWebComponent<? extends Component>> clazz,
             File outputDirectory, boolean compatibilityMode) {
         String tag = getTag(clazz);
 
@@ -132,14 +132,14 @@ public final class WebComponentModulesWriter implements Serializable {
     }
 
     private static String generateModule(
-            Class<? extends WebComponentExporter<? extends Component>> exporterClass,
+            Class<? extends ExportsWebComponent<? extends Component>> exporterClass,
             boolean compatibilityMode) {
         return WebComponentGenerator.generateModule(exporterClass, "../",
                 compatibilityMode);
     }
 
     private static String getTag(
-            Class<? extends WebComponentExporter<? extends Component>> exporterClass) {
+            Class<? extends ExportsWebComponent<? extends Component>> exporterClass) {
         WebComponentExporterTagExtractor exporterTagExtractor = new WebComponentExporterTagExtractor();
         return exporterTagExtractor.apply(exporterClass);
     }
@@ -164,7 +164,7 @@ public final class WebComponentModulesWriter implements Serializable {
          *            {@code WebComponentModulesWriter} class
          * @param exporterClasses
          *            set of
-         *            {@link com.vaadin.flow.component.WebComponentExporter}
+         *            {@link ExportsWebComponent}
          *            classes, loaded with the same class loader as
          *            {@code writer}
          * @param outputDirectory

--- a/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentModulesWriter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentModulesWriter.java
@@ -35,7 +35,7 @@ import java.util.stream.Stream;
 import org.apache.commons.io.FileUtils;
 
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.ExportsWebComponent;
+import com.vaadin.flow.component.internal.ExportsWebComponent;
 import com.vaadin.flow.internal.ReflectTools;
 
 /**

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeClassFinderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeClassFinderTest.java
@@ -25,8 +25,7 @@ import java.util.stream.Stream;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.vaadin.flow.component.ExportsWebComponent;
-import com.vaadin.flow.component.WebComponentExporter;
+import com.vaadin.flow.component.internal.ExportsWebComponent;
 import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.JsModule;

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeClassFinderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeClassFinderTest.java
@@ -25,6 +25,7 @@ import java.util.stream.Stream;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.vaadin.flow.component.ExportsWebComponent;
 import com.vaadin.flow.component.WebComponentExporter;
 import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.dependency.JavaScript;
@@ -50,7 +51,7 @@ public class DevModeClassFinderTest {
         Assert.assertTrue(classes.contains(Route.class));
         Assert.assertTrue(classes.contains(UIInitListener.class));
         Assert.assertTrue(classes.contains(VaadinServiceInitListener.class));
-        Assert.assertTrue(classes.contains(WebComponentExporter.class));
+        Assert.assertTrue(classes.contains(ExportsWebComponent.class));
         Assert.assertTrue(classes.contains(NpmPackage.class));
         Assert.assertTrue(classes.contains(NpmPackage.Container.class));
         Assert.assertTrue(classes.contains(JsModule.class));


### PR DESCRIPTION
Part of https://github.com/vaadin/portlet-support/issues/34. 
- Extracted interface  `ExportsWebComponent` from `WebComponentExporter` for use with `VaadinPortlet`.
- Maven plugin: add `portlet-api` to classfinder even if not in runtime dependencies. This is required since bytecode inspection of `VaadinPortlet` will fail if any superinterface is not known to the classfinder (`portlet-api` is in provided, not runtime, dependencies).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6674)
<!-- Reviewable:end -->
