### PR TITLE
Re-enable embedding ITs

### DIFF
--- a/flow-tests/test-embedding/test-embedding-generic/pom.xml
+++ b/flow-tests/test-embedding/test-embedding-generic/pom.xml
@@ -39,10 +39,6 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
                     <dependenciesToScan>com.vaadin:flow-embedding-test-assets</dependenciesToScan>
-                    <excludes>
-                        <!-- Remove once #5732 is fixed -->
-                        <exclude>**/UpdateServerSideWebComponentIT.java</exclude>
-                    </excludes>
                 </configuration>
             </plugin>
 

--- a/flow-tests/test-embedding/test-embedding-production-mode/pom.xml
+++ b/flow-tests/test-embedding/test-embedding-production-mode/pom.xml
@@ -46,10 +46,6 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
                     <dependenciesToScan>com.vaadin:flow-embedding-test-assets</dependenciesToScan>
-                    <excludes>
-                        <!-- Remove once #5732 is fixed -->
-                        <exclude>**/UpdateServerSideWebComponentIT.java</exclude>
-                    </excludes>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Fixes #5732

Re-enabling the tests, since the log seems to rely on resync implementation, which now exists. If these flake again, there is something to actually fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7036)
<!-- Reviewable:end -->
