### PR TITLE
Replaced method reference with anonymous class in addDataProviderListener

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataProvider.java
@@ -45,7 +45,13 @@ public abstract class AbstractDataProvider<T, F> implements DataProvider<T, F> {
     @Override
     public Registration addDataProviderListener(
             DataProviderListener<T> listener) {
-        return addListener(DataChangeEvent.class, listener::onDataChange);
+        SerializableConsumer<DataChangeEvent> consumer = new SerializableConsumer<DataChangeEvent>() {
+            @Override
+            public void accept(DataChangeEvent dataChangeEvent) {
+                listener.onDataChange(dataChangeEvent);
+            }
+        };
+        return addListener(DataChangeEvent.class, consumer);
     }
 
     @Override

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataProvider.java
@@ -45,6 +45,9 @@ public abstract class AbstractDataProvider<T, F> implements DataProvider<T, F> {
     @Override
     public Registration addDataProviderListener(
             DataProviderListener<T> listener) {
+        // Using an anonymous class instead of lambda or method reference to prevent potential
+        // self reference serialization issues when clients holds a reference
+        // to the Registration instance returned by this method
         SerializableConsumer<DataChangeEvent> consumer = new SerializableConsumer<DataChangeEvent>() {
             @Override
             public void accept(DataChangeEvent dataChangeEvent) {

--- a/flow-data/src/test/java/com/vaadin/flow/tests/data/DataSerializableTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/tests/data/DataSerializableTest.java
@@ -23,7 +23,7 @@ public class DataSerializableTest extends ClassesSerializableTest {
      * to the dataprovider itself that is already referenced by the outer component
      */
     @Test
-    public void testSelfReferenceSerialization() throws Throwable {
+    public void selfReferenceSerialization() throws Throwable {
         Outer outer = new Outer();
         Outer out = serializeAndDeserialize(outer);
         assertNotNull(out);

--- a/flow-data/src/test/java/com/vaadin/flow/tests/data/DataSerializableTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/tests/data/DataSerializableTest.java
@@ -1,6 +1,58 @@
 package com.vaadin.flow.tests.data;
 
+import java.io.Serializable;
+import java.util.Collections;
+
+import com.vaadin.flow.data.binder.HasDataProvider;
+import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.flow.data.provider.ListDataProvider;
+import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.testutil.ClassesSerializableTest;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
 
 public class DataSerializableTest extends ClassesSerializableTest {
+
+    /*
+     * AbstractDataProvider.addDataProviderListener may return a Registration instance
+     * that is not deserializable due to self references.
+     * This happens for example if the dataprovider, member of a component,
+     * is used to add a com.vaadin.flow.data.provider.DataProviderListener
+     * into an inner component; the resulting Registration handles a reference
+     * to the dataprovider itself that is already referenced by the outer component
+     */
+    @Test
+    public void testSelfReferenceSerialization() throws Throwable {
+        Outer outer = new Outer();
+        Outer out = serializeAndDeserialize(outer);
+        assertNotNull(out);
+    }
+
+    static class Inner implements HasDataProvider<Object>, Serializable {
+
+        private Registration registration;
+
+        @Override
+        public void setDataProvider(DataProvider<Object, ?> dataProvider) {
+            if (registration != null) {
+                registration.remove();
+            }
+            registration = dataProvider.addDataProviderListener(event -> onDataProviderChange());
+        }
+
+        void onDataProviderChange() {
+
+        }
+
+    }
+
+    static class Outer implements Serializable {
+        private final ListDataProvider<Object> dataProvider = new ListDataProvider<>(Collections.emptyList());
+        private final Inner inner = new Inner();
+
+        public Outer() {
+            inner.setDataProvider(dataProvider);
+        }
+    }
 }


### PR DESCRIPTION
The replacement prevents potential self reference
serialization issues when holding a reference
to the Registration instance returned
by addDataProviderListener method

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6823)
<!-- Reviewable:end -->
