### PR TITLE
Fix nullRepresentation argument not used

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/renderer/LocalDateRenderer.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/renderer/LocalDateRenderer.java
@@ -183,6 +183,7 @@ public class LocalDateRenderer<SOURCE>
         }
 
         this.formatter = formatter;
+        this.nullRepresentation = nullRepresentation;
     }
 
     @Override


### PR DESCRIPTION
nullRepresentation was not set in constructor LocalDateRenderer(valueProvider, formatter, nullRepresentation)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7084)
<!-- Reviewable:end -->
