### PR TITLE
Avoid shadow root access in TemplateInitializer

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -127,6 +127,9 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo {
             + Constants.LOCAL_FRONTEND_RESOURCES_PATH)
     protected File frontendResourcesDirectory;
 
+    @Parameter
+    private String polymerVersion;
+
     /**
      * Whether to use byte code scanner strategy to discover frontend
      * components.
@@ -183,7 +186,8 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo {
                         .enableImportsUpdate(true)
                         .withEmbeddableWebComponents(
                                 generateEmbeddableWebComponents)
-                        .withTokenFile(getTokenFile()).build().execute();
+                        .withTokenFile(getTokenFile())
+                        .withPolymerVersion(polymerVersion).build().execute();
     }
 
     private void runWebpack() {

--- a/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/IdMapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/IdMapper.java
@@ -20,7 +20,6 @@ import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Optional;
 import java.util.function.Consumer;
-import java.util.stream.Stream;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
@@ -74,25 +73,7 @@ public class IdMapper implements Serializable {
      */
     public void mapComponentOrElement(Field field, String id, String tag,
             Consumer<Element> beforeComponentInject) {
-        Element element = getElementById(id).orElse(null);
-
-        if (element == null) {
-            injectClientSideElement(tag, id, field, beforeComponentInject);
-        } else {
-            injectServerSideElement(element, field, beforeComponentInject);
-        }
-    }
-
-    private void injectServerSideElement(Element element, Field field,
-            Consumer<Element> beforeComponentInject) {
-        if (getElement().equals(element)) {
-            throw new IllegalArgumentException(
-                    "Cannot map the root element of the template. "
-                            + "This is always mapped to the template instance itself ("
-                            + getContainerClass().getName() + ')');
-        } else if (element != null) {
-            injectTemplateElement(element, field, beforeComponentInject);
-        }
+        injectClientSideElement(tag, id, field, beforeComponentInject);
     }
 
     private Class<? extends Component> getContainerClass() {
@@ -130,20 +111,6 @@ public class IdMapper implements Serializable {
 
     private Element getElement() {
         return template.getElement();
-    }
-
-    private Optional<Element> getElementById(String id) {
-        return getOrCreateShadowRoot().getChildren()
-                .flatMap(this::flattenChildren)
-                .filter(element -> id.equals(element.getAttribute("id")))
-                .findFirst();
-    }
-
-    private Stream<Element> flattenChildren(Element node) {
-        if (node.getChildCount() > 0) {
-            return node.getChildren().flatMap(this::flattenChildren);
-        }
-        return Stream.of(node);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/TemplateInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/TemplateInitializer.java
@@ -116,8 +116,6 @@ public class TemplateInitializer {
         if (idMapper.isMapped(id)) {
             return;
         }
-        // make sure that shadow root is available
-        idMapper.getOrCreateShadowRoot();
 
         Element element = new Element(tag);
         VirtualChildrenList list = getElement().getNode()

--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -208,11 +208,15 @@ public final class Constants implements Serializable {
 
     /**
      * Boolean parameter for enabling/disabling bytecode scanning in dev mode.
-     * If enabled, entry points are scanned for reachable frontend resources.
-     * If disabled, all classes on the classpath are scanned.
+     * If enabled, entry points are scanned for reachable frontend resources. If
+     * disabled, all classes on the classpath are scanned.
      */
     public static final String SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE = "devmode.optimizeBundle";
 
+    /**
+     * Configuration parameter name for polymer version.
+     */
+    public static final String SERVLET_PARAMETER_DEVMODE_POLYMER_VERSION = "devmode.polymer.version";
 
     /**
      * The path used in the vaadin servlet for handling static resources.

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -47,6 +47,10 @@ public class NodeTasks implements FallibleCommand {
     /**
      * Build a <code>NodeExecutor</code> instance.
      */
+    /**
+     * @author Vaadin Ltd
+     *
+     */
     public static class Builder implements Serializable {
 
         private final ClassFinder classFinder;
@@ -82,6 +86,8 @@ public class NodeTasks implements FallibleCommand {
         private JsonObject tokenFileData;
 
         private File tokenFile;
+
+        private String polymerVersion;
 
         /**
          * Directory for for npm and folders and files.
@@ -328,6 +334,18 @@ public class NodeTasks implements FallibleCommand {
             this.tokenFile = tokenFile;
             return this;
         }
+
+        /**
+         * Sets the polymer version to use.
+         *
+         * @param version
+         *            a polymer version
+         * @return the builder, for chaining
+         */
+        public Builder withPolymerVersion(String version) {
+            this.polymerVersion = version;
+            return this;
+        }
     }
 
     private final Collection<FallibleCommand> commands = new ArrayList<>();
@@ -354,7 +372,8 @@ public class NodeTasks implements FallibleCommand {
 
         if (builder.createMissingPackageJson) {
             TaskCreatePackageJson packageCreator = new TaskCreatePackageJson(
-                    builder.npmFolder, builder.generatedFolder);
+                    builder.npmFolder, builder.generatedFolder,
+                    builder.polymerVersion);
             commands.add(packageCreator);
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -47,10 +47,6 @@ public class NodeTasks implements FallibleCommand {
     /**
      * Build a <code>NodeExecutor</code> instance.
      */
-    /**
-     * @author Vaadin Ltd
-     *
-     */
     public static class Builder implements Serializable {
 
         private final ClassFinder classFinder;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -207,15 +207,21 @@ public abstract class NodeUpdater implements FallibleCommand {
         return packageJson;
     }
 
-    boolean updateMainDefaultDependencies(JsonObject packageJson) {
+    boolean updateMainDefaultDependencies(JsonObject packageJson,
+            String polymerVersion) {
         boolean added = false;
         added = addDependency(packageJson, null, DEP_NAME_KEY, DEP_NAME_DEFAULT)
                 || added;
         added = addDependency(packageJson, null, DEP_LICENSE_KEY,
                 DEP_LICENSE_DEFAULT) || added;
 
+        String polymerDepVersion = polymerVersion;
+        if (polymerDepVersion == null) {
+            polymerDepVersion = "3.2.0";
+        }
+
         added = addDependency(packageJson, DEPENDENCIES, "@polymer/polymer",
-                "3.2.0") || added;
+                polymerDepVersion) || added;
         added = addDependency(packageJson, DEPENDENCIES,
                 "@webcomponents/webcomponentsjs", "^2.2.10") || added;
         // dependency for the custom package.json placed in the generated

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCreatePackageJson.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCreatePackageJson.java
@@ -33,6 +33,8 @@ public class TaskCreatePackageJson extends NodeUpdater {
 
     protected static final String FORCE_INSTALL_HASH = "Main dependencies updated, force install";
 
+    private final String polymerVersion;
+
     /**
      * Create an instance of the updater given all configurable parameters.
      *
@@ -40,9 +42,14 @@ public class TaskCreatePackageJson extends NodeUpdater {
      *            folder with the `package.json` file.
      * @param generatedPath
      *            folder where flow generated files will be placed.
+     * @param polymerVersion
+     *            polymer version, may be {@code null} ({@code "3.2.0"} by
+     *            default)
      */
-    TaskCreatePackageJson(File npmFolder, File generatedPath) {
+    TaskCreatePackageJson(File npmFolder, File generatedPath,
+            String polymerVersion) {
         super(null, null, npmFolder, generatedPath);
+        this.polymerVersion = polymerVersion;
     }
 
     @Override
@@ -53,7 +60,8 @@ public class TaskCreatePackageJson extends NodeUpdater {
             if (mainContent == null) {
                 mainContent = Json.createObject();
             }
-            modified = updateMainDefaultDependencies(mainContent);
+            modified = updateMainDefaultDependencies(mainContent,
+                    polymerVersion);
             if (modified) {
                 if (mainContent.hasKey(APP_PACKAGE_HASH)) {
                     log().debug(

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -55,11 +55,11 @@ import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.vaadin.flow.component.internal.ExportsWebComponent;
 import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.component.internal.ExportsWebComponent;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.Constants;
@@ -264,6 +264,9 @@ public class DevModeInitializer implements ServletContainerInitializer,
                         SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE,
                         Boolean.FALSE.toString())));
 
+        String polymerVersion = config.getStringProperty(
+                Constants.SERVLET_PARAMETER_DEVMODE_POLYMER_VERSION, null);
+
         VaadinContext vaadinContext = new VaadinServletContext(context);
         JsonObject tokenFileData = Json.createObject();
         try {
@@ -274,7 +277,8 @@ public class DevModeInitializer implements ServletContainerInitializer,
                             Constants.LOCAL_FRONTEND_RESOURCES_PATH))
                     .enableImportsUpdate(true).runNpmInstall(true)
                     .withEmbeddableWebComponents(true)
-                    .populateTokenFileData(tokenFileData).build().execute();
+                    .populateTokenFileData(tokenFileData)
+                    .withPolymerVersion(polymerVersion).build().execute();
 
             FallbackChunk chunk = FrontendUtils
                     .readFallbackChunk(tokenFileData);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
@@ -77,7 +77,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         NodeUpdateTestUtil.createStubNode(true, true,
                 baseDir.getAbsolutePath());
 
-        packageCreator = new TaskCreatePackageJson(baseDir, generatedDir);
+        packageCreator = new TaskCreatePackageJson(baseDir, generatedDir, null);
 
         ClassFinder classFinder = getClassFinder();
         packageUpdater = new TaskUpdatePackages(classFinder,

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -122,7 +122,7 @@ public class NodeUpdaterTest {
     }
 
     @Test
-    public void updateMainDefaultDependencies_polymerVersionIsProvided_useDefault() {
+    public void updateMainDefaultDependencies_polymerVersionIsProvided_useProvided() {
         JsonObject object = Json.createObject();
         nodeUpdater.updateMainDefaultDependencies(object, "foo");
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.server.frontend;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -32,6 +31,9 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
+
+import elemental.json.Json;
+import elemental.json.JsonObject;
 
 import static com.vaadin.flow.server.Constants.COMPATIBILITY_RESOURCES_FRONTEND_DEFAULT;
 import static com.vaadin.flow.server.Constants.RESOURCES_FRONTEND_DEFAULT;
@@ -92,7 +94,8 @@ public class NodeUpdaterTest {
     }
 
     @Test
-    public void getGeneratedModules_should_excludeByFileName() throws IOException {
+    public void getGeneratedModules_should_excludeByFileName()
+            throws IOException {
         File generated = temporaryFolder.newFolder();
         File fileA = new File(generated, "a.js");
         File fileB = new File(generated, "b.js");
@@ -100,13 +103,37 @@ public class NodeUpdaterTest {
         fileA.createNewFile();
         fileB.createNewFile();
         fileC.createNewFile();
-        
-        Set<String> modules = NodeUpdater.getGeneratedModules(generated, Stream
-                .of("a.js", "/b.js").collect(Collectors.toSet()));
+
+        Set<String> modules = NodeUpdater.getGeneratedModules(generated,
+                Stream.of("a.js", "/b.js").collect(Collectors.toSet()));
 
         Assert.assertEquals(1, modules.size());
         // GENERATED/ is an added prefix for files from this method
         Assert.assertTrue(modules.contains("GENERATED/c.js"));
+    }
+
+    @Test
+    public void updateMainDefaultDependencies_polymerVersionIsNull_useDefault() {
+        JsonObject object = Json.createObject();
+        nodeUpdater.updateMainDefaultDependencies(object, null);
+
+        String version = getPolymerVersion(object);
+        Assert.assertEquals("3.2.0", version);
+    }
+
+    @Test
+    public void updateMainDefaultDependencies_polymerVersionIsProvided_useDefault() {
+        JsonObject object = Json.createObject();
+        nodeUpdater.updateMainDefaultDependencies(object, "foo");
+
+        String version = getPolymerVersion(object);
+        Assert.assertEquals("foo", version);
+    }
+
+    private String getPolymerVersion(JsonObject object) {
+        JsonObject deps = object.get("dependencies");
+        String version = deps.getString("@polymer/polymer");
+        return version;
     }
 
     private void resolveResource_happyPath(String resourceFolder) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTestBase.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTestBase.java
@@ -29,7 +29,6 @@ import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_PRODUCTION_MODE;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_REUSE_DEV_SERVER;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_CONFIG;
 import static com.vaadin.flow.server.frontend.NodeUpdateTestUtil.createStubNode;
@@ -56,7 +55,7 @@ public class DevModeInitializerTestBase {
     public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Before
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public void setup() throws Exception {
         temporaryFolder.create();
         baseDir = temporaryFolder.getRoot().getPath();
@@ -65,7 +64,8 @@ public class DevModeInitializerTestBase {
         createStubWebpackServer("Compiled", 0, baseDir);
 
         servletContext = Mockito.mock(ServletContext.class);
-        ServletRegistration registration = Mockito.mock(ServletRegistration.class);
+        ServletRegistration registration = Mockito
+                .mock(ServletRegistration.class);
 
         initParams = new HashMap<>();
         initParams.put(FrontendUtils.PROJECT_BASEDIR, baseDir);
@@ -106,7 +106,6 @@ public class DevModeInitializerTestBase {
         System.clearProperty("vaadin." + SERVLET_PARAMETER_COMPATIBILITY_MODE);
         System.clearProperty("vaadin." + SERVLET_PARAMETER_PRODUCTION_MODE);
         System.clearProperty("vaadin." + SERVLET_PARAMETER_REUSE_DEV_SERVER);
-        System.clearProperty("vaadin." + SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE);
 
         webpackFile.delete();
         mainPackageFile.delete();
@@ -125,7 +124,6 @@ public class DevModeInitializerTestBase {
     public void runDestroy() throws Exception {
         devModeInitializer.contextDestroyed(null);
     }
-
 
     static List<URL> getClasspathURLs() {
         return Arrays.stream(


### PR DESCRIPTION
* There is no need to create shadow root for polymer templates: it will
be created out of the box.
* There is no need to check whether the server side components with the
required id are added for the component: the code is executed at the
polymer component construction phase which means there can't be any
child (in any sense) server side component yet.

Fixes #6009

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6889)
<!-- Reviewable:end -->
