### PR TITLE
Do not build an ES5 version

### DIFF
--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -160,13 +160,6 @@ module.exports = {
             'last 1 Chrome major versions'
           ],
           esModule: true
-        },
-        'es5': { // IE11
-          browsers: [
-            'ie 11'
-          ],
-          tagAssetsWithKey: true, // append a suffix to the file name
-          noModule: true
         }
       }
     }),


### PR DESCRIPTION
The ES5 version was only needed for IE11

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6852)
<!-- Reviewable:end -->
