### PR TITLE
During war deployment, WebLogic puts WEB-INF/classes contents into a jar called _wl_cls_gen.jar; accept this jar when searching resources for the token file

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
@@ -88,6 +88,9 @@ public final class DeploymentConfigurationFactory implements Serializable {
 
     public static final String DEV_FOLDER_MISSING_MESSAGE = "Running project in development mode with no access to folder '%s'.%n"
             + "Build project in production mode instead, see https://vaadin.com/docs/v14/flow/production/tutorial-production-mode-basic.html";
+
+    private static final String WEBLOGIC_GENERATED_JAR = "_wl_cls_gen.jar";
+
     private static final Logger logger = LoggerFactory
             .getLogger(DeploymentConfigurationFactory.class);
 
@@ -301,8 +304,12 @@ public final class DeploymentConfigurationFactory implements Serializable {
                         .getResources(tokenResource));
         // Accept resource that doesn't contain
         // 'jar!/META-INF/Vaadin/config/flow-build-info.json'
+        // #6965 Oracle WebLogic repackages resources in a generated jar called
+        // called '_wl_cls_gen.jar', so accept the token file if in there also.
         URL resource = resources.stream()
-                .filter(url -> !url.getPath().endsWith("jar!/" + tokenResource))
+                .filter(url -> !url.getPath().endsWith("jar!/" + tokenResource)
+                        || url.getPath().endsWith(
+                                WEBLOGIC_GENERATED_JAR + "!/" + tokenResource))
                 .findFirst().orElse(null);
         if (resource == null && !resources.isEmpty()) {
             // For no non jar build info, in production mode check for


### PR DESCRIPTION
When deploying a war, WebLogic repackages everything inside `WEB-INF/classes` into a jar called `_wl_cls_gen.jar`. Since the resource filtering skipped everything that ends with `jar!<TOKENFILE>` the token file was not found.

Added a special case for WebLogic. Please advice if there are other places where the same peculiarity may cause breakage so they can be patched as well.

Fixes #6965.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7118)
<!-- Reviewable:end -->
