### PR TITLE
CCDM: remove reading request.body key which errors in Safari

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/Connect.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Connect.ts
@@ -23,15 +23,6 @@ const throwConnectException = (errorJson: ConnectExceptionData) => {
   }
 };
 
-// when in tests, body is not set correctly by calling `new Request`
-export const createRequest = (input: RequestInfo, init?: RequestInit) => {
-  const request = new Request(input, init);
-  if (init && init.body && !request.body) {
-    (request as any).body = init.body;
-  }
-  return request;
-};
-
 /**
  * Throws a TypeError if the response is not 200 OK.
  * @param response The response to assert.
@@ -297,7 +288,7 @@ export class ConnectClient {
       return obj;
     }
 
-    const request = createRequest(
+    const request = new Request(
        `${this.endpoint}/${service}/${method}`, {
          method: 'POST',
          headers,

--- a/flow-client/src/test/frontend/ConnectTests.ts
+++ b/flow-client/src/test/frontend/ConnectTests.ts
@@ -3,7 +3,7 @@ const {expect} = intern.getPlugin('chai');
 const {fetchMock} = intern.getPlugin('fetchMock');
 const {sinon} = intern.getPlugin('sinon');
 
-import { ConnectClient, VaadinConnectError, VaadinConnectValidationError, createRequest } from "../../main/resources/META-INF/resources/frontend/Connect";
+import { ConnectClient, VaadinConnectError, VaadinConnectValidationError } from "../../main/resources/META-INF/resources/frontend/Connect";
 
 // `connectClient.call` adds the host and context to the service request.
 // we need to add this origin when configuring fetch-mock
@@ -226,9 +226,9 @@ describe('ConnectClient', () => {
     it('should pass 3rd argument as JSON request body', async() => {
       await client.call('FooService', 'fooMethod', {fooParam: 'foo'});
 
-      const requestBody = fetchMock.lastCall().request.body;
-      expect(requestBody).to.exist;
-      expect(JSON.parse(requestBody.toString())).to.deep.equal({fooParam: 'foo'});
+      const request = fetchMock.lastCall().request;
+      expect(request).to.exist;
+      expect(await request.json()).to.deep.equal({fooParam: 'foo'});
     });
 
     describe('middleware invocation', () => {
@@ -268,7 +268,7 @@ describe('ConnectClient', () => {
         fetchMock.post(myUrl, {});
 
         const myMiddleware = async(context: any, next?: any) => {
-          context.request = createRequest(
+          context.request = new Request(
             myUrl,
             {
               method: 'POST',
@@ -287,8 +287,7 @@ describe('ConnectClient', () => {
         const request = fetchMock.lastCall().request;
         expect(request.url).to.equal(myUrl);
         expect(request.headers.get('X-Foo')).to.equal('Bar');
-        expect(request.body).to.exist;
-        // expect(request.body.toString()).to.equal('{"baz": "qux"}');
+        expect(await request.text()).to.equal('{"baz": "qux"}');
       });
 
       it('should allow modified response', async() => {


### PR DESCRIPTION
Fix #6918

Connect Client was using the request.body getter in order to ensure it
exists for tests introspection purpose. Some implementations choose not
to include the `body` getter (e. g., Chrome), that is why a workaround
was necessary. This workaround was creating errors with Safari
implementation though, because once the `body` getter is used, the
Request object becomes not usable with `fetch` anymore.

However, since per spec Request implements Body, a different introspection
technique is possible without using the `body` getter, but rather with using
the Body methods of Request directly.

This change makes use of Body methods when inspecting the Request body
in the tests, and removes the `body` getter workaround, which also fixes
the Connect Client errors in Safari.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6927)
<!-- Reviewable:end -->
