### PR TITLE
Fix bug in Element::removeFromTree not removing virtual child nodes from their parent (#7054)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentWrapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentWrapper.java
@@ -18,7 +18,7 @@ package com.vaadin.flow.component.webcomponent;
 import java.util.Objects;
 import java.util.Optional;
 
-import com.vaadin.flow.internal.nodefeature.VirtualChildrenList;
+import com.vaadin.flow.dom.ElementUtil;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.ClientCallable;
@@ -120,24 +120,10 @@ public class WebComponentWrapper extends Component {
                         if (event.getSource().getInternals()
                                 .getLastHeartbeatTimestamp()
                                 - disconnect > timeout) {
-                            removeFromParent(getElement());
+                            ElementUtil.removeVirtualChildFromParent(getElement());
                         }
                     });
         }
     }
 
-    private static void removeFromParent(Element webComponentWrapperElement) {
-        Element parent = webComponentWrapperElement.getParent();
-        if (parent.getNode().hasFeature(VirtualChildrenList.class)) {
-            VirtualChildrenList childrenList = parent.getNode()
-                    .getFeature(VirtualChildrenList.class);
-            int index = childrenList
-                    .indexOf(webComponentWrapperElement.getNode());
-            if (index == -1) {
-                throw new IllegalArgumentException(
-                        "Failing to clean-up an embedded Flow web component, parent UI doesn't contain it as a virtual child.");
-            }
-            childrenList.remove(index);
-        }
-    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -585,14 +585,13 @@ public class Element extends Node<Element> {
      * @return this element
      */
     public Element removeFromTree() {
-
         Node<?> parent = getParentNode();
         if (parent != null) {
             if (parent.getChildren().anyMatch(Predicate.isEqual(this))) {
                 parent.removeChild(this);
             }
             if (isVirtualChild()) {
-                parent.removeVirtualChild(this);
+                ElementUtil.removeVirtualChildFromParent(this);
             }
         }
         getNode().removeFromTree();

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -585,10 +585,15 @@ public class Element extends Node<Element> {
      * @return this element
      */
     public Element removeFromTree() {
+
         Node<?> parent = getParentNode();
-        if (parent != null
-                && parent.getChildren().anyMatch(Predicate.isEqual(this))) {
-            parent.removeChild(this);
+        if (parent != null) {
+            if (parent.getChildren().anyMatch(Predicate.isEqual(this))) {
+                parent.removeChild(this);
+            }
+            if (isVirtualChild()) {
+                parent.removeVirtualChild(this);
+            }
         }
         getNode().removeFromTree();
         return this;

--- a/flow-server/src/main/java/com/vaadin/flow/dom/ElementUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/ElementUtil.java
@@ -25,6 +25,7 @@ import org.jsoup.nodes.TextNode;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Composite;
+import com.vaadin.flow.internal.nodefeature.VirtualChildrenList;
 
 /**
  * Provides utility methods for {@link Element}.
@@ -260,4 +261,26 @@ public class ElementUtil {
                 && "script".equalsIgnoreCase(element.getTag());
     }
 
+
+    /**
+     * Ensure the virtual child is removed from its parent.
+     * 
+     * @param element
+     *            the element to remove as a virtual child
+     */
+    public static void removeVirtualChildFromParent(Element element) {
+        assert(element.isVirtualChild());
+        Element parent = element.getParent();
+        if (parent.getNode().hasFeature(VirtualChildrenList.class)) {
+            VirtualChildrenList childrenList = parent.getNode()
+                    .getFeature(VirtualChildrenList.class);
+            int index = childrenList
+                    .indexOf(element.getNode());
+            if (index == -1) {
+                throw new IllegalArgumentException(
+                        "Failing to clean-up an embedded Flow web component, parent UI doesn't contain it as a virtual child.");
+            }
+            childrenList.remove(index);
+        }
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
@@ -34,8 +34,10 @@ import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
 import com.vaadin.flow.internal.nodefeature.ElementListenersTest;
 import com.vaadin.flow.internal.nodefeature.ElementPropertyMap;
 import com.vaadin.flow.internal.nodefeature.ElementStylePropertyMap;
+import com.vaadin.flow.internal.nodefeature.NodeProperties;
 import com.vaadin.flow.internal.nodefeature.SynchronizedPropertiesList;
 import com.vaadin.flow.internal.nodefeature.SynchronizedPropertyEventsList;
+import com.vaadin.flow.internal.nodefeature.VirtualChildrenList;
 import com.vaadin.flow.server.MockVaadinServletService;
 import com.vaadin.flow.server.StreamResource;
 import com.vaadin.flow.server.VaadinSession;
@@ -2065,6 +2067,23 @@ public class ElementTest extends AbstractNodeTest {
         body.removeAllChildren();
 
         Assert.assertEquals(null, child.getParent());
+    }
+
+    @Test
+    public void testRemoveFromTree_isVirtualChild_removedFromParent() {
+        Element body = new UI().getElement();
+        Element child = ElementFactory.createDiv();
+
+        body.getNode().getFeature(VirtualChildrenList.class)
+                .append(child.getNode(), "");
+
+        Assert.assertTrue(child.isVirtualChild());
+
+        child.removeFromTree();
+
+        Assert.assertFalse(child.isVirtualChild());
+        Assert.assertEquals(0,
+                body.getNode().getFeature(VirtualChildrenList.class).size());
     }
 
     private StreamResource createEmptyResource(String resName) {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7057)
<!-- Reviewable:end -->
