### PR TITLE
Set direction along with the Locale for the UI

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/Direction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Direction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2019 Vaadin Ltd.
+ * Copyright 2000-2020 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -22,6 +22,12 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 
+/**
+ * Class for setting the direction on the document element.
+ *
+ * @author Vaadin Ltd
+ * @since
+ */
 class Direction implements Serializable {
 
     private static final Set<String> rtlSet;

--- a/flow-server/src/main/java/com/vaadin/flow/component/Direction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Direction.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2000-2019 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.component;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
+class Direction implements Serializable {
+
+    static void set(UI ui, Locale locale) {
+        ui.getElement().executeJs("document.querySelector('html').dir=$0", getDirectionForLocale(locale));
+    }
+
+    private static final Set<String> rtlSet;
+
+    static {
+        Set<String> lang = new HashSet<>();
+        lang.add("ar"); // Arabic
+        lang.add("dv"); // Divehi
+        lang.add("fa"); // Persian
+        lang.add("ha"); // Hausa
+        lang.add("he"); // Hebrew
+        lang.add("iw"); // Hebrew
+        lang.add("ji"); // Yiddish
+        lang.add("ps"); // Pushto
+        lang.add("sd"); // Sindhi
+        lang.add("ug"); // Uighur
+        lang.add("ur"); // Urdu
+        lang.add("yi"); // Yiddish
+
+        rtlSet = Collections.unmodifiableSet(lang);
+    }
+
+    public static String getDirectionForLocale(Locale locale) {
+        return rtlSet.contains(locale.getLanguage()) ? "rtl" : "ltr";
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/Direction.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Direction.java
@@ -24,10 +24,6 @@ import java.util.Set;
 
 class Direction implements Serializable {
 
-    static void set(UI ui, Locale locale) {
-        ui.getElement().executeJs("document.querySelector('html').dir=$0", getDirectionForLocale(locale));
-    }
-
     private static final Set<String> rtlSet;
 
     static {
@@ -48,6 +44,19 @@ class Direction implements Serializable {
         rtlSet = Collections.unmodifiableSet(lang);
     }
 
+    static void set(UI ui, Locale locale) {
+        ui.getElement().executeJs("document.querySelector('html').dir=$0",
+                getDirectionForLocale(locale));
+    }
+
+    /**
+     * Returns direction string based on the locale provided.
+     *
+     * @param locale
+     *            the locale set for the UI
+     *
+     * @return the direction string
+     */
     public static String getDirectionForLocale(Locale locale) {
         return rtlSet.contains(locale.getLanguage()) ? "rtl" : "ltr";
     }

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -732,6 +732,7 @@ public class UI extends Component
         assert locale != null : "Null locale is not supported!";
         if (!this.locale.equals(locale)) {
             this.locale = locale;
+            Direction.set(this, locale);
             EventUtil.informLocaleChangeObservers(this);
         }
     }

--- a/flow-server/src/test/java/com/vaadin/flow/component/UITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/UITest.java
@@ -7,9 +7,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
 import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Assert;
@@ -256,6 +258,23 @@ public class UITest {
         Location value = location.getValue();
         Assert.assertEquals(route, value.getPath());
         Assert.assertEquals(params, value.getQueryParameters());
+    }
+
+    @Test
+    public void localeSet_directionUpdated() {
+        MockUI ui = new MockUI();
+
+        ui.setLocale(Locale.forLanguageTag("ar"));
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        List<PendingJavaScriptInvocation> pendingJavaScriptInvocations = ui
+                .dumpPendingJsInvocations();
+
+        Assert.assertEquals(1, pendingJavaScriptInvocations.size());
+        Assert.assertEquals("rtl",
+                pendingJavaScriptInvocations.get(0).
+                        getInvocation().getParameters().get(0));
     }
 
     @Test


### PR DESCRIPTION
Connected to https://github.com/vaadin/components-team-tasks/issues/497

This allows to set the direction based on the `Locale` provided with the predefined set of right-to-left locales. (in order to support all language codes, as based on small research `ComponentOrientation` is not working for several cases).

`Direction` is implemented as a separate class in order to preserve possibility to expose API for overriding the direction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7294)
<!-- Reviewable:end -->
