### PR TITLE
CCDM: Enable ui.navigate("")

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUI.java
@@ -208,8 +208,10 @@ public class JavaScriptBootstrapUI extends UI {
         } else {
             // client-side routing
             getPage().executeJs(
-                    "window.dispatchEvent(new CustomEvent('vaadin-router-go', {detail: {pathname: '/"
-                            + location.getPathWithQueryParameters() + "'}}))");
+                    "window.dispatchEvent(new CustomEvent('vaadin-router-go',"
+                            + " {detail: new URL($0, document.baseURI)}))",
+                    location.getPathWithQueryParameters()
+            );
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/History.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/History.java
@@ -220,8 +220,8 @@ public class History implements Serializable {
     public void replaceState(JsonValue state, Location location) {
         // Second parameter is title which is currently ignored according to
         // https://developer.mozilla.org/en-US/docs/Web/API/History_API
-        ui.getPage().executeJs("history.replaceState($0, '', $1)",
-                state, location.getPathWithQueryParameters());
+        ui.getPage().executeJs("history.replaceState($0, '', $1)", state,
+                location.getPathWithQueryParameters());
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/router/Location.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/Location.java
@@ -181,9 +181,10 @@ public class Location implements Serializable {
 
         String params = queryParameters.getQueryString();
         if (params.isEmpty()) {
-            return !basePath.isEmpty() ? basePath : ".";
+            return basePath;
+        } else {
+            return basePath + QUERY_SEPARATOR + params;
         }
-        return basePath + QUERY_SEPARATOR + params;
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/router/LocationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/LocationTest.java
@@ -265,7 +265,7 @@ public class LocationTest {
     }
 
     @Test
-    public void pathShouldNotBeEmpty() {
-        assertEquals(".", new Location("").getPathWithQueryParameters());
+    public void pathShouldBeEmpty() {
+        assertEquals("", new Location("").getPathWithQueryParameters());
     }
 }

--- a/flow-tests/test-ccdm/frontend/client-router.js
+++ b/flow-tests/test-ccdm/frontend/client-router.js
@@ -37,6 +37,7 @@ export function loadRouter(flow) {
   navigationContainer.appendChild(createNavigationLink('Server view', 'serverview'));
   navigationContainer.appendChild(createNavigationLink('View with all events', 'view-with-all-events'));
   navigationContainer.appendChild(createNavigationLink('Prevent leaving view', 'prevent-leaving'));
+  navigationContainer.appendChild(createNavigationLink('View with home button', 'serverview/view-with-home-button'));
   routerContainer.appendChild(navigationContainer);
 
   const outlet = document.createElement('div');

--- a/flow-tests/test-ccdm/package.json
+++ b/flow-tests/test-ccdm/package.json
@@ -20,5 +20,6 @@
     "html-webpack-plugin": "3.2.0",
     "compression-webpack-plugin": "3.0.0",
     "script-ext-html-webpack-plugin": "2.1.4"
-  }
+  },
+  "vaadinAppPackageHash": ""
 }

--- a/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/ViewWithHomeButton.java
+++ b/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/ViewWithHomeButton.java
@@ -15,14 +15,18 @@
  */
 package com.vaadin.flow.ccdmtest;
 
-import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.Route;
 
-@Route("")
-public class EmptyUI extends Div {
-    public EmptyUI() {
-        setId("emptyUi");
-        add(new Text("Empty view"));
+@Route(value = "serverview/view-with-home-button", layout = MainLayout.class)
+public class ViewWithHomeButton extends Div {
+    public ViewWithHomeButton() {
+        setId("viewWithHomeButton");
+        NativeButton homeButton = new NativeButton("Go home",
+                e -> UI.getCurrent().navigate(""));
+        homeButton.setId("homeButton");
+        add(homeButton);
     }
 }

--- a/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/IndexHtmlRequestHandlerIT.java
+++ b/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/IndexHtmlRequestHandlerIT.java
@@ -465,4 +465,33 @@ public class IndexHtmlRequestHandlerIT extends ChromeBrowserTest {
         Assert.assertEquals("Should be able to navigate to other view",
                 "Main" + " layout\nServer view", mainLayoutContent);
     }
+
+    @Test
+    public void should_goToHomeView_When_ServerNavigatesToEmptyPath() {
+        openTestUrl("/");
+        waitForElementPresent(By.id("loadVaadinRouter"));
+        findElement(By.id("loadVaadinRouter")).click();
+        waitForElementPresent(By.id("outlet"));
+
+        findElement(By.linkText("View with home button")).click();
+        waitForElementPresent(By.id("viewWithHomeButton"));
+        findElement(By.id("homeButton")).click();
+
+        waitForElementPresent(By.id("emptyUi"));
+        String homeViewContent = findElement(By.id("emptyUi")).getText();
+        Assert.assertEquals(
+                "Should render home view when calling ui.navigate(\"\")",
+                "Empty view",
+                homeViewContent
+        );
+
+        String expectedUrl = getRootURL() + "/foo/";
+        String actualUrl = getDriver().getCurrentUrl();
+        Assert.assertEquals(
+                "Should update URL to context path when calling"
+                        + " ui.navigate(\"\"),",
+                expectedUrl,
+                actualUrl
+        );
+    }
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HistoryIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/HistoryIT.java
@@ -85,9 +85,18 @@ public class HistoryIT extends ChromeBrowserTest {
 
         // Navigate to empty string should go to the context path root
         stateField.clear();
+        locationField.setValue("qwerty/x");
+        pushButton.click();
         locationField.clear();
         pushButton.click();
 
+        Assert.assertEquals(baseUrl.resolve("."), getCurrentUrl());
+
+        // Replacing with empty string should go to the context path root
+        locationField.setValue("qwerty/x");
+        replaceButton.click();
+        locationField.clear();
+        replaceButton.click();
         Assert.assertEquals(baseUrl.resolve("."), getCurrentUrl());
     }
 


### PR DESCRIPTION
Fixes #6661
Related #6195

Moves the workaround for History API loosing context path from Location
class to History class. Also for client-side navigation, the pathname is
passed to the client-side Vaadin Router in a context-aware way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6700)
<!-- Reviewable:end -->
