### PR TITLE
CCDM: respect nullable return type

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/ExplicitNullableTypeChecker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/ExplicitNullableTypeChecker.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.server.connect;
 
 import javax.annotation.Nullable;
 
+import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -36,16 +37,21 @@ public class ExplicitNullableTypeChecker {
      *
      * @param value
      *            the value to validate
-     * @param method
-     *            the method to be checked return type
+     * @param annotatedElement
+     *            the entity to be type checked
      * @return error message when the value is null while the expected type does
      *         not explicitly allow null, or null meaning the value is OK.
      */
-    public String checkValueForReturnType(Object value, Method method) {
-        if (method.isAnnotationPresent(Nullable.class)) {
+    public String checkValueForAnnotatedElement(Object value,
+            AnnotatedElement annotatedElement) {
+        if (annotatedElement.isAnnotationPresent(Nullable.class)) {
             return null;
         }
-        return checkValueForType(value, method.getGenericReturnType());
+        if (annotatedElement instanceof Method) {
+            return checkValueForType(value,
+                    ((Method) annotatedElement).getGenericReturnType());
+        }
+        return null;
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/ExplicitNullableTypeChecker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/ExplicitNullableTypeChecker.java
@@ -16,6 +16,9 @@
 
 package com.vaadin.flow.server.connect;
 
+import javax.annotation.Nullable;
+
+import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Arrays;
@@ -26,6 +29,25 @@ import java.util.Optional;
  * parameter and return types.
  */
 public class ExplicitNullableTypeChecker {
+
+    /**
+     * Validates the given value for the given expected method return value
+     * type.
+     *
+     * @param value
+     *            the value to validate
+     * @param method
+     *            the method to be checked return type
+     * @return error message when the value is null while the expected type does
+     *         not explicitly allow null, or null meaning the value is OK.
+     */
+    public String checkValueForReturnType(Object value, Method method) {
+        if (method.isAnnotationPresent(Nullable.class)) {
+            return null;
+        }
+        return checkValueForType(value, method.getGenericReturnType());
+    }
+
     /**
      * Validates the given value for the given expected method parameter or
      * return value type.
@@ -37,7 +59,7 @@ public class ExplicitNullableTypeChecker {
      * @return error message when the value is null while the expected type does
      *         not explicitly allow null, or null meaning the value is OK.
      */
-    public String checkValueForType(Object value, Type expectedType) {
+    String checkValueForType(Object value, Type expectedType) {
         Class<?> clazz;
         if (expectedType instanceof ParameterizedType) {
             clazz = (Class<?>) ((ParameterizedType) expectedType).getRawType();

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectController.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectController.java
@@ -19,6 +19,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
+
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -371,8 +372,7 @@ public class VaadinConnectController {
         }
 
         String implicitNullError = this.explicitNullableTypeChecker
-                .checkValueForType(returnValue,
-                        methodToInvoke.getGenericReturnType());
+                .checkValueForReturnType(returnValue, methodToInvoke);
         if (implicitNullError != null) {
             VaadinConnectException returnValueException = new VaadinConnectException(
                     String.format(

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectController.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectController.java
@@ -372,7 +372,7 @@ public class VaadinConnectController {
         }
 
         String implicitNullError = this.explicitNullableTypeChecker
-                .checkValueForReturnType(returnValue, methodToInvoke);
+                .checkValueForAnnotatedElement(returnValue, methodToInvoke);
         if (implicitNullError != null) {
             VaadinConnectException returnValueException = new VaadinConnectException(
                     String.format(

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/OpenApiObjectGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/OpenApiObjectGenerator.java
@@ -582,6 +582,9 @@ public class OpenApiObjectGenerator {
         MediaType mediaItem = new MediaType();
         Type methodReturnType = methodDeclaration.getType();
         Schema schema = parseTypeToSchema(methodReturnType, "");
+        if (methodDeclaration.isAnnotationPresent(Nullable.class)) {
+            schema = schemaResolver.createNullableWrapper(schema);
+        }
         usedTypes.putAll(collectUsedTypesFromSchema(schema));
         mediaItem.schema(schema);
         return mediaItem;

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/SchemaResolver.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/SchemaResolver.java
@@ -97,6 +97,10 @@ class SchemaResolver {
     private Schema createOptionalSchema(ResolvedReferenceType type) {
         ResolvedType typeInOptional = type.getTypeParametersMap().get(0).b;
         Schema nestedTypeSchema = parseResolvedTypeToSchema(typeInOptional);
+        return createNullableWrapper(nestedTypeSchema);
+    }
+
+    Schema createNullableWrapper(Schema nestedTypeSchema) {
         if (nestedTypeSchema.get$ref() == null) {
             nestedTypeSchema.setNullable(true);
             return nestedTypeSchema;

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/ExplicitNullableTypeCheckerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/ExplicitNullableTypeCheckerTest.java
@@ -273,6 +273,22 @@ public class ExplicitNullableTypeCheckerTest {
                 error);
     }
 
+    @Test
+    public void should_InvokeCheckValueForType_When_NotAnnotatedNullable()
+            throws NoSuchMethodException {
+        explicitNullableTypeChecker = spy(explicitNullableTypeChecker);
+        String notNullValue = "someValue";
+        String error = explicitNullableTypeChecker
+                .checkValueForAnnotatedElement(notNullValue,
+                        getClass().getMethod("stringNotNullable"));
+
+        Assert.assertNull("Should allow not null value",
+                error);
+
+        verify(explicitNullableTypeChecker).checkValueForType(notNullValue,
+                String.class);
+    }
+
     public List<String> parametrizedListMethod(String... args) {
         final List<String> list = new ArrayList<String>();
         for (String arg : args) {
@@ -290,6 +306,13 @@ public class ExplicitNullableTypeCheckerTest {
      */
     @Nullable
     public String stringNullable() {
+        return "";
+    }
+
+    /**
+     * Method for testing
+     */
+    public String stringNotNullable() {
         return "";
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/ExplicitNullableTypeCheckerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/ExplicitNullableTypeCheckerTest.java
@@ -16,11 +16,12 @@
 
 package com.vaadin.flow.server.connect;
 
+import javax.annotation.Nullable;
+
 import java.lang.reflect.Type;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -256,6 +257,22 @@ public class ExplicitNullableTypeCheckerTest {
         Assert.assertTrue(error.contains("Bean"));
     }
 
+    @Test
+    public void should_ReturnNull_When_AnnotatedNullable()
+            throws NoSuchMethodException {
+        String error = explicitNullableTypeChecker.checkValueForReturnType(null,
+                getClass().getMethod("stringNullable"));
+
+        Assert.assertNull("Nullable return type should allow null value",
+                error);
+
+        error = explicitNullableTypeChecker.checkValueForReturnType(
+                "Not null value", getClass().getMethod("stringNullable"));
+
+        Assert.assertNull("Nullable return type should allow null value",
+                error);
+    }
+
     public List<String> parametrizedListMethod(String... args) {
         final List<String> list = new ArrayList<String>();
         for (String arg : args) {
@@ -266,6 +283,14 @@ public class ExplicitNullableTypeCheckerTest {
 
     public String[] arrayMethod(String... args) {
         return args;
+    }
+
+    /**
+     * Method for testing
+     */
+    @Nullable
+    public String stringNullable() {
+        return "";
     }
 
     private class Bean {

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/ExplicitNullableTypeCheckerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/ExplicitNullableTypeCheckerTest.java
@@ -260,13 +260,13 @@ public class ExplicitNullableTypeCheckerTest {
     @Test
     public void should_ReturnNull_When_AnnotatedNullable()
             throws NoSuchMethodException {
-        String error = explicitNullableTypeChecker.checkValueForReturnType(null,
+        String error = explicitNullableTypeChecker.checkValueForAnnotatedElement(null,
                 getClass().getMethod("stringNullable"));
 
         Assert.assertNull("Nullable return type should allow null value",
                 error);
 
-        error = explicitNullableTypeChecker.checkValueForReturnType(
+        error = explicitNullableTypeChecker.checkValueForAnnotatedElement(
                 "Not null value", getClass().getMethod("stringNullable"));
 
         Assert.assertNull("Nullable return type should allow null value",

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/services/nullable/NullableService.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/services/nullable/NullableService.java
@@ -50,7 +50,13 @@ public class NullableService {
 
     }
 
+    @Nullable
+    public String stringNullable() {
+        return "";
+    }
+
     public static class NullableModel {
+
         String foo;
         String bar;
         int shouldBeNotNullByDefault;

--- a/flow-server/src/test/resources/com/vaadin/flow/server/connect/generator/services/nullable/expected-NullableService.ts
+++ b/flow-server/src/test/resources/com/vaadin/flow/server/connect/generator/services/nullable/expected-NullableService.ts
@@ -12,11 +12,11 @@ export function echoMap(
 
 export function echoNonNullMode(
   nullableModels: Array<NullableModel>
-): Promise<NullableModel> {
+): Promise<NullableModel | undefined> {
   return client.call('NullableService', 'echoNonNullMode', {nullableModels});
 }
 
-export function getNotNullReturnType(): Promise<ReturnType> {
+export function getNotNullReturnType(): Promise<ReturnType | undefined> {
   return client.call('NullableService', 'getNotNullReturnType');
 }
 
@@ -30,4 +30,8 @@ export function sendParameterType(
   parameterType?: ParameterType
 ): Promise<void> {
   return client.call('NullableService', 'sendParameterType', {parameterType});
+}
+
+export function stringNullable(): Promise<string | undefined> {
+  return client.call('NullableService', 'stringNullable');
 }


### PR DESCRIPTION
Follow up #6837 
The PR takes `@Nullable` return type into account. The annotation is also respected in ExplicitNullableTypeChecker

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6895)
<!-- Reviewable:end -->
