### PR TITLE
Cherry-pick: Use setStatus for non error response code (#6676)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
@@ -366,6 +366,8 @@ public final class DevModeHandler implements Serializable {
             // Copies response payload
             writeStream(response.getOutputStream(),
                     connection.getInputStream());
+        } else if (responseCode < 400) {
+            response.setStatus(responseCode);
         } else {
             // Copies response code
             response.sendError(responseCode);


### PR DESCRIPTION
Fixes #304

(cherry picked from commit 69a9d2ef7b7ba55277b70c73a4bcf1ea9422423f)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6695)
<!-- Reviewable:end -->
