### PR TITLE
Optimize stats contents

### DIFF
--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -159,30 +159,22 @@ module.exports = {
     function (compiler) {
       compiler.hooks.afterEmit.tapAsync("FlowIdPlugin", (compilation, done) => {
         let statsJson = compilation.getStats().toJson();
+        // Get bundles as accepted keys (except any es5 bunlde)
+        let acceptedKeys = Object.keys(statsJson.assetsByChunkName).filter(key => !/es5$/.test(key));
+
+        // If there exists a namedChunkGroups in stats chunk names should be changed to named keys
+        if(statsJson.namedChunkGroups) {
+          let namedChunks = [];
+          acceptedKeys.forEach(key => {
+            statsJson.namedChunkGroups[key].chunks.forEach(chunk => namedChunks.push(chunk));
+          });
+          acceptedKeys = namedChunks;
+        }
+
+        // Collect all modules for the given keys
+        const modules = collectModules(statsJson, acceptedKeys);
 
         if (!devMode) {
-
-          let modules = [];
-          statsJson.modules.forEach(function (module) {
-            let moduleTarget = /generated-flow-imports.js\?babel-target=es6( \+ \d+ modules)?$/;
-            if (moduleTarget.test(module.name) && module.modules) {
-              let slimModules = [];
-              module.modules.forEach(function (module) {
-                const slimModule = {
-                  name: module.name,
-                  source: module.source
-                };
-                slimModules.push(slimModule);
-              });
-              const slimModule = {
-                id: module.id,
-                name: module.name,
-                source: module.source,
-                modules: slimModules
-              };
-              modules.push(slimModule);
-            }
-          });
           let customStats = {
             hash: statsJson.hash,
             assetsByChunkName: statsJson.assetsByChunkName,
@@ -190,38 +182,18 @@ module.exports = {
           };
           // eslint-disable-next-line no-console
           console.log("         Emitted " + statsFile);
-
           fs.writeFile(statsFile, JSON.stringify(customStats, null, 1), done);
         } else {
           // eslint-disable-next-line no-console
           console.log("         Serving the 'stats.json' file dynamically.");
 
-          const chunks = [];
-          statsJson.chunks.forEach(function (chunk) {
-            if (chunk.id === "bundle") {
-              const modules = [];
-              chunk.modules.forEach(function (module) {
-                const slimModule = {
-                  id: module.id,
-                  name: module.name,
-                  source: module.source,
-                };
-                modules.push(slimModule);
-              });
-              const slimChunk = {
-                id: chunk.id,
-                names: chunk.names,
-                files: chunk.files,
-                hash: chunk.hash,
-                modules: modules
-              }
-              chunks.push(slimChunk);
-            }
-          });
+          // Collect accepted chunks and their modules
+          const chunks = collectChunks(statsJson, acceptedKeys);
           let customStats = {
             hash: statsJson.hash,
             assetsByChunkName: statsJson.assetsByChunkName,
-            chunks: chunks
+            chunks: chunks,
+            modules: modules
           };
           stats = customStats;
           done();
@@ -237,3 +209,78 @@ module.exports = {
     }]),
   ]
 };
+
+/**
+ * Collect chunk data for accepted chunk ids.
+ * @param statsJson full stats.json content
+ * @param acceptedKeys chunk ids that are accepted
+ * @returns slimmed down chunks
+ */
+function collectChunks(statsJson, acceptedChunks) {
+  const chunks = [];
+  // only handle chunks if they exist for stats
+  if (statsJson.chunks) {
+    statsJson.chunks.forEach(function (chunk) {
+      // Acc chunk if chunk id is in accepted chunks
+      if (acceptedChunks.includes(chunk.id)) {
+        const modules = [];
+        // Add all modules for chunk as slimmed down modules
+        chunk.modules.forEach(function (module) {
+          const slimModule = {
+            id: module.id,
+            name: module.name,
+            source: module.source,
+          };
+          modules.push(slimModule);
+        });
+        const slimChunk = {
+          id: chunk.id,
+          names: chunk.names,
+          files: chunk.files,
+          hash: chunk.hash,
+          modules: modules
+        }
+        chunks.push(slimChunk);
+      }
+    });
+  }
+  return chunks;
+}
+
+/**
+ * Collect all modules that are for a chunk in  acceptedChunks.
+ * @param statsJson full stats.json
+ * @param acceptedChunks chunk names that are accepted for modules
+ * @returns slimmed down modules
+ */
+function collectModules(statsJson, acceptedChunks) {
+  let modules = [];
+  // skip if no modules defined
+  if (statsJson.modules) {
+    statsJson.modules.forEach(function (module) {
+      // Add module if module chunks contain an accepted chunk and the module is generated-flow-imports.js module
+      if (module.chunks.filter(key => acceptedChunks.includes(key)).length > 0
+          && module.name.includes("generated-flow-imports.js")) {
+        let subModules = [];
+        // Create sub modules only if they are available
+        if (module.modules) {
+          module.modules.forEach(function (module) {
+            const subModule = {
+              name: module.name,
+              source: module.source
+            };
+            subModules.push(subModule);
+          });
+        }
+        const slimModule = {
+          id: module.id,
+          name: module.name,
+          source: module.source,
+          modules: subModules
+        };
+        modules.push(slimModule);
+      }
+    });
+  }
+  return modules;
+}


### PR DESCRIPTION
Optimize contents by only adding
needed things on createion instead of
later handling the whole generated stats.json.

This drops the production stats size for megabundle from
40mb to 1.9mb or for bakery from 42mb to 686kb

This would make it feasible to serve the stats publicly over http as
there is no build time information left in the file.

Fixes #6922 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6919)
<!-- Reviewable:end -->
