### PR TITLE
Don't add abstract error targets

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ApplicationRouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ApplicationRouteRegistry.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.server.startup;
 
 import javax.servlet.ServletContext;
 import java.io.Serializable;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -302,6 +303,7 @@ public class ApplicationRouteRegistry extends AbstractRouteRegistry {
         errorNavigationTargets.stream()
                 .filter(target -> !defaultErrorHandlers.contains(target))
                 .filter(this::allErrorFiltersMatch)
+                .filter(handler -> !Modifier.isAbstract(handler.getModifiers()))
                 .forEach(target -> addErrorTarget(target, exceptionTargetsMap));
 
         initErrorTargets(exceptionTargetsMap);

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/ApplicationRouteRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/ApplicationRouteRegistryTest.java
@@ -2,8 +2,11 @@ package com.vaadin.flow.server.startup;
 
 import javax.servlet.ServletContext;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -17,6 +20,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.router.RouteBaseData;
+import com.vaadin.flow.router.internal.ErrorTargetEntry;
 import com.vaadin.flow.server.RouteRegistry;
 import com.vaadin.flow.server.VaadinServletContext;
 
@@ -351,6 +355,20 @@ public class ApplicationRouteRegistryTest extends RouteRegistryTestBase {
         Assert.assertEquals(
                 "Removing the alias route should be seen in the event", 1,
                 removed.size());
+    }
+
+    @Test
+    public void setErrorNavigationTargets_abstractClassesAreIgnored() {
+        registry.setErrorNavigationTargets(new HashSet<>(
+                Arrays.asList(ErrorView.class, AbstractErrorView.class)));
+
+        Optional<ErrorTargetEntry> errorNavigationTarget = registry
+                .getErrorNavigationTarget(new NullPointerException());
+
+        Assert.assertTrue("Error navigation target was not registered",
+                errorNavigationTarget.isPresent());
+        Assert.assertEquals("Wrong errorNavigationTarget was registered",
+                ErrorView.class, errorNavigationTarget.get().getNavigationTarget());
     }
 
     @Override

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/RouteRegistryTestBase.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/RouteRegistryTestBase.java
@@ -27,6 +27,9 @@ import org.junit.Test;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.ErrorParameter;
+import com.vaadin.flow.router.HasErrorParameter;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteAlias;
 import com.vaadin.flow.router.RouteData;
@@ -274,5 +277,20 @@ public abstract class RouteRegistryTestBase {
     @Tag("div")
     protected static class MiddleLayout extends Component
             implements RouterLayout {
+    }
+
+    @Tag("div")
+    public static abstract class AbstractErrorView<EXCEPTION_TYPE extends Exception> extends Component implements
+            HasErrorParameter<EXCEPTION_TYPE> {
+    }
+
+    @Tag("div")
+    public static class ErrorView extends AbstractErrorView<NullPointerException> {
+
+        @Override
+        public int setErrorParameter(BeforeEnterEvent event,
+                ErrorParameter<NullPointerException> parameter) {
+            return 0;
+        }
     }
 }


### PR DESCRIPTION
Filter out any abstract classes from
error navigation targets as they can't
be instantiated anyway.

Fixes vaadin/spring#530

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7215)
<!-- Reviewable:end -->
