### PR TITLE
Export usage stats for the new Index page

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/UsageStatisticsExporter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/UsageStatisticsExporter.java
@@ -1,5 +1,6 @@
 package com.vaadin.flow.internal;
 
+import java.io.Serializable;
 import java.util.stream.Collectors;
 
 import elemental.json.Json;
@@ -12,9 +13,7 @@ import org.jsoup.nodes.Document;
  * @author Vaadin Ltd
  * @since 3.0
  */
-public class UsageStatisticsExporter {
-
-    private static final String SCRIPT_TAG = "script";
+public class UsageStatisticsExporter implements Serializable {
 
     /**
      * Export {@link UsageStatistics} entries to a document. It appends a
@@ -30,13 +29,12 @@ public class UsageStatisticsExporter {
         if (!entries.isEmpty()) {
             // Registers the entries in a way that is picked up as a Vaadin
             // WebComponent by the usage stats gatherer
-            StringBuilder builder = new StringBuilder();
-            builder.append("window.Vaadin = window.Vaadin || {};\n")
-                    .append("window.Vaadin.registrations = window.Vaadin.registrations || [];\n")
-                    .append("window.Vaadin.registrations.push(")
-                    .append(entries)
-                    .append(");");
-            document.body().appendElement(SCRIPT_TAG).text(builder.toString());
+            String builder = "window.Vaadin = window.Vaadin || {};\n" +
+                    "window.Vaadin.registrations = window.Vaadin.registrations || [];\n" +
+                    "window.Vaadin.registrations.push(" +
+                    entries +
+                    ");";
+            document.body().appendElement("script").text(builder);
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/internal/UsageStatisticsExporter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/UsageStatisticsExporter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package com.vaadin.flow.internal;
 
 import java.io.Serializable;

--- a/flow-server/src/main/java/com/vaadin/flow/internal/UsageStatisticsExporter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/UsageStatisticsExporter.java
@@ -18,7 +18,7 @@ public class UsageStatisticsExporter {
 
     /**
      * Export {@link UsageStatistics} entries to a document. It appends a
-     * <code><script></code> element to the <code><body></code>
+     * {@code <script>} element to the {@code <body>} element.
      *
      * @param document the document where the statistic entries to be exported to.
      */

--- a/flow-server/src/main/java/com/vaadin/flow/internal/UsageStatisticsExporter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/UsageStatisticsExporter.java
@@ -1,0 +1,51 @@
+package com.vaadin.flow.internal;
+
+import java.util.stream.Collectors;
+
+import elemental.json.Json;
+import elemental.json.JsonObject;
+import org.jsoup.nodes.Document;
+
+/**
+ * A class for exporting {@link UsageStatistics} entries.
+ *
+ * @author Vaadin Ltd
+ * @since 3.0
+ */
+public class UsageStatisticsExporter {
+
+    private static final String SCRIPT_TAG = "script";
+
+    /**
+     * Export {@link UsageStatistics} entries to a document. It appends a
+     * <code><script></code> element to the <code><body></code>
+     *
+     * @param document the document where the statistic entries to be exported to.
+     */
+    public static void exportUsageStatisticsToDocument(Document document) {
+        String entries = UsageStatistics.getEntries()
+                .map(UsageStatisticsExporter::createUsageStatisticsJson)
+                .collect(Collectors.joining(","));
+
+        if (!entries.isEmpty()) {
+            // Registers the entries in a way that is picked up as a Vaadin
+            // WebComponent by the usage stats gatherer
+            StringBuilder builder = new StringBuilder();
+            builder.append("window.Vaadin = window.Vaadin || {};\n")
+                    .append("window.Vaadin.registrations = window.Vaadin.registrations || [];\n")
+                    .append("window.Vaadin.registrations.push(")
+                    .append(entries)
+                    .append(");");
+            document.body().appendElement(SCRIPT_TAG).text(builder.toString());
+        }
+    }
+
+    private static String createUsageStatisticsJson(UsageStatistics.UsageEntry entry) {
+        JsonObject json = Json.createObject();
+
+        json.put("is", entry.getName());
+        json.put("version", entry.getVersion());
+
+        return json.toJson();
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -507,7 +507,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                             head, initialPageSettings));
 
             if (!config.isProductionMode()) {
-                exportNpmUsageStatistics(document);
+                exportUsageStatistics(document);
             }
 
             setupPwa(document, context);
@@ -529,7 +529,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             return clientEngineFile.get();
         }
 
-        private void exportNpmUsageStatistics(Document document) {
+        private void exportUsageStatistics(Document document) {
             String entries = UsageStatistics.getEntries()
                     .map(BootstrapPageBuilder::createUsageStatisticsJson)
                     .collect(Collectors.joining(","));

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -63,6 +63,7 @@ import com.vaadin.flow.internal.AnnotationReader;
 import com.vaadin.flow.internal.ReflectTools;
 import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.internal.UsageStatistics.UsageEntry;
+import com.vaadin.flow.internal.UsageStatisticsExporter;
 import com.vaadin.flow.server.communication.AtmospherePushConnection;
 import com.vaadin.flow.server.communication.PushConnectionFactory;
 import com.vaadin.flow.server.communication.UidlWriter;
@@ -507,7 +508,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                             head, initialPageSettings));
 
             if (!config.isProductionMode()) {
-                exportUsageStatistics(document);
+                UsageStatisticsExporter.exportUsageStatisticsToDocument(document);
             }
 
             setupPwa(document, context);
@@ -527,30 +528,6 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
 
         private String getClientEngine() {
             return clientEngineFile.get();
-        }
-
-        private void exportUsageStatistics(Document document) {
-            String entries = UsageStatistics.getEntries()
-                    .map(BootstrapPageBuilder::createUsageStatisticsJson)
-                    .collect(Collectors.joining(","));
-
-            if (!entries.isEmpty()) {
-                // Registers the entries in a way that is picked up as a Vaadin
-                // WebComponent by the usage stats gatherer
-                document.body().appendElement(SCRIPT_TAG).text(
-                        "window.Vaadin.registrations = window.Vaadin.registrations || [];\n"
-                                + "window.Vaadin.registrations.push(" + entries
-                                + ");");
-            }
-        }
-
-        private static String createUsageStatisticsJson(UsageEntry entry) {
-            JsonObject json = Json.createObject();
-
-            json.put("is", entry.getName());
-            json.put("version", entry.getVersion());
-
-            return json.toJson();
         }
 
         private Element createDependencyElement(BootstrapContext context,

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -38,7 +38,6 @@ import java.util.ServiceLoader;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.jsoup.Jsoup;
@@ -61,8 +60,6 @@ import com.vaadin.flow.component.page.Viewport;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.AnnotationReader;
 import com.vaadin.flow.internal.ReflectTools;
-import com.vaadin.flow.internal.UsageStatistics;
-import com.vaadin.flow.internal.UsageStatistics.UsageEntry;
 import com.vaadin.flow.internal.UsageStatisticsExporter;
 import com.vaadin.flow.server.communication.AtmospherePushConnection;
 import com.vaadin.flow.server.communication.PushConnectionFactory;

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -278,8 +278,6 @@ public abstract class VaadinService implements Serializable {
             logger.debug("The application has the following routes: ");
             getRouteRegistry().getRegisteredRoutes().stream()
                     .map(Object::toString).forEach(logger::debug);
-
-            UsageStatistics.markAsUsed("flow/npm", null);
         }
 
         initialized = true;

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -57,7 +57,6 @@ import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.i18n.I18NProvider;
 import com.vaadin.flow.internal.CurrentInstance;
 import com.vaadin.flow.internal.LocaleUtil;
-import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.router.Router;
 import com.vaadin.flow.server.HandlerHelper.RequestType;
 import com.vaadin.flow.server.communication.AtmospherePushConnection;

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
@@ -17,9 +17,7 @@ package com.vaadin.flow.server.communication;
 
 import java.io.IOException;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
-import elemental.json.Json;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.DataNode;
 import org.jsoup.nodes.Document;
@@ -30,8 +28,8 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.function.DeploymentConfiguration;
-import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.server.AppShellRegistry;
+import com.vaadin.flow.internal.UsageStatisticsExporter;
 import com.vaadin.flow.server.VaadinContext;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
@@ -55,8 +53,6 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
 
     private static final Pattern PATH_WITH_EXTENSION = Pattern
             .compile("\\.[A-z][A-z\\d]+$");
-
-    private static final String SCRIPT_TAG = "script";
 
     private transient IndexHtmlResponse indexHtmlResponse;
 
@@ -91,7 +87,7 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
 
         DeploymentConfiguration config = session.getConfiguration();
         if (!config.isProductionMode()) {
-            exportUsageStatistics(indexDocument);
+            UsageStatisticsExporter.exportUsageStatisticsToDocument(indexDocument);
         }
 
         // modify the page based on the @PWA annotation
@@ -112,33 +108,6 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
             return false;
         }
         return true;
-    }
-
-    private void exportUsageStatistics(Document document) {
-        String entries = UsageStatistics.getEntries()
-                .map(IndexHtmlRequestHandler::createUsageStatisticsJson)
-                .collect(Collectors.joining(","));
-
-        if (!entries.isEmpty()) {
-            // Registers the entries in a way that is picked up as a Vaadin
-            // WebComponent by the usage stats gatherer
-            StringBuilder builder = new StringBuilder();
-            builder.append("window.Vaadin = window.Vaadin || {};\n")
-                    .append("window.Vaadin.registrations = window.Vaadin.registrations || [];\n")
-                    .append("window.Vaadin.registrations.push(")
-                    .append(entries)
-                    .append(");");
-            document.body().appendElement(SCRIPT_TAG).text(builder.toString());
-        }
-    }
-
-    static String createUsageStatisticsJson(UsageStatistics.UsageEntry entry) {
-        JsonObject json = Json.createObject();
-
-        json.put("is", entry.getName());
-        json.put("version", entry.getVersion());
-
-        return json.toJson();
     }
 
     private void includeInitialUidl(VaadinSession session,

--- a/flow-server/src/test/java/com/vaadin/flow/internal/UsageStatisticsExporterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/UsageStatisticsExporterTest.java
@@ -1,0 +1,44 @@
+package com.vaadin.flow.internal;
+
+import java.util.stream.Collectors;
+
+import elemental.json.Json;
+import elemental.json.JsonObject;
+import org.jsoup.internal.StringUtil;
+import org.jsoup.nodes.DataNode;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class UsageStatisticsExporterTest {
+
+    @Test
+    public void should_append_script_element_to_the_body(){
+        Document document = new Document("");
+        Element html = document.appendElement("html");
+        html.appendElement("body");
+
+        UsageStatisticsExporter.exportUsageStatisticsToDocument(document);
+
+        String entries = UsageStatistics.getEntries().map(entry -> {
+            JsonObject json = Json.createObject();
+
+            json.put("is", entry.getName());
+            json.put("version", entry.getVersion());
+
+            return json.toString();
+        }).collect(Collectors.joining(","));
+
+        String expected = StringUtil.normaliseWhitespace(
+                "window.Vaadin = window.Vaadin || {};\n" +
+                        "window.Vaadin.registrations = window.Vaadin.registrations || [];\n"
+                        + "window.Vaadin.registrations.push(" + entries
+                        + ");");
+
+        Elements bodyInlineElements = document.body().getElementsByTag("script");
+        assertEquals(StringUtil.normaliseWhitespace(expected), bodyInlineElements.get(0).childNode(0).outerHtml());
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
@@ -483,7 +483,7 @@ public class IndexHtmlRequestHandlerTest {
                             + "window.Vaadin.registrations.push(" + entries
                             + ");");
 
-        assertEquals(StringUtil.normaliseWhitespace(expected), ((DataNode)bodyInlineElements.get(1).childNode(0)).getWholeData());
+        assertEquals(StringUtil.normaliseWhitespace(expected), bodyInlineElements.get(1).childNode(0).outerHtml());
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
@@ -22,10 +22,12 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import com.sun.net.httpserver.HttpServer;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.internal.JavaScriptBootstrapUI;
+import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.server.AppShellRegistry;
 import com.vaadin.flow.server.AppShellRegistry.AppShellRegistryWrapper;
 import com.vaadin.flow.server.DevModeHandler;
@@ -37,8 +39,15 @@ import com.vaadin.flow.server.frontend.FrontendUtils;
 import com.vaadin.flow.server.startup.VaadinAppShellInitializerTest.MyAppShellWithConfigurator;
 import com.vaadin.flow.server.startup.VaadinAppShellInitializerTest.MyAppShellWithMultipleAnnotations;
 import com.vaadin.tests.util.MockDeploymentConfiguration;
+
+import elemental.json.Json;
+import elemental.json.JsonObject;
 import org.jsoup.Jsoup;
+import org.jsoup.internal.StringUtil;
+import org.jsoup.nodes.DataNode;
 import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.TextNode;
 import org.jsoup.select.Elements;
 import org.junit.After;
 import org.junit.Assert;
@@ -52,6 +61,7 @@ import static com.vaadin.flow.component.internal.JavaScriptBootstrapUI.SERVER_RO
 import static com.vaadin.flow.server.DevModeHandlerTest.createStubWebpackTcpListener;
 import static com.vaadin.flow.server.frontend.NodeUpdateTestUtil.createStubWebpackServer;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class IndexHtmlRequestHandlerTest {
     private MockServletServiceSessionSetup mocks;
@@ -401,7 +411,7 @@ public class IndexHtmlRequestHandlerTest {
         assertEquals("body,#outlet{width:my-width;height:my-height;}", headInlineAndStyleElements.get(2).childNode(0).toString());
 
         Elements bodyInlineElements = document.body().getElementsByTag("script");
-        assertEquals(3, bodyInlineElements.size());
+        assertEquals(4, bodyInlineElements.size());
     }
 
     @Test
@@ -441,7 +451,54 @@ public class IndexHtmlRequestHandlerTest {
         assertEquals("body,#outlet{width:my-width;height:my-height;}", headInlineAndStyleElements.get(2).childNode(0).toString());
 
         Elements bodyInlineElements = document.body().getElementsByTag("script");
+        assertEquals(3, bodyInlineElements.size());
+    }
+
+    @Test
+    public void should_export_usage_statistics_in_development_mode() throws IOException {
+        deploymentConfiguration.setProductionMode(false);
+
+        indexHtmlRequestHandler.synchronizedHandleRequest(session,
+                createVaadinRequest("/"), response);
+
+        String indexHtml = responseOutput
+                .toString(StandardCharsets.UTF_8.name());
+        Document document = Jsoup.parse(indexHtml);
+
+        Elements bodyInlineElements = document.body().getElementsByTag("script");
         assertEquals(2, bodyInlineElements.size());
+
+        String entries = UsageStatistics.getEntries().map(entry -> {
+            JsonObject json = Json.createObject();
+
+            json.put("is", entry.getName());
+            json.put("version", entry.getVersion());
+
+            return json.toString();
+        }).collect(Collectors.joining(","));
+
+        String expected = StringUtil.normaliseWhitespace(
+                    "window.Vaadin = window.Vaadin || {}; " +
+                            "window.Vaadin.registrations = window.Vaadin.registrations || [];\n"
+                            + "window.Vaadin.registrations.push(" + entries
+                            + ");");
+
+        assertEquals(StringUtil.normaliseWhitespace(expected), ((DataNode)bodyInlineElements.get(1).childNode(0)).getWholeData());
+    }
+
+    @Test
+    public void should_NOT_export_usage_statistics_in_production_mode() throws IOException {
+        deploymentConfiguration.setProductionMode(true);
+
+        indexHtmlRequestHandler.synchronizedHandleRequest(session,
+                createVaadinRequest("/"), response);
+
+        String indexHtml = responseOutput
+                .toString(StandardCharsets.UTF_8.name());
+        Document document = Jsoup.parse(indexHtml);
+
+        Elements bodyInlineElements = document.body().getElementsByTag("script");
+        assertEquals(1, bodyInlineElements.size());
     }
 
     @After


### PR DESCRIPTION
- Add missing usage statistics in the IndexHtmlHandler
- Removed flow/npm usage statistic entry, it was needed to differentiate from bower, as in v15, there is only npm.
- Renamed method exportNpmUsageStatistics() to exportUsageStatistics(), as there is no more bower.
Fixes #7310
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7329)
<!-- Reviewable:end -->
