### PR TITLE
Allow storing a value in VaadinContext based on a super type

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinContext.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinContext.java
@@ -55,20 +55,41 @@ public interface VaadinContext extends Serializable {
     }
 
     /**
+     * Sets the attribute value for the give type, overriding previously
+     * existing one. Values are based on exact type, meaning only one attribute
+     * of given type is possible at any given time.
+     *
+     * @param clazz
+     *            the type to associate the value with, not <code>null</code>
+     *
+     * @param value
+     *            the attribute value to set, or <code>null</code> to remove the
+     *            current value
+     * @since
+     */
+    <T> void setAttribute(Class<T> clazz, T value);
+
+    /**
      * Sets the attribute value, overriding previously existing one. Values are
      * based on exact type, meaning only one attribute of given type is possible
      * at any given time.
      *
      * @param value
-     *            Value of the attribute. May not be {@code null}.
+     *            attribute value, not {@code null}.
      * @see #removeAttribute(Class) for removing attributes.
      */
-    <T> void setAttribute(T value);
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    default void setAttribute(Object value) {
+        assert value != null;
+
+        Class clazz = value.getClass();
+        setAttribute(clazz, value);
+    }
 
     /**
      * Removes an attribute identified by the given type. If the attribute does
      * not exist, no action will be taken.
-     * 
+     *
      * @param clazz
      *            Attribute type.
      *
@@ -90,9 +111,9 @@ public interface VaadinContext extends Serializable {
      * the parameter does not exist.
      *
      * @param name
-     *         name of the parameter whose value is requested
+     *            name of the parameter whose value is requested
      * @return parameter value as <code>String</code> or <code>null</code> for
-     * no parameter
+     *         no parameter
      */
     String getContextParameter(String name);
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletContext.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletContext.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.server;
 
 import javax.servlet.ServletContext;
+
 import java.util.Enumeration;
 import java.util.function.Supplier;
 
