### PR TITLE
Add getChildren method in HasOrderedComponents interface

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/HasOrderedComponents.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasOrderedComponents.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.component;
 
 import java.util.Iterator;
+import java.util.stream.Stream;
 
 import com.vaadin.flow.dom.Element;
 
@@ -85,7 +86,7 @@ public interface HasOrderedComponents<T extends Component>
             throw new IllegalArgumentException(
                     "The 'component' parameter cannot be null");
         }
-        Iterator<Component> it = ((T) this).getChildren().sequential()
+        Iterator<Component> it = this.getChildren().sequential()
                 .iterator();
         int index = 0;
         while (it.hasNext()) {
@@ -104,7 +105,7 @@ public interface HasOrderedComponents<T extends Component>
      * @return the number of components
      */
     default int getComponentCount() {
-        return (int) ((T) this).getChildren().count();
+        return (int) this.getChildren().count();
     }
 
     /**
@@ -125,10 +126,19 @@ public interface HasOrderedComponents<T extends Component>
                     "The 'index' argument should be greater than or equal to 0. It was: "
                             + index);
         }
-        return ((T) this).getChildren().sequential().skip(index).findFirst()
+        return this.getChildren().sequential().skip(index).findFirst()
                 .orElseThrow(() -> new IllegalArgumentException(
                         "The 'index' argument should not be greater than or equals to the number of children components. It was: "
                                 + index));
     }
+
+    /**
+     * Gets the child components of this component.
+     *
+     * @see Component#getChildren()
+     *
+     * @return the child components of this component
+     */
+     Stream<Component> getChildren();
 
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasOrderedComponentsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasOrderedComponentsTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.dom.Element;
+
+public class HasOrderedComponentsTest {
+
+    static class TestOrderedComponents implements HasOrderedComponents {
+
+        @Override
+        public Element getElement() {
+            return null;
+        }
+
+        @Override
+        public Stream<Component> getChildren() {
+            return null;
+        }
+
+    }
+
+    private HasOrderedComponents components = Mockito
+            .spy(TestOrderedComponents.class);
+
+    @Test
+    public void indexOf_componentIsChild_returnsIndexOfChild() {
+        Component comp = Mockito.mock(Component.class);
+        Mockito.when(components.getChildren())
+                .thenReturn(Arrays.asList(Mockito.mock(Component.class), comp,
+                        Mockito.mock(Component.class)).stream());
+
+        Assert.assertEquals(1, components.indexOf(comp));
+    }
+
+    @Test
+    public void indexOf_componentIsNotChild_returnsNegative() {
+        Component comp = Mockito.mock(Component.class);
+        Mockito.when(components.getChildren())
+                .thenReturn(Arrays.asList(Mockito.mock(Component.class),
+                        Mockito.mock(Component.class)).stream());
+
+        Assert.assertEquals(-1, components.indexOf(comp));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void indexOf_componentIsNull_throws() {
+        Mockito.when(components.getChildren()).thenReturn(Stream.empty());
+
+        components.indexOf(null);
+    }
+
+    @Test
+    public void getComponentCount_returnsChildrenSize() {
+        Mockito.when(components.getChildren())
+                .thenReturn(Arrays.asList(Mockito.mock(Component.class),
+                        Mockito.mock(Component.class)).stream());
+        Assert.assertEquals(2, components.getComponentCount());
+    }
+
+    @Test
+    public void getComponentAt_returnsComponentAtIndex() {
+        Component comp = Mockito.mock(Component.class);
+        Mockito.when(components.getChildren())
+                .thenReturn(Arrays.asList(Mockito.mock(Component.class), comp,
+                        Mockito.mock(Component.class)).stream());
+
+        Assert.assertSame(comp, components.getComponentAt(1));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getComponentAt_negativeIndex_throws() {
+        Mockito.when(components.getChildren())
+                .thenReturn(Arrays.asList(Mockito.mock(Component.class),
+                        Mockito.mock(Component.class)).stream());
+
+        components.getComponentAt(-1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getComponentAt_indexIsGreaterThanSize_throws() {
+        Mockito.when(components.getChildren())
+                .thenReturn(Stream.of(Mockito.mock(Component.class)));
+
+        components.getComponentAt(-2);
+    }
+}


### PR DESCRIPTION
`HasOrderedComponents` declares a type parameter `T` that is _the type of the component which implements the interface_ (`T extends Component`).

This type parameter is only used in the default implementation of `indexOf(Component)`, `getComponentCount()`, and `getComponentAt(int)`, for the purpose of calling `((T)this).getChildren()` (because `getChildren()` is a method of `Component`). It follows that mixin-style implementations of `HasOrderedComponents` must already be a subtype of `Component`.

It makes sense to define `getChildren` in `HasOrderedComponents`, since the operation that retrieves those children is clearly part of the contract of _a component where the children components are ordered_.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7264)
<!-- Reviewable:end -->
