### PR TITLE
Add isIPad to extendedClientDetails

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
@@ -170,9 +170,7 @@ public class ExtendedClientDetails implements Serializable {
         }
 
         this.windowName = windowName;
-        if(navigatorPlatform != null) {
-            this.navigatorPlatform = navigatorPlatform;
-        }
+        this.navigatorPlatform = navigatorPlatform;
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
@@ -19,6 +19,9 @@ import java.io.Serializable;
 import java.util.Date;
 import java.util.TimeZone;
 
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.server.WebBrowser;
+
 /**
  * Provides extended information about the web browser, such as screen
  * resolution and time zone.
@@ -32,10 +35,10 @@ import java.util.TimeZone;
  * @since 2.0
  */
 public class ExtendedClientDetails implements Serializable {
-    private int screenHeight = -1;
     private int screenWidth = -1;
-    private int windowInnerHeight = -1;
+    private int screenHeight = -1;
     private int windowInnerWidth = -1;
+    private int windowInnerHeight = -1;
     private int bodyClientWidth = -1;
     private int bodyClientHeight = -1;
     private int timezoneOffset = 0;
@@ -43,10 +46,11 @@ public class ExtendedClientDetails implements Serializable {
     private int dstSavings;
     private boolean dstInEffect;
     private String timeZoneId;
+    private long clientServerTimeDelta;
     private boolean touchDevice;
     private double devicePixelRatio = -1.0D;
-    private long clientServerTimeDelta;
     private String windowName;
+    private String navigatorPlatform;
 
     /**
      * For internal use only. Updates all properties in the class according to
@@ -83,13 +87,15 @@ public class ExtendedClientDetails implements Serializable {
      *            the resolution in CSS pixels
      * @param windowName
      *            a unique browser window name which persists on reload
+     * @param navigatorPlatform
+     *            navigation platform received from the browser
      */
     ExtendedClientDetails(String screenWidth, String screenHeight,
             String windowInnerWidth, String windowInnerHeight,
             String bodyClientWidth, String bodyClientHeight, String tzOffset,
             String rawTzOffset, String dstShift, String dstInEffect,
             String tzId, String curDate, String touchDevice,
-            String devicePixelRatio, String windowName) {
+            String devicePixelRatio, String windowName, String navigatorPlatform) {
         if (screenWidth != null) {
             try {
                 this.screenWidth = Integer.parseInt(screenWidth);
@@ -164,6 +170,9 @@ public class ExtendedClientDetails implements Serializable {
         }
 
         this.windowName = windowName;
+        if(navigatorPlatform != null) {
+            this.navigatorPlatform = navigatorPlatform;
+        }
     }
 
     /**
@@ -353,4 +362,17 @@ public class ExtendedClientDetails implements Serializable {
         return windowName;
     }
 
+    /**
+     * Check if the browser is run on IPad.
+     *
+     * @return true if run on IPad false if the user is not using IPad or if no
+     *         information from the browser is present
+     */
+    public boolean isIPad() {
+        if (navigatorPlatform != null) {
+            return navigatorPlatform.startsWith("iPad");
+        }
+        WebBrowser browser = VaadinSession.getCurrent().getBrowser();
+        return browser.isIPad() || (browser.isMacOSX() && isTouchDevice());
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -682,7 +682,8 @@ public class Page implements Serializable {
                         getStringElseNull.apply("v-curdate"),
                         getStringElseNull.apply("v-td"),
                         getStringElseNull.apply("v-pr"),
-                        getStringElseNull.apply("v-wn")));
+                        getStringElseNull.apply("v-wn"),
+                        getStringElseNull.apply("v-np")));
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/WebBrowser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/WebBrowser.java
@@ -26,6 +26,9 @@ import com.vaadin.flow.shared.BrowserDetails;
  * available in the request, for instance browser name and version and IP
  * address.
  *
+ * Note! browser details rely on the user agent from the browser and thus
+ * the details are not always correct.
+ *
  * @author Vaadin Ltd
  * @since 1.0.
  */
@@ -273,8 +276,15 @@ public class WebBrowser implements Serializable {
      * Tests if the browser is run on IPad.
      *
      * @return true if run on IPad false if the user is not using IPad or if no
-     *         information on the browser is present
+     * information on the browser is present
+     *
+     * @deprecated isIPad will return the wrong value for iOS 13 and later. To
+     * match for iPad running iOS 13 the check will need to check {@link
+     * WebBrowser#isMacOSX()} and {@link com.vaadin.flow.component.page.ExtendedClientDetails#isTouchDevice()}.
+     * e.g. the check for iPad needs to be '<code>webBrowser.isIPad() ||
+     * (webBrowser.isMacOSX() && extendedDetails.isTouchDevice())</code>'
      */
+    @Deprecated
     public boolean isIPad() {
         return browserDetails.isIPad();
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/WebBrowser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/WebBrowser.java
@@ -19,6 +19,7 @@ package com.vaadin.flow.server;
 import java.io.Serializable;
 import java.util.Locale;
 
+import com.vaadin.flow.component.page.ExtendedClientDetails;
 import com.vaadin.flow.shared.BrowserDetails;
 
 /**
@@ -276,13 +277,9 @@ public class WebBrowser implements Serializable {
      * Tests if the browser is run on IPad.
      *
      * @return true if run on IPad false if the user is not using IPad or if no
-     * information on the browser is present
-     *
-     * @deprecated isIPad will return the wrong value for iOS 13 and later. To
-     * match for iPad running iOS 13 the check will need to check {@link
-     * WebBrowser#isMacOSX()} and {@link com.vaadin.flow.component.page.ExtendedClientDetails#isTouchDevice()}.
-     * e.g. the check for iPad needs to be '<code>webBrowser.isIPad() ||
-     * (webBrowser.isMacOSX() && extendedDetails.isTouchDevice())</code>'
+     *         information on the browser is present
+     * @deprecated isIPad will return the wrong value for iOS 13 and later. Use
+     *             instead {@link ExtendedClientDetails#isIPad()}
      */
     @Deprecated
     public boolean isIPad() {

--- a/flow-server/src/main/java/com/vaadin/flow/shared/BrowserDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/BrowserDetails.java
@@ -594,7 +594,10 @@ public class BrowserDetails implements Serializable {
      * Tests if the browser is run on iPad.
      *
      * @return true if run on iPad, false otherwise
+     *
+     * @deprecated isIPad will return the wrong value for iOS 13 and later
      */
+    @Deprecated
     public boolean isIPad() {
         return isIPad;
     }

--- a/flow-server/src/main/resources/com/vaadin/flow/server/BootstrapHandler.js
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/BootstrapHandler.js
@@ -223,6 +223,10 @@
       /* Device Pixel Ratio */
       params['v-pr'] = window.devicePixelRatio;
 
+      if(navigator.platform) {
+        params['v-np'] = navigator.platform;
+      }
+      
       /* Stringify each value (they are parsed on the server side) */
       Object.keys(params).forEach(function(key) {
         var value = params[key];

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/ExtendedClientDetailsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/ExtendedClientDetailsTest.java
@@ -1,28 +1,19 @@
 package com.vaadin.flow.component.page;
 
-import org.junit.Test;
 import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.internal.CurrentInstance;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.server.WebBrowser;
 
 public class ExtendedClientDetailsTest {
 
     @Test
     public void initializeWithClientValues_gettersReturnExpectedValues() {
-        final ExtendedClientDetails details = new ExtendedClientDetails(
-                "2560",
-                "1450",
-                "2400",
-                "1400",
-                "1600",
-                "1360",
-                "-270", // minutes from UTC
-                "-210", // minutes from UTC without DST
-                "60", // dist shift amount
-                "true",
-                "Asia/Tehran",
-                "1555000000000", // Apr 11 2019
-                "false",
-                "2.0",
-                "ROOT-1234567-0.1234567");
+        final ExtendedClientDetails details = new ExtendBuilder().buildDetails();
+
         Assert.assertEquals(2560, details.getScreenWidth());
         Assert.assertEquals(1450, details.getScreenHeight());
         Assert.assertEquals(2400, details.getWindowInnerWidth());
@@ -37,8 +28,160 @@ public class ExtendedClientDetailsTest {
         Assert.assertEquals(false, details.isTouchDevice());
         Assert.assertEquals(2.0D, details.getDevicePixelRatio(), 0.0);
         Assert.assertEquals("ROOT-1234567-0.1234567", details.getWindowName());
+        Assert.assertFalse(details.isIPad());
 
         // Don't test getCurrentDate() and time delta due to the dependency on
         // server-side time
+    }
+
+    @Test
+    public void differentNavigatorPlatformDetails_isIPadReturnsExpectedValue() {
+        ExtendBuilder detailsBuilder = new ExtendBuilder();
+
+        ExtendedClientDetails details = detailsBuilder.buildDetails();
+        Assert.assertFalse("Linux is not an iPad", details.isIPad());
+
+        detailsBuilder.setNavigatorPlatform("iPad");
+        details = detailsBuilder.buildDetails();
+
+        Assert.assertTrue("'iPad' is an iPad", details.isIPad());
+
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        CurrentInstance.setCurrent(session);
+        WebBrowser browser = Mockito.mock(WebBrowser.class);
+        Mockito.when(session.getBrowser()).thenReturn(browser);
+
+        Mockito.when(browser.isIPad()).thenReturn(true);
+        Mockito.when(browser.isMacOSX()).thenReturn(false);
+
+        detailsBuilder.setNavigatorPlatform(null);
+        details = detailsBuilder.buildDetails();
+
+        Assert.assertTrue("No platform on with iPad is iPad", details.isIPad());
+
+        Mockito.when(browser.isIPad()).thenReturn(false);
+        Assert.assertFalse("No platform and ipad false on linux should not be an iPad", details.isIPad());
+
+        Mockito.when(browser.isMacOSX()).thenReturn(true);
+        Assert.assertFalse("No platform MacOSX, but not touch is not an iPad", details.isIPad());
+
+        detailsBuilder.setTouchDevice("true");
+        details = detailsBuilder.buildDetails();
+        Assert.assertTrue("No platform on MacOSX with touch is an iPad", details.isIPad());
+
+        CurrentInstance.clearAll();
+    }
+
+    /**
+     * Builder to create modified extended details.
+     * Default values apply.
+     */
+    private class ExtendBuilder {
+        private String screenWidth = "2560";
+        private String screenHeight = "1450";
+        private String windowInnerWidth = "2400";
+        private String windowInnerHeight = "1400";
+        private String bodyClientWidth = "1600";
+        private String bodyClientHeight = "1360";
+        private String timezoneOffset = "-270"; // minutes from UTC
+        private String rawTimezoneOffset = "-210"; // minutes from UTC without DST
+        private String dstSavings = "60"; // dist shift amount
+        private String dstInEffect = "true";
+        private String timeZoneId = "Asia/Tehran";
+        private String clientServerTimeDelta = "1555000000000"; // Apr 11 2019
+        private String touchDevice = "false";
+        private String devicePixelRatio = "2.0";
+        private String windowName = "ROOT-1234567-0.1234567";
+        private String navigatorPlatform = "Linux i686";
+
+        public ExtendedClientDetails buildDetails() {
+            return new ExtendedClientDetails(screenWidth, screenHeight,
+                    windowInnerWidth, windowInnerHeight, bodyClientWidth,
+                    bodyClientHeight, timezoneOffset, rawTimezoneOffset,
+                    dstSavings, dstInEffect, timeZoneId, clientServerTimeDelta,
+                    touchDevice, devicePixelRatio, windowName,
+                    navigatorPlatform);
+        }
+
+        public ExtendBuilder setScreenWidth(String screenWidth) {
+            this.screenWidth = screenWidth;
+            return this;
+        }
+
+        public ExtendBuilder setScreenHeight(String screenHeight) {
+            this.screenHeight = screenHeight;
+            return this;
+        }
+
+        public ExtendBuilder setWindowInnerWidth(String windowInnerWidth) {
+            this.windowInnerWidth = windowInnerWidth;
+            return this;
+        }
+
+        public ExtendBuilder setWindowInnerHeight(String windowInnerHeight) {
+            this.windowInnerHeight = windowInnerHeight;
+            return this;
+        }
+
+        public ExtendBuilder setBodyClientWidth(String bodyClientWidth) {
+            this.bodyClientWidth = bodyClientWidth;
+            return this;
+        }
+
+        public ExtendBuilder setBodyClientHeight(String bodyClientHeight) {
+            this.bodyClientHeight = bodyClientHeight;
+            return this;
+        }
+
+        public ExtendBuilder setTimezoneOffset(String timezoneOffset) {
+            this.timezoneOffset = timezoneOffset;
+            return this;
+        }
+
+        public ExtendBuilder setRawTimezoneOffset(String rawTimezoneOffset) {
+            this.rawTimezoneOffset = rawTimezoneOffset;
+            return this;
+        }
+
+        public ExtendBuilder setDstSavings(String dstSavings) {
+            this.dstSavings = dstSavings;
+            return this;
+        }
+
+        public ExtendBuilder setDstInEffect(String dstInEffect) {
+            this.dstInEffect = dstInEffect;
+            return this;
+        }
+
+        public ExtendBuilder setTimeZoneId(String timeZoneId) {
+            this.timeZoneId = timeZoneId;
+            return this;
+        }
+
+        public ExtendBuilder setClientServerTimeDelta(
+                String clientServerTimeDelta) {
+            this.clientServerTimeDelta = clientServerTimeDelta;
+            return this;
+        }
+
+        public ExtendBuilder setTouchDevice(String touchDevice) {
+            this.touchDevice = touchDevice;
+            return this;
+        }
+
+        public ExtendBuilder setDevicePixelRatio(String devicePixelRatio) {
+            this.devicePixelRatio = devicePixelRatio;
+            return this;
+        }
+
+        public ExtendBuilder setWindowName(String windowName) {
+            this.windowName = windowName;
+            return this;
+        }
+
+        public ExtendBuilder setNavigatorPlatform(String navigatorPlatform) {
+            this.navigatorPlatform = navigatorPlatform;
+            return this;
+        }
     }
 }


### PR DESCRIPTION
Update deprecation text and add
isIPad method to extendedClientDetails
where we use navigator.platform if available.

Builds on #6981

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6983)
<!-- Reviewable:end -->
