### PR TITLE
Find the name of the search path environment variable before manipulating it

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -488,15 +488,29 @@ public class FrontendUtils {
         File commandFile = new File(command.get(0));
         if (commandFile.isAbsolute()) {
             String commandPath = commandFile.getParent();
-
             Map<String, String> environment = processBuilder.environment();
-            String path = environment.get("PATH");
+
+            String pathEnvVar;
+            if (isWindows()) {
+                /*
+                 * Determine the name of the PATH environment variable on
+                 * Windows, as variables names are not case-sensitive (the
+                 * common name is "Path").
+                 */
+                pathEnvVar = environment.keySet().stream()
+                        .filter(s -> s.toUpperCase().equals("PATH")).findFirst()
+                        .orElse("Path");
+            } else {
+                pathEnvVar = "PATH";
+            }
+
+            String path = environment.get(pathEnvVar);
             if (path == null || path.isEmpty()) {
                 path = commandPath;
             } else if (!path.contains(commandPath)) {
                 path += File.pathSeparatorChar + commandPath;
             }
-            environment.put("PATH", path);
+            environment.put(pathEnvVar, path);
         }
 
         return processBuilder;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -498,7 +498,7 @@ public class FrontendUtils {
                  * common name is "Path").
                  */
                 pathEnvVar = environment.keySet().stream()
-                        .filter(s -> s.toUpperCase().equals("PATH")).findFirst()
+                        .filter("PATH"::equalsIgnoreCase).findFirst()
                         .orElse("Path");
             } else {
                 pathEnvVar = "PATH";


### PR DESCRIPTION
On Windows, environment variables are not case sensitive. So the variable may be named `PATH` or `Path`, and in the latter case adding `PATH` on top of `Path` in the `ProcessBuilder` env variable map would discard the contents of the existing `Path`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7277)
<!-- Reviewable:end -->
