### PR TITLE
Make asRequired conditional on binding.setAsRequiredEnabled(..)

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -211,6 +211,30 @@ public class Binder<BEAN> implements Serializable {
          * @return the setter
          */
         Setter<BEAN, TARGET> getSetter();
+
+        /**
+         * Enable or disable asRequired validator.
+         * The validator is enabled by default.
+         *
+         * @see BindingBuilder#asRequired(String)
+         * @see BindingBuilder#asRequired(ErrorMessageProvider)
+         *
+         * @param asRequiredEnabled
+         *            {@code false} if asRequired validator should
+         *            be disabled, {@code true} otherwise (default)
+         */
+        public void setAsRequiredEnabled(boolean asRequiredEnabled);
+
+        /**
+         * Returns whether asRequired validator is currently enabled or not
+         *
+         * @see BindingBuilder#asRequired(String)
+         * @see BindingBuilder#asRequired(ErrorMessageProvider)
+         *
+         * @return {@code false} if asRequired validator is disabled
+         *         {@code true} otherwise (default)
+         */
+        public boolean isAsRequiredEnabled();
     }
 
     /**
@@ -741,6 +765,8 @@ public class Binder<BEAN> implements Serializable {
          */
         private Converter<FIELDVALUE, ?> converterValidatorChain;
 
+        private boolean asRequiredSet;
+
         /**
          * Creates a new binding builder associated with the given field.
          * Initializes the builder with the given converter chain and status
@@ -886,8 +912,15 @@ public class Binder<BEAN> implements Serializable {
         public BindingBuilder<BEAN, TARGET> asRequired(
                 Validator<TARGET> customRequiredValidator) {
             checkUnbound();
+            this.asRequiredSet = true;
             field.setRequiredIndicatorVisible(true);
-            return withValidator(customRequiredValidator);
+            return withValidator((value, context) -> {
+                if (!field.isRequiredIndicatorVisible()) {
+                    return ValidationResult.ok();
+                } else {
+                    return customRequiredValidator.apply(value, context);
+                }
+            });
         }
 
         /**
@@ -993,12 +1026,15 @@ public class Binder<BEAN> implements Serializable {
          */
         private final Converter<FIELDVALUE, TARGET> converterValidatorChain;
 
+        private final boolean asRequiredSet;
+
         public BindingImpl(BindingBuilderImpl<BEAN, FIELDVALUE, TARGET> builder,
                 ValueProvider<BEAN, TARGET> getter,
                 Setter<BEAN, TARGET> setter) {
             binder = builder.getBinder();
             field = builder.field;
             statusHandler = builder.statusHandler;
+            this.asRequiredSet = builder.asRequiredSet;
             converterValidatorChain = ((Converter<FIELDVALUE, TARGET>) builder.converterValidatorChain);
 
             onValueChange = getField().addValueChangeListener(
@@ -1253,6 +1289,24 @@ public class Binder<BEAN> implements Serializable {
         @Override
         public Setter<BEAN, TARGET> getSetter() {
             return setter;
+        }
+
+        @Override
+        public void setAsRequiredEnabled(boolean asRequiredEnabled) {
+            if (!asRequiredSet) {
+                throw new IllegalStateException(
+                 "Unable to toggle asRequired validation since " 
+                         + "asRequired has not been set.");
+            }
+            if (asRequiredEnabled != isAsRequiredEnabled()) {
+                field.setRequiredIndicatorVisible(asRequiredEnabled);
+                validate();
+            }
+        }
+
+        @Override
+        public boolean isAsRequiredEnabled() {
+            return field.isRequiredIndicatorVisible();
         }
     }
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -226,7 +226,7 @@ public class Binder<BEAN> implements Serializable {
         public void setAsRequiredEnabled(boolean asRequiredEnabled);
 
         /**
-         * Returns whether asRequired validator is currently enabled or not
+         * Returns whether asRequired validator is currently enabled or not.
          *
          * @see BindingBuilder#asRequired(String)
          * @see BindingBuilder#asRequired(ErrorMessageProvider)

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -501,13 +501,13 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         TestTextField textField = new TestTextField();
         assertFalse(textField.isRequiredIndicatorVisible());
 
-        BindingBuilder<Person, String> binding = binder.forField(textField);
+        BindingBuilder<Person, String> bindingBuilder = binder.forField(textField);
         assertFalse(textField.isRequiredIndicatorVisible());
 
-        binding.asRequired("foobar");
+        bindingBuilder.asRequired("foobar");
         assertTrue(textField.isRequiredIndicatorVisible());
 
-        binding.bind(Person::getFirstName, Person::setFirstName);
+        Binding<Person, String> binding = bindingBuilder.bind(Person::getFirstName, Person::setFirstName);
         binder.setBean(item);
         assertThat(textField.getErrorMessage(), isEmptyString());
 
@@ -517,6 +517,24 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         textField.setValue("value");
         assertFalse(textField.isInvalid());
         assertTrue(textField.isRequiredIndicatorVisible());
+
+        binding.setAsRequiredEnabled(false);
+        assertFalse(textField.isRequiredIndicatorVisible());
+        textField.setValue("");
+        assertFalse(textField.isInvalid());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void settingAsRequiredEnabledFalseWhenNoAsRequired() {
+        TestTextField textField = new TestTextField();
+
+        BindingBuilder<Person, String> bindingBuilder = binder.forField(textField);
+        Binding<Person, String> binding = bindingBuilder.bind(Person::getFirstName, Person::setFirstName);
+
+        binder.readBean(item);
+
+        // TextField input is not set required, this should trigger IllegalStateExceptipon
+        binding.setAsRequiredEnabled(false);
     }
 
     @Test


### PR DESCRIPTION
It is a very common use case in complex form that whether a field is required or not, it depends on input on other fields. Hypothetical use case sample could be that we have form for a Product and price of the product is needed except in case the Product's type is Sample. So in that kind of scenarios it would be needed to turn off asRequired() validation easily. The purpose of this enhancement and new binding.setAsRequiredEnabled(..) API is to help implementation of this kind of use cases more easily.

There is more generic ticket about conditional validation, and this PR is partially addressing it #10709

Cherry pick from vaadin/framework#11834

Requested in #5030

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7232)
<!-- Reviewable:end -->
