### PR TITLE
`querySelector` param for critical errors

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/SystemErrorHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/SystemErrorHandler.java
@@ -15,9 +15,11 @@
  */
 package com.vaadin.client;
 
+import java.util.Optional;
 import java.util.Set;
 
 import com.google.web.bindery.event.shared.UmbrellaException;
+
 import com.vaadin.client.bootstrap.ErrorMessage;
 
 import elemental.client.Browser;
@@ -197,7 +199,10 @@ public class SystemErrorHandler {
             // if querySelector does not match an element on the page, the
             // error will not be displayed
             if (baseElement != null) {
-                baseElement.appendChild(systemErrorContainer);
+                // if the baseElement has a shadow root, add the warning to
+                // the shadow - otherwise add it to the baseElement
+                findShadowRoot(baseElement).orElse(baseElement)
+                        .appendChild(systemErrorContainer);
             }
         } else {
             document.getBody().appendChild(systemErrorContainer);
@@ -215,5 +220,14 @@ public class SystemErrorHandler {
         }
         return e;
     }
+
+    private Optional<Element> findShadowRoot(Element host) {
+        return Optional.ofNullable(getShadowRootElement(host));
+    }
+
+    private native Element getShadowRootElement(Element host)
+    /*-{
+        return host.shadowRoot;
+    }-*/;
 
 }

