### PR TITLE
Pass response object to WebComponentBootstrapHandler::getServiceUrl and WebComponentProvider::generateNPMResponse

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
@@ -135,7 +135,7 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
                     + PATH_PATTERN.toString());
         }
 
-        String serviceUrl = getServiceUrl(request);
+        String serviceUrl = getServiceUrl(request, response);
 
         String pushURL = context.getSession().getConfiguration().getPushURL();
         if (pushURL == null) {
@@ -188,7 +188,7 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
             ServletHelper.setResponseNoCacheHeaders(response::setHeader,
                     response::setDateHeader);
 
-            String serviceUrl = getServiceUrl(request);
+            String serviceUrl = getServiceUrl(request, response);
 
             Document document = getPageBuilder().getBootstrapPage(context);
             writeBootstrapPage(response, document.head(), serviceUrl);
@@ -342,7 +342,8 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
      * @param request Request.
      * @return Service url for the given request.
      */
-    protected String getServiceUrl(VaadinRequest request) {
+    protected String getServiceUrl(VaadinRequest request,
+            VaadinResponse response) {
         // get service url from 'url' parameter
         String url = request.getParameter(REQ_PARAM_URL);
         // if 'url' parameter was not available, use request url

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
@@ -339,7 +339,11 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
 
     /**
      * Returns the service url needed for initialising the UI.
-     * @param request Request.
+     * 
+     * @param request
+     *            the request object
+     * @param response
+     *            the response object
      * @return Service url for the given request.
      */
     protected String getServiceUrl(VaadinRequest request,

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentProvider.java
@@ -250,6 +250,8 @@ public class WebComponentProvider extends SynchronizedRequestHandler {
      *         tag name of component
      * @param request
      *         current VaadinRequest
+     * @param response
+     *         current VaadinResponse
      * @return npm response script
      */
     protected String generateNPMResponse(String tagName, VaadinRequest request,

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentProvider.java
@@ -144,7 +144,7 @@ public class WebComponentProvider extends SynchronizedRequestHandler {
                 response.setContentType(CONTENT_TYPE_TEXT_JAVASCRIPT_UTF_8);
                 responder = () ->
                         generateNPMResponse(webComponentConfiguration.getTag(),
-                                request);
+                                request, response);
             }
             if (cache == null) {
                 generated = responder.get();
@@ -252,7 +252,8 @@ public class WebComponentProvider extends SynchronizedRequestHandler {
      *         current VaadinRequest
      * @return npm response script
      */
-    protected String generateNPMResponse(String tagName, VaadinRequest request) {
+    protected String generateNPMResponse(String tagName, VaadinRequest request,
+            VaadinResponse response) {
         // get the running script
         return getThisScript(tagName) + "var scriptUri = thisScript.src;"
                 + "var index = scriptUri.lastIndexOf('" + WEB_COMPONENT_PATH


### PR DESCRIPTION
As discussed in the [portlet-support PR 63](https://github.com/vaadin/portlet-support/pull/63), pass the response object to overridden methods in order to not have to rely on static methods for getting the current response in internal code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6775)
<!-- Reviewable:end -->
