### PR TITLE
proposal: typos, wording, and minor modifications

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/page/VaadinAppShell.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/VaadinAppShell.java
@@ -18,18 +18,22 @@ package com.vaadin.flow.component.page;
 import java.io.Serializable;
 
 /**
- * A marker class to configure the index.hml page when in client-side
+ * A marker class to configure the index.hml page when using client-side
  * bootstrapping. This class supports the following annotations that affect the
  * generated index.html page:
  * 
  * <ul>
- * <li>{@link Meta}: appends an HTML &lt;meta&gt; tag to the bottom of the  &lt;head&gt;
- * element other annotations to be added here and some more There should be at
- * max one class extending {@link VaadinAppShell} in the application.
+ * <li>{@link Meta}: appends an HTML {@code <meta>} tag to the bottom of the
+ * {@code <head>} element</li>
  * </ul>
  * 
  * <p>
- * NOTE: the application shell class is the only valid target to place the page
+ * There should be at max one class extending {@link VaadinAppShell} in the
+ * application.
+ * </p>
+ * 
+ * <p>
+ * NOTE: the application shell class is the only valid target for the page
  * configuration annotations listed above. The application would fail to start
  * if any of these annotations is wrongly placed on a class other than the
  * application shell class.
@@ -43,5 +47,5 @@ import java.io.Serializable;
  *
  * @since 3.0
  */
