### PR TITLE
Accept a build-info

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.util.Properties;
 
 import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.UI;
@@ -87,6 +88,8 @@ public final class DeploymentConfigurationFactory implements Serializable {
 
     public static final String DEV_FOLDER_MISSING_MESSAGE = "Running project in development mode with no access to folder '%s'.%n"
             + "Build project in production mode instead, see https://vaadin.com/docs/v14/flow/production/tutorial-production-mode-basic.html";
+    private static final Logger logger = LoggerFactory
+            .getLogger(DeploymentConfigurationFactory.class);
 
     private DeploymentConfigurationFactory() {
     }
@@ -330,11 +333,10 @@ public final class DeploymentConfigurationFactory implements Serializable {
         if (Boolean.toString(parsedBoolean).equalsIgnoreCase(booleanString)) {
             return parsedBoolean;
         }
-        LoggerFactory.getLogger(DeploymentConfigurationFactory.class)
-                .debug(String
-                        .format("Property named '%s' is boolean, but contains incorrect value '%s' that is not boolean '%s'",
-                                SERVLET_PARAMETER_PRODUCTION_MODE,
-                                booleanString, parsedBoolean));
+        logger.debug(String.format(
+                "Property named '%s' is boolean, but contains incorrect value '%s' that is not boolean '%s'",
+                SERVLET_PARAMETER_PRODUCTION_MODE, booleanString,
+                parsedBoolean));
         return false;
     }
 
@@ -363,6 +365,23 @@ public final class DeploymentConfigurationFactory implements Serializable {
                     return FrontendUtils.streamToString(resource.openStream());
                 }
             }
+        } else {
+            URL firstResource = resources.get(0);
+            if (resources.size() > 1) {
+                String warningMessage = String
+                        .format("Unable to fully determine correct flow-build-info.%n"
+                                        + "Accepting file '%s' first match of '%s' possible.%n"
+                                        + "Please verify flow-build-info file content.",
+                                firstResource.getPath(), resources.size());
+                logger.warn(warningMessage);
+            } else {
+                String debugMessage = String
+                        .format("Unable to fully determine correct flow-build-info.%n"
+                                        + "Accepting file '%s'",
+                                firstResource.getPath());
+                logger.debug(debugMessage);
+            }
+            return FrontendUtils.streamToString(firstResource.openStream());
         }
         // No applicable resources found.
         return null;
@@ -422,7 +441,7 @@ public final class DeploymentConfigurationFactory implements Serializable {
         if (!hasTokenFile && hasWebpackConfig) {
             // the current working directory will be used automatically by the
             // dev server unless it's specified explicitly
-            LoggerFactory.getLogger(DeploymentConfigurationFactory.class).warn(
+            logger.warn(
                     "Found 'webpack.config.js' in the project/working directory. "
                             + "Will use it for webpack dev server.");
         }


### PR DESCRIPTION
In case we have build info in a jar and
we can't determine a valid one,
accept at least a single one for use and
log the information that we are using a
non verified flow-build-info.json

This will make flattened Uber jars work
but they have other missmatch problems also
with files so the user probably knows how to handle
the situation.

Fixes #7060

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7066)
<!-- Reviewable:end -->