@@ -30,7 +31,9 @@ public class VaadinServletContext implements VaadinContext {
 
     /**
      * Creates an instance of this context with given {@link ServletContext}.
-     * @param context Context.
+     *
+     * @param context
+     *            the servlet context to use
      */
     public VaadinServletContext(ServletContext context) {
         this.context = context;
@@ -38,6 +41,7 @@ public class VaadinServletContext implements VaadinContext {
 
     /**
      * Returns the underlying context.
+     *
      * @return A non-null {@link ServletContext}.
      */
     public ServletContext getContext() {
@@ -48,10 +52,13 @@ public class VaadinServletContext implements VaadinContext {
      * Ensures there is a valid instance of {@link ServletContext}.
      */
     private void ensureServletContext() {
-        if(context == null && VaadinService.getCurrent() instanceof VaadinServletService) {
-            context = ((VaadinServletService)VaadinService.getCurrent()).getServlet().getServletContext();
-        } else if(context == null) {
-            throw new IllegalStateException("The underlying ServletContext of VaadinServletContext is null and there is no VaadinServletService to obtain it from.");
+        if (context == null
+                && VaadinService.getCurrent() instanceof VaadinServletService) {
+            context = ((VaadinServletService) VaadinService.getCurrent())
+                    .getServlet().getServletContext();
+        } else if (context == null) {
+            throw new IllegalStateException(
+                    "The underlying ServletContext of VaadinServletContext is null and there is no VaadinServletService to obtain it from.");
         }
     }
 
@@ -69,10 +76,13 @@ public class VaadinServletContext implements VaadinContext {
     }
 
     @Override
-    public <T> void setAttribute(T value) {
-        assert value != null;
-        ensureServletContext();
-        context.setAttribute(value.getClass().getName(), value);
+    public <T> void setAttribute(Class<T> clazz, T value) {
+        if (value == null) {
+            removeAttribute(clazz);
+        } else {
+            ensureServletContext();
+            context.setAttribute(clazz.getName(), value);
+        }
     }
 
     @Override

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletContextTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletContextTest.java
@@ -1,6 +1,7 @@
 package com.vaadin.flow.server;
 
 import javax.servlet.ServletContext;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -17,24 +18,31 @@ import org.mockito.Mockito;
  * @since 2.0.0
  */
 public class VaadinServletContextTest {
-    
+
     private static String testAttributeProvider() {
         return "RELAX_THIS_IS_A_TEST";
     }
-    
+
     private VaadinServletContext context;
-    
+
     private final Map<String, Object> attributeMap = new HashMap<>();
     private Map<String, String> properties;
 
     @Before
     public void setup() {
         ServletContext servletContext = Mockito.mock(ServletContext.class);
-        Mockito.when(servletContext.getAttribute(Mockito.anyString())).then(invocationOnMock -> attributeMap.get(invocationOnMock.getArguments()[0].toString()));
+        Mockito.when(servletContext.getAttribute(Mockito.anyString()))
+                .then(invocationOnMock -> attributeMap
+                        .get(invocationOnMock.getArguments()[0].toString()));
+        Mockito.doAnswer(invocationOnMock -> {
+            attributeMap.remove(invocationOnMock.getArguments()[0].toString());
+            return null;
+        }).when(servletContext).removeAttribute(Mockito.anyString());
+
         Mockito.doAnswer(invocationOnMock -> attributeMap.put(
-            invocationOnMock.getArguments()[0].toString(),
-            invocationOnMock.getArguments()[1]
-            )).when(servletContext).setAttribute(Mockito.anyString(), Mockito.any());
+                invocationOnMock.getArguments()[0].toString(),
+                invocationOnMock.getArguments()[1])).when(servletContext)
+                .setAttribute(Mockito.anyString(), Mockito.any());
 
         properties = new HashMap<>();
         properties.put(Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE, "false");
@@ -43,9 +51,8 @@ public class VaadinServletContextTest {
 
         Mockito.when(servletContext.getInitParameterNames())
                 .thenReturn(Collections.enumeration(properties.keySet()));
-        Mockito.when(servletContext.getInitParameter(Mockito.anyString()))
-                .then(invocation -> properties
-                        .get(invocation.getArguments()[0]));
+        Mockito.when(servletContext.getInitParameter(Mockito.anyString())).then(
+                invocation -> properties.get(invocation.getArguments()[0]));
         context = new VaadinServletContext(servletContext);
     }
 
@@ -54,11 +61,11 @@ public class VaadinServletContextTest {
         Assert.assertNull(context.getAttribute(String.class));
 
         String value = context.getAttribute(String.class,
-            VaadinServletContextTest::testAttributeProvider);
+                VaadinServletContextTest::testAttributeProvider);
         Assert.assertEquals(testAttributeProvider(), value);
 
         Assert.assertEquals("Value from provider should be persisted",
-            testAttributeProvider(), context.getAttribute(String.class));
+                testAttributeProvider(), context.getAttribute(String.class));
     }
 
     @Test(expected = AssertionError.class)
@@ -84,16 +91,56 @@ public class VaadinServletContextTest {
         result = context.getAttribute(String.class);
         Assert.assertEquals(newValue, result);
         // now the provider should not be called, so value should be still there
-        result = context.getAttribute(String.class,
-            () -> {
-                throw new AssertionError("Should not be called");
-            });
+        result = context.getAttribute(String.class, () -> {
+            throw new AssertionError("Should not be called");
+        });
         Assert.assertEquals(newValue, result);
     }
 
     @Test
+    public void setValueBasedOnSuperType_implicitClass_notFound() {
+        String value = testAttributeProvider();
+        context.setAttribute(value);
+
+        CharSequence retrieved = context.getAttribute(CharSequence.class);
+        Assert.assertNull(
+                "Value set base on its own type should not be found based on a super type",
+                retrieved);
+    }
+
+    @Test
+    public void setValueBasedOnSuperType_explicitClass_found() {
+        String value = testAttributeProvider();
+        context.setAttribute(CharSequence.class, value);
+
+        CharSequence retrieved = context.getAttribute(CharSequence.class);
+        Assert.assertSame(
+                "Value should be found based on the type used when setting",
+                value, retrieved);
+    }
+
+    @Test
+    public void removeValue_removeMethod_valueIsRemoved() {
+        context.setAttribute(testAttributeProvider());
+        context.removeAttribute(String.class);
+
+        Assert.assertNull("Value should be removed",
+                context.getAttribute(String.class));
+    }
+
+    @Test
+    public void removeValue_setWithClass_valueIsRemoved() {
+        context.setAttribute(testAttributeProvider());
+        context.setAttribute(String.class, null);
+
+        Assert.assertNull("Value should be removed",
+                context.getAttribute(String.class));
+    }
+
+    @Test
     public void getPropertyNames_returnsExpectedProperties() {
-        List<String> list = Collections.list(context.getContextParameterNames());
+        List<String> list = Collections
+                .list(context.getContextParameterNames());
         Assert.assertEquals(
                 "Context should return only keys defined in ServletContext",
                 properties.size(), list.size());


### PR DESCRIPTION
Also removes a redundant type parameter from the API.
Also adds a test for the original removeAttribute method
Also tweaks some javadocs to be consistent with other Vaadin javadocs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7315)
<!-- Reviewable:end -->
