### PR TITLE
fix: use the latest Spring version

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -15,8 +15,8 @@
     <properties>
         <validation.api.version>2.0.1.Final</validation.api.version>
         <jackson.version>2.9.7</jackson.version>
-        <spring.version>5.1.2.RELEASE</spring.version>
-        <spring.autoconfigure.version>2.1.0.RELEASE</spring.autoconfigure.version>
+        <spring.version>5.2.0.RELEASE</spring.version>
+        <spring.autoconfigure.version>2.2.0.RELEASE</spring.autoconfigure.version>
         <javax.annotation.api.version>1.3.2</javax.annotation.api.version>
         <javaparser.version>3.15.1</javaparser.version>
         <commons.configuration.version>2.6</commons.configuration.version>

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectControllerConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectControllerConfiguration.java
@@ -61,29 +61,18 @@ public class VaadinConnectControllerConfiguration {
             public RequestMappingHandlerMapping getRequestMappingHandlerMapping() {
                 return new RequestMappingHandlerMapping() {
 
-                    // If Spring application context initialization fails here with a stack overflow
-                    // when starting a project that also has the `vaadin-spring` dependency, make sure
-                    // that the Spring version in `flow-server` and in `vaadin-spring` is the same.
                     @Override
                     protected void registerHandlerMethod(Object handler,
                             Method method, RequestMappingInfo mapping) {
+                        // If Spring context initialization fails here with a
+                        // stack overflow in a project that also has the
+                        // `vaadin-spring` dependency, make sure that the Spring
+                        // version in `flow-server` and in `vaadin-spring` is
+                        // the same.
 
                         if (VaadinConnectController.class
                                 .equals(method.getDeclaringClass())) {
-                            PatternsRequestCondition connectServicePattern = new PatternsRequestCondition(
-                                    vaadinConnectProperties
-                                            .getVaadinConnectEndpoint())
-                                                    .combine(mapping
-                                                            .getPatternsCondition());
-
-                            mapping = new RequestMappingInfo(mapping.getName(),
-                                    connectServicePattern,
-                                    mapping.getMethodsCondition(),
-                                    mapping.getParamsCondition(),
-                                    mapping.getHeadersCondition(),
-                                    mapping.getConsumesCondition(),
-                                    mapping.getProducesCondition(),
-                                    mapping.getCustomCondition());
+                            mapping = prependConnectEndpointUrl(mapping);
                         }
 
                         super.registerHandlerMethod(handler, method, mapping);
@@ -91,6 +80,27 @@ public class VaadinConnectControllerConfiguration {
                 };
             }
         };
+    }
+
+    /**
+     * Prepends the Connect endpoint URL from the Vaadin Connect properties to
+     * the {@code pattern} of a {@link RequestMappingInfo} object, and returns
+     * the updated mapping as a new object (not modifying the given
+     * {@param mapping} parameter).
+     *
+     * @return a new mapping with the Connect endpoint URL prepended to the
+     *         mapping pattern
+     */
+    private RequestMappingInfo prependConnectEndpointUrl(
+            RequestMappingInfo mapping) {
+        PatternsRequestCondition connectServicePattern = new PatternsRequestCondition(
+                vaadinConnectProperties.getVaadinConnectEndpoint())
+                        .combine(mapping.getPatternsCondition());
+
+        return new RequestMappingInfo(mapping.getName(), connectServicePattern,
+                mapping.getMethodsCondition(), mapping.getParamsCondition(),
+                mapping.getHeadersCondition(), mapping.getConsumesCondition(),
+                mapping.getProducesCondition(), mapping.getCustomCondition());
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectControllerConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectControllerConfiguration.java
@@ -17,8 +17,6 @@
 package com.vaadin.flow.server.connect;
 
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcRegistrations;
 import org.springframework.context.annotation.Bean;
@@ -63,19 +61,12 @@ public class VaadinConnectControllerConfiguration {
             public RequestMappingHandlerMapping getRequestMappingHandlerMapping() {
                 return new RequestMappingHandlerMapping() {
 
-                    private List<Method> registered = new ArrayList<>();
-
+                    // If Spring application context initialization fails here with a stack overflow
+                    // when starting a project that also has the `vaadin-spring` dependency, make sure
+                    // that the Spring version in `flow-server` and in `vaadin-spring` is the same.
                     @Override
                     protected void registerHandlerMethod(Object handler,
                             Method method, RequestMappingInfo mapping) {
-
-                        // Avoid registering twice, it rarely happens, but
-                        // removing this check causes infinite loops in
-                        // vaadin-spring tests.
-                        if (registered.contains(method)) {
-                            return;
-                        }
-                        registered.add(method);
 
                         if (VaadinConnectController.class
                                 .equals(method.getDeclaringClass())) {

--- a/flow-tests/test-ccdm-connect/pom.xml
+++ b/flow-tests/test-ccdm-connect/pom.xml
@@ -15,8 +15,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <spring.version>2.1.6.RELEASE</spring.version>
-        <vaadin.spring.version>15.0-SNAPSHOT</vaadin.spring.version>
+        <!-- this version has to match the Spring version used by `flow-server` -->
+        <spring.version>2.2.0.RELEASE</spring.version>
         <server.port>8888</server.port>
         <vaadin.clientSideMode>true</vaadin.clientSideMode>
     </properties>
@@ -41,17 +41,6 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>vaadin-spring-boot-starter</artifactId>
-            <version>${vaadin.spring.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.vaadin</groupId>
-                    <artifactId>vaadin-core</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-spring</artifactId>
             <version>12.2-SNAPSHOT</version>
             <exclusions>
@@ -73,6 +62,10 @@
             <groupId>com.vaadin</groupId>
             <artifactId>flow-server-production-mode</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/flow-tests/test-ccdm-connect/pom.xml
+++ b/flow-tests/test-ccdm-connect/pom.xml
@@ -17,6 +17,7 @@
     <properties>
         <!-- this version has to match the Spring version used by `flow-server` -->
         <spring.version>2.2.0.RELEASE</spring.version>
+        <vaadin.spring.version>15.0-SNAPSHOT</vaadin.spring.version>
         <server.port>8888</server.port>
         <vaadin.clientSideMode>true</vaadin.clientSideMode>
     </properties>
@@ -41,6 +42,17 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-spring-boot-starter</artifactId>
+            <version>${vaadin.spring.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.vaadin</groupId>
+                    <artifactId>vaadin-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-spring</artifactId>
             <version>12.2-SNAPSHOT</version>
             <exclusions>
@@ -62,10 +74,6 @@
             <groupId>com.vaadin</groupId>
             <artifactId>flow-server-production-mode</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/flow-tests/test-ccdm-connect/src/main/java/com/vaadin/flow/connect/SecurityConfiguration.java
+++ b/flow-tests/test-ccdm-connect/src/main/java/com/vaadin/flow/connect/SecurityConfiguration.java
@@ -71,7 +71,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
      * Allows access to static resources, bypassing Spring security.
      */
     @Override
-    public void configure(WebSecurity web) throws Exception {
+    public void configure(WebSecurity web) {
         web.ignoring().antMatchers(
                 // Vaadin Flow static resources
                 "/VAADIN/**");


### PR DESCRIPTION
This fixes the Spring version mismatch between flow-server-3.0-SNAPSHOT and vaadin-spring-13.0-SNAPSHOT.
Also removes the workaround added to avoid a runtime failure caused by the version mismatch (added in https://github.com/vaadin/flow/pull/7024).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7028)
<!-- Reviewable:end -->
