### PR TITLE
Change external stats default config

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
@@ -173,12 +173,17 @@ public final class DeploymentConfigurationFactory implements Serializable {
         // already set.
         if (json != null) {
             JsonObject buildInfo = JsonUtil.parse(json);
+            if (buildInfo.hasKey(SERVLET_PARAMETER_PRODUCTION_MODE)) {
+                initParameters.setProperty(SERVLET_PARAMETER_PRODUCTION_MODE,
+                        String.valueOf(buildInfo.getBoolean(
+                                SERVLET_PARAMETER_PRODUCTION_MODE)));
+            }
             if (buildInfo.hasKey(EXTERNAL_STATS_FILE_TOKEN) || buildInfo
                     .hasKey(EXTERNAL_STATS_URL_TOKEN)) {
-                // If external stats file is flagged then we should always run in
-                // npm production mode.
-                initParameters.setProperty(SERVLET_PARAMETER_PRODUCTION_MODE,
-                        Boolean.toString(true));
+                // If external stats file is flagged then compatibility mode and
+                // dev server should both be false - only variable that can
+                // be configured, in addition to stats variables, is
+                // production mode
                 initParameters.setProperty(SERVLET_PARAMETER_COMPATIBILITY_MODE,
                         Boolean.toString(false));
                 initParameters.setProperty(SERVLET_PARAMETER_ENABLE_DEV_SERVER,
@@ -189,12 +194,8 @@ public final class DeploymentConfigurationFactory implements Serializable {
                     initParameters.setProperty(EXTERNAL_STATS_URL,
                             buildInfo.getString(EXTERNAL_STATS_URL_TOKEN));
                 }
+                // NO OTHER CONFIGURATION:
                 return;
-            }
-            if (buildInfo.hasKey(SERVLET_PARAMETER_PRODUCTION_MODE)) {
-                initParameters.setProperty(SERVLET_PARAMETER_PRODUCTION_MODE,
-                        String.valueOf(buildInfo.getBoolean(
-                                SERVLET_PARAMETER_PRODUCTION_MODE)));
             }
             if (buildInfo.hasKey(SERVLET_PARAMETER_COMPATIBILITY_MODE)) {
                 initParameters.setProperty(SERVLET_PARAMETER_COMPATIBILITY_MODE,

--- a/flow-server/src/test/java/com/vaadin/flow/server/DeploymentConfigurationFactoryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DeploymentConfigurationFactoryTest.java
@@ -426,7 +426,7 @@ public class DeploymentConfigurationFactoryTest {
         DeploymentConfiguration config = createConfig(Collections
                 .singletonMap(PARAM_TOKEN_FILE, tokenFile.getPath()));
 
-        assertEquals(true, config.isProductionMode());
+        assertEquals(false, config.isProductionMode());
         assertEquals(false, config.isCompatibilityMode());
         assertEquals(false, config.enableDevServer());
         assertEquals(true, config.isStatsExternal());
@@ -442,7 +442,7 @@ public class DeploymentConfigurationFactoryTest {
         DeploymentConfiguration config = createConfig(Collections
                 .singletonMap(PARAM_TOKEN_FILE, tokenFile.getPath()));
 
-        assertEquals(true, config.isProductionMode());
+        assertEquals(false, config.isProductionMode());
         assertEquals(false, config.isCompatibilityMode());
         assertEquals(false, config.enableDevServer());
         assertEquals(true, config.isStatsExternal());
@@ -456,7 +456,9 @@ public class DeploymentConfigurationFactoryTest {
         FileUtils.writeLines(tokenFile, Arrays.asList("{",
                 "\"compatibilityMode\": true,",
                 "\"enableDevServer\": true,",
-                "\"productionMode\": false,",
+                // production mode can be altered even when external stats
+                // are used
+                "\"productionMode\": true,",
                 "\"externalStatsFile\": true",
                 "}"));
 


### PR DESCRIPTION
Allow production mode be configured via build-info when external stats.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6985)
<!-- Reviewable:end -->
