### PR TITLE
CCDM: set commons-lang3 version when running generators in maven goals

### DIFF
--- a/flow-maven-plugin/pom.xml
+++ b/flow-maven-plugin/pom.xml
@@ -77,10 +77,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.sonatype.plexus</groupId>
             <artifactId>plexus-build-api</artifactId>
             <version>0.0.7</version>

--- a/flow-maven-plugin/pom.xml
+++ b/flow-maven-plugin/pom.xml
@@ -76,7 +76,10 @@
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.sonatype.plexus</groupId>
             <artifactId>plexus-build-api</artifactId>

--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -249,11 +249,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- Need to be revised and removed to avoid conflicts-->
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
+
         <!-- Connect Testing dependendies -->
 
         <!-- TODO: re-enable tests mocking final classes in the connect

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/GeneratorUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/GeneratorUtils.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.connect.generator;
+
+import java.util.Arrays;
+
+/**
+ * A set of static methods used in CCDM generators, so as flow do not depend on
+ * external libraries for these operations.
+ */
+final class GeneratorUtils {
+    
+    private GeneratorUtils() {
+    }
+
+    static boolean equals(String s1, String s2) {
+        return s1 == s2 || s1 != null && s1.equals(s2);
+    }
+
+    static int compare(String s1, String s2) {
+        return equals(s1, s2) ? 0
+                : s1 == null ? -1 : s2 == null ? 1 : s1.compareTo(s2);
+    }
+
+    static String capitalize(String s) {
+        return s == null ? s : s.substring(0, 1).toUpperCase() + s.substring(1);
+    }
+
+    static boolean isBlank(String s) {
+        return s == null || s.replaceAll("\\s+","").isEmpty();
+    }
+
+    static boolean isNotBlank(String s) {
+        return !isBlank(s);
+    }
+
+    static String firstNonBlank(String... values) {
+        return Arrays.stream(values).filter(GeneratorUtils::isNotBlank)
+                .findFirst().orElse(null);
+    }
+
+    static boolean isTrue(Boolean b) {
+        return Boolean.TRUE.equals(b);
+    }
+
+    static boolean isNotTrue(Boolean b) {
+        return !isTrue(b);
+    }
+
+    static <T> T defaultIfNull(T o, T def) {
+        return o != null ? o : def;
+    }
+    
+    static String replaceChars(String s, char c1, final char c2) {
+        return s == null ? s : s.replace(c1, c2);
+    }
+    
+    @SuppressWarnings("squid:S2259")
+    static boolean contains(String s, String p) {
+        return isNotBlank(s) && isNotBlank(p) && s.contains(p);
+    }
+
+    @SuppressWarnings("squid:S2259")
+    static String substringAfter(String s, String p) {
+        return contains(s, p) ? s.substring(s.indexOf(p) + p.length()) : "";
+    }
+
+    @SuppressWarnings("squid:S2259")
+    static String substringAfterLast(String s, String p) {
+        return contains(s, p) ? s.substring(s.lastIndexOf(p) + p.length()) : "";
+    }
+
+    @SuppressWarnings("squid:S2259")
+    static String substringBeforeLast(String s, String p) {
+        return contains(s, p) ? s.substring(0, s.lastIndexOf(p)) : s;
+    }
+
+    @SuppressWarnings("squid:S2259")
+    static boolean endsWith(String s, String p) {
+        return contains(s, p) && s.length() == p.length() + s.lastIndexOf(p);
+    }
+
+    @SuppressWarnings("squid:S2259")
+    static String removeEnd(String s, String p) {
+        return endsWith(s, p) ? s.substring(0, s.lastIndexOf(p)) : s;
+    }
+
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/OpenApiObjectGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/OpenApiObjectGenerator.java
@@ -88,8 +88,6 @@ import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import io.swagger.v3.oas.models.tags.Tag;
-import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -314,7 +312,7 @@ public class OpenApiObjectGenerator {
                 .map(SingleMemberAnnotationExpr::getMemberValue)
                 .map(Expression::asStringLiteralExpr)
                 .map(LiteralStringValueExpr::getValue)
-                .filter(StringUtils::isNotBlank)
+                .filter(GeneratorUtils::isNotBlank)
                 .orElse(classDeclaration.getNameAsString());
 
         String validationError = serviceNameChecker.check(serviceName);
@@ -375,7 +373,7 @@ public class OpenApiObjectGenerator {
                 typeDeclaration);
         schema.properties(properties);
         List<String> requiredList = properties.entrySet().stream()
-                .filter(stringSchemaEntry -> BooleanUtils
+                .filter(stringSchemaEntry -> GeneratorUtils
                         .isNotTrue(stringSchemaEntry.getValue().getNullable()))
                 .map(Map.Entry::getKey).collect(Collectors.toList());
         // Nullable is represented in requiredList instead.
@@ -410,7 +408,7 @@ public class OpenApiObjectGenerator {
                         variableDeclarator.getType(),
                         fieldDescription.orElse(""));
                 if (field.isAnnotationPresent(Nullable.class)
-                        || BooleanUtils.isTrue(propertySchema.getNullable())) {
+                        || GeneratorUtils.isTrue(propertySchema.getNullable())) {
                     // Temporarily set nullable to indicate this property is
                     // not required
                     propertySchema.setNullable(true);
@@ -425,9 +423,9 @@ public class OpenApiObjectGenerator {
     private Map<String, ResolvedReferenceType> collectUsedTypesFromSchema(
             Schema schema) {
         Map<String, ResolvedReferenceType> map = new HashMap<>();
-        if (StringUtils.isNotBlank(schema.getName())
-                || StringUtils.isNotBlank(schema.get$ref())) {
-            String name = StringUtils.firstNonBlank(schema.getName(),
+        if (GeneratorUtils.isNotBlank(schema.getName())
+                || GeneratorUtils.isNotBlank(schema.get$ref())) {
+            String name = GeneratorUtils.firstNonBlank(schema.getName(),
                     schemaResolver.getSimpleRef(schema.get$ref()));
             ResolvedReferenceType resolvedReferenceType = schemaResolver
                     .getFoundTypeByQualifiedName(name);
@@ -614,12 +612,12 @@ public class OpenApiObjectGenerator {
             usedTypes.putAll(collectUsedTypesFromSchema(paramSchema));
             String name = (isReservedWord(parameter.getNameAsString()) ? "_"
                     : "").concat(parameter.getNameAsString());
-            if (StringUtils.isBlank(paramSchema.get$ref())) {
+            if (GeneratorUtils.isBlank(paramSchema.get$ref())) {
                 paramSchema.description(
                         paramsDescription.remove(parameter.getNameAsString()));
             }
             requestSchema.addProperties(name, paramSchema);
-            if (BooleanUtils.isNotTrue(paramSchema.getNullable())
+            if (GeneratorUtils.isNotTrue(paramSchema.getNullable())
                     && !parameter.isAnnotationPresent(Nullable.class)) {
                 requestSchema.addRequiredItem(name);
             }
@@ -636,7 +634,7 @@ public class OpenApiObjectGenerator {
     private Schema parseTypeToSchema(Type javaType, String description) {
         try {
             Schema schema = parseResolvedTypeToSchema(javaType.resolve());
-            if (StringUtils.isNotBlank(description)) {
+            if (GeneratorUtils.isNotBlank(description)) {
                 schema.setDescription(description);
             }
             return schema;
@@ -801,13 +799,13 @@ public class OpenApiObjectGenerator {
                 .getTypeDeclaration();
         String packageName = typeDeclaration.getPackageName();
         String canonicalName = typeDeclaration.getQualifiedName();
-        if (StringUtils.isBlank(packageName)) {
-            return StringUtils.replaceChars(canonicalName, '.', '$');
+        if (GeneratorUtils.isBlank(packageName)) {
+            return GeneratorUtils.replaceChars(canonicalName, '.', '$');
         } else {
-            String name = StringUtils.substringAfterLast(canonicalName,
+            String name = GeneratorUtils.substringAfterLast(canonicalName,
                     packageName + ".");
             return String.format("%s.%s", packageName,
-                    StringUtils.replaceChars(name, '.', '$'));
+                    GeneratorUtils.replaceChars(name, '.', '$'));
         }
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/OpenApiSpecGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/OpenApiSpecGenerator.java
@@ -25,7 +25,6 @@ import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.models.OpenAPI;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -117,7 +116,7 @@ public class OpenApiSpecGenerator {
             PropertiesConfiguration applicationProperties) {
         String endpoint = applicationProperties.getString(ENDPOINT,
                 DEFAULT_ENDPOINT);
-        String server = StringUtils.removeEnd(
+        String server = GeneratorUtils.removeEnd(
                 applicationProperties.getString(SERVER, DEFAULT_SERVER), "/");
         String serverDescription = applicationProperties
                 .getString(SERVER_DESCRIPTION, DEFAULT_SERVER_DESCRIPTION);

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/OpenApiSpecGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/OpenApiSpecGenerator.java
@@ -20,10 +20,10 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Properties;
 
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.models.OpenAPI;
-import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,7 +59,7 @@ public class OpenApiSpecGenerator {
      * @param applicationProperties
      *            the properties with the data required for the generation
      */
-    public OpenApiSpecGenerator(PropertiesConfiguration applicationProperties) {
+    public OpenApiSpecGenerator(Properties applicationProperties) {
         generator = new OpenApiObjectGenerator();
         generator.setOpenApiConfiguration(
                 extractOpenApiConfiguration(applicationProperties));
@@ -113,17 +113,18 @@ public class OpenApiSpecGenerator {
     }
 
     private OpenApiConfiguration extractOpenApiConfiguration(
-            PropertiesConfiguration applicationProperties) {
-        String endpoint = applicationProperties.getString(ENDPOINT,
+            Properties applicationProperties) {
+        String endpoint = (String) applicationProperties.getOrDefault(ENDPOINT,
                 DEFAULT_ENDPOINT);
-        String server = GeneratorUtils.removeEnd(
-                applicationProperties.getString(SERVER, DEFAULT_SERVER), "/");
-        String serverDescription = applicationProperties
-                .getString(SERVER_DESCRIPTION, DEFAULT_SERVER_DESCRIPTION);
-        String applicationTitle = applicationProperties
-                .getString(APPLICATION_TITLE, DEFAULT_APPLICATION_TITLE);
-        String applicationApiVersion = applicationProperties.getString(
-                APPLICATION_API_VERSION, DEFAULT_APPLICATION_API_VERSION);
+        String server = GeneratorUtils.removeEnd((String) applicationProperties
+                .getOrDefault(SERVER, DEFAULT_SERVER), "/");
+        String serverDescription = (String) applicationProperties
+                .getOrDefault(SERVER_DESCRIPTION, DEFAULT_SERVER_DESCRIPTION);
+        String applicationTitle = (String) applicationProperties
+                .getOrDefault(APPLICATION_TITLE, DEFAULT_APPLICATION_TITLE);
+        String applicationApiVersion = (String) applicationProperties
+                .getOrDefault(APPLICATION_API_VERSION,
+                        DEFAULT_APPLICATION_API_VERSION);
         return new OpenApiConfiguration(applicationTitle, applicationApiVersion,
                 server + endpoint, serverDescription);
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/SchemaResolver.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/SchemaResolver.java
@@ -43,7 +43,6 @@ import io.swagger.v3.oas.models.media.NumberSchema;
 import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
-import org.apache.commons.lang3.StringUtils;
 
 class SchemaResolver {
 
@@ -217,8 +216,8 @@ class SchemaResolver {
     }
 
     String getSimpleRef(String ref) {
-        if (StringUtils.contains(ref, SCHEMA_REF_PREFIX)) {
-            return StringUtils.substringAfter(ref, SCHEMA_REF_PREFIX);
+        if (GeneratorUtils.contains(ref, SCHEMA_REF_PREFIX)) {
+            return GeneratorUtils.substringAfter(ref, SCHEMA_REF_PREFIX);
         }
         return ref;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/VaadinConnectClientGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/VaadinConnectClientGenerator.java
@@ -21,9 +21,9 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.Properties;
 import java.util.stream.Collectors;
 
-import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,8 +54,8 @@ public class VaadinConnectClientGenerator {
      *            the properties with the data required for the generation
      */
     public VaadinConnectClientGenerator(
-            PropertiesConfiguration applicationProperties) {
-        this.serviceEndpoint = applicationProperties.getString(ENDPOINT,
+            Properties applicationProperties) {
+        this.serviceEndpoint = (String)applicationProperties.getOrDefault(ENDPOINT,
                 DEFAULT_ENDPOINT);
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractTaskConnectGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractTaskConnectGenerator.java
@@ -20,9 +20,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.Properties;
 
-import org.apache.commons.configuration2.PropertiesConfiguration;
-import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,15 +37,14 @@ abstract class AbstractTaskConnectGenerator implements FallibleCommand {
         this.applicationProperties = applicationProperties;
     }
 
-    protected PropertiesConfiguration readApplicationProperties() {
-        PropertiesConfiguration config = new PropertiesConfiguration();
+    protected Properties readApplicationProperties() {
+        Properties config = new Properties();
 
         if (applicationProperties != null && applicationProperties.exists()) {
-            try {
-                BufferedReader bufferedReader = Files.newBufferedReader(
-                        applicationProperties.toPath(), StandardCharsets.UTF_8);
-                config.read(bufferedReader);
-            } catch (IOException | ConfigurationException e) {
+            try (BufferedReader bufferedReader = Files.newBufferedReader(
+                    applicationProperties.toPath(), StandardCharsets.UTF_8)) {
+                config.load(bufferedReader);
+            } catch (IOException e) {
                 log().info(String.format(
                         "Can't read the application"
                                 + ".properties file from %s",

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/TestUtils.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/TestUtils.java
@@ -21,18 +21,17 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.util.Properties;
 import java.util.stream.Collectors;
-
-import org.apache.commons.configuration2.PropertiesConfiguration;
 
 public final class TestUtils {
     private TestUtils() {
     }
 
-    public static PropertiesConfiguration readProperties(String filePath) {
-        PropertiesConfiguration properties = new PropertiesConfiguration();
+    public static Properties readProperties(String filePath) {
+        Properties properties = new Properties();
         try {
-            properties.read(new FileReader(filePath));
+            properties.load(new FileReader(filePath));
         } catch (Exception e) {
             throw new AssertionError(String.format(
                     "Failed to read the properties file '%s", filePath));

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/VaadinConnectClientGeneratorTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/VaadinConnectClientGeneratorTest.java
@@ -19,8 +19,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Properties;
 
-import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.Before;
@@ -44,7 +44,7 @@ public class VaadinConnectClientGeneratorTest {
     public void should_GenerateConnectClientDefault_When_NoApplicationPropertiesInput()
             throws Exception {
         VaadinConnectClientGenerator generator = new VaadinConnectClientGenerator(
-                new PropertiesConfiguration());
+                new Properties());
 
         generator.generateVaadinConnectClientFile(outputPath);
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/openapi/OpenApiSpecBasedTests.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/openapi/OpenApiSpecBasedTests.java
@@ -23,8 +23,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Properties;
 
-import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -114,7 +114,7 @@ public class OpenApiSpecBasedTests {
                 outputDirectory.getRoot().getAbsolutePath(),
                 VaadinConnectClientGenerator.CONNECT_CLIENT_NAME);
         VaadinConnectClientGenerator vaadinConnectClientGenerator = new VaadinConnectClientGenerator(
-                new PropertiesConfiguration());
+                new Properties());
         // First generating round
         vaadinConnectClientGenerator
                 .generateVaadinConnectClientFile(defaultConnectClient);

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/services/AbstractServiceGenerationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/services/AbstractServiceGenerationTest.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.server.connect.generator.services;
 
 import javax.annotation.Nullable;
 import javax.annotation.security.DenyAll;
+
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -42,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -64,13 +66,8 @@ import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.parser.OpenAPIV3Parser;
-import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
@@ -83,6 +80,11 @@ import com.vaadin.flow.server.connect.generator.OpenApiObjectGenerator;
 import com.vaadin.flow.server.connect.generator.OpenApiSpecGenerator;
 import com.vaadin.flow.server.connect.generator.TestUtils;
 import com.vaadin.flow.server.connect.generator.VaadinConnectTsGenerator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public abstract class AbstractServiceGenerationTest {
     private static final List<Class<?>> JSON_NUMBER_CLASSES = Arrays.asList(
@@ -153,8 +155,8 @@ public abstract class AbstractServiceGenerationTest {
 
     private void generateAndVerify(URL customApplicationProperties,
             URL expectedOpenApiJsonResourceUrl) {
-        PropertiesConfiguration applicationProperties = customApplicationProperties == null
-                ? new PropertiesConfiguration()
+        Properties applicationProperties = customApplicationProperties == null
+                ? new Properties()
                 : TestUtils
                         .readProperties(customApplicationProperties.getPath());
         new OpenApiSpecGenerator(applicationProperties).generateOpenApiSpec(
@@ -565,7 +567,7 @@ public abstract class AbstractServiceGenerationTest {
      * .ts</code>. For example: The generated model of
      * <code>com.vaadin.flow.server.connect.SomeModel</code> will be expected to
      * be the same as file <code>expected-model-connect.SomeModel.ts</code>
-     * 
+     *
      * @param expectedClass
      * @return
      */

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/services/json/JsonTestServiceGeneratedTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/services/json/JsonTestServiceGeneratedTest.java
@@ -19,18 +19,18 @@ package com.vaadin.flow.server.connect.generator.services.json;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Properties;
 
 import com.fasterxml.jackson.core.Version;
-import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.junit.Test;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 import com.vaadin.flow.server.connect.generator.OpenApiSpecGenerator;
 import com.vaadin.flow.server.connect.generator.VaadinConnectClientGenerator;
 import com.vaadin.flow.server.connect.generator.VaadinConnectTsGenerator;
 import com.vaadin.flow.server.connect.generator.services.AbstractServiceGenerationTest;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class JsonTestServiceGeneratedTest
     extends AbstractServiceGenerationTest {
@@ -66,7 +66,7 @@ public class JsonTestServiceGeneratedTest
     String expectedImport = String.format("import client from '%s';",
         customConnectClientPath);
 
-    new OpenApiSpecGenerator(new PropertiesConfiguration()).generateOpenApiSpec(
+    new OpenApiSpecGenerator(new Properties()).generateOpenApiSpec(
         Collections
             .singletonList(java.nio.file.Paths.get("src/test/java", getClass()
                 .getPackage().getName().replace('.', File.separatorChar))),


### PR DESCRIPTION
Fixes #6920 

commons-lang3 3.9+ is needed in order to call `StringUtils.firstNonBlank` and other methods  that are used in `com.vaadin.flow.server.connect.generator.OpenApiObjectGenerator.

In `flow-server` the dependency is transitively resolved and set to a higher version, otherwise in `flow-maven-plugin` it takes a lower version from a `maven-core`. Forcing it to `3.9` fixes the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6950)
<!-- Reviewable:end -->
