### PR TITLE
Prevent npm --version from querying the internets for updates (#6860)

### DIFF
--- a/flow-migration/src/test/java/com/vaadin/flow/migration/MigrationTest.java
+++ b/flow-migration/src/test/java/com/vaadin/flow/migration/MigrationTest.java
@@ -130,12 +130,12 @@ public class MigrationTest {
                 Paths.get(sourcesFolder.getPath(), "foobar").toFile());
 
         // Expected execution calls:
-        // 1 - npm install polymer-modulizer
+        // 1 - npm --no-update-notifier install polymer-modulizer
         // 2 - node {tempFolder} i -F --confid.interactive=false -S polymer#2.8.0
-        // 3 - npm i
+        // 3 - npm --no-update-notifier i
         // 4 - node node_modules/polymer-modulizer/bin/modulizer.js --force --out , --import-style=name
 
-        LinkedList<Integer> excecuteExpectations = Stream.of(3, 7, 2, 6)
+        LinkedList<Integer> excecuteExpectations = Stream.of(4, 7, 3, 6)
                 .collect(Collectors.toCollection(LinkedList::new));
         
         Migration migration = new Migration(configuration) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -306,15 +306,19 @@ public class FrontendUtils {
         // not work because it's a shell or windows script that looks for node
         // and will fail. Thus we look for the `mpn-cli` node script instead
         File file = new File(baseDir, "node/node_modules/npm/bin/npm-cli.js");
+        List<String> returnCommand = new ArrayList<>();
         if (file.canRead()) {
             // We return a two element list with node binary and npm-cli script
-            return Arrays.asList(getNodeExecutable(baseDir),
-                    file.getAbsolutePath());
+            returnCommand.add(getNodeExecutable(baseDir));
+            returnCommand.add(file.getAbsolutePath());
+        } else {
+            // Otherwise look for regulan `npm`
+            String command = isWindows() ? "npm.cmd" : "npm";
+            returnCommand.add(
+                    getExecutable(baseDir, command, null).getAbsolutePath());
         }
-        // Otherwise look for regulan `npm`
-        String command = isWindows() ? "npm.cmd" : "npm";
-        return Arrays.asList(
-                getExecutable(baseDir, command, null).getAbsolutePath());
+        returnCommand.add("--no-update-notifier");
+        return returnCommand;
     }
 
     /**
@@ -578,7 +582,8 @@ public class FrontendUtils {
             List<String> nodeVersionCommand = new ArrayList<>();
             nodeVersionCommand.add(FrontendUtils.getNodeExecutable(baseDir));
             nodeVersionCommand.add("--version");
-            FrontendVersion nodeVersion = getVersion("node", nodeVersionCommand);
+            FrontendVersion nodeVersion = getVersion("node",
+                    nodeVersionCommand);
             validateToolVersion("node", nodeVersion, SUPPORTED_NODE_VERSION,
                     SHOULD_WORK_NODE_VERSION);
         } catch (UnknownVersionException e) {
@@ -586,8 +591,8 @@ public class FrontendUtils {
         }
 
         try {
-            List<String> npmVersionCommand = new ArrayList<>();
-            npmVersionCommand.addAll(FrontendUtils.getNpmExecutable(baseDir));
+            List<String> npmVersionCommand = new ArrayList<>(
+                    FrontendUtils.getNpmExecutable(baseDir));
             npmVersionCommand.add("--version");
             FrontendVersion npmVersion = getVersion("npm", npmVersionCommand);
             validateToolVersion("npm", npmVersion, SUPPORTED_NPM_VERSION,
@@ -763,8 +768,8 @@ public class FrontendUtils {
         }
     }
 
-    private static FrontendVersion getVersion(String tool, List<String> versionCommand)
-            throws UnknownVersionException {
+    private static FrontendVersion getVersion(String tool,
+            List<String> versionCommand) throws UnknownVersionException {
         try {
             Process process = FrontendUtils.createProcessBuilder(versionCommand)
                     .start();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -112,12 +112,15 @@ public class FrontendUtilsTest {
                 containsString("node"));
         assertThat(FrontendUtils.getNodeExecutable(baseDir),
                 not(containsString(DEFAULT_NODE)));
-        assertThat(FrontendUtils.getNpmExecutable(baseDir)
-                .get(0), containsString("npm"));
         assertThat(FrontendUtils.getNodeExecutable(baseDir),
                 not(containsString(NPM_CLI_STRING)));
-        assertEquals(1, FrontendUtils
+
+        assertEquals(2, FrontendUtils
                 .getNpmExecutable(baseDir).size());
+        assertThat(FrontendUtils.getNpmExecutable(baseDir)
+                .get(0), containsString("npm"));
+        assertThat(FrontendUtils.getNpmExecutable(baseDir)
+                .get(1), containsString("--no-update-notifier"));
     }
 
     @Test


### PR DESCRIPTION
* Prevent npm --version from querying the internets for updates

(cherry picked from commit 1c988745bb80f99543e6e1bb326855a09e516cbb)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6887)
<!-- Reviewable:end -->
