### PR TITLE
Enable fat-/uber-jar production mode (#6685)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
@@ -25,6 +25,7 @@ import java.io.Serializable;
 import java.io.UncheckedIOException;
 import java.lang.reflect.Method;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;


### PR DESCRIPTION
* Enable fat-/uber-jar production mode

Be more strict with the resource filter.
Accept production mode build file in
production mode build, this enables
production mode in fat- and uber-jars.

Fixes #6679

(cherry picked from commit 64531679dbf0854a7659156c1170325706fb95e8)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6735)
<!-- Reviewable:end -->
