### PR TITLE
CCDM: do not remove `flow-frontend/package.json` on clean

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -332,7 +332,7 @@ public abstract class NodeUpdater implements FallibleCommand {
                 new File(generatedFolder, PACKAGE_JSON));
     }
 
-    String writeDepsPackageFile(JsonObject packageJson) throws IOException {
+    String writeResourcesPackageFile(JsonObject packageJson) throws IOException {
         return writePackageFile(packageJson,
                 new File(flowResourcesFolder, PACKAGE_JSON));
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCreatePackageJson.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCreatePackageJson.java
@@ -91,7 +91,7 @@ public class TaskCreatePackageJson extends NodeUpdater {
                 if (depsContent == null) {
                     depsContent = Json.createObject();
                     updateResourcesDependencies(depsContent);
-                    writeDepsPackageFile(depsContent);
+                    writeResourcesPackageFile(depsContent);
                     modified = true;
                 }
             }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -38,6 +38,9 @@ import elemental.json.Json;
 import elemental.json.JsonObject;
 import elemental.json.JsonValue;
 
+import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
+import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
+
 /**
  * Updates <code>package.json</code> by visiting {@link NpmPackage} annotations
  * found in the classpath. It also visits classes annotated with
@@ -185,11 +188,15 @@ public class TaskUpdatePackages extends NodeUpdater {
         removeDir(nodeModulesFolder);
 
         if (flowResourcesFolder != null) {
-            removeDir(flowResourcesFolder);
+            // Clean all files but `package.json`
+            for (File file: flowResourcesFolder.listFiles()) {
+                if (!file.getName().equals(PACKAGE_JSON)) {
+                    file.delete();
+                }
+            }
         }
 
-        File generatedNodeModules = new File(generatedFolder,
-                FrontendUtils.NODE_MODULES);
+        File generatedNodeModules = new File(generatedFolder, NODE_MODULES);
         if (generatedNodeModules.exists()) {
             removeDir(generatedNodeModules);
         }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendResourcesAreCopiedAfterCleaningTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendResourcesAreCopiedAfterCleaningTest.java
@@ -56,7 +56,8 @@ public class FrontendResourcesAreCopiedAfterCleaningTest {
         assertCopiedFrontendFileAmount(3);
 
         performPackageClean();
-        assertCopiedFrontendFileAmount(0);
+        // Should keep the `package.json` file
+        assertCopiedFrontendFileAmount(1);
 
         copyResources();
         assertCopiedFrontendFileAmount(3);


### PR DESCRIPTION
This fixes the following error when after cleanUp

`Could not install from "target/flow-frontend" as it does not contain a package.json file.`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6991)
<!-- Reviewable:end -->
