### PR TITLE
Copy when jar

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
@@ -19,8 +19,11 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
@@ -147,14 +150,23 @@ public class PrepareFrontendMojo extends FlowModeAbstractMojo {
                             + "'. Verify that you may write to path.", e);
         }
         try {
-            new NodeTasks.Builder(getClassFinder(project), npmFolder,
+            NodeTasks.Builder builder = new NodeTasks.Builder(getClassFinder(project), npmFolder,
                     generatedFolder, frontendDirectory)
                             .withWebpack(webpackOutputDirectory,
                                     webpackTemplate, webpackGeneratedTemplate)
                             .createMissingPackageJson(true)
                             .enableImportsUpdate(false)
-                            .enablePackagesUpdate(false).runNpmInstall(false)
-                            .build().execute();
+                            .enablePackagesUpdate(false).runNpmInstall(false);
+            // If building a jar project copy jar artifact contents now as we might
+            // not be able to read files from jar path.
+            if("jar".equals(project.getPackaging())) {
+                Set<File> jarFiles = project.getArtifacts().stream()
+                        .filter(artifact -> "jar".equals(artifact.getType()))
+                        .map(Artifact::getFile).collect(Collectors.toSet());
+                builder.copyResources(jarFiles);
+            }
+
+            builder.build().execute();
         } catch (ExecutionFailedException exception) {
             throw new MojoFailureException(
                     "Could not execute prepare-frontend goal.", exception);

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
@@ -24,7 +24,6 @@ import com.vaadin.flow.plugin.TestUtils;
 import elemental.json.Json;
 import elemental.json.JsonObject;
 import elemental.json.impl.JsonUtil;
-
 import static com.vaadin.flow.plugin.maven.BuildFrontendMojoTest.assertContainsPackage;
 import static com.vaadin.flow.plugin.maven.BuildFrontendMojoTest.getPackageJson;
 import static com.vaadin.flow.plugin.maven.BuildFrontendMojoTest.setProject;
@@ -54,6 +53,7 @@ public class PrepareFrontendMojoTest {
     private File projectBase;
     private File webpackOutputDirectory;
     private File tokenFile;
+    private MavenProject project;
 
     @Before
     public void setup() throws Exception {
@@ -62,7 +62,7 @@ public class PrepareFrontendMojoTest {
         tokenFile = new File(temporaryFolder.getRoot(),
                 VAADIN_SERVLET_RESOURCES + TOKEN_FILE);
 
-        MavenProject project = Mockito.mock(MavenProject.class);
+        project = Mockito.mock(MavenProject.class);
         Mockito.when(project.getBasedir()).thenReturn(projectBase);
 
         nodeModulesPath = new File(projectBase, NODE_MODULES);
@@ -160,6 +160,19 @@ public class PrepareFrontendMojoTest {
         JsonObject packageJsonObject = getPackageJson(packageJson);
         assertContainsPackage(packageJsonObject.getObject("dependencies"),
                 "foo");
+    }
+
+    @Test
+    public void jarPackaging_copyProjectFrontendResources()
+            throws MojoExecutionException, MojoFailureException,
+            IllegalAccessException {
+        Mockito.when(project.getPackaging()).thenReturn("jar");
+
+        ReflectionUtils.setVariableValueInObject(mojo, "project", project);
+
+        mojo.execute();
+
+        Mockito.verify(project, Mockito.atLeastOnce()).getArtifacts();
     }
 
     private void assertPackageJsonContent() throws IOException {


### PR DESCRIPTION
If packaging the project as
a jar then we will copy the
frontend files during prepare-frontend.

This way running the development
mode jar should have all frontend
files available.

Fixes #6994

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7175)
<!-- Reviewable:end -->
