### PR TITLE
Allow server->server when calling navigation in the same round-trip

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
@@ -143,11 +143,12 @@ public class JavaScriptBootstrapHandler extends BootstrapHandler {
                 throw new IllegalArgumentException(e);
             }
             Location location = new Location(route);
-            ui.getRouter().initializeUI(ui, location);
 
             // App is using classic server-routing, set a session attribute
             // to know that in future navigation calls
             ui.getSession().setAttribute(SERVER_ROUTING, Boolean.TRUE);
+
+            ui.getRouter().initializeUI(ui, location);
         }
     }
 


### PR DESCRIPTION
This PR fixes a couple of issues in bookstore-example
- When updating pushState it should be delayed otherwise router will overwrite the route in the URL after navigation happens
- When calling `navigate` in a server action, it should be resolved in server-side when possible, to avoid extra round-trip or having to call page reload. This is the case in `LoginScreen.login` that calls `navigate`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7169)
<!-- Reviewable:end -->
