### PR TITLE
CCDM: use default serviceUrl from flow-client

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
@@ -123,8 +123,6 @@ public class JavaScriptBootstrapHandler extends BootstrapHandler {
                 .getPushConfiguration();
         pushConfiguration.setPushUrl(pushURL);
 
-        config.put(ApplicationConstants.SERVICE_URL, serviceUrl);
-
         // TODO(manolo) this comment is left intentionally because we
         // need to revise whether the info passed to client is valid
         // when initialising push. Right now ccdm is not doing

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandlerTest.java
@@ -93,7 +93,9 @@ public class JavaScriptBootstrapHandlerTest {
         Assert.assertFalse(json.getObject("appConfig").hasKey("webComponentMode"));
 
         Assert.assertEquals("./", json.getObject("appConfig").getString("contextRootUrl"));
-        Assert.assertEquals("./..", json.getObject("appConfig").getString("serviceUrl"));
+        Assert.assertNull(
+                "ServiceUrl should not be set. It will be computed by flow-client",
+                json.getObject("appConfig").get("serviceUrl"));
         Assert.assertEquals("http://localhost:8888/foo/", json.getObject("appConfig").getString("requestURL"));
 
         // Using regex, because version depends on the build

--- a/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/IndexHtmlRequestHandlerIT.java
+++ b/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/IndexHtmlRequestHandlerIT.java
@@ -143,6 +143,18 @@ public class IndexHtmlRequestHandlerIT extends ChromeBrowserTest {
         Assert.assertTrue(content.contains("Empty view"));
     }
 
+
+    @Test
+    public void should_bootstrapFlowCorrectly_When_CallingFromMultipleSegmentsPath() {
+        openTestUrl("/foo/bar/far");
+        waitForElementPresent(By.id("button3"));
+        findElement(By.id("button3")).click();
+        waitForElementPresent(By.id("result"));
+
+        String content = findElement(By.id("result")).getText();
+        Assert.assertTrue(content.contains("Empty view"));
+    }
+
     @Test
     public void should_removeFirstSlash_whenRouteStartsWithSlash() {
         openTestUrl("/");


### PR DESCRIPTION
The current situation is that:
  - We calculate a relative URL from the current request path to the context path. Then the url will be set for `serviceUrl` property of the initial configuration JSON which is used in `flow-client` for bootstrapping. And it is also set as the `base href`.
  - `flow-client` uses `serviceURL` to construct the initial UIDL request.
  - When making the initial UIDL request, because `serviceUrl` is a relative URL, it will be resolved using `document.baseURI` (or `base href`) => the actual request will be relativized to `baseURI` twice.

This PR removes the code to set `serviceUrl` property in the initial configuration. So that `flow-client` will calculate `serviceUrl` by itself (same as v14)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6711)
<!-- Reviewable:end -->
