### PR TITLE
Prevent npm --version from querying the internets for updates (#6860)

### DIFF
--- a/flow-migration/src/test/java/com/vaadin/flow/migration/MigrationTest.java
+++ b/flow-migration/src/test/java/com/vaadin/flow/migration/MigrationTest.java
@@ -130,12 +130,12 @@ public class MigrationTest {
                 Paths.get(sourcesFolder.getPath(), "foobar").toFile());
 
         // Expected execution calls:
-        // 1 - npm install polymer-modulizer
+        // 1 - npm --no-update-notifier install polymer-modulizer
         // 2 - node {tempFolder} i -F --confid.interactive=false -S polymer#2.8.0
-        // 3 - npm i
+        // 3 - npm --no-update-notifier i
         // 4 - node node_modules/polymer-modulizer/bin/modulizer.js --force --out , --import-style=name
 
-        LinkedList<Integer> excecuteExpectations = Stream.of(3, 7, 2, 6)
+        LinkedList<Integer> excecuteExpectations = Stream.of(4, 7, 3, 6)
                 .collect(Collectors.toCollection(LinkedList::new));
         
         Migration migration = new Migration(configuration) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -112,12 +112,15 @@ public class FrontendUtilsTest {
                 containsString("node"));
         assertThat(FrontendUtils.getNodeExecutable(baseDir),
                 not(containsString(DEFAULT_NODE)));
-        assertThat(FrontendUtils.getNpmExecutable(baseDir)
-                .get(0), containsString("npm"));
         assertThat(FrontendUtils.getNodeExecutable(baseDir),
                 not(containsString(NPM_CLI_STRING)));
-        assertEquals(1, FrontendUtils
+
+        assertEquals(2, FrontendUtils
                 .getNpmExecutable(baseDir).size());
+        assertThat(FrontendUtils.getNpmExecutable(baseDir)
+                .get(0), containsString("npm"));
+        assertThat(FrontendUtils.getNpmExecutable(baseDir)
+                .get(1), containsString("--no-update-notifier"));
     }
 
     @Test


### PR DESCRIPTION
* Prevent npm --version from querying the internets for updates

(cherry picked from commit 1c988745bb80f99543e6e1bb326855a09e516cbb)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6886)
<!-- Reviewable:end -->
