### PR TITLE
CCDM: fix bug with escaped content when using eagerServerLoad

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.regex.Pattern;
 
 import org.jsoup.Jsoup;
+import org.jsoup.nodes.DataNode;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
@@ -89,8 +90,8 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
 
         Element elm = new Element("script");
         elm.attr("initial", "");
-        elm.text("window.Vaadin = {Flow : {initial: "
-                + JsonUtil.stringify(initial) + "}}");
+        elm.appendChild(new DataNode("window.Vaadin = {Flow : {initial: "
+                + JsonUtil.stringify(initial) + "}}"));
         indexDocument.head().insertChildren(0, elm);
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
@@ -243,8 +243,12 @@ public class IndexHtmlRequestHandlerTest {
         Elements scripts = document.head().getElementsByTag("script");
         Assert.assertEquals(1, scripts.size());
         Assert.assertEquals("", scripts.get(0).attr("initial"));
+        String scriptContent = scripts.get(0).toString();
         Assert.assertTrue(
-                scripts.get(0).toString().contains("Could not navigate"));
+                scriptContent.contains("Could not navigate"));
+        Assert.assertFalse("Initial object content should not be escaped",
+                scriptContent.contains("&lt;")
+                        || scriptContent.contains("&gt;"));
         Assert.assertNotNull(UI.getCurrent());
     }
 


### PR DESCRIPTION
Fixes #6948 

The initial script should add content using `DataNode` to avoid escaping when Jsoup serializes content to html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/6998)
<!-- Reviewable:end -->