--- a/flow-client/src/main/java/com/vaadin/client/SystemErrorHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/SystemErrorHandler.java
@@ -69,7 +69,7 @@ public class SystemErrorHandler {
     protected void handleUnrecoverableError(String details,
             ErrorMessage message) {
         handleUnrecoverableError(message.getCaption(), message.getMessage(),
-                details, message.getUrl());
+                details, message.getUrl(), null);
     }
 
     /**
@@ -87,13 +87,37 @@ public class SystemErrorHandler {
      *            {@code null} to refresh on click
      */
     public void handleUnrecoverableError(String caption, String message,
-            String details, String url) {
+                                         String details, String url) {
+        handleUnrecoverableError(caption, message, details, url, null);
+    }
+
+    /**
+     * Shows an error notification for an error which is unrecoverable, using
+     * the given parameters.
+     *
+     * @param caption
+     *            the caption of the message
+     * @param message
+     *            the message body
+     * @param details
+     *            message details or {@code null} if there are no details
+     * @param url
+     *            a URL to redirect to when the user clicks the message or
+     *            {@code null} to refresh on click
+     * @param querySelector
+     *            query selector to find the element under which the error will
+     *            be added . If element is not found or the selector is
+     *            {@code null}, body will be used
+     */
+    public void handleUnrecoverableError(String caption, String message,
+            String details, String url, String querySelector) {
         if (caption == null && message == null && details == null) {
             WidgetUtil.redirect(url);
             return;
         }
 
-        Element systemErrorContainer = handleError(caption, message, details);
+        Element systemErrorContainer =
+                handleError(caption, message, details, querySelector);
         systemErrorContainer.addEventListener("click",
                 e -> WidgetUtil.redirect(url), false);
 
@@ -118,7 +142,7 @@ public class SystemErrorHandler {
             return;
         }
 
-        Element errorContainer = handleError(null, errorMessage, null);
+        Element errorContainer = handleError(null, errorMessage, null, null);
         errorContainer.addEventListener("click", e -> {
             // Allow user to dismiss the error by clicking it.
             errorContainer.getParentElement().removeChild(errorContainer);
@@ -142,7 +166,7 @@ public class SystemErrorHandler {
     }
 
     private Element handleError(String caption, String message,
-            String details) {
+            String details, String querySelector) {
         Document document = Browser.getDocument();
         Element systemErrorContainer = document.createDivElement();
         systemErrorContainer.setClassName("v-system-error");
@@ -168,8 +192,11 @@ public class SystemErrorHandler {
             systemErrorContainer.appendChild(detailsDiv);
             Console.error(details);
         }
-
-        document.getBody().appendChild(systemErrorContainer);
+        Element baseElement = document.querySelector(querySelector);
+        if (baseElement == null) {
+            baseElement = document.getBody();
+        }
+        baseElement.appendChild(systemErrorContainer);
         return systemErrorContainer;
     }
 

--- a/flow-client/src/main/java/com/vaadin/client/SystemErrorHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/SystemErrorHandler.java
@@ -192,11 +192,17 @@ public class SystemErrorHandler {
             systemErrorContainer.appendChild(detailsDiv);
             Console.error(details);
         }
-        Element baseElement = document.querySelector(querySelector);
-        if (baseElement == null) {
-            baseElement = document.getBody();
+        if (querySelector != null) {
+            Element baseElement = document.querySelector(querySelector);
+            // if querySelector does not match an element on the page, the
+            // error will not be displayed
+            if (baseElement != null) {
+                baseElement.appendChild(systemErrorContainer);
+            }
+        } else {
+            document.getBody().appendChild(systemErrorContainer);
         }
-        baseElement.appendChild(systemErrorContainer);
+
         return systemErrorContainer;
     }
 

--- a/flow-client/src/main/java/com/vaadin/client/bootstrap/ErrorMessage.java
+++ b/flow-client/src/main/java/com/vaadin/client/bootstrap/ErrorMessage.java
@@ -42,4 +42,9 @@ public final class ErrorMessage extends JavaScriptObject {
     /*-{
         return this.url;
     }-*/;
+
+    public native String getQuerySelector()
+    /*-{
+        return this.querySelector;
+    }-*/;
 }

--- a/flow-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
@@ -418,7 +418,9 @@ public class MessageHandler {
                     registry.getSystemErrorHandler().handleUnrecoverableError(
                             error.getString("caption"),
                             error.getString("message"),
-                            error.getString("details"), error.getString("url"));
+                            error.getString("details"),
+                            error.getString("url"),
+                            error.getString("querySelector"));
 
                     registry.getUILifecycle().setState(UIState.TERMINATED);
                 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -1717,12 +1717,42 @@ public abstract class VaadinService implements Serializable {
      */
     public static String createCriticalNotificationJSON(String caption,
             String message, String details, String url) {
+        return createCriticalNotificationJSON(caption, message, details, url,
+                null);
+    }
+
+    /**
+     * Creates a JSON message which, when sent to client as-is, will cause a
+     * critical error to be shown with the given details.
+     *
+     * @param caption
+     *            The caption of the error or null to omit
+     * @param message
+     *            The error message or null to omit
+     * @param details
+     *            Additional error details or null to omit
+     * @param url
+     *            A url to redirect to. If no other details are given then the
+     *            user will be immediately redirected to this URL. Otherwise the
+     *            message will be shown and the browser will redirect to the
+     *            given URL only after the user acknowledges the message. If
+     *            null then the browser will refresh the current page.
+     * @param querySelector
+     *            Query selector to find the element under which the error will
+     *            be added . If element is not found or the selector is
+     *            {@code null}, body will be used
+     * @return A JSON string to be sent to the client
+     */
+    public static String createCriticalNotificationJSON(
+            String caption, String message, String details, String url,
+            String querySelector) {
         try {
             JsonObject appError = Json.createObject();
             putValueOrJsonNull(appError, "caption", caption);
             putValueOrJsonNull(appError, "url", url);
             putValueOrJsonNull(appError, "message", message);
             putValueOrJsonNull(appError, "details", details);
+            putValueOrJsonNull(appError, "querySelector", querySelector);
 
             JsonObject meta = Json.createObject();
             meta.put("appError", appError);


### PR DESCRIPTION
One way to replace the error message would be to add a `querySelector` parameter to critical error message. One downside is that `querySelector` cannot (per current spec) select parent element. Other is that the _thing_ constructing the message needs to know where to place the box.

Thoughts for a better approach?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7002)
<!-- Reviewable:end -->
