### PR TITLE
Deprecate isSafariOrIOS

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/shared/BrowserDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/BrowserDetails.java
@@ -440,9 +440,12 @@ public class BrowserDetails implements Serializable {
     /**
      * Tests if the browser is Safari or runs on IOS (covering also Chrome on
      * iOS).
-     *
+     * 
      * @return true if it is Safari or running on IOS, false otherwise
+     * @deprecated will return the wrong value for iOS 13 and later. Use
+     *             {@link ExtendedClientDetails#isIOS()} instead.
      */
+    @Deprecated
     public boolean isSafariOrIOS() {
         return isSafari() || isIOS();
     }

--- a/flow-server/src/main/java/com/vaadin/flow/shared/BrowserDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/BrowserDetails.java
@@ -17,6 +17,8 @@ package com.vaadin.flow.shared;
 
 import java.io.Serializable;
 
+import com.vaadin.flow.component.page.ExtendedClientDetails;
+
 /**
  * Parses the user agent string from the browser and provides information about
  * the browser.


### PR DESCRIPTION
It does not work reliably and should be removed in 3.0 like other isIOS method in BrowserDetails.

Related to #6510

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7322)
<!-- Reviewable:end -->
