### PR TITLE
CP: Fix embedding: removing virtual child (#6903)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentWrapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentWrapper.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.webcomponent;
 import java.util.Objects;
 import java.util.Optional;
 
+import com.vaadin.flow.internal.nodefeature.VirtualChildrenList;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.ClientCallable;
@@ -119,9 +120,24 @@ public class WebComponentWrapper extends Component {
                         if (event.getSource().getInternals()
                                 .getLastHeartbeatTimestamp()
                                 - disconnect > timeout) {
-                            this.getElement().removeFromParent();
+                            removeFromParent(getElement());
                         }
                     });
+        }
+    }
+
+    private static void removeFromParent(Element webComponentWrapperElement) {
+        Element parent = webComponentWrapperElement.getParent();
+        if (parent.getNode().hasFeature(VirtualChildrenList.class)) {
+            VirtualChildrenList childrenList = parent.getNode()
+                    .getFeature(VirtualChildrenList.class);
+            int index = childrenList
+                    .indexOf(webComponentWrapperElement.getNode());
+            if (index == -1) {
+                throw new IllegalArgumentException(
+                        "Failing to clean-up an embedded Flow web component, parent UI doesn't contain it as a virtual child.");
+            }
+            childrenList.remove(index);
         }
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/AbstractNodeStateProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/AbstractNodeStateProvider.java
@@ -120,10 +120,9 @@ public abstract class AbstractNodeStateProvider
         ElementChildrenList childrenFeature = getChildrenFeature(node);
         int pos = childrenFeature.indexOf(child.getNode());
         if (pos == -1) {
-            throw new IllegalArgumentException("Not in the list");
+            throw new IllegalArgumentException("Trying to detach an element from parent that does not have it.");
         }
         childrenFeature.remove(pos);
-
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/VirtualChildrenList.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/VirtualChildrenList.java
@@ -154,8 +154,17 @@ public class VirtualChildrenList extends StateNodeNodeList {
     }
 
     @Override
-    protected StateNode remove(int index) {
-        throw new UnsupportedOperationException();
+    public int indexOf(StateNode node) {
+        return super.indexOf(node);
+    }
+
+    @Override
+    public StateNode remove(int index) {
+        // removing the payload in case the element is reused
+        get(index).getFeature(ElementData.class).remove(NodeProperties.PAYLOAD);
+
+        // this should not omit a node change to client side.
+        return super.remove(index);
     }
 
     @Override

--- a/flow-server/src/test/java/com/vaadin/flow/component/webcomponent/WebComponentWrapperTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/webcomponent/WebComponentWrapperTest.java
@@ -249,7 +249,7 @@ public class WebComponentWrapperTest {
         when(ui.getInternals()).thenReturn(internals);
 
         Component parent = new Parent();
-        parent.getElement().appendChild(wrapperElement);
+        parent.getElement().appendVirtualChild(wrapperElement);
 
         VaadinSession session = mock(VaadinSession.class);
         DeploymentConfiguration configuration = mock(

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
@@ -19,11 +19,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
-import org.easymock.EasyMock;
-import org.junit.Assert;
-import org.junit.Test;
-import org.mockito.Mockito;
-
 import com.vaadin.flow.component.Html;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
@@ -49,11 +44,15 @@ import com.vaadin.flow.shared.Registration;
 import com.vaadin.tests.util.AlwaysLockedVaadinSession;
 import com.vaadin.tests.util.MockUI;
 import com.vaadin.tests.util.TestUtil;
+import net.jcip.annotations.NotThreadSafe;
+import org.easymock.EasyMock;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
 
 import elemental.json.Json;
 import elemental.json.JsonValue;
 import elemental.json.impl.JreJsonObject;
-import net.jcip.annotations.NotThreadSafe;
 
 @NotThreadSafe
 public class ElementTest extends AbstractNodeTest {
@@ -2480,6 +2479,16 @@ public class ElementTest extends AbstractNodeTest {
 
         // Should not trigger assert in the listener
         element.setProperty("property", "value");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void removeFromParent_virtualChild_fails() {
+        Element parent = new Element("root");
+        Element child1 = new Element("main");
+
+        parent.appendVirtualChild(child1);
+
+        child1.removeFromParent();
     }
 
     @Override

--- a/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/VirtualChildrenListTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/VirtualChildrenListTest.java
@@ -21,13 +21,9 @@ import java.util.Spliterators;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import com.vaadin.flow.internal.StateNode;
 import org.junit.Assert;
 import org.junit.Test;
-
-import com.vaadin.flow.internal.StateNode;
-import com.vaadin.flow.internal.nodefeature.ElementData;
-import com.vaadin.flow.internal.nodefeature.NodeProperties;
-import com.vaadin.flow.internal.nodefeature.VirtualChildrenList;
 
 import elemental.json.JsonObject;
 
@@ -98,10 +94,20 @@ public class VirtualChildrenListTest {
         Assert.assertEquals(0, set.size());
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void remove_throw() {
+    @Test
+    public void remove_withIndex_removesNodeAndPayload() {
         list.append(child, "foo");
+
+        Assert.assertEquals(child, list.get(0));
+
         list.remove(0);
+
+        Assert.assertEquals(0, list.size());
+        Assert.assertEquals(-1, list.indexOf(child));
+
+        JsonObject payload = (JsonObject) child.getFeature(ElementData.class)
+                .getPayload();
+        Assert.assertNull(payload);
     }
 
     @Test(expected = UnsupportedOperationException.class)


### PR DESCRIPTION
Adopted cherry pick, which doesn't add new public API (only in internal
package).
Can be backported to 2.1 and 2.0

Fixes #6822

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6916)
<!-- Reviewable:end -->
