### PR TITLE
Binder: revalidate when invalid-property changed elsewhere

### DIFF
--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -479,6 +479,23 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
     }
 
     @Test
+    public void changeInvalidManually_binderRevalidates() {
+        binder.forField(nameField)
+                .withValidator(value -> value.length() > 1, "Error from binder")
+                .bind(Person::getFirstName, Person::setFirstName);
+        binder.setBean(item);
+
+        nameField.setValue("aa");
+        nameField.setInvalid(true);
+        nameField.setErrorMessage("Other error");
+        assertValidField(nameField);
+
+        nameField.setValue("a");
+        nameField.setInvalid(false);
+        assertInvalidField("Error from binder", nameField);
+    }
+
+    @Test
     public void setRequired_withErrorMessage_fieldGetsRequiredIndicatorAndValidator() {
         TestTextField textField = new TestTextField();
         assertFalse(textField.isRequiredIndicatorVisible());
@@ -1344,7 +1361,6 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
 
         binder.readBean(new AtomicReference<>());
     }
-
 
     @Test
     public void nullRejetingField_otherRejectedValue_originalExceptionIsThrown() {

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/testcomponents/AbstractTestHasValueAndValidation.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/testcomponents/AbstractTestHasValueAndValidation.java
@@ -15,7 +15,6 @@ public abstract class AbstractTestHasValueAndValidation<C extends AbstractSingle
     }
 
     private String errorMessage = "";
-    private boolean invalid;
 
     @Override
     public void setErrorMessage(String errorMessage) {
@@ -32,11 +31,11 @@ public abstract class AbstractTestHasValueAndValidation<C extends AbstractSingle
 
     @Override
     public void setInvalid(boolean invalid) {
-        this.invalid = invalid;
+        getElement().setProperty("invalid", invalid);
     }
 
     @Override
     public boolean isInvalid() {
-        return invalid;
+        return getElement().getProperty("invalid", false);
     }
 }


### PR DESCRIPTION
This prevents the server-side validation built into the Flow components from overriding the Binder validation.

Fix for https://github.com/vaadin/vaadin-text-field-flow/issues/257 (tests should be added to `TextField` repo before closing the issue). The problem exists in other field components with server-side validation as well.

This is a temporary fix, which can be included in a maintenance release.

A proper fix would require new API and a minor release: #6803. After that change is released and components integrated with the new API, this temporary fix can be reverted.

More comprehensive explanation can be found in https://docs.google.com/document/d/1XY06swbXDMev4UEN3RLS5r8b4Mx1Kro4yTyCg2CGYBo/edit#
(visible only for Vaadin employees)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6801)
<!-- Reviewable:end -->
