### PR TITLE
Remove redundancy from CssImport javadocs

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/dependency/CssImport.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/dependency/CssImport.java
@@ -24,7 +24,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Instructs flow to import a CSS file into the application bundle.
+ * Imports a CSS file into the application bundle.
  * <p>
  * The CSS files should be located in the place as JS module files:
  * <ul>


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6731)
<!-- Reviewable:end -->
