### PR TITLE
Fix embedding with custom httpservlet

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
@@ -15,6 +15,21 @@
  */
 package com.vaadin.flow.server.communication;
 
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.lang.annotation.Annotation;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+
+import org.jsoup.nodes.Attribute;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
 import com.vaadin.flow.component.PushConfiguration;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.webcomponent.WebComponentUI;
@@ -34,25 +49,6 @@ import com.vaadin.flow.theme.ThemeDefinition;
 import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
-import org.jsoup.nodes.Attribute;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
-import org.slf4j.LoggerFactory;
-
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.regex.Pattern;
-
 import static com.vaadin.flow.shared.ApplicationConstants.CONTENT_TYPE_TEXT_JAVASCRIPT_UTF_8;
 import static java.nio.charset.StandardCharsets.UTF_8;
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
@@ -65,8 +65,6 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
     private static final Pattern PATH_PATTERN =
             Pattern.compile(".*" + PATH_PREFIX + "-(ui|bootstrap)\\.(js|html)$");
 
-    private String servletPath;
-
     private static class WebComponentBootstrapContext extends BootstrapContext {
 
         private WebComponentBootstrapContext(VaadinRequest request,
@@ -134,8 +132,6 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
                     + "component UI which should handle path "
                     + PATH_PATTERN.toString());
         }
-
-        servletPath = getRelativeServletPath((VaadinServletRequest) request);
 
         final String serviceUrl = getServiceUrl(request, response);
 
@@ -390,20 +386,5 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
                 // replace http:// or https:// with // to work with https:// proxies
                 // which proxies to the same http:// url
                 .replaceFirst("^" + ".*://", "//");
-    }
-
-    private static String getRelativeServletPath(VaadinServletRequest request) {
-        String servletPath = request.getServletPath();
-        StringBuilder pathBuilder = new StringBuilder();
-        if (servletPath.startsWith("/")) {
-            pathBuilder.append(".");
-        } else if (!servletPath.startsWith(".")) {
-            pathBuilder.append("./");
-        }
-        pathBuilder.append(servletPath);
-        if (!servletPath.endsWith("/")) {
-            pathBuilder.append("/");
-        }
-        return pathBuilder.toString();
     }
 }

--- a/flow-tests/test-embedding/embedding-test-assets/src/main/java/com/vaadin/flow/webcomponent/servlets/WebComponentVaadinServlet.java
+++ b/flow-tests/test-embedding/embedding-test-assets/src/main/java/com/vaadin/flow/webcomponent/servlets/WebComponentVaadinServlet.java
@@ -19,6 +19,6 @@ import javax.servlet.annotation.WebServlet;
 
 import com.vaadin.flow.server.VaadinServlet;
 
-@WebServlet(urlPatterns = { "/*", "/vaadin/*"}, asyncSupported = true)
+@WebServlet(urlPatterns = { "/vaadin/*"}, asyncSupported = true)
 public class WebComponentVaadinServlet extends VaadinServlet {
 }

--- a/flow-tests/test-embedding/test-embedding-generic-compatibility/src/main/java/com/vaadin/flow/webcomponent/CompatibilityDevServlet.java
+++ b/flow-tests/test-embedding/test-embedding-generic-compatibility/src/main/java/com/vaadin/flow/webcomponent/CompatibilityDevServlet.java
@@ -13,21 +13,12 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.flow.webcomponent;
 
 import javax.servlet.annotation.WebServlet;
-import java.io.PrintWriter;
-import java.util.function.Consumer;
 
-import com.vaadin.flow.webcomponent.servlets.AbstractPlainServlet;
+import com.vaadin.flow.server.VaadinServlet;
 
