### PR TITLE
All modules should stay sorted (#6836)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -179,7 +179,7 @@ abstract class AbstractUpdateImports implements Runnable, Serializable {
     List<String> resolveModules(Collection<String> modules,
             boolean isJsModule) {
         return modules.stream()
-                .map(module -> resolveResource(module, isJsModule))
+                .map(module -> resolveResource(module, isJsModule)).sorted()
                 .collect(Collectors.toList());
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
@@ -18,8 +18,9 @@
 package com.vaadin.flow.server.frontend;
 
 import java.io.File;
-import java.io.IOException;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -27,6 +28,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.CoreMatchers;
@@ -43,6 +46,10 @@ import org.mockito.internal.util.collections.Sets;
 import org.slf4j.Logger;
 import org.slf4j.impl.SimpleLogger;
 
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.dependency.JavaScript;
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.CssData;
@@ -55,6 +62,7 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DI
 import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
 import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -66,6 +74,7 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
+    private File tmpRoot;
     private File generatedPath;
     private File frontendDirectory;
     private File nodeModulesPath;
@@ -149,7 +158,7 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
 
     @Before
     public void setup() throws Exception {
-        File tmpRoot = temporaryFolder.getRoot();
+        tmpRoot = temporaryFolder.getRoot();
 
         // Use a file for logs so as tests can assert the warnings shown to the
         // user.
@@ -377,7 +386,7 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
     }
 
     @Test
-    public void generate_containsLumoThemeFiles() throws Exception {
+    public void generate_containsLumoThemeFiles() {
         updater.run();
 
         assertContainsImports(true, "@vaadin/vaadin-lumo-styles/color.js",
@@ -390,8 +399,7 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
 
     // flow #6408
     @Test
-    public void jsModuleOnRouterLayout_shouldBe_addedAfterLumoStyles()
-            throws Exception {
+    public void jsModuleOnRouterLayout_shouldBe_addedAfterLumoStyles() {
         updater.run();
 
         assertContainsImports(true, "Frontend/common-js-file.js");
@@ -404,15 +412,70 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
     }
 
     @Test
-    public void jsModulesOrderIsPreservedAnsAfterJsModules() throws Exception {
+    public void jsModulesOrderIsPreservedAnsAfterJsModules() {
         updater.run();
 
         assertImportOrder("jsmodule/g.js", "javascript/a.js", "javascript/b.js",
                 "javascript/c.js");
     }
 
-    private void assertContainsImports(boolean contains, String... imports)
-            throws IOException {
+    @Route(value = "")
+    private static class MainView extends Component {
+        NodeTestComponents.TranslatedImports translatedImports;
+        NodeTestComponents.LocalP3Template localP3Template;
+        NodeTestComponents.JavaScriptOrder javaScriptOrder;
+    }
+
+    @Test
+    public void assertFullSortOrder() throws MalformedURLException {
+        Class[] testClasses = { MainView.class, NodeTestComponents.TranslatedImports.class,
+                NodeTestComponents.LocalP3Template.class,
+                NodeTestComponents.JavaScriptOrder.class };
+        ClassFinder classFinder = getClassFinder(testClasses);
+
+        updater = new UpdateImports(classFinder, getScanner(classFinder),
+                tmpRoot);
+        updater.run();
+
+        // Imports are collected as
+        // - theme and css
+        // - JsModules (external e.g. in node_modules/)
+        // - JavaScript
+        // - Generated webcompoents
+        // - JsModules (internal e.g. in frontend/)
+        List<String> expectedImports = new ArrayList<>();
+        expectedImports.addAll(updater.getThemeLines());
+
+        getAnntotationsAsStream(JsModule.class, testClasses).map(JsModule::value).map(this::updateToImport).sorted().forEach(expectedImports::add);
+        getAnntotationsAsStream(JavaScript.class, testClasses).map(JavaScript::value).map(this::updateToImport).sorted().forEach(expectedImports::add);
+
+        List<String> internals = expectedImports.stream().filter(importValue -> importValue.contains(FrontendUtils.WEBPACK_PREFIX_ALIAS)).sorted().collect(
+                Collectors.toList());
+        updater.getGeneratedModules().stream().map(this::updateToImport).forEach(expectedImports::add);
+        // Remove internals from the full list
+        expectedImports.removeAll(internals);
+        // Add internals to end of list
+        expectedImports.addAll(internals);
+
+        Assert.assertEquals(expectedImports, updater.resultingLines);
+    }
+
+    private <T extends Annotation> Stream<T> getAnntotationsAsStream(Class<T> annotation, Class<?>... classes) {
+        Stream<T> stream = Stream.empty();
+        for(Class<?> clazz : classes) {
+            stream = Stream.concat(stream, Stream.of(clazz.getAnnotationsByType(annotation)));
+        }
+        return stream;
+    }
+
+    private String updateToImport(String value) {
+        if(value.startsWith("./")) {
+            value = value.replace("./", FrontendUtils.WEBPACK_PREFIX_ALIAS);
+        }
+        return String.format("import '%s';", value);
+    }
+
+    private void assertContainsImports(boolean contains, String... imports) {
         for (String line : imports) {
             boolean result = updater.resultingLines
                     .contains("import '" + addWebpackPrefix(line) + "';");
@@ -426,7 +489,7 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
         }
     }
 
-    private void assertImportOrder(String... imports) throws IOException {
+    private void assertImportOrder(String... imports) {
         int curIndex = -1;
         for (String line : imports) {
             String prefixed = addWebpackPrefix(line);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateTestUtil.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateTestUtil.java
@@ -45,6 +45,11 @@ public class NodeUpdateTestUtil {
                 NodeTestComponents.class.getDeclaredClasses());
     }
 
+    static ClassFinder getClassFinder(Class<?>... classes) throws MalformedURLException {
+        return new DefaultClassFinder(new URLClassLoader(getClassPath()),
+                classes);
+    }
+
     static URL[] getClassPath() throws MalformedURLException {
         // Add folder with test classes
         List<URL> classPaths = new ArrayList<>();


### PR DESCRIPTION
All modules and scripts collected should stay as sorted to not make
un-necessary script updates due positions changing.

Removed usage of sets and linked sets in favor of lists and
distinct to remove duplicates.

Fixes #6818

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6843)
<!-- Reviewable:end -->
