### PR TITLE
Fix bug in Element::removeFromTree not removing virtual child nodes from their parent

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -585,10 +585,15 @@ public class Element extends Node<Element> {
      * @return this element
      */
     public Element removeFromTree() {
+
         Node<?> parent = getParentNode();
-        if (parent != null
-                && parent.getChildren().anyMatch(Predicate.isEqual(this))) {
-            parent.removeChild(this);
+        if (parent != null) {
+            if (parent.getChildren().anyMatch(Predicate.isEqual(this))) {
+                parent.removeChild(this);
+            }
+            if (isVirtualChild()) {
+                parent.removeVirtualChild(this);
+            }
         }
         getNode().removeFromTree();
         return this;

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
@@ -34,8 +34,10 @@ import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
 import com.vaadin.flow.internal.nodefeature.ElementListenersTest;
 import com.vaadin.flow.internal.nodefeature.ElementPropertyMap;
 import com.vaadin.flow.internal.nodefeature.ElementStylePropertyMap;
+import com.vaadin.flow.internal.nodefeature.NodeProperties;
 import com.vaadin.flow.internal.nodefeature.SynchronizedPropertiesList;
 import com.vaadin.flow.internal.nodefeature.SynchronizedPropertyEventsList;
+import com.vaadin.flow.internal.nodefeature.VirtualChildrenList;
 import com.vaadin.flow.server.MockVaadinServletService;
 import com.vaadin.flow.server.StreamResource;
 import com.vaadin.flow.server.VaadinSession;
@@ -2065,6 +2067,23 @@ public class ElementTest extends AbstractNodeTest {
         body.removeAllChildren();
 
         Assert.assertEquals(null, child.getParent());
+    }
+
+    @Test
+    public void testRemoveFromTree_isVirtualChild_removedFromParent() {
+        Element body = new UI().getElement();
+        Element child = ElementFactory.createDiv();
+
+        body.getNode().getFeature(VirtualChildrenList.class)
+                .append(child.getNode(), "");
+
+        Assert.assertTrue(child.isVirtualChild());
+
+        child.removeFromTree();
+
+        Assert.assertFalse(child.isVirtualChild());
+        Assert.assertEquals(0,
+                body.getNode().getFeature(VirtualChildrenList.class).size());
     }
 
     private StreamResource createEmptyResource(String resName) {


### PR DESCRIPTION
When using `@PreserveOnRefresh` exported web components this lead to an inconsistent old tree, eventually leading to an infinite loop busting the heap on session expiration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7054)
<!-- Reviewable:end -->
