### PR TITLE
Make asRequired conditional on binding.setAsRequiredEnabled(..)

### DIFF
--- a/drivers.xml
+++ b/drivers.xml
@@ -2,10 +2,10 @@
 <root>
     <windows>
         <driver id="googlechrome">
-            <version id="78.0.3904.70">
+            <version id="79.0.3945.36">
                 <bitrate thirtytwobit="true" sixtyfourbit="true">
-                    <filelocation>https://chromedriver.storage.googleapis.com/78.0.3904.70/chromedriver_win32.zip</filelocation>
-                    <hash>26705e683632c6e1f9c62179b6143b409f4d7681</hash>
+                    <filelocation>https://chromedriver.storage.googleapis.com/79.0.3945.36/chromedriver_win32.zip</filelocation>
+                    <hash>671dafdf4380e1194268f72278f6c0324f47ae8e</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
             </version>
@@ -13,10 +13,10 @@
     </windows>
     <linux>
         <driver id="googlechrome">
-            <version id="78.0.3904.70">
+            <version id="79.0.3945.36">
                 <bitrate sixtyfourbit="true">
-                    <filelocation>https://chromedriver.storage.googleapis.com/78.0.3904.70/chromedriver_linux64.zip</filelocation>
-                    <hash>63e13e5f0df96af1cc3a2006c00b2f1871b62caf</hash>
+                    <filelocation>https://chromedriver.storage.googleapis.com/79.0.3945.36/chromedriver_linux64.zip</filelocation>
+                    <hash>3cf7d35a154ad53c7df627ad8d33d70dc941e658</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
             </version>
@@ -24,10 +24,10 @@
     </linux>
     <osx>
         <driver id="googlechrome">
-            <version id="78.0.3904.70">
+            <version id="79.0.3945.36">
                 <bitrate sixtyfourbit="true">
-                    <filelocation>https://chromedriver.storage.googleapis.com/78.0.3904.70/chromedriver_mac64.zip</filelocation>
-                    <hash>ce06a7d3a9d18b3d054d3b4c3c32d2cd74e81a91</hash>
+                    <filelocation>https://chromedriver.storage.googleapis.com/79.0.3945.36/chromedriver_mac64.zip</filelocation>
+                    <hash>a6009cbaadc86cab54982195bb760c64e926cf59</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
             </version>

--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
@@ -1266,9 +1266,12 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
             }
         }
 
+        JsArray<Runnable> commands = JsCollections.array();
+        synchronizeProperties.forEach(
+                name -> commands.push(getSyncPropertyCommand(name, context)));
+
         Consumer<String> sendCommand = debouncePhase -> {
-            synchronizeProperties
-                    .forEach(name -> syncPropertyIfNeeded(name, context));
+            commands.forEach(Runnable::run);
 
             sendEventToServer(node, type, eventData, debouncePhase);
         };
@@ -1280,6 +1283,13 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
             // Send if there were not filters or at least one matched
             sendCommand.accept(null);
         }
