### PR TITLE
CCDM: generate OpenAPI in DevMode

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
@@ -167,8 +167,9 @@ public class PrepareFrontendMojo extends FlowModeAbstractMojo {
         }
 
         try {
-            new NodeTasks.Builder(getClassFinder(project), npmFolder,
-                    generatedFolder, frontendDirectory)
+            new NodeTasks.Builder(
+                    getClassFinder(project), npmFolder, generatedFolder,
+                    frontendDirectory)
                             .withWebpack(webpackOutputDirectory,
                                     webpackTemplate, webpackGeneratedTemplate)
                             .enableClientSideMode(isClientSideMode())
@@ -180,7 +181,6 @@ public class PrepareFrontendMojo extends FlowModeAbstractMojo {
                             .withConnectJavaSourceFolder(javaSourceFolder)
                             .withConnectGeneratedOpenApiJson(openApiJsonFile)
                             .build().execute();
-
         } catch (ExecutionFailedException exception) {
             throw new MojoFailureException(
                     "Could not execute prepare-frontend goal.", exception);

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
@@ -167,9 +167,8 @@ public class PrepareFrontendMojo extends FlowModeAbstractMojo {
         }
 
         try {
-            new NodeTasks.Builder(
-                    getClassFinder(project), npmFolder, generatedFolder,
-                    frontendDirectory)
+            new NodeTasks.Builder(getClassFinder(project), npmFolder,
+                    generatedFolder, frontendDirectory)
                             .withWebpack(webpackOutputDirectory,
                                     webpackTemplate, webpackGeneratedTemplate)
                             .enableClientSideMode(isClientSideMode())
@@ -181,6 +180,7 @@ public class PrepareFrontendMojo extends FlowModeAbstractMojo {
                             .withConnectJavaSourceFolder(javaSourceFolder)
                             .withConnectGeneratedOpenApiJson(openApiJsonFile)
                             .build().execute();
+
         } catch (ExecutionFailedException exception) {
             throw new MojoFailureException(
                     "Could not execute prepare-frontend goal.", exception);

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
@@ -41,9 +41,11 @@ import elemental.json.JsonObject;
 import elemental.json.impl.JsonUtil;
 
 import static com.vaadin.flow.plugin.common.FlowPluginFrontendUtils.getClassFinder;
+import static com.vaadin.flow.server.Constants.CONNECT_APPLICATION_PROPERTIES_TOKEN;
+import static com.vaadin.flow.server.Constants.CONNECT_JAVA_SOURCE_FOLDER_TOKEN;
+import static com.vaadin.flow.server.Constants.CONNECT_OPEN_API_FILE_TOKEN;
 import static com.vaadin.flow.server.Constants.FRONTEND_TOKEN;
 import static com.vaadin.flow.server.Constants.GENERATED_TOKEN;
-import static com.vaadin.flow.server.Constants.JAVA_SOURCE_FOLDER_TOKEN;
 import static com.vaadin.flow.server.Constants.NPM_TOKEN;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_CLIENT_SIDE_MODE;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE;
@@ -198,8 +200,12 @@ public class PrepareFrontendMojo extends FlowModeAbstractMojo {
         buildInfo.put(NPM_TOKEN, npmFolder.getAbsolutePath());
         buildInfo.put(GENERATED_TOKEN, generatedFolder.getAbsolutePath());
         buildInfo.put(FRONTEND_TOKEN, frontendDirectory.getAbsolutePath());
-        buildInfo.put(JAVA_SOURCE_FOLDER_TOKEN,
+        buildInfo.put(CONNECT_JAVA_SOURCE_FOLDER_TOKEN,
                 javaSourceFolder.getAbsolutePath());
+        buildInfo.put(CONNECT_APPLICATION_PROPERTIES_TOKEN,
+                applicationProperties.getAbsolutePath());
+        buildInfo.put(CONNECT_OPEN_API_FILE_TOKEN,
+                openApiJsonFile.getAbsolutePath());
         try {
             FileUtils.forceMkdir(token.getParentFile());
             FileUtils.write(token, JsonUtil.stringify(buildInfo, 2) + "\n",

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
@@ -88,6 +88,9 @@ public class PrepareFrontendMojoTest {
         ReflectionUtils.setVariableValueInObject(mojo, "openApiJsonFile",
                 new File(projectBase,
                         "target/generated-resources/openapi.json"));
+        ReflectionUtils.setVariableValueInObject(mojo, "applicationProperties",
+                new File(projectBase,
+                        "src/main/resources/application.properties"));
         ReflectionUtils.setVariableValueInObject(mojo, "javaSourceFolder",
                 defaultJavaSource);
 

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
@@ -17,8 +17,9 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
+import com.vaadin.flow.server.connect.VaadinService;
+
 import elemental.json.Json;
-import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 import elemental.json.impl.JsonUtil;
 
@@ -218,5 +219,10 @@ public class PrepareFrontendMojoTest {
             }
             return Collections.emptyList();
         }
+    }
+
+    @VaadinService
+    public static class MyService {
+        // an empty class to generate OpenAPI spec.
     }
 }

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
@@ -25,7 +25,6 @@ import elemental.json.impl.JsonUtil;
 import static com.vaadin.flow.plugin.maven.BuildFrontendMojoTest.assertContainsPackage;
 import static com.vaadin.flow.plugin.maven.BuildFrontendMojoTest.getPackageJson;
 import static com.vaadin.flow.plugin.maven.BuildFrontendMojoTest.setProject;
-import static com.vaadin.flow.server.Constants.JAVA_SOURCE_FOLDER_TOKEN;
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_CLIENT_SIDE_MODE;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE;

--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -40,7 +40,9 @@ public final class Constants implements Serializable {
     public static final String NPM_TOKEN = "npmFolder";
     public static final String FRONTEND_TOKEN = "frontendFolder";
     public static final String GENERATED_TOKEN = "generatedFolder";
-    public static final String JAVA_SOURCE_FOLDER_TOKEN = "javaSourceFolder";
+    public static final String CONNECT_JAVA_SOURCE_FOLDER_TOKEN = "connect.javaSourceFolder";
+    public static final String CONNECT_APPLICATION_PROPERTIES_TOKEN = "connect.applicationProperties";
+    public static final String CONNECT_OPEN_API_FILE_TOKEN = "connect.openApiFile";
 
     /**
      * enable it if your project is a Polymer 2.0 one, should be removed in V15

--- a/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
@@ -31,6 +31,8 @@ import java.util.Enumeration;
 import java.util.Optional;
 import java.util.Properties;
 
+import static com.vaadin.flow.server.Constants.CONNECT_APPLICATION_PROPERTIES_TOKEN;
+import static com.vaadin.flow.server.Constants.CONNECT_OPEN_API_FILE_TOKEN;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.LoggerFactory;
 
@@ -45,6 +47,7 @@ import elemental.json.JsonObject;
 import elemental.json.impl.JsonUtil;
 
 import static com.vaadin.flow.server.Constants.FRONTEND_TOKEN;
+import static com.vaadin.flow.server.Constants.CONNECT_JAVA_SOURCE_FOLDER_TOKEN;
 import static com.vaadin.flow.server.Constants.NPM_TOKEN;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_CLIENT_SIDE_MODE;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE;
@@ -277,6 +280,21 @@ public final class DeploymentConfigurationFactory implements Serializable {
                 initParameters.setProperty(SERVLET_PARAMETER_REUSE_DEV_SERVER,
                         String.valueOf(buildInfo.getBoolean(
                                 SERVLET_PARAMETER_REUSE_DEV_SERVER)));
+            }
+
+            if (buildInfo.hasKey(CONNECT_JAVA_SOURCE_FOLDER_TOKEN)) {
+                initParameters.setProperty(CONNECT_JAVA_SOURCE_FOLDER_TOKEN,
+                        buildInfo.getString(CONNECT_JAVA_SOURCE_FOLDER_TOKEN));
+            }
+
+            if (buildInfo.hasKey(CONNECT_OPEN_API_FILE_TOKEN)) {
+                initParameters.setProperty(CONNECT_OPEN_API_FILE_TOKEN,
+                        buildInfo.getString(CONNECT_OPEN_API_FILE_TOKEN));
+            }
+
+            if (buildInfo.hasKey(CONNECT_APPLICATION_PROPERTIES_TOKEN)) {
+                initParameters.setProperty(CONNECT_APPLICATION_PROPERTIES_TOKEN,
+                        buildInfo.getString(CONNECT_APPLICATION_PROPERTIES_TOKEN));
             }
 
             FallbackChunk fallbackChunk = FrontendUtils

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -140,11 +140,22 @@ public class FrontendUtils {
      */
     public static final String INDEX_JS = "index.js";
 
+    /**
+     * Default Java source folder for OpenAPI generator.
+     */
     public static final String DEFAULT_CONNECT_JAVA_SOURCE_FOLDER = "src/main/java";
 
+    /**
+     * Default application properties file path in Connect project.
+     */
     public static final String DEFAULT_CONNECT_APPLICATION_PROPERTIES = "src/main/resources/application.properties";
+
+    /**
+     * Default generated path for OpenAPI spec file.
+     */
     public static final String DEFAULT_CONNECT_OPENAPI_JSON_FILE = TARGET
             + "generated-resources/openapi.json";
+
     /**
      * Name of the file that contains all application imports, javascript, theme
      * and style annotations which are not discovered by the current scanning

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -140,8 +140,7 @@ public class FrontendUtils {
      */
     public static final String INDEX_JS = "index.js";
 
-    public static final String DEFAULT_CONNECT_JAVA_SOURCE_FOLDER = "src/main"
-            + "/java";
+    public static final String DEFAULT_CONNECT_JAVA_SOURCE_FOLDER = "src/main/java";
 
     public static final String DEFAULT_CONNECT_APPLICATION_PROPERTIES = "src/main/resources/application.properties";
     public static final String DEFAULT_CONNECT_OPENAPI_JSON_FILE = TARGET

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -140,6 +140,12 @@ public class FrontendUtils {
      */
     public static final String INDEX_JS = "index.js";
 
+    public static final String DEFAULT_CONNECT_JAVA_SOURCE_FOLDER = "src/main"
+            + "/java";
+
+    public static final String DEFAULT_CONNECT_APPLICATION_PROPERTIES = "src/main/resources/application.properties";
+    public static final String DEFAULT_CONNECT_OPENAPI_JSON_FILE = TARGET
+            + "generated-resources/openapi.json";
     /**
      * Name of the file that contains all application imports, javascript, theme
      * and style annotations which are not discovered by the current scanning

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.FallibleCommand;
+import com.vaadin.flow.server.connect.VaadinService;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 
@@ -479,8 +480,7 @@ public class NodeTasks implements FallibleCommand {
             TaskGenerateTsConfig taskGenerateTsConfig = new TaskGenerateTsConfig(
                     builder.frontendDirectory, builder.npmFolder);
             commands.add(taskGenerateTsConfig);
-            if (builder.connectJavaSourceFolder != null
-                    && builder.connectGeneratedOpenApiFile != null) {
+            if (shouldGenerateOpenApi(builder)) {
                 TaskGenerateOpenApi taskGenerateOpenApi = new TaskGenerateOpenApi(
                         builder.connectApplicationProperties,
                         builder.connectJavaSourceFolder,
@@ -489,6 +489,13 @@ public class NodeTasks implements FallibleCommand {
                 commands.add(taskGenerateOpenApi);
             }
         }
+    }
+
+    private boolean shouldGenerateOpenApi(Builder builder) {
+        return builder.connectJavaSourceFolder != null
+                && builder.connectGeneratedOpenApiFile != null
+                && !builder.classFinder.getAnnotatedClasses(VaadinService.class)
+                        .isEmpty();
     }
 
     private FrontendDependenciesScanner getFallbackScanner(Builder builder,

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -37,6 +37,7 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -256,17 +257,21 @@ public class DevModeInitializer implements ServletContainerInitializer,
             builder.withWebpack(builder.npmFolder, FrontendUtils.WEBPACK_CONFIG,
                     FrontendUtils.WEBPACK_GENERATED);
         }
-        builder.enableClientSideMode(config.isClientSideMode());
+
         if (config.isClientSideMode()) {
+            builder.enableClientSideMode(config.isClientSideMode());
             String connectJavaSourceFolder = config.getStringProperty(
                     CONNECT_JAVA_SOURCE_FOLDER_TOKEN,
-                    DEFAULT_CONNECT_JAVA_SOURCE_FOLDER);
+                    Paths.get(baseDir, DEFAULT_CONNECT_JAVA_SOURCE_FOLDER)
+                            .toString());
             String connectApplicationProperties = config.getStringProperty(
                     CONNECT_APPLICATION_PROPERTIES_TOKEN,
-                    DEFAULT_CONNECT_APPLICATION_PROPERTIES);
+                    Paths.get(baseDir, DEFAULT_CONNECT_APPLICATION_PROPERTIES)
+                            .toString());
             String connectOpenApiJsonFile = config.getStringProperty(
                     CONNECT_OPEN_API_FILE_TOKEN,
-                    DEFAULT_CONNECT_OPENAPI_JSON_FILE);
+                    Paths.get(baseDir, DEFAULT_CONNECT_OPENAPI_JSON_FILE)
+                            .toString());
             builder.withConnectJavaSourceFolder(
                     new File(connectJavaSourceFolder))
                     .withConnectApplicationProperties(

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -229,8 +229,7 @@ public class DevModeInitializer implements ServletContainerInitializer,
         String frontendFolder = config.getStringProperty(PARAM_FRONTEND_DIR,
                 System.getProperty(PARAM_FRONTEND_DIR, DEFAULT_FRONTEND_DIR));
 
-        DevModeClassFinder devModeClassFinder = new DevModeClassFinder(classes);
-        Builder builder = new NodeTasks.Builder(devModeClassFinder,
+        Builder builder = new NodeTasks.Builder(new DevModeClassFinder(classes),
                 new File(baseDir), new File(generatedDir),
                 new File(frontendFolder));
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeClassFinderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeClassFinderTest.java
@@ -67,7 +67,8 @@ public class DevModeClassFinderTest {
             CssImport.class,
             CssImport.Container.class,
             Theme.class,
-            NoTheme.class);
+            NoTheme.class,
+            VaadinService.class);
 
         for (Class<?> clz : classes) {
             assertTrue("should be a known class " + clz.getName(), knownClasses.contains(clz));

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
@@ -236,7 +236,7 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
         Assert.assertFalse(generatedOpenApiJson.exists());
         devModeInitializer.onStartup(classes, servletContext);
         Assert.assertFalse(
-                "Should generate OpenAPI spec if VaadinService is used.",
+                "Should not generate OpenAPI spec if VaadinService is not used.",
                 generatedOpenApiJson.exists());
     }
 


### PR DESCRIPTION
Fixes #6642 
This PR triggers the generator in DevModeInitializer if `@VaadinService` is used. The regenerate works out of the box if `enableDevServer` is true and the application use `spring-boot-devtools` or jetty auto reload.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6734)
<!-- Reviewable:end -->
