### PR TITLE
Remove plural from add(String) javadoc

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/HasComponents.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasComponents.java
@@ -55,7 +55,7 @@ public interface HasComponents extends HasElement, HasEnabled {
     }
 
     /**
-     * Add the given text as children of this component.
+     * Add the given text as a child of this component.
      *
      * @param text
      *            the text to add


### PR DESCRIPTION
The text is most likely copy-pasted from the add(Component...) method
that does accept multiple children.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6904)
<!-- Reviewable:end -->
