### PR TITLE
CCDM: implement proper getChildren in JavaScriptBootstrapUI

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUI.java
@@ -17,9 +17,12 @@ package com.vaadin.flow.component.internal;
 
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.Stream.Builder;
 
 import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
@@ -55,6 +58,22 @@ public class JavaScriptBootstrapUI extends UI {
      */
     public JavaScriptBootstrapUI() {
         super(new JavaScriptUIInternalUpdater());
+    }
+
+    @Override
+    public Stream<Component> getChildren() {
+        // server-side routing
+        if (wrapperElement == null) {
+            return super.getChildren();
+        }
+
+        // client-side routing,
+        // since virtual child is used, it is necessary to change the original
+        // UI element to the wrapperElement
+        Builder<Component> childComponents = Stream.builder();
+        wrapperElement.getChildren().forEach(childElement -> ComponentUtil
+                .findComponents(childElement, childComponents::add));
+        return childComponents.build();
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
@@ -1,8 +1,8 @@
 package com.vaadin.flow.component.internal;
 
 import java.util.Collections;
+import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertFalse;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -20,6 +20,7 @@ import com.vaadin.flow.server.VaadinRequest;
 
 import static com.vaadin.flow.component.internal.JavaScriptBootstrapUI.SERVER_ROUTING;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -90,6 +91,12 @@ public class JavaScriptBootstrapUITest  {
         ui.connectClient("foo", "bar", "/dirty");
         assertEquals(Tag.SPAN, ui.wrapperElement.getChild(0).getTag());
         assertEquals(Tag.H1, ui.wrapperElement.getChild(0).getChild(0).getTag());
+    }
+
+    @Test
+    public void getChildren_should_notReturnAnEmptyList() {
+        ui.connectClient("foo", "bar", "/clean");
+        assertEquals(1, ui.getChildren().count());
     }
 
     @Test


### PR DESCRIPTION
Fixes issue described in thread https://vaadin.slack.com/archives/CDNTYMS9H/p1575461414031000:

> Various parts of the app find the main layout through `UI.getCurrent().getChildren` It is some kind of custom DI
>
> ok, then in the `JavaScriptUI` we need to override `getChildren` so as it returns the actual elements added to the wrapper used for inserting the server views in the router outlet

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7104)
<!-- Reviewable:end -->
