### PR TITLE
CCDM: check userPrincipal for non-anonymous methods

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -170,19 +170,19 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
             <version>${spring.version}</version>
-            <scope>provided</scope>
+<!--            <scope>provided</scope>-->
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
             <version>${spring.version}</version>
-            <scope>provided</scope>
+<!--            <scope>provided</scope>-->
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
             <version>${spring.autoconfigure.version}</version>
-            <scope>provided</scope>
+<!--            <scope>provided</scope>-->
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -170,19 +170,19 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
             <version>${spring.version}</version>
-<!--            <scope>provided</scope>-->
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webmvc</artifactId>
             <version>${spring.version}</version>
-<!--            <scope>provided</scope>-->
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
             <version>${spring.autoconfigure.version}</version>
-<!--            <scope>provided</scope>-->
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectController.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectController.java
@@ -239,6 +239,8 @@ public class VaadinConnectController {
      * @param body
      *            optional request body, that should be specified if the method
      *            called has parameters
+     * @param request
+     *            the current request which triggers the service call
      * @return execution result as a JSON string or an error message string
      */
     @PostMapping(path = "/{service}/{method}", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectController.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectController.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.server.connect;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
@@ -244,7 +245,8 @@ public class VaadinConnectController {
     public ResponseEntity<String> serveVaadinService(
             @PathVariable("service") String serviceName,
             @PathVariable("method") String methodName,
-            @RequestBody(required = false) ObjectNode body) {
+            @RequestBody(required = false) ObjectNode body,
+            HttpServletRequest request) {
         getLogger().debug("Service: {}, method: {}, request body: {}",
                 serviceName, methodName, body);
 
@@ -265,7 +267,7 @@ public class VaadinConnectController {
 
         try {
             return invokeVaadinServiceMethod(serviceName, methodName,
-                    methodToInvoke, body, vaadinServiceData);
+                    methodToInvoke, body, vaadinServiceData, request);
         } catch (JsonProcessingException e) {
             String errorMessage = String.format(
                     "Failed to serialize service '%s' method '%s' response. "
@@ -287,9 +289,9 @@ public class VaadinConnectController {
 
     private ResponseEntity<String> invokeVaadinServiceMethod(String serviceName,
             String methodName, Method methodToInvoke, ObjectNode body,
-            VaadinServiceData vaadinServiceData)
+            VaadinServiceData vaadinServiceData, HttpServletRequest request)
             throws JsonProcessingException {
-        String checkError = accessChecker.check(methodToInvoke);
+        String checkError = accessChecker.check(methodToInvoke, request);
         if (checkError != null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(createResponseErrorObject(String.format(

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/auth/VaadinConnectAccessChecker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/auth/VaadinConnectAccessChecker.java
@@ -19,10 +19,12 @@ package com.vaadin.flow.server.connect.auth;
 import javax.annotation.security.DenyAll;
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
+import javax.servlet.http.HttpServletRequest;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.security.Principal;
 
 /**
  * Component used for checking role-based ACL in Vaadin Services.
@@ -75,9 +77,8 @@ public class VaadinConnectAccessChecker {
      * @return an error String with an issue description, if any validation
      *         issues occur, {@code null} otherwise
      */
-    public String check(Method method) {
-        // NOP, will be implemented soon
-        return null;
+    public String check(Method method, HttpServletRequest request) {
+        return verifyAnonymousUser(method, request);
     }
 
     /**
@@ -98,6 +99,15 @@ public class VaadinConnectAccessChecker {
         }
         return hasSecurityAnnotation(method) ? method
                 : method.getDeclaringClass();
+    }
+
+    private String verifyAnonymousUser(Method method,
+            HttpServletRequest request) {
+        if (getSecurityTarget(method).isAnnotationPresent(
+                AnonymousAllowed.class) || request.getUserPrincipal() != null) {
+            return null;
+        }
+        return "Anonymous access is not allowed";
     }
 
     private boolean hasSecurityAnnotation(Method method) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/auth/VaadinConnectAccessChecker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/auth/VaadinConnectAccessChecker.java
@@ -24,7 +24,6 @@ import javax.servlet.http.HttpServletRequest;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.security.Principal;
 
 /**
  * Component used for checking role-based ACL in Vaadin Services.
@@ -74,6 +73,8 @@ public class VaadinConnectAccessChecker {
      *
      * @param method
      *            the vaadin service method to check ACL
+     * @param request
+     *            the request triggers the <code>method</code> invocation
      * @return an error String with an issue description, if any validation
      *         issues occur, {@code null} otherwise
      */

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/VaadinConnectControllerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/VaadinConnectControllerTest.java
@@ -60,6 +60,7 @@ public class VaadinConnectControllerTest {
     private static final Method TEST_METHOD;
     private static final Method TEST_VALIDATION_METHOD;
     private HttpServletRequest requestMock;
+
     static {
         TEST_METHOD = Stream.of(TEST_SERVICE.getClass().getDeclaredMethods())
                 .filter(method -> "testMethod".equals(method.getName()))
@@ -126,6 +127,7 @@ public class VaadinConnectControllerTest {
         requestMock = mock(HttpServletRequest.class);
         when(requestMock.getUserPrincipal()).thenReturn(mock(Principal.class));
     }
+
     @Test
     public void should_ThrowException_When_ContextHasNoBeanData() {
         String beanName = "test";
@@ -271,16 +273,7 @@ public class VaadinConnectControllerTest {
 
     @Test
     public void should_NotCallMethod_When_UserPrincipalIsNull() {
-        when(requestMock.getUserPrincipal()).thenReturn(null);
-        VaadinConnectAccessChecker accessCheckerMock = new VaadinConnectAccessChecker();
-
-        VaadinServiceNameChecker nameCheckerMock = mock(
-                VaadinServiceNameChecker.class);
-        when(nameCheckerMock.check(TEST_SERVICE_NAME)).thenReturn(null);
-
-        VaadinConnectController vaadinController = createVaadinController(
-                TEST_SERVICE, new ObjectMapper(), accessCheckerMock,
-                nameCheckerMock);
+        VaadinConnectController vaadinController = createVaadinControllerWithoutPrincipal();
         ResponseEntity<String> response = vaadinController.serveVaadinService(
                 TEST_SERVICE_NAME, TEST_METHOD.getName(),
                 createRequestParameters("{\"value\": 222}"), requestMock);
@@ -294,16 +287,7 @@ public class VaadinConnectControllerTest {
 
     @Test
     public void should_CallMethodAnonymously_When_UserPrincipalIsNullAndAnonymousAllowed() {
-        when(requestMock.getUserPrincipal()).thenReturn(null);
-        VaadinConnectAccessChecker accessCheckerMock = new VaadinConnectAccessChecker();
-
-        VaadinServiceNameChecker nameCheckerMock = mock(
-                VaadinServiceNameChecker.class);
-        when(nameCheckerMock.check(TEST_SERVICE_NAME)).thenReturn(null);
-
-        VaadinConnectController vaadinController = createVaadinController(
-                TEST_SERVICE, new ObjectMapper(), accessCheckerMock,
-                nameCheckerMock);
+        VaadinConnectController vaadinController = createVaadinControllerWithoutPrincipal();
         ResponseEntity<String> response = vaadinController.serveVaadinService(
                 TEST_SERVICE_NAME, "testAnonymousMethod",
                 createRequestParameters("{}"), requestMock);
@@ -866,6 +850,18 @@ public class VaadinConnectControllerTest {
                 .thenReturn((Class) serviceClass);
         return new VaadinConnectController(vaadinServiceMapper, accessChecker,
                 serviceNameChecker, contextMock);
+    }
+
+    private VaadinConnectController createVaadinControllerWithoutPrincipal() {
+        when(requestMock.getUserPrincipal()).thenReturn(null);
+        VaadinConnectAccessChecker accessCheckerMock = new VaadinConnectAccessChecker();
+
+        VaadinServiceNameChecker nameCheckerMock = mock(
+                VaadinServiceNameChecker.class);
+        when(nameCheckerMock.check(TEST_SERVICE_NAME)).thenReturn(null);
+
+        return createVaadinController(TEST_SERVICE, new ObjectMapper(),
+                accessCheckerMock, nameCheckerMock);
     }
 
     private Method createServiceMethodMockThatThrows(Object argument,

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/VaadinConnectControllerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/VaadinConnectControllerTest.java
@@ -1,11 +1,13 @@
 package com.vaadin.flow.server.connect;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.security.Principal;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -20,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.type.SimpleType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -55,7 +58,7 @@ public class VaadinConnectControllerTest {
             .getSimpleName();
     private static final Method TEST_METHOD;
     private static final Method TEST_VALIDATION_METHOD;
-
+    private HttpServletRequest requestMock;
     static {
         TEST_METHOD = Stream.of(TEST_SERVICE.getClass().getDeclaredMethods())
                 .filter(method -> "testMethod".equals(method.getName()))
@@ -112,6 +115,11 @@ public class VaadinConnectControllerTest {
     @Rule
     public final ExpectedException exception = ExpectedException.none();
 
+    @Before
+    public void setUp() {
+        requestMock = mock(HttpServletRequest.class);
+        when(requestMock.getUserPrincipal()).thenReturn(mock(Principal.class));
+    }
     @Test
     public void should_ThrowException_When_ContextHasNoBeanData() {
         String beanName = "test";
@@ -120,7 +128,6 @@ public class VaadinConnectControllerTest {
         when(contextMock.getType(beanName)).thenReturn(null);
         when(contextMock.getBeansWithAnnotation(VaadinService.class))
                 .thenReturn(Collections.singletonMap(beanName, null));
-
         exception.expect(IllegalStateException.class);
         exception.expectMessage(beanName);
         new VaadinConnectController(mock(ObjectMapper.class), null, null,
@@ -163,7 +170,7 @@ public class VaadinConnectControllerTest {
         assertNotEquals(missingServiceName, TEST_SERVICE_NAME);
 
         ResponseEntity<?> response = createVaadinController(TEST_SERVICE)
-                .serveVaadinService(missingServiceName, null, null);
+                .serveVaadinService(missingServiceName, null, null, requestMock);
 
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
     }
@@ -175,7 +182,7 @@ public class VaadinConnectControllerTest {
 
         ResponseEntity<?> response = createVaadinController(TEST_SERVICE)
                 .serveVaadinService(TEST_SERVICE_NAME, missingServiceMethod,
-                        null);
+                        null, requestMock);
 
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
         assertNull(response.getBody());
@@ -187,7 +194,7 @@ public class VaadinConnectControllerTest {
 
         VaadinConnectAccessChecker restrictingCheckerMock = mock(
                 VaadinConnectAccessChecker.class);
-        when(restrictingCheckerMock.check(TEST_METHOD))
+        when(restrictingCheckerMock.check(TEST_METHOD, requestMock))
                 .thenReturn(accessErrorMessage);
 
         VaadinServiceNameChecker nameCheckerMock = mock(
@@ -197,7 +204,7 @@ public class VaadinConnectControllerTest {
         ResponseEntity<String> response = createVaadinController(TEST_SERVICE,
                 new ObjectMapper(), restrictingCheckerMock, nameCheckerMock)
                         .serveVaadinService(TEST_SERVICE_NAME,
-                                TEST_METHOD.getName(), null);
+                                TEST_METHOD.getName(), null, requestMock);
 
         assertEquals(HttpStatus.UNAUTHORIZED, response.getStatusCode());
         String responseBody = response.getBody();
@@ -205,15 +212,15 @@ public class VaadinConnectControllerTest {
         assertTrue(String.format("Invalid response body: '%s'", responseBody),
                 responseBody.contains(accessErrorMessage));
 
-        verify(restrictingCheckerMock, only()).check(TEST_METHOD);
-        verify(restrictingCheckerMock, times(1)).check(TEST_METHOD);
+        verify(restrictingCheckerMock, only()).check(TEST_METHOD, requestMock);
+        verify(restrictingCheckerMock, times(1)).check(TEST_METHOD, requestMock);
     }
 
     @Test
     public void should_Return400_When_LessParametersSpecified1() {
         ResponseEntity<String> response = createVaadinController(TEST_SERVICE)
                 .serveVaadinService(TEST_SERVICE_NAME, TEST_METHOD.getName(),
-                        null);
+                        null, requestMock);
 
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         String responseBody = response.getBody();
@@ -230,7 +237,7 @@ public class VaadinConnectControllerTest {
         ResponseEntity<String> response = createVaadinController(TEST_SERVICE)
                 .serveVaadinService(TEST_SERVICE_NAME, TEST_METHOD.getName(),
                         createRequestParameters(
-                                "{\"value1\": 222, \"value2\": 333}"));
+                                "{\"value1\": 222, \"value2\": 333}"), requestMock);
 
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         String responseBody = response.getBody();
@@ -246,7 +253,7 @@ public class VaadinConnectControllerTest {
     public void should_Return400_When_IncorrectParameterTypesAreProvided() {
         ResponseEntity<String> response = createVaadinController(TEST_SERVICE)
                 .serveVaadinService(TEST_SERVICE_NAME, TEST_METHOD.getName(),
-                        createRequestParameters("{\"value\": [222]}"));
+                        createRequestParameters("{\"value\": [222]}"), requestMock);
 
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         String responseBody = response.getBody();
@@ -273,7 +280,7 @@ public class VaadinConnectControllerTest {
         ResponseEntity<String> response = controller.serveVaadinService(
                 TEST_SERVICE_NAME, TEST_METHOD.getName(),
                 createRequestParameters(
-                        String.format("{\"value\": %s}", inputValue)));
+                        String.format("{\"value\": %s}", inputValue)), requestMock);
 
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         String responseBody = response.getBody();
@@ -303,7 +310,7 @@ public class VaadinConnectControllerTest {
         ResponseEntity<String> response = controller.serveVaadinService(
                 TEST_SERVICE_NAME, TEST_METHOD.getName(),
                 createRequestParameters(
-                        String.format("{\"value\": %s}", inputValue)));
+                        String.format("{\"value\": %s}", inputValue)), requestMock);
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR,
                 response.getStatusCode());
@@ -334,7 +341,7 @@ public class VaadinConnectControllerTest {
         ResponseEntity<String> response = controller.serveVaadinService(
                 TEST_SERVICE_NAME, TEST_METHOD.getName(),
                 createRequestParameters(
-                        String.format("{\"value\": %s}", inputValue)));
+                        String.format("{\"value\": %s}", inputValue)), requestMock);
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR,
                 response.getStatusCode());
@@ -366,7 +373,7 @@ public class VaadinConnectControllerTest {
         ResponseEntity<String> response = controller.serveVaadinService(
                 TEST_SERVICE_NAME, TEST_METHOD.getName(),
                 createRequestParameters(
-                        String.format("{\"value\": %s}", inputValue)));
+                        String.format("{\"value\": %s}", inputValue)), requestMock);
 
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         String responseBody = response.getBody();
@@ -403,7 +410,7 @@ public class VaadinConnectControllerTest {
         ResponseEntity<String> response = controller.serveVaadinService(
                 TEST_SERVICE_NAME, TEST_METHOD.getName(),
                 createRequestParameters(
-                        String.format("{\"value\": %s}", inputValue)));
+                        String.format("{\"value\": %s}", inputValue)), requestMock);
 
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         String responseBody = response.getBody();
@@ -439,7 +446,7 @@ public class VaadinConnectControllerTest {
         ResponseEntity<String> response = createVaadinController(TEST_SERVICE,
                 mapperMock).serveVaadinService(TEST_SERVICE_NAME,
                         TEST_METHOD.getName(),
-                        createRequestParameters("{\"value\": 222}"));
+                        createRequestParameters("{\"value\": 222}"), requestMock);
 
         assertEquals(HttpStatus.INTERNAL_SERVER_ERROR,
                 response.getStatusCode());
@@ -478,7 +485,7 @@ public class VaadinConnectControllerTest {
         exception.expectMessage("Unexpected");
         createVaadinController(TEST_SERVICE, mapperMock).serveVaadinService(
                 TEST_SERVICE_NAME, TEST_METHOD.getName(),
-                createRequestParameters("{\"value\": 222}"));
+                createRequestParameters("{\"value\": 222}"), requestMock);
     }
 
     @Test
@@ -489,7 +496,7 @@ public class VaadinConnectControllerTest {
         ResponseEntity<String> response = createVaadinController(TEST_SERVICE)
                 .serveVaadinService(TEST_SERVICE_NAME, TEST_METHOD.getName(),
                         createRequestParameters(
-                                String.format("{\"value\": %s}", inputValue)));
+                                String.format("{\"value\": %s}", inputValue)), requestMock);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(String.format("\"%s\"", expectedOutput),
@@ -505,7 +512,7 @@ public class VaadinConnectControllerTest {
         ResponseEntity<String> response = createVaadinController(testService)
                 .serveVaadinService(testService.getClass().getSimpleName(),
                         testMethodName, createRequestParameters(String.format(
-                                "{\"value\": {\"id\": \"%s\"}}", inputId)));
+                                "{\"value\": {\"id\": \"%s\"}}", inputId)), requestMock);
         assertEquals(expectedResult, response.getBody());
     }
 
@@ -518,7 +525,7 @@ public class VaadinConnectControllerTest {
         ResponseEntity<String> response = createVaadinController(testService)
                 .serveVaadinService(testService.getClass().getSimpleName(),
                         testMethodName, createRequestParameters(
-                                String.format("{\"value\": %s}", inputId)));
+                                String.format("{\"value\": %s}", inputId)), requestMock);
         assertEquals(inputId, response.getBody());
     }
 
@@ -531,7 +538,7 @@ public class VaadinConnectControllerTest {
         ResponseEntity<String> response = createVaadinController(testService)
                 .serveVaadinService(testService.getClass().getSimpleName(),
                         testMethodName, createRequestParameters(
-                                String.format("{\"value\": %s}", inputId)));
+                                String.format("{\"value\": %s}", inputId)), requestMock);
         assertEquals(inputId, response.getBody());
     }
 
@@ -555,7 +562,7 @@ public class VaadinConnectControllerTest {
         ResponseEntity<String> response = vaadinConnectController
                 .serveVaadinService("CustomService", "testMethod",
                         createRequestParameters(
-                                String.format("{\"value\": %s}", input)));
+                                String.format("{\"value\": %s}", input)), requestMock);
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(String.format("\"%s\"", expectedOutput),
                 response.getBody());
@@ -628,7 +635,7 @@ public class VaadinConnectControllerTest {
         ResponseEntity<String> response = createVaadinController(TEST_SERVICE)
                 .serveVaadinService(TEST_SERVICE_NAME, TEST_METHOD.getName(),
                         createRequestParameters(
-                                String.format("{\"value\": %s}", inputValue)));
+                                String.format("{\"value\": %s}", inputValue)), requestMock);
 
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         ObjectNode jsonNodes = new ObjectMapper().readValue(response.getBody(),
@@ -659,7 +666,7 @@ public class VaadinConnectControllerTest {
                 TEST_SERVICE_NAME, testMethodName);
         ResponseEntity<String> response = createVaadinController(TEST_SERVICE)
                 .serveVaadinService(TEST_SERVICE_NAME, testMethodName,
-                        createRequestParameters(inputValue));
+                        createRequestParameters(inputValue), requestMock);
 
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         ObjectNode jsonNodes = new ObjectMapper().readValue(response.getBody(),
@@ -688,7 +695,7 @@ public class VaadinConnectControllerTest {
         ResponseEntity<String> response = createVaadinController(TEST_SERVICE)
                 .serveVaadinService(TEST_SERVICE_NAME,
                         TEST_VALIDATION_METHOD.getName(),
-                        createRequestParameters("{\"parameter\": null}"));
+                        createRequestParameters("{\"parameter\": null}"), requestMock);
 
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         ObjectNode jsonNodes = new ObjectMapper().readValue(response.getBody(),
@@ -726,7 +733,7 @@ public class VaadinConnectControllerTest {
                         TEST_VALIDATION_METHOD.getName(),
                         createRequestParameters(String.format(
                                 "{\"parameter\": {\"count\": %d}}",
-                                invalidPropertyValue)));
+                                invalidPropertyValue)), requestMock);
 
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         ObjectNode jsonNodes = new ObjectMapper().readValue(response.getBody(),
@@ -771,7 +778,7 @@ public class VaadinConnectControllerTest {
     private <T> VaadinConnectController createVaadinController(T service) {
         VaadinConnectAccessChecker accessCheckerMock = mock(
                 VaadinConnectAccessChecker.class);
-        when(accessCheckerMock.check(TEST_METHOD)).thenReturn(null);
+        when(accessCheckerMock.check(TEST_METHOD, requestMock)).thenReturn(null);
 
         VaadinServiceNameChecker nameCheckerMock = mock(
                 VaadinServiceNameChecker.class);
@@ -785,7 +792,7 @@ public class VaadinConnectControllerTest {
             ObjectMapper vaadinServiceMapper) {
         VaadinConnectAccessChecker accessCheckerMock = mock(
                 VaadinConnectAccessChecker.class);
-        when(accessCheckerMock.check(TEST_METHOD)).thenReturn(null);
+        when(accessCheckerMock.check(TEST_METHOD, requestMock)).thenReturn(null);
 
         VaadinServiceNameChecker nameCheckerMock = mock(
                 VaadinServiceNameChecker.class);

--- a/flow-tests/test-ccdm-connect/frontend/src/test-component.js
+++ b/flow-tests/test-ccdm-connect/frontend/src/test-component.js
@@ -7,6 +7,7 @@ class TestComponent extends PolymerElement {
     return html`
         <button id="button">Click</button>
         <button id="connect" on-click="connect">Click</button>
+        <button id="connectAnonymous" on-click="connectAnonymous">Click anonymous</button>
         <div id="content"></div>
     `;
   }
@@ -21,5 +22,12 @@ class TestComponent extends PolymerElement {
       .then(response => this.$.content.textContent = response)
       .catch(error => this.$.content.textContent = 'Error:' + error);
   }
+
+  connectAnonymous(e) {
+      connectServices
+        .helloAnonymous()
+        .then(response => this.$.content.textContent = response)
+        .catch(error => this.$.content.textContent = 'Error:' + error);
+    }
 }
 customElements.define(TestComponent.is, TestComponent);

--- a/flow-tests/test-ccdm-connect/src/main/java/com/vaadin/flow/connect/ConnectServices.java
+++ b/flow-tests/test-ccdm-connect/src/main/java/com/vaadin/flow/connect/ConnectServices.java
@@ -1,14 +1,20 @@
 package com.vaadin.flow.connect;
 
 import com.vaadin.flow.server.connect.VaadinService;
+import com.vaadin.flow.server.connect.auth.AnonymousAllowed;
 
 /**
  * Simple Vaadin Connect Service definition.
  */
 @VaadinService
 public class ConnectServices {
-    
+
     public String hello(String name) {
         return "Hello, " + name + "!";
+    }
+
+    @AnonymousAllowed
+    public String helloAnonymous() {
+        return "Hello, stranger!";
     }
 }

--- a/flow-tests/test-ccdm-connect/src/main/java/com/vaadin/flow/connect/VaadinView.java
+++ b/flow-tests/test-ccdm-connect/src/main/java/com/vaadin/flow/connect/VaadinView.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.connect;
 
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.VaadinRequest;
 
 @Route(value = "")
 public class VaadinView extends Div {

--- a/flow-tests/test-ccdm-connect/src/test/java/com/vaadin/flow/connect/VaadinViewIT.java
+++ b/flow-tests/test-ccdm-connect/src/test/java/com/vaadin/flow/connect/VaadinViewIT.java
@@ -65,6 +65,18 @@ public class VaadinViewIT extends ChromeBrowserTest {
         WebElement content = testComponent.$(TestBenchElement.class).id("content");
         // Wait for the server connect response
         waitUntil(ExpectedConditions.textToBePresentInElement(content,
-                "Hello, Friend!"), 25);
+                "Anonymous access is not allowed"), 25);
+    }
+
+    @Test
+    public void should_requestAnonymously_connect_service() throws Exception {
+        WebElement button = testComponent.$(TestBenchElement.class).id(
+                "connectAnonymous");
+        button.click();
+
+        WebElement content = testComponent.$(TestBenchElement.class).id("content");
+        // Wait for the server connect response
+        waitUntil(ExpectedConditions.textToBePresentInElement(content,
+                "Hello, stranger!"), 25);
     }
 }


### PR DESCRIPTION
Connected to #6754 
Use `accessChecker` to verify the method accessibility. If the method/class is annotated with `@AnonymousAllowed`, the method is publicly available. Otherwise, `HttpServletRequest.getUserPrincipal()` should return a not null Principal object to access the method.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6782)
<!-- Reviewable:end -->
