### PR TITLE
include flow-server-production-mode into flow-bom

### DIFF
--- a/flow-bom/pom.xml
+++ b/flow-bom/pom.xml
@@ -40,6 +40,11 @@
             </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>
+                <artifactId>flow-server-production-mode</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.vaadin</groupId>
                 <artifactId>flow-html-components-testbench</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
Including the `flow-server-production-mode` module flow-bom allows using flow-bom in production-mode builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6786)
<!-- Reviewable:end -->
