### PR TITLE
fix: @Transactional works in @VaadinService classes

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectController.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectController.java
@@ -54,6 +54,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.ClassUtils;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -149,13 +150,7 @@ public class VaadinConnectController {
             ApplicationContext context, String name, Object serviceBean) {
         // Check the bean type instead of the implementation type in
         // case of e.g. proxies
-        Class<?> beanType = context.getType(name);
-        if (beanType == null) {
-            throw new IllegalStateException(String.format(
-                    "Unable to determine a type for the bean with name '%s', "
-                            + "double check your bean configuration",
-                    name));
-        }
+        Class<?> beanType = ClassUtils.getUserClass(serviceBean.getClass());
 
         String serviceName = Optional
                 .ofNullable(beanType.getAnnotation(VaadinService.class))

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/VaadinConnectControllerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/VaadinConnectControllerTest.java
@@ -641,10 +641,9 @@ public class VaadinConnectControllerTest {
         ApplicationContext contextMock = mock(ApplicationContext.class);
         TestClass service = new TestClass();
         TestClass proxy = mock(TestClass.class, CALLS_REAL_METHODS);
-        String serviceBeanName = service.getClass().getSimpleName();
-        when(contextMock.getType(serviceBeanName)).thenReturn((Class) proxy.getClass());
-        Map<String, Object> annotatedBeans = Collections.singletonMap(serviceBeanName, proxy);
-        when(contextMock.getBeansWithAnnotation(VaadinService.class)).thenReturn(annotatedBeans);
+        when(contextMock.getBeansWithAnnotation(VaadinService.class))
+                .thenReturn(Collections.singletonMap(
+                        service.getClass().getSimpleName(), proxy));
 
         VaadinConnectController vaadinConnectController = new VaadinConnectController(
                 new ObjectMapper(), mock(VaadinConnectAccessChecker.class),
@@ -712,8 +711,6 @@ public class VaadinConnectControllerTest {
         String beanName = TestClassWithCustomServiceName.class.getSimpleName();
 
         ApplicationContext contextMock = mock(ApplicationContext.class);
-        when(contextMock.getType(beanName))
-                .thenReturn((Class) TestClassWithCustomServiceName.class);
         when(contextMock.getBeansWithAnnotation(VaadinService.class))
                 .thenReturn(Collections.singletonMap(beanName,
                         new TestClassWithCustomServiceName()));
@@ -738,10 +735,9 @@ public class VaadinConnectControllerTest {
         TestClassWithCustomServiceName service = new TestClassWithCustomServiceName();
         TestClassWithCustomServiceName proxy = mock(
                 TestClassWithCustomServiceName.class, CALLS_REAL_METHODS);
-        String serviceBeanName = service.getClass().getSimpleName();
-        when(contextMock.getType(serviceBeanName)).thenReturn((Class) proxy.getClass());
-        Map<String, Object> annotatedBeans = Collections.singletonMap(serviceBeanName, proxy);
-        when(contextMock.getBeansWithAnnotation(VaadinService.class)).thenReturn(annotatedBeans);
+        when(contextMock.getBeansWithAnnotation(VaadinService.class))
+                .thenReturn(Collections.singletonMap(
+                        service.getClass().getSimpleName(), proxy));
 
         VaadinConnectController vaadinConnectController = new VaadinConnectController(
                 new ObjectMapper(), mock(VaadinConnectAccessChecker.class),
@@ -1060,8 +1056,6 @@ public class VaadinConnectControllerTest {
         when(contextMock.getBeansWithAnnotation(VaadinService.class))
                 .thenReturn(Collections.singletonMap(serviceClass.getName(),
                         service));
-        when(contextMock.getType(serviceClass.getName()))
-                .thenReturn((Class) serviceClass);
 
         if (vaadinServiceMapper == null) {
             vaadinServiceMapper = new ObjectMapper();

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/VaadinConnectControllerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/VaadinConnectControllerTest.java
@@ -14,6 +14,7 @@ import java.security.Principal;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
@@ -50,6 +51,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.only;
@@ -161,20 +163,6 @@ public class VaadinConnectControllerTest {
         requestMock = mock(HttpServletRequest.class);
         when(requestMock.getUserPrincipal()).thenReturn(mock(Principal.class));
         when(requestMock.getHeader("X-Requested-With")).thenReturn("Vaadin CCDM");
-    }
-
-    @Test
-    public void should_ThrowException_When_ContextHasNoBeanData() {
-        String beanName = "test";
-
-        ApplicationContext contextMock = mock(ApplicationContext.class);
-        when(contextMock.getType(beanName)).thenReturn(null);
-        when(contextMock.getBeansWithAnnotation(VaadinService.class))
-                .thenReturn(Collections.singletonMap(beanName, null));
-        exception.expect(IllegalStateException.class);
-        exception.expectMessage(beanName);
-        new VaadinConnectController(mock(ObjectMapper.class), null, null,
-                null, contextMock);
     }
 
     @Test
@@ -648,6 +636,36 @@ public class VaadinConnectControllerTest {
     }
 
     @Test
+    public void should_ReturnCorrectResponse_When_ServiceClassIsProxied() {
+
+        ApplicationContext contextMock = mock(ApplicationContext.class);
+        TestClass service = new TestClass();
+        TestClass proxy = mock(TestClass.class, CALLS_REAL_METHODS);
+        String serviceBeanName = service.getClass().getSimpleName();
+        when(contextMock.getType(serviceBeanName)).thenReturn((Class) proxy.getClass());
+        Map<String, Object> annotatedBeans = Collections.singletonMap(serviceBeanName, proxy);
+        when(contextMock.getBeansWithAnnotation(VaadinService.class)).thenReturn(annotatedBeans);
+
+        VaadinConnectController vaadinConnectController = new VaadinConnectController(
+                new ObjectMapper(), mock(VaadinConnectAccessChecker.class),
+                mock(VaadinServiceNameChecker.class),
+                mock(ExplicitNullableTypeChecker.class), contextMock);
+
+        int inputValue = 222;
+        String expectedOutput = service.testMethod(inputValue);
+
+        ResponseEntity<String> response = vaadinConnectController
+                .serveVaadinService("TestClass", "testMethod",
+                        createRequestParameters(
+                                String.format("{\"value\": %s}", inputValue)),
+                        requestMock);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(String.format("\"%s\"", expectedOutput),
+                response.getBody());
+    }
+
+    @Test
     public void should_NotUseBridgeMethod_When_ServiceHasBridgeMethodFromInterface() {
         String inputId = "2222";
         String expectedResult = String.format("{\"id\":\"%s\"}", inputId);
@@ -708,6 +726,36 @@ public class VaadinConnectControllerTest {
                 .serveVaadinService("CustomService", "testMethod",
                         createRequestParameters(
                                 String.format("{\"value\": %s}", input)), requestMock);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(String.format("\"%s\"", expectedOutput),
+                response.getBody());
+    }
+
+    @Test
+    public void should_UseCustomServiceName_When_ServiceClassIsProxied() {
+
+        ApplicationContext contextMock = mock(ApplicationContext.class);
+        TestClassWithCustomServiceName service = new TestClassWithCustomServiceName();
+        TestClassWithCustomServiceName proxy = mock(
+                TestClassWithCustomServiceName.class, CALLS_REAL_METHODS);
+        String serviceBeanName = service.getClass().getSimpleName();
+        when(contextMock.getType(serviceBeanName)).thenReturn((Class) proxy.getClass());
+        Map<String, Object> annotatedBeans = Collections.singletonMap(serviceBeanName, proxy);
+        when(contextMock.getBeansWithAnnotation(VaadinService.class)).thenReturn(annotatedBeans);
+
+        VaadinConnectController vaadinConnectController = new VaadinConnectController(
+                new ObjectMapper(), mock(VaadinConnectAccessChecker.class),
+                mock(VaadinServiceNameChecker.class),
+                mock(ExplicitNullableTypeChecker.class), contextMock);
+
+        int input = 111;
+        String expectedOutput = service.testMethod(input);
+
+        ResponseEntity<String> response = vaadinConnectController
+                .serveVaadinService("CustomService", "testMethod",
+                        createRequestParameters(
+                                String.format("{\"value\": %s}", input)),
+                        requestMock);
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(String.format("\"%s\"", expectedOutput),
                 response.getBody());


### PR DESCRIPTION
Vaadin now supports cases when `@VaadinService` classes are wrapped into proxies (e.g. because of using Spring AOP, such as by putting the `@Transactional` annotation on methods).

Fixes #7205

A demo project to verify that this PR also fixes the issue with `@Transactional`: [v15-transactional-on-vaadin-service.zip](https://github.com/vaadin/flow/files/3985649/v15-transactional-on-vaadin-service.zip) (since tests are not `@Transactional`-specific).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7209)
<!-- Reviewable:end -->