### PR TITLE
Windows uses \ not /

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/common/FlowPluginFrontendUtils.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/common/FlowPluginFrontendUtils.java
@@ -38,7 +38,7 @@ public class FlowPluginFrontendUtils {
      * Additionally include compile-time-only dependencies matching the pattern.
      */
     private static final String INCLUDE_FROM_COMPILE_DEPS_REGEX =
-            ".*/portlet-api-.+jar$";
+            ".*(/|\\\\)portlet-api-.+jar$";
 
     private FlowPluginFrontendUtils() {
     }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6693)
<!-- Reviewable:end -->
