### PR TITLE
CCDM: fix(generator): remove extra TS imports for bean grandparents

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/OpenApiObjectGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/OpenApiObjectGenerator.java
@@ -667,9 +667,10 @@ public class OpenApiObjectGenerator {
         generatedSchema.add(qualifiedName);
 
         List<ResolvedReferenceType> directAncestors = resolvedType
-                .getAllClassesAncestors().stream()
-                .filter(parent -> !Object.class.getName()
-                        .equals(parent.getQualifiedName()))
+                .getDirectAncestors().stream()
+                .filter(parent -> parent.getTypeDeclaration().isClass()
+                        && !Object.class.getName()
+                                .equals(parent.getQualifiedName()))
                 .collect(Collectors.toList());
 
         if (directAncestors.isEmpty()) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/services/complexhierarchymodel/GrandParentModel.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/services/complexhierarchymodel/GrandParentModel.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.server.connect.generator.services.complexhierarchymodel;
+
+public class GrandParentModel {
+    int build;
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/services/complexhierarchymodel/Model.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/services/complexhierarchymodel/Model.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.server.connect.generator.services.complexhierarchymodel;
+
+public class Model extends ParentModel {
+    String name;
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/services/complexhierarchymodel/ParentModel.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/services/complexhierarchymodel/ParentModel.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.server.connect.generator.services.complexhierarchymodel;
+
+public class ParentModel extends GrandParentModel {
+    String id;
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/services/complexhierarchyservice/ComplexHierarchyService.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/services/complexhierarchyservice/ComplexHierarchyService.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.connect.generator.services.complexhierarchyservice;
+
+import com.vaadin.flow.server.connect.VaadinService;
+import com.vaadin.flow.server.connect.generator.services.complexhierarchymodel.Model;
+
+@VaadinService
+public class ComplexHierarchyService {
+
+    // Using Model from another package is intentional here to verify the
+    // generator's parsing logic for that case
+    public Model getModel() {
+        return new Model();
+    }
+
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/services/complexhierarchyservice/ComplexHierarchyServiceTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/services/complexhierarchyservice/ComplexHierarchyServiceTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.connect.generator.services.complexhierarchyservice;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+
+import com.vaadin.flow.server.connect.generator.services.AbstractServiceGenerationTest;
+import com.vaadin.flow.server.connect.generator.services.complexhierarchymodel.GrandParentModel;
+import com.vaadin.flow.server.connect.generator.services.complexhierarchymodel.Model;
+import com.vaadin.flow.server.connect.generator.services.complexhierarchymodel.ParentModel;
+
+public class ComplexHierarchyServiceTest extends AbstractServiceGenerationTest {
+    public ComplexHierarchyServiceTest() {
+        super(Arrays.asList(ComplexHierarchyService.class, Model.class,
+                ParentModel.class, GrandParentModel.class));
+    }
+
+    @Test
+    public void should_GenerateParentModel_When_UsingChildModel() {
+        verifyOpenApiObjectAndGeneratedTs();
+    }
+}

--- a/flow-server/src/test/resources/com/vaadin/flow/server/connect/generator/services/complexhierarchyservice/expected-ComplexHierarchyService.ts
+++ b/flow-server/src/test/resources/com/vaadin/flow/server/connect/generator/services/complexhierarchyservice/expected-ComplexHierarchyService.ts
@@ -1,0 +1,7 @@
+// @ts-ignore
+import client from './connect-client.default';
+import Model from './com/vaadin/flow/server/connect/generator/services/complexhierarchymodel/Model';
+
+export function getModel(): Promise<Model> {
+  return client.call('ComplexHierarchyService', 'getModel');
+}

--- a/flow-server/src/test/resources/com/vaadin/flow/server/connect/generator/services/complexhierarchyservice/expected-model-complexhierarchymodel.GrandParentModel.ts
+++ b/flow-server/src/test/resources/com/vaadin/flow/server/connect/generator/services/complexhierarchyservice/expected-model-complexhierarchymodel.GrandParentModel.ts
@@ -1,0 +1,3 @@
+export default interface GrandParentModel {
+  build: number;
+}

--- a/flow-server/src/test/resources/com/vaadin/flow/server/connect/generator/services/complexhierarchyservice/expected-model-complexhierarchymodel.Model.ts
+++ b/flow-server/src/test/resources/com/vaadin/flow/server/connect/generator/services/complexhierarchyservice/expected-model-complexhierarchymodel.Model.ts
@@ -1,0 +1,5 @@
+import ParentModel from './ParentModel';
+
+export default interface Model extends ParentModel {
+  name: string;
+}

--- a/flow-server/src/test/resources/com/vaadin/flow/server/connect/generator/services/complexhierarchyservice/expected-model-complexhierarchymodel.ParentModel.ts
+++ b/flow-server/src/test/resources/com/vaadin/flow/server/connect/generator/services/complexhierarchyservice/expected-model-complexhierarchymodel.ParentModel.ts
@@ -1,0 +1,5 @@
+import GrandParentModel from './GrandParentModel';
+
+export default interface ParentModel extends GrandParentModel {
+  id: string;
+}


### PR DESCRIPTION
Fix #6908

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6968)
<!-- Reviewable:end -->
