### PR TITLE
update bytebuddy version from 1.9.13 to 1.10.1

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
-            <version>1.9.13</version>
+            <version>1.10.1</version>
         </dependency>
 
         <!-- Small reflection library -->


### PR DESCRIPTION
Tests are running successfully after updating the bytebuddy dependency locally. Anything else to do/check here?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6675)
<!-- Reviewable:end -->
