### PR TITLE
2.0.16 cherry-picks

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
@@ -18,12 +18,14 @@ package com.vaadin.client;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
+
 import com.vaadin.client.communication.LoadingIndicatorConfigurator;
 import com.vaadin.client.communication.PollConfigurator;
 import com.vaadin.client.communication.ReconnectDialogConfiguration;
 import com.vaadin.client.flow.RouterLinkHandler;
 import com.vaadin.client.flow.StateNode;
 import com.vaadin.client.flow.binding.Binder;
+
 import elemental.client.Browser;
 import elemental.dom.Element;
 import elemental.dom.Node;
@@ -57,9 +59,8 @@ public class ApplicationConnection {
         // Bind UI configuration objects
         PollConfigurator.observe(rootNode, registry.getPoller());
         ReconnectDialogConfiguration.bind(registry.getConnectionStateHandler());
-        LoadingIndicatorConfigurator.observe(rootNode, registry.getLoadingIndicator());
-
-
+        LoadingIndicatorConfigurator.observe(rootNode,
+                registry.getLoadingIndicator());
 
         Element body = Browser.getDocument().getBody();
 
@@ -173,12 +174,12 @@ public class ApplicationConnection {
             return pd;
         });
         }
-        $wnd.Vaadin.Flow.resolveUri = $entry(function(uriToResolve) {
+        client.resolveUri = $entry(function(uriToResolve) {
             var ur = ap.@ApplicationConnection::registry.@com.vaadin.client.Registry::getURIResolver()();
             return ur.@com.vaadin.client.URIResolver::resolveVaadinUri(Ljava/lang/String;)(uriToResolve);
         });
 
-        $wnd.Vaadin.Flow.sendEventMessage = $entry(function(nodeId, eventType, eventData) {
+        client.sendEventMessage = $entry(function(nodeId, eventType, eventData) {
             var sc = ap.@ApplicationConnection::registry.@com.vaadin.client.Registry::getServerConnector()();
             sc.@com.vaadin.client.communication.ServerConnector::sendEventMessage(ILjava/lang/String;Lelemental/json/JsonObject;)(nodeId,eventType,eventData);
         });

--- a/flow-client/src/main/java/com/vaadin/client/ScrollPositionHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/ScrollPositionHandler.java
@@ -328,8 +328,8 @@ public class ScrollPositionHandler {
             responseHandlingEndedHandler.removeHandler();
         }
 
-        if (xPositions.length() < currentHistoryIndex
-                || yPositions.length() < currentHistoryIndex) {
+        if (currentHistoryIndex >= xPositions.length()
+                || currentHistoryIndex >= yPositions.length()) {
             Console.warn("No matching scroll position found (entries X:"
                     + xPositions.length() + ", Y:" + yPositions.length()
                     + ") for opened history index (" + currentHistoryIndex

--- a/flow-data/src/main/java/com/vaadin/flow/data/renderer/RendererUtil.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/renderer/RendererUtil.java
@@ -91,10 +91,9 @@ public class RendererUtil {
             runOnAttach(contentTemplate.getNode(), () -> getUI(contentTemplate)
                     .getInternals().getStateTree()
                     .beforeClientResponse(templateDataHost.getNode(),
-                            context -> context.getUI().getPage()
-                                    .executeJs("$0.__dataHost = $1;",
-                                            contentTemplate,
-                                            templateDataHost)));
+                            context -> context.getUI().getPage().executeJs(
+                                    "$0.__dataHost = $1;", contentTemplate,
+                                    templateDataHost)));
         }
     }
 
@@ -125,9 +124,9 @@ public class RendererUtil {
         // vaadin.sendEventMessage is an exported function at the client
         // side
         ui.getPage().executeJs(String.format(
-                "$0.%s = function(e) {Vaadin.Flow.sendEventMessage(%d, '%s', {key: e.model ? e.model.__data.item.key : e.target.__dataHost.__data.item.key})}",
+                "$0.%s = function(e) {Vaadin.Flow.clients[$1].sendEventMessage(%d, '%s', {key: e.model ? e.model.__data.item.key : e.target.__dataHost.__data.item.key})}",
                 handlerName, eventOrigin.getNode().getId(), handlerName),
-                eventOrigin);
+                eventOrigin, ui.getInternals().getAppId());
 
         DomListenerRegistration registration = eventOrigin.addEventListener(
                 handlerName, event -> processEventFromTemplateRenderer(event,

--- a/flow-data/src/test/java/com/vaadin/flow/data/renderer/RendererUtilTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/renderer/RendererUtilTest.java
@@ -133,7 +133,7 @@ public class RendererUtilTest {
                 "The javascript executions don't contain dataHost assignement",
                 expressons.remove("$0.__dataHost = $1;"));
         Assert.assertEquals(
-                "$0.foo = function(e) {Vaadin.Flow.sendEventMessage("
+                "$0.foo = function(e) {Vaadin.Flow.clients[$1].sendEventMessage("
                         + templateDataHost.getNode().getId()
                         + ", 'foo', {key: e.model ? e.model.__data.item.key : e.target.__dataHost.__data.item.key})}",
                 expressons.iterator().next());

--- a/flow-server/src/main/java/com/vaadin/flow/component/EventData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/EventData.java
@@ -23,12 +23,14 @@ import java.lang.annotation.Target;
 
 import com.vaadin.flow.dom.DomListenerRegistration;
 
+import elemental.json.JsonValue;
+
 /**
  * Maps data from a DOM event to a {@link ComponentEvent}.
  * <p>
- * This annotation should be added to the DOM event constructor in a
- * {@link ComponentEvent}, mapped using @{@link DomEvent}. See the @
- * {@link DomEvent} documentation for more information.
+ * This annotation should be added to parameters in the DOM event constructor in
+ * a {@link ComponentEvent}, mapped using @{@link DomEvent}. See
+ * the @{@link DomEvent} documentation for more information.
  * <p>
  * The annotation {@link #value()} will be evaluated as JavaScript when the
  * event is handled in the browser. The expression is evaluated in a context
@@ -36,6 +38,10 @@ import com.vaadin.flow.dom.DomListenerRegistration;
  * registered and <code>event</code> refers to the fired event. The value of the
  * expression is passed back to the server and injected into the annotated
  * {@link ComponentEvent} constructor parameter.
+ * <p>
+ * Supported parameter types are {@link String}, {@link JsonValue},
+ * {@link Integer}, {@link Double}, {@link Boolean} and their respective
+ * primitive types.
  *
  * @see DomEvent
  * @see DomListenerRegistration#addEventData(String)

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -95,12 +95,11 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
 
     public static final String POLYFILLS_JS = "frontend://bower_components/webcomponentsjs/webcomponents-loader.js";
 
-    private static final CharSequence GWT_STAT_EVENTS_JS =
-            "if (typeof window.__gwtStatsEvent != 'function') {"
-                    + "window.Vaadin.Flow.gwtStatsEvents = [];"
-                    + "window.__gwtStatsEvent = function(event) {"
-                    + "window.Vaadin.Flow.gwtStatsEvents.push(event); "
-                    + "return true;};};";
+    private static final CharSequence GWT_STAT_EVENTS_JS = "if (typeof window.__gwtStatsEvent != 'function') {"
+            + "window.Vaadin.Flow.gwtStatsEvents = [];"
+            + "window.__gwtStatsEvent = function(event) {"
+            + "window.Vaadin.Flow.gwtStatsEvents.push(event); "
+            + "return true;};};";
     static final String CONTENT_ATTRIBUTE = "content";
     private static final String DEFER_ATTRIBUTE = "defer";
     static final String VIEWPORT = "viewport";
@@ -110,14 +109,14 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
     /**
      * Location of client nocache file, relative to the context root.
      */
-    private static final String CLIENT_ENGINE_NOCACHE_FILE =
-            ApplicationConstants.CLIENT_ENGINE_PATH + "/client.nocache.js";
+    private static final String CLIENT_ENGINE_NOCACHE_FILE = ApplicationConstants.CLIENT_ENGINE_PATH
+            + "/client.nocache.js";
     private static final String BOOTSTRAP_JS = readResource(
             "BootstrapHandler.js");
     private static final String BABEL_HELPERS_JS = readResource(
             "babel-helpers.min.js");
-    private static final String ES6_COLLECTIONS =
-            "//<![CDATA[\n" + readResource("es6-collections.js") + "//]]>";
+    private static final String ES6_COLLECTIONS = "//<![CDATA[\n"
+            + readResource("es6-collections.js") + "//]]>";
     private static final String CSS_TYPE_ATTRIBUTE_VALUE = "text/css";
 
     private static final String CAPTION = "caption";
@@ -139,7 +138,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
      * Creates an instance of the handler using provided page builder.
      *
      * @param pageBuilder
-     *         Page builder to use.
+     *            Page builder to use.
      */
     protected BootstrapHandler(PageBuilder pageBuilder) {
         this.pageBuilder = pageBuilder;
@@ -179,13 +178,13 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          * Creates a new context instance using the given parameters.
          *
          * @param request
-         *         the request object
+         *            the request object
          * @param response
-         *         the response object
+         *            the response object
          * @param session
-         *         the current session
+         *            the current session
          * @param ui
-         *         the UI object
+         *            the UI object
          */
         protected BootstrapContext(VaadinRequest request,
                 VaadinResponse response, VaadinSession session, UI ui,
@@ -194,8 +193,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             this.response = response;
             this.session = session;
             this.ui = ui;
-            parameterBuilder = new ApplicationParameterBuilder(
-                    contextCallback);
+            parameterBuilder = new ApplicationParameterBuilder(contextCallback);
 
             pageConfigurationHolder = BootstrapUtils
                     .resolvePageConfigurationHolder(ui, request).orElse(null);
@@ -252,8 +250,8 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                             .getDeploymentConfiguration().getPushMode();
                 }
 
-                if (pushMode.isEnabled() && !getRequest().getService()
-                        .ensurePushAvailable()) {
+                if (pushMode.isEnabled()
+                        && !getRequest().getService().ensurePushAvailable()) {
                     /*
                      * Fall back if not supported (ensurePushAvailable will log
                      * information to the developer the first time this happens)
@@ -274,8 +272,8 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          */
         public String getAppId() {
             if (appId == null) {
-                appId = getRequest().getService()
-                        .getMainDivId(getSession(), getRequest());
+                appId = getRequest().getService().getMainDivId(getSession(),
+                        getRequest());
             }
             return appId;
         }
@@ -311,7 +309,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          * Checks if the application is running in production mode.
          *
          * @return <code>true</code> if in production mode, <code>false</code>
-         * otherwise.
+         *         otherwise.
          */
         public boolean isProductionMode() {
             return request.getService().getDeploymentConfiguration()
@@ -323,20 +321,19 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          * target hierarchy.
          *
          * @param <T>
-         *         the type of the annotation
+         *            the type of the annotation
          * @param annotationType
-         *         the type of the annotation to get
+         *            the type of the annotation to get
          * @return an annotation, or an empty optional if there is no current
-         * navigation target or if it doesn't have the annotation
+         *         navigation target or if it doesn't have the annotation
          */
         public <T extends Annotation> Optional<T> getPageConfigurationAnnotation(
                 Class<T> annotationType) {
             if (pageConfigurationHolder == null) {
                 return Optional.empty();
             } else {
-                return AnnotationReader
-                        .getAnnotationFor(pageConfigurationHolder,
-                                annotationType);
+                return AnnotationReader.getAnnotationFor(
+                        pageConfigurationHolder, annotationType);
             }
         }
 
@@ -345,20 +342,19 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          * navigation target hierarchy.
          *
          * @param <T>
-         *         the type of the annotations
+         *            the type of the annotations
          * @param annotationType
-         *         the type of the annotation to get
+         *            the type of the annotation to get
          * @return a list of annotation, or an empty list if there is no current
-         * navigation target or if it doesn't have the annotation
+         *         navigation target or if it doesn't have the annotation
          */
         public <T extends Annotation> List<T> getPageConfigurationAnnotations(
                 Class<T> annotationType) {
             if (pageConfigurationHolder == null) {
                 return Collections.emptyList();
             } else {
-                return AnnotationReader
-                        .getAnnotationsFor(pageConfigurationHolder,
-                                annotationType);
+                return AnnotationReader.getAnnotationsFor(
+                        pageConfigurationHolder, annotationType);
             }
         }
 
@@ -367,7 +363,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          * pageConfigurationHolder of this context, if any.
          *
          * @return the theme definition, or empty if none is found, or
-         * pageConfigurationHolder is <code>null</code>
+         *         pageConfigurationHolder is <code>null</code>
          * @see UI#getThemeFor(Class, String)
          */
         protected Optional<ThemeDefinition> getTheme() {
@@ -386,7 +382,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          * Creates a new bootstrap resolver based on the given ui.
          *
          * @param ui
-         *         the ui to resolve for
+         *            the ui to resolve for
          */
         protected BootstrapUriResolver(UI ui) {
             this(ui.getInternals().getContextRootRelativePath(),
@@ -397,16 +393,16 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          * Creates a new bootstrap resolver based on the given session.
          *
          * @param contextRootRelatiePath
-         *         the relative path from the UI (servlet) path to the
-         *         context root
+         *            the relative path from the UI (servlet) path to the
+         *            context root
          * @param session
-         *         the vaadin session
+         *            the vaadin session
          */
         public BootstrapUriResolver(String contextRootRelatiePath,
                 VaadinSession session) {
             servletPathToContextRoot = contextRootRelatiePath;
             DeploymentConfiguration config = session.getConfiguration();
-            if(config.isCompatibilityMode()) {
+            if (config.isCompatibilityMode()) {
                 if (session.getBrowser().isEs6Supported()) {
                     frontendRootUrl = config.getEs6FrontendPrefix();
                 } else {
@@ -429,15 +425,14 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          * - resolves to the build path where web components were compiled.
          * Browsers supporting ES6 can receive different, more optimized files
          * than browsers that only support ES5.</li>
-         * <li><code>{@value ApplicationConstants#BASE_PROTOCOL_PREFIX}</code>
-         * -
+         * <li><code>{@value ApplicationConstants#BASE_PROTOCOL_PREFIX}</code> -
          * resolves to the base URI of the page</li>
          * </ul>
          * Any other URI protocols, such as <code>http://</code> or
          * <code>https://</code> are passed through this method unmodified.
          *
          * @param uri
-         *         the URI to resolve
+         *            the URI to resolve
          * @return the resolved URI
          */
         public String resolveVaadinUri(String uri) {
@@ -483,7 +478,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          * Creates the bootstrap page.
          *
          * @param context
-         *         Context to build page for.
+         *            Context to build page for.
          * @return A non-null {@link Document} with bootstrap page.
          */
         Document getBootstrapPage(BootstrapContext context);
@@ -501,7 +496,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          * Returns the bootstrap page for the given context.
          *
          * @param context
-         *         Context to generate bootstrap page for.
+         *            Context to generate bootstrap page for.
          * @return A document with the corresponding HTML page.
          */
         @Override
@@ -526,8 +521,8 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
 
             document.outputSettings().prettyPrint(false);
 
-            BootstrapUtils.getInlineTargets(context).ifPresent(
-                    targets -> handleInlineTargets(context, head,
+            BootstrapUtils.getInlineTargets(context)
+                    .ifPresent(targets -> handleInlineTargets(context, head,
                             document.body(), targets));
 
             BootstrapUtils.getInitialPageSettings(context).ifPresent(
@@ -567,8 +562,8 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             if (devMode != null) {
                 String errorMsg = devMode.getFailedOutput();
                 if (errorMsg != null) {
-                    document.body().appendChild(
-                            new Element(Tag.valueOf("div"), "")
+                    document.body()
+                            .appendChild(new Element(Tag.valueOf("div"), "")
                                     .attr("class", "v-system-error")
                                     .html("<h3>Webpack Error</h3><pre>"
                                             + errorMsg + "</pre>"));
@@ -589,8 +584,8 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
 
                 // Registers the entry in a way that is picked up as a Vaadin
                 // WebComponent by the usage stats gatherer
-                return String
-                        .format("window.Vaadin[%s]=%s;", escapedName, json);
+                return String.format("window.Vaadin[%s]=%s;", escapedName,
+                        json);
             }).collect(Collectors.joining("\n"));
 
             if (!registerScript.isEmpty()) {
@@ -612,8 +607,8 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             if (themeContents != null) {
                 themeContents.stream()
                         .map(dependency -> createDependencyElement(context,
-                                dependency)).forEach(
-                        element -> insertElements(element,
+                                dependency))
+                        .forEach(element -> insertElements(element,
                                 document.head()::appendChild));
             }
 
@@ -639,55 +634,59 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                 return createDependencyElement(context.getUriResolver(),
                         LoadMode.INLINE, dependencyJson, dependencyType);
             }
-            return Jsoup
-                    .parse(dependencyJson.getString(Dependency.KEY_CONTENTS),
-                            "", Parser.xmlParser());
+            return Jsoup.parse(
+                    dependencyJson.getString(Dependency.KEY_CONTENTS), "",
+                    Parser.xmlParser());
         }
 
         private void handleInlineTargets(BootstrapContext context, Element head,
                 Element body, InlineTargets targets) {
-            targets.getInlineHead(Inline.Position.PREPEND).stream()
-                    .map(dependency -> createDependencyElement(context,
-                            dependency)).forEach(
-                    element -> insertElements(element, head::prependChild));
-            targets.getInlineHead(Inline.Position.APPEND).stream()
-                    .map(dependency -> createDependencyElement(context,
-                            dependency)).forEach(
-                    element -> insertElements(element, head::appendChild));
+            targets.getInlineHead(Inline.Position.PREPEND).stream().map(
+                    dependency -> createDependencyElement(context, dependency))
+                    .forEach(element -> insertElements(element,
+                            head::prependChild));
+            targets.getInlineHead(Inline.Position.APPEND).stream().map(
+                    dependency -> createDependencyElement(context, dependency))
+                    .forEach(element -> insertElements(element,
+                            head::appendChild));
 
-            targets.getInlineBody(Inline.Position.PREPEND).stream()
-                    .map(dependency -> createDependencyElement(context,
-                            dependency)).forEach(
-                    element -> insertElements(element, body::prependChild));
-            targets.getInlineBody(Inline.Position.APPEND).stream()
-                    .map(dependency -> createDependencyElement(context,
-                            dependency)).forEach(
-                    element -> insertElements(element, body::appendChild));
+            targets.getInlineBody(Inline.Position.PREPEND).stream().map(
+                    dependency -> createDependencyElement(context, dependency))
+                    .forEach(element -> insertElements(element,
+                            body::prependChild));
+            targets.getInlineBody(Inline.Position.APPEND).stream().map(
+                    dependency -> createDependencyElement(context, dependency))
+                    .forEach(element -> insertElements(element,
+                            body::appendChild));
         }
 
         private void handleInitialPageSettings(BootstrapContext context,
                 Element head, InitialPageSettings initialPageSettings) {
             if (initialPageSettings.getViewport() != null) {
-                Elements viewport = head
-                        .getElementsByAttributeValue("name", VIEWPORT);
+                Elements viewport = head.getElementsByAttributeValue("name",
+                        VIEWPORT);
                 if (!viewport.isEmpty() && viewport.size() == 1) {
                     viewport.get(0).attr(CONTENT_ATTRIBUTE,
                             initialPageSettings.getViewport());
                 } else {
-                    head.appendElement(META_TAG).attr("name", VIEWPORT)
-                            .attr(CONTENT_ATTRIBUTE,
-                                    initialPageSettings.getViewport());
+                    head.appendElement(META_TAG).attr("name", VIEWPORT).attr(
+                            CONTENT_ATTRIBUTE,
+                            initialPageSettings.getViewport());
                 }
             }
 
             initialPageSettings.getInline(InitialPageSettings.Position.PREPEND)
-                    .stream().map(dependency -> createDependencyElement(context,
-                    dependency)).forEach(
-                    element -> insertElements(element, head::prependChild));
+                    .stream()
+                    .map(dependency -> createDependencyElement(context,
+                            dependency))
+                    .forEach(element -> insertElements(element,
+                            head::prependChild));
             initialPageSettings.getInline(InitialPageSettings.Position.APPEND)
-                    .stream().map(dependency -> createDependencyElement(context,
-                    dependency)).forEach(
-                    element -> insertElements(element, head::appendChild));
+                    .stream()
+                    .map(dependency -> createDependencyElement(context,
+                            dependency))
+                    .forEach(element -> insertElements(element,
+                            head::appendChild));
 
             initialPageSettings.getElement(InitialPageSettings.Position.PREPEND)
                     .forEach(element -> insertElements(element,
@@ -700,8 +699,9 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
         private void insertElements(Element element, Consumer<Element> action) {
             if (element instanceof Document) {
                 element.getAllElements().stream()
-                        .filter(item -> !(item instanceof Document) && element
-                                .equals(item.parent())).forEach(action::accept);
+                        .filter(item -> !(item instanceof Document)
+                                && element.equals(item.parent()))
+                        .forEach(action::accept);
             } else if (element != null) {
                 action.accept(element);
             }
@@ -725,7 +725,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          * bootstrap page.
          *
          * @param ui
-         *         the UI for which the UIDL should be generated
+         *            the UI for which the UIDL should be generated
          * @return a JSON object with the initial UIDL message
          */
         protected JsonObject getInitialUidl(UI ui) {
@@ -747,9 +747,9 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          * object.
          *
          * @param response
-         *         the response JSON object to write security key into
+         *            the response JSON object to write security key into
          * @param session
-         *         the vaadin session to which the security key belongs
+         *            the vaadin session to which the security key belongs
          */
         private void writePushIdUIDL(JsonObject response,
                 VaadinSession session) {
@@ -762,9 +762,9 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          * JSON object.
          *
          * @param response
-         *         the response JSON object to write security key into
+         *            the response JSON object to write security key into
          * @param ui
-         *         the UI to which the security key belongs
+         *            the UI to which the security key belongs
          */
         private void writeSecurityKeyUIDL(JsonObject response, UI ui) {
             String seckey = ui.getCsrfToken();
@@ -777,9 +777,9 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             List<Element> dependenciesToInlineInBody = new ArrayList<>();
             for (Map.Entry<LoadMode, JsonArray> entry : dependenciesToProcessOnServer
                     .entrySet()) {
-                dependenciesToInlineInBody.addAll(inlineDependenciesInHead(head,
-                        context.getUriResolver(), entry.getKey(),
-                        entry.getValue()));
+                dependenciesToInlineInBody.addAll(
+                        inlineDependenciesInHead(head, context.getUriResolver(),
+                                entry.getKey(), entry.getValue()));
             }
             return dependenciesToInlineInBody;
         }
@@ -828,11 +828,11 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                 inlineEs6Collections(head, context);
                 appendWebComponentsPolyfills(head, context);
             } else {
-                conf.getPolyfills().forEach(polyfill -> head.appendChild(
-                        createJavaScriptElement(
+                conf.getPolyfills().forEach(
+                        polyfill -> head.appendChild(createJavaScriptElement(
                                 "./" + VAADIN_MAPPING + polyfill, false)));
                 try {
-                    appendNpmBundle(head, service);
+                    appendNpmBundle(head, service, context);
                 } catch (IOException e) {
                     throw new BootstrapException(
                             "Unable to read webpack stats file.", e);
@@ -848,15 +848,15 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                     createJavaScriptElement(getClientEngineUrl(context)));
         }
 
-        private void appendNpmBundle(Element head, VaadinService service)
-                throws IOException {
+        private void appendNpmBundle(Element head, VaadinService service,
+                BootstrapContext context) throws IOException {
             String content = FrontendUtils.getStatsAssetsByChunkName(service);
             if (content == null) {
                 throw new IOException(
                         "The stats file from webpack (stats.json) was not found.\n"
-                        + "This typically mean that you have started the application without executing the 'prepare-frontend' Maven target.\n"
-                        + "If you are using Spring Boot and are launching the Application class directly, "
-                        + "you need to run \"mvn install\" once first or launch the application using \"mvn spring-boot:run\"");
+                                + "This typically mean that you have started the application without executing the 'prepare-frontend' Maven target.\n"
+                                + "If you are using Spring Boot and are launching the Application class directly, "
+                                + "you need to run \"mvn install\" once first or launch the application using \"mvn spring-boot:run\"");
             }
             JsonObject chunks = Json.parse(content);
 
@@ -874,15 +874,16 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
         private String getClientEngineUrl(BootstrapContext context) {
             // use nocache version of client engine if it
             // has been compiled by SDM or eclipse
-            // In production mode, this should really be loaded by the static block
+            // In production mode, this should really be loaded by the static
+            // block
             // so emit a warning if we get here (tests will always get here)
             final boolean productionMode = context.getSession()
                     .getConfiguration().isProductionMode();
 
             boolean resolveNow = !productionMode || getClientEngine() == null;
-            if (resolveNow && ClientResourcesUtils.getResource(
-                    "/META-INF/resources/" + CLIENT_ENGINE_NOCACHE_FILE)
-                    != null) {
+            if (resolveNow
+                    && ClientResourcesUtils.getResource("/META-INF/resources/"
+                            + CLIENT_ENGINE_NOCACHE_FILE) != null) {
                 return context.getUriResolver().resolveVaadinUri(
                         "context://" + CLIENT_ENGINE_NOCACHE_FILE);
             }
@@ -904,8 +905,8 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
         }
 
         private void setupCss(Element head, BootstrapContext context) {
-            Element styles = head.appendElement("style")
-                    .attr("type", CSS_TYPE_ATTRIBUTE_VALUE);
+            Element styles = head.appendElement("style").attr("type",
+                    CSS_TYPE_ATTRIBUTE_VALUE);
             // Add any body style that is defined for the application using
             // @BodySize
             String bodySizeContent = BootstrapUtils.getBodySizeContent(context);
@@ -941,13 +942,13 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
 
             head.appendElement("base").attr("href", getServiceUrl(context));
 
-            head.appendElement(META_TAG).attr("name", VIEWPORT)
-                    .attr(CONTENT_ATTRIBUTE,
-                            BootstrapUtils.getViewportContent(context)
-                                    .orElse(Viewport.DEFAULT));
+            head.appendElement(META_TAG).attr("name", VIEWPORT).attr(
+                    CONTENT_ATTRIBUTE,
+                    BootstrapUtils.getViewportContent(context)
+                            .orElse(Viewport.DEFAULT));
 
-            BootstrapUtils.getMetaTargets(context).forEach(
-                    (name, content) -> head.appendElement(META_TAG)
+            BootstrapUtils.getMetaTargets(context)
+                    .forEach((name, content) -> head.appendElement(META_TAG)
                             .attr("name", name)
                             .attr(CONTENT_ATTRIBUTE, content));
 
@@ -988,8 +989,8 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                         .attr(CONTENT_ATTRIBUTE, config.getThemeColor());
 
                 // Add manifest
-                head.appendElement("link").attr("rel", "manifest")
-                        .attr("href", config.getManifestPath());
+                head.appendElement("link").attr("rel", "manifest").attr("href",
+                        config.getManifestPath());
 
                 // Add icons
                 for (PwaIcon icon : registry.getHeaderIcons()) {
@@ -1038,8 +1039,8 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                         createInlineJavaScriptElement(BABEL_HELPERS_JS));
 
                 if (session.getBrowser().isEs5AdapterNeeded()) {
-                    head.appendChild(createJavaScriptElement(
-                            context.getUriResolver()
+                    head.appendChild(
+                            createJavaScriptElement(context.getUriResolver()
                                     .resolveVaadinUri(es5AdapterUrl), false));
                 }
             }
@@ -1061,12 +1062,12 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
         }
 
         private Element createJavaScriptElement(String sourceUrl,
-                                                boolean defer) {
+                boolean defer) {
             return createJavaScriptElement(sourceUrl, defer, "text/javascript");
         }
 
         private Element createJavaScriptElement(String sourceUrl, boolean defer,
-                                                String type) {
+                String type) {
             Element jsElement = new Element(Tag.valueOf(SCRIPT_TAG), "")
                     .attr("type", type).attr(DEFER_ATTRIBUTE, defer);
             if (sourceUrl != null) {
@@ -1083,10 +1084,10 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                 LoadMode loadMode, JsonObject dependency,
                 Dependency.Type type) {
             boolean inlineElement = loadMode == LoadMode.INLINE;
-            String url = dependency.hasKey(Dependency.KEY_URL) ?
-                    resolver.resolveVaadinUri(
-                            dependency.getString(Dependency.KEY_URL)) :
-                    null;
+            String url = dependency.hasKey(Dependency.KEY_URL)
+                    ? resolver.resolveVaadinUri(
+                            dependency.getString(Dependency.KEY_URL))
+                    : null;
 
             final Element dependencyElement;
             switch (type) {
@@ -1141,15 +1142,15 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                         .attr("type", CSS_TYPE_ATTRIBUTE_VALUE)
                         .attr("href", url);
             } else {
-                cssElement = new Element(Tag.valueOf("style"), "")
-                        .attr("type", CSS_TYPE_ATTRIBUTE_VALUE);
+                cssElement = new Element(Tag.valueOf("style"), "").attr("type",
+                        CSS_TYPE_ATTRIBUTE_VALUE);
             }
             return cssElement;
         }
 
         private void setupDocumentBody(Document document) {
-            document.body().appendElement("noscript")
-                    .append("You have to enable javascript in your browser to use this web site.");
+            document.body().appendElement("noscript").append(
+                    "You have to enable javascript in your browser to use this web site.");
         }
 
         private Element getPushScript(BootstrapContext context) {
@@ -1176,9 +1177,8 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
 
         private Element getBootstrapScript(JsonValue initialUIDL,
                 BootstrapContext context) {
-            return createInlineJavaScriptElement(
-                    "//<![CDATA[\n" + getBootstrapJS(initialUIDL, context)
-                            + "//]]>");
+            return createInlineJavaScriptElement("//<![CDATA[\n"
+                    + getBootstrapJS(initialUIDL, context) + "//]]>");
         }
 
         private String getBootstrapJS() {
@@ -1207,8 +1207,8 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             /*
              * The < symbol is escaped to prevent two problems:
              *
-             * 1 - The browser interprets </script> as end of script no matter if it
-             * is inside a string
+             * 1 - The browser interprets </script> as end of script no matter
+             * if it is inside a string
              *
              * 2 - Scripts can be injected with <!-- <script>, that can cause
              * unexpected behavior or complete crash of the app
@@ -1217,8 +1217,8 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
 
             if (!productionMode) {
                 // only used in debug mode by profiler
-                result = result
-                        .replace("{{GWT_STAT_EVENTS}}", GWT_STAT_EVENTS_JS);
+                result = result.replace("{{GWT_STAT_EVENTS}}",
+                        GWT_STAT_EVENTS_JS);
             } else {
                 result = result.replace("{{GWT_STAT_EVENTS}}", "");
             }
@@ -1231,7 +1231,8 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
 
             // set productionMode early because WC detector might be run before
             // client initialization finishes.
-            result = result.replace("{{PRODUCTION_MODE}}", String.valueOf(productionMode));
+            result = result.replace("{{PRODUCTION_MODE}}",
+                    String.valueOf(productionMode));
             return result;
         }
     }
@@ -1245,11 +1246,11 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
         }
 
         /**
-         * Creates application parameters for the provided {@link
-         * BootstrapContext}.
+         * Creates application parameters for the provided
+         * {@link BootstrapContext}.
          *
          * @param context
-         *         Non-null context to provide application parameters for.
+         *            Non-null context to provide application parameters for.
          * @return A non-null {@link JsonObject} with application parameters.
          */
         public JsonObject getApplicationParameters(BootstrapContext context) {
@@ -1343,7 +1344,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
      * Gets the service URL as a URL relative to the request URI.
      *
      * @param context
-     *         the bootstrap context
+     *            the bootstrap context
      * @return the relative service URL
      */
     protected static String getServiceUrl(BootstrapContext context) {
@@ -1365,7 +1366,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
      * cancels any pending JS execution for it.
      *
      * @param context
-     *         the bootstrap context
+     *            the bootstrap context
      * @return the optional initial page title
      */
     protected static Optional<String> resolvePageTitle(
@@ -1427,11 +1428,11 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
      * {@code request}, {@code response} and {@code ui}.
      *
      * @param request
-     *         the request object
+     *            the request object
      * @param response
-     *         the response object
+     *            the response object
      * @param ui
-     *         the UI object
+     *            the UI object
      * @return a new bootstrap context instance
      */
     protected BootstrapContext createBootstrapContext(VaadinRequest request,
@@ -1463,7 +1464,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
      * This method is protected for testing purposes.
      *
      * @param request
-     *         the request for the UI
+     *            the request for the UI
      * @return the UI class for the request
      */
     protected static Class<? extends UI> getUIClass(VaadinRequest request) {
@@ -1481,17 +1482,19 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                     .asSubclass(UI.class);
         } catch (ClassNotFoundException e) {
             throw new BootstrapException(
-                    "Vaadin Servlet mapped to the request path " + request
-                            .getPathInfo()
+                    "Vaadin Servlet mapped to the request path "
+                            + request.getPathInfo()
                             + " cannot find the mapped UI class with name "
-                            + uiClassName, e);
+                            + uiClassName,
+                    e);
         }
     }
 
     protected static String readResource(String fileName) {
-        try (InputStream stream = BootstrapHandler.class.getResourceAsStream(
-                fileName); BufferedReader bf = new BufferedReader(
-                new InputStreamReader(stream, StandardCharsets.UTF_8))) {
+        try (InputStream stream = BootstrapHandler.class
+                .getResourceAsStream(fileName);
+                BufferedReader bf = new BufferedReader(new InputStreamReader(
+                        stream, StandardCharsets.UTF_8))) {
             StringBuilder builder = new StringBuilder();
             bf.lines().forEach(builder::append);
             return builder.toString();
@@ -1509,8 +1512,8 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
 
         private static String readClientEngine() {
             // read client engine file name
-            try (InputStream prop = ClientResourcesUtils.getResource(
-                    "/META-INF/resources/"
+            try (InputStream prop = ClientResourcesUtils
+                    .getResource("/META-INF/resources/"
                             + ApplicationConstants.CLIENT_ENGINE_PATH
                             + "/compile.properties")) {
                 // null when running SDM or tests
@@ -1520,8 +1523,8 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                     return ApplicationConstants.CLIENT_ENGINE_PATH + "/"
                             + properties.getProperty("jsFile");
                 } else {
-                    getLogger()
-                            .warn("No compile.properties available on initialization, "
+                    getLogger().warn(
+                            "No compile.properties available on initialization, "
                                     + "could not read client engine file name.");
                 }
             } catch (IOException e) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -63,6 +63,7 @@ import com.vaadin.flow.internal.AnnotationReader;
 import com.vaadin.flow.internal.ReflectTools;
 import com.vaadin.flow.internal.UrlUtil;
 import com.vaadin.flow.internal.UsageStatistics;
+import com.vaadin.flow.internal.UsageStatistics.UsageEntry;
 import com.vaadin.flow.server.BootstrapUtils.ThemeSettings;
 import com.vaadin.flow.server.communication.AtmospherePushConnection;
 import com.vaadin.flow.server.communication.PushConnectionFactory;
@@ -535,7 +536,11 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             }
 
             if (!config.isProductionMode()) {
-                exportUsageStatistics(document);
+                if (config.isBowerMode()) {
+                    exportBowerUsageStatistics(document);
+                } else {
+                    exportNpmUsageStatistics(document);
+                }
             }
 
             setupPwa(document, context);
@@ -571,16 +576,11 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             }
         }
 
-        private void exportUsageStatistics(Document document) {
+        private void exportBowerUsageStatistics(Document document) {
             String registerScript = UsageStatistics.getEntries().map(entry -> {
-                String name = entry.getName();
-                String version = entry.getVersion();
+                String json = createUsageStatisticsJson(entry);
 
-                JsonObject json = Json.createObject();
-                json.put("is", name);
-                json.put("version", version);
-
-                String escapedName = Json.create(name).toJson();
+                String escapedName = Json.create(entry.getName()).toJson();
 
                 // Registers the entry in a way that is picked up as a Vaadin
                 // WebComponent by the usage stats gatherer
@@ -591,6 +591,30 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             if (!registerScript.isEmpty()) {
                 document.body().appendElement(SCRIPT_TAG).text(registerScript);
             }
+        }
+
+        private void exportNpmUsageStatistics(Document document) {
+            String entries = UsageStatistics.getEntries()
+                    .map(BootstrapPageBuilder::createUsageStatisticsJson)
+                    .collect(Collectors.joining(","));
+
+            if (!entries.isEmpty()) {
+                // Registers the entries in a way that is picked up as a Vaadin
+                // WebComponent by the usage stats gatherer
+                document.body().appendElement(SCRIPT_TAG)
+                        .text("window.Vaadin.registrations = window.Vaadin.registrations || [];\n"
+                                + "window.Vaadin.registrations.push(" + entries
+                                + ");");
+            }
+        }
+
+        private static String createUsageStatisticsJson(UsageEntry entry) {
+            JsonObject json = Json.createObject();
+
+            json.put("is", entry.getName());
+            json.put("version", entry.getVersion());
+
+            return json.toJson();
         }
 
         private void handleThemeContents(BootstrapContext context,
@@ -1099,11 +1123,12 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                         !inlineElement);
                 break;
             case JS_MODULE:
-                if (url != null && UrlUtil.isExternal(url))
+                if (url != null && UrlUtil.isExternal(url)) {
                     dependencyElement = createJavaScriptElement(url,
                             !inlineElement, "module");
-                else
+                } else {
                     dependencyElement = null;
+                }
                 break;
             case HTML_IMPORT:
                 dependencyElement = createHtmlImportElement(url);

--- a/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
@@ -38,8 +38,11 @@ public class DefaultDeploymentConfiguration
     private static final String SEPARATOR = "\n====================================================================";
 
     public static final String NOT_PRODUCTION_MODE_INFO = SEPARATOR
-            + "\nVaadin is running in DEBUG MODE.\nAdd productionMode=true to web.xml "
-            + "to disable debug features." + SEPARATOR;
+            + "\nVaadin is running in DEBUG MODE.\n" +
+            "In order to run your application in production mode and disable debug features, " +
+            "you should enable it by setting the servlet init parameter productionMode to true.\n" +
+            "See https://vaadin.com/docs/v14/flow/production/tutorial-production-mode-basic.html " +
+            "for more information about the production mode." + SEPARATOR;
 
     public static final String WARNING_COMPATIBILITY_MODE = SEPARATOR
             + "\nRunning in Vaadin 13 (Flow 1) compatibility mode.\n\n"

--- a/flow-server/src/main/resources/com/vaadin/flow/server/webcomponent/webcomponent-script-template.js
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/webcomponent/webcomponent-script-template.js
@@ -100,7 +100,17 @@ class _TagCamel_ extends HTMLElement {
 
     poller();
   }
+  _getClient() {
+    if (_TagCamel_._getClientStrategy){
+        return _TagCamel_._getClientStrategy(this);
+    }
+    var clients = _TagCamel_._getClients();
+    if (!clients){
+        return undefined;
+    }
 
+    return Object.values(clients).find(client => client.exportedWebComponents && client.exportedWebComponents.indexOf('_TagDash_') != -1)
+  }
   disconnectedCallback() {
     this.$server.disconnected();
 
@@ -158,5 +168,12 @@ class _TagCamel_ extends HTMLElement {
 }
 
 _TagCamel_.id = 0;
+
+_TagCamel_._getClients = function(){
+    if (!window.Vaadin || !window.Vaadin.Flow || !window.Vaadin.Flow.clients) {
+        return undefined;
+    }
+    return window.Vaadin.Flow.clients;
+}
 
 customElements.define('_TagDash_', _TagCamel_);

--- a/flow-tests/test-dev-mode/src/main/java/com/vaadin/flow/uitest/ui/frontend/FrontendProtocolView.java
+++ b/flow-tests/test-dev-mode/src/main/java/com/vaadin/flow/uitest/ui/frontend/FrontendProtocolView.java
@@ -15,12 +15,12 @@
  */
 package com.vaadin.flow.uitest.ui.frontend;
 
-import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 
 /**
  * Wrapper view for the {@link FrontendProtocolTemplate} component. This class

--- a/flow-tests/test-dev-mode/src/test/java/com/vaadin/flow/uitest/ui/frontend/FrontendProtocolIT.java
+++ b/flow-tests/test-dev-mode/src/test/java/com/vaadin/flow/uitest/ui/frontend/FrontendProtocolIT.java
@@ -80,14 +80,14 @@ public class FrontendProtocolIT extends ChromeBrowserTest {
         Assert.assertEquals("File loaded from property-defined path",
                 getComponentInnerText());
 
-        Assert.assertEquals(
-                getRootURL()
-                        + "/frontend/com/vaadin/flow/uitest/components/frontend-protocol.html",
+        Assert.assertEquals(getRootURL()
+                + "/frontend/com/vaadin/flow/uitest/components/frontend-protocol.html",
                 executeClientSideResolveUri());
     }
 
     private Object executeClientSideResolveUri() {
-        return executeScript("return window.Vaadin.Flow.resolveUri(arguments[0]);",
+        return executeScript(
+                "return window.Vaadin.Flow.clients[window.Vaadin.Flow.getAppIds()[0].replace(/-\\d+$/, '')].resolveUri(arguments[0]);",
                 "frontend://components/frontend-protocol.html");
     }
 


### PR DESCRIPTION
@denis-anisimov can you check that the cherry-pick of "Use application id to call client side app context methods (#6702)" looks correct. Since 2.0 does not have fallback chunk, there were a lot of conflicts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6723)
<!-- Reviewable:end -->
