### PR TITLE
CCDM: add webpack progress to improve DX

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -207,14 +209,15 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo {
         String nodePath = FrontendUtils
                 .getNodeExecutable(npmFolder.getAbsolutePath());
 
+        List<String> command = Arrays.asList(nodePath,
+                webpackExecutable.getAbsolutePath(), "--progress");
+        ProcessBuilder builder = FrontendUtils.createProcessBuilder(command)
+                .directory(project.getBasedir()).inheritIO();
+        getLog().info("Running webpack ...");
+
         Process webpackLaunch = null;
         try {
-            getLog().info("Running webpack ...");
-            webpackLaunch = new ProcessBuilder(nodePath,
-                    webpackExecutable.getAbsolutePath())
-                            .directory(project.getBasedir())
-                            .redirectOutput(ProcessBuilder.Redirect.INHERIT)
-                            .start();
+            webpackLaunch = builder.start();
             int errorCode = webpackLaunch.waitFor();
             if (errorCode != 0) {
                 readDetailsAndThrowException(webpackLaunch);

--- a/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
@@ -133,6 +133,9 @@ public final class DevModeHandler implements Serializable {
                     port));
         }
 
+        long start = System.nanoTime();
+        getLogger().info("Starting webpack-dev-server");
+
         watchDog = new DevServerWatchDog();
 
         // Look for a free port
@@ -156,7 +159,6 @@ public final class DevModeHandler implements Serializable {
                         "-d --inline=false --progress --colors")
                 .split(" +")));
 
-        getLogger().info("Starting webpack-dev-server");
 
         console(GREEN, START);
         console(YELLOW, WordUtils
@@ -198,6 +200,9 @@ public final class DevModeHandler implements Serializable {
                         SERVLET_PARAMETER_DEVMODE_WEBPACK_TIMEOUT,
                         DEFAULT_TIMEOUT_FOR_PATTERN)));
             }
