### PR TITLE
Add method writeBeanAsDraft(bean) in Binder

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -1766,6 +1766,23 @@ public class Binder<BEAN> implements Serializable {
     }
 
     /**
+     * Writes successfully converted and validated changes from the bound fields
+     * to the bean even if there are other fields with non-validated changes.
+     *
+     * @see #writeBean(Object)
+     * @see #writeBeanIfValid(Object)
+     * @see #readBean(Object)
+     * @see #setBean(Object)
+     *
+     * @param bean
+     *            the object to which to write the field values, not
+     *            {@code null}
+     */
+    public void writeBeanAsDraft(BEAN bean) {
+        doWriteDraft(bean, new ArrayList<>(bindings));
+    }
+    
+    /**
      * Writes changes from the bound fields to the given bean if all validators
      * (binding and bean level) pass.
      * <p>
@@ -1852,6 +1869,23 @@ public class Binder<BEAN> implements Serializable {
         return status;
     }
 
+    /**
+     * Writes the successfully converted and validated field values into the
+     * given bean.
+     *
+     * @param bean
+     *            the bean to write field values into
+     * @param bindings
+     *            the set of bindings to write to the bean
+     */
+    @SuppressWarnings({ "unchecked" })
+    private void doWriteDraft(BEAN bean, Collection<Binding<BEAN, ?>> bindings) {
+        Objects.requireNonNull(bean, "bean cannot be null");
+
+        bindings.forEach(binding -> ((BindingImpl<BEAN, ?, ?>) binding)
+                    .writeFieldValue(bean));
+    }
+    
     /**
      * Restores the state of the bean from the given values.
      *

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -329,6 +329,39 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
     }
 
     @Test
+    public void save_bound_beanAsDraft() {
+        Binder<Person> binder = new Binder<>();
+        binder.forField(nameField)
+            .withValidator((value,context) -> {
+                if (value.equals("Mike")) return ValidationResult.ok();
+                else return ValidationResult.error("value must be Mike");
+            })
+            .bind(Person::getFirstName, Person::setFirstName);
+        binder.forField(ageField)
+                .withConverter(new StringToIntegerConverter(""))
+                .bind(Person::getAge, Person::setAge);
+
+        Person person = new Person();
+
+        String fieldValue = "John";
+        nameField.setValue(fieldValue);
+
+        int age = 10;
+        ageField.setValue("10");
+
+        person.setFirstName("Mark");
+
+        binder.writeBeanAsDraft(person);
+
+        // name is not written to draft as validation / conversion
+        // does not pass
+        assertNotEquals(fieldValue, person.getFirstName());
+        // age is written to draft even if firstname validation
+        // fails
+        assertEquals(age, person.getAge());
+    }
+
+    @Test
     public void load_bound_fieldValueIsUpdated() {
         binder.bind(nameField, Person::getFirstName, Person::setFirstName);
 

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -330,39 +330,15 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
 
     @Test
     public void save_bound_beanAsDraft() {
-        Binder<Person> binder = new Binder<>();
-        binder.forField(nameField)
-            .withValidator((value,context) -> {
-                if (value.equals("Mike")) return ValidationResult.ok();
-                else return ValidationResult.error("value must be Mike");
-            })
-            .bind(Person::getFirstName, Person::setFirstName);
-        binder.forField(ageField)
-                .withConverter(new StringToIntegerConverter(""))
-                .bind(Person::getAge, Person::setAge);
-
-        Person person = new Person();
-
-        String fieldValue = "John";
-        nameField.setValue(fieldValue);
-
-        int age = 10;
-        ageField.setValue("10");
-
-        person.setFirstName("Mark");
-
-        binder.writeBeanAsDraft(person);
-
-        // name is not written to draft as validation / conversion
-        // does not pass
-        assertNotEquals(fieldValue, person.getFirstName());
-        // age is written to draft even if firstname validation
-        // fails
-        assertEquals(age, person.getAge());
+        do_test_save_bound_beanAsDraft(false);
     }
 
     @Test
     public void save_bound_beanAsDraft_setBean() {
+        do_test_save_bound_beanAsDraft(true);
+    }
+
+    private void do_test_save_bound_beanAsDraft(boolean setBean) {
         Binder<Person> binder = new Binder<>();
         binder.forField(nameField)
             .withValidator((value,context) -> {
@@ -375,7 +351,7 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
                 .bind(Person::getAge, Person::setAge);
 
         Person person = new Person();
-        binder.setBean(person);
+        if (setBean) binder.setBean(person);
 
         String fieldValue = "John";
         nameField.setValue(fieldValue);

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -362,6 +362,40 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
     }
 
     @Test
+    public void save_bound_beanAsDraft_setBean() {
+        Binder<Person> binder = new Binder<>();
+        binder.forField(nameField)
+            .withValidator((value,context) -> {
+                if (value.equals("Mike")) return ValidationResult.ok();
+                else return ValidationResult.error("value must be Mike");
+            })
+            .bind(Person::getFirstName, Person::setFirstName);
+        binder.forField(ageField)
+                .withConverter(new StringToIntegerConverter(""))
+                .bind(Person::getAge, Person::setAge);
+
+        Person person = new Person();
+        binder.setBean(person);
+
+        String fieldValue = "John";
+        nameField.setValue(fieldValue);
+
+        int age = 10;
+        ageField.setValue("10");
+
+        person.setFirstName("Mark");
+
+        binder.writeBeanAsDraft(person);
+
+        // name is not written to draft as validation / conversion
+        // does not pass
+        assertNotEquals(fieldValue, person.getFirstName());
+        // age is written to draft even if firstname validation
+        // fails
+        assertEquals(age, person.getAge());
+    }
+    
+    @Test
     public void load_bound_fieldValueIsUpdated() {
         binder.bind(nameField, Person::getFirstName, Person::setFirstName);
 


### PR DESCRIPTION
With current Binder implementation it is not easy to support Forms, which you want to save as draft, i.e. incomplete. For example there can be big text areas, that require time to fill, or lot of fields. Therefore it is needed to that form can be saved, e.g. to other bean in incomplete state when it is not yet passing validation and this other bean can be persisted to draft storage for further editing in the future. This method helps to achieve that easily.

Cherry pick from: https://github.com/vaadin/framework/pull/11833

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7097)
<!-- Reviewable:end -->
