### PR TITLE
Copy when jar 2.1 (#7175)

### DIFF
--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
@@ -22,7 +22,6 @@ import org.mockito.Mockito;
 import elemental.json.Json;
 import elemental.json.JsonObject;
 import elemental.json.impl.JsonUtil;
-
 import static com.vaadin.flow.plugin.maven.BuildFrontendMojoTest.assertContainsPackage;
 import static com.vaadin.flow.plugin.maven.BuildFrontendMojoTest.getPackageJson;
 import static com.vaadin.flow.plugin.maven.BuildFrontendMojoTest.setProject;
@@ -52,6 +51,7 @@ public class PrepareFrontendMojoTest {
     private File projectBase;
     private File webpackOutputDirectory;
     private File tokenFile;
+    private MavenProject project;
 
     @Before
     public void setup() throws Exception {
@@ -60,7 +60,7 @@ public class PrepareFrontendMojoTest {
         tokenFile = new File(temporaryFolder.getRoot(),
                 VAADIN_SERVLET_RESOURCES + TOKEN_FILE);
 
-        MavenProject project = Mockito.mock(MavenProject.class);
+        project = Mockito.mock(MavenProject.class);
         Mockito.when(project.getBasedir()).thenReturn(projectBase);
 
         nodeModulesPath = new File(projectBase, NODE_MODULES);
@@ -156,6 +156,19 @@ public class PrepareFrontendMojoTest {
         JsonObject packageJsonObject = getPackageJson(packageJson);
         assertContainsPackage(packageJsonObject.getObject("dependencies"),
                 "foo");
+    }
+
+    @Test
+    public void jarPackaging_copyProjectFrontendResources()
+            throws MojoExecutionException, MojoFailureException,
+            IllegalAccessException {
+        Mockito.when(project.getPackaging()).thenReturn("jar");
+
+        ReflectionUtils.setVariableValueInObject(mojo, "project", project);
+
+        mojo.execute();
+
+        Mockito.verify(project, Mockito.atLeastOnce()).getArtifacts();
     }
 
     private void assertPackageJsonContent() throws IOException {


### PR DESCRIPTION
If packaging the project as
a jar then we will copy the
frontend files during prepare-frontend.

This way running the development
mode jar should have all frontend
files available.

Fixes #6994

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7180)
<!-- Reviewable:end -->