-public class VaadinAppShell implements Serializable {
+public abstract class VaadinAppShell implements Serializable {
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractAnnotationValidator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractAnnotationValidator.java
@@ -137,9 +137,8 @@ public abstract class AbstractAnnotationValidator implements Serializable {
                             clazz.getName(), getClassAnnotations(clazz)));
                 }
             } else if (VaadinAppShell.class.isAssignableFrom(clazz)) {
-                // Validations in classes extending VaadinAppShell is done when
-                // the
-                // VaadinShellInitializer is run
+                // Annotations on the app shell classes are validated in
+                // VaadinAppShellInitializer
             } else if (!RouterLayout.class.isAssignableFrom(clazz)) {
                 if (!Modifier.isAbstract(clazz.getModifiers())) {
                     handleNonRouterLayout(clazz)

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinAppShellInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinAppShellInitializer.java
@@ -122,7 +122,7 @@ public class VaadinAppShellInitializer implements ServletContainerInitializer,
             } else {
                 String message = String.format(
                         VaadinAppShellRegistry.ERROR_HEADER_OFFENDING,
-                        registry.getShell().getClass(),
+                        registry.getShell(),
                         String.join("\n  ", offendingAnnotations));
                 throw new InvalidApplicationConfigurationException(message);
             }

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
@@ -45,7 +45,7 @@ import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.frontend.FrontendUtils;
 import com.vaadin.flow.server.startup.VaadinAppShellInitializerTest.MyAppShellWithMultipleMeta;
 import com.vaadin.flow.server.startup.VaadinAppShellRegistry;
-import com.vaadin.flow.server.startup.VaadinAppShellRegistry.VaadinAppShellRegistryAttribute;
+import com.vaadin.flow.server.startup.VaadinAppShellRegistry.VaadinAppShellRegistryWrapper;
 import com.vaadin.tests.util.MockDeploymentConfiguration;
 
 import static com.vaadin.flow.component.internal.JavaScriptBootstrapUI.SERVER_ROUTING;
@@ -351,9 +351,9 @@ public class IndexHtmlRequestHandlerTest {
         // Set class in context and do not call initializer
         VaadinAppShellRegistry registry = new VaadinAppShellRegistry();
         registry.setShell(MyAppShellWithMultipleMeta.class);
-        Mockito.when(
-                mocks.getServletContext().getAttribute(VaadinAppShellRegistryAttribute.class.getName()))
-                .thenReturn(new VaadinAppShellRegistryAttribute(registry));
+        Mockito.when(mocks.getServletContext()
+                .getAttribute(VaadinAppShellRegistryWrapper.class.getName()))
+                .thenReturn(new VaadinAppShellRegistryWrapper(registry));
 
         indexHtmlRequestHandler.synchronizedHandleRequest(session,
                 createVaadinRequest("/"), response);

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/VaadinAppShellInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/VaadinAppShellInitializerTest.java
@@ -23,7 +23,7 @@ import com.vaadin.flow.component.page.Meta;
 import com.vaadin.flow.component.page.VaadinAppShell;
 import com.vaadin.flow.server.InvalidApplicationConfigurationException;
 import com.vaadin.flow.server.VaadinServletContext;
-import com.vaadin.flow.server.startup.VaadinAppShellRegistry.VaadinAppShellRegistryAttribute;
+import com.vaadin.flow.server.startup.VaadinAppShellRegistry.VaadinAppShellRegistryWrapper;
 
 import static com.vaadin.flow.server.DevModeHandler.getDevModeHandler;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -41,7 +41,7 @@ public class VaadinAppShellInitializerTest {
     }
 
     @Meta(name = "", content = "")
-    public static class OfendingClass {
+    public static class OffendingClass {
     }
 
     @Rule
@@ -98,7 +98,7 @@ public class VaadinAppShellInitializerTest {
 
         initializer.onStartup(classes, servletContext);
         VaadinAppShellRegistry.getInstance(context)
-                .applyModifications(document);
+                .modifyIndexHtmlResponse(document);
 
         List<Element> elements = document.head().children();
         assertEquals(2, elements.size());
@@ -112,7 +112,7 @@ public class VaadinAppShellInitializerTest {
     public void should_not_haveMetas_when_not_callingInitializer()
             throws Exception {
         VaadinAppShellRegistry.getInstance(context)
-                .applyModifications(document);
+                .modifyIndexHtmlResponse(document);
         List<Element> elements = document.head().children();
         assertEquals(0, elements.size());
     }
@@ -124,10 +124,10 @@ public class VaadinAppShellInitializerTest {
         // Set class in context and do not call initializer
         VaadinAppShellRegistry registry = new VaadinAppShellRegistry();
         registry.setShell(MyAppShellWithMultipleMeta.class);
-        context.setAttribute(new VaadinAppShellRegistryAttribute(registry));
+        context.setAttribute(new VaadinAppShellRegistryWrapper(registry));
 
         VaadinAppShellRegistry.getInstance(context)
-                .applyModifications(document);
+                .modifyIndexHtmlResponse(document);
 
         List<Element> elements = document.head().children();
 
@@ -139,24 +139,24 @@ public class VaadinAppShellInitializerTest {
     }
 
     @Test
-    public void should_throw_when_ofendingClass() throws Exception {
+    public void should_throw_when_offendingClass() throws Exception {
         exception.expect(InvalidApplicationConfigurationException.class);
         exception.expectMessage(
                 containsString("Found configuration annotations"));
 
         classes.add(MyAppShellWithoutMeta.class);
-        classes.add(OfendingClass.class);
+        classes.add(OffendingClass.class);
         initializer.onStartup(classes, servletContext);
     }
 
     @Test
-    public void should_not_throw_when_noAppShell_and_ofendingClass()
+    public void should_not_throw_when_noAppShell_and_offendingClass()
             throws Exception {
-        classes.add(OfendingClass.class);
+        classes.add(OffendingClass.class);
         initializer.onStartup(classes, servletContext);
 
         VaadinAppShellRegistry.getInstance(context)
-                .applyModifications(document);
+                .modifyIndexHtmlResponse(document);
 
         List<Element> elements = document.head().children();
         assertEquals(0, elements.size());

--- a/flow-tests/test-ccdm/package.json
+++ b/flow-tests/test-ccdm/package.json
@@ -5,13 +5,14 @@
     "@polymer/polymer": "3.2.0",
     "@webcomponents/webcomponentsjs": "^2.2.10",
     "@vaadin/flow-deps": "./target/frontend",
-    "@vaadin/router": "^1.4.1"
+    "@vaadin/router": "^1.4.1",
+    "@vaadin/flow-frontend": "./target/flow-frontend"
   },
   "devDependencies": {
     "webpack": "4.30.0",
     "webpack-cli": "3.3.0",
     "webpack-dev-server": "3.3.0",
-    "webpack-babel-multi-target-plugin": "2.1.0",
+    "webpack-babel-multi-target-plugin": "2.3.1",
     "copy-webpack-plugin": "5.0.3",
     "webpack-merge": "4.2.1",
     "raw-loader": "3.0.0",


### PR DESCRIPTION
Feel free to pick changes that make sense for you. Some of these changes are quire subjective:
 - VaadinAppShell
    - fix wording in the class Javadoc
    - make the class abstract (it's not meant to be instantiated anyway)
  - IndexHtmlRequestHandler
    - inline the `includeAppShellElements` method (it's very short)
    - call the app shell registry right next to index HTML request listeners (they are similar: both modify the response document)
  - AbstractAnnotationValidator
    - fix wording in a comment
  - VaadinAppShellInitializer
    - fix the error message (it should show the app shell class name, not `java.lang.Class`)
  - VaadinAppShellRegistry
    - slightly the wording of the error messages (subjective)
    - fix a typo in one of the error messages (VaadinAppnShell -> VaadinAppShell)
    - rename `VaadinAppShellRegistryAttribute` into `VaadinAppShellRegistryWrapper` (to make it follow the same pattern as in `ApplicationRouteRegistry`)
    - getInstance() now requires `VaadinContext` (less specific than `VaadinServletContext`, thus no need to downcast in `IndexHtmlRequestHandler`)
    - remove an obsolete parameter from the `setShell` method Javadoc
    - rename `applyModifications()` into `modifyIndexHtmlResponse()` to make it look exactly the same as the `VaadinService.modifyIndexHtmlResponse()` method that calls index HTML request listeners. Both methods are essentially doing the same thing.
    - update the `modifyIndexHtmlResponse` method Javadoc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7058)
<!-- Reviewable:end -->