+    }
+
+    private Runnable getSyncPropertyCommand(String propertyName,
+            BindingContext context) {
+        return context.node.getMap(NodeFeatures.ELEMENT_PROPERTIES)
+                .getProperty(propertyName).getSyncToServerCommand(WidgetUtil
+                        .getJsProperty(context.htmlNode, propertyName));
     }
 
     private static void sendEventToServer(StateNode node, String type,

--- a/flow-client/src/main/java/com/vaadin/client/flow/nodefeature/MapProperty.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/nodefeature/MapProperty.java
@@ -43,6 +43,9 @@ public class MapProperty implements ReactiveValue {
      */
     private boolean isServerUpdate;
 
+    private static final Runnable NO_OP = () -> {
+    };
+
     private final ReactiveEventRouter<MapPropertyChangeListener, MapPropertyChangeEvent> eventRouter = new ReactiveEventRouter<MapPropertyChangeListener, MapPropertyChangeEvent>(
             this) {
         @Override
@@ -262,8 +265,20 @@ public class MapProperty implements ReactiveValue {
      *
      * @param newValue
      *            the new value to set.
+     * @see #getSyncToServerCommand(Object)
      */
     public void syncToServer(Object newValue) {
+        getSyncToServerCommand(newValue).run();
+    }
+
+    /**
+     * Sets the value of this property and returns a synch to server command.
+     *
+     * @param newValue
+     *            the new value to set.
+     * @see #syncToServer(Object)
+     */
+    public Runnable getSyncToServerCommand(Object newValue) {
         Object currentValue = hasValue() ? getValue() : null;
 
         if (Objects.equals(newValue, currentValue)) {
@@ -282,7 +297,7 @@ public class MapProperty implements ReactiveValue {
             if (tree.isActive(node)) {
                 doSetValue(newValue);
 
-                tree.sendNodePropertySyncToServer(this);
+                return () -> tree.sendNodePropertySyncToServer(this);
             } else {
                 /*
                  * Fire an fake event to reset the property value back in the
@@ -297,5 +312,6 @@ public class MapProperty implements ReactiveValue {
                 Reactive.flush();
             }
         }
+        return NO_OP;
     }
 }

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/BeanValidationBinder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/BeanValidationBinder.java
@@ -58,7 +58,25 @@ public class BeanValidationBinder<BEAN> extends Binder<BEAN> {
      *            the bean type to use, not <code>null</code>
      */
     public BeanValidationBinder(Class<BEAN> beanType) {
-        super(beanType);
+        this(beanType,false);
+    }
+
+    /**
+     * Creates a new binder that uses reflection based on the provided bean type
+     * to resolve bean properties. It assumes that JSR-303 bean validation
+     * implementation is present on the classpath. If there is no such
+     * implementation available then {@link Binder} class should be used instead
+     * (this constructor will throw an exception). Otherwise
+     * {@link BeanValidator} is added to each binding that is defined using a
+     * property name.
+     *
+     * @param beanType
+     *            the bean type to use, not {@code null}
+     * @param scanNestedDefinitions
+     *            if {@code true}, scan for nested property definitions as well
+     */
+    public BeanValidationBinder(Class<BEAN> beanType, boolean scanNestedDefinitions) {
+        super(beanType, scanNestedDefinitions);
         if (!BeanUtil.checkBeanValidationAvailable()) {
             throw new IllegalStateException(
                     BeanValidationBinder.class.getSimpleName()

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -1467,6 +1467,20 @@ public class Binder<BEAN> implements Serializable {
     }
 
     /**
+     * Creates a new binder that uses reflection based on the provided bean type
+     * to resolve bean properties.
+     *
+     * @param beanType
+     *            the bean type to use, not {@code null}
+     * @param scanNestedDefinitions
+     *            if {@code true}, scan for nested property definitions as well
+     */
+    public Binder(Class<BEAN> beanType, boolean scanNestedDefinitions) {
+        this(BeanPropertySet.get(beanType, scanNestedDefinitions,
+                PropertyFilterDefinition.getDefaultFilter()));
+    }
+
+    /**
      * Creates a binder using a custom {@link PropertySet} implementation for
      * finding and resolving property names for
      * {@link #bindInstanceFields(Object)}, {@link #bind(HasValue, String)} and
@@ -1508,20 +1522,6 @@ public class Binder<BEAN> implements Serializable {
         } else {
             binding.validate();
         }
-    }
-
-    /**
-     * Creates a new binder that uses reflection based on the provided bean type
-     * to resolve bean properties.
-     *
-     * @param beanType
-     *            the bean type to use, not {@code null}
-     * @param scanNestedDefinitions
-     *            if {@code true}, scan for nested property definitions as well
-     */
-    public Binder(Class<BEAN> beanType, boolean scanNestedDefinitions) {
-        this(BeanPropertySet.get(beanType, scanNestedDefinitions,
-                PropertyFilterDefinition.getDefaultFilter()));
     }
 
     /**

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -915,10 +915,11 @@ public class Binder<BEAN> implements Serializable {
             this.asRequiredSet = true;
             field.setRequiredIndicatorVisible(true);
             return withValidator((value, context) -> {
-                if (!field.isRequiredIndicatorVisible())
+                if (!field.isRequiredIndicatorVisible()) {
                     return ValidationResult.ok();
-                else
+                } else {
                     return customRequiredValidator.apply(value, context);
+                }
             });
         }
 
@@ -1025,7 +1026,7 @@ public class Binder<BEAN> implements Serializable {
          */
         private final Converter<FIELDVALUE, TARGET> converterValidatorChain;
 
-        private boolean asRequiredSet;
+        private final boolean asRequiredSet;
 
         public BindingImpl(BindingBuilderImpl<BEAN, FIELDVALUE, TARGET> builder,
                 ValueProvider<BEAN, TARGET> getter,
@@ -1299,7 +1300,7 @@ public class Binder<BEAN> implements Serializable {
             }
             if (asRequiredEnabled != isAsRequiredEnabled()) {
                 field.setRequiredIndicatorVisible(asRequiredEnabled);
-                        validate();
+                validate();
             }
         }
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -211,6 +211,30 @@ public class Binder<BEAN> implements Serializable {
          * @return the setter
          */
         Setter<BEAN, TARGET> getSetter();
+
+        /**
+         * Enable or disable asRequired validator.
+         * The validator is enabled by default.
+         *
+         * @see #asRequired(String)
+         * @see #asRequired(ErrorMessageProvider)
+         *
+         * @param asRequiredEnabled
+         *            {@code false} if asRequired validator should
+         *            be disabled, {@code true} otherwise (default)
+         */
+        public void setAsRequiredEnabled(boolean asRequiredEnabled);
+
+        /**
+         * Returns whether asRequired validator is currently enabled or not
+         *
+         * @see #asRequired(String)
+         * @see #asRequired(ErrorMessageProvider)
+         *
+         * @return {@code false} if asRequired validator is disabled
+         *         {@code true} otherwise (default)
+         */
+        public boolean isAsRequiredEnabled();
     }
 
     /**
@@ -741,6 +765,8 @@ public class Binder<BEAN> implements Serializable {
          */
         private Converter<FIELDVALUE, ?> converterValidatorChain;
 
+        private boolean asRequiredSet;
+
         /**
          * Creates a new binding builder associated with the given field.
          * Initializes the builder with the given converter chain and status
@@ -886,8 +912,15 @@ public class Binder<BEAN> implements Serializable {
         public BindingBuilder<BEAN, TARGET> asRequired(
                 Validator<TARGET> customRequiredValidator) {
             checkUnbound();
+            this.asRequiredSet = true;
             field.setRequiredIndicatorVisible(true);
             return withValidator(customRequiredValidator);
+            return withValidator((value, context) -> {
+                if (!field.isRequiredIndicatorVisible())
+                    return ValidationResult.ok();
+                else
+                    return customRequiredValidator.apply(value, context);
+            });
         }
 
         /**
@@ -993,12 +1026,15 @@ public class Binder<BEAN> implements Serializable {
          */
         private final Converter<FIELDVALUE, TARGET> converterValidatorChain;
 
+        private boolean asRequiredSet;
+
         public BindingImpl(BindingBuilderImpl<BEAN, FIELDVALUE, TARGET> builder,
                 ValueProvider<BEAN, TARGET> getter,
                 Setter<BEAN, TARGET> setter) {
             binder = builder.getBinder();
             field = builder.field;
             statusHandler = builder.statusHandler;
+            this.asRequiredSet = builder.asRequiredSet;
             converterValidatorChain = ((Converter<FIELDVALUE, TARGET>) builder.converterValidatorChain);
 
             onValueChange = getField().addValueChangeListener(
@@ -1253,6 +1289,24 @@ public class Binder<BEAN> implements Serializable {
         @Override
         public Setter<BEAN, TARGET> getSetter() {
             return setter;
+        }
+
+        @Override
+        public void setAsRequiredEnabled(boolean asRequiredEnabled) {
+            if (!asRequiredSet) {
+                throw new IllegalStateException(
+                 "Unable to toggle asRequired validation since " 
+                         + "asRequired has not been set.");
+            }
+            if (asRequiredEnabled != isAsRequiredEnabled()) {
+                field.setRequiredIndicatorVisible(asRequiredEnabled);
+                        validate();
+            }
+        }
+
+        @Override
+        public boolean isAsRequiredEnabled() {
+            return field.isRequiredIndicatorVisible();
         }
     }
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -914,7 +914,6 @@ public class Binder<BEAN> implements Serializable {
             checkUnbound();
             this.asRequiredSet = true;
             field.setRequiredIndicatorVisible(true);
-            return withValidator(customRequiredValidator);
             return withValidator((value, context) -> {
                 if (!field.isRequiredIndicatorVisible())
                     return ValidationResult.ok();

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -216,8 +216,8 @@ public class Binder<BEAN> implements Serializable {
          * Enable or disable asRequired validator.
          * The validator is enabled by default.
          *
-         * @see #asRequired(String)
-         * @see #asRequired(ErrorMessageProvider)
+         * @see BindingBuilder#asRequired(String)
+         * @see BindingBuilder#asRequired(ErrorMessageProvider)
          *
          * @param asRequiredEnabled
          *            {@code false} if asRequired validator should
@@ -228,8 +228,8 @@ public class Binder<BEAN> implements Serializable {
         /**
          * Returns whether asRequired validator is currently enabled or not
          *
-         * @see #asRequired(String)
-         * @see #asRequired(ErrorMessageProvider)
+         * @see BindingBuilder#asRequired(String)
+         * @see BindingBuilder#asRequired(ErrorMessageProvider)
          *
          * @return {@code false} if asRequired validator is disabled
          *         {@code true} otherwise (default)

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -501,13 +501,13 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         TestTextField textField = new TestTextField();
         assertFalse(textField.isRequiredIndicatorVisible());
 
-        BindingBuilder<Person, String> binding = binder.forField(textField);
-        assertFalse(textField.isRequiredIndicatorVisible());
+        BindingBuilder<Person, String> bindingBuilder = binder.forField(textField);
+        assertFalse(textField.isRequiredIndicatorVisible())
 
-        binding.asRequired("foobar");
+        bindingBuilder.asRequired("foobar");
         assertTrue(textField.isRequiredIndicatorVisible());
 
-        binding.bind(Person::getFirstName, Person::setFirstName);
+        Binding<Person, String> binding = bindingBuilder.bind(Person::getFirstName, Person::setFirstName);
         binder.setBean(item);
         assertThat(textField.getErrorMessage(), isEmptyString());
 
@@ -517,6 +517,9 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         textField.setValue("value");
         assertFalse(textField.isInvalid());
         assertTrue(textField.isRequiredIndicatorVisible());
+
+        binding.setAsRequiredEnabled(false);
+        assertFalse(textField.isRequiredIndicatorVisible());
     }
 
     @Test

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -525,7 +525,7 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
     }
 
     @Test(expected = IllegalStateException.class)
-    public void beanvalidation_isValid_throws_with_readBean() {
+    public void settingAsRequiredEnabledFalseWhenNoAsRequired() {
         TestTextField textField = new TestTextField();
 
         BindingBuilder<Person, String> bindingBuilder = binder.forField(textField);

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -502,7 +502,7 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         assertFalse(textField.isRequiredIndicatorVisible());
 
         BindingBuilder<Person, String> bindingBuilder = binder.forField(textField);
-        assertFalse(textField.isRequiredIndicatorVisible())
+        assertFalse(textField.isRequiredIndicatorVisible());
 
         bindingBuilder.asRequired("foobar");
         assertTrue(textField.isRequiredIndicatorVisible());

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -520,8 +520,23 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
 
         binding.setAsRequiredEnabled(false);
         assertFalse(textField.isRequiredIndicatorVisible());
+        textField.setValue("");
+        assertFalse(textField.isInvalid());
     }
 
+    @Test(expected = IllegalStateException.class)
+    public void beanvalidation_isValid_throws_with_readBean() {
+        TestTextField textField = new TestTextField();
+
+        BindingBuilder<Person, String> bindingBuilder = binder.forField(textField);
+        Binding<Person, String> binding = bindingBuilder.bind(Person::getFirstName, Person::setFirstName);
+
+        binder.readBean(item);
+
+        // TextField input is not set required, this should trigger IllegalStateExceptipon
+        binding.setAsRequiredEnabled(false);
+    }    
+    
     @Test
     public void readNullBeanRemovesError() {
         TestTextField textField = new TestTextField();

--- a/flow-dnd/src/main/java/com/vaadin/flow/component/dnd/internal/DndUtil.java
+++ b/flow-dnd/src/main/java/com/vaadin/flow/component/dnd/internal/DndUtil.java
@@ -22,6 +22,7 @@ import com.vaadin.flow.component.dnd.DragSource;
 import com.vaadin.flow.component.dnd.DropTarget;
 import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.server.Command;
+import com.vaadin.flow.server.WebBrowser;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.shared.ui.LoadMode;
 
@@ -83,6 +84,26 @@ public class DndUtil {
      */
     private static final String DETACH_LISTENER_FOR_DROP_TARGET = "_detachListenerForDropTarget";
 
+    // package protected for unit test
+    //@formatter:off
+    static final String MOBILE_POLYFILL_INJECT_SCRIPT =
+            "if ((/iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream)"
+            + "|| (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)) {"
+            + "var script1 = document.createElement('script');"
+            + "var script2 = document.createElement('script');"
+            + "script1.async = false;"
+            + "script2.async = false;"
+            + "script1.src = \"%1$s\";"
+            + "script2.src = \"%2$s\";"
+            + "window.Vaadin.__forceApplyMobileDragDrop = true;"
+            + "document.head.appendChild(script1);"
+            + "document.head.appendChild(script2);}";
+    //@formatter:on
+
+    private static final String DND_POLYFILL_SCRIPT_KEY = "DND-POLYFILL-SCRIPT";
+    private static final String MOBILE_DND_POLYFILL_URL = "context://webjars/mobile-drag-drop/2.3.0-rc.1/index.min.js";
+    private static final String VAADIN_MOBILE_DND_POLYFILL_URL = "context://webjars/vaadin__vaadin-mobile-drag-drop/1.0.0/index.min.js";
+
     private DndUtil() {
         // no instances from this class
     }
@@ -120,12 +141,22 @@ public class DndUtil {
      */
     public static void addMobileDndPolyfillIfNeeded(Component component) {
         component.getElement().getNode().runWhenAttached(ui -> {
-            if (ui.getSession().getBrowser().isIOS()) {
-                ui.getPage().addJavaScript(
-                        "context://webjars/mobile-drag-drop/2.3.0-rc.1/index.min.js");
-                ui.getPage().addJavaScript(
-                        "context://webjars/vaadin__vaadin-mobile-drag-drop/1.0.0/index.min.js");
+            if (ComponentUtil.getData(ui, DND_POLYFILL_SCRIPT_KEY) != null) {
+                return;
             }
+            // #7123 need to delegate iOS checking to client side due to iPads
+            // with iOS 13
+            WebBrowser browser = ui.getSession().getBrowser();
+            String url1 = ui.getSession().getService().resolveResource(
+                    MOBILE_DND_POLYFILL_URL,
+                    browser);
+            String url2 = ui.getSession().getService().resolveResource(
+                    VAADIN_MOBILE_DND_POLYFILL_URL,
+                    browser);
+
+            ui.getPage().executeJs(
+                    String.format(MOBILE_POLYFILL_INJECT_SCRIPT, url1, url2));
+            ComponentUtil.setData(ui, DND_POLYFILL_SCRIPT_KEY, true);
         });
     }
 

--- a/flow-dnd/src/test/java/com/vaadin/flow/component/dnd/AbstractDnDUnitTest.java
+++ b/flow-dnd/src/test/java/com/vaadin/flow/component/dnd/AbstractDnDUnitTest.java
@@ -17,14 +17,17 @@
 package com.vaadin.flow.component.dnd;
 
 import java.util.Collection;
-import java.util.Iterator;
+import java.util.List;
 import java.util.Properties;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.dnd.internal.DnDUtilHelper;
 import com.vaadin.flow.component.internal.DependencyList;
+import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
 import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.router.RouterLink;
 import com.vaadin.flow.server.DefaultDeploymentConfiguration;
+import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServlet;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.WebBrowser;
@@ -52,9 +55,14 @@ public abstract class AbstractDnDUnitTest {
         WebBrowser browser = Mockito.mock(WebBrowser.class);
         Mockito.when(browser.isIOS()).then(invocation -> iOS);
 
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(service.resolveResource(Mockito.anyString(),
+                Mockito.any(WebBrowser.class))).thenReturn("");
+
         VaadinSession session = Mockito.mock(VaadinSession.class);
         Mockito.when(session.getConfiguration()).thenReturn(configuration);
         Mockito.when(session.getBrowser()).thenReturn(browser);
+        Mockito.when(session.getService()).thenReturn(service);
 
         ui = new MockUI(session);
     }
@@ -106,31 +114,26 @@ public abstract class AbstractDnDUnitTest {
     }
 
     @Test
-    public void testExtension_iOS_mobileDnDpolyfillLoaded() {
+    public void testExtension_iOS_mobileDnDpolyfillScriptInjected() {
         iOS = true;
-        ui.getInternals().getDependencyList().clearPendingSendToClient();
+        ui.getInternals().dumpPendingJavaScriptInvocations();
 
         RouterLink component = new RouterLink();
         ui.add(component);
         runStaticCreateMethodForExtension(component);
 
-        DependencyList dependencyList = ui.getInternals().getDependencyList();
-        Collection<Dependency> pendingSendToClient = dependencyList
-                .getPendingSendToClient();
+        List<PendingJavaScriptInvocation> pendingJavaScriptInvocations = ui
+                .getInternals().dumpPendingJavaScriptInvocations();
 
-        Assert.assertEquals("No dependency added", 2,
-                pendingSendToClient.size());
+        Assert.assertEquals(1, pendingJavaScriptInvocations.size());
 
-        Iterator<Dependency> iterator = pendingSendToClient.iterator();
-        Dependency dependency = iterator.next();
-        Assert.assertEquals("Wrong dependency loaded",
-                "context://webjars/mobile-drag-drop/2.3.0-rc.1/index.min.js",
-                dependency.getUrl());
-        dependency = iterator.next();
-        Assert.assertEquals("Wrong dependency loaded",
-                "context://webjars/vaadin__vaadin-mobile-drag-drop/1.0.0/index.min.js",
-                dependency.getUrl());
-
+        PendingJavaScriptInvocation pendingJavaScriptInvocation = pendingJavaScriptInvocations
+                .get(0);
+        // the urls are switched to "" by the mocked service method
+        String fake = String.format(DnDUtilHelper.MOBILE_DND_INJECT_SCRIPT, "",
+                "");
+        Assert.assertEquals(fake,
+                pendingJavaScriptInvocation.getInvocation().getExpression());
     }
 
     protected abstract void runStaticCreateMethodForExtension(

--- a/flow-dnd/src/test/java/com/vaadin/flow/component/dnd/internal/DnDUtilHelper.java
+++ b/flow-dnd/src/test/java/com/vaadin/flow/component/dnd/internal/DnDUtilHelper.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.component.dnd.internal;
+
+public class DnDUtilHelper {
+
+    public static final String MOBILE_DND_INJECT_SCRIPT = DndUtil.MOBILE_POLYFILL_INJECT_SCRIPT;
+
+    private DnDUtilHelper() {
+        // sonarqube
+    }
+}

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.html;
 import java.util.Optional;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Focusable;
 import com.vaadin.flow.component.HtmlContainer;
 import com.vaadin.flow.component.PropertyDescriptor;
 import com.vaadin.flow.component.PropertyDescriptors;
@@ -32,7 +33,7 @@ import com.vaadin.flow.server.StreamResource;
  * @since 1.0
  */
 @Tag(Tag.A)
-public class Anchor extends HtmlContainer {
+public class Anchor extends HtmlContainer implements Focusable<Anchor> {
 
     private static final PropertyDescriptor<String, String> hrefDescriptor = PropertyDescriptors
             .attributeWithDefault("href", "", false);

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
@@ -19,8 +19,11 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
@@ -147,14 +150,23 @@ public class PrepareFrontendMojo extends FlowModeAbstractMojo {
                             + "'. Verify that you may write to path.", e);
         }
         try {
-            new NodeTasks.Builder(getClassFinder(project), npmFolder,
+            NodeTasks.Builder builder = new NodeTasks.Builder(getClassFinder(project), npmFolder,
                     generatedFolder, frontendDirectory)
                             .withWebpack(webpackOutputDirectory,
                                     webpackTemplate, webpackGeneratedTemplate)
                             .createMissingPackageJson(true)
                             .enableImportsUpdate(false)
-                            .enablePackagesUpdate(false).runNpmInstall(false)
-                            .build().execute();
+                            .enablePackagesUpdate(false).runNpmInstall(false);
+            // If building a jar project copy jar artifact contents now as we might
+            // not be able to read files from jar path.
+            if("jar".equals(project.getPackaging())) {
+                Set<File> jarFiles = project.getArtifacts().stream()
+                        .filter(artifact -> "jar".equals(artifact.getType()))
+                        .map(Artifact::getFile).collect(Collectors.toSet());
+                builder.copyResources(jarFiles);
+            }
+
+            builder.build().execute();
         } catch (ExecutionFailedException exception) {
             throw new MojoFailureException(
                     "Could not execute prepare-frontend goal.", exception);

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
@@ -24,7 +24,6 @@ import com.vaadin.flow.plugin.TestUtils;
 import elemental.json.Json;
 import elemental.json.JsonObject;
 import elemental.json.impl.JsonUtil;
-
 import static com.vaadin.flow.plugin.maven.BuildFrontendMojoTest.assertContainsPackage;
 import static com.vaadin.flow.plugin.maven.BuildFrontendMojoTest.getPackageJson;
 import static com.vaadin.flow.plugin.maven.BuildFrontendMojoTest.setProject;
@@ -54,6 +53,7 @@ public class PrepareFrontendMojoTest {
     private File projectBase;
     private File webpackOutputDirectory;
     private File tokenFile;
+    private MavenProject project;
 
     @Before
     public void setup() throws Exception {
@@ -62,7 +62,7 @@ public class PrepareFrontendMojoTest {
         tokenFile = new File(temporaryFolder.getRoot(),
                 VAADIN_SERVLET_RESOURCES + TOKEN_FILE);
 
-        MavenProject project = Mockito.mock(MavenProject.class);
+        project = Mockito.mock(MavenProject.class);
         Mockito.when(project.getBasedir()).thenReturn(projectBase);
 
         nodeModulesPath = new File(projectBase, NODE_MODULES);
@@ -160,6 +160,19 @@ public class PrepareFrontendMojoTest {
         JsonObject packageJsonObject = getPackageJson(packageJson);
         assertContainsPackage(packageJsonObject.getObject("dependencies"),
                 "foo");
+    }
+
+    @Test
+    public void jarPackaging_copyProjectFrontendResources()
+            throws MojoExecutionException, MojoFailureException,
+            IllegalAccessException {
+        Mockito.when(project.getPackaging()).thenReturn("jar");
+
+        ReflectionUtils.setVariableValueInObject(mojo, "project", project);
+
+        mojo.execute();
+
+        Mockito.verify(project, Mockito.atLeastOnce()).getArtifacts();
     }
 
     private void assertPackageJsonContent() throws IOException {

--- a/flow-migration/src/test/java/com/vaadin/flow/migration/MigrationTest.java
+++ b/flow-migration/src/test/java/com/vaadin/flow/migration/MigrationTest.java
@@ -27,12 +27,14 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 
+import com.vaadin.flow.server.frontend.FrontendUtils;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 
 public class MigrationTest {
@@ -42,6 +44,13 @@ public class MigrationTest {
 
     private MigrationConfiguration configuration = Mockito
             .mock(MigrationConfiguration.class);
+
+    private File targetFolder;
+
+    @After
+    public void cleanup() {
+        targetFolder = null;
+    }
 
     @Test(expected = IllegalArgumentException.class)
     public void createMigration_noBaseDir_throw() {
@@ -127,14 +136,20 @@ public class MigrationTest {
     public void migratePnpmPassesHappyPath() throws MigrationFailureException,
             MigrationToolsException, IOException {
         Mockito.when(configuration.isPnpmDisabled()).thenReturn(false);
+        targetFolder = makeTempDirectoryStructure();
+        Path pnpmBin = Files
+                .createDirectories(Paths.get(targetFolder.getAbsolutePath(),
+                        "foo", "node_modules", "pnpm", "bin"));
+        new File(pnpmBin.toFile(), "pnpm.js").createNewFile();
+
         // Expected execution calls:
-        // 1 - pnpm --shamefully-hoist=true install polymer-modulizer
+        // 1 - node node_modules/pnpm/bin/pnpm.js --shamefully-hoist=true install polymer-modulizer
         // 2 - node {tempFolder} i -F --confid.interactive=false -S
         // polymer#2.8.0
-        // 3 - pnpm --shamefully-hoist=true i
+        // 3 - node node_modules/pnpm/bin/pnpm.js --shamefully-hoist=true i
         // 4 - node node_modules/polymer-modulizer/bin/modulizer.js --force
         // --out , --import-style=name
-        migratePassesHappyPath(Stream.of(4, 7, 3, 6)
+        migratePassesHappyPath(Stream.of(5, 7, 4, 6)
                 .collect(Collectors.toCollection(LinkedList::new)));
     }
 
@@ -179,7 +194,8 @@ public class MigrationTest {
             @Override
             protected boolean executeProcess(List<String> command,
                     String errorMsg, String successMsg, String exceptionMsg) {
-                Assert.assertEquals("Unexpected command",
+                Assert.assertEquals(
+                        "Unexpected command '" + command.toString() + "'",
                         (int) excecuteExpectations.pop(), command.size());
                 // Skip actual execution of commands.
                 return true;
@@ -209,8 +225,13 @@ public class MigrationTest {
     }
 
     private File makeTempDirectoryStructure() throws IOException {
-        File folder = temporaryFolder.newFolder();
-        folder.mkdirs();
+        File folder;
+        if(targetFolder == null) {
+            folder = temporaryFolder.newFolder();
+            folder.mkdirs();
+        } else {
+            folder = targetFolder;
+        }
         Files.createDirectories(Paths.get(folder.getAbsolutePath(), "foo",
                 "src", "main", "webapp"));
         Files.createDirectories(Paths.get(folder.getAbsolutePath(), "bar",

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -533,7 +533,7 @@ public class UIInternals implements Serializable {
         List<E> registeredListeners = (List<E>) listeners
                 .computeIfAbsent(handler, key -> new ArrayList<>());
 
-        return Collections.unmodifiableList(registeredListeners);
+        return Collections.unmodifiableList(new ArrayList<>(registeredListeners));
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
@@ -95,7 +95,8 @@ public class ExtendedClientDetails implements Serializable {
             String bodyClientWidth, String bodyClientHeight, String tzOffset,
             String rawTzOffset, String dstShift, String dstInEffect,
             String tzId, String curDate, String touchDevice,
-            String devicePixelRatio, String windowName, String navigatorPlatform) {
+            String devicePixelRatio, String windowName,
+            String navigatorPlatform) {
         if (screenWidth != null) {
             try {
                 this.screenWidth = Integer.parseInt(screenWidth);
@@ -206,7 +207,7 @@ public class ExtendedClientDetails implements Serializable {
     /**
      * Gets the inner width of the browser window {@code window.innerWidth} in
      * pixels. This includes the scrollbar, if it is visible.
-     * 
+     *
      * @return the browser window inner width in pixels
      */
     public int getWindowInnerWidth() {
@@ -215,7 +216,7 @@ public class ExtendedClientDetails implements Serializable {
 
     /**
      * Gets the height of the body element in the document in pixels.
-     * 
+     *
      * @return the height of the body element
      */
     public int getBodyClientHeight() {
@@ -337,11 +338,13 @@ public class ExtendedClientDetails implements Serializable {
 
     /**
      * Gets the device pixel ratio, {@code window.devicePixelRatio}. See more
-     * from <a href="https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio">MDN web docs</a>.
+     * from <a href=
+     * "https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio">MDN
+     * web docs</a>.
      * <p>
      * A value of -1 indicates that the value was not reported by the browser
      * correctly.
-     * 
+     *
      * @return double-precision floating-point value indicating the ratio of the
      *         display's resolution in physical pixels to the resolution in CSS
      *         pixels
@@ -372,5 +375,15 @@ public class ExtendedClientDetails implements Serializable {
         }
         WebBrowser browser = VaadinSession.getCurrent().getBrowser();
         return browser.isIPad() || (browser.isMacOSX() && isTouchDevice());
+    }
+
+    /**
+     * Check if the browser is run on IOS.
+     *
+     * @return {@code true} if run on IOS , {@code false} if the user is not
+     *         using IOS or if no information from the browser is present
+     */
+    public boolean isIOS() {
+        return isIPad() || VaadinSession.getCurrent().getBrowser().isIOS();
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -37,11 +37,11 @@ import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
 import com.vaadin.flow.component.internal.UIInternals.JavaScriptInvocation;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.internal.UrlUtil;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.shared.ui.Dependency;
 import com.vaadin.flow.shared.ui.Dependency.Type;
 import com.vaadin.flow.shared.ui.LoadMode;
-
 import elemental.json.JsonObject;
 import elemental.json.JsonType;
 import elemental.json.JsonValue;
@@ -269,32 +269,37 @@ public class Page implements Serializable {
      * Adds the given external JavaScript module to the page and ensures that it
      * is loaded successfully.
      * <p>
-     * If the JavaScript modules are local or do not need to be added
-     * dynamically, you should use the {@link JsModule @JsModule} annotation
-     * instead.
+     * If the JavaScript modules do not need to be added dynamically, you should
+     * use the {@link JsModule @JsModule} annotation instead.
      *
      * @param url
      *            the URL to load the JavaScript module from, not
      *            <code>null</code>
      */
     public void addJsModule(String url) {
-        addJsModule(url, LoadMode.EAGER);
+        if (UrlUtil.isExternal(url) || url.startsWith("/")) {
+            addDependency(new Dependency(Type.JS_MODULE, url, LoadMode.EAGER));
+        } else {
+            throw new IllegalArgumentException(
+                    "url argument must contains either a protocol (eg. starts with \"http://\" or \"//\"), or starts with \"/\".");
+        }
     }
 
     /**
      * Adds the given external JavaScript module to the page and ensures that it
      * is loaded successfully.
      * <p>
-     * If the JavaScript modules are local or do not need to be added
-     * dynamically, you should use the {@link JsModule @JsModule} annotation
-     * instead.
+     * If the JavaScript modules do not need to be added dynamically, you should
+     * use the {@link JsModule @JsModule} annotation instead.
      *
      * @param url
      *            the URL to load the JavaScript module from, not
      *            <code>null</code>
      * @param loadMode
-     *            determines dependency load mode, refer to {@link LoadMode} for
-     *            details
+     *            this argument is ignored and the <code>loadMode</code> will
+     *            always be {@link LoadMode#EAGER} since {@link LoadMode}
+     *            doesn't work with {@link Type#JS_MODULE}. See Deprecated
+     *            section for more details.
      * @deprecated {@code LoadMode} is not functional with external JavaScript
      *             modules, as those are loaded as deferred due to
      *             {@code type=module} in {@code scrip} tag. Use
@@ -302,7 +307,7 @@ public class Page implements Serializable {
      */
     @Deprecated
     public void addJsModule(String url, LoadMode loadMode) {
-        addDependency(new Dependency(Type.JS_MODULE, url, loadMode));
+        addJsModule(url);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentWrapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentWrapper.java
@@ -62,7 +62,7 @@ public class WebComponentWrapper extends Component {
         Objects.requireNonNull(binding,
                 "Parameter 'binding' must not be null!");
 
-        this.webComponentBinding = binding;
+        webComponentBinding = binding;
         getElement().attachShadow()
                 .appendChild(webComponentBinding.getComponent().getElement());
     }
@@ -145,8 +145,9 @@ public class WebComponentWrapper extends Component {
                         if (event.getSource().getInternals()
                                 .getLastHeartbeatTimestamp()
                                 - disconnect > timeout) {
-                            Element element = this.getElement();
+                            Element element = getElement();
                             element.getParent().removeVirtualChild(element);
+                            disconnectRegistration.remove();
                         }
                     });
         }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -19,9 +19,9 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -784,7 +784,12 @@ public class Element extends Node<Element> {
         verifySetPropertyName(name);
 
         if ("innerHTML".equals(name)) {
-            removeAllChildren();
+            Serializable oldValue = getStateProvider()
+                    .getProperty(getNode(), name);
+            if(!Objects.equals(value, oldValue)) {
+                // Only remove all children for value change
+                removeAllChildren();
+            }
         }
         getStateProvider().setProperty(getNode(), name, value, true);
 
@@ -1800,41 +1805,8 @@ public class Element extends Node<Element> {
     public Element setEnabled(final boolean enabled) {
         getNode().setEnabled(enabled);
 
-        Optional<Component> componentOptional = getComponent();
-        if (componentOptional.isPresent()) {
-            Component component = componentOptional.get();
-            component.onEnabledStateChanged(enabled);
-            informChildrenOfStateChange(enabled, component);
-        }
+        informEnabledStateChange(enabled, this);
         return getSelf();
-    }
-
-    private void informChildrenOfStateChange(boolean enabled,
-            Component component) {
-        component.getChildren().forEach(child -> {
-            child.onEnabledStateChanged(
-                    enabled ? child.getElement().isEnabled() : false);
-            informChildrenOfStateChange(enabled, child);
-        });
-        if (component.getElement().getNode()
-                .hasFeature(VirtualChildrenList.class)) {
-            component.getElement().getNode()
-                    .getFeatureIfInitialized(VirtualChildrenList.class)
-                    .ifPresent(list -> {
-                        final Consumer<Component> stateChangeInformer = virtual -> {
-                            virtual.onEnabledStateChanged(
-                                    enabled ? virtual.getElement().isEnabled()
-                                            : false);
-
-                            informChildrenOfStateChange(enabled, virtual);
-                        };
-                        final Consumer<StateNode> childNodeConsumer = childNode -> Element
-                                .get(childNode).getComponent()
-                                .ifPresent(stateChangeInformer);
-
-                        list.forEachChild(childNodeConsumer);
-                    });
-        }
     }
 
     /**
@@ -1853,6 +1825,28 @@ public class Element extends Node<Element> {
     @Override
     protected Element getSelf() {
         return this;
+    }
+
+    private void informEnabledStateChange(boolean enabled, Element element) {
+        Optional<Component> componentOptional = element.getComponent();
+        if (componentOptional.isPresent()) {
+            Component component = componentOptional.get();
+            component.onEnabledStateChanged(
+                    enabled ? element.isEnabled() : false);
+        }
+        informChildrenOfStateChange(enabled, element);
+    }
+
+    private void informChildrenOfStateChange(boolean enabled, Element element) {
+        element.getChildren().forEach(child -> {
+            informEnabledStateChange(enabled, child);
+        });
+        if (element.getNode().hasFeature(VirtualChildrenList.class)) {
+            element.getNode().getFeatureIfInitialized(VirtualChildrenList.class)
+                    .ifPresent(list -> list.forEachChild(
+                            node -> informEnabledStateChange(enabled,
+                                    Element.get(node))));
+        }
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/BasicElementStateProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/BasicElementStateProvider.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.dom.impl;
 
+import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collection;
@@ -429,4 +430,7 @@ public class BasicElementStateProvider extends AbstractNodeStateProvider {
         return features;
     }
 
+    protected Object readResolve() throws ObjectStreamException {
+        return instance;
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/BasicTextElementStateProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/BasicTextElementStateProvider.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.dom.impl;
 
+import java.io.ObjectStreamException;
 import java.util.Collections;
 
 import com.vaadin.flow.dom.Node;
@@ -90,4 +91,7 @@ public class BasicTextElementStateProvider
         return BasicElementStateProvider.get().getParent(node);
     }
 
+    protected Object readResolve() throws ObjectStreamException {
+        return INSTANCE;
+    }    
 }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/ShadowRootStateProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/ShadowRootStateProvider.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.dom.impl;
 
+import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -239,4 +240,8 @@ public class ShadowRootStateProvider extends AbstractNodeStateProvider {
     public boolean isVisible(StateNode node) {
         throw new UnsupportedOperationException();
     }
+    
+    protected Object readResolve() throws ObjectStreamException {
+        return INSTANCE;
+    }    
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouterLink.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouterLink.java
@@ -21,6 +21,7 @@ import java.util.Optional;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Focusable;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasStyle;
 import com.vaadin.flow.component.HasText;
@@ -42,8 +43,8 @@ import com.vaadin.flow.shared.ApplicationConstants;
  * @since 1.0
  */
 @Tag(Tag.A)
-public class RouterLink extends Component
-        implements HasText, HasComponents, HasStyle, AfterNavigationObserver {
+public class RouterLink extends Component implements HasText, HasComponents,
+        HasStyle, AfterNavigationObserver, Focusable<RouterLink> {
 
     private static final PropertyDescriptor<String, String> HREF = PropertyDescriptors
             .attributeWithDefault("href", "", false);

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -443,7 +443,7 @@ public abstract class AbstractNavigationStateRenderer
                 .getUrlBase(targetType)
                 .orElseThrow(() -> new IllegalStateException(String.format(
                         "The target component '%s' has no registered route",
-                        targetType))));
+                        targetType))), event.getLocation().getQueryParameters());
 
         if (beforeNavigation.hasForwardTarget()) {
             List<String> segments = new ArrayList<>(location.getSegments());

--- a/flow-server/src/main/java/com/vaadin/flow/server/WebBrowser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/WebBrowser.java
@@ -27,23 +27,20 @@ import com.vaadin.flow.shared.BrowserDetails;
  * available in the request, for instance browser name and version and IP
  * address.
  *
- * Note! browser details rely on the user agent from the browser and thus
- * the details are not always correct.
+ * Note! browser details rely on the user agent from the browser and thus the
+ * details are not always correct.
  *
  * @author Vaadin Ltd
  * @since 1.0.
  */
 public class WebBrowser implements Serializable {
 
-
     private String browserApplication = null;
     private Locale locale;
     private String address;
     private boolean secureConnection;
 
-
     private BrowserDetails browserDetails;
-
 
     /**
      * Get the browser user-agent string.
@@ -258,7 +255,10 @@ public class WebBrowser implements Serializable {
      *
      * @return true if run in iOS false if the user is not using iOS or if no
      *         information on the browser is present
+     * @deprecated isIOS will return the wrong value for iOS 13 and later. Use
+     *             instead {@link ExtendedClientDetails#isIOS()}
      */
+    @Deprecated
     public boolean isIOS() {
         return browserDetails.isIOS();
     }
@@ -295,7 +295,6 @@ public class WebBrowser implements Serializable {
     public boolean isChromeOS() {
         return browserDetails.isChromeOS();
     }
-
 
     /**
      * For internal use only. Updates all properties in the class according to

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -271,6 +271,8 @@ abstract class AbstractUpdateImports implements Runnable {
         lines.addAll(Arrays.asList(content.split("\\R")));
     }
 
+    protected abstract String getImportsNotFoundMessage();
+
     private void collectModules(List<String> lines) {
         Set<String> modules = new LinkedHashSet<>();
         modules.addAll(resolveModules(getModules(), true));
@@ -357,9 +359,7 @@ abstract class AbstractUpdateImports implements Runnable {
         if (!npmNotFound.isEmpty() && getLogger().isInfoEnabled()) {
             getLogger().info(notFoundMessage(npmNotFound,
                     "Failed to find the following imports in the `node_modules` tree:",
-                    "If the build fails, check that npm packages are installed.\n\n"
-                            + "  To fix the build remove `package-lock.json` and `node_modules` directory to reset modules.\n"
-                            + "  In addition you may run `npm install` to fix `node_modules` tree structure."));
+                    getImportsNotFoundMessage()));
         }
 
         return es6ImportPaths;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -63,6 +63,11 @@ import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
  */
 public class FrontendUtils {
 
+    private static final String PNMP_INSTALLED_BY_NPM_FOLDER = "node_modules/pnpm/";
+
+    private static final String PNMP_INSTALLED_BY_NPM = PNMP_INSTALLED_BY_NPM_FOLDER
+            + "bin/pnpm.js";
+
     public static final String PROJECT_BASEDIR = "project.basedir";
 
     /**
@@ -369,14 +374,13 @@ public class FrontendUtils {
     public static List<String> getPnpmExecutable(String baseDir,
             boolean failOnAbsence) {
         // First try local pnpm JS script if it exists
-        File file = new File(baseDir, "node_modules/pnpm/bin/pnpm.js");
         List<String> returnCommand = new ArrayList<>();
-        if (file.canRead()) {
-            // We return a two element list with node binary and npm-cli script
+        Optional<File> localPnpmScript = getLocalPnpmScript(baseDir);
+        if (localPnpmScript.isPresent()) {
             returnCommand.add(getNodeExecutable(baseDir));
-            returnCommand.add(file.getAbsolutePath());
+            returnCommand.add(localPnpmScript.get().getAbsolutePath());
         } else {
-            // Otherwise look for regulag `pnpm`
+            // Otherwise look for regular `pnpm`
             String command = isWindows() ? "pnpm.cmd" : "pnpm";
             if (failOnAbsence) {
                 returnCommand.add(getExecutable(baseDir, command, null)
@@ -572,11 +576,7 @@ public class FrontendUtils {
         // else fallback on 127.0.0.1:8080
         if (externalStatsUrl.startsWith("/")) {
             VaadinRequest request = VaadinRequest.getCurrent();
-            String host = request.getHeader("host");
-            if (host == null) {
-                host = "http://127.0.0.1:8080";
-            }
-            url = host + externalStatsUrl;
+            url = getHostString(request) + externalStatsUrl;
         } else {
             url = externalStatsUrl;
         }
@@ -611,6 +611,20 @@ public class FrontendUtils {
                     url, e);
         }
         return null;
+    }
+
+    private static String getHostString(VaadinRequest request) {
+        String host = request.getHeader("host");
+        if (host == null) {
+            host = "http://127.0.0.1:8080";
+        } else if (!host.contains("://")) {
+            String scheme = request.getHeader("scheme");
+            if (scheme == null) {
+                scheme = "http";
+            }
+            host = scheme + "://" + host;
+        }
+        return host;
     }
 
     private static InputStream getStatsFromClassPath(VaadinService service) {
@@ -761,32 +775,38 @@ public class FrontendUtils {
      */
     public static void ensurePnpm(String baseDir, boolean ensure) {
         if (ensure && getPnpmExecutable(baseDir, false).isEmpty()) {
-            List<String> npmExecutable = FrontendUtils
-                    .getNpmExecutable(baseDir);
-            List<String> command = new ArrayList<>();
-            command.addAll(npmExecutable);
-            command.add("install");
-            command.add("pnpm");
-
-            ProcessBuilder builder = createProcessBuilder(command);
-            builder.environment().put("ADBLOCK", "1");
-            builder.directory(new File(baseDir));
-
-            Process process = null;
-            try {
-                process = builder.inheritIO().start();
-                int errorCode = process.waitFor();
-                if (errorCode != 0) {
-                    getLogger().error("Couldn't install 'pnpm'");
-                } else {
-                    getLogger().debug("Pnpm is successfully installed");
+            // copy the current content of package.json file to a temporary
+            // location
+            File packageJson = new File(baseDir, "package.json");
+            File tempFile = null;
+            boolean packageJsonExists = packageJson.canRead();
+            if (packageJsonExists) {
+                try {
+                    tempFile = File.createTempFile("package", "json");
+                    FileUtils.copyFile(packageJson, tempFile);
+                } catch (IOException exception) {
+                    throw new IllegalStateException(
+                            "Couldn't make a copy of package.json file",
+                            exception);
                 }
-            } catch (InterruptedException | IOException e) {
-                getLogger().error("Error when running `npm install`", e);
-            } finally {
-                if (process != null) {
-                    process.destroyForcibly();
+                packageJson.delete();
+            }
+            // install pnpm locally using npm
+            installPnpm(baseDir, getNpmExecutable(baseDir));
+
+            // remove package-lock.json which contains pnpm as a dependency.
+            new File(baseDir, "package-lock.json").delete();
+
+            if (packageJsonExists && tempFile != null) {
+                // return back the original package.json
+                try {
+                    FileUtils.copyFile(tempFile, packageJson);
+                } catch (IOException exception) {
+                    throw new IllegalStateException(
+                            "Couldn't restore package.json file back",
+                            exception);
                 }
+                tempFile.delete();
             }
         }
     }
@@ -797,6 +817,35 @@ public class FrontendUtils {
                     npmVersion.getFullVersion(),
                     "by updating your global npm installation with `npm install -g npm@latest`");
             throw new IllegalStateException(badNpmVersion);
+        }
+    }
+
+    private static void installPnpm(String baseDir,
+            List<String> installCommand) {
+        List<String> command = new ArrayList<>();
+        command.addAll(installCommand);
+        command.add("install");
+        command.add("pnpm@4.5.0");
+
+        ProcessBuilder builder = createProcessBuilder(command);
+        builder.environment().put("ADBLOCK", "1");
+        builder.directory(new File(baseDir));
+
+        Process process = null;
+        try {
+            process = builder.inheritIO().start();
+            int errorCode = process.waitFor();
+            if (errorCode != 0) {
+                getLogger().error("Couldn't install 'pnpm'");
+            } else {
+                getLogger().debug("Pnpm is successfully installed");
+            }
+        } catch (InterruptedException | IOException e) {
+            getLogger().error("Error when running `npm install`", e);
+        } finally {
+            if (process != null) {
+                process.destroyForcibly();
+            }
         }
     }
 
@@ -992,6 +1041,27 @@ public class FrontendUtils {
 
     private static Logger getLogger() {
         return LoggerFactory.getLogger(FrontendUtils.class);
+    }
+
+    private static Optional<File> getLocalPnpmScript(String baseDir) {
+        File npmInstalled = new File(baseDir, PNMP_INSTALLED_BY_NPM);
+        if (npmInstalled.canRead()) {
+            return Optional.of(npmInstalled);
+        }
+
+        // For version 4.3.3 check ".ignored" folders
+        File movedPnpmScript = new File(baseDir,
+                "node_modules/.ignored_pnpm/bin/pnpm.js");
+        if (movedPnpmScript.canRead()) {
+            return Optional.of(movedPnpmScript);
+        }
+
+        movedPnpmScript = new File(baseDir,
+                "node_modules/.ignored/pnpm/bin/pnpm.js");
+        if (movedPnpmScript.canRead()) {
+            return Optional.of(movedPnpmScript);
+        }
+        return Optional.empty();
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -376,7 +376,8 @@ public class NodeTasks implements FallibleCommand {
         if (builder.enablePackagesUpdate) {
             TaskUpdatePackages packageUpdater = new TaskUpdatePackages(
                     classFinder, frontendDependencies, builder.npmFolder,
-                    builder.generatedFolder, builder.cleanNpmFiles);
+                    builder.generatedFolder, builder.cleanNpmFiles,
+                    builder.disablePnpm);
             commands.add(packageUpdater);
 
             if (builder.runNpmInstall) {
@@ -409,7 +410,7 @@ public class NodeTasks implements FallibleCommand {
                             finder -> getFallbackScanner(builder, finder),
                             builder.npmFolder, builder.generatedFolder,
                             builder.frontendDirectory, builder.tokenFile,
-                            builder.tokenFileData));
+                            builder.tokenFileData, builder.disablePnpm));
 
         }
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -37,6 +37,7 @@ import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 
 import elemental.json.Json;
 import elemental.json.JsonObject;
+
 import static com.vaadin.flow.server.Constants.COMPATIBILITY_RESOURCES_FRONTEND_DEFAULT;
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 import static com.vaadin.flow.server.Constants.RESOURCES_FRONTEND_DEFAULT;
@@ -118,6 +119,10 @@ public abstract class NodeUpdater implements FallibleCommand {
         this.generatedFolder = generatedPath;
     }
 
+    private File getPackageJsonFile() {
+        return new File(npmFolder, PACKAGE_JSON);
+    }
+
     static Set<String> getGeneratedModules(File directory,
             Set<String> excludes) {
         if (!directory.exists()) {
@@ -182,14 +187,13 @@ public abstract class NodeUpdater implements FallibleCommand {
     }
 
     JsonObject getPackageJson() throws IOException {
-        JsonObject packageJson = getJsonFileContent(
-                new File(npmFolder, PACKAGE_JSON));
+        JsonObject packageJson = getJsonFileContent(getPackageJsonFile());
         if (packageJson == null) {
             packageJson = Json.createObject();
             packageJson.put(DEP_NAME_KEY, DEP_NAME_DEFAULT);
             packageJson.put(DEP_LICENSE_KEY, DEP_LICENSE_DEFAULT);
         }
-        if(!packageJson.hasKey(VAADIN_DEP_KEY)) {
+        if (!packageJson.hasKey(VAADIN_DEP_KEY)) {
             packageJson.put(VAADIN_DEP_KEY, createVaadinPackagesJson());
         }
         return packageJson;
@@ -223,7 +227,6 @@ public abstract class NodeUpdater implements FallibleCommand {
     }
 
     static Map<String, String> getDefaultDependencies() {
-
         Map<String, String> defaults = new HashMap<>();
 
         defaults.put("@polymer/polymer", POLYMER_VERSION);
@@ -236,12 +239,12 @@ public abstract class NodeUpdater implements FallibleCommand {
         Map<String, String> defaults = new HashMap<>();
 
         defaults.put("webpack", "4.30.0");
-        defaults.put("webpack-cli", "3.3.0");
-        defaults.put("webpack-dev-server", "3.3.0");
-        defaults.put("webpack-babel-multi-target-plugin", "2.3.1");
-        defaults.put("copy-webpack-plugin", "5.0.3");
-        defaults.put("compression-webpack-plugin", "3.0.0");
-        defaults.put("webpack-merge", "4.2.1");
+        defaults.put("webpack-cli", "3.3.10");
+        defaults.put("webpack-dev-server", "3.9.0");
+        defaults.put("webpack-babel-multi-target-plugin", "2.3.3");
+        defaults.put("copy-webpack-plugin", "5.1.0");
+        defaults.put("compression-webpack-plugin", "3.0.1");
+        defaults.put("webpack-merge", "4.2.2");
         defaults.put("raw-loader", "3.0.0");
 
         return defaults;
@@ -252,14 +255,14 @@ public abstract class NodeUpdater implements FallibleCommand {
      * package.json.
      *
      * @param packageJson
-     *         package.json json object to update with dependencies
+     *            package.json json object to update with dependencies
      * @return true if items were added or removed from the {@code packageJson}
      */
     boolean updateDefaultDependencies(JsonObject packageJson) {
         int added = 0;
 
-        for (Map.Entry<String, String> entry : getDefaultDependencies(
-                ).entrySet()) {
+        for (Map.Entry<String, String> entry : getDefaultDependencies()
+                .entrySet()) {
             added += addDependency(packageJson, DEPENDENCIES, entry.getKey(),
                     entry.getValue());
         }
@@ -269,7 +272,7 @@ public abstract class NodeUpdater implements FallibleCommand {
                     entry.getKey(), entry.getValue());
         }
 
-        if(added > 0) {
+        if (added > 0) {
             log().info("Added {} dependencies to main package.json", added);
         }
         return added > 0;
@@ -311,12 +314,14 @@ public abstract class NodeUpdater implements FallibleCommand {
         FrontendVersion vaadinVersion = toVersion(vaadinDeps, pkg);
         if (json.hasKey(pkg)) {
             FrontendVersion packageVersion = toVersion(json, pkg);
-            // Vaadin and package.json versions are the same, but dependency updates (can be up or down)
-            if (vaadinVersion.isEqualTo(packageVersion) && !vaadinVersion
-                    .isEqualTo(newVersion)) {
+            // Vaadin and package.json versions are the same, but dependency
+            // updates (can be up or down)
+            if (vaadinVersion.isEqualTo(packageVersion)
+                    && !vaadinVersion.isEqualTo(newVersion)) {
                 json.put(pkg, version);
                 added = true;
-                // if vaadin and package not the same, but new version is newer update package version.
+                // if vaadin and package not the same, but new version is newer
+                // update package version.
             } else if (newVersion.isNewerThan(packageVersion)) {
                 json.put(pkg, version);
                 added = true;
@@ -328,7 +333,7 @@ public abstract class NodeUpdater implements FallibleCommand {
         // always update vaadin version to the latest set version
         vaadinDeps.put(pkg, version);
 
-        if(added) {
+        if (added) {
             log().debug("Added \"{}\": \"{}\" line.", pkg, version);
         }
         return added ? 1 : 0;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.server.frontend;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import com.vaadin.flow.server.ExecutionFailedException;
@@ -34,6 +35,8 @@ public class TaskRunNpmInstall implements FallibleCommand {
 
     private final NodeUpdater packageUpdater;
 
+    private final List<String> ignoredNodeFolders = Arrays
+            .asList(".bin", "pnpm", ".ignored_pnpm", ".pnpm", ".modules.yaml");
     private final boolean disablePnpm;
 
     /**
@@ -64,8 +67,7 @@ public class TaskRunNpmInstall implements FallibleCommand {
             // Ignore .bin and pnpm folders as those are always installed for
             // pnpm execution
             File[] installedPackages = packageUpdater.nodeModulesFolder
-                    .listFiles((dir, name) -> !(".bin".equals(name) || "pnpm"
-                            .equals(name)));
+                    .listFiles((dir, name) -> !ignoredNodeFolders.contains(name));
             assert installedPackages != null;
             return installedPackages.length == 0
                     || (installedPackages.length == 1 && FLOW_NPM_PACKAGE_NAME

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -75,6 +75,8 @@ public class TaskUpdateImports extends NodeUpdater {
     private final File tokenFile;
     private final JsonObject tokenFileData;
 
+    private final boolean disablePnpm;
+
     private class UpdateMainImportsFile extends AbstractUpdateImports {
 
         private final File generatedFlowImports;
@@ -193,6 +195,11 @@ public class TaskUpdateImports extends NodeUpdater {
         protected Logger getLogger() {
             return log();
         }
+
+        @Override
+        protected String getImportsNotFoundMessage() {
+            return getAbsentPackagesMessage();
+        }
     }
 
     private class UpdateFallBackImportsFile extends AbstractUpdateImports {
@@ -274,6 +281,11 @@ public class TaskUpdateImports extends NodeUpdater {
             return log();
         }
 
+        @Override
+        protected String getImportsNotFoundMessage() {
+            return getAbsentPackagesMessage();
+        }
+
         File getGeneratedFallbackFile() {
             return generatedFallBack;
         }
@@ -296,14 +308,17 @@ public class TaskUpdateImports extends NodeUpdater {
      *            a directory with project's frontend files
      * @param tokenFile
      *            the token (flow-build-info.json) path, may be {@code null}
+     * @param disablePnpm
+     *            if {@code true} then npm is used instead of pnpm, otherwise
+     *            pnpm is used
      */
     TaskUpdateImports(ClassFinder finder,
             FrontendDependenciesScanner frontendDepScanner,
             SerializableFunction<ClassFinder, FrontendDependenciesScanner> fallBackScannerProvider,
             File npmFolder, File generatedPath, File frontendDirectory,
-            File tokenFile) {
+            File tokenFile, boolean disablePnpm) {
         this(finder, frontendDepScanner, fallBackScannerProvider, npmFolder,
-                generatedPath, frontendDirectory, tokenFile, null);
+                generatedPath, frontendDirectory, tokenFile, null, disablePnpm);
     }
 
     /**
@@ -325,18 +340,22 @@ public class TaskUpdateImports extends NodeUpdater {
      *            the token (flow-build-info.json) path, may be {@code null}
      * @param tokenFileData
      *            object to fill with token file data, may be {@code null}
+     * @param disablePnpm
+     *            if {@code true} then npm is used instead of pnpm, otherwise
+     *            pnpm is used
      */
     TaskUpdateImports(ClassFinder finder,
             FrontendDependenciesScanner frontendDepScanner,
             SerializableFunction<ClassFinder, FrontendDependenciesScanner> fallBackScannerProvider,
             File npmFolder, File generatedPath, File frontendDirectory,
-            File tokenFile, JsonObject tokenFileData) {
+            File tokenFile, JsonObject tokenFileData, boolean disablePnpm) {
         super(finder, frontendDepScanner, npmFolder, generatedPath);
         this.frontendDirectory = frontendDirectory;
         fallbackScanner = fallBackScannerProvider.apply(finder);
         this.finder = finder;
         this.tokenFile = tokenFile;
         this.tokenFileData = tokenFileData;
+        this.disablePnpm = disablePnpm;
     }
 
     @Override
@@ -464,6 +483,20 @@ public class TaskUpdateImports extends NodeUpdater {
             object.put("value", data.getValue());
         }
         return object;
+    }
+
+    private String getAbsentPackagesMessage() {
+        String lockFile = disablePnpm ? "package-lock.json" : "pnpm-lock.yaml";
+        String command = disablePnpm ? "npm" : "pnpm";
+        String note = "";
+        if (!disablePnpm) {
+            note = "\nMake sure first that `pnpm` command is installed, otherwise you should install it using npm: `npm add -g pnpm@4.5.0`";
+        }
+        return String.format(
+                "If the build fails, check that npm packages are installed.\n\n"
+                        + "  To fix the build remove `%s` and `node_modules` directory to reset modules.\n"
+                        + "  In addition you may run `%s install` to fix `node_modules` tree structure.%s",
+                lockFile, command, note);
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -35,12 +35,15 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.commons.io.FileUtils;
+
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 
 import elemental.json.JsonObject;
 import elemental.json.JsonValue;
+
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 
 /**
@@ -52,9 +55,11 @@ import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
  */
 public class TaskUpdatePackages extends NodeUpdater {
 
+    private static final String VAADIN_FLOW_DEPS = "@vaadin/flow-deps";
     private static final String VERSION = "version";
     private static final String SHRINK_WRAP = "@vaadin/vaadin-shrinkwrap";
-    private boolean forceCleanUp;
+    private final boolean forceCleanUp;
+    private final boolean disablePnpm;
 
     private static class RemoveFileVisitor extends SimpleFileVisitor<Path>
             implements Serializable {
@@ -78,22 +83,26 @@ public class TaskUpdatePackages extends NodeUpdater {
      * Create an instance of the updater given all configurable parameters.
      *
      * @param finder
-     *         a reusable class finder
+     *            a reusable class finder
      * @param frontendDependencies
-     *         a reusable frontend dependencies
+     *            a reusable frontend dependencies
      * @param npmFolder
-     *         folder with the `package.json` file
+     *            folder with the `package.json` file
      * @param generatedPath
-     *         folder where flow generated files will be placed.
+     *            folder where flow generated files will be placed.
      * @param forceCleanUp
-     *         forces the clean up process to be run. If {@code false}, clean
-     *         up will be performed when platform version update is detected.
+     *            forces the clean up process to be run. If {@code false}, clean
+     *            up will be performed when platform version update is detected.
+     * @param disablePnpm
+     *            if {@code true} then npm is used instead of pnpm, otherwise
+     *            pnpm is used
      */
     TaskUpdatePackages(ClassFinder finder,
             FrontendDependenciesScanner frontendDependencies, File npmFolder,
-            File generatedPath, boolean forceCleanUp) {
+            File generatedPath, boolean forceCleanUp, boolean disablePnpm) {
         super(finder, frontendDependencies, npmFolder, generatedPath);
         this.forceCleanUp = forceCleanUp;
+        this.disablePnpm = disablePnpm;
     }
 
     @Override
@@ -127,23 +136,26 @@ public class TaskUpdatePackages extends NodeUpdater {
 
         // Remove obsolete dependencies
         JsonObject dependencies = packageJson.getObject(DEPENDENCIES);
-        List<String> dependencyCollection = Stream.concat(deps.entrySet().stream(),
-                getDefaultDependencies().entrySet().stream())
+        List<String> dependencyCollection = Stream
+                .concat(deps.entrySet().stream(),
+                        getDefaultDependencies().entrySet().stream())
                 .map(Entry::getKey).collect(Collectors.toList());
 
         JsonObject vaadinDependencies = packageJson.getObject(VAADIN_DEP_KEY)
                 .getObject(DEPENDENCIES);
         boolean doCleanUp = forceCleanUp;
-        int removed = 0;
+        int removed = ensureVersionUpgrade(packageJson) ? 1 : 0;
         if (dependencies != null) {
             for (String key : dependencies.keys()) {
-                if (!dependencyCollection.contains(key) && vaadinDependencies.hasKey(key)) {
+                if (!dependencyCollection.contains(key)
+                        && vaadinDependencies.hasKey(key)) {
                     dependencies.remove(key);
                     log().debug("Removed \"{}\".", key);
                     removed++;
                 }
             }
-            doCleanUp = doCleanUp || !ensureReleaseVersion(dependencies);
+            doCleanUp = doCleanUp
+                    || disablePnpm && !ensureReleaseVersion(dependencies);
         }
 
         if (removed > 0) {
@@ -154,7 +166,8 @@ public class TaskUpdatePackages extends NodeUpdater {
             cleanUp();
         }
 
-        String oldHash = packageJson.getObject(VAADIN_DEP_KEY).getString(HASH_KEY);
+        String oldHash = packageJson.getObject(VAADIN_DEP_KEY)
+                .getString(HASH_KEY);
         String newHash = generatePackageJsonHash(packageJson);
         // update packageJson hash value, if no changes it will not be written
         packageJson.getObject(VAADIN_DEP_KEY).put(HASH_KEY, newHash);
@@ -170,7 +183,7 @@ public class TaskUpdatePackages extends NodeUpdater {
      * target/frontend/node_modules folders in case the versions are different.
      *
      * @param dependencies
-     *         dependencies object with the vaadin-shrinkwrap version
+     *            dependencies object with the vaadin-shrinkwrap version
      * @throws IOException
      */
     private boolean ensureReleaseVersion(JsonObject dependencies)
@@ -181,6 +194,32 @@ public class TaskUpdatePackages extends NodeUpdater {
         }
 
         return Objects.equals(shrinkWrapVersion, getCurrentShrinkWrapVersion());
+    }
+
+    private boolean ensureVersionUpgrade(JsonObject packageJson)
+            throws IOException {
+        boolean result = false;
+        /*
+         * In modern Flow versions "@vaadin/flow-deps" should not exist.
+         */
+        if (packageJson.hasKey(DEPENDENCIES)) {
+            JsonObject object = packageJson.getObject(DEPENDENCIES);
+            if (object.hasKey(VAADIN_FLOW_DEPS)) {
+                object.remove(VAADIN_FLOW_DEPS);
+                result = true;
+            }
+        }
+        if (disablePnpm) {
+            return result;
+        }
+        /*
+         * In case of PNPM tool we package-lock should not be used at all.
+         */
+        File packageLockFile = getPackageLockFile();
+        if (packageLockFile.exists()) {
+            FileUtils.forceDelete(getPackageLockFile());
+        }
+        return result;
     }
 
     private void cleanUp() throws IOException {
@@ -217,6 +256,22 @@ public class TaskUpdatePackages extends NodeUpdater {
     }
 
     private String getPackageLockShrinkWrapVersion() throws IOException {
+        JsonObject dependencies = getPackageLockDependencies();
+        if (dependencies == null) {
+            return null;
+        }
+
+        if (!dependencies.hasKey(SHRINK_WRAP)) {
+            return null;
+        }
+        JsonObject shrinkWrap = dependencies.getObject(SHRINK_WRAP);
+        if (shrinkWrap.hasKey(VERSION)) {
+            return shrinkWrap.get(VERSION).asString();
+        }
+        return null;
+    }
+
+    private JsonObject getPackageLockDependencies() throws IOException {
         File packageLock = getPackageLockFile();
         if (!packageLock.exists()) {
             return null;
@@ -229,15 +284,7 @@ public class TaskUpdatePackages extends NodeUpdater {
             return null;
         }
         JsonObject dependencies = packageLockJson.getObject(DEPENDENCIES);
-        if (!dependencies.hasKey(SHRINK_WRAP)) {
-            return null;
-        }
-
-        JsonObject shrinkWrap = dependencies.getObject(SHRINK_WRAP);
-        if (shrinkWrap.hasKey(VERSION)) {
-            return shrinkWrap.get(VERSION).asString();
-        }
-        return null;
+        return dependencies;
     }
 
     private File getPackageLockFile() {
@@ -267,7 +314,7 @@ public class TaskUpdatePackages extends NodeUpdater {
      * dependencies in different order will not trigger npm install.
      *
      * @param packageJson
-     *         JsonObject built in the same format as package.json
+     *            JsonObject built in the same format as package.json
      * @return has for dependencies and devDependencies
      */
     static String generatePackageJsonHash(JsonObject packageJson) {
@@ -276,23 +323,24 @@ public class TaskUpdatePackages extends NodeUpdater {
             JsonObject dependencies = packageJson.getObject(DEPENDENCIES);
             hashContent.append("\"dependencies\": {");
             String sortedDependencies = Arrays.stream(dependencies.keys())
-                    .sorted(String::compareToIgnoreCase).map(key -> String
-                            .format("\"%s\": \"%s\"", key,
-                                    dependencies.getString(key)))
+                    .sorted(String::compareToIgnoreCase)
+                    .map(key -> String.format("\"%s\": \"%s\"", key,
+                            dependencies.getString(key)))
                     .collect(Collectors.joining(",\n  "));
             hashContent.append(sortedDependencies);
             hashContent.append("}");
         }
         if (packageJson.hasKey(DEV_DEPENDENCIES)) {
-            if(hashContent.length() > 0) {
+            if (hashContent.length() > 0) {
                 hashContent.append(",\n");
             }
-            JsonObject devDependencies = packageJson.getObject(DEV_DEPENDENCIES);
+            JsonObject devDependencies = packageJson
+                    .getObject(DEV_DEPENDENCIES);
             hashContent.append("\"devDependencies\": {");
             String sortedDevDependencies = Arrays.stream(devDependencies.keys())
-                    .sorted(String::compareToIgnoreCase).map(key -> String
-                            .format("\"%s\": \"%s\"", key,
-                                    devDependencies.getString(key)))
+                    .sorted(String::compareToIgnoreCase)
+                    .map(key -> String.format("\"%s\": \"%s\"", key,
+                            devDependencies.getString(key)))
                     .collect(Collectors.joining(",\n  "));
             hashContent.append(sortedDevDependencies);
             hashContent.append("}");

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScanner.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScanner.java
@@ -184,14 +184,20 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
             Set<Class<?>> annotatedClasses = getFinder()
                     .getAnnotatedClasses(loadedAnnotation);
             Map<String, String> result = new HashMap<>();
+            Set<String> logs = new HashSet<>();
             for (Class<?> clazz : annotatedClasses) {
                 classes.add(clazz.getName());
                 List<? extends Annotation> packageAnnotations = annotationFinder
                         .apply(clazz, loadedAnnotation);
-                packageAnnotations.forEach(pckg -> result.put(
-                        invokeAnnotationMethodAsString(pckg, VALUE),
-                        invokeAnnotationMethodAsString(pckg, "version")));
+                packageAnnotations.forEach(pckg -> {
+                    String value = invokeAnnotationMethodAsString(pckg, VALUE);
+                    String vers = invokeAnnotationMethodAsString(pckg,
+                            "version");
+                    logs.add(value + " " + vers + " " + clazz.getName());
+                    result.put(value, vers);
+                });
             }
+            debug("npm dependencies", logs);
             return result;
         } catch (ClassNotFoundException exception) {
             throw new IllegalStateException(
@@ -225,17 +231,32 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
             BiConsumer<Class<?>, String> valueHandler, Class<T> annotationType,
             Function<Annotation, String> valueExtractor) {
         try {
+            Set<String> logs = new HashSet<>();
             Class<? extends Annotation> loadedAnnotation = getFinder()
                     .loadClass(annotationType.getName());
             Set<Class<?>> annotatedClasses = getFinder()
                     .getAnnotatedClasses(loadedAnnotation);
+
             annotatedClasses.stream().forEach(clazz -> annotationFinder
-                    .apply(clazz, loadedAnnotation).forEach(ann -> valueHandler
-                            .accept(clazz, valueExtractor.apply(ann))));
+                    .apply(clazz, loadedAnnotation).forEach(ann -> {
+                        String value = valueExtractor.apply(ann);
+                        valueHandler.accept(clazz, value);
+                        logs.add(value + " " + clazz);
+                    }));
+
+            debug("@" + annotationType.getSimpleName(), logs);
         } catch (ClassNotFoundException exception) {
             throw new IllegalStateException(
                     COULD_NOT_LOAD_ERROR_MSG + annotationType.getName(),
                     exception);
+        }
+    }
+
+    private void debug(String label, Set<String> log) {
+        if (getLogger().isDebugEnabled()) {
+            log.add("\n List of " + label + " found in the project:");
+            getLogger().debug(log.stream().sorted()
+                    .collect(Collectors.joining("\n  - ")));
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ApplicationRouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ApplicationRouteRegistry.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.server.startup;
 
 import javax.servlet.ServletContext;
 import java.io.Serializable;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -302,6 +303,7 @@ public class ApplicationRouteRegistry extends AbstractRouteRegistry {
         errorNavigationTargets.stream()
                 .filter(target -> !defaultErrorHandlers.contains(target))
                 .filter(this::allErrorFiltersMatch)
+                .filter(handler -> !Modifier.isAbstract(handler.getModifiers()))
                 .forEach(target -> addErrorTarget(target, exceptionTargetsMap));
 
         initErrorTargets(exceptionTargetsMap);

--- a/flow-server/src/main/java/com/vaadin/flow/shared/BrowserDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/BrowserDetails.java
@@ -567,7 +567,9 @@ public class BrowserDetails implements Serializable {
      * Tests if the browser is run in iOS.
      *
      * @return true if run in iOS, false otherwise
+     * @deprecated isIOS will return the wrong value for iOS 13 and later
      */
+    @Deprecated
     public boolean isIOS() {
         return os == OperatingSystem.IOS;
     }

--- a/flow-server/src/main/resources/com/vaadin/flow/server/safari-10-1-script-nomodule.js
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/safari-10-1-script-nomodule.js
@@ -1,0 +1,1 @@
+!function(){const e=document.createElement("script");if("onbeforeload"in e){let t=!1;document.addEventListener("beforeload",function(n){if(n.target===e)t=!0;else if(!n.target.hasAttribute("nomodule")||!t)return;n.preventDefault()},!0),e.type="module",e.src=".",document.head.appendChild(e),e.remove()}}();

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -133,6 +133,9 @@ module.exports = {
     // Transpile with babel, and produce different bundles per browser
     new BabelMultiTargetPlugin({
       babel: {
+        // workaround for Safari 10 scope issue (https://bugs.webkit.org/show_bug.cgi?id=159270)
+        plugins: ["@babel/plugin-transform-block-scoping"],
+
         presetOptions: {
           useBuiltIns: false // polyfills are provided from webcomponents-loader.js
         }

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
@@ -1238,17 +1238,38 @@ public class ComponentTest {
 
     @Test // 3818
     public void enabledStateChangeOnAttachCalledForParentState() {
-        enabledStateChangeOnAttachCalledForParentState(
+        enabledStateChangeOnAttachCalledForParentState(false,
                 (parent, child) -> parent.add(child));
+    }
+
+    @Test // 7085
+    public void enabledStateChangeOnDisableParent() {
+        enabledStateChangeOnAttachCalledForParentState(true,
+                (parent, child) -> {
+                    parent.add(child);
+                    parent.setEnabled(false);
+                });
     }
 
     @Test
     public void enabledStateChangeOnAttachCalledForParentOfVirtualChildState() {
-        enabledStateChangeOnAttachCalledForParentState((parent, child) -> {
-            Element wrapper = new Element("div");
-            parent.getElement().appendVirtualChild(wrapper);
-            wrapper.appendChild(child.getElement());
-        });
+        enabledStateChangeOnAttachCalledForParentState(false,
+                (parent, child) -> {
+                    Element wrapper = ElementFactory.createAnchor();
+                    parent.getElement().appendVirtualChild(wrapper);
+                    wrapper.appendChild(child.getElement());
+                });
+    }
+
+    @Test
+    public void enabledStateChangeOnDisableParentOfVirtualChild() {
+        enabledStateChangeOnAttachCalledForParentState(true,
+                (parent, child) -> {
+                    Element wrapper = ElementFactory.createAnchor();
+                    parent.getElement().appendVirtualChild(wrapper);
+                    wrapper.appendChild(child.getElement());
+                    parent.setEnabled(false);
+                });
     }
 
     @Test // 3818
@@ -1299,7 +1320,7 @@ public class ComponentTest {
     @Test
     public void enabledStateChangeOnParentOfVirtualChildDetachReturnsOldState() {
         enabledStateChangeOnParentDetachReturnsOldState((parent, child) -> {
-            Element wrapper = new Element("div");
+            Element wrapper = ElementFactory.createAnchor();
             parent.getElement().appendVirtualChild(wrapper);
             wrapper.appendChild(child.getElement());
         });
@@ -1601,11 +1622,12 @@ public class ComponentTest {
     }
 
     private void enabledStateChangeOnAttachCalledForParentState(
+            boolean initiallyEnabled,
             BiConsumer<EnabledDiv, Component> modificationStartegy) {
         UI ui = new UI();
 
         EnabledDiv parent = new EnabledDiv();
-        parent.setEnabled(false);
+        parent.setEnabled(initiallyEnabled);
         ui.add(parent);
 
         AtomicReference<Boolean> stateChange = new AtomicReference<>();
@@ -1618,7 +1640,8 @@ public class ComponentTest {
             }
         };
 
-        Assert.assertFalse("Parent should be disabled", parent.isEnabled());
+        Assert.assertEquals("Parent should be disabled", initiallyEnabled,
+                parent.isEnabled());
         Assert.assertTrue("Child should be enabled.", child.isEnabled());
         Assert.assertNull(child.getElement().getAttribute("disabled"));
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/ExtendedClientDetailsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/ExtendedClientDetailsTest.java
@@ -1,5 +1,6 @@
 package com.vaadin.flow.component.page;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -10,9 +11,15 @@ import com.vaadin.flow.server.WebBrowser;
 
 public class ExtendedClientDetailsTest {
 
+    @After
+    public void tearDown() {
+        CurrentInstance.clearAll();
+    }
+
     @Test
     public void initializeWithClientValues_gettersReturnExpectedValues() {
-        final ExtendedClientDetails details = new ExtendBuilder().buildDetails();
+        final ExtendedClientDetails details = new ExtendBuilder()
+                .buildDetails();
 
         Assert.assertEquals(2560, details.getScreenWidth());
         Assert.assertEquals(1450, details.getScreenHeight());
@@ -60,21 +67,66 @@ public class ExtendedClientDetailsTest {
         Assert.assertTrue("No platform on with iPad is iPad", details.isIPad());
 
         Mockito.when(browser.isIPad()).thenReturn(false);
-        Assert.assertFalse("No platform and ipad false on linux should not be an iPad", details.isIPad());
+        Assert.assertFalse(
+                "No platform and ipad false on linux should not be an iPad",
+                details.isIPad());
 
         Mockito.when(browser.isMacOSX()).thenReturn(true);
-        Assert.assertFalse("No platform MacOSX, but not touch is not an iPad", details.isIPad());
+        Assert.assertFalse("No platform MacOSX, but not touch is not an iPad",
+                details.isIPad());
 
         detailsBuilder.setTouchDevice("true");
         details = detailsBuilder.buildDetails();
-        Assert.assertTrue("No platform on MacOSX with touch is an iPad", details.isIPad());
+        Assert.assertTrue("No platform on MacOSX with touch is an iPad",
+                details.isIPad());
 
         CurrentInstance.clearAll();
     }
 
+    @Test
+    public void isIOS_isIPad_returnsTrue() {
+        ExtendedClientDetails details = Mockito
+                .mock(ExtendedClientDetails.class);
+        Mockito.doCallRealMethod().when(details).isIOS();
+        Mockito.when(details.isIPad()).thenReturn(true);
+
+        Assert.assertTrue(details.isIOS());
+    }
+
+    @Test
+    public void isIOS_notIPad_deprecatedIsIOS_returnsTrue() {
+        ExtendedClientDetails details = Mockito
+                .mock(ExtendedClientDetails.class);
+        Mockito.doCallRealMethod().when(details).isIOS();
+
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        VaadinSession.setCurrent(session);
+
+        WebBrowser browser = Mockito.mock(WebBrowser.class);
+        Mockito.when(session.getBrowser()).thenReturn(browser);
+
+        Mockito.when(browser.isIOS()).thenReturn(true);
+
+        Assert.assertTrue(details.isIOS());
+    }
+
+    @Test
+    public void isIOS_notIPad_deprecatedIsNotIOS_returnsFalse() {
+        ExtendedClientDetails details = Mockito
+                .mock(ExtendedClientDetails.class);
+        Mockito.doCallRealMethod().when(details).isIOS();
+
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        VaadinSession.setCurrent(session);
+
+        WebBrowser browser = Mockito.mock(WebBrowser.class);
+        Mockito.when(session.getBrowser()).thenReturn(browser);
+
+        Assert.assertFalse(details.isIOS());
+    }
+
     /**
-     * Builder to create modified extended details.
-     * Default values apply.
+     * Builder to create modified extended details. Default values apply.
      */
     private class ExtendBuilder {
         private String screenWidth = "2560";
@@ -84,7 +136,8 @@ public class ExtendedClientDetailsTest {
         private String bodyClientWidth = "1600";
         private String bodyClientHeight = "1360";
         private String timezoneOffset = "-270"; // minutes from UTC
-        private String rawTimezoneOffset = "-210"; // minutes from UTC without DST
+        private String rawTimezoneOffset = "-210"; // minutes from UTC without
+                                                   // DST
         private String dstSavings = "60"; // dist shift amount
         private String dstInEffect = "true";
         private String timeZoneId = "Asia/Tehran";

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/PageTest.java
@@ -16,22 +16,25 @@
 package com.vaadin.flow.component.page;
 
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
-
-import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
-import org.junit.Test;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.JsonUtils;
 import com.vaadin.flow.shared.Registration;
+import com.vaadin.flow.shared.ui.Dependency;
+import com.vaadin.flow.shared.ui.LoadMode;
 import com.vaadin.tests.util.MockUI;
-
 import elemental.json.Json;
 import elemental.json.JsonValue;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Test;
 
 public class PageTest {
 
@@ -44,15 +47,15 @@ public class PageTest {
 
     private class TestPage extends Page {
 
-        public TestPage() {
-            super(new TestUI());
-        }
-
         private int count = 0;
 
         private String expression;
 
         private Serializable firstParam;
+
+        public TestPage(UI ui) {
+            super(ui);
+        }
 
         @Override
         public PendingJavaScriptResult executeJs(String expression,
@@ -64,7 +67,9 @@ public class PageTest {
         }
     }
 
-    private TestPage page = new TestPage();
+    private UI ui = new TestUI();
+
+    private TestPage page = new TestPage(ui);
 
     private BrowserWindowResizeListener listener = event -> {
     };
@@ -210,5 +215,52 @@ public class PageTest {
                 mockUI.getInternals().dumpPendingJavaScriptInvocations().size();
         Assert.assertEquals(1, jsInvocations);
         Assert.assertEquals(2, callbackInvocations.get());
+    }
+
+    @Test
+    public void addJsModule_accepts_onlyExternalAndStartingSlash() {
+        List<String> urls = new LinkedList<>();
+        urls.add("http://sample.com/mod.js");
+        urls.add("https://sample.com/mod.js");
+        urls.add("//sample.com/mod.js");
+        urls.add("/mod.js");
+
+        for (String url: urls) {
+            page.addJsModule(url);
+        }
+
+        Collection<Dependency> pendingSendToClient = ui.getInternals()
+                .getDependencyList().getPendingSendToClient();
+
+        Assert.assertEquals("There should be 4 dependencies added.", 4,
+                pendingSendToClient.size());
+
+        for (Dependency dependency : pendingSendToClient) {
+            Assert.assertEquals("Dependency should be a JSModule",
+                    Dependency.Type.JS_MODULE, dependency.getType());
+            Assert.assertEquals("JS module dependency should be EAGER",
+                    LoadMode.EAGER, dependency.getLoadMode());
+
+            Assert.assertTrue(
+                    "Dependency " + dependency.getUrl()
+                            + " is not found in the source list.",
+                    urls.contains(dependency.getUrl()));
+
+            urls.remove(dependency.getUrl());
+        }
+
+        Assert.assertEquals("Not all urls were added as dependencies", 0,
+                urls.size());
+    }
+
+    @Test
+    public void addJsModule_rejects_files() {
+        try {
+            page.addJsModule("mod.js");
+
+            Assert.fail(
+                    "Adding a file without starting \"/\" is not to be allowed.");
+        } catch (IllegalArgumentException e) {
+        }
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/dom/impl/ElementStateProviderDeserializationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/impl/ElementStateProviderDeserializationTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.dom.impl;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.dom.Element;
+
+/**
+ * @author Muammer Yucel
+ * @since 2.2.
+ * @see https://github.com/vaadin/flow/issues/7190
+ */
+public class ElementStateProviderDeserializationTest {
+
+    @Test
+    public void shouldRemoveChildComponentFromDeserializedParent() throws Exception {
+
+        TestParentComponent parent = (TestParentComponent) deserialize(
+                serialize(new TestParentComponent(new TestChildComponent())));
+
+        Component child = parent.getChildren().findFirst().orElseThrow(IllegalStateException::new);
+
+        parent.remove(child);
+
+        Assert.assertEquals("Child component should have been removed.", 0, parent.getChildren().count());
+    }
+
+    private byte[] serialize(Object object) throws IOException {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(object);
+            oos.flush();
+            return baos.toByteArray();
+        }
+    }
+
+    private Object deserialize(byte[] bytes) throws IOException, ClassNotFoundException {
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+                ObjectInputStream ois = new ObjectInputStream(bais)) {
+            return ois.readObject();
+        }
+    }
+
+    private static class TestParentComponent extends Component implements HasComponents {
+
+        private static final long serialVersionUID = 1L;
+
+        public TestParentComponent(Component... components) {
+            super(new Element(Tag.DIV));
+            add(components);
+        }
+    }
+
+    private static class TestChildComponent extends Component {
+
+        private static final long serialVersionUID = 1L;
+
+        public TestChildComponent() {
+            super(new Element(Tag.DIV));
+        }
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
@@ -25,9 +25,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EventObject;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -1435,7 +1437,11 @@ public class RouterTest extends RoutingTestBase {
 
         router.navigate(ui, new Location(""), NavigationTrigger.PROGRAMMATIC);
 
-        router.navigate(ui, new Location("reroute"),
+        Map<String, String> params = new HashMap<>();
+        params.put("foo", "bar");
+        QueryParameters queryParameters = QueryParameters.simple(params);
+
+        router.navigate(ui, new Location("reroute", queryParameters),
                 NavigationTrigger.PROGRAMMATIC);
 
         Assert.assertEquals("Expected event amount was wrong", 1,
@@ -1450,6 +1456,15 @@ public class RouterTest extends RoutingTestBase {
                 ReroutingNavigationTarget.events.get(0).getClass());
         Assert.assertEquals(BeforeEnterEvent.class,
                 FooBarNavigationTarget.events.get(0).getClass());
+
+        QueryParameters rerouteQueryParameters = FooBarNavigationTarget.events
+                .get(0).getLocation().getQueryParameters();
+        Assert.assertNotNull(rerouteQueryParameters);
+
+        List<String> foo = rerouteQueryParameters.getParameters().get("foo");
+        Assert.assertNotNull(foo);
+        Assert.assertFalse(foo.isEmpty());
+        Assert.assertEquals(foo.get(0), "bar");
     }
 
     @Test
@@ -2462,8 +2477,8 @@ public class RouterTest extends RoutingTestBase {
 
         Assert.assertEquals(MyTheme.class, themeObject.getClass());
     }
-    
-    
+
+
     @Test
     public void theme_is_not_gotten_from_the_super_class_when_in_npm_mode()
             throws InvalidRouteConfigurationException, Exception {

--- a/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
@@ -1,7 +1,7 @@
 package com.vaadin.flow.server;
 
 import javax.servlet.http.HttpServletRequest;
-
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -1097,14 +1097,14 @@ public class BootstrapHandlerTest {
                                         + "build/webcomponentsjs/webcomponents-loader.js\"></script>")));
 
         Assert.assertTrue(
-                "index.js should be added to head for ES6 browsers. (type module)",
+                "index.js should be added to head for ES6 browsers. (type module with crossorigin)",
                 allElements.stream().map(Object::toString)
                         .anyMatch(element -> element
                                 .equals("<script type=\"module\" src=\"./"
                                         + VAADIN_MAPPING
                                         + "build/index-1111.cache.js\" data-app-id=\""
                                         + testUI.getInternals().getAppId()
-                                        + "\"></script>")));
+                                        + "\" crossorigin></script>")));
 
         Assert.assertTrue(
                 "index.js should be added to head for ES5 browsers. (deferred and nomodule)",
@@ -1721,6 +1721,39 @@ public class BootstrapHandlerTest {
         Assert.assertFalse(bundle.hasAttr("defer"));
     }
 
+    @Test // #7158
+    public void getBootstrapPage_assetChunksIsAnARRAY_bootstrapParsesOk()
+            throws ServiceException {
+
+        initUI(testUI);
+
+        ClassLoader classLoader = Mockito.mock(ClassLoader.class);
+        service.setClassLoader(classLoader);
+
+        String statsJson = "{\n" + " \"errors\": [],\n" + " \"warnings\": [],\n"
+                + " \"assetsByChunkName\": {\n" + "  \"bundle\": [\n"
+                + "    \"build/vaadin-bundle-e77008557c8d410bf0dc.cache.js\",\n"
+                + "    \"build/vaadin-bundle-e77008557c8d410bf0dc.cache.js.map\"\n"
+                + "  ],\n" + "  \"bundle.es5\": [\n"
+                + "    \"build/vaadin-bundle.es5-e71a5a09679e828010c4.cache.js\",\n"
+                + "    \"build/vaadin-bundle.es5-e71a5a09679e828010c4.cache.js.map\"\n"
+                + "  ]" + " }" + "}";
+
+        Mockito.when(classLoader.getResourceAsStream(Mockito.anyString()))
+                .thenReturn(new ByteArrayInputStream(statsJson.getBytes()));
+
+        BootstrapContext bootstrapContext = new BootstrapContext(request, null,
+                session, testUI, this::contextRootRelativePath);
+        Document page = pageBuilder.getBootstrapPage(bootstrapContext);
+
+        Elements scripts = page.head().getElementsByTag("script");
+
+        Element bundle = scripts.stream().filter(el -> el.attr("src")
+                .equals("./VAADIN/build/vaadin-bundle-e77008557c8d410bf0dc.cache.js"))
+                .findFirst().get();
+        Assert.assertFalse(bundle.hasAttr("defer"));
+    }
+
     private void assertStringEquals(String message, String expected,
             String actual) {
         Assert.assertThat(message,
@@ -1841,5 +1874,28 @@ public class BootstrapHandlerTest {
 
         Assert.assertTrue(
                 testUI.getReconnectDialogConfiguration().isDialogModal());
+    }
+
+    @Test
+    public void safari_10_1_script_nomodule_fix_index_appended_to_head_in_npm()
+            throws InvalidRouteConfigurationException {
+        WebBrowser mockedWebBrowser = Mockito.mock(WebBrowser.class);
+        Mockito.when(session.getBrowser()).thenReturn(mockedWebBrowser);
+        Mockito.when(mockedWebBrowser.isEs6Supported()).thenReturn(true);
+        Mockito.when(mockedWebBrowser.isSafari()).thenReturn(true);
+        Mockito.when(mockedWebBrowser.getBrowserMajorVersion()).thenReturn(10);
+        Mockito.when(mockedWebBrowser.getBrowserMinorVersion()).thenReturn(1);
+
+        initUI(testUI, createVaadinRequest(),
+                Collections.singleton(MyThemeTest.class));
+
+        Document page = pageBuilder.getBootstrapPage(new BootstrapContext(
+                request, null, session, testUI, this::contextRootRelativePath));
+
+        Elements allElements = page.head().getAllElements();
+        Assert.assertTrue("fix for Safari 10.1 script nomodule should be added",
+                allElements.stream().map(Object::toString)
+                        .anyMatch(element -> element.contains(
+                                BootstrapHandler.SAFARI_10_1_SCRIPT_NOMODULE_FIX)));
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/WebComponentProviderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/WebComponentProviderTest.java
@@ -18,9 +18,9 @@ package com.vaadin.flow.server.communication;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletResponse;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -308,12 +308,11 @@ public class WebComponentProviderTest {
 
         WebComponentExporter.WebComponentConfigurationFactory factory = new WebComponentExporter.WebComponentConfigurationFactory();
 
-        registry.setConfigurations(
-                (Set<WebComponentConfiguration<? extends Component>>) set
-                        .stream()
-                        .map(clazz -> new DefaultWebComponentExporterFactory(
-                                clazz).create())
-                        .map(factory::create).collect(Collectors.toSet()));
+        Set<WebComponentConfiguration<? extends Component>> configurations = new HashSet<>();
+        for (Class<? extends WebComponentExporter<? extends Component>> exporter : exporters)
+            configurations.add(factory.create(
+                    new DefaultWebComponentExporterFactory(exporter).create()));
+        registry.setConfigurations(configurations);
 
         return registry;
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdateImportsTest.java
@@ -96,7 +96,7 @@ public abstract class AbstractNodeUpdateImportsTest extends NodeUpdateTestUtil {
         ClassFinder classFinder = getClassFinder();
         updater = new TaskUpdateImports(classFinder, getScanner(classFinder),
                 finder -> null, tmpRoot, generatedPath, frontendDirectory, null,
-                null) {
+                null, false) {
             @Override
             Logger log() {
                 if (useMockLog) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
@@ -41,6 +41,7 @@ import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 import elemental.json.Json;
 import elemental.json.JsonObject;
 import elemental.json.JsonValue;
+
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
 import static elemental.json.impl.JsonUtil.stringify;
@@ -63,6 +64,8 @@ public abstract class AbstractNodeUpdatePackagesTest
     private File generatedDir;
     private File packageJson;
 
+    private ClassFinder classFinder;
+
     private File mainNodeModules;
     private File packageLock;
     private File appNodeModules;
@@ -73,14 +76,14 @@ public abstract class AbstractNodeUpdatePackagesTest
 
         generatedDir = new File(baseDir, DEFAULT_GENERATED_DIR);
 
-        NodeUpdateTestUtil
-                .createStubNode(true, true, baseDir.getAbsolutePath());
+        NodeUpdateTestUtil.createStubNode(true, true,
+                baseDir.getAbsolutePath());
 
         packageCreator = new TaskCreatePackageJson(baseDir, generatedDir);
 
-        ClassFinder classFinder = getClassFinder();
+        classFinder = getClassFinder();
         packageUpdater = new TaskUpdatePackages(classFinder,
-                getScanner(classFinder), baseDir, generatedDir, false);
+                getScanner(classFinder), baseDir, generatedDir, false, true);
         packageJson = new File(baseDir, PACKAGE_JSON);
 
         mainNodeModules = new File(baseDir, FrontendUtils.NODE_MODULES);
@@ -146,14 +149,78 @@ public abstract class AbstractNodeUpdatePackagesTest
         makeNodeModulesAndPackageLock();
 
         // Change the versions
-        getDependencies(packageUpdater.getPackageJson())
-                .put(SHRINKWRAP, "1.1.1");
+        getDependencies(packageUpdater.getPackageJson()).put(SHRINKWRAP,
+                "1.1.1");
 
         // run it again with existing generated package.json and mismatched
         // versions
         packageUpdater.execute();
 
         assertVersionAndCleanUp();
+    }
+
+    @Test
+    public void pnpmIsInUse_packageJsonContainsFlowDeps_removeFlowDeps()
+            throws IOException {
+        // use package updater with disabled PNPM
+        packageUpdater = new TaskUpdatePackages(classFinder,
+                getScanner(classFinder), baseDir, generatedDir, false, true);
+        // Generate package json in a proper format first
+        packageCreator.execute();
+        packageUpdater.execute();
+
+        packageUpdater = new TaskUpdatePackages(classFinder,
+                getScanner(classFinder), baseDir, generatedDir, false, false);
+        packageUpdater.execute();
+
+        assertPackageJsonFlowDeps();
+    }
+
+    @Test
+    public void pnpmIsInUse_packageLockExists_removePackageLock()
+            throws IOException {
+        // use package updater with disabled PNPM
+        packageUpdater = new TaskUpdatePackages(classFinder,
+                getScanner(classFinder), baseDir, generatedDir, false, true);
+        // Generate package json in a proper format first
+        packageCreator.execute();
+        packageUpdater.execute();
+
+        Files.write(packageLock.toPath(), Collections.singletonList("{}"));
+
+        packageUpdater = new TaskUpdatePackages(classFinder,
+                getScanner(classFinder), baseDir, generatedDir, false, false);
+        packageUpdater.execute();
+        Assert.assertFalse(packageLock.exists());
+    }
+
+    @Test
+    public void npmIsInUse_packageJsonContainsFlowDeps_removeFlowDeps()
+            throws IOException {
+        // Generate package json in a proper format first
+        packageCreator.execute();
+        packageUpdater.execute();
+
+        JsonObject packJsonObject = getPackageJson(packageJson);
+        JsonObject deps = packJsonObject.get(DEPENDENCIES);
+
+        packageUpdater.execute();
+
+        assertPackageJsonFlowDeps();
+    }
+
+    @Test
+    public void npmIsInUse_packageLockJsonContainsNonPMPMDeps_packageLockNotRemoved()
+            throws IOException {
+        // use package updater with disabled PNPM
+        // Generate package json in a proper format first
+        packageCreator.execute();
+        packageUpdater.execute();
+
+        Files.write(packageLock.toPath(), Collections.singletonList("{  }"));
+
+        packageUpdater.execute();
+        Assert.assertTrue(packageLock.exists());
     }
 
     /**
@@ -206,36 +273,23 @@ public abstract class AbstractNodeUpdatePackagesTest
     }
 
     @Test
-    public void versionsDoNotMatch_inMainJson_cleanUp() throws IOException {
-        FrontendDependencies frontendDependencies = Mockito
-                .mock(FrontendDependencies.class);
-
-        Map<String, String> packages = new HashMap<>();
-        packages.put("@polymer/iron-list", "3.0.2");
-        packages.put("@vaadin/vaadin-confirm-dialog", "1.1.4");
-        packages.put("@vaadin/vaadin-checkbox", "2.2.10");
-        packages.put("@polymer/iron-icon", "3.0.1");
-        packages.put("@vaadin/vaadin-time-picker", "2.0.2");
-        packages.put(SHRINKWRAP, "1.2.3");
-
-        Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
-
-        packageUpdater = new TaskUpdatePackages(null, frontendDependencies,
-                baseDir, generatedDir, false);
-
-        // Generate package json in a proper format first
-        packageCreator.execute();
-
-        makeNodeModulesAndPackageLock();
-
-        JsonObject packageJson = getPackageJson(this.packageJson);
-        packageJson.put(SHRINKWRAP, "1.1.1");
-        Files.write(packageLock.toPath(),
-                Collections.singletonList(stringify(packageJson)));
-
-        packageUpdater.execute();
-
+    public void versionsDoNotMatch_inMainJson_npm_cleanUp() throws IOException {
+        versionsDoNotMatch_inMainJson_cleanUp(true);
         assertVersionAndCleanUp();
+    }
+
+    @Test
+    public void versionsDoNotMatch_inMainJson_pnpm_cleanUp()
+            throws IOException {
+        versionsDoNotMatch_inMainJson_cleanUp(true);
+        JsonValue value = getDependencies(packageUpdater.getPackageJson())
+                .get(SHRINKWRAP);
+        Assert.assertEquals("1.2.3", value.asString());
+
+        // nothing is removed
+        Assert.assertFalse(mainNodeModules.exists());
+        Assert.assertFalse(appNodeModules.exists());
+        Assert.assertFalse(packageLock.exists());
     }
 
     @Test
@@ -254,7 +308,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
         packageUpdater = new TaskUpdatePackages(null, frontendDependencies,
-                baseDir, generatedDir, false);
+                baseDir, generatedDir, false, true);
 
         // Generate package json in a proper format first
         packageCreator.execute();
@@ -283,7 +337,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         ClassFinder classFinder = getClassFinder();
         // create a new package updater, with forced clean up enabled
         packageUpdater = new TaskUpdatePackages(classFinder,
-                getScanner(classFinder), baseDir, generatedDir, true);
+                getScanner(classFinder), baseDir, generatedDir, true, true);
         packageUpdater.execute();
 
         // clean up happened
@@ -305,7 +359,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
         packageUpdater = new TaskUpdatePackages(null, frontendDependencies,
-                baseDir, generatedDir, false);
+                baseDir, generatedDir, false, true);
 
         packageCreator.execute();
         packageUpdater.execute();
@@ -335,7 +389,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
         packageUpdater = new TaskUpdatePackages(null, frontendDependencies,
-                baseDir, generatedDir, false);
+                baseDir, generatedDir, false, true);
 
         packageCreator.execute();
         packageUpdater.execute();
@@ -380,7 +434,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
         packageUpdater = new TaskUpdatePackages(null, frontendDependencies,
-                baseDir, generatedDir, false);
+                baseDir, generatedDir, false, true);
 
         packageCreator.execute();
         packageUpdater.execute();
@@ -411,7 +465,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
         packageUpdater = new TaskUpdatePackages(null, frontendDependencies,
-                baseDir, generatedDir, false);
+                baseDir, generatedDir, false, true);
 
         packageCreator.execute();
         packageUpdater.execute();
@@ -434,7 +488,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
         packageUpdater = new TaskUpdatePackages(null, frontendDependencies,
-                baseDir, generatedDir, false);
+                baseDir, generatedDir, false, true);
 
         packageCreator.execute();
         packageUpdater.execute();
@@ -460,7 +514,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
         packageUpdater = new TaskUpdatePackages(null, frontendDependencies,
-                baseDir, generatedDir, false);
+                baseDir, generatedDir, false, true);
 
         packageCreator.execute();
         packageUpdater.execute();
@@ -488,7 +542,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
         packageUpdater = new TaskUpdatePackages(null, frontendDependencies,
-                baseDir, generatedDir, false);
+                baseDir, generatedDir, false, true);
 
         packageCreator.execute();
         JsonObject json = getPackageJson(packageJson);
@@ -521,7 +575,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
         packageUpdater = new TaskUpdatePackages(null, frontendDependencies,
-                baseDir, generatedDir, false);
+                baseDir, generatedDir, false, true);
 
         packageCreator.execute();
         packageUpdater.execute();
@@ -567,7 +621,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
         packageUpdater = new TaskUpdatePackages(null, frontendDependencies,
-                baseDir, generatedDir, false);
+                baseDir, generatedDir, false, true);
 
         packageCreator.execute();
         packageUpdater.execute();
@@ -614,8 +668,7 @@ public abstract class AbstractNodeUpdatePackagesTest
 
         JsonObject dependencies = json.getObject(DEPENDENCIES);
         for (Map.Entry<String, String> entry : NodeUpdater
-                .getDefaultDependencies()
-                .entrySet()) {
+                .getDefaultDependencies().entrySet()) {
             Assert.assertTrue("Missing '" + entry.getKey() + "' package",
                     dependencies.hasKey(entry.getKey()));
         }
@@ -650,11 +703,51 @@ public abstract class AbstractNodeUpdatePackagesTest
         return object;
     }
 
+    private void versionsDoNotMatch_inMainJson_cleanUp(boolean isNpm)
+            throws IOException {
+        FrontendDependencies frontendDependencies = Mockito
+                .mock(FrontendDependencies.class);
+
+        Map<String, String> packages = new HashMap<>();
+        packages.put("@polymer/iron-list", "3.0.2");
+        packages.put("@vaadin/vaadin-confirm-dialog", "1.1.4");
+        packages.put("@vaadin/vaadin-checkbox", "2.2.10");
+        packages.put("@polymer/iron-icon", "3.0.1");
+        packages.put("@vaadin/vaadin-time-picker", "2.0.2");
+        packages.put(SHRINKWRAP, "1.2.3");
+
+        Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
+
+        packageUpdater = new TaskUpdatePackages(null, frontendDependencies,
+                baseDir, generatedDir, false, isNpm);
+
+        // Generate package json in a proper format first
+        packageCreator.execute();
+
+        makeNodeModulesAndPackageLock();
+
+        JsonObject packageJson = getPackageJson(this.packageJson);
+        packageJson.put(SHRINKWRAP, "1.1.1");
+        Files.write(packageLock.toPath(),
+                Collections.singletonList(stringify(packageJson)));
+
+        packageUpdater.execute();
+    }
+
+    private void assertPackageJsonFlowDeps() throws IOException {
+        JsonObject packJsonObject = getPackageJson(packageJson);
+        JsonObject deps = packJsonObject.get(DEPENDENCIES);
+        // No Flow deps
+        Assert.assertFalse(deps.hasKey("@vaadin/flow-deps"));
+        // Contains initially generated default polymer dep
+        Assert.assertTrue(deps.hasKey("@polymer/polymer"));
+    }
+
     JsonObject getPackageJson(File packageFile) throws IOException {
         JsonObject packageJson = null;
         if (packageFile.exists()) {
-            String fileContent = FileUtils
-                    .readFileToString(packageFile, UTF_8.name());
+            String fileContent = FileUtils.readFileToString(packageFile,
+                    UTF_8.name());
             packageJson = Json.parse(fileContent);
         }
         return packageJson;

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateImportsTest.java
@@ -112,7 +112,7 @@ public class NodeUpdateImportsTest extends NodeUpdateTestUtil {
                 finder -> new FrontendDependenciesScannerFactory()
                         .createScanner(true, finder, true),
                 tmpRoot, generatedPath, frontendDirectory, tokenFile,
-                fallBackData) {
+                fallBackData, false) {
             @Override
             Logger log() {
                 return logger;
@@ -230,7 +230,8 @@ public class NodeUpdateImportsTest extends NodeUpdateTestUtil {
                         classFinder, true),
                 finder -> new FrontendDependenciesScannerFactory()
                         .createScanner(true, finder, true),
-                tmpRoot, generatedPath, frontendDirectory, tokenFile, null) {
+                tmpRoot, generatedPath, frontendDirectory, tokenFile, null,
+                false) {
             @Override
             Logger log() {
                 return logger;
@@ -299,7 +300,7 @@ public class NodeUpdateImportsTest extends NodeUpdateTestUtil {
                 new FrontendDependenciesScannerFactory().createScanner(false,
                         classFinder, true),
                 finder -> null, tmpRoot, generatedPath, frontendDirectory,
-                tokenFile, null) {
+                tokenFile, null, false) {
             @Override
             Logger log() {
                 return logger;
@@ -344,7 +345,7 @@ public class NodeUpdateImportsTest extends NodeUpdateTestUtil {
                 new FrontendDependenciesScannerFactory().createScanner(false,
                         classFinder, true),
                 finder -> null, tmpRoot, generatedPath, frontendDirectory,
-                tokenFile, null) {
+                tokenFile, null, false) {
             @Override
             Logger log() {
                 return logger;

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/UpdateThemedImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/UpdateThemedImportsTest.java
@@ -142,7 +142,7 @@ public class UpdateThemedImportsTest extends NodeUpdateTestUtil {
             }
         };
         updater = new TaskUpdateImports(finder, deps, cf -> null, tmpRoot,
-                generatedPath, frontendDirectory, null, null);
+                generatedPath, frontendDirectory, null, null, false);
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/ApplicationRouteRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/ApplicationRouteRegistryTest.java
@@ -2,8 +2,11 @@ package com.vaadin.flow.server.startup;
 
 import javax.servlet.ServletContext;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -17,6 +20,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.router.RouteBaseData;
+import com.vaadin.flow.router.internal.ErrorTargetEntry;
 import com.vaadin.flow.server.RouteRegistry;
 import com.vaadin.flow.server.VaadinServletContext;
 
@@ -351,6 +355,20 @@ public class ApplicationRouteRegistryTest extends RouteRegistryTestBase {
         Assert.assertEquals(
                 "Removing the alias route should be seen in the event", 1,
                 removed.size());
+    }
+
+    @Test
+    public void setErrorNavigationTargets_abstractClassesAreIgnored() {
+        registry.setErrorNavigationTargets(new HashSet<>(
+                Arrays.asList(ErrorView.class, AbstractErrorView.class)));
+
+        Optional<ErrorTargetEntry> errorNavigationTarget = registry
+                .getErrorNavigationTarget(new NullPointerException());
+
+        Assert.assertTrue("Error navigation target was not registered",
+                errorNavigationTarget.isPresent());
+        Assert.assertEquals("Wrong errorNavigationTarget was registered",
+                ErrorView.class, errorNavigationTarget.get().getNavigationTarget());
     }
 
     @Override

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/RouteRegistryTestBase.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/RouteRegistryTestBase.java
@@ -27,6 +27,9 @@ import org.junit.Test;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.ErrorParameter;
+import com.vaadin.flow.router.HasErrorParameter;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteAlias;
 import com.vaadin.flow.router.RouteData;
@@ -274,5 +277,20 @@ public abstract class RouteRegistryTestBase {
     @Tag("div")
     protected static class MiddleLayout extends Component
             implements RouterLayout {
+    }
+
+    @Tag("div")
+    public static abstract class AbstractErrorView<EXCEPTION_TYPE extends Exception> extends Component implements
+            HasErrorParameter<EXCEPTION_TYPE> {
+    }
+
+    @Tag("div")
+    public static class ErrorView extends AbstractErrorView<NullPointerException> {
+
+        @Override
+        public int setErrorParameter(BeforeEnterEvent event,
+                ErrorParameter<NullPointerException> parameter) {
+            return 0;
+        }
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/WebComponentConfigurationRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/WebComponentConfigurationRegistryTest.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.server.webcomponent;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
@@ -29,7 +30,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import net.jcip.annotations.NotThreadSafe;
 import org.junit.Assert;
@@ -252,11 +252,13 @@ public class WebComponentConfigurationRegistryTest {
     protected Set<WebComponentConfiguration<? extends Component>> createConfigurations(
             Class<? extends WebComponentExporter<? extends Component>>... exporters) {
         WebComponentExporter.WebComponentConfigurationFactory factory = new WebComponentExporter.WebComponentConfigurationFactory();
-        return (Set<WebComponentConfiguration<? extends Component>>) Stream
-                .of(exporters)
-                .map(clazz -> new DefaultWebComponentExporterFactory(clazz)
-                        .create())
-                .map(factory::create).collect(Collectors.toSet());
+
+        Set<WebComponentConfiguration<? extends Component>> configurations = new HashSet<>();
+        for (Class<? extends WebComponentExporter<? extends Component>> exporter : exporters)
+            configurations.add(factory
+                    .create(new DefaultWebComponentExporterFactory(exporter)
+                            .create()));
+        return configurations;
     }
 
     protected class MyComponent extends Component {

--- a/flow-tests/test-memory-leaks/src/test/java/com/vaadin/flow/memoryleaks/ui/RedeployLeakIT.java
+++ b/flow-tests/test-memory-leaks/src/test/java/com/vaadin/flow/memoryleaks/ui/RedeployLeakIT.java
@@ -89,7 +89,7 @@ public class RedeployLeakIT extends AbstractTestBenchTest {
         // DO NOT RUN FROM ECLIPSE
         // The test uses files from the target folder
         setup(7778);
-        RemoteWebDriver driver = new RemoteWebDriver(DesiredCapabilities.chrome());
+        RemoteWebDriver driver = new RemoteWebDriver(Browser.CHROME.getDesiredCapabilities());
         try {
             driver.get("http://"+ getCurrentHostAddress() + ":7778/");
             Assert.assertNotNull(driver.findElement(By.id("hello")));

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ElementInnerHtmlView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ElementInnerHtmlView.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+@Route(value = "com.vaadin.flow.uitest.ui.ElementInnerHtmlView", layout = ViewTestLayout.class)
+public class ElementInnerHtmlView extends AbstractDivView {
+
+    Div innerHtml;
+
+    @Override
+    protected void onShow() {
+        innerHtml = new Div();
+        innerHtml.setId("inner-html-field");
+        add(createButton("Foo"), createButton("Boo"), getNullButton(),
+                innerHtml);
+
+    }
+
+    private NativeButton createButton(String value) {
+        NativeButton button = new NativeButton("Set value " + value,
+                click -> innerHtml.getElement().setProperty("innerHTML",
+                        String.format("<p>%s</p>", value)));
+        button.setId("set-" + value.toLowerCase());
+        return button;
+    }
+
+    private NativeButton getNullButton() {
+        NativeButton button = new NativeButton("Set value null",
+                click -> innerHtml.getElement().setProperty("innerHTML", null));
+        button.setId("set-null");
+        return button;
+    }
+
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/VerifyBrowserVersionIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/VerifyBrowserVersionIT.java
@@ -25,7 +25,7 @@ public class VerifyBrowserVersionIT extends ChromeBrowserTest {
             // Chrome version does not necessarily match the desired version
             // because of auto updates...
             browserIdentifier = getExpectedUserAgentString(
-                    getDesiredCapabilities()) + "78";
+                    getDesiredCapabilities()) + "79";
         } else if (BrowserUtil.isFirefox(getDesiredCapabilities())) {
             browserIdentifier = getExpectedUserAgentString(
                     getDesiredCapabilities()) + "58";

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ElementInnerHtmlIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ElementInnerHtmlIT.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.html.testbench.DivElement;
+import com.vaadin.flow.component.html.testbench.NativeButtonElement;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class ElementInnerHtmlIT extends ChromeBrowserTest {
+
+    @Test
+    public void elementInitOrder() {
+        open();
+        DivElement innerHtml = $(DivElement.class).id("inner-html-field");
+
+        Assert.assertEquals("", innerHtml.getPropertyString("innerHTML"));
+
+        $(NativeButtonElement.class).id("set-foo").click();
+        Assert.assertEquals("<p>Foo</p>", innerHtml.getPropertyString("innerHTML"));
+
+        $(NativeButtonElement.class).id("set-foo").click();
+        Assert.assertEquals("<p>Foo</p>", innerHtml.getPropertyString("innerHTML"));
+
+        $(NativeButtonElement.class).id("set-boo").click();
+        Assert.assertEquals("<p>Boo</p>", innerHtml.getPropertyString("innerHTML"));
+
+        $(NativeButtonElement.class).id("set-boo").click();
+        Assert.assertEquals("<p>Boo</p>", innerHtml.getPropertyString("innerHTML"));
+
+        $(NativeButtonElement.class).id("set-null").click();
+        Assert.assertEquals("", innerHtml.getPropertyString("innerHTML"));
+
+    }
+}


### PR DESCRIPTION
It is a very common use case in complex form that whether a field is required or not, it depends on input on other fields. Hypothetical use case sample could be that we have form for a Product and price of the product is needed except in case the Product's type is Sample. So in that kind of scenarios it would be needed to turn off asRequired() validation easily. The purpose of this enhancement and new binding.setAsRequiredEnabled(..) API is to help implementation of this kind of use cases more easily.

There is more generic ticket about conditional validation, and this PR is partially addressing it #10709

Cherry pick from https://github.com/vaadin/framework/pull/11834

Requested in https://github.com/vaadin/flow/issues/5030

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7098)
<!-- Reviewable:end -->
