### PR TITLE
Implement VaadinConfig

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
@@ -452,6 +452,9 @@ public final class DeploymentConfigurationFactory implements Serializable {
 
     }
 
+    /**
+     * Servlet exception for configuration read exception.
+     */
     public static class RuntimeServletException extends RuntimeException {
 
         /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
@@ -144,18 +144,18 @@ public final class DeploymentConfigurationFactory implements Serializable {
 
         // Read default parameters from server.xml
         final VaadinContext context = vaadinConfig.getVaadinContext();
-        for (final Enumeration<String> e = context.getInitParameterNames(); e
+        for (final Enumeration<String> e = context.getContextParameterNames(); e
                 .hasMoreElements();) {
             final String name = e.nextElement();
-            initParameters.setProperty(name, context.getInitParameter(name));
+            initParameters.setProperty(name, context.getContextParameter(name));
         }
 
         // Override with application config from web.xml
         for (final Enumeration<String> e = vaadinConfig
-                .getInitParameterNames(); e.hasMoreElements(); ) {
+                .getConfigParameterNames(); e.hasMoreElements(); ) {
             final String name = e.nextElement();
             initParameters
-                    .setProperty(name, vaadinConfig.getInitParameter(name));
+                    .setProperty(name, vaadinConfig.getConfigParameter(name));
         }
 
         readBuildInfo(initParameters);

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinConfig.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinConfig.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.flow.server;
 
 import java.io.Serializable;

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinConfig.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinConfig.java
@@ -1,0 +1,46 @@
+package com.vaadin.flow.server;
+
+import java.io.Serializable;
+import java.util.Enumeration;
+
+/**
+ * Configuration in which {@link VaadinService} is running.
+ * This is a wrapper for Config objects for instance <code>ServletConfig</code> and
+ * <code>PortletConfig</code>.
+ *
+ * @since
+ */
+public interface VaadinConfig extends Serializable {
+
+    /**
+     * Get the VaadinContext for this configuration.
+     *
+     * @return VaadinContext object for this VaadinConfiguration
+     */
+    VaadinContext getVaadinContext();
+
+    /**
+     * Returns the names of the context's initialization parameters as an
+     * <code>Enumeration</code> of <code>String</code> objects, or an
+     * empty <code>Enumeration</code> if the context has no initialization
+     * parameters.
+     *
+     * @return an <code>Enumeration</code> of <code>String</code>
+     * objects containing the names of the context's
+     * initialization parameters
+     */
+    Enumeration<String> getInitParameterNames();
+
+    /**
+     * Returns a <code>String</code> containing the value of the named
+     * initialization parameter, or <code>null</code> if the
+     * parameter does not exist.
+     *
+     * @param name
+     *         a <code>String</code> containing the name of the
+     *         parameter whose value is requested
+     * @return parameter value as <code>String</code> or <code>null</code> for
+     * no parameter
+     */
+    String getInitParameter(String name);
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinConfig.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinConfig.java
@@ -20,8 +20,8 @@ import java.util.Enumeration;
 
 /**
  * Configuration in which {@link VaadinService} is running.
- * This is a wrapper for Config objects for instance <code>ServletConfig</code> and
- * <code>PortletConfig</code>.
+ * This is a wrapper for Config objects for instance <code>ServletConfig</code>
+ * and <code>PortletConfig</code>.
  *
  * @since
  */
@@ -35,27 +35,22 @@ public interface VaadinConfig extends Serializable {
     VaadinContext getVaadinContext();
 
     /**
-     * Returns the names of the context's initialization parameters as an
-     * <code>Enumeration</code> of <code>String</code> objects, or an
-     * empty <code>Enumeration</code> if the context has no initialization
-     * parameters.
+     * Returns the names of the initialization parameters as an
+     * <code>Enumeration</code>, or an empty <code>Enumeration</code> if there
+     * are o initialization parameters.
      *
-     * @return an <code>Enumeration</code> of <code>String</code>
-     * objects containing the names of the context's
-     * initialization parameters
+     * @return initialization parameters as a <code>Enumeration</code>
      */
-    Enumeration<String> getInitParameterNames();
+    Enumeration<String> getConfigParameterNames();
 
     /**
-     * Returns a <code>String</code> containing the value of the named
-     * initialization parameter, or <code>null</code> if the
-     * parameter does not exist.
+     * Returns the value for the requested parameter, or <code>null</code> if
+     * the parameter does not exist.
      *
      * @param name
-     *         a <code>String</code> containing the name of the
-     *         parameter whose value is requested
+     *         name of the parameter whose value is requested
      * @return parameter value as <code>String</code> or <code>null</code> for
      * no parameter
      */
-    String getInitParameter(String name);
+    String getConfigParameter(String name);
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinConfigurationException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinConfigurationException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server;
+
+/**
+ * Exception thrown for failures in the generation of a deployment configuration
+ * object.
+ */
+public class VaadinConfigurationException extends Exception {
+
+    /**
+     * Exception constructor.
+     *
+     * @param message
+     *         exception message
+     * @param exception
+     *         exception cause
+     */
+    public VaadinConfigurationException(String message, Exception exception) {
+        super(message, exception);
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinContext.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinContext.java
@@ -77,26 +77,22 @@ public interface VaadinContext extends Serializable {
     void removeAttribute(Class<?> clazz);
 
     /**
-     * Returns the names of the context's initialization parameters as an
-     * <code>Enumeration</code> of <code>String</code> objects, or an
-     * empty <code>Enumeration</code> if the context has no initialization
-     * parameters.
+     * Returns the names of the initialization parameters as an
+     * <code>Enumeration</code>, or an empty <code>Enumeration</code> if there
+     * are o initialization parameters.
      *
-     * @return an <code>Enumeration</code> of <code>String</code>
-     * objects containing the names of the context's
-     * initialization parameters
+     * @return initialization parameters as a <code>Enumeration</code>
      */
-    Enumeration<String> getInitParameterNames();
+    Enumeration<String> getContextParameterNames();
 
     /**
-     * Returns a <code>String</code> containing the value of the named
-     * initialization parameter, or <code>null</code> if the
-     * parameter does not exist.
+     * Returns the value for the requested parameter, or <code>null</code> if
+     * the parameter does not exist.
      *
+     * @param name
+     *         name of the parameter whose value is requested
      * @return parameter value as <code>String</code> or <code>null</code> for
      * no parameter
-     * @param    name    a <code>String</code> containing the name of the
-     * parameter whose value is requested
      */
-    String getInitParameter(String name);
+    String getContextParameter(String name);
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinContext.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinContext.java
@@ -16,15 +16,17 @@
 package com.vaadin.flow.server;
 
 import java.io.Serializable;
+import java.util.Enumeration;
 import java.util.function.Supplier;
 
 /**
  * Context in which {@link VaadinService} is running.
  *
- * It is used to store service-scoped attributes.
+ * This is used to store service-scoped attributes and also works as a wrapper
+ * for context objects with properties e.g. <code>ServletContext</code> and
+ * <code>PortletContext</code>
  *
- * @author miki
- * @since 14.0.0
+ * @since 2.0.0
  */
 public interface VaadinContext extends Serializable {
 
@@ -73,4 +75,28 @@ public interface VaadinContext extends Serializable {
      * @see #setAttribute(Object) for setting attributes.
      */
     void removeAttribute(Class<?> clazz);
+
+    /**
+     * Returns the names of the context's initialization parameters as an
+     * <code>Enumeration</code> of <code>String</code> objects, or an
+     * empty <code>Enumeration</code> if the context has no initialization
+     * parameters.
+     *
+     * @return an <code>Enumeration</code> of <code>String</code>
+     * objects containing the names of the context's
+     * initialization parameters
+     */
+    Enumeration<String> getInitParameterNames();
+
+    /**
+     * Returns a <code>String</code> containing the value of the named
+     * initialization parameter, or <code>null</code> if the
+     * parameter does not exist.
+     *
+     * @return parameter value as <code>String</code> or <code>null</code> for
+     * no parameter
+     * @param    name    a <code>String</code> containing the name of the
+     * parameter whose value is requested
+     */
+    String getInitParameter(String name);
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
@@ -141,9 +141,14 @@ public class VaadinServlet extends HttpServlet {
      *
      * @return the created deployment configuration
      */
-    protected DeploymentConfiguration createDeploymentConfiguration() {
-        return createDeploymentConfiguration(DeploymentConfigurationFactory
-                .createInitParameters(getClass(), new VaadinServletConfig(getServletConfig())));
+    protected DeploymentConfiguration createDeploymentConfiguration()
+            throws ServletException {
+        try {
+            return createDeploymentConfiguration(DeploymentConfigurationFactory
+                    .createInitParameters(getClass(), new VaadinServletConfig(getServletConfig())));
+        }catch (VaadinConfigurationException e) {
+            throw new ServletException("Failed to construct DeploymentConfiguration.", e);
+        }
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
@@ -143,13 +143,13 @@ public class VaadinServlet extends HttpServlet {
      *
      * @throws ServletException
      *             if construction of the {@link Properties} for
-     *             {@link DeploymentConfigurationFactory#createInitParameters(Class, ServletConfig)}
+     *             {@link DeploymentConfigurationFactory#createInitParameters(Class, VaadinConfig)}
      *             fails
      */
     protected DeploymentConfiguration createDeploymentConfiguration()
             throws ServletException {
         return createDeploymentConfiguration(DeploymentConfigurationFactory
-                .createInitParameters(getClass(), getServletConfig()));
+                .createInitParameters(getClass(), new VaadinServletConfig(getServletConfig())));
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
@@ -140,14 +140,8 @@ public class VaadinServlet extends HttpServlet {
      * frameworks.
      *
      * @return the created deployment configuration
-     *
-     * @throws ServletException
-     *             if construction of the {@link Properties} for
-     *             {@link DeploymentConfigurationFactory#createInitParameters(Class, VaadinConfig)}
-     *             fails
      */
-    protected DeploymentConfiguration createDeploymentConfiguration()
-            throws ServletException {
+    protected DeploymentConfiguration createDeploymentConfiguration() {
         return createDeploymentConfiguration(DeploymentConfigurationFactory
                 .createInitParameters(getClass(), new VaadinServletConfig(getServletConfig())));
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletConfig.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletConfig.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.server;
 
 import javax.servlet.ServletConfig;
 import java.util.Enumeration;
+import java.util.Objects;
 
 /**
  * {@link VaadinConfig} implementation for Servlets.
@@ -31,9 +32,10 @@ public class VaadinServletConfig implements VaadinConfig {
      * Vaadin servlet configuration wrapper constructor.
      *
      * @param config
-     *         servlet configuration object
+     *         servlet configuration object, not <code>null</code>
      */
     public VaadinServletConfig(ServletConfig config) {
+        Objects.requireNonNull(config, "VaadinServletConfig requires the ServletConfig object");
         this.config = config;
     }
 
@@ -58,13 +60,13 @@ public class VaadinServletConfig implements VaadinConfig {
     }
 
     @Override
-    public Enumeration<String> getInitParameterNames() {
+    public Enumeration<String> getConfigParameterNames() {
         ensureServletConfig();
         return config.getInitParameterNames();
     }
 
     @Override
-    public String getInitParameter(String name) {
+    public String getConfigParameter(String name) {
         ensureServletConfig();
         return config.getInitParameter(name);
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletConfig.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletConfig.java
@@ -1,0 +1,41 @@
+package com.vaadin.flow.server;
+
+import javax.servlet.ServletConfig;
+import java.util.Enumeration;
+
+public class VaadinServletConfig implements VaadinConfig {
+
+    private ServletConfig config;
+
+    public VaadinServletConfig(ServletConfig config) {
+        this.config = config;
+    }
+
+    /**
+     * Ensures there is a valid instance of {@link ServletConfig}.
+     */
+    private void ensureServletConfig() {
+        if(config == null && VaadinService.getCurrent() instanceof VaadinServletService) {
+            config = ((VaadinServletService)VaadinService.getCurrent()).getServlet().getServletConfig();
+        } else if(config == null) {
+            throw new IllegalStateException("The underlying ServletContext of VaadinServletContext is null and there is no VaadinServletService to obtain it from.");
+        }
+    }
+
+    @Override
+    public VaadinContext getVaadinContext() {
+        return new VaadinServletContext(config.getServletContext());
+    }
+
+    @Override
+    public Enumeration<String> getInitParameterNames() {
+        ensureServletConfig();
+        return config.getInitParameterNames();
+    }
+
+    @Override
+    public String getInitParameter(String name) {
+        ensureServletConfig();
+        return config.getInitParameter(name);
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletConfig.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletConfig.java
@@ -1,12 +1,38 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.flow.server;
 
 import javax.servlet.ServletConfig;
 import java.util.Enumeration;
 
+/**
+ * {@link VaadinConfig} implementation for Servlets.
+ *
+ * @since
+ */
 public class VaadinServletConfig implements VaadinConfig {
 
-    private ServletConfig config;
+    private transient ServletConfig config;
 
+    /**
+     * Vaadin servlet configuration wrapper constructor.
+     *
+     * @param config
+     *         servlet configuration object
+     */
     public VaadinServletConfig(ServletConfig config) {
         this.config = config;
     }
@@ -15,15 +41,19 @@ public class VaadinServletConfig implements VaadinConfig {
      * Ensures there is a valid instance of {@link ServletConfig}.
      */
     private void ensureServletConfig() {
-        if(config == null && VaadinService.getCurrent() instanceof VaadinServletService) {
-            config = ((VaadinServletService)VaadinService.getCurrent()).getServlet().getServletConfig();
-        } else if(config == null) {
-            throw new IllegalStateException("The underlying ServletContext of VaadinServletContext is null and there is no VaadinServletService to obtain it from.");
+        if (config == null && VaadinService
+                .getCurrent() instanceof VaadinServletService) {
+            config = ((VaadinServletService) VaadinService.getCurrent())
+                    .getServlet().getServletConfig();
+        } else if (config == null) {
+            throw new IllegalStateException(
+                    "The underlying ServletContext of VaadinServletContext is null and there is no VaadinServletService to obtain it from.");
         }
     }
 
     @Override
     public VaadinContext getVaadinContext() {
+        ensureServletConfig();
         return new VaadinServletContext(config.getServletContext());
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletContext.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletContext.java
@@ -82,13 +82,13 @@ public class VaadinServletContext implements VaadinContext {
     }
 
     @Override
-    public Enumeration<String> getInitParameterNames() {
+    public Enumeration<String> getContextParameterNames() {
         ensureServletContext();
         return context.getInitParameterNames();
     }
 
     @Override
-    public String getInitParameter(String name) {
+    public String getContextParameter(String name) {
         ensureServletContext();
         return context.getInitParameter(name);
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletContext.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletContext.java
@@ -16,12 +16,13 @@
 package com.vaadin.flow.server;
 
 import javax.servlet.ServletContext;
+import java.util.Enumeration;
 import java.util.function.Supplier;
 
 /**
  * {@link VaadinContext} that goes with {@link VaadinServletService}.
- * @author miki
- * @since 14.0.0
+ *
+ * @since 2.0.0
  */
 public class VaadinServletContext implements VaadinContext {
 
@@ -78,6 +79,18 @@ public class VaadinServletContext implements VaadinContext {
     public void removeAttribute(Class<?> clazz) {
         ensureServletContext();
         context.removeAttribute(clazz.getName());
+    }
+
+    @Override
+    public Enumeration<String> getInitParameterNames() {
+        ensureServletContext();
+        return context.getInitParameterNames();
+    }
+
+    @Override
+    public String getInitParameter(String name) {
+        ensureServletContext();
+        return context.getInitParameter(name);
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletDeployer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletDeployer.java
@@ -38,6 +38,7 @@ import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.DeploymentConfigurationFactory;
 import com.vaadin.flow.server.FrontendVaadinServlet;
 import com.vaadin.flow.server.VaadinServlet;
+import com.vaadin.flow.server.VaadinServletConfig;
 import com.vaadin.flow.server.VaadinServletConfiguration;
 import com.vaadin.flow.server.VaadinServletContext;
 import com.vaadin.flow.server.webcomponent.WebComponentConfigurationRegistry;
@@ -142,8 +143,8 @@ public class ServletDeployer implements ServletContextListener {
                         registration);
                 return DeploymentConfigurationFactory
                         .createPropertyDeploymentConfiguration(servletClass,
-                                servletConfig);
-            } catch (ServletException e) {
+                                new VaadinServletConfig(servletConfig));
+            } catch (DeploymentConfigurationFactory.RuntimeServletException e) {
                 throw new IllegalStateException(String.format(
                         "Failed to get deployment configuration data for servlet with name '%s' and class '%s'",
                         registration.getName(), servletClass), e);

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletDeployer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletDeployer.java
@@ -20,7 +20,6 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
-import javax.servlet.ServletException;
 import javax.servlet.ServletRegistration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -37,6 +36,7 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.DeploymentConfigurationFactory;
 import com.vaadin.flow.server.FrontendVaadinServlet;
+import com.vaadin.flow.server.VaadinConfigurationException;
 import com.vaadin.flow.server.VaadinServlet;
 import com.vaadin.flow.server.VaadinServletConfig;
 import com.vaadin.flow.server.VaadinServletConfiguration;
@@ -144,7 +144,7 @@ public class ServletDeployer implements ServletContextListener {
                 return DeploymentConfigurationFactory
                         .createPropertyDeploymentConfiguration(servletClass,
                                 new VaadinServletConfig(servletConfig));
-            } catch (DeploymentConfigurationFactory.RuntimeServletException e) {
+            } catch (VaadinConfigurationException e) {
                 throw new IllegalStateException(String.format(
                         "Failed to get deployment configuration data for servlet with name '%s' and class '%s'",
                         registration.getName(), servletClass), e);

--- a/flow-server/src/test/java/com/vaadin/flow/server/DeploymentConfigurationFactoryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DeploymentConfigurationFactoryTest.java
@@ -100,7 +100,7 @@ public class DeploymentConfigurationFactoryTest {
 
         DeploymentConfiguration config = DeploymentConfigurationFactory
                 .createDeploymentConfiguration(servlet,
-                        createServletConfigMock(servletConfigParams,
+                        createVaadinConfigMock(servletConfigParams,
                                 Collections.singletonMap(PARAM_TOKEN_FILE,
                                         tokenFile.getPath())));
 
@@ -123,7 +123,7 @@ public class DeploymentConfigurationFactoryTest {
                 defaultServletParams);
 
         DeploymentConfiguration config = DeploymentConfigurationFactory
-                .createDeploymentConfiguration(servlet, createServletConfigMock(
+                .createDeploymentConfiguration(servlet, createVaadinConfigMock(
                         servletConfigParams, emptyMap()));
 
         Class<?> notUiClass = servlet.getEnclosingClass();
@@ -143,7 +143,7 @@ public class DeploymentConfigurationFactoryTest {
                 defaultServletParams);
 
         DeploymentConfiguration config = DeploymentConfigurationFactory
-                .createDeploymentConfiguration(servlet, createServletConfigMock(
+                .createDeploymentConfiguration(servlet, createVaadinConfigMock(
                         servletConfigParams, emptyMap()));
 
         assertTrue(String.format(
@@ -170,7 +170,7 @@ public class DeploymentConfigurationFactoryTest {
                 Integer.toString(overridingHeartbeatIntervalValue));
 
         DeploymentConfiguration config = DeploymentConfigurationFactory
-                .createDeploymentConfiguration(servlet, createServletConfigMock(
+                .createDeploymentConfiguration(servlet, createVaadinConfigMock(
                         servletConfigParams, emptyMap()));
 
         assertEquals(
@@ -198,7 +198,7 @@ public class DeploymentConfigurationFactoryTest {
                 Integer.toString(overridingHeartbeatIntervalValue));
 
         DeploymentConfiguration config = DeploymentConfigurationFactory
-                .createDeploymentConfiguration(servlet, createServletConfigMock(
+                .createDeploymentConfiguration(servlet, createVaadinConfigMock(
                         emptyMap(), servletContextParams));
 
         assertEquals(
@@ -235,7 +235,7 @@ public class DeploymentConfigurationFactoryTest {
                 Integer.toString(servletContextHeartbeatIntervalValue));
 
         DeploymentConfiguration config = DeploymentConfigurationFactory
-                .createDeploymentConfiguration(servlet, createServletConfigMock(
+                .createDeploymentConfiguration(servlet, createVaadinConfigMock(
                         servletConfigParams, servletContextParams));
 
         assertEquals(
@@ -266,7 +266,7 @@ public class DeploymentConfigurationFactoryTest {
 
         DeploymentConfigurationFactory.createDeploymentConfiguration(
                 VaadinServlet.class,
-                createServletConfigMock(Collections.singletonMap(
+                createVaadinConfigMock(Collections.singletonMap(
                         Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE,
                         Boolean.FALSE.toString()), emptyMap()));
     }
@@ -285,7 +285,7 @@ public class DeploymentConfigurationFactoryTest {
         FileUtils.writeLines(webPack, Arrays.asList("./webpack.generated.js"));
 
         DeploymentConfigurationFactory.createDeploymentConfiguration(
-                VaadinServlet.class, createServletConfigMock(map, emptyMap()));
+                VaadinServlet.class, createVaadinConfigMock(map, emptyMap()));
     }
 
     @Test
@@ -309,7 +309,7 @@ public class DeploymentConfigurationFactoryTest {
         webPack.createNewFile();
 
         DeploymentConfigurationFactory.createDeploymentConfiguration(
-                VaadinServlet.class, createServletConfigMock(map, emptyMap()));
+                VaadinServlet.class, createVaadinConfigMock(map, emptyMap()));
     }
 
     @Test
@@ -431,7 +431,7 @@ public class DeploymentConfigurationFactoryTest {
                 .thenReturn(tokenFile.getPath());
 
         Properties properties = DeploymentConfigurationFactory
-                .createInitParameters(Object.class, config);
+                .createInitParameters(Object.class, new VaadinServletConfig(config));
 
         Object object = properties
                 .get(DeploymentConfigurationFactory.FALLBACK_CHUNK);
@@ -454,7 +454,13 @@ public class DeploymentConfigurationFactoryTest {
     private DeploymentConfiguration createConfig(Map<String, String> map)
             throws Exception {
         return DeploymentConfigurationFactory.createDeploymentConfiguration(
-                VaadinServlet.class, createServletConfigMock(map, emptyMap()));
+                VaadinServlet.class, createVaadinConfigMock(map, emptyMap()));
+    }
+
+    private VaadinConfig createVaadinConfigMock(
+            Map<String, String> servletConfigParameters,
+            Map<String, String> servletContextParameters) throws Exception {
+        return new VaadinServletConfig(createServletConfigMock(servletConfigParameters,servletContextParameters));
     }
 
     private ServletConfig createServletConfigMock(

--- a/flow-server/src/test/java/com/vaadin/flow/server/DeploymentConfigurationFactoryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DeploymentConfigurationFactoryTest.java
@@ -407,7 +407,7 @@ public class DeploymentConfigurationFactoryTest {
 
     @Test
     public void createInitParameters_fallbackChunkObjectIsInInitParams()
-            throws ServletException, IOException {
+            throws VaadinConfigurationException, IOException {
         ServletContext context = Mockito.mock(ServletContext.class);
         ServletConfig config = Mockito.mock(ServletConfig.class);
         Mockito.when(config.getServletContext()).thenReturn(context);

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletConfigTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletConfigTest.java
@@ -54,14 +54,14 @@ public class VaadinServletConfigTest {
 
     @Test
     public void getPropertyNames_returnsExpectedProperties() {
-        List<String> list = Collections.list(config.getInitParameterNames());
+        List<String> list = Collections.list(config.getConfigParameterNames());
         Assert.assertEquals(
                 "Context should return only keys defined in ServletContext",
                 properties.size(), list.size());
         for (String key : properties.keySet()) {
             Assert.assertEquals(String.format(
                     "Value should be same from context for key '%s'", key),
-                    properties.get(key), config.getInitParameter(key));
+                    properties.get(key), config.getConfigParameter(key));
         }
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletConfigTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletConfigTest.java
@@ -53,7 +53,7 @@ public class VaadinServletConfigTest {
     }
 
     @Test
-    public void testGetPropertyNames_returnsExpectedProperties() {
+    public void getPropertyNames_returnsExpectedProperties() {
         List<String> list = Collections.list(config.getInitParameterNames());
         Assert.assertEquals(
                 "Context should return only keys defined in ServletContext",
@@ -67,7 +67,7 @@ public class VaadinServletConfigTest {
 
 
     @Test
-    public void testVaadinContextThroughConfig_setAndGetAttribute() {
+    public void vaadinContextThroughConfig_setAndGetAttribute() {
         String value = "my-attribute";
         config.getVaadinContext().setAttribute(value);
         String result = config.getVaadinContext().getAttribute(String.class);

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletConfigTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletConfigTest.java
@@ -1,0 +1,87 @@
+package com.vaadin.flow.server;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletContext;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Test VaadinServletConfig property handling and function with VaadinContext.
+ */
+public class VaadinServletConfigTest {
+
+    private VaadinServletConfig config;
+
+    private ServletContext servletContext;
+    private final Map<String, Object> attributeMap = new HashMap<>();
+    private Map<String, String> properties;
+
+    @Before
+    public void setup() {
+        ServletConfig servletConfig = Mockito.mock(ServletConfig.class);
+        servletContext = Mockito.mock(ServletContext.class);
+
+        Mockito.when(servletConfig.getServletContext()).thenReturn(servletContext);
+
+        Mockito.when(servletContext.getAttribute(Mockito.anyString()))
+                .then(invocationOnMock -> attributeMap
+                        .get(invocationOnMock.getArguments()[0].toString()));
+        Mockito.doAnswer(invocationOnMock -> attributeMap
+                .put(invocationOnMock.getArguments()[0].toString(),
+                        invocationOnMock.getArguments()[1]))
+                .when(servletContext)
+                .setAttribute(Mockito.anyString(), Mockito.any());
+
+        properties = new HashMap<>();
+        properties.put(Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE, "false");
+        properties.put(Constants.SERVLET_PARAMETER_PRODUCTION_MODE, "true");
+        properties.put(Constants.SERVLET_PARAMETER_ENABLE_DEV_SERVER, "false");
+
+        Mockito.when(servletConfig.getInitParameterNames())
+                .thenReturn(Collections.enumeration(properties.keySet()));
+        Mockito.when(servletConfig.getInitParameter(Mockito.anyString()))
+                .then(invocation -> properties
+                        .get(invocation.getArguments()[0]));
+        config = new VaadinServletConfig(servletConfig);
+    }
+
+    @Test
+    public void testGetPropertyNames_returnsExpectedProperties() {
+        List<String> list = Collections.list(config.getInitParameterNames());
+        Assert.assertEquals(
+                "Context should return only keys defined in ServletContext",
+                properties.size(), list.size());
+        for (String key : properties.keySet()) {
+            Assert.assertEquals(String.format(
+                    "Value should be same from context for key '%s'", key),
+                    properties.get(key), config.getInitParameter(key));
+        }
+    }
+
+
+    @Test
+    public void testVaadinContextThroughConfig_setAndGetAttribute() {
+        String value = "my-attribute";
+        config.getVaadinContext().setAttribute(value);
+        String result = config.getVaadinContext().getAttribute(String.class);
+        Assert.assertEquals(value, result);
+        // overwrite
+        String newValue = "this is a new value";
+        config.getVaadinContext().setAttribute(newValue);
+        result = config.getVaadinContext().getAttribute(String.class);
+        Assert.assertEquals(newValue, result);
+        // now the provider should not be called, so value should be still there
+        result = config.getVaadinContext().getAttribute(String.class,
+                () -> {
+                    throw new AssertionError("Should not be called");
+                });
+        Assert.assertEquals(newValue, result);
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletContextTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletContextTest.java
@@ -92,7 +92,7 @@ public class VaadinServletContextTest {
     }
 
     @Test
-    public void testGetPropertyNames_returnsExpectedProperties() {
+    public void getPropertyNames_returnsExpectedProperties() {
         List<String> list = Collections.list(context.getInitParameterNames());
         Assert.assertEquals(
                 "Context should return only keys defined in ServletContext",

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletContextTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletContextTest.java
@@ -93,14 +93,14 @@ public class VaadinServletContextTest {
 
     @Test
     public void getPropertyNames_returnsExpectedProperties() {
-        List<String> list = Collections.list(context.getInitParameterNames());
+        List<String> list = Collections.list(context.getContextParameterNames());
         Assert.assertEquals(
                 "Context should return only keys defined in ServletContext",
                 properties.size(), list.size());
         for (String key : properties.keySet()) {
             Assert.assertEquals(String.format(
                     "Value should be same from context for key '%s'", key),
-                    properties.get(key), context.getInitParameter(key));
+                    properties.get(key), context.getContextParameter(key));
         }
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletContextTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletContextTest.java
@@ -1,17 +1,20 @@
 package com.vaadin.flow.server;
 
+import javax.servlet.ServletContext;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import javax.servlet.ServletContext;
-import java.util.HashMap;
-import java.util.Map;
-
 /**
- * @author miki
- * @since 2019-05-27
+ * Tests for VaadinServletContext attribute storage and property delegation.
+ *
+ * @since 2.0.0
  */
 public class VaadinServletContextTest {
     
@@ -22,6 +25,7 @@ public class VaadinServletContextTest {
     private VaadinServletContext context;
     
     private final Map<String, Object> attributeMap = new HashMap<>();
+    private Map<String, String> properties;
 
     @Before
     public void setup() {
@@ -31,7 +35,17 @@ public class VaadinServletContextTest {
             invocationOnMock.getArguments()[0].toString(),
             invocationOnMock.getArguments()[1]
             )).when(servletContext).setAttribute(Mockito.anyString(), Mockito.any());
-        
+
+        properties = new HashMap<>();
+        properties.put(Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE, "false");
+        properties.put(Constants.SERVLET_PARAMETER_PRODUCTION_MODE, "true");
+        properties.put(Constants.SERVLET_PARAMETER_ENABLE_DEV_SERVER, "false");
+
+        Mockito.when(servletContext.getInitParameterNames())
+                .thenReturn(Collections.enumeration(properties.keySet()));
+        Mockito.when(servletContext.getInitParameter(Mockito.anyString()))
+                .then(invocation -> properties
+                        .get(invocation.getArguments()[0]));
         context = new VaadinServletContext(servletContext);
     }
 
@@ -75,5 +89,18 @@ public class VaadinServletContextTest {
                 throw new AssertionError("Should not be called");
             });
         Assert.assertEquals(newValue, result);
+    }
+
+    @Test
+    public void testGetPropertyNames_returnsExpectedProperties() {
+        List<String> list = Collections.list(context.getInitParameterNames());
+        Assert.assertEquals(
+                "Context should return only keys defined in ServletContext",
+                properties.size(), list.size());
+        for (String key : properties.keySet()) {
+            Assert.assertEquals(String.format(
+                    "Value should be same from context for key '%s'", key),
+                    properties.get(key), context.getInitParameter(key));
+        }
     }
 }


### PR DESCRIPTION
Added VaadinConfig so we can initialize the
DeploymentConfiguration through the
DeploymentConfigurationFactory and get
all the required configuration infotmation even
for a non servlet environment.

Part of vaadin/portlet-support#103

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6820)
<!-- Reviewable:end -->
