### PR TITLE
Added default method I18NProvider.getTranslation(String, Object..)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/i18n/I18NProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/i18n/I18NProvider.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.i18n;
 
+import com.vaadin.flow.server.VaadinService;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Locale;
@@ -33,6 +34,22 @@ public interface I18NProvider extends Serializable {
      * @return provided locales
      */
     List<Locale> getProvidedLocales();
+
+    /**
+     * Get the translation for key with the locale found in the current request.
+     * <p>
+     * Note! For usability and catching missing translations implementation
+     * should never return a null, but an exception string e.g. '!{key}!'
+     *
+     * @param key
+     *            translation key
+     * @param params
+     *            parameters used in translation string
+     * @return translation for key if found
+     */
+    default String getTranslation(String key, Object... params) {
+        return getTranslation(key, VaadinService.getCurrentRequest().getLocale(), params);
+    }
 
     /**
      * Get the translation for key with given locale.


### PR DESCRIPTION
Many users will have to write a lot of code like this

```java
i18NProvider.getTranslation(key, VaadinService.getCurrentRequest().getLocale());
```
This PR intends to simplify the usage of I18NProvider by introducing a default overload for getTranslation(), so the above code is simplified to

```java
i18NProvider.getTranslation(key)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6990)
<!-- Reviewable:end -->
