### PR TITLE
move `flow-frontend` from `node_modules` to `target` folder.

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -165,7 +165,8 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo {
                         .enableClientSideMode(isClientSideMode())
                         .enablePackagesUpdate(true)
                         .useByteCodeScanner(optimizeBundle)
-                        .copyResources(frontendDepsDirectory, jarFiles)
+                        .withFrontendDependencies(frontendDepsDirectory)
+                        .copyResources(jarFiles)
                         .copyLocalResources(frontendResourcesDirectory)
                         .enableImportsUpdate(true)
                         .withEmbeddableWebComponents(

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -165,7 +165,7 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo {
                         .enableClientSideMode(isClientSideMode())
                         .enablePackagesUpdate(true)
                         .useByteCodeScanner(optimizeBundle)
-                        .withFrontendDependencies(frontendDepsDirectory)
+                        .withFlowResourcesFolder(flowResourcesFolder)
                         .copyResources(jarFiles)
                         .copyLocalResources(frontendResourcesDirectory)
                         .enableImportsUpdate(true)

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -24,10 +24,9 @@ import org.apache.maven.plugins.annotations.Parameter;
 
 import com.vaadin.flow.server.Constants;
 
-import static com.vaadin.flow.server.Constants.*;
-import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
+import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEAULT_FLOW_RESOURCES_FOLDER;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FRONTEND;
-import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
 
 /**
  * The base class of Flow Mojos in order to compute correctly the modes.
@@ -61,7 +60,7 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo {
     /**
      * A directory with project's frontend source files.
      */
-    @Parameter(defaultValue = "${project.basedir}/" + NODE_MODULES + FLOW_NPM_PACKAGE_NAME)
+    @Parameter(defaultValue = "${project.basedir}/" + DEAULT_FLOW_RESOURCES_FOLDER)
     public File frontendDepsDirectory;
 
     /**

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -24,8 +24,10 @@ import org.apache.maven.plugins.annotations.Parameter;
 
 import com.vaadin.flow.server.Constants;
 
-import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
+import static com.vaadin.flow.server.Constants.*;
+import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FRONTEND;
+import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
 
 /**
  * The base class of Flow Mojos in order to compute correctly the modes.
@@ -34,6 +36,33 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.FRONTEND;
  */
 public abstract class FlowModeAbstractMojo extends AbstractMojo {
     static final String VAADIN_COMPATIBILITY_MODE = "vaadin.compatibilityMode";
+
+    /**
+     * The folder where `package.json` file is located. Default is project root
+     * dir.
+     */
+    @Parameter(defaultValue = "${project.basedir}")
+    public File npmFolder;
+
+    /**
+     * The folder where flow will put generated files that will be used by
+     * webpack.
+     */
+    @Parameter(defaultValue = "${project.build.directory}/" + FRONTEND)
+    public File generatedFolder;
+
+    /**
+     * A directory with project's frontend source files.
+     */
+    @Parameter(defaultValue = "${project.basedir}/" + FRONTEND)
+    public File frontendDirectory;
+
+
+    /**
+     * A directory with project's frontend source files.
+     */
+    @Parameter(defaultValue = "${project.basedir}/" + NODE_MODULES + FLOW_NPM_PACKAGE_NAME)
+    public File frontendDepsDirectory;
 
     /**
      * Whether or not we are running in compatibility mode.

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -58,10 +58,10 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo {
 
 
     /**
-     * A directory with project's frontend source files.
+     * The directory where flow resources from jars will be copied to.
      */
     @Parameter(defaultValue = "${project.basedir}/" + DEAULT_FLOW_RESOURCES_FOLDER)
-    public File frontendDepsDirectory;
+    public File flowResourcesFolder;
 
     /**
      * Whether or not we are running in compatibility mode.

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
@@ -52,7 +52,6 @@ import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_CLIENT_SIDE_MOD
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_INITIAL_UIDL;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_PRODUCTION_MODE;
-import static com.vaadin.flow.server.frontend.FrontendUtils.FRONTEND;
 import static com.vaadin.flow.server.frontend.FrontendUtils.TOKEN_FILE;
 
 /**
@@ -88,13 +87,6 @@ public class PrepareFrontendMojo extends FlowModeAbstractMojo {
     private MavenProject project;
 
     /**
-     * The folder where `package.json` file is located. Default is project root
-     * dir.
-     */
-    @Parameter(defaultValue = "${project.basedir}")
-    private File npmFolder;
-
-    /**
      * Copy the `webapp.config.js` from the specified URL if missing. Default is
      * the template provided by this plugin. Set it to empty string to disable
      * the feature.
@@ -110,21 +102,8 @@ public class PrepareFrontendMojo extends FlowModeAbstractMojo {
     @Parameter(defaultValue = FrontendUtils.WEBPACK_GENERATED)
     private String webpackGeneratedTemplate;
 
-    /**
-     * The folder where flow will put generated files that will be used by
-     * webpack.
-     */
-    @Parameter(defaultValue = "${project.build.directory}/" + FRONTEND)
-    private File generatedFolder;
-
     @Component
     private BuildContext buildContext; // m2eclipse integration
-
-    /**
-     * A directory with project's frontend source files.
-     */
-    @Parameter(defaultValue = "${project.basedir}/" + FRONTEND)
-    private File frontendDirectory;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
@@ -135,7 +135,7 @@ public class PrepareFrontendMojo extends FlowModeAbstractMojo {
                             .withWebpack(webpackOutputDirectory,
                                     webpackTemplate, webpackGeneratedTemplate)
                             .enableClientSideMode(isClientSideMode())
-                            .withFrontendDependencies(frontendDepsDirectory)
+                            .withFlowResourcesFolder(flowResourcesFolder)
                             .createMissingPackageJson(true)
                             .enableImportsUpdate(false)
                             .enablePackagesUpdate(false)

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
@@ -135,9 +135,11 @@ public class PrepareFrontendMojo extends FlowModeAbstractMojo {
                             .withWebpack(webpackOutputDirectory,
                                     webpackTemplate, webpackGeneratedTemplate)
                             .enableClientSideMode(isClientSideMode())
+                            .withFrontendDependencies(frontendDepsDirectory)
                             .createMissingPackageJson(true)
                             .enableImportsUpdate(false)
-                            .enablePackagesUpdate(false).runNpmInstall(false)
+                            .enablePackagesUpdate(false)
+                            .runNpmInstall(false)
                             .build().execute();
         } catch (ExecutionFailedException exception) {
             throw new MojoFailureException(

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
@@ -88,6 +88,7 @@ public class BuildFrontendMojoTest {
     private String openApiJsonFile;
     private File generatedTsFolder;
 
+
     private File tokenFile;
 
     private final BuildFrontendMojo mojo = new BuildFrontendMojo();
@@ -156,6 +157,8 @@ public class BuildFrontendMojoTest {
                 defaultJavaSource);
         ReflectionUtils.setVariableValueInObject(mojo, "generatedTsFolder",
                 generatedTsFolder);
+        ReflectionUtils.setVariableValueInObject(mojo, "frontendDepsDirectory",
+                flowPackagPath);
 
         flowPackagPath.mkdirs();
         generatedFolder.mkdirs();

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
@@ -79,7 +79,7 @@ public class BuildFrontendMojoTest {
     private File importsFile;
     private File generatedFolder;
     private File nodeModulesPath;
-    private File flowPackagePath;
+    private File flowResourcesFolder;
     private File projectFrontendResourcesDirectory;
     private String mainPackage;
     private String appPackage;
@@ -106,7 +106,7 @@ public class BuildFrontendMojoTest {
         generatedFolder = new File(npmFolder, DEFAULT_GENERATED_DIR);
         importsFile = new File(generatedFolder, IMPORTS_NAME);
         nodeModulesPath = new File(npmFolder, NODE_MODULES);
-        flowPackagePath = new File(nodeModulesPath, FLOW_NPM_PACKAGE_NAME);
+        flowResourcesFolder = new File(nodeModulesPath, FLOW_NPM_PACKAGE_NAME);
         File frontendDirectory = new File(npmFolder, DEFAULT_FRONTEND_DIR);
 
         mainPackage = new File(npmFolder, PACKAGE_JSON).getAbsolutePath();
@@ -157,10 +157,10 @@ public class BuildFrontendMojoTest {
                 defaultJavaSource);
         ReflectionUtils.setVariableValueInObject(mojo, "generatedTsFolder",
                 generatedTsFolder);
-        ReflectionUtils.setVariableValueInObject(mojo, "frontendDepsDirectory",
-                flowPackagePath);
+        ReflectionUtils.setVariableValueInObject(mojo, "flowResourcesFolder",
+                flowResourcesFolder);
 
-        flowPackagePath.mkdirs();
+        flowResourcesFolder.mkdirs();
         generatedFolder.mkdirs();
 
         setProject(mojo, npmFolder);
@@ -241,7 +241,7 @@ public class BuildFrontendMojoTest {
         assertContainsImports(true, expectedLines.toArray(new String[0]));
 
         Assert.assertTrue(
-                new File(flowPackagePath, "ExampleConnector.js").exists());
+                new File(flowResourcesFolder, "ExampleConnector.js").exists());
     }
 
     @Test

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
@@ -79,7 +79,7 @@ public class BuildFrontendMojoTest {
     private File importsFile;
     private File generatedFolder;
     private File nodeModulesPath;
-    private File flowPackagPath;
+    private File flowPackagePath;
     private File projectFrontendResourcesDirectory;
     private String mainPackage;
     private String appPackage;
@@ -106,7 +106,7 @@ public class BuildFrontendMojoTest {
         generatedFolder = new File(npmFolder, DEFAULT_GENERATED_DIR);
         importsFile = new File(generatedFolder, IMPORTS_NAME);
         nodeModulesPath = new File(npmFolder, NODE_MODULES);
-        flowPackagPath = new File(nodeModulesPath, FLOW_NPM_PACKAGE_NAME);
+        flowPackagePath = new File(nodeModulesPath, FLOW_NPM_PACKAGE_NAME);
         File frontendDirectory = new File(npmFolder, DEFAULT_FRONTEND_DIR);
 
         mainPackage = new File(npmFolder, PACKAGE_JSON).getAbsolutePath();
@@ -158,9 +158,9 @@ public class BuildFrontendMojoTest {
         ReflectionUtils.setVariableValueInObject(mojo, "generatedTsFolder",
                 generatedTsFolder);
         ReflectionUtils.setVariableValueInObject(mojo, "frontendDepsDirectory",
-                flowPackagPath);
+                flowPackagePath);
 
-        flowPackagPath.mkdirs();
+        flowPackagePath.mkdirs();
         generatedFolder.mkdirs();
 
         setProject(mojo, npmFolder);
@@ -241,7 +241,7 @@ public class BuildFrontendMojoTest {
         assertContainsImports(true, expectedLines.toArray(new String[0]));
 
         Assert.assertTrue(
-                new File(flowPackagPath, "ExampleConnector.js").exists());
+                new File(flowPackagePath, "ExampleConnector.js").exists());
     }
 
     @Test

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
@@ -44,7 +44,7 @@ public class PrepareFrontendMojoTest {
 
     private final PrepareFrontendMojo mojo = new PrepareFrontendMojo();
     private File nodeModulesPath;
-    private File flowPackagePath;
+    private File flowResourcesFolder;
     private String webpackConfig;
     private String packageJson;
     private File projectBase;
@@ -62,7 +62,7 @@ public class PrepareFrontendMojoTest {
                 VAADIN_SERVLET_RESOURCES + TOKEN_FILE);
 
         nodeModulesPath = new File(projectBase, NODE_MODULES);
-        flowPackagePath = new File(nodeModulesPath, FLOW_NPM_PACKAGE_NAME);
+        flowResourcesFolder = new File(nodeModulesPath, FLOW_NPM_PACKAGE_NAME);
         webpackConfig = new File(projectBase, WEBPACK_CONFIG).getAbsolutePath();
         packageJson = new File(projectBase, PACKAGE_JSON).getAbsolutePath();
         webpackOutputDirectory = new File(projectBase,
@@ -93,10 +93,10 @@ public class PrepareFrontendMojoTest {
                 defaultJavaSource);
         ReflectionUtils.setVariableValueInObject(mojo, "generatedTsFolder",
                 generatedTsFolder);
-        ReflectionUtils.setVariableValueInObject(mojo, "frontendDepsDirectory",
-                flowPackagePath);
+        ReflectionUtils.setVariableValueInObject(mojo, "flowResourcesFolder",
+                flowResourcesFolder);
 
-        Assert.assertTrue(flowPackagePath.mkdirs());
+        Assert.assertTrue(flowResourcesFolder.mkdirs());
         setProject(mojo, projectBase);
     }
 

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
@@ -93,6 +93,8 @@ public class PrepareFrontendMojoTest {
                 defaultJavaSource);
         ReflectionUtils.setVariableValueInObject(mojo, "generatedTsFolder",
                 generatedTsFolder);
+        ReflectionUtils.setVariableValueInObject(mojo, "frontendDepsDirectory",
+                flowPackagePath);
 
         Assert.assertTrue(flowPackagePath.mkdirs());
         setProject(mojo, projectBase);

--- a/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/BundleParser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/BundleParser.java
@@ -26,13 +26,12 @@ import org.jsoup.select.Elements;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.vaadin.flow.server.frontend.FrontendUtils;
-
 import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 import elemental.json.JsonType;
 
+import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
 import static elemental.json.JsonType.ARRAY;
 import static elemental.json.JsonType.OBJECT;
 import static elemental.json.JsonType.STRING;
@@ -261,7 +260,7 @@ public final class BundleParser {
             // For polymer templates inside add-ons we will not find the sources
             // using ./ as the actual path contains
             // "node_modules/@vaadin/flow-frontend/" instead of "./"
-            if (name.contains(FrontendUtils.FLOW_NPM_PACKAGE_NAME)) {
+            if (name.contains(FLOW_NPM_PACKAGE_NAME)) {
                 alternativeFileName = alternativeFileName.replaceFirst("\\./",
                         "");
             }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -435,8 +435,7 @@ abstract class AbstractUpdateImports implements Runnable {
         }
         // file is a flow resource e.g.
         // /node_modules/@vaadin/flow-frontend/gridConnector.js
-        file = getFile(new File(getNodeModulesDir(), NODE_MODULES),
-                FLOW_NPM_PACKAGE_NAME, jsImport);
+        file = getFile(getNodeModulesDir(), FLOW_NPM_PACKAGE_NAME, jsImport);
         return file.exists() ? file : null;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -106,6 +106,11 @@ public class FrontendUtils {
     public static final String WEBPACK_GENERATED = "webpack.generated.js";
 
     /**
+     * Default target folder for the java project.
+     */
+    public static final String TARGET = "target/";
+
+    /**
      * The NPM package name that will be used for the javascript files present
      * in jar resources that will to be copied to the npm folder so as they are
      * accessible to webpack.
@@ -116,12 +121,7 @@ public class FrontendUtils {
     /**
      * Default folder for copying front-end resources present in the classpath jars.
      */
-    public static final String FLOW_NPM_DEPS_FOLDER = NODE_MODULES + FLOW_NPM_PACKAGE_NAME;
-
-    /**
-     * Default target folder for the java project.
-     */
-    public static final String TARGET = "target/";
+    public static final String DEAULT_FLOW_RESOURCES_FOLDER = TARGET + "flow-frontend";
 
     /**
      * Default folder name for flow generated stuff relative to the

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -112,6 +112,12 @@ public class FrontendUtils {
      */
     public static final String FLOW_NPM_PACKAGE_NAME = "@vaadin/flow-frontend/";
 
+
+    /**
+     * Default folder for copying front-end resources present in the classpath jars.
+     */
+    public static final String FLOW_NPM_DEPS_FOLDER = NODE_MODULES + FLOW_NPM_PACKAGE_NAME;
+
     /**
      * Default target folder for the java project.
      */

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -469,7 +469,7 @@ public class NodeTasks implements FallibleCommand {
         if (builder.enablePackagesUpdate) {
             TaskUpdatePackages packageUpdater = new TaskUpdatePackages(
                     classFinder, frontendDependencies, builder.npmFolder,
-                    builder.generatedFolder, builder.cleanNpmFiles);
+                    builder.generatedFolder, builder.frontendDepsTargetDirectory, builder.cleanNpmFiles);
             commands.add(packageUpdater);
 
             if (builder.runNpmInstall) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -252,23 +252,32 @@ public class NodeTasks implements FallibleCommand {
         }
 
         /**
-         * Sets whether copy resources from classpath to the appropriate npm
-         * package folder so as they are available for webpack build.
-         *
+         * Sets the appropriate npm package folder for copying flow resources in
+         * jars.
          *
          * @param frontendDepsDirectory
          *            target folder
+         * @return the builder
+         */
+        public Builder withFrontendDependencies(File frontendDepsDirectory) {
+            this.frontendDepsTargetDirectory = frontendDepsDirectory
+                    .isAbsolute() ? frontendDepsDirectory
+                            : new File(npmFolder,
+                                    frontendDepsDirectory.getPath());
+            return this;
+        }
+
+        /**
+         * Sets whether copy resources from classpath to the appropriate npm
+         * package folder so as they are available for webpack build.
+         *
          * @param jars
          *            set of class nodes to be visited. Not {@code null}
          *
          * @return the builder
          */
-        public Builder copyResources(File frontendDepsDirectory, Set<File> jars) {
+        public Builder copyResources(Set<File> jars) {
             Objects.requireNonNull(jars, "Parameter 'jars' must not be null!");
-            this.frontendDepsTargetDirectory = frontendDepsDirectory
-                    .isAbsolute() ? frontendDepsDirectory
-                            : new File(npmFolder,
-                                    frontendDepsDirectory.getPath());
             this.jarFiles = jars;
             return this;
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -252,9 +252,12 @@ public class NodeTasks implements FallibleCommand {
         }
 
         /**
-         * Sets whether copy resources from classpath to the `node_modules`
-         * folder as they are available for webpack build.
+         * Sets whether copy resources from classpath to the appropriate npm
+         * package folder so as they are available for webpack build.
          *
+         *
+         * @param frontendDepsDirectory
+         *            target folder
          * @param jars
          *            set of class nodes to be visited. Not {@code null}
          *
@@ -449,7 +452,7 @@ public class NodeTasks implements FallibleCommand {
         if (builder.createMissingPackageJson) {
             TaskCreatePackageJson packageCreator = new TaskCreatePackageJson(
                     builder.npmFolder, builder.generatedFolder,
-                    builder.polymerVersion);
+                    builder.frontendDepsTargetDirectory, builder.polymerVersion);
             commands.add(packageCreator);
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -72,9 +72,9 @@ public class NodeTasks implements FallibleCommand {
 
         private boolean cleanNpmFiles = false;
 
-        private File frontendDepsTargetDirectory = null;
+        private File flowResourcesFolder = null;
 
-        private File frontendResourcesDirectory = null;
+        private File localResourcesFolder = null;
 
         private boolean useByteCodeScanner = false;
 
@@ -255,15 +255,15 @@ public class NodeTasks implements FallibleCommand {
          * Sets the appropriate npm package folder for copying flow resources in
          * jars.
          *
-         * @param frontendDepsDirectory
+         * @param flowResourcesFolder
          *            target folder
          * @return the builder
          */
-        public Builder withFrontendDependencies(File frontendDepsDirectory) {
-            this.frontendDepsTargetDirectory = frontendDepsDirectory
-                    .isAbsolute() ? frontendDepsDirectory
+        public Builder withFlowResourcesFolder(File flowResourcesFolder) {
+            this.flowResourcesFolder = flowResourcesFolder
+                    .isAbsolute() ? flowResourcesFolder
                             : new File(npmFolder,
-                                    frontendDepsDirectory.getPath());
+                                    flowResourcesFolder.getPath());
             return this;
         }
 
@@ -311,12 +311,12 @@ public class NodeTasks implements FallibleCommand {
         /**
          * Set local frontend files to be copied from given folder.
          *
-         * @param frontendResourcesDirectory
+         * @param localResourcesFolder
          *            folder to copy local frontend files from
          * @return the builder, for chaining
          */
-        public Builder copyLocalResources(File frontendResourcesDirectory) {
-            this.frontendResourcesDirectory = frontendResourcesDirectory;
+        public Builder copyLocalResources(File localResourcesFolder) {
+            this.localResourcesFolder = localResourcesFolder;
             return this;
         }
 
@@ -461,7 +461,7 @@ public class NodeTasks implements FallibleCommand {
         if (builder.createMissingPackageJson) {
             TaskCreatePackageJson packageCreator = new TaskCreatePackageJson(
                     builder.npmFolder, builder.generatedFolder,
-                    builder.frontendDepsTargetDirectory, builder.polymerVersion);
+                    builder.flowResourcesFolder, builder.polymerVersion);
             commands.add(packageCreator);
         }
 
@@ -478,7 +478,8 @@ public class NodeTasks implements FallibleCommand {
         if (builder.enablePackagesUpdate) {
             TaskUpdatePackages packageUpdater = new TaskUpdatePackages(
                     classFinder, frontendDependencies, builder.npmFolder,
-                    builder.generatedFolder, builder.frontendDepsTargetDirectory, builder.cleanNpmFiles);
+                    builder.generatedFolder, builder.flowResourcesFolder,
+                    builder.cleanNpmFiles);
             commands.add(packageUpdater);
 
             if (builder.runNpmInstall) {
@@ -490,12 +491,12 @@ public class NodeTasks implements FallibleCommand {
 
         if (builder.jarFiles != null) {
             commands.add(new TaskCopyFrontendFiles(
-                    builder.frontendDepsTargetDirectory, builder.jarFiles));
+                    builder.flowResourcesFolder, builder.jarFiles));
 
-            if (builder.frontendResourcesDirectory != null) {
+            if (builder.localResourcesFolder != null) {
                 commands.add(new TaskCopyLocalFrontendFiles(
-                        builder.frontendDepsTargetDirectory,
-                        builder.frontendResourcesDirectory));
+                        builder.flowResourcesFolder,
+                        builder.localResourcesFolder));
             }
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -237,20 +237,33 @@ public abstract class NodeUpdater implements FallibleCommand {
                 polymerDepVersion) || added;
         added = addDependency(packageJson, DEPENDENCIES,
                 "@webcomponents/webcomponentsjs", "^2.2.10") || added;
-        // dependency for the custom package.json placed in the generated
-        // folder.
         try {
+            // dependency for the custom package.json placed in the generated
+            // folder.
             String customPkg = "./" + FrontendUtils.getUnixRelativePath(
                     npmFolder.getAbsoluteFile().toPath(),
                     generatedFolder.getAbsoluteFile().toPath());
             added = addDependency(packageJson, DEPENDENCIES, DEP_NAME_FLOW_DEPS,
                     customPkg) || added;
+
+            // dependency for the package.json in the folder where frontend
+            // dependencies are copied
+            if (frontendDepsFolder != null
+                    // Skip if deps are copied directly to `node_modules` folder
+                    && !frontendDepsFolder.toString().contains(NODE_MODULES)) {
+                String depsPkg = "./" + FrontendUtils.getUnixRelativePath(
+                        npmFolder.getAbsoluteFile().toPath(),
+                        frontendDepsFolder.getAbsoluteFile().toPath());
+                added = addDependency(packageJson, DEPENDENCIES, DEP_NAME_FLOW_JARS,
+                        depsPkg) || added;
+            }
         } catch (IllegalArgumentException iae) {
             log().error("Exception in relativization of '{}' to '{}'",
                     npmFolder.getAbsoluteFile().toPath(),
                     generatedFolder.getAbsoluteFile().toPath());
             throw iae;
         }
+
         added = addDevDependency(packageJson, "webpack", "4.30.0", added);
         added = addDevDependency(packageJson, "webpack-cli", "3.3.0", added);
         added = addDevDependency(packageJson, "webpack-dev-server", "3.3.0",

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -93,7 +93,7 @@ public abstract class NodeUpdater implements FallibleCommand {
     /**
      * Base directory for flow dependencies coming from jars.
      */
-    protected final File frontendDepsFolder;
+    protected final File flowResourcesFolder;
 
     /**
      * The {@link FrontendDependencies} object representing the application
@@ -116,18 +116,18 @@ public abstract class NodeUpdater implements FallibleCommand {
      *            folder with the `package.json` file
      * @param generatedPath
      *            folder where flow generated files will be placed.
-     * @param frontendDepsFolder
+     * @param flowResourcesPath
      *            folder where flow dependencies will be copied to.
      */
     protected NodeUpdater(ClassFinder finder,
             FrontendDependenciesScanner frontendDependencies, File npmFolder,
-            File generatedPath, File frontendDepsFolder) {
+            File generatedPath, File flowResourcesPath) {
         this.frontDeps = frontendDependencies;
         this.finder = finder;
         this.npmFolder = npmFolder;
         this.nodeModulesFolder = new File(npmFolder, NODE_MODULES);
         this.generatedFolder = generatedPath;
-        this.frontendDepsFolder = frontendDepsFolder;
+        this.flowResourcesFolder = flowResourcesPath;
     }
 
     static Set<String> getGeneratedModules(File directory,
@@ -208,8 +208,8 @@ public abstract class NodeUpdater implements FallibleCommand {
         return getPackageJson(new File(generatedFolder, PACKAGE_JSON));
     }
 
-    JsonObject getDepsPackageJson() throws IOException {
-        return getPackageJson(new File(frontendDepsFolder, PACKAGE_JSON));
+    JsonObject getResourcesPackageJson() throws IOException {
+        return getPackageJson(new File(flowResourcesFolder, PACKAGE_JSON));
     }
 
     JsonObject getPackageJson(File packageFile) throws IOException {
@@ -250,12 +250,12 @@ public abstract class NodeUpdater implements FallibleCommand {
 
             // dependency for the package.json in the folder where frontend
             // dependencies are copied
-            if (frontendDepsFolder != null
+            if (flowResourcesFolder != null
                     // Skip if deps are copied directly to `node_modules` folder
-                    && !frontendDepsFolder.toString().contains(NODE_MODULES)) {
+                    && !flowResourcesFolder.toString().contains(NODE_MODULES)) {
                 String depsPkg = "./" + FrontendUtils.getUnixRelativePath(
                         npmFolder.getAbsoluteFile().toPath(),
-                        frontendDepsFolder.getAbsoluteFile().toPath());
+                        flowResourcesFolder.getAbsoluteFile().toPath());
                 added = addDependency(packageJson, DEPENDENCIES, DEP_NAME_FLOW_JARS,
                         depsPkg) || added;
             }
@@ -300,7 +300,7 @@ public abstract class NodeUpdater implements FallibleCommand {
         addDependency(packageJson, null, DEP_MAIN_KEY, IMPORTS_NAME);
     }
 
-    void updateJarDependencies(JsonObject packageJson) {
+    void updateResourcesDependencies(JsonObject packageJson) {
         addDependency(packageJson, null, DEP_NAME_KEY, DEP_NAME_FLOW_JARS);
         addDependency(packageJson, null, DEP_VERSION_KEY, DEP_VERSION_DEFAULT);
         addDependency(packageJson, null, DEP_LICENSE_KEY, DEP_LICENSE_DEFAULT);
@@ -334,7 +334,7 @@ public abstract class NodeUpdater implements FallibleCommand {
 
     String writeDepsPackageFile(JsonObject packageJson) throws IOException {
         return writePackageFile(packageJson,
-                new File(frontendDepsFolder, PACKAGE_JSON));
+                new File(flowResourcesFolder, PACKAGE_JSON));
     }
 
     String writePackageFile(JsonObject json, File packageFile)

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -67,6 +67,7 @@ public abstract class NodeUpdater implements FallibleCommand {
     private static final String DEP_NAME_KEY = "name";
     private static final String DEP_NAME_DEFAULT = "no-name";
     protected static final String DEP_NAME_FLOW_DEPS = "@vaadin/flow-deps";
+    protected static final String DEP_NAME_FLOW_JARS = "@vaadin/flow-frontend";
     private static final String DEP_VERSION_KEY = "version";
     private static final String DEP_VERSION_DEFAULT = "1.0.0";
 
@@ -85,6 +86,12 @@ public abstract class NodeUpdater implements FallibleCommand {
      * Base directory for flow generated files.
      */
     protected final File generatedFolder;
+
+
+    /**
+     * Base directory for flow dependencies coming from jars.
+     */
+    protected final File frontendDepsFolder;
 
     /**
      * The {@link FrontendDependencies} object representing the application
@@ -107,15 +114,18 @@ public abstract class NodeUpdater implements FallibleCommand {
      *            folder with the `package.json` file
      * @param generatedPath
      *            folder where flow generated files will be placed.
+     * @param frontendDepsFolder
+     *            folder where flow dependencies will be copied to.
      */
     protected NodeUpdater(ClassFinder finder,
             FrontendDependenciesScanner frontendDependencies, File npmFolder,
-            File generatedPath) {
+            File generatedPath, File frontendDepsFolder) {
         this.frontDeps = frontendDependencies;
         this.finder = finder;
         this.npmFolder = npmFolder;
         this.nodeModulesFolder = new File(npmFolder, NODE_MODULES);
         this.generatedFolder = generatedPath;
+        this.frontendDepsFolder = frontendDepsFolder;
     }
 
     static Set<String> getGeneratedModules(File directory,
@@ -196,6 +206,10 @@ public abstract class NodeUpdater implements FallibleCommand {
         return getPackageJson(new File(generatedFolder, PACKAGE_JSON));
     }
 
+    JsonObject getDepsPackageJson() throws IOException {
+        return getPackageJson(new File(frontendDepsFolder, PACKAGE_JSON));
+    }
+
     JsonObject getPackageJson(File packageFile) throws IOException {
         JsonObject packageJson = null;
         if (packageFile.exists()) {
@@ -270,6 +284,12 @@ public abstract class NodeUpdater implements FallibleCommand {
         addDependency(packageJson, null, DEP_LICENSE_KEY, DEP_LICENSE_DEFAULT);
     }
 
+    void updateJarDependencies(JsonObject packageJson) {
+        addDependency(packageJson, null, DEP_NAME_KEY, DEP_NAME_FLOW_JARS);
+        addDependency(packageJson, null, DEP_VERSION_KEY, DEP_VERSION_DEFAULT);
+        addDependency(packageJson, null, DEP_LICENSE_KEY, DEP_LICENSE_DEFAULT);
+    }
+
     boolean addDependency(JsonObject json, String key, String pkg,
             String vers) {
         if (key != null) {
@@ -293,6 +313,11 @@ public abstract class NodeUpdater implements FallibleCommand {
     String writeAppPackageFile(JsonObject packageJson) throws IOException {
         return writePackageFile(packageJson,
                 new File(generatedFolder, PACKAGE_JSON));
+    }
+
+    String writeDepsPackageFile(JsonObject packageJson) throws IOException {
+        return writePackageFile(packageJson,
+                new File(frontendDepsFolder, PACKAGE_JSON));
     }
 
     String writePackageFile(JsonObject json, File packageFile)

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -41,6 +41,7 @@ import static com.vaadin.flow.server.Constants.COMPATIBILITY_RESOURCES_FRONTEND_
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 import static com.vaadin.flow.server.Constants.RESOURCES_FRONTEND_DEFAULT;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
+import static com.vaadin.flow.server.frontend.FrontendUtils.IMPORTS_NAME;
 import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
 import static com.vaadin.flow.shared.ApplicationConstants.FRONTEND_PROTOCOL_PREFIX;
 import static elemental.json.impl.JsonUtil.stringify;
@@ -66,6 +67,7 @@ public abstract class NodeUpdater implements FallibleCommand {
     private static final String DEP_LICENSE_DEFAULT = "UNLICENSED";
     private static final String DEP_NAME_KEY = "name";
     private static final String DEP_NAME_DEFAULT = "no-name";
+    private static final String DEP_MAIN_KEY = "main";
     protected static final String DEP_NAME_FLOW_DEPS = "@vaadin/flow-deps";
     protected static final String DEP_NAME_FLOW_JARS = "@vaadin/flow-frontend";
     private static final String DEP_VERSION_KEY = "version";
@@ -295,12 +297,14 @@ public abstract class NodeUpdater implements FallibleCommand {
         addDependency(packageJson, null, DEP_NAME_KEY, DEP_NAME_FLOW_DEPS);
         addDependency(packageJson, null, DEP_VERSION_KEY, DEP_VERSION_DEFAULT);
         addDependency(packageJson, null, DEP_LICENSE_KEY, DEP_LICENSE_DEFAULT);
+        addDependency(packageJson, null, DEP_MAIN_KEY, IMPORTS_NAME);
     }
 
     void updateJarDependencies(JsonObject packageJson) {
         addDependency(packageJson, null, DEP_NAME_KEY, DEP_NAME_FLOW_JARS);
         addDependency(packageJson, null, DEP_VERSION_KEY, DEP_VERSION_DEFAULT);
         addDependency(packageJson, null, DEP_LICENSE_KEY, DEP_LICENSE_DEFAULT);
+        addDependency(packageJson, null, DEP_MAIN_KEY, "Flow");
     }
 
     boolean addDependency(JsonObject json, String key, String pkg,

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCopyFrontendFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCopyFrontendFiles.java
@@ -25,8 +25,6 @@ import org.slf4j.LoggerFactory;
 
 import static com.vaadin.flow.server.Constants.COMPATIBILITY_RESOURCES_FRONTEND_DEFAULT;
 import static com.vaadin.flow.server.Constants.RESOURCES_FRONTEND_DEFAULT;
-import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
-import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
 
 
 /**
@@ -49,13 +47,12 @@ public class TaskCopyFrontendFiles implements FallibleCommand {
      * @param resourcesToScan
      *            folders and jar files to scan.
      */
-    TaskCopyFrontendFiles(File npmFolder, Set<File> resourcesToScan) {
-        Objects.requireNonNull(npmFolder,
-                "Parameter 'npmFolder' must not be " + "null");
+    TaskCopyFrontendFiles(File targetDirectory, Set<File> resourcesToScan) {
+        Objects.requireNonNull(targetDirectory,
+                "Parameter 'targetDirectory' must not be " + "null");
         Objects.requireNonNull(resourcesToScan,
                 "Parameter 'jarFilesToScan' must not be null");
-        this.targetDirectory = new File(npmFolder,
-                NODE_MODULES + FLOW_NPM_PACKAGE_NAME);
+        this.targetDirectory = targetDirectory;
         resourceLocations = resourcesToScan.stream().filter(File::exists)
                 .collect(Collectors.toSet());
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCopyLocalFrontendFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCopyLocalFrontendFiles.java
@@ -31,8 +31,8 @@ import org.slf4j.LoggerFactory;
  */
 public class TaskCopyLocalFrontendFiles implements FallibleCommand {
 
-    private final File targetDirectory;
-    private final File frontendResourcesDirectory;
+    private final File flowResourcesFolder;
+    private final File localResourcesFolder;
 
     /**
      * Copy project local frontend files from defined frontendResourcesDirectory
@@ -42,20 +42,20 @@ public class TaskCopyLocalFrontendFiles implements FallibleCommand {
      * @param npmFolder
      *            target directory for the discovered files
      */
-    TaskCopyLocalFrontendFiles(File targetDirectory,
-            File frontendResourcesDirectory) {
-        this.targetDirectory = targetDirectory;
-        this.frontendResourcesDirectory = frontendResourcesDirectory;
+    TaskCopyLocalFrontendFiles(File flowResourcesFolder,
+            File localResourcesFolder) {
+        this.flowResourcesFolder = flowResourcesFolder;
+        this.localResourcesFolder = localResourcesFolder;
     }
 
     @Override
     public void execute() {
-        createTargetFolder(targetDirectory);
+        createTargetFolder(flowResourcesFolder);
 
-        if (frontendResourcesDirectory != null
-                && frontendResourcesDirectory.isDirectory()) {
+        if (localResourcesFolder != null
+                && localResourcesFolder.isDirectory()) {
             log().info("Copying project local frontend resources.");
-            copyLocalResources(frontendResourcesDirectory, targetDirectory);
+            copyLocalResources(localResourcesFolder, flowResourcesFolder);
             log().info("Copying frontend directory completed.");
         } else {
             log().debug("Found no local frontend resources for the project");

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCopyLocalFrontendFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCopyLocalFrontendFiles.java
@@ -24,9 +24,6 @@ import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
-import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
-
 /**
  * Copies JavaScript files from the given local frontend folder.
  *
@@ -45,10 +42,9 @@ public class TaskCopyLocalFrontendFiles implements FallibleCommand {
      * @param npmFolder
      *            target directory for the discovered files
      */
-    TaskCopyLocalFrontendFiles(File npmFolder,
+    TaskCopyLocalFrontendFiles(File targetDirectory,
             File frontendResourcesDirectory) {
-        this.targetDirectory = new File(npmFolder,
-                NODE_MODULES + FLOW_NPM_PACKAGE_NAME);
+        this.targetDirectory = targetDirectory;
         this.frontendResourcesDirectory = frontendResourcesDirectory;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCreatePackageJson.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCreatePackageJson.java
@@ -82,16 +82,15 @@ public class TaskCreatePackageJson extends NodeUpdater {
                 modified = true;
             }
 
-            if (frontendDepsFolder != null) {
-                if (!new File(npmFolder, NODE_MODULES + FLOW_NPM_PACKAGE_NAME)
-                        .equals(frontendDepsFolder)) {
-                    JsonObject depsContent = getDepsPackageJson();
-                    if (depsContent == null) {
-                        depsContent = Json.createObject();
-                        updateJarDependencies(depsContent);
-                        writeDepsPackageFile(depsContent);
-                        modified = true;
-                    }
+            if (frontendDepsFolder != null && !new File(npmFolder,
+                    NODE_MODULES + FLOW_NPM_PACKAGE_NAME)
+                            .equals(frontendDepsFolder)) {
+                JsonObject depsContent = getDepsPackageJson();
+                if (depsContent == null) {
+                    depsContent = Json.createObject();
+                    updateJarDependencies(depsContent);
+                    writeDepsPackageFile(depsContent);
+                    modified = true;
                 }
             }
         } catch (IOException e) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCreatePackageJson.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCreatePackageJson.java
@@ -47,8 +47,8 @@ public class TaskCreatePackageJson extends NodeUpdater {
      *            default)
      */
     TaskCreatePackageJson(File npmFolder, File generatedPath,
-            String polymerVersion) {
-        super(null, null, npmFolder, generatedPath);
+            File frontendDepsFolder, String polymerVersion) {
+        super(null, null, npmFolder, generatedPath, frontendDepsFolder);
         this.polymerVersion = polymerVersion;
     }
 
@@ -72,12 +72,21 @@ public class TaskCreatePackageJson extends NodeUpdater {
                 }
                 writeMainPackageFile(mainContent);
             }
-            JsonObject customContent = getAppPackageJson();
-            if (customContent == null) {
-                customContent = Json.createObject();
-                updateAppDefaultDependencies(customContent);
-                writeAppPackageFile(customContent);
+            JsonObject appContent = getAppPackageJson();
+            if (appContent == null) {
+                appContent = Json.createObject();
+                updateAppDefaultDependencies(appContent);
+                writeAppPackageFile(appContent);
                 modified = true;
+            }
+            if (frontendDepsFolder != null) {
+                JsonObject depsContent = getDepsPackageJson();
+                if (depsContent == null) {
+                    depsContent = Json.createObject();
+                    updateJarDependencies(depsContent);
+                    writeDepsPackageFile(depsContent);
+                    modified = true;
+                }
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCreatePackageJson.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCreatePackageJson.java
@@ -44,13 +44,15 @@ public class TaskCreatePackageJson extends NodeUpdater {
      *            folder with the `package.json` file.
      * @param generatedPath
      *            folder where flow generated files will be placed.
+     * @param flowResourcesPath
+     *            folder where flow resources taken from jars will be placed.
      * @param polymerVersion
      *            polymer version, may be {@code null} ({@code "3.2.0"} by
      *            default)
      */
     TaskCreatePackageJson(File npmFolder, File generatedPath,
-            File frontendDepsFolder, String polymerVersion) {
-        super(null, null, npmFolder, generatedPath, frontendDepsFolder);
+            File flowResourcesPath, String polymerVersion) {
+        super(null, null, npmFolder, generatedPath, flowResourcesPath);
         this.polymerVersion = polymerVersion;
     }
 
@@ -82,13 +84,13 @@ public class TaskCreatePackageJson extends NodeUpdater {
                 modified = true;
             }
 
-            if (frontendDepsFolder != null && !new File(npmFolder,
+            if (flowResourcesFolder != null && !new File(npmFolder,
                     NODE_MODULES + FLOW_NPM_PACKAGE_NAME)
-                            .equals(frontendDepsFolder)) {
-                JsonObject depsContent = getDepsPackageJson();
+                            .equals(flowResourcesFolder)) {
+                JsonObject depsContent = getResourcesPackageJson();
                 if (depsContent == null) {
                     depsContent = Json.createObject();
-                    updateJarDependencies(depsContent);
+                    updateResourcesDependencies(depsContent);
                     writeDepsPackageFile(depsContent);
                     modified = true;
                 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCreatePackageJson.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCreatePackageJson.java
@@ -22,6 +22,8 @@ import java.io.UncheckedIOException;
 import elemental.json.Json;
 import elemental.json.JsonObject;
 
+import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
+import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
 import static com.vaadin.flow.server.frontend.TaskUpdatePackages.APP_PACKAGE_HASH;
 
 /**
@@ -79,13 +81,17 @@ public class TaskCreatePackageJson extends NodeUpdater {
                 writeAppPackageFile(appContent);
                 modified = true;
             }
+
             if (frontendDepsFolder != null) {
-                JsonObject depsContent = getDepsPackageJson();
-                if (depsContent == null) {
-                    depsContent = Json.createObject();
-                    updateJarDependencies(depsContent);
-                    writeDepsPackageFile(depsContent);
-                    modified = true;
+                if (!new File(npmFolder, NODE_MODULES + FLOW_NPM_PACKAGE_NAME)
+                        .equals(frontendDepsFolder)) {
+                    JsonObject depsContent = getDepsPackageJson();
+                    if (depsContent == null) {
+                        depsContent = Json.createObject();
+                        updateJarDependencies(depsContent);
+                        writeDepsPackageFile(depsContent);
+                        modified = true;
+                    }
                 }
             }
         } catch (IOException e) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -344,7 +344,7 @@ public class TaskUpdateImports extends NodeUpdater {
             SerializableFunction<ClassFinder, FrontendDependenciesScanner> fallBackScannerProvider,
             File npmFolder, File generatedPath, File frontendDirectory,
             File tokenFile, JsonObject tokenFileData) {
-        super(finder, frontendDepScanner, npmFolder, generatedPath);
+        super(finder, frontendDepScanner, npmFolder, generatedPath, null);
         this.frontendDirectory = frontendDirectory;
         fallbackScanner = fallBackScannerProvider.apply(finder);
         this.tokenFile = tokenFile;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -17,14 +17,8 @@ package com.vaadin.flow.server.frontend;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.Serializable;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Map;
@@ -32,6 +26,8 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.apache.commons.io.FileUtils;
 
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.server.Constants;
@@ -56,24 +52,6 @@ public class TaskUpdatePackages extends NodeUpdater {
     private static final String SHRINK_WRAP = "@vaadin/vaadin-shrinkwrap";
     private boolean forceCleanUp;
 
-    private static class RemoveFileVisitor extends SimpleFileVisitor<Path>
-            implements Serializable {
-
-        @Override
-        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
-                throws IOException {
-            Files.delete(file);
-            return super.visitFile(file, attrs);
-        }
-
-        @Override
-        public FileVisitResult postVisitDirectory(Path dir, IOException exc)
-                throws IOException {
-            Files.delete(dir);
-            return super.postVisitDirectory(dir, exc);
-        }
-    }
-
     /**
      * Create an instance of the updater given all configurable parameters.
      *
@@ -91,8 +69,8 @@ public class TaskUpdatePackages extends NodeUpdater {
      */
     TaskUpdatePackages(ClassFinder finder,
             FrontendDependenciesScanner frontendDependencies, File npmFolder,
-            File generatedPath, boolean forceCleanUp) {
-        super(finder, frontendDependencies, npmFolder, generatedPath, null);
+            File generatedPath, File frontendDepsTargetDirectory, boolean forceCleanUp) {
+        super(finder, frontendDependencies, npmFolder, generatedPath, frontendDepsTargetDirectory);
         this.forceCleanUp = forceCleanUp;
     }
 
@@ -200,9 +178,13 @@ public class TaskUpdatePackages extends NodeUpdater {
                         + "This file has been generated with a different platform version. Try to remove it manually.");
             }
         }
-        if (nodeModulesFolder.exists()) {
-            removeDir(nodeModulesFolder);
+
+        removeDir(nodeModulesFolder);
+
+        if (frontendDepsFolder != null) {
+            removeDir(frontendDepsFolder);
         }
+
         File generatedNodeModules = new File(generatedFolder,
                 FrontendUtils.NODE_MODULES);
         if (generatedNodeModules.exists()) {
@@ -210,8 +192,8 @@ public class TaskUpdatePackages extends NodeUpdater {
         }
     }
 
-    private void removeDir(File file) throws IOException {
-        Files.walkFileTree(file.toPath(), new RemoveFileVisitor());
+    private void removeDir(File folder) throws IOException {
+        FileUtils.deleteDirectory(folder);
     }
 
     private String getCurrentShrinkWrapVersion() throws IOException {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -63,14 +63,17 @@ public class TaskUpdatePackages extends NodeUpdater {
      *            folder with the `package.json` file
      * @param generatedPath
      *            folder where flow generated files will be placed.
+     * @param flowResourcesPath
+     *            folder where flow dependencies taken from resources files will
+     *            be placed.
      * @param forceCleanUp
      *            forces the clean up process to be run. If {@code false}, clean
      *            up will be performed when platform version update is detected.
      */
     TaskUpdatePackages(ClassFinder finder,
             FrontendDependenciesScanner frontendDependencies, File npmFolder,
-            File generatedPath, File frontendDepsTargetDirectory, boolean forceCleanUp) {
-        super(finder, frontendDependencies, npmFolder, generatedPath, frontendDepsTargetDirectory);
+            File generatedPath, File flowResourcesPath, boolean forceCleanUp) {
+        super(finder, frontendDependencies, npmFolder, generatedPath, flowResourcesPath);
         this.forceCleanUp = forceCleanUp;
     }
 
@@ -181,8 +184,8 @@ public class TaskUpdatePackages extends NodeUpdater {
 
         removeDir(nodeModulesFolder);
 
-        if (frontendDepsFolder != null) {
-            removeDir(frontendDepsFolder);
+        if (flowResourcesFolder != null) {
+            removeDir(flowResourcesFolder);
         }
 
         File generatedNodeModules = new File(generatedFolder,

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -92,7 +92,7 @@ public class TaskUpdatePackages extends NodeUpdater {
     TaskUpdatePackages(ClassFinder finder,
             FrontendDependenciesScanner frontendDependencies, File npmFolder,
             File generatedPath, boolean forceCleanUp) {
-        super(finder, frontendDependencies, npmFolder, generatedPath);
+        super(finder, frontendDependencies, npmFolder, generatedPath, null);
         this.forceCleanUp = forceCleanUp;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -96,7 +96,7 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_CONNECT_JAVA
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_CONNECT_OPENAPI_JSON_FILE;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
-import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_DEPS_FOLDER;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEAULT_FLOW_RESOURCES_FOLDER;
 import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_FRONTEND_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_GENERATED;
@@ -232,7 +232,7 @@ public class DevModeInitializer implements ServletContainerInitializer,
         String frontendFolder = config.getStringProperty(PARAM_FRONTEND_DIR,
                 System.getProperty(PARAM_FRONTEND_DIR, DEFAULT_FRONTEND_DIR));
 
-        File frontendDepsFolder = new File(baseDir, FLOW_NPM_DEPS_FOLDER);
+        File frontendDepsFolder = new File(baseDir, DEAULT_FLOW_RESOURCES_FOLDER);
 
         Builder builder = new NodeTasks.Builder(new DevModeClassFinder(classes),
                 new File(baseDir), new File(generatedDir),

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -315,7 +315,8 @@ public class DevModeInitializer implements ServletContainerInitializer,
         try {
             builder.enablePackagesUpdate(true)
                     .useByteCodeScanner(useByteCodeScanner)
-                    .copyResources(frontendDepsFolder, frontendLocations)
+                    .withFrontendDependencies(frontendDepsFolder)
+                    .copyResources(frontendLocations)
                     .copyLocalResources(new File(baseDir,
                             Constants.LOCAL_FRONTEND_RESOURCES_PATH))
                     .enableImportsUpdate(true).runNpmInstall(true)

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -96,6 +96,8 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_CONNECT_JAVA
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_CONNECT_OPENAPI_JSON_FILE;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
+import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
+import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
 import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_FRONTEND_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_GENERATED;
@@ -231,6 +233,8 @@ public class DevModeInitializer implements ServletContainerInitializer,
         String frontendFolder = config.getStringProperty(PARAM_FRONTEND_DIR,
                 System.getProperty(PARAM_FRONTEND_DIR, DEFAULT_FRONTEND_DIR));
 
+        File frontendDepsFolder = new File(baseDir, NODE_MODULES + FLOW_NPM_PACKAGE_NAME);
+
         Builder builder = new NodeTasks.Builder(new DevModeClassFinder(classes),
                 new File(baseDir), new File(generatedDir),
                 new File(frontendFolder));
@@ -312,7 +316,7 @@ public class DevModeInitializer implements ServletContainerInitializer,
         try {
             builder.enablePackagesUpdate(true)
                     .useByteCodeScanner(useByteCodeScanner)
-                    .copyResources(frontendLocations)
+                    .copyResources(frontendDepsFolder, frontendLocations)
                     .copyLocalResources(new File(baseDir,
                             Constants.LOCAL_FRONTEND_RESOURCES_PATH))
                     .enableImportsUpdate(true).runNpmInstall(true)

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -96,8 +96,7 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_CONNECT_JAVA
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_CONNECT_OPENAPI_JSON_FILE;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
-import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
-import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
+import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_DEPS_FOLDER;
 import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_FRONTEND_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_GENERATED;
@@ -233,7 +232,7 @@ public class DevModeInitializer implements ServletContainerInitializer,
         String frontendFolder = config.getStringProperty(PARAM_FRONTEND_DIR,
                 System.getProperty(PARAM_FRONTEND_DIR, DEFAULT_FRONTEND_DIR));
 
-        File frontendDepsFolder = new File(baseDir, NODE_MODULES + FLOW_NPM_PACKAGE_NAME);
+        File frontendDepsFolder = new File(baseDir, FLOW_NPM_DEPS_FOLDER);
 
         Builder builder = new NodeTasks.Builder(new DevModeClassFinder(classes),
                 new File(baseDir), new File(generatedDir),

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -232,7 +232,7 @@ public class DevModeInitializer implements ServletContainerInitializer,
         String frontendFolder = config.getStringProperty(PARAM_FRONTEND_DIR,
                 System.getProperty(PARAM_FRONTEND_DIR, DEFAULT_FRONTEND_DIR));
 
-        File frontendDepsFolder = new File(baseDir, DEAULT_FLOW_RESOURCES_FOLDER);
+        File flowResourcesFolder = new File(baseDir, DEAULT_FLOW_RESOURCES_FOLDER);
 
         Builder builder = new NodeTasks.Builder(new DevModeClassFinder(classes),
                 new File(baseDir), new File(generatedDir),
@@ -315,7 +315,7 @@ public class DevModeInitializer implements ServletContainerInitializer,
         try {
             builder.enablePackagesUpdate(true)
                     .useByteCodeScanner(useByteCodeScanner)
-                    .withFrontendDependencies(frontendDepsFolder)
+                    .withFlowResourcesFolder(flowResourcesFolder)
                     .copyResources(frontendLocations)
                     .copyLocalResources(new File(baseDir,
                             Constants.LOCAL_FRONTEND_RESOURCES_PATH))

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
@@ -81,7 +81,7 @@ public abstract class AbstractNodeUpdatePackagesTest
 
         ClassFinder classFinder = getClassFinder();
         packageUpdater = new TaskUpdatePackages(classFinder,
-                getScanner(classFinder), baseDir, generatedDir, false);
+                getScanner(classFinder), baseDir, generatedDir, null, false);
         mainPackageJson = new File(baseDir, PACKAGE_JSON);
         appPackageJson = new File(generatedDir, PACKAGE_JSON);
 
@@ -238,7 +238,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
         packageUpdater = new TaskUpdatePackages(null, frontendDependencies,
-                baseDir, generatedDir, false);
+                baseDir, generatedDir, null, false);
 
         // Generate package json in a proper format first
         packageCreator.execute();
@@ -271,7 +271,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
         packageUpdater = new TaskUpdatePackages(null, frontendDependencies,
-                baseDir, generatedDir, false);
+                baseDir, generatedDir, null, false);
 
         // Generate package json in a proper format first
         packageCreator.execute();
@@ -300,7 +300,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         ClassFinder classFinder = getClassFinder();
         // create a new package updater, with forced clean up enabled
         packageUpdater = new TaskUpdatePackages(classFinder,
-                getScanner(classFinder), baseDir, generatedDir, true);
+                getScanner(classFinder), baseDir, generatedDir, null, true);
         packageUpdater.execute();
 
         // clean up happened
@@ -353,7 +353,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
         packageUpdater = new TaskUpdatePackages(null, frontendDependencies,
-                baseDir, generatedDir, false);
+                baseDir, generatedDir, null, false);
 
         packageCreator.execute();
         packageUpdater.execute();
@@ -385,7 +385,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
         packageUpdater = new TaskUpdatePackages(null, frontendDependencies,
-                baseDir, generatedDir, false);
+                baseDir, generatedDir, null, false);
 
         packageCreator.execute();
         packageUpdater.execute();
@@ -419,7 +419,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
         packageUpdater = new TaskUpdatePackages(null, frontendDependencies,
-                baseDir, generatedDir, false);
+                baseDir, generatedDir, null, false);
 
         packageCreator.execute();
         packageUpdater.execute();
@@ -447,7 +447,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
         packageUpdater = new TaskUpdatePackages(null, frontendDependencies,
-                baseDir, generatedDir, false);
+                baseDir, generatedDir, null, false);
 
         packageCreator.execute();
         packageUpdater.execute();
@@ -478,7 +478,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
         packageUpdater = new TaskUpdatePackages(null, frontendDependencies,
-                baseDir, generatedDir, false);
+                baseDir, generatedDir, null, false);
 
         // Set a package Hash
         JsonObject mainJson = Json.createObject();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
@@ -77,7 +77,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         NodeUpdateTestUtil.createStubNode(true, true,
                 baseDir.getAbsolutePath());
 
-        packageCreator = new TaskCreatePackageJson(baseDir, generatedDir, null);
+        packageCreator = new TaskCreatePackageJson(baseDir, generatedDir, null, null);
 
         ClassFinder classFinder = getClassFinder();
         packageUpdater = new TaskUpdatePackages(classFinder,

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
@@ -57,7 +57,6 @@ import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 import com.vaadin.flow.theme.AbstractTheme;
 import com.vaadin.flow.theme.ThemeDefinition;
 
-import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
@@ -57,6 +57,7 @@ import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 import com.vaadin.flow.theme.AbstractTheme;
 import com.vaadin.flow.theme.ThemeDefinition;
 
+import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendResourcesAreCopiedAfterCleaningTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendResourcesAreCopiedAfterCleaningTest.java
@@ -82,7 +82,8 @@ public class FrontendResourcesAreCopiedAfterCleaningTest {
         builder.withEmbeddableWebComponents(false).enableImportsUpdate(false)
                 .createMissingPackageJson(true).enableImportsUpdate(true)
                 .runNpmInstall(false).enablePackagesUpdate(true)
-                .copyResources(depsFolder, Collections.singleton(testJar)).build()
+                .withFrontendDependencies(depsFolder)
+                .copyResources(Collections.singleton(testJar)).build()
                 .execute();
     }
 
@@ -96,7 +97,8 @@ public class FrontendResourcesAreCopiedAfterCleaningTest {
         builder.withEmbeddableWebComponents(false).enableImportsUpdate(false)
                 .createMissingPackageJson(true).enableImportsUpdate(true)
                 .runNpmInstall(false).enableNpmFileCleaning(true)
-                .copyResources(depsFolder, Collections.emptySet())
+                .withFrontendDependencies(depsFolder)
+                .copyResources(Collections.emptySet())
                 .enablePackagesUpdate(true).build().execute();
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendResourcesAreCopiedAfterCleaningTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendResourcesAreCopiedAfterCleaningTest.java
@@ -31,7 +31,7 @@ import org.junit.rules.TemporaryFolder;
 import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 
-import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_DEPS_FOLDER;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEAULT_FLOW_RESOURCES_FOLDER;
 
 public class FrontendResourcesAreCopiedAfterCleaningTest {
 
@@ -64,7 +64,7 @@ public class FrontendResourcesAreCopiedAfterCleaningTest {
 
     private void assertCopiedFrontendFileAmount(int fileCount)
             throws IOException {
-        File dir = new File(npmFolder, "node_modules/@vaadin/flow-frontend");
+        File dir = new File(npmFolder, DEAULT_FLOW_RESOURCES_FOLDER);
         FileUtils.forceMkdir(dir);
         List<String> files = TestUtils.listFilesRecursively(dir);
 
@@ -78,7 +78,7 @@ public class FrontendResourcesAreCopiedAfterCleaningTest {
                         .getClassLoader());
         NodeTasks.Builder builder = new NodeTasks.Builder(classFinder,
                 npmFolder);
-        File depsFolder = new File(npmFolder, FLOW_NPM_DEPS_FOLDER);
+        File depsFolder = new File(npmFolder, DEAULT_FLOW_RESOURCES_FOLDER);
         builder.withEmbeddableWebComponents(false).enableImportsUpdate(false)
                 .createMissingPackageJson(true).enableImportsUpdate(true)
                 .runNpmInstall(false).enablePackagesUpdate(true)
@@ -92,9 +92,11 @@ public class FrontendResourcesAreCopiedAfterCleaningTest {
                         .getClassLoader());
         NodeTasks.Builder builder = new NodeTasks.Builder(classFinder,
                 npmFolder);
+        File depsFolder = new File(npmFolder, DEAULT_FLOW_RESOURCES_FOLDER);
         builder.withEmbeddableWebComponents(false).enableImportsUpdate(false)
                 .createMissingPackageJson(true).enableImportsUpdate(true)
                 .runNpmInstall(false).enableNpmFileCleaning(true)
+                .copyResources(depsFolder, Collections.emptySet())
                 .enablePackagesUpdate(true).build().execute();
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendResourcesAreCopiedAfterCleaningTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendResourcesAreCopiedAfterCleaningTest.java
@@ -31,8 +31,7 @@ import org.junit.rules.TemporaryFolder;
 import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 
-import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
-import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
+import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_DEPS_FOLDER;
 
 public class FrontendResourcesAreCopiedAfterCleaningTest {
 
@@ -79,7 +78,7 @@ public class FrontendResourcesAreCopiedAfterCleaningTest {
                         .getClassLoader());
         NodeTasks.Builder builder = new NodeTasks.Builder(classFinder,
                 npmFolder);
-        File depsFolder = new File(npmFolder, NODE_MODULES + FLOW_NPM_PACKAGE_NAME);
+        File depsFolder = new File(npmFolder, FLOW_NPM_DEPS_FOLDER);
         builder.withEmbeddableWebComponents(false).enableImportsUpdate(false)
                 .createMissingPackageJson(true).enableImportsUpdate(true)
                 .runNpmInstall(false).enablePackagesUpdate(true)

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendResourcesAreCopiedAfterCleaningTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendResourcesAreCopiedAfterCleaningTest.java
@@ -54,13 +54,13 @@ public class FrontendResourcesAreCopiedAfterCleaningTest {
     public void frontendResources_should_beCopiedFromJars_when_TaskUpdatePackagesRemovesThem()
             throws IOException, ExecutionFailedException {
         copyResources();
-        assertCopiedFrontendFileAmount(2);
+        assertCopiedFrontendFileAmount(3);
 
         performPackageClean();
         assertCopiedFrontendFileAmount(0);
 
         copyResources();
-        assertCopiedFrontendFileAmount(2);
+        assertCopiedFrontendFileAmount(3);
     }
 
     private void assertCopiedFrontendFileAmount(int fileCount)

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendResourcesAreCopiedAfterCleaningTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendResourcesAreCopiedAfterCleaningTest.java
@@ -31,6 +31,9 @@ import org.junit.rules.TemporaryFolder;
 import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 
+import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
+import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
+
 public class FrontendResourcesAreCopiedAfterCleaningTest {
 
     @Rule
@@ -76,10 +79,11 @@ public class FrontendResourcesAreCopiedAfterCleaningTest {
                         .getClassLoader());
         NodeTasks.Builder builder = new NodeTasks.Builder(classFinder,
                 npmFolder);
+        File depsFolder = new File(npmFolder, NODE_MODULES + FLOW_NPM_PACKAGE_NAME);
         builder.withEmbeddableWebComponents(false).enableImportsUpdate(false)
                 .createMissingPackageJson(true).enableImportsUpdate(true)
                 .runNpmInstall(false).enablePackagesUpdate(true)
-                .copyResources(Collections.singleton(testJar)).build()
+                .copyResources(depsFolder, Collections.singleton(testJar)).build()
                 .execute();
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendResourcesAreCopiedAfterCleaningTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendResourcesAreCopiedAfterCleaningTest.java
@@ -78,11 +78,11 @@ public class FrontendResourcesAreCopiedAfterCleaningTest {
                         .getClassLoader());
         NodeTasks.Builder builder = new NodeTasks.Builder(classFinder,
                 npmFolder);
-        File depsFolder = new File(npmFolder, DEAULT_FLOW_RESOURCES_FOLDER);
+        File resourcesFolder = new File(npmFolder, DEAULT_FLOW_RESOURCES_FOLDER);
         builder.withEmbeddableWebComponents(false).enableImportsUpdate(false)
                 .createMissingPackageJson(true).enableImportsUpdate(true)
                 .runNpmInstall(false).enablePackagesUpdate(true)
-                .withFrontendDependencies(depsFolder)
+                .withFlowResourcesFolder(resourcesFolder)
                 .copyResources(Collections.singleton(testJar)).build()
                 .execute();
     }
@@ -93,11 +93,11 @@ public class FrontendResourcesAreCopiedAfterCleaningTest {
                         .getClassLoader());
         NodeTasks.Builder builder = new NodeTasks.Builder(classFinder,
                 npmFolder);
-        File depsFolder = new File(npmFolder, DEAULT_FLOW_RESOURCES_FOLDER);
+        File resourcesFolder = new File(npmFolder, DEAULT_FLOW_RESOURCES_FOLDER);
         builder.withEmbeddableWebComponents(false).enableImportsUpdate(false)
                 .createMissingPackageJson(true).enableImportsUpdate(true)
                 .runNpmInstall(false).enableNpmFileCleaning(true)
-                .withFrontendDependencies(depsFolder)
+                .withFlowResourcesFolder(resourcesFolder)
                 .copyResources(Collections.emptySet())
                 .enablePackagesUpdate(true).build().execute();
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -37,6 +37,7 @@ import elemental.json.JsonObject;
 
 import static com.vaadin.flow.server.Constants.COMPATIBILITY_RESOURCES_FRONTEND_DEFAULT;
 import static com.vaadin.flow.server.Constants.RESOURCES_FRONTEND_DEFAULT;
+import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
 
 public class NodeUpdaterTest {
 
@@ -139,9 +140,9 @@ public class NodeUpdaterTest {
     private void resolveResource_happyPath(String resourceFolder) {
         Mockito.when(finder.getResource(resourceFolder + "/foo"))
                 .thenReturn(url);
-        Assert.assertEquals(FrontendUtils.FLOW_NPM_PACKAGE_NAME + "foo",
+        Assert.assertEquals(FLOW_NPM_PACKAGE_NAME + "foo",
                 nodeUpdater.resolveResource("foo", true));
-        Assert.assertEquals(FrontendUtils.FLOW_NPM_PACKAGE_NAME + "foo",
+        Assert.assertEquals(FLOW_NPM_PACKAGE_NAME + "foo",
                 nodeUpdater.resolveResource("foo", false));
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -58,7 +58,7 @@ public class NodeUpdaterTest {
         finder = Mockito.mock(ClassFinder.class);
         nodeUpdater = new NodeUpdater(finder,
                 Mockito.mock(FrontendDependencies.class), npmFolder,
-                new File("")) {
+                new File(""), null) {
 
             @Override
             public void execute() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskCopyFrontendFilesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskCopyFrontendFilesTest.java
@@ -66,7 +66,7 @@ public class TaskCopyFrontendFilesTest extends NodeUpdateTestUtil {
         // - resourceInFolder.js
         File dir = TestUtils.getTestFolder(fsDir);
 
-        TaskCopyFrontendFiles task = new TaskCopyFrontendFiles(npmFolder,
+        TaskCopyFrontendFiles task = new TaskCopyFrontendFiles(targetFolder,
                 jars(jar, dir));
 
         task.execute();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskCopyFrontendFilesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskCopyFrontendFilesTest.java
@@ -94,7 +94,6 @@ public class TaskCopyFrontendFilesTest extends NodeUpdateTestUtil {
         task.execute();
 
         List<String> files = TestUtils.listFilesRecursively(frontendDepsFolder);
-        System.err.println(files);
         Assert.assertEquals(3, files.size());
 
         Assert.assertTrue("Js resource should have been copied from jar file",

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -49,7 +49,7 @@ public class TaskRunNpmInstallTest {
         npmFolder = temporaryFolder.newFolder();
         nodeUpdater = new NodeUpdater(Mockito.mock(ClassFinder.class),
                 Mockito.mock(FrontendDependencies.class), npmFolder,
-                new File("")) {
+                new File(""), null) {
 
             @Override
             public void execute() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerClassLoaderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerClassLoaderTest.java
@@ -12,8 +12,7 @@ import org.junit.Test;
 
 import com.vaadin.flow.server.frontend.TestUtils;
 
-import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
-import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
+import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_DEPS_FOLDER;
 
 public class DevModeInitializerClassLoaderTest {
 
@@ -55,7 +54,7 @@ public class DevModeInitializerClassLoaderTest {
         customLoader.close();
 
         List<String> files = TestUtils.listFilesRecursively(
-                new File(baseDir, NODE_MODULES + FLOW_NPM_PACKAGE_NAME));
+                new File(baseDir, FLOW_NPM_DEPS_FOLDER));
         Assert.assertEquals(3, files.size());
 
         Assert.assertTrue("Js resource should have been copied from jar file",

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerClassLoaderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerClassLoaderTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
 
 import com.vaadin.flow.server.frontend.TestUtils;
 
-import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_DEPS_FOLDER;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEAULT_FLOW_RESOURCES_FOLDER;
 
 public class DevModeInitializerClassLoaderTest {
 
@@ -54,8 +54,11 @@ public class DevModeInitializerClassLoaderTest {
         customLoader.close();
 
         List<String> files = TestUtils.listFilesRecursively(
-                new File(baseDir, FLOW_NPM_DEPS_FOLDER));
-        Assert.assertEquals(3, files.size());
+                new File(baseDir, DEAULT_FLOW_RESOURCES_FOLDER));
+        Assert.assertEquals(4, files.size());
+
+        Assert.assertTrue("A package.json file should be created",
+                files.contains("package.json"));
 
         Assert.assertTrue("Js resource should have been copied from jar file",
                 files.contains("ExampleConnector.js"));


### PR DESCRIPTION
Fixes #6911 

This fixes the problem of the `node_modules/@vaadin/flow-frontend`  folder being 
removed alfter running `npm install`  by the following changes:

- the target folder for copying resources is configurable.
- added a `package.json` in the folder for copied resources.
- added `main` entries to `flow-deps` and `flow-frontend` so as in CCDM projects the 
   following syntax is allowed.
```
        import { Flow } from '@vaadin/flow-frontend';
        import('@vaadin/flow-deps')
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6977)
<!-- Reviewable:end -->
