### PR TITLE
Handle possible array 2.1 (#7159)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -78,6 +78,7 @@ import com.vaadin.flow.theme.ThemeDefinition;
 import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
+import elemental.json.JsonType;
 import elemental.json.JsonValue;
 import elemental.json.impl.JsonUtil;
 
@@ -883,15 +884,21 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             }
             JsonObject chunks = Json.parse(content);
             for (String key : chunks.keys()) {
+                String chunkName;
+                if(chunks.get(key).getType().equals(JsonType.ARRAY)) {
+                    chunkName = getArrayChunkName(chunks, key);
+                } else {
+                    chunkName = chunks.getString(key);
+                }
                 if (key.endsWith(".es5")) {
                     Element script = createJavaScriptElement(
-                            "./" + VAADIN_MAPPING + chunks.getString(key));
+                            "./" + VAADIN_MAPPING + chunkName);
                     head.appendChild(
                             script.attr("nomodule", true).attr("data-app-id",
                                     context.getUI().getInternals().getAppId()));
                 } else {
                     Element script = createJavaScriptElement(
-                            "./" + VAADIN_MAPPING + chunks.getString(key),
+                            "./" + VAADIN_MAPPING + chunkName,
                             false);
                     head.appendChild(script.attr("type", "module")
                             .attr("data-app-id",
@@ -900,6 +907,18 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                             .attr("crossorigin", true));
                 }
             }
+        }
+
+        private String getArrayChunkName(JsonObject chunks, String key) {
+            JsonArray chunkArray = chunks.getArray(key);
+
+            for(int i = 0; i <chunkArray.length(); i++) {
+                String chunkName = chunkArray.getString(0);
+                if(chunkName.endsWith(".js")){
+                    return chunkName;
+                }
+            }
+            return "";
         }
 
         private String getClientEngineUrl(BootstrapContext context) {


### PR DESCRIPTION
If building sourcemaps for webpack
the assets array will contain an array
of bundles instead of a single string.

Fixes #7158

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7161)
<!-- Reviewable:end -->
