### PR TITLE
fix: construct the app shell instance after VaadinService init

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/AppShellRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AppShellRegistry.java
@@ -76,7 +76,6 @@ public class AppShellRegistry implements Serializable {
             "meta[name=description]", "title", "base" };
 
     private Class<? extends AppShellConfigurator> appShellClass;
-    private AppShellConfigurator appShellInstance;
 
     /**
      * A wrapper class for storing the {@link AppShellRegistry} instance
@@ -123,7 +122,6 @@ public class AppShellRegistry implements Serializable {
      */
     public void reset() {
         this.appShellClass = null;
-        this.appShellInstance = null;
     }
 
     /**
@@ -140,9 +138,6 @@ public class AppShellRegistry implements Serializable {
                             this.appShellClass.getName(), shell.getName()));
         }
         this.appShellClass = shell;
-        this.appShellInstance = shell != null
-                ? ReflectTools.createInstance(shell)
-                : null;
     }
 
     /**
@@ -240,8 +235,9 @@ public class AppShellRegistry implements Serializable {
      */
     public void modifyIndexHtml(Document document, VaadinRequest request) {
         AppShellSettings settings = createSettings();
-        if (appShellInstance != null) {
-            appShellInstance.configurePage(settings);
+        if (appShellClass != null) {
+            ReflectTools.createInstance(appShellClass)
+                    .configurePage(settings);
         }
 
         settings.getHeadElements(Position.PREPEND).forEach(

--- a/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/AppShell.java
+++ b/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/AppShell.java
@@ -5,7 +5,9 @@ import com.vaadin.flow.component.page.Meta;
 import com.vaadin.flow.component.page.AppShellConfigurator;
 import com.vaadin.flow.component.page.Push;
 import com.vaadin.flow.component.page.Viewport;
+import com.vaadin.flow.server.AppShellSettings;
 import com.vaadin.flow.server.PWA;
+import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.shared.communication.PushMode;
 
 @Meta(name = "foo", content = "bar")
@@ -14,4 +16,14 @@ import com.vaadin.flow.shared.communication.PushMode;
 @BodySize(height = "50vh", width = "50vw")
 @Push(PushMode.AUTOMATIC)
 public class AppShell implements AppShellConfigurator {
+    private final String url;
+
+    public AppShell() {
+        url = VaadinService.getCurrent().resolveResource("my-resource");
+    }
+
+    @Override
+    public void configurePage(AppShellSettings settings) {
+        settings.addMetaTag("test-resource-url", url);
+    }
 }

--- a/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/TestApplicationServiceInitListener.java
+++ b/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/TestApplicationServiceInitListener.java
@@ -26,24 +26,25 @@ public class TestApplicationServiceInitListener
         implements VaadinServiceInitListener {
     @Override
     public void serviceInit(ServiceInitEvent event) {
-        Element el = new Element("label");
-        el.text("Modified page");
-        event.addIndexHtmlRequestListener(
-                response -> response.getDocument().body().appendChild(el));
+        event.addIndexHtmlRequestListener(response -> {
+            Element el = new Element("label");
+            el.text("Modified page");
+            response.getDocument().body().appendChild(el);
+        });
 
-        Element meta = new Element("meta");
-        meta.attr("name", "og:image");
         event.addIndexHtmlRequestListener(indexHtmlResponse -> {
+            Element meta = new Element("meta");
+            meta.attr("name", "og:image");
             meta.attr("content",
                     getBaseUrl(indexHtmlResponse) + "/image/my_app.png");
             indexHtmlResponse.getDocument().head().appendChild(meta);
         });
 
-        Element styleElem = new Element("style");
-        meta.attr("type", "text/css");
-        styleElem.text("body,#outlet{height:50vh;width:50vw;}");
-        event.addIndexHtmlRequestListener(
-                response -> response.getDocument().head().appendChild(styleElem));
+        event.addIndexHtmlRequestListener(response -> {
+            Element styleElem = new Element("style");
+            styleElem.text("body,#outlet{height:50vh;width:50vw;}");
+            response.getDocument().head().appendChild(styleElem);
+        });
     }
 
     private static String getBaseUrl(IndexHtmlResponse indexHtmlResponse) {

--- a/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/IndexHtmlRequestHandlerIT.java
+++ b/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/IndexHtmlRequestHandlerIT.java
@@ -61,6 +61,15 @@ public class IndexHtmlRequestHandlerIT extends ChromeBrowserTest {
     }
 
     @Test
+    public void should_accessVaadinService_getCurrent_inAppShellConstructor() {
+        openTestUrl("/");
+        waitForElementPresent(By.tagName("meta"));
+        WebElement meta = findElement(By.cssSelector("meta[name=test-resource-url]"));
+        Assert.assertNotNull(meta);
+        Assert.assertEquals("my-resource", meta.getAttribute("content"));
+    }
+
+    @Test
     public void should_show_pwaDialog() {
         openTestUrl("/");
         waitForElementPresent(By.id("pwa-ip"));


### PR DESCRIPTION
Create the app shell instance lazily, after the VaadinService init finishes, just before calling the `appShell.configurePage()` method.

Fixes #7262

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7274)
<!-- Reviewable:end -->
