### PR TITLE
Use recommended API to get chrome capabilities

### DIFF
--- a/flow-tests/test-memory-leaks/src/test/java/com/vaadin/flow/memoryleaks/ui/RedeployLeakIT.java
+++ b/flow-tests/test-memory-leaks/src/test/java/com/vaadin/flow/memoryleaks/ui/RedeployLeakIT.java
@@ -89,7 +89,7 @@ public class RedeployLeakIT extends AbstractTestBenchTest {
         // DO NOT RUN FROM ECLIPSE
         // The test uses files from the target folder
         setup(7778);
-        RemoteWebDriver driver = new RemoteWebDriver(DesiredCapabilities.chrome());
+        RemoteWebDriver driver = new RemoteWebDriver(Browser.CHROME.getDesiredCapabilities());
         try {
             driver.get("http://"+ getCurrentHostAddress() + ":7778/");
             Assert.assertNotNull(driver.findElement(By.id("hello")));


### PR DESCRIPTION
DesiredCapabilities.chrome will be deprecated and removed.
Current usage results in logged warnings "Using `new ChromeOptions()` is preferred to `DesiredCapabilities.chrome()`"
https://github.com/SeleniumHQ/selenium/blob/selenium-3.141.59/java/client/src/org/openqa/selenium/remote/DesiredCapabilities.java#L115-L118

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7138)
<!-- Reviewable:end -->
