### PR TITLE
CCDM: show webpack errors in `index.html`

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -1599,8 +1599,10 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                 document.body()
                         .appendChild(new Element(Tag.valueOf("div"), "")
                                 .attr("class", "v-system-error")
-                                .html("<h3>Webpack Error</h3><pre>"
-                                        + errorMsg + "</pre>"));
+                                .html("<h3>Webpack Error</h3><pre>" + errorMsg
+                                        // Make error lines more prominent
+                                        .replaceAll("(ERROR.+?\n)", "<b>$1</b>")
+                                        + "</pre>"));
             }
         }
     }
@@ -1622,8 +1624,10 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                 "max-height: calc(100vh - 4em);" +
                 "overflow: auto;" +
                 "} .v-system-error {" +
-                "color: red;" +
+                "color: indianred;" +
                 "pointer-events: auto;" +
+                "} .v-system-error h3, .v-system-error b {" +
+                "color: red;" +
                 "}");
      // @formatter:on
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -546,7 +546,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             setupPwa(document, context);
 
             if (!config.isCompatibilityMode() && !config.isProductionMode()) {
-                checkWebpackStatus(document);
+                showWebpackErrors(document);
             }
 
             BootstrapPageResponse response = new BootstrapPageResponse(
@@ -560,20 +560,6 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
 
         private String getClientEngine() {
             return clientEngineFile.get();
-        }
-
-        private void checkWebpackStatus(Document document) {
-            DevModeHandler devMode = DevModeHandler.getDevModeHandler();
-            if (devMode != null) {
-                String errorMsg = devMode.getFailedOutput();
-                if (errorMsg != null) {
-                    document.body()
-                            .appendChild(new Element(Tag.valueOf("div"), "")
-                                    .attr("class", "v-system-error")
-                                    .html("<h3>Webpack Error</h3><pre>"
-                                            + errorMsg + "</pre>"));
-                }
-            }
         }
 
         private void exportBowerUsageStatistics(Document document) {
@@ -943,22 +929,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
 
             // Basic reconnect and system error dialog styles just to make them
             // visible and outside of normal flow
-            styles.appendText(".v-reconnect-dialog, .v-system-error {" // @formatter:off
-                    +   "position: absolute;"
-                    +   "color: black;"
-                    +   "background: white;"
-                    +   "top: 1em;"
-                    +   "right: 1em;"
-                    +   "border: 1px solid black;"
-                    +   "padding: 1em;"
-                    +   "z-index: 10000;"
-                    +   "max-width: calc(100vw - 4em);"
-                    +   "max-height: calc(100vh - 4em);"
-                    +   "overflow: auto;"
-                    + "} .v-system-error {"
-                    +   "color: red;"
-                    +   "pointer-events: auto;"
-                    + "}"); // @formatter:on
+            setupErrorDialogs(styles);
         }
 
         private void setupMetaAndTitle(Element head, BootstrapContext context) {
@@ -1618,5 +1589,42 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
 
         pushJSPath += versionQueryParam;
         return pushJSPath;
+    }
+
+    protected static void showWebpackErrors(Document document) {
+        DevModeHandler devMode = DevModeHandler.getDevModeHandler();
+        if (devMode != null) {
+            String errorMsg = devMode.getFailedOutput();
+            if (errorMsg != null) {
+                document.body()
+                        .appendChild(new Element(Tag.valueOf("div"), "")
+                                .attr("class", "v-system-error")
+                                .html("<h3>Webpack Error</h3><pre>"
+                                        + errorMsg + "</pre>"));
+            }
+        }
+    }
+
+    protected static void setupErrorDialogs(Element style) {
+        // @formatter:off
+        style.appendText(
+                ".v-reconnect-dialog," +
+                ".v-system-error {" +
+                "position: absolute;" +
+                "color: black;" +
+                "background: white;" +
+                "top: 1em;" +
+                "right: 1em;" +
+                "border: 1px solid black;" +
+                "padding: 1em;" +
+                "z-index: 10000;" +
+                "max-width: calc(100vw - 4em);" +
+                "max-height: calc(100vh - 4em);" +
+                "overflow: auto;" +
+                "} .v-system-error {" +
+                "color: red;" +
+                "pointer-events: auto;" +
+                "}");
+     // @formatter:on
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
@@ -64,6 +64,9 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
             session.setAttribute(SERVER_ROUTING, Boolean.TRUE);
         }
 
+        configureErrorDialogStyles(indexDocument);
+        showWebpackErrors(indexDocument);
+
         response.setContentType(CONTENT_TYPE_TEXT_HTML_UTF_8);
 
         request.getService().modifyIndexHtmlResponse(
@@ -104,6 +107,12 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
                 .includeInitialUidl(request)) {
             ui.getRouter().initializeUI(ui, request);
         }
+    }
+
+    private void configureErrorDialogStyles(Document document) {
+        Element styles = document.createElement("style");
+        document.head().appendChild(styles);
+        setupErrorDialogs(styles);
     }
 
     private static void prependBaseHref(VaadinRequest request,

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
@@ -153,12 +153,14 @@ public class JavaScriptBootstrapHandler extends BootstrapHandler {
 
     @Override
     protected BootstrapContext createBootstrapContext(VaadinRequest request,
-                                                      VaadinResponse response, UI ui, Function<VaadinRequest, String> callback) {
+            VaadinResponse response, UI ui,
+            Function<VaadinRequest, String> callback) {
         return new JavaScriptBootstrapContext(request, response, ui, callback);
     }
 
     @Override
-    public boolean synchronizedHandleRequest(VaadinSession session, VaadinRequest request, VaadinResponse response) throws IOException {
+    public boolean synchronizedHandleRequest(VaadinSession session,
+            VaadinRequest request, VaadinResponse response) throws IOException {
 
         ServletHelper.setResponseNoCacheHeaders(response::setHeader,
                 response::setDateHeader);
@@ -166,7 +168,6 @@ public class JavaScriptBootstrapHandler extends BootstrapHandler {
         writeResponse(response, getInitialJson(request, response, session));
         return true;
     }
-
 
     /**
      * Gets the service URL as a URL relative to the request URI.

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -766,7 +766,7 @@ public class FrontendUtils {
     /**
      * Get relative path from a source path to a target path in Unix form. All
      * the Windows' path separator will be replaced.
-     * 
+     *
      * @param source
      *            the source path
      * @param target
@@ -779,7 +779,7 @@ public class FrontendUtils {
 
     /**
      * Get path as a String in Unix form.
-     * 
+     *
      * @param source
      *            path to get
      * @return path as a String in Unix form.

--- a/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
@@ -413,13 +413,19 @@ public class DevModeHandlerTest {
         if (port == 0) {
             port = DevModeHandler.getFreePort();
         }
-        httpServer = HttpServer.create(new InetSocketAddress(port), 0);
+        httpServer = createStubWebpackTcpListener(port, status, response);
+        return port;
+    }
+
+    public static HttpServer createStubWebpackTcpListener(int port, int status, String response)
+            throws Exception {
+        HttpServer httpServer = HttpServer.create(new InetSocketAddress(port), 0);
         httpServer.createContext("/", exchange -> {
             exchange.sendResponseHeaders(status, response.length());
             exchange.getResponseBody().write(response.getBytes());
             exchange.close();
         });
         httpServer.start();
-        return port;
+        return httpServer;
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
@@ -18,27 +18,36 @@ package com.vaadin.flow.server.communication;
 import javax.servlet.http.HttpServletRequest;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 
+import com.sun.net.httpserver.HttpServer;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.internal.JavaScriptBootstrapUI;
+import com.vaadin.flow.server.DevModeHandler;
 import com.vaadin.flow.server.MockServletServiceSessionSetup;
 import com.vaadin.flow.server.VaadinResponse;
 import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.server.frontend.FrontendUtils;
 import com.vaadin.tests.util.MockDeploymentConfiguration;
 
 import static com.vaadin.flow.component.internal.JavaScriptBootstrapUI.SERVER_ROUTING;
+import static com.vaadin.flow.server.DevModeHandlerTest.createStubWebpackTcpListener;
+import static com.vaadin.flow.server.frontend.NodeUpdateTestUtil.createStubWebpackServer;
 
 public class IndexHtmlRequestHandlerTest {
 
@@ -49,6 +58,10 @@ public class IndexHtmlRequestHandlerTest {
     private VaadinResponse response;
     private ByteArrayOutputStream responseOutput;
     private MockDeploymentConfiguration deploymentConfiguration;
+    private HttpServer httpServer;
+
+    @Rule
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Before
     public void setUp() throws Exception {
@@ -74,6 +87,9 @@ public class IndexHtmlRequestHandlerTest {
         Assert.assertTrue(
                 "Response should have content from the index.html template",
                 indexHtml.contains("index.html template content"));
+        Assert.assertTrue(
+                "Response should have styles for the system-error dialogs",
+                indexHtml.contains(".v-system-error"));
     }
 
     @Test
@@ -273,10 +289,52 @@ public class IndexHtmlRequestHandlerTest {
                 Boolean.FALSE);
     }
 
+    @Test
+    public void should_attachWebpackErrors() throws Exception {
+        // Create a webpack-dev-server command that should fail the compilation
+        File npmFolder = temporaryFolder.getRoot();
+        String baseDir = npmFolder.getAbsolutePath();
+        new File(baseDir, FrontendUtils.WEBPACK_CONFIG).createNewFile();
+        createStubWebpackServer("Failed to compile", 300, baseDir);
+
+        // Create a DevModeHandler
+        deploymentConfiguration.setEnableDevServer(true);
+        deploymentConfiguration.setProductionMode(false);
+        DevModeHandler handler = DevModeHandler.start(0, deploymentConfiguration, npmFolder);
+        // Ask to the DevModeHandler for the computed random port
+        Method runningPort = DevModeHandler.class.getDeclaredMethod("getRunningDevServerPort");
+        runningPort.setAccessible(true);
+        int port = (Integer)runningPort.invoke(handler);
+
+        // Configure webpack-dev-server tcp listener to return the `index.html` content
+        httpServer = createStubWebpackTcpListener(port, 200, "<html></html>");
+
+        // Send the request
+        indexHtmlRequestHandler.synchronizedHandleRequest(session,
+                createVaadinRequest("/"), response);
+
+        String indexHtml = responseOutput
+                .toString(StandardCharsets.UTF_8.name());
+        Assert.assertTrue(
+                "Should have a system error dialog",
+                indexHtml.contains("<div class=\"v-system-error\">"));
+        Assert.assertTrue(
+                "Should show webpack failure error",
+                indexHtml.contains("Failed to compile"));
+    }
+
     @After
     public void tearDown() {
         session.unlock();
         mocks.cleanup();
+        if (httpServer != null) {
+            httpServer.stop(0);
+            httpServer = null;
+        }
+        DevModeHandler handler = DevModeHandler.getDevModeHandler();
+        if (handler != null) {
+            handler.stop();
+        }
     }
 
     private VaadinServletRequest createVaadinRequest(String pathInfo) {


### PR DESCRIPTION
Fixes #6910 

- reuse  the code in regular `BootstrapHandler` to show a message in the `v-system-error` dialog.
- add styles for vaadin error dialogs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6964)
<!-- Reviewable:end -->
