### PR TITLE
Correct Safari version range to support Safari 11.1

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/shared/BrowserDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/BrowserDetails.java
@@ -638,7 +638,7 @@ public class BrowserDetails implements Serializable {
         // Safari 11.1+
         if (isSafari() && (getBrowserMajorVersion() < 11
                 || getBrowserMajorVersion() == 11
-                        && getBrowserMinorVersion() <= 1)) {
+                        && getBrowserMinorVersion() < 1)) {
             return true;
         }
         // Firefox 43+ for now


### PR DESCRIPTION
according to the comment https://github.com/vaadin/flow/issues/6856#issuecomment-566935840 , we should support Safari 11.1 +, which means that safari 11.1 is included in the version range.

#7244 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7243)
<!-- Reviewable:end -->
