### PR TITLE
Fix embedding with custom httpservlet (#6829)

### DIFF
--- a/flow-tests/test-embedding/test-embedding-generic-compatibility/src/main/java/com/vaadin/flow/webcomponent/CompatibilityDevServlet.java
+++ b/flow-tests/test-embedding/test-embedding-generic-compatibility/src/main/java/com/vaadin/flow/webcomponent/CompatibilityDevServlet.java
@@ -13,12 +13,12 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.flow.webcomponent.servlets;
+package com.vaadin.flow.webcomponent;
 
 import javax.servlet.annotation.WebServlet;
 
 import com.vaadin.flow.server.VaadinServlet;
 
-@WebServlet(urlPatterns = { "/vaadin/*"}, asyncSupported = true)
-public class WebComponentVaadinServlet extends VaadinServlet {
+@WebServlet(urlPatterns = { "/frontend/*", "/VAADIN/*" }, asyncSupported = true)
+public class CompatibilityDevServlet extends VaadinServlet {
 }

--- a/flow-tests/test-embedding/test-embedding-generic-compatibility/src/main/java/com/vaadin/flow/webcomponent/CompatibilityPlainServlet.java
+++ b/flow-tests/test-embedding/test-embedding-generic-compatibility/src/main/java/com/vaadin/flow/webcomponent/CompatibilityPlainServlet.java
@@ -22,7 +22,7 @@ import java.util.function.Consumer;
 
 import com.vaadin.flow.webcomponent.servlets.AbstractPlainServlet;
 
-@WebServlet(urlPatterns = { "/items/*"}, asyncSupported = true)
+@WebServlet(urlPatterns = { "/items/*" }, asyncSupported = true)
 public class CompatibilityPlainServlet extends AbstractPlainServlet {
     @Override
     protected Consumer<PrintWriter> getImportsWriter() {

--- a/flow-tests/test-embedding/test-embedding-generic/src/main/java/src/com/vaadin/flow/webcomponent/NpmPlainServlet.java
+++ b/flow-tests/test-embedding/test-embedding-generic/src/main/java/src/com/vaadin/flow/webcomponent/NpmPlainServlet.java
@@ -20,10 +20,11 @@ import javax.servlet.annotation.WebServlet;
 import java.io.PrintWriter;
 import java.util.function.Consumer;
 
-import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.webcomponent.servlets.AbstractPlainServlet;
 
-@WebServlet(urlPatterns = { "/items/*"}, asyncSupported = true)
+// npm mode is able to survive a root-mapped servlet, while compatibility
+// mode is not
+@WebServlet(urlPatterns = { "/*", "/items/*" }, asyncSupported = true)
 public class NpmPlainServlet extends AbstractPlainServlet {
     @Override
     protected Consumer<PrintWriter> getImportsWriter() {

--- a/flow-tests/test-embedding/test-embedding-production-mode-compatibility/src/main/java/com/vaadin/flow/webcomponent/CompatibilityProdPlainServlet.java
+++ b/flow-tests/test-embedding/test-embedding-production-mode-compatibility/src/main/java/com/vaadin/flow/webcomponent/CompatibilityProdPlainServlet.java
@@ -22,7 +22,7 @@ import java.util.function.Consumer;
 
 import com.vaadin.flow.webcomponent.servlets.AbstractPlainServlet;
 
-@WebServlet(urlPatterns = { "/items/*"}, asyncSupported = true)
+@WebServlet(urlPatterns = { "/items/*" }, asyncSupported = true)
 public class CompatibilityProdPlainServlet extends AbstractPlainServlet {
     @Override
     protected Consumer<PrintWriter> getImportsWriter() {

--- a/flow-tests/test-embedding/test-embedding-production-mode/src/main/java/com/vaadin/flow/webcomponent/NpmProdPlainServlet.java
+++ b/flow-tests/test-embedding/test-embedding-production-mode/src/main/java/com/vaadin/flow/webcomponent/NpmProdPlainServlet.java
@@ -22,7 +22,9 @@ import java.util.function.Consumer;
 
 import com.vaadin.flow.webcomponent.servlets.AbstractPlainServlet;
 
-@WebServlet(urlPatterns = { "/items/*"}, asyncSupported = true)
+// npm mode is able to survive a root-mapped servlet, while compatibility
+// mode is not
+@WebServlet(urlPatterns = { "/*", "/items/*" }, asyncSupported = true)
 public class NpmProdPlainServlet extends AbstractPlainServlet {
     @Override
     protected Consumer<PrintWriter> getImportsWriter() {


### PR DESCRIPTION
Fixes #6819 in npm mode.

This issue is not necessarily worth the trouble in compatibility mode. It is easy enough to work around and /* mapping is bad practice anyway. I'll address the compatibility mode in documentation instead.

(cherry picked from commit a8e78af9ac742417e3d813ea866b56b001933503)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6832)
<!-- Reviewable:end -->
