### PR TITLE
Add explicit "crossorigin" attribute to bundle script tag in bootstrap

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -908,9 +908,11 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                     Element script = createJavaScriptElement(
                             "./" + VAADIN_MAPPING + chunks.getString(key),
                             false);
-                    head.appendChild(
-                            script.attr("type", "module").attr("data-app-id",
-                                    context.getUI().getInternals().getAppId()));
+                    head.appendChild(script.attr("type", "module")
+                            .attr("data-app-id",
+                                    context.getUI().getInternals().getAppId())
+                            // Fixes basic auth in Safari #6560
+                            .attr("crossorigin", true));
                 }
             }
         }

--- a/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
@@ -1097,14 +1097,14 @@ public class BootstrapHandlerTest {
                                         + "build/webcomponentsjs/webcomponents-loader.js\"></script>")));
 
         Assert.assertTrue(
-                "index.js should be added to head for ES6 browsers. (type module)",
+                "index.js should be added to head for ES6 browsers. (type module with crossorigin)",
                 allElements.stream().map(Object::toString)
                         .anyMatch(element -> element
                                 .equals("<script type=\"module\" src=\"./"
                                         + VAADIN_MAPPING
                                         + "build/index-1111.cache.js\" data-app-id=\""
                                         + testUI.getInternals().getAppId()
-                                        + "\"></script>")));
+                                        + "\" crossorigin></script>")));
 
         Assert.assertTrue(
                 "index.js should be added to head for ES5 browsers. (deferred and nomodule)",


### PR DESCRIPTION
Workaround for Safari not asking credentials when requesting the bundle. See: https://stackoverflow.com/questions/56557082/safari-blocked-https-from-asking-for-credentials-because-it-is-a-cross-o
 
Fixes #6560. Fixes #7087.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7124)
<!-- Reviewable:end -->
