### PR TITLE
Error message if dev-server not responding 2.1 (#7034)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.server.frontend;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -189,6 +189,11 @@ public class FrontendUtils {
     public static final String INSTALL_NODE_LOCALLY = "%n  $ mvn com.github.eirslett:frontend-maven-plugin:1.7.6:install-node-and-npm -DnodeVersion=\"v12.13.0\" ";
     public static final String DISABLE_CHECK = "%nYou can disable the version check using -D%s=true";
 
+    private static final String NO_CONNECTION =
+            "Webpack-dev-server couldn't be reached for %s.%n"
+                    + "Check the startup logs for exceptions in running webpack-dev-server.%n"
+                    + "If server should be running in production mode check that production mode flag is set correctly.";
+
     private static final String NOT_FOUND = "%n%n======================================================================================================"
             + "%nFailed to determine '%s' tool." + "%nPlease install it either:"
             + "%n  - by following the https://nodejs.org/en/download/ guide to install it globally"
@@ -462,8 +467,15 @@ public class FrontendUtils {
         DeploymentConfiguration config = service.getDeploymentConfiguration();
         if (!config.isProductionMode() && config.enableDevServer()) {
             DevModeHandler handler = DevModeHandler.getDevModeHandler();
-            return streamToString(handler
-                    .prepareConnection("/stats.hash", "GET").getInputStream())
+            HttpURLConnection statsConnection = handler
+                    .prepareConnection("/stats.hash", "GET");
+            if (statsConnection.getResponseCode()
+                    != HttpURLConnection.HTTP_OK) {
+                throw new WebpackConnectionException(
+                        String.format(NO_CONNECTION,
+                                "getting the stats content hash."));
+            }
+            return streamToString(statsConnection.getInputStream())
                             .replaceAll("\"", "");
         }
 
@@ -472,7 +484,13 @@ public class FrontendUtils {
 
     private static InputStream getStatsFromWebpack() throws IOException {
         DevModeHandler handler = DevModeHandler.getDevModeHandler();
-        return handler.prepareConnection("/stats.json", "GET").getInputStream();
+        HttpURLConnection statsConnection = handler
+                .prepareConnection("/stats.json", "GET");
+        if (statsConnection.getResponseCode() != HttpURLConnection.HTTP_OK) {
+            throw new WebpackConnectionException(
+                    String.format(NO_CONNECTION, "downloading stats.json"));
+        }
+        return statsConnection.getInputStream();
     }
 
     private static InputStream getStatsFromClassPath(VaadinService service) {
@@ -507,9 +525,15 @@ public class FrontendUtils {
         DeploymentConfiguration config = service.getDeploymentConfiguration();
         if (!config.isProductionMode() && config.enableDevServer()) {
             DevModeHandler handler = DevModeHandler.getDevModeHandler();
-            return streamToString(
-                    handler.prepareConnection("/assetsByChunkName", "GET")
-                            .getInputStream());
+            HttpURLConnection assetsConnection = handler
+                    .prepareConnection("/assetsByChunkName", "GET");
+            if (assetsConnection.getResponseCode()
+                    != HttpURLConnection.HTTP_OK) {
+                throw new WebpackConnectionException(
+                        String.format(NO_CONNECTION,
+                                "getting assets by chunk name."));
+            }
+            return streamToString(assetsConnection.getInputStream());
         }
 
         String stats = config

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/WebpackConnectionException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/WebpackConnectionException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.frontend;
+
+/**
+ * Exception thrown when webpack server doesn't respond with HTTP_OK for a
+ * request.
+ *
+ * This exception usually means that webpack-dev-server failed compilation of
+ * the frontend bundle and any error in the output should be fixed.
+ */
+public class WebpackConnectionException extends RuntimeException {
+
+    /**
+     * Constructs a new exception with the specified detail message.
+     *
+     * @param message
+     *         the detailed message on the problem.
+     */
+    public WebpackConnectionException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
Give the user a better error message and throw
a named exception if the webpack-dev-server
is not responding.

Fixes #6785

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7047)
<!-- Reviewable:end -->
