### PR TITLE
Use latest leaf bean instance from data provider

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicationController.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicationController.java
@@ -259,6 +259,8 @@ public class HierarchicalCommunicationController<T> implements Serializable {
             boolean mapperHasKey = keyMapper.has(bean);
             String key = keyMapper.key(bean);
             if (mapperHasKey) {
+                // Ensure latest instance from provider is used
+                keyMapper.refresh(bean);
                 passivatedByUpdate.values()
                         .forEach(set -> set.remove(key));
             }

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicatorDataTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicatorDataTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.data.provider.hierarchy;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.data.provider.CompositeDataGenerator;
+import com.vaadin.flow.data.provider.DataCommunicatorTest;
+import com.vaadin.flow.data.provider.hierarchy.HierarchicalArrayUpdater.HierarchicalUpdate;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.function.ValueProvider;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
+import elemental.json.JsonValue;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+public class HierarchicalCommunicatorDataTest {
+    /**
+     * Test item that uses id for identity.
+     */
+    private static class Item {
+        private final int id;
+        private String value;
+
+        public Item(int id, String value) {
+            this.id = id;
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return id + ": " + value;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj instanceof Item) {
+                Item that = (Item) obj;
+                return that.id == id;
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return id;
+        }
+    }
+
+    private static final Item ROOT = new Item(0, "ROOT");
+    private static final Item FOLDER = new Item(1, "FOLDER");
+    private static final Item LEAF = new Item( 2, "LEAF");
+    private TreeDataProvider<Item> dataProvider;
+    private HierarchicalDataCommunicator<Item> communicator;
+    private TreeData<Item> treeData;
+
+    private List<String> enqueueFunctions = new ArrayList<>();
+
+    private Element element;
+    private MockUI ui;
+
+    private class UpdateQueue implements HierarchicalUpdate {
+        @Override
+        public void clear(int start, int length) {
+        }
+
+        @Override
+        public void set(int start, List<JsonValue> items) {
+        }
+
+        @Override
+        public void commit(int updateId) {
+        }
+
+        @Override
+        public void enqueue(String name, Serializable... arguments) {
+            enqueueFunctions.add(name);
+        }
+
+        @Override
+        public void set(int start, List<JsonValue> items, String parentKey) {
+        }
+
+        @Override
+        public void clear(int start, int length, String parentKey) {
+        }
+
+        @Override
+        public void commit(int updateId, String parentKey, int levelSize) {
+        }
+
+        @Override
+        public void commit() {
+        }
+    }
+
+    private final HierarchicalArrayUpdater arrayUpdater = new HierarchicalArrayUpdater() {
+        @Override
+        public HierarchicalUpdate startUpdate(int sizeChange) {
+            return new UpdateQueue();
+        }
+
+        @Override
+        public void initialize() {
+        }
+    };
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        ui = new MockUI();
+        element = new Element("div");
+        ui.getElement().appendChild(element);
+
+        treeData = new TreeData<>();
+        treeData.addItems(null, ROOT);
+        treeData.addItems(ROOT, FOLDER);
+        treeData.addItems(FOLDER, LEAF);
+        dataProvider = new TreeDataProvider<>(treeData);
+        communicator = new HierarchicalDataCommunicator<>(
+                Mockito.mock(CompositeDataGenerator.class), arrayUpdater,
+                json -> {
+                }, element.getNode(), () -> (ValueProvider<Item, String>) item -> String.valueOf(item.id)
+        );
+        communicator.setDataProvider(dataProvider, null);
+    }
+
+    @Test
+    public void sameKeyDifferentInstance_latestInstanceUsed() {
+        communicator.expand(ROOT);
+        communicator.expand(FOLDER);
+
+        fakeClientCommunication();
+
+        Item originalLeaf = treeData.getChildren(FOLDER).get(0);
+        String key = communicator.getKeyMapper().key(originalLeaf);
+
+        Assert.assertSame(originalLeaf,
+                communicator.getKeyMapper().get(key));
+
+        Item updatedLeaf = new Item(originalLeaf.id, "Updated");
+        treeData.removeItem(LEAF);
+        treeData.addItems(FOLDER, updatedLeaf);
+
+        fakeClientCommunication();
+
+        dataProvider.refreshItem(FOLDER, true);
+
+        fakeClientCommunication();
+
+        Assert.assertSame(updatedLeaf,
+                communicator.getKeyMapper().get(key));
+    }
+
+    private void fakeClientCommunication() {
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+        ui.getInternals().getStateTree().collectChanges(ignore -> {
+        });
+    }
+
+    public static class MockUI extends UI {
+
+        public MockUI() {
+            this(findOrcreateSession());
+        }
+
+        public MockUI(VaadinSession session) {
+            getInternals().setSession(session);
+            setCurrent(this);
+        }
+
+        @Override
+        protected void init(VaadinRequest request) {
+            // Do nothing
+        }
+
+        private static VaadinSession findOrcreateSession() {
+            VaadinSession session = VaadinSession.getCurrent();
+            if (session == null) {
+                session = new DataCommunicatorTest.AlwaysLockedVaadinSession(null);
+                VaadinSession.setCurrent(session);
+            }
+            return session;
+        }
+    }
+
+    public static class AlwaysLockedVaadinSession extends DataCommunicatorTest.MockVaadinSession {
+
+        public AlwaysLockedVaadinSession(VaadinService service) {
+            super(service);
+            lock();
+        }
+
+    }
+
+}

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicatorDataTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicatorDataTest.java
@@ -71,17 +71,13 @@ public class HierarchicalCommunicatorDataTest {
 
     private static final Item ROOT = new Item(0, "ROOT");
     private static final Item FOLDER = new Item(1, "FOLDER");
-    private static final Item LEAF = new Item( 2, "LEAF");
+    private static final Item LEAF = new Item(2, "LEAF");
     private TreeDataProvider<Item> dataProvider;
     private HierarchicalDataCommunicator<Item> communicator;
     private TreeData<Item> treeData;
-
-    private List<String> enqueueFunctions = new ArrayList<>();
-
-    private Element element;
     private MockUI ui;
 
-    private class UpdateQueue implements HierarchicalUpdate {
+    private static class UpdateQueue implements HierarchicalUpdate {
         @Override
         public void clear(int start, int length) {
         }
@@ -96,7 +92,6 @@ public class HierarchicalCommunicatorDataTest {
 
         @Override
         public void enqueue(String name, Serializable... arguments) {
-            enqueueFunctions.add(name);
         }
 
         @Override
@@ -131,7 +126,7 @@ public class HierarchicalCommunicatorDataTest {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
         ui = new MockUI();
-        element = new Element("div");
+        Element element = new Element("div");
         ui.getElement().appendChild(element);
 
         treeData = new TreeData<>();
@@ -142,8 +137,9 @@ public class HierarchicalCommunicatorDataTest {
         communicator = new HierarchicalDataCommunicator<>(
                 Mockito.mock(CompositeDataGenerator.class), arrayUpdater,
                 json -> {
-                }, element.getNode(), () -> (ValueProvider<Item, String>) item -> String.valueOf(item.id)
-        );
+                }, element.getNode(),
+                () -> (ValueProvider<Item, String>) item -> String
+                        .valueOf(item.id));
         communicator.setDataProvider(dataProvider, null);
     }
 
@@ -157,8 +153,7 @@ public class HierarchicalCommunicatorDataTest {
         Item originalLeaf = treeData.getChildren(FOLDER).get(0);
         String key = communicator.getKeyMapper().key(originalLeaf);
 
-        Assert.assertSame(originalLeaf,
-                communicator.getKeyMapper().get(key));
+        Assert.assertSame(originalLeaf, communicator.getKeyMapper().get(key));
 
         Item updatedLeaf = new Item(originalLeaf.id, "Updated");
         treeData.removeItem(LEAF);
@@ -170,8 +165,7 @@ public class HierarchicalCommunicatorDataTest {
 
         fakeClientCommunication();
 
-        Assert.assertSame(updatedLeaf,
-                communicator.getKeyMapper().get(key));
+        Assert.assertSame(updatedLeaf, communicator.getKeyMapper().get(key));
     }
 
     private void fakeClientCommunication() {
@@ -183,7 +177,7 @@ public class HierarchicalCommunicatorDataTest {
     public static class MockUI extends UI {
 
         public MockUI() {
-            this(findOrcreateSession());
+            this(findOrCreateSession());
         }
 
         public MockUI(VaadinSession session) {
@@ -196,17 +190,19 @@ public class HierarchicalCommunicatorDataTest {
             // Do nothing
         }
 
-        private static VaadinSession findOrcreateSession() {
+        private static VaadinSession findOrCreateSession() {
             VaadinSession session = VaadinSession.getCurrent();
             if (session == null) {
-                session = new DataCommunicatorTest.AlwaysLockedVaadinSession(null);
+                session = new DataCommunicatorTest.AlwaysLockedVaadinSession(
+                        null);
                 VaadinSession.setCurrent(session);
             }
             return session;
         }
     }
 
-    public static class AlwaysLockedVaadinSession extends DataCommunicatorTest.MockVaadinSession {
+    public static class AlwaysLockedVaadinSession
+            extends DataCommunicatorTest.MockVaadinSession {
 
         public AlwaysLockedVaadinSession(VaadinService service) {
             super(service);


### PR DESCRIPTION
Fixes https://github.com/vaadin/vaadin-grid-flow/issues/792

Ensuring the latest item instance from the data provider is the same as the item that stored in the key mapper. The same is done for [`DataCommunicator`](https://github.com/vaadin/flow/blob/2864b8698c244425082da2ae83b8808cd7d08243/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java#L647).

Wasn't able to incorporate within existing `HierarchicalCommunicatorTest` tests as I need the actual MockUI with attached element to be present in order to play around `runExecutionsBeforeClientResponse`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7048)
<!-- Reviewable:end -->
