### PR TITLE
Log a warning for obviously invalid style or class bindings

### DIFF
--- a/flow-data/src/test/java/com/vaadin/flow/data/renderer/TemplateRendererTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/renderer/TemplateRendererTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.data.renderer;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TemplateRendererTest {
+    @Test
+    public void missingAttributeBindingDetector() {
+        String[] missingDollar = {
+                // Basic case
+                "<div class='[[item.className]]'>",
+                // Spaces around =
+                "<div class = '[[item.className]]'>",
+                // Double quotes
+                "<div class=\"[[item.className]]\">",
+                // No quotes
+                "<div class=[[item.className]]>",
+                // Two-way binding
+                "<div class={{item.className}}>",
+                // Style property binding
+                "<div style='[[item.style]]'>" };
+
+        String[] notMissingDollar = {
+                // Basic case with dollar
+                "<div class$='[[item.className]]'>",
+                // Spaces around =
+                "<div class$ = [[item.className]]>",
+                // Style binding
+                "<div style$='[[item.style]]'>",
+                // Attribute name prefix
+                "<div my-style='[[item.style]]'>",
+                // Classname binding
+                "<div className='[[item.className]]'>",
+                // Static list, i.e. not a binding at all
+                "<div class='static list'>",
+                // Binding-like syntax that still isn't binding
+                "<div class=((item.not_a_binding))>" };
+
+        for (String template : missingDollar) {
+            if (!TemplateRenderer.hasClassOrStyleWithoutDollar(template)) {
+                Assert.fail("Missing dollar should be detected for the string: "
+                        + template);
+            }
+        }
+
+        for (String template : notMissingDollar) {
+            if (TemplateRenderer.hasClassOrStyleWithoutDollar(template)) {
+                Assert.fail(
+                        "Missing dollar should not be detected for the string: "
+                        + template);
+            }
+        }
+    }
+}


### PR DESCRIPTION
It is quite easy to forget to use $ in a template binding when defining
a class or inline styles. To help developers recover from that
particular trap, we are explicitly checking for it and logging a
warning.

The check is done based on a simple regular expression that will give
false positives e.g. if a matching string is used as static text instead
of inside a tag declaration. It is, however, seen as very unlikely that
anyone would want to use that kind of text content in their templates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7337)
<!-- Reviewable:end -->
