### PR TITLE
Correction 2.1.portal-SNAPSHOT to 2.2-SNAPSHOT in two tests

### DIFF
--- a/flow-tests/test-no-root-context/pom.xml
+++ b/flow-tests/test-no-root-context/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>2.1.portal-SNAPSHOT</version>
+        <version>2.2-SNAPSHOT</version>
     </parent>
     <artifactId>test-no-root-context</artifactId>
     <name>Test servlets with no root context mapping</name>

--- a/flow-tests/test-no-theme/pom.xml
+++ b/flow-tests/test-no-theme/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>2.1.portal-SNAPSHOT</version>
+        <version>2.2-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-no-theme</artifactId>
     <name>Flow tests for no theme in NPM mode</name>


### PR DESCRIPTION
Corrects merge-oops in https://github.com/vaadin/flow/pull/6722

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6727)
<!-- Reviewable:end -->
