### PR TITLE
Elide (p)npm stdout unless command fails

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.shared.util.SharedUtil;
@@ -55,7 +56,9 @@ public class TaskRunNpmInstall implements FallibleCommand {
     public void execute() throws ExecutionFailedException {
         String toolName = disablePnpm ? "npm" : "pnpm";
         if (packageUpdater.modified || shouldRunNpmInstall()) {
-            packageUpdater.log().info("Running `" + toolName + " install` ...");
+            packageUpdater.log().info("Running `" + toolName + "` to resolve "
+                    + "and optionally download frontend dependencies. This "
+                    + "may take a moment, please stand by...");
             runNpmInstall();
         } else {
             packageUpdater.log().info("Skipping `" + toolName + " install`.");
@@ -102,13 +105,20 @@ public class TaskRunNpmInstall implements FallibleCommand {
 
         Process process = null;
         try {
-            process = builder.inheritIO().start();
+            process = builder.redirectInput(ProcessBuilder.Redirect.INHERIT)
+                    .redirectError(ProcessBuilder.Redirect.INHERIT).start();
+
             int errorCode = process.waitFor();
             if (errorCode != 0) {
                 packageUpdater.log().error(
                         ">>> Dependency ERROR. Check that all required dependencies are "
                                 + "deployed in {} repositories.",
                         toolName);
+                String commandString = command.stream()
+                        .collect(Collectors.joining(" "));
+                final String toolOutput = FrontendUtils.streamToString(process.getInputStream());
+                packageUpdater.log().error("Output of `{}`:\n{}",
+                        commandString, toolOutput);
                 throw new ExecutionFailedException(
                         SharedUtil.capitalize(toolName)
                                 + " install has exited with non zero status. "
@@ -116,7 +126,7 @@ public class TaskRunNpmInstall implements FallibleCommand {
                                 + toolName + " command output");
             } else {
                 packageUpdater.log().info(
-                        "package.json updated and dependencies are installed. ");
+                        "Frontend dependencies resolved successfully.");
             }
         } catch (InterruptedException | IOException e) {
             packageUpdater.log().error("Error when running `{} install`",

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -56,9 +56,9 @@ public class TaskRunNpmInstall implements FallibleCommand {
     public void execute() throws ExecutionFailedException {
         String toolName = disablePnpm ? "npm" : "pnpm";
         if (packageUpdater.modified || shouldRunNpmInstall()) {
-            packageUpdater.log().info("Running `" + toolName + "` to resolve "
-                    + "and optionally download frontend dependencies. This "
-                    + "may take a moment, please stand by...");
+            packageUpdater.log().info("Running `" + toolName + " install` to "
+                    + "resolve and optionally download frontend dependencies. "
+                    + "This may take a moment, please stand by...");
             runNpmInstall();
         } else {
             packageUpdater.log().info("Skipping `" + toolName + " install`.");

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -109,7 +109,9 @@ public class TaskRunNpmInstallTest {
     }
 
     private String getRunningMsg() {
-        return "Running `" + getToolName() + " install` ...";
+        return"Running `" + getToolName() + " install` to "
+                + "resolve and optionally download frontend dependencies. "
+                + "This may take a moment, please stand by...";
     }
 
     protected NodeUpdater getNodeUpdater() {

--- a/flow-tests/test-npm-only-features/test-npm-performance-regression/src/test/java/com/vaadin/flow/testnpmonlyfeatures/performanceregression/StartupPerformanceIT.java
+++ b/flow-tests/test-npm-only-features/test-npm-performance-regression/src/test/java/com/vaadin/flow/testnpmonlyfeatures/performanceregression/StartupPerformanceIT.java
@@ -36,7 +36,7 @@ public class StartupPerformanceIT {
 
         int npmInstallTime = measureLogEntryTimeDistance(
                 "dev-updater - Running `pnpm install`",
-                "dev-updater - package.json updated and dependencies are installed",
+                "dev-updater - Frontend dependencies resolved successfully",
                 false);
 
         int startupTimeWithoutNpmInstallTime = startupTime - npmInstallTime;


### PR DESCRIPTION
To avoid bloating the log, only standard error output of `pnpm install` (`npm install` if the user has elected to choose it) is echoed to the console. If the command fails (non-zero exit code), print the standard output contents in the log at ERROR level.

Fixes #7259

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7306)
<!-- Reviewable:end -->
