### PR TITLE
Cherry-pick: Remove duplicate import entries from generated-flow-imports.js #6668

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -239,12 +239,12 @@ public class TaskUpdateImports extends NodeUpdater {
         return found;
     }
 
-    private Collection<String> getModuleLines(Set<String> modules) {
+    private Set<String> getUniqueEs6ImportPaths(Collection<String> modules) {
         Set<String> resourceNotFound = new HashSet<>();
         Set<String> npmNotFound = new HashSet<>();
         Set<String> visited = new HashSet<>();
         AbstractTheme theme = frontDeps.getTheme();
-        Collection<String> lines = new ArrayList<>();
+        Set<String> es6ImportPaths = new LinkedHashSet<>();
 
         for (String originalModulePath : modules) {
             String translatedModulePath = originalModulePath;
@@ -265,23 +265,21 @@ public class TaskUpdateImports extends NodeUpdater {
 
             if (localModulePath != null
                     && frontendFileExists(localModulePath)) {
-                lines.add(String.format(IMPORT_TEMPLATE,
-                        toValidBrowserImport(localModulePath)));
+                es6ImportPaths.add(toValidBrowserImport(localModulePath));
             } else if (importedFileExists(translatedModulePath)) {
-                lines.add(String.format(IMPORT_TEMPLATE,
-                        toValidBrowserImport(translatedModulePath)));
+                es6ImportPaths.add(toValidBrowserImport(translatedModulePath));
             } else if (importedFileExists(originalModulePath)) {
-                lines.add(String.format(IMPORT_TEMPLATE,
-                        toValidBrowserImport(originalModulePath)));
+                es6ImportPaths.add(toValidBrowserImport(originalModulePath));
             } else if (originalModulePath.startsWith("./")) {
                 resourceNotFound.add(originalModulePath);
             } else {
                 npmNotFound.add(originalModulePath);
-                lines.add(String.format(IMPORT_TEMPLATE, originalModulePath));
+                es6ImportPaths.add(originalModulePath);
             }
 
             if (theme != null) {
-                handleImports(originalModulePath, theme, lines, visited);
+                handleImports(originalModulePath, theme, es6ImportPaths,
+                        visited);
             }
         }
 
@@ -309,7 +307,14 @@ public class TaskUpdateImports extends NodeUpdater {
                     + "  To fix the build remove `node_modules` directory to reset modules.\n"
                     + "  In addition you may run `npm install` to fix `node_modules` tree structure."));
         }
-        return lines;
+
+        return es6ImportPaths;
+    }
+
+    private Collection<String> getModuleLines(Set<String> modules) {
+        return getUniqueEs6ImportPaths(modules).stream()
+                .map(path -> String.format(IMPORT_TEMPLATE, path))
+                .collect(Collectors.toList());
     }
 
     private String notFoundMessage(Set<String> files, String prefix,
@@ -364,9 +369,10 @@ public class TaskUpdateImports extends NodeUpdater {
             }
             if (resolvedPath.contains(theme.getBaseUrl())) {
                 String translatedPath = theme.translateUrl(resolvedPath);
-                if (importedFileExists(translatedPath)) {
-                    imports.add(String.format(IMPORT_TEMPLATE,
-                            normalizeImportPath(translatedPath)));
+                if (!visitedImports.contains(translatedPath)
+                        && importedFileExists(translatedPath)) {
+                    visitedImports.add(translatedPath);
+                    imports.add(normalizeImportPath(translatedPath));
                 }
             }
             handleImports(resolvedPath, theme, imports, visitedImports);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/UpdateThemedImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/UpdateThemedImportsTest.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
@@ -89,7 +90,8 @@ public class UpdateThemedImportsTest extends NodeUpdateTestUtil {
         Assert.assertTrue(nodeModulesPath.mkdirs());
         createImport("./src/subfolder/sub-template.js", "");
         createImport("./src/client-side-template.js",
-                "import 'xx' from './subfolder/sub-template.js';");
+                "import 'xx' from './subfolder/sub-template.js';"
+                        + "import '@vaadin/vaadin-button/src/vaadin-button.js'");
         createImport("./src/client-side-no-themed-template.js", "");
         createImport("./src/main-template.js",
                 "import 'xx' from './client-side-template.js';"
@@ -161,6 +163,20 @@ public class UpdateThemedImportsTest extends NodeUpdateTestUtil {
                         "import '@vaadin/vaadin-button/theme/myTheme/vaadin-button.js';"),
                 CoreMatchers.not(CoreMatchers.containsString(
                         "import 'theme/myTheme/wrong-themed-template.js';"))));
+    }
+
+    @Test
+    public void noDuplicateImportEntryIsWrittenIntoImportsFile()
+            throws Exception {
+        updater.execute();
+
+        String content = FileUtils.readFileToString(importsFile,
+                Charset.defaultCharset());
+        int count = StringUtils.countMatches(content,
+                "import '@vaadin/vaadin-button/theme/myTheme/vaadin-button.js';");
+        Assert.assertEquals(
+                "Import entries in the imports file should be unique.", 1,
+                count);
     }
 
     private void createImport(String path, String content) throws IOException {


### PR DESCRIPTION
(reimplemented since the fix was originally in a different class)

(original commit 0b8a74cc8f71514206539df22eb774c8393e2306)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6718)
<!-- Reviewable:end -->