-// npm mode is able to survive a root-mapped servlet, while compatibility
-// mode is not
-@WebServlet(urlPatterns = { "/*", "/items/*" }, asyncSupported = true)
-public class NpmProdPlainServlet extends AbstractPlainServlet {
-    @Override
-    protected Consumer<PrintWriter> getImportsWriter() {
-        return this::writeNpmImports;
-    }
+@WebServlet(urlPatterns = { "/frontend/*", "/VAADIN/*" }, asyncSupported = true)
+public class CompatibilityDevServlet extends VaadinServlet {
 }

--- a/flow-tests/test-embedding/test-embedding-generic-compatibility/src/main/java/com/vaadin/flow/webcomponent/CompatibilityPlainServlet.java
+++ b/flow-tests/test-embedding/test-embedding-generic-compatibility/src/main/java/com/vaadin/flow/webcomponent/CompatibilityPlainServlet.java
@@ -22,7 +22,7 @@ import java.util.function.Consumer;
 
 import com.vaadin.flow.webcomponent.servlets.AbstractPlainServlet;
 
-@WebServlet(urlPatterns = { "/items/*"}, asyncSupported = true)
+@WebServlet(urlPatterns = { "/*","/items/*"}, asyncSupported = true)
 public class CompatibilityPlainServlet extends AbstractPlainServlet {
     @Override
     protected Consumer<PrintWriter> getImportsWriter() {

--- a/flow-tests/test-embedding/test-embedding-generic-compatibility/src/main/java/com/vaadin/flow/webcomponent/CompatibilityPlainServlet.java
+++ b/flow-tests/test-embedding/test-embedding-generic-compatibility/src/main/java/com/vaadin/flow/webcomponent/CompatibilityPlainServlet.java
@@ -22,7 +22,7 @@ import java.util.function.Consumer;
 
 import com.vaadin.flow.webcomponent.servlets.AbstractPlainServlet;
 
-@WebServlet(urlPatterns = { "/*","/items/*"}, asyncSupported = true)
+@WebServlet(urlPatterns = { "/items/*" }, asyncSupported = true)
 public class CompatibilityPlainServlet extends AbstractPlainServlet {
     @Override
     protected Consumer<PrintWriter> getImportsWriter() {

--- a/flow-tests/test-embedding/test-embedding-generic/src/main/java/src/com/vaadin/flow/webcomponent/NpmPlainServlet.java
+++ b/flow-tests/test-embedding/test-embedding-generic/src/main/java/src/com/vaadin/flow/webcomponent/NpmPlainServlet.java
@@ -23,7 +23,7 @@ import java.util.function.Consumer;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.webcomponent.servlets.AbstractPlainServlet;
 
-@WebServlet(urlPatterns = { "/items/*"}, asyncSupported = true)
+@WebServlet(urlPatterns = { "/*","/items/*"}, asyncSupported = true)
 public class NpmPlainServlet extends AbstractPlainServlet {
     @Override
     protected Consumer<PrintWriter> getImportsWriter() {

--- a/flow-tests/test-embedding/test-embedding-generic/src/main/java/src/com/vaadin/flow/webcomponent/NpmPlainServlet.java
+++ b/flow-tests/test-embedding/test-embedding-generic/src/main/java/src/com/vaadin/flow/webcomponent/NpmPlainServlet.java
@@ -20,10 +20,11 @@ import javax.servlet.annotation.WebServlet;
 import java.io.PrintWriter;
 import java.util.function.Consumer;
 
-import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.webcomponent.servlets.AbstractPlainServlet;
 
-@WebServlet(urlPatterns = { "/*","/items/*"}, asyncSupported = true)
+// npm mode is able to survive a root-mapped servlet, while compatibility
+// mode is not
+@WebServlet(urlPatterns = { "/*", "/items/*" }, asyncSupported = true)
 public class NpmPlainServlet extends AbstractPlainServlet {
     @Override
     protected Consumer<PrintWriter> getImportsWriter() {

--- a/flow-tests/test-embedding/test-embedding-production-mode-compatibility/src/main/java/com/vaadin/flow/webcomponent/CompatibilityProdPlainServlet.java
+++ b/flow-tests/test-embedding/test-embedding-production-mode-compatibility/src/main/java/com/vaadin/flow/webcomponent/CompatibilityProdPlainServlet.java
@@ -22,7 +22,7 @@ import java.util.function.Consumer;
 
 import com.vaadin.flow.webcomponent.servlets.AbstractPlainServlet;
 
-@WebServlet(urlPatterns = { "/*","/items/*"}, asyncSupported = true)
+@WebServlet(urlPatterns = { "/items/*" }, asyncSupported = true)
 public class CompatibilityProdPlainServlet extends AbstractPlainServlet {
     @Override
     protected Consumer<PrintWriter> getImportsWriter() {

--- a/flow-tests/test-embedding/test-embedding-production-mode-compatibility/src/main/java/com/vaadin/flow/webcomponent/CompatibilityProdPlainServlet.java
+++ b/flow-tests/test-embedding/test-embedding-production-mode-compatibility/src/main/java/com/vaadin/flow/webcomponent/CompatibilityProdPlainServlet.java
@@ -22,7 +22,7 @@ import java.util.function.Consumer;
 
 import com.vaadin.flow.webcomponent.servlets.AbstractPlainServlet;
 
-@WebServlet(urlPatterns = { "/items/*"}, asyncSupported = true)
+@WebServlet(urlPatterns = { "/*","/items/*"}, asyncSupported = true)
 public class CompatibilityProdPlainServlet extends AbstractPlainServlet {
     @Override
     protected Consumer<PrintWriter> getImportsWriter() {

--- a/flow-tests/test-embedding/test-embedding-production-mode/src/main/java/com/vaadin/flow/webcomponent/NpmProdPlainServlet.java
+++ b/flow-tests/test-embedding/test-embedding-production-mode/src/main/java/com/vaadin/flow/webcomponent/NpmProdPlainServlet.java
@@ -22,7 +22,7 @@ import java.util.function.Consumer;
 
 import com.vaadin.flow.webcomponent.servlets.AbstractPlainServlet;
 
-@WebServlet(urlPatterns = { "/items/*"}, asyncSupported = true)
+@WebServlet(urlPatterns = { "/*","/items/*"}, asyncSupported = true)
 public class NpmProdPlainServlet extends AbstractPlainServlet {
     @Override
     protected Consumer<PrintWriter> getImportsWriter() {


### PR DESCRIPTION
Fixes #6819 in npm mode. 

This issue is not necessarily worth the trouble in compatibility mode. It is easy enough to work around and `/*` mapping is bad practice anyway. I'll address the compatibility mode in documentation instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6829)
<!-- Reviewable:end -->
