### PR TITLE
Wait for custom elements to load before adding demo contents

### DIFF
--- a/flow-component-demo-helpers/src/main/java/com/vaadin/flow/demo/DemoView.java
+++ b/flow-component-demo-helpers/src/main/java/com/vaadin/flow/demo/DemoView.java
@@ -29,7 +29,6 @@ import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.HasTheme;
 import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H3;
@@ -51,7 +50,6 @@ import com.vaadin.flow.theme.lumo.Lumo;
 @Theme(Lumo.class)
 @StyleSheet("src/css/demo.css")
 @StyleSheet("src/css/prism.css")
-@JavaScript("src/script/prism.js")
 public abstract class DemoView extends Component
         implements HasComponents, HasUrlParameter<String>, HasStyle {
     static final String VARIANT_TOGGLE_BUTTONS_DIV_ID = "variantToggleButtonsDiv";
@@ -164,14 +162,19 @@ public abstract class DemoView extends Component
         }
 
         Card card = new Card();
-        if (components != null && components.length > 0) {
-            card.add(components);
-        }
+        card.getElement().getNode().runWhenAttached(ui -> {
+            WhenDefinedManager.get(ui).whenDefined(components, () -> {
+                if (components != null && components.length > 0) {
+                    card.add(components);
+                }
 
-        List<SourceCodeExample> list = sourceCodeExamples.get(heading);
-        if (list != null) {
-            list.stream().map(this::createSourceContent).forEach(card::add);
-        }
+                List<SourceCodeExample> list = sourceCodeExamples.get(heading);
+                if (list != null) {
+                    list.stream().map(this::createSourceContent)
+                            .forEach(card::add);
+                }
+            });
+        });
 
         tab.add(card);
         return card;
@@ -211,8 +214,6 @@ public abstract class DemoView extends Component
             container.removeAll();
             container.add(tab);
             navBar.setActive(getTabUrl(tabUrl));
-            tab.getElement().getNode().runWhenAttached(ui -> ui.getPage()
-                    .executeJavaScript("Prism.highlightAll();"));
         }
     }
 

--- a/flow-component-demo-helpers/src/main/java/com/vaadin/flow/demo/SourceContent.java
+++ b/flow-component-demo-helpers/src/main/java/com/vaadin/flow/demo/SourceContent.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.demo;
 
+import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.dom.Element;
@@ -27,6 +28,7 @@ import com.vaadin.flow.dom.Element;
  * @since 1.0
  */
 @StyleSheet("src/css/sources.css")
