### PR TITLE
Always consume the stdout stream from (p)npm and log at debug level

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -117,13 +117,15 @@ public class TaskRunNpmInstall implements FallibleCommand {
             process = builder.start();
 
             packageUpdater.log().debug("Output of `{}`:", commandString);
-            BufferedReader reader = new BufferedReader(new InputStreamReader(
-                    process.getInputStream(), StandardCharsets.UTF_8));
-            String stdoutLine;
             StringBuilder toolOutput = new StringBuilder();
-            while ((stdoutLine = reader.readLine()) != null) {
-                packageUpdater.log().debug(stdoutLine);
-                toolOutput.append(stdoutLine);
+            try (BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(process.getInputStream(),
+                            StandardCharsets.UTF_8))) {
+                String stdoutLine;
+                while ((stdoutLine = reader.readLine()) != null) {
+                    packageUpdater.log().debug(stdoutLine);
+                    toolOutput.append(stdoutLine);
+                }
             }
 
             int errorCode = process.waitFor();


### PR DESCRIPTION
This also fixes `pnpm` invocation hanging on Windows due to the standard output not being consumed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7325)
<!-- Reviewable:end -->
