### PR TITLE
Cherry-pick: Visit method references in byte code traversal (#6686)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendClassVisitor.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendClassVisitor.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import net.bytebuddy.jar.asm.AnnotationVisitor;
 import net.bytebuddy.jar.asm.ClassVisitor;
 import net.bytebuddy.jar.asm.FieldVisitor;
+import net.bytebuddy.jar.asm.Handle;
 import net.bytebuddy.jar.asm.MethodVisitor;
 import net.bytebuddy.jar.asm.Opcodes;
 import net.bytebuddy.jar.asm.Type;
@@ -94,6 +95,30 @@ final class FrontendClassVisitor extends ClassVisitor {
         public void visitLdcInsn(Object value) {
             if (value instanceof Type) {
                 addSignatureToClasses(children, value.toString());
+            }
+        }
+
+        // Visit dynamic invocations and method references. In particular, we
+        // are interested in the case Supplier<Component> s = MyComponent::new;
+        // flow #6524
+        @Override
+        public void visitInvokeDynamicInsn(String name, String descriptor, Handle bootstrapMethodHandle, Object... bootstrapMethodArguments) {
+            addSignatureToClasses(children, descriptor);
+            addSignatureToClasses(children, bootstrapMethodHandle.getOwner());
+            addSignatureToClasses(children, bootstrapMethodHandle.getDesc());
+            for (Object obj : bootstrapMethodArguments) {
+                if (obj instanceof Type) {
+                    addSignatureToClasses(children, obj.toString());
+                } else if (obj instanceof Handle) {
+                    // The owner of the Handle is the reference information
+                    addSignatureToClasses(children, ((Handle) obj).getOwner());
+                    // the descriptor for the Handle won't be scanned, as it
+                    // adds from +10% to 40%  to the execution time and does not
+                    // affect the fix in itself
+                }
+                // the case for ConstantDynamic is also skipped for
+                // performance reasons. It does not directly affect the fix
+                // and slows down the execution.
             }
         }
     }
@@ -198,6 +223,7 @@ final class FrontendClassVisitor extends ClassVisitor {
         addSignatureToClasses(children, descriptor);
         return methodVisitor;
     }
+
 
     // Executed for each annotation in the class.
     @Override

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
@@ -27,7 +27,6 @@ import java.util.stream.Stream;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
@@ -41,6 +40,7 @@ import com.vaadin.flow.server.frontend.scanner.samples.MyServiceListener;
 import com.vaadin.flow.server.frontend.scanner.samples.MyUIInitListener;
 import com.vaadin.flow.server.frontend.scanner.samples.RouteComponent;
 import com.vaadin.flow.server.frontend.scanner.samples.RouteComponentWithLayout;
+import com.vaadin.flow.server.frontend.scanner.samples.RouteComponentWithMethodReference;
 import com.vaadin.flow.theme.AbstractTheme;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -149,6 +149,22 @@ public class FrontendDependenciesTest {
         Assert.assertThat("Theme's annotations should come first",
                     dependencies.getModules(), is(expectedOrder)
                 );
+    }
+
+    // flow #6524
+    @Test
+    public void extractsAndScansClassesFromMethodReferences() {
+        Mockito.when(classFinder.getAnnotatedClasses(Route.class))
+                .thenReturn(Collections.singleton(RouteComponentWithMethodReference.class));
+
+        FrontendDependencies dependencies =
+                new FrontendDependencies(classFinder, false);
+
+        List<String> modules = dependencies.getModules();
+        Assert.assertEquals(3, modules.size());
+        Assert.assertTrue(modules.contains("foo.js"));
+        Assert.assertTrue(modules.contains("bar.js"));
+        Assert.assertTrue(modules.contains("baz.js"));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/samples/RouteComponentWithMethodReference.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/samples/RouteComponentWithMethodReference.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.server.frontend.scanner.samples;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.router.Route;
+
+@Route("")
+public class RouteComponentWithMethodReference extends Component implements HasComponents {
+
+    @JsModule("foo.js")
+    public static class MyComponent extends Component {
+    }
+
+    @JsModule("bar.js")
+    public static class AnotherComponent extends Component {
+    }
+
+    @JsModule("baz.js")
+    public static class YetAnotherComponent extends Component {
+    }
+
+    private Supplier<Component> fieldGenerator = YetAnotherComponent::new;
+
+    public RouteComponentWithMethodReference() {
+        List<Supplier<Component>> suppliers =
+                Collections.singletonList(AnotherComponent::new);
+
+        Supplier<Component> generator = MyComponent::new;
+        add(generator.get(), fieldGenerator.get());
+    }
+}


### PR DESCRIPTION
* Fix #6524

(cherry picked from commit 7401fe75797a7ce58da82806b5103da1f1de719b)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6694)
<!-- Reviewable:end -->
