### PR TITLE
Fix using host value from the request

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -612,7 +612,7 @@ public class FrontendUtils {
         String host = request.getHeader("host");
         if (host == null) {
             host = "http://127.0.0.1:8080";
-        } else {
+        } else if (!host.contains("://")) {
             String scheme = request.getHeader("scheme");
             if (scheme == null) {
                 scheme = "http";

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -575,6 +575,8 @@ public class FrontendUtils {
             String host = request.getHeader("host");
             if (host == null) {
                 host = "http://127.0.0.1:8080";
+            } else {
+                host = "http://" + host;
             }
             url = host + externalStatsUrl;
         } else {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -50,7 +50,6 @@ import com.vaadin.flow.server.frontend.FallbackChunk.CssImportData;
 
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
-
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_STATISTICS_JSON;
 import static com.vaadin.flow.server.Constants.STATISTICS_JSON_DEFAULT;
 import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
@@ -572,13 +571,7 @@ public class FrontendUtils {
         // else fallback on 127.0.0.1:8080
         if (externalStatsUrl.startsWith("/")) {
             VaadinRequest request = VaadinRequest.getCurrent();
-            String host = request.getHeader("host");
-            if (host == null) {
-                host = "http://127.0.0.1:8080";
-            } else {
-                host = "http://" + host;
-            }
-            url = host + externalStatsUrl;
+            url = getHostString(request) + externalStatsUrl;
         } else {
             url = externalStatsUrl;
         }
@@ -613,6 +606,20 @@ public class FrontendUtils {
                     url, e);
         }
         return null;
+    }
+
+    private static String getHostString(VaadinRequest request) {
+        String host = request.getHeader("host");
+        if (host == null) {
+            host = "http://127.0.0.1:8080";
+        } else {
+            String scheme = request.getHeader("scheme");
+            if (scheme == null) {
+                scheme = "http";
+            }
+            host = scheme + "://" + host;
+        }
+        return host;
     }
 
     private static InputStream getStatsFromClassPath(VaadinService service) {


### PR DESCRIPTION
When using the host value from the request header
we need to add the transport as
host only contains the server and port.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7115)
<!-- Reviewable:end -->