+
+            long ms = (System.nanoTime() - start) / 1000000;
+            getLogger().info("Started webpack-dev-server. Time: {}ms", ms);
 
             if (!webpackProcess.isAlive()) {
                 throw new IllegalStateException("Webpack exited prematurely");
@@ -452,9 +457,9 @@ public final class DevModeHandler implements Serializable {
 
     private void readLinesLoop(Pattern success, Pattern failure,
             InputStreamReader reader) throws IOException {
-        StringBuffer line = new StringBuffer();
-        for (int c; (c = reader.read()) >= 0;) {
-            char ch = (char) c;
+        StringBuilder line = new StringBuilder();
+        for (int i; (i = reader.read()) >= 0;) {
+            char ch = (char) i;
             console("%c", ch);
             line.append(ch);
             if (ch == '\n') {
@@ -636,7 +641,9 @@ public final class DevModeHandler implements Serializable {
         removeRunningDevServerPort();
     }
 
-    private static void console(String color, Object s) {
-        System.out.print(format(color, s));
+    @SuppressWarnings("squid:S106")
+    private static void console(String format, Object s) {
+        // intentionally send to console instead to log
+        System.out.print(format(format, s));
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
@@ -19,7 +19,6 @@ import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -37,10 +36,10 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.text.WordUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,9 +53,9 @@ import static com.vaadin.flow.server.Constants.VAADIN_MAPPING;
 import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_CONFIG;
 import static com.vaadin.flow.server.frontend.FrontendUtils.getNodeExecutable;
 import static com.vaadin.flow.server.frontend.FrontendUtils.validateNodeAndNpmVersion;
+import static java.lang.String.format;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_OK;
-
 /**
  * Handles getting resources from <code>webpack-dev-server</code>.
  * <p>
@@ -79,11 +78,13 @@ public final class DevModeHandler implements Serializable {
     // `Failed` in the last line
     private static final String DEFAULT_OUTPUT_PATTERN = ": Compiled.";
     private static final String DEFAULT_ERROR_PATTERN = ": Failed to compile.";
-    private static final String FAILED_MSG = "\n------------------ Frontend compilation failed. -----------------";
-    private static final String SUCCEED_MSG = "\n----------------- Frontend compiled successfully. -----------------";
-    private static final String YELLOW = "\u001b[38;5;111m{}\u001b[0m";
-    private static final String RED = "\u001b[38;5;196m{}\u001b[0m";
-    private static final String GREEN = "\u001b[38;5;35m{}\u001b[0m";
+    private static final String FAILED_MSG = "\n------------------ Frontend compilation failed. ------------------\n\n";
+    private static final String SUCCEED_MSG = "\n----------------- Frontend compiled successfully. -----------------\n\n";
+    private static final String START = "\n------------------ Starting Frontend compilation. ------------------\n\n";
+    private static final String END = "\n------------------------- Webpack stopped  -------------------------\n";
+    private static final String YELLOW = "\u001b[38;5;111m%s\u001b[0m";
+    private static final String RED = "\u001b[38;5;196m%s\u001b[0m";
+    private static final String GREEN = "\u001b[38;5;35m%s\u001b[0m";
 
     // If after this time in millisecs, the pattern was not found, we unlock the
     // process and continue. It might happen if webpack changes their output
@@ -108,6 +109,8 @@ public final class DevModeHandler implements Serializable {
     private final boolean reuseDevServer;
     private transient DevServerWatchDog watchDog;
 
+    private StringBuilder cumulativeOutput = new StringBuilder();
+
     private DevModeHandler(DeploymentConfiguration config, int runningPort,
             File npmFolder, File webpack, File webpackConfig) {
 
@@ -125,7 +128,7 @@ public final class DevModeHandler implements Serializable {
                 watchDog = null;
                 return;
             }
-            throw new IllegalStateException(String.format(
+            throw new IllegalStateException(format(
                     "webpack-dev-server port '%d' is defined but it's not working properly",
                     port));
         }
@@ -150,14 +153,16 @@ public final class DevModeHandler implements Serializable {
         command.add("--watchDogPort=" + watchDog.getWatchDogPort());
         command.addAll(Arrays.asList(config
                 .getStringProperty(SERVLET_PARAMETER_DEVMODE_WEBPACK_OPTIONS,
-                        "-d --inline=false")
+                        "-d --inline=false --progress --colors")
                 .split(" +")));
 
-        if (getLogger().isInfoEnabled()) {
-            getLogger().info(
-                    "Starting webpack-dev-server, port: {} dir: {}\n   {}",
-                    port, npmFolder, String.join(" ", command));
-        }
+        getLogger().info("Starting webpack-dev-server");
+
+        console(GREEN, START);
+        console(YELLOW, WordUtils
+                        .wrap(String.join(" ", command)
+                                .replace(npmFolder.getAbsolutePath(), "."), 50)
+                        .replace("\n", " \\ \n    ") + "\n\n");
 
         processBuilder.command(command);
         try {
@@ -423,12 +428,17 @@ public final class DevModeHandler implements Serializable {
     private void logStream(InputStream input, Pattern success,
             Pattern failure) {
         Thread thread = new Thread(() -> {
-            BufferedReader reader = new BufferedReader(
-                    new InputStreamReader(input, StandardCharsets.UTF_8));
+            InputStreamReader reader = new InputStreamReader(input,
+                    StandardCharsets.UTF_8);
             try {
                 readLinesLoop(success, failure, reader);
             } catch (IOException e) {
-                getLogger().error("Exception when reading webpack output.", e);
+                if ("Stream closed".equals(e.getMessage())) {
+                    console(GREEN, END);
+                    getLogger().debug("Exception when reading webpack output.", e);
+                } else {
+                    getLogger().error("Exception when reading webpack output.", e);
+                }
             }
 
             // Process closed stream, means that it exited, notify
@@ -441,40 +451,49 @@ public final class DevModeHandler implements Serializable {
     }
 
     private void readLinesLoop(Pattern success, Pattern failure,
-            BufferedReader reader) throws IOException {
-        StringBuilder output = new StringBuilder();
-        Consumer<String> info = s -> getLogger().info(GREEN, s);
-        Consumer<String> error = s -> getLogger().error(RED, s);
-        Consumer<String> warn = s -> getLogger().warn(YELLOW, s);
-        Consumer<String> log = info;
-        for (String line; ((line = reader.readLine()) != null);) {
-            String cleanLine = line
-                    // remove color escape codes for console
-                    .replaceAll("\u001b\\[[;\\d]*m", "")
-                    // remove babel query string which is confusing
-                    .replaceAll("\\?babel-target=[\\w\\d]+", "");
-
-            // write each line read to logger, but selecting its correct level
-            log = line.contains("WARNING") ? warn
-                    : line.contains("ERROR") ? error : log;
-            log.accept(cleanLine);
-
-            // save output so as it can be used to alert user in browser.
-            output.append(cleanLine).append('\n');
-
-            boolean succeed = success.matcher(line).find();
-            boolean failed = failure.matcher(line).find();
-            // We found the success or failure pattern in stream
-            if (succeed || failed) {
-                log.accept(succeed ? SUCCEED_MSG : FAILED_MSG);
-                // save output in case of failure
-                failedOutput = failed ? output.toString() : null;
-                // reset output and logger for the next compilation
-                output = new StringBuilder();
-                log = info;
-                // Notify DevModeHandler to continue
-                doNotify();
+            InputStreamReader reader) throws IOException {
+        StringBuffer line = new StringBuffer();
+        for (int c; (c = reader.read()) >= 0;) {
+            char ch = (char) c;
+            console("%c", ch);
+            line.append(ch);
+            if (ch == '\n') {
+                processLine(line.toString(), success, failure);
+                line.setLength(0);
             }
+        }
+    }
+
+    private void processLine(String line, Pattern success, Pattern failure) {
+        // skip progress lines
+        if (line.contains("\b")) {
+            return;
+        }
+
+        // remove color escape codes for console
+        String cleanLine = line
+                .replaceAll("(\u001b\\[[;\\d]*m|[\b\r]+)", "");
+
+        // save output so as it can be used to alert user in browser.
+        cumulativeOutput.append(cleanLine);
+
+        boolean succeed = success.matcher(line).find();
+        boolean failed = failure.matcher(line).find();
+        // We found the success or failure pattern in stream
+        if (succeed || failed) {
+            if (succeed) {
+                console(GREEN, SUCCEED_MSG);
+            } else {
+                console(RED, FAILED_MSG);
+            }
+            // save output in case of failure
+            failedOutput = failed ? cumulativeOutput.toString() : null;
+            
+            // reset cumulative buffer for the next compilation
+            cumulativeOutput = new StringBuilder();
+
+            // Notify DevModeHandler to continue
+            doNotify();
         }
     }
 
@@ -488,8 +507,7 @@ public final class DevModeHandler implements Serializable {
     }
 
     private static Logger getLogger() {
-        // Using an short prefix so as webpack output is more readable
-        return LoggerFactory.getLogger("dev-webpack");
+        return LoggerFactory.getLogger(DevModeHandler.class);
     }
 
     /**
@@ -616,5 +634,9 @@ public final class DevModeHandler implements Serializable {
 
         atomicHandler.set(null);
         removeRunningDevServerPort();
+    }
+
+    private static void console(String color, Object s) {
+        System.out.print(format(color, s));
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -300,7 +300,6 @@ public abstract class NodeUpdater implements FallibleCommand {
     }
 
     Logger log() {
-        // Using short prefix so as npm output is more readable
-        return LoggerFactory.getLogger("dev-updater");
+        return LoggerFactory.getLogger(this.getClass());
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCopyFrontendFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCopyFrontendFiles.java
@@ -91,7 +91,7 @@ public class TaskCopyFrontendFiles implements FallibleCommand {
                 resourceLocations.size(), ms);
     }
 
-    private static Logger log() {
-        return LoggerFactory.getLogger("dev-updater");
+    private Logger log() {
+        return LoggerFactory.getLogger(this.getClass());
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateWebpack.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateWebpack.java
@@ -73,7 +73,7 @@ public class TaskUpdateWebpack implements FallibleCommand {
      * @param generatedFlowImports
      *            name of the JS file to update with the Flow project imports
      * @param isClientSideMode
-     *            whether the application running with clientSideBootstrapMode* 
+     *            whether the application running with clientSideBootstrapMode*
      */
     TaskUpdateWebpack(File frontendDirectory, File webpackConfigFolder,
             File webpackOutputDirectory, String webpackTemplate,
@@ -217,7 +217,6 @@ public class TaskUpdateWebpack implements FallibleCommand {
     }
 
     private Logger log() {
-        // Using short prefix so as npm output is more readable
-        return LoggerFactory.getLogger("dev-updater");
+        return LoggerFactory.getLogger(this.getClass());
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
@@ -362,9 +362,8 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
         }
     }
 
-    private static Logger log() {
-        // Using short prefix so as npm output is more readable
-        return LoggerFactory.getLogger("dev-updater");
+    private Logger log() {
+        return LoggerFactory.getLogger(this.getClass());
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScanner.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScanner.java
@@ -387,8 +387,7 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
     }
 
     private Logger getLogger() {
-        // Using short prefix so as npm output is more readable
-        return LoggerFactory.getLogger("dev-updater");
+        return LoggerFactory.getLogger(this.getClass());
     }
 
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
@@ -34,8 +34,8 @@ import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_COMPATIBILITY_M
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_PRODUCTION_MODE;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_REUSE_DEV_SERVER;
+import static com.vaadin.flow.server.DevModeHandler.getDevModeHandler;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_CONNECT_GENERATED_TS_DIR;
-import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_CONNECT_JAVA_SOURCE_FOLDER;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_CONNECT_OPENAPI_JSON_FILE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -119,6 +119,7 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
     @Test
     public void should_Not_Run_Updaters_when_NoMainPackageFile()
             throws Exception {
+        assertNull(getDevModeHandler());
         mainPackageFile.delete();
         assertNull(getDevModeHandler());
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTestBase.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTestBase.java
@@ -21,8 +21,6 @@ import org.junit.Before;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 
-import com.vaadin.flow.server.DevModeHandler;
-import com.vaadin.flow.server.DevModeHandlerTest;
 import com.vaadin.flow.server.frontend.FrontendUtils;
 
 import static com.vaadin.flow.server.Constants.CONNECT_JAVA_SOURCE_FOLDER_TOKEN;
@@ -31,11 +29,13 @@ import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_COMPATIBILITY_M
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_PRODUCTION_MODE;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_REUSE_DEV_SERVER;
+import static com.vaadin.flow.server.DevModeHandler.getDevModeHandler;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_CONNECT_JAVA_SOURCE_FOLDER;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_CONFIG;
 import static com.vaadin.flow.server.frontend.NodeUpdateTestUtil.createStubNode;
 import static com.vaadin.flow.server.frontend.NodeUpdateTestUtil.createStubWebpackServer;
+import static org.junit.Assert.assertNull;
 
 /**
  * Base class for DevModeInitializer tests. It is an independent class so as it
@@ -60,11 +60,13 @@ public class DevModeInitializerTestBase {
     @Before
     @SuppressWarnings({"unchecked", "rawtypes"})
     public void setup() throws Exception {
+        assertNull(getDevModeHandler());
+
         temporaryFolder.create();
         baseDir = temporaryFolder.getRoot().getPath();
 
         createStubNode(false, true, baseDir);
-        createStubWebpackServer("Compiled", 0, baseDir);
+        createStubWebpackServer("Compiled", 500, baseDir);
 
         servletContext = Mockito.mock(ServletContext.class);
         ServletRegistration registration = Mockito.mock(ServletRegistration.class);
@@ -116,10 +118,9 @@ public class DevModeInitializerTestBase {
         mainPackageFile.delete();
         appPackageFile.delete();
         temporaryFolder.delete();
-        if (DevModeHandler.getDevModeHandler() != null) {
-            DevModeHandler.getDevModeHandler().removeRunningDevServerPort();
+        if (getDevModeHandler() != null) {
+            getDevModeHandler().stop();
         }
-        DevModeHandlerTest.removeDevModeHandlerInstance();
     }
 
     public void runOnStartup() throws Exception {
@@ -143,7 +144,4 @@ public class DevModeInitializerTestBase {
                 }).collect(Collectors.toList());
     }
 
-    public DevModeHandler getDevModeHandler() {
-        return DevModeHandler.getDevModeHandler();
-    }
 }

--- a/flow-tests/test-npm-only-features/test-npm-performance-regression/src/test/java/com/vaadin/flow/testnpmonlyfeatures/performanceregression/StartupPerformanceIT.java
+++ b/flow-tests/test-npm-only-features/test-npm-performance-regression/src/test/java/com/vaadin/flow/testnpmonlyfeatures/performanceregression/StartupPerformanceIT.java
@@ -31,11 +31,11 @@ public class StartupPerformanceIT {
     public void devModeInitializerToWebpackUpIsBelow5500ms() {
         int startupTime = measureLogEntryTimeDistance(
                 "com.vaadin.flow.server.startup.DevModeInitializer - Starting dev-mode updaters in",
-                "dev-webpack.*Time: [0-9]+ms", true);
+                ".*Time: .*[0-9]+ms", true);
 
         int npmInstallTime = measureLogEntryTimeDistance(
-                "dev-updater - Running `npm install`",
-                "dev-updater - package.json updated and npm dependencies installed",
+                "- Running `npm install`",
+                "- package.json updated and npm dependencies installed",
                 false);
 
         int startupTimeWithoutNpmInstallTime = startupTime - npmInstallTime;


### PR DESCRIPTION
Fixes #6912 

- Adding `--progress` option to `webpack` and `webpack-dev-mode`
- Change `DevModeHandler` to be able to read webpack and output byte by byte.
- Fix maven-plugin for writing in console by using inheritIO
- Some improvements in output messages and colors.
- Unify loggers to use classnames because by using console for outputting  webpack messages it's not needed to reduce log name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6958)
<!-- Reviewable:end -->
