### PR TITLE
Maven plugin: include javax.servlet-api as well if in provided dependencies for bytecode scanner

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/common/FlowPluginFrontendUtils.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/common/FlowPluginFrontendUtils.java
@@ -38,7 +38,7 @@ public class FlowPluginFrontendUtils {
      * Additionally include compile-time-only dependencies matching the pattern.
      */
     private static final String INCLUDE_FROM_COMPILE_DEPS_REGEX =
-            ".*(/|\\\\)portlet-api-.+jar$";
+            ".*(/|\\\\)(portlet-api|javax\\.servlet-api)-.+jar$";
 
     private FlowPluginFrontendUtils() {
     }


### PR DESCRIPTION
For the bytecode scanner to not throw an exception for or ignore classes in `javax.servlet`.  Needed for refactoring of `VaadinPortlet`.

This PR will most likely make #6678 unreproducible. Still this PR is kind of temporary fix and a proper solution should be devised so the ticket is still valid.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6769)
<!-- Reviewable:end -->
