### PR TITLE
Show error in console when dynamic import fails

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/ResourceLoader.java
+++ b/flow-client/src/main/java/com/vaadin/client/ResourceLoader.java
@@ -775,9 +775,10 @@ public class ResourceLoader {
                 throw new Error('The expression "'+expression+'" result is not a Promise.');
             }
             promise.then( function(result) { onSuccess.@java.lang.Runnable::run(*)(); } ,
-                          function(error) { onError.@java.lang.Runnable::run(*)(); } );
+                          function(error) { console.error(error); onError.@java.lang.Runnable::run(*)(); } );
           }
           catch(error) {
+               console.error(error);
                onError.@java.lang.Runnable::run(*)();
           }
     }-*/;

--- a/flow-test-util/src/main/java/com/vaadin/flow/testutil/TestBenchHelpers.java
+++ b/flow-test-util/src/main/java/com/vaadin/flow/testutil/TestBenchHelpers.java
@@ -324,6 +324,9 @@ public class TestBenchHelpers extends ParallelTest {
      * @return log entries from the browser
      */
     protected List<LogEntry> getLogEntries(Level level) {
+        // https://github.com/vaadin/testbench/issues/1233
+        getCommandExecutor().waitForVaadin();
+
         return driver.manage().logs().get(LogType.BROWSER).getAll().stream()
                 .filter(logEntry -> logEntry.getLevel().intValue() >= level
                         .intValue())

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/dependencies/DynamicDependencyView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/dependencies/DynamicDependencyView.java
@@ -16,27 +16,46 @@
 package com.vaadin.flow.uitest.ui.dependencies;
 
 import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.Route;
 
 @Route("com.vaadin.flow.uitest.ui.dependencies.DynamicDependencyView")
 public class DynamicDependencyView extends Div {
+    private final Div newComponent = new Div();
 
     @Override
     protected void onAttach(AttachEvent attachEvent) {
         if (attachEvent.isInitialAttach()) {
-            Div div = new Div();
-            div.setId("new-component");
-            add(div);
+            newComponent.setId("new-component");
+            add(newComponent);
 
             attachEvent.getUI().getPage()
                     .addDynamicImport("return new Promise( "
-                            + " function( resolve, regject){ "
+                            + " function( resolve, reject){ "
                             + "   var div = document.createElement(\"div\");\n"
                             + "     div.setAttribute('id','dep');\n"
                             + "     div.textContent = document.querySelector('#new-component')==null;\n"
                             + "     document.body.appendChild(div);resolve('');}"
                             + ");");
+
+            add(createLoadButton("nopromise", "Load non-promise dependency",
+                    "document.querySelector('#new-component').textContent = 'import has been run'"));
+            add(createLoadButton("throw", "Load throwing dependency",
+                    "throw Error('Throw on purpose')"));
+            add(createLoadButton("reject", "Load rejecting dependency",
+                    "return new Promise(function(resolve, reject) { reject(Error('Reject on purpose')); });"));
         }
+    }
+
+    private NativeButton createLoadButton(String id, String name,
+            String expression) {
+        NativeButton button = new NativeButton(name, event -> {
+            UI.getCurrent().getPage().addDynamicImport(expression);
+            newComponent.setText("Div updated for " + id);
+        });
+        button.setId(id);
+        return button;
     }
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/dependencies/DynamicDependencyIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/dependencies/DynamicDependencyIT.java
@@ -15,10 +15,15 @@
  */
 package com.vaadin.flow.uitest.ui.dependencies;
 
+import java.util.List;
+import java.util.logging.Level;
+
+import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.logging.LogEntry;
 
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
@@ -31,5 +36,39 @@ public class DynamicDependencyIT extends ChromeBrowserTest {
         WebElement depElement = findElement(By.id("dep"));
         // true means that the added component (a new one) is not yet in the DOM
         Assert.assertEquals(Boolean.TRUE.toString(), depElement.getText());
+    }
+
+    @Test
+    public void dependecyIsNoPromise_errorLogged() {
+        testErrorCase("nopromise", "result is not a Promise");
+    }
+
+    @Test
+    public void dependecyLoaderThrows_errorLogged()
+            throws InterruptedException {
+        testErrorCase("throw", "Throw on purpose");
+    }
+
+    @Test
+    public void dependecyLoaderRejects_errorLogged()
+            throws InterruptedException {
+        testErrorCase("reject", "Reject on purpose");
+    }
+
+    private void testErrorCase(String caseName, String errorMessageSnippet) {
+        open();
+
+        findElement(By.id(caseName)).click();
+
+        String statusText = findElement(By.id("new-component")).getText();
+        Assert.assertEquals("Div updated for " + caseName, statusText);
+
+        List<LogEntry> entries = getLogEntries(Level.SEVERE);
+        Assert.assertEquals(2, entries.size());
+
+        Assert.assertThat(entries.get(0).getMessage(),
+                Matchers.containsString(errorMessageSnippet));
+        Assert.assertThat(entries.get(1).getMessage(),
+                Matchers.containsString("could not be loaded"));
     }
 }


### PR DESCRIPTION
No automatic test since there isn't any easy way of testing browser
console log output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6778)
<!-- Reviewable:end -->