+@JavaScript("src/script/prism.js")
 public class SourceContent extends Div {
 
     /**
@@ -85,5 +87,6 @@ public class SourceContent extends Div {
         code.getClassList().add(className);
         code.setText(text);
         getElement().appendChild(pre);
+        code.executeJs("Prism.highlightElement(this);");
     }
 }

--- a/flow-component-demo-helpers/src/main/java/com/vaadin/flow/demo/WhenDefinedManager.java
+++ b/flow-component-demo-helpers/src/main/java/com/vaadin/flow/demo/WhenDefinedManager.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.demo;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.NodeVisitor;
+import com.vaadin.flow.dom.ShadowRoot;
+import com.vaadin.flow.server.Command;
+
+/**
+ * Helper that invokes a callback once all Vaadin custom elements from a
+ * component tree are defined. This is used for all demo contents because of the
+ * way custom element definitions are lazy loaded to improve performance on
+ * vaadin.com.
+ *
+ * @author Vaadin Ltd
+ */
+public class WhenDefinedManager implements Serializable {
+    /**
+     * Marker type for the marker instance that is used as the value for tags
+     * that have already been defined. We need to have an explicit class in this
+     * case to support the edge case when sessions may be migrated between
+     * different JVMs.
+     */
+    private static class DoneMarker extends ArrayList<Command> {
+        @Override
+        public boolean add(Command ignore) {
+            // Reduce the risk of accidental modification
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    /**
+     * Marker instance for tags that have already been defined.
+     */
+    private static final DoneMarker DONE_MARKER = new DoneMarker();
+
+    private final UI ui;
+    private final HashMap<String, ArrayList<Command>> tagToWaiters = new HashMap<>();
+
+    private WhenDefinedManager(UI ui) {
+        this.ui = ui;
+    }
+
+    /**
+     * Runs the provided command once the custom element has been defined for
+     * all Vaadin elements from the give component trees have.
+     * <p>
+     * The command may run immediately in case no custom elements are used or if
+     * they have already been defined.
+     *
+     * @param rootComponents
+     *            an array of component hierarchies from which to find used
+     *            Vaadin elements
+     * @param command
+     *            the command to run once all custom elements are defined
+     */
+    public void whenDefined(Component[] rootComponents, Command command) {
+        Set<String> vaadinTagNames = collectVaadinTagNames(rootComponents);
+
+        HashSet<String> missingTagNames = new HashSet<>();
+        for (String tagName : vaadinTagNames) {
+            ArrayList<Command> tagWaiters = tagToWaiters.get(tagName);
+            if (tagWaiters instanceof DoneMarker) {
+                continue;
+            }
+
+            missingTagNames.add(tagName);
+
+            // First one to wait for this tag
+            if (tagWaiters == null) {
+                tagWaiters = new ArrayList<>();
+                tagToWaiters.put(tagName, tagWaiters);
+                ui.getPage()
+                        .executeJs("return customElements.whenDefined($0)",
+                                tagName)
+                        .then(ignore -> handleLoadedTag(tagName));
+            }
+
+            tagWaiters.add(() -> {
+                missingTagNames.remove(tagName);
+                if (missingTagNames.isEmpty()) {
+                    command.execute();
+                }
+            });
+        }
+
+        // If everything was already loaded
+        if (missingTagNames.isEmpty()) {
+            command.execute();
+        }
+    }
+
+    private void handleLoadedTag(String tagName) {
+        ArrayList<Command> waiters = tagToWaiters.get(tagName);
+        tagToWaiters.put(tagName, DONE_MARKER);
+        waiters.forEach(Command::execute);
+    }
+
+    private static Set<String> collectVaadinTagNames(
+            Component[] rootComponents) {
+        Set<String> vaadinTagNames = new HashSet<>();
+
+        for (Component rootComponent : rootComponents) {
+            rootComponent.getElement().accept(new NodeVisitor() {
+                @Override
+                public boolean visit(ElementType type, Element element) {
+                    if (!element.isTextNode()) {
+                        String tag = element.getTag();
+                        if (tag.startsWith("vaadin-")) {
+                            vaadinTagNames.add(tag);
+                        }
+                    }
+                    return true;
+                }
+
+                @Override
+                public boolean visit(ShadowRoot root) {
+                    return true;
+                }
+            });
+        }
+
+        return vaadinTagNames;
+    }
+
+    /**
+     * Gets or creates the manager instance for the given UI.
+     * 
+     * @param ui
+     *            the UI for which to get an instance, not <code>null</code>
+     * @return the manager for the given UI, not <code>null</code>
+     */
+    public static WhenDefinedManager get(UI ui) {
+        WhenDefinedManager instance = ComponentUtil.getData(ui,
+                WhenDefinedManager.class);
+        if (instance == null) {
+            instance = new WhenDefinedManager(ui);
+            ComponentUtil.setData(ui, WhenDefinedManager.class, instance);
+        }
+        return instance;
+    }
+}


### PR DESCRIPTION
This is needed for some component demos on vaadin.com because of how a
custom workaround is used to lazy load the Vaadin component
implementations while still eagerly rendering other content.

To deal with lazily initialized cards, Prism initialization is done
individually for each source block instead of one global initialization
of all code blocks currently in the DOM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7069)
<!-- Reviewable:end -->
