### PR TITLE
Fix uber jar build file finding. (#6858)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
@@ -241,7 +241,7 @@ public final class DeploymentConfigurationFactory implements Serializable {
         try {
             json = getResourceFromFile(initParameters);
             if (json == null) {
-                json = getResourceFromClassloader(initParameters);
+                json = getResourceFromClassloader();
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -264,7 +264,7 @@ public final class DeploymentConfigurationFactory implements Serializable {
         return json;
     }
 
-    private static String getResourceFromClassloader(Properties initParameters)
+    private static String getResourceFromClassloader()
             throws IOException {
         String json = null;
         // token file is in the class-path of the application
@@ -277,10 +277,11 @@ public final class DeploymentConfigurationFactory implements Serializable {
         URL resource = resources.stream()
                 .filter(url -> !url.getPath().endsWith("jar!/" + tokenResource))
                 .findFirst().orElse(null);
-        if (resource == null && isProductionMode(initParameters)) {
-            // For no non jar build info, in production mode check jar files
-            // for production mode jar.
-            json = getProductionModeResource(resources);
+        if (resource == null && !resources.isEmpty()) {
+            // For no non jar build info, in production mode check for
+            // webpack.generated.json if it's in a jar in a jar then accept
+            // single jar flow-build-info.
+            json = getPossibleJarResource(resources);
         } else if (resource != null) {
             json = FrontendUtils.streamToString(resource.openStream());
         }
@@ -314,28 +315,37 @@ public final class DeploymentConfigurationFactory implements Serializable {
     }
 
     /**
-     * Check resources for a production mode resource if all resources were
-     * from JAR files as we may be running from a JAR and add-ons are not
-     * packaged in productionMode.
+     * Check if the webpack.generated.js resources is inside 2 jars
+     * (flow-server.jar and application.jar) if this is the case then we can
+     * accept a build info file from inside  jar with a single jar in the path.
      *
      * @param resources
      *         flow-build-info url resource files
-     * @return production mode flow-build-info string
+     * @return flow-build-info json string or <code>null</code> if no applicable files found
      * @throws IOException
      *         exception reading stream
      */
-    private static String getProductionModeResource(List<URL> resources)
+    private static String getPossibleJarResource(List<URL> resources)
             throws IOException {
-        for (URL resource : resources) {
-            String json = FrontendUtils.streamToString(resource.openStream());
-            if (json != null && !json.contains(NPM_TOKEN) && !json
-                    .contains(FRONTEND_TOKEN) && json
-                    .contains("\"productionMode\": true")) {
-                return json;
+        URL webpackGenerated = DeploymentConfiguration.class.getClassLoader()
+                .getResource(FrontendUtils.WEBPACK_GENERATED);
+        // If jar!/ exists 2 times for webpack.generated.json then we are
+        // running from a jar
+        if (countInstances(webpackGenerated.getPath(), "jar!/") >= 2) {
+            for (URL resource : resources) {
+                // As we now know that we are running from a jar we can accept a
+                // build info with a single jar in the path
+                if (countInstances(resource.getPath(), "jar!/") == 1) {
+                    return FrontendUtils.streamToString(resource.openStream());
+                }
             }
         }
         // No applicable resources found.
         return null;
+    }
+
+    private static int countInstances(String input, String value) {
+        return input.split(value, -1).length - 1;
     }
 
     /**


### PR DESCRIPTION
Now the flow-build-info.json file
is found automatically even for a jar execution.

Fixes #6759
Fixes #6768
Fixes #6657
Fixes vaadin/spring#503


(cherry picked from commit 2363bbcdb982f51c88a6cf9413ebef478213636f)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6870)
<!-- Reviewable:end -->
