### PR TITLE
Use getChildren method directly in the interface

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/HasOrderedComponents.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasOrderedComponents.java
@@ -16,19 +16,17 @@
 package com.vaadin.flow.component;
 
 import java.util.Iterator;
+import java.util.stream.Stream;
 
 import com.vaadin.flow.dom.Element;
 
 /**
  * A component which the children components are ordered, so the index of each
  * child matters for the layout.
- * 
- * @param <T>
- *            the type of the component which implements the interface
+ *
  * @since 1.0
  */
-public interface HasOrderedComponents<T extends Component>
-        extends HasComponents {
+public interface HasOrderedComponents extends HasComponents {
 
     /**
      * Replaces the component in the container with another one without changing
@@ -38,12 +36,12 @@ public interface HasOrderedComponents<T extends Component>
      * the container. If the both component are already in the container, their
      * positions are swapped. Component attach and detach events should be taken
      * care as with add and remove.
-     * 
+     *
      * @param oldComponent
      *            the old component that will be replaced. Can be
      *            <code>null</code>, which will make the newComponent to be
      *            added to the layout without replacing any other
-     * 
+     *
      * @param newComponent
      *            the new component to be replaced. Can be <code>null</code>,
      *            which will make the oldComponent to be removed from the layout
@@ -75,7 +73,7 @@ public interface HasOrderedComponents<T extends Component>
 
     /**
      * Returns the index of the given component.
-     * 
+     *
      * @param component
      *            the component to look up, can not be <code>null</code>
      * @return the index of the component or -1 if the component is not a child
@@ -85,8 +83,7 @@ public interface HasOrderedComponents<T extends Component>
             throw new IllegalArgumentException(
                     "The 'component' parameter cannot be null");
         }
-        Iterator<Component> it = ((T) this).getChildren().sequential()
-                .iterator();
+        Iterator<Component> it = getChildren().sequential().iterator();
         int index = 0;
         while (it.hasNext()) {
             Component next = it.next();
@@ -100,16 +97,16 @@ public interface HasOrderedComponents<T extends Component>
 
     /**
      * Gets the number of children components.
-     * 
+     *
      * @return the number of components
      */
     default int getComponentCount() {
-        return (int) ((T) this).getChildren().count();
+        return (int) getChildren().count();
     }
 
     /**
      * Returns the component at the given position.
-     * 
+     *
      * @param index
      *            the position of the component, must be greater than or equals
      *            to 0 and less than the number of children components
@@ -125,10 +122,19 @@ public interface HasOrderedComponents<T extends Component>
                     "The 'index' argument should be greater than or equal to 0. It was: "
                             + index);
         }
-        return ((T) this).getChildren().sequential().skip(index).findFirst()
+        return getChildren().sequential().skip(index).findFirst()
                 .orElseThrow(() -> new IllegalArgumentException(
                         "The 'index' argument should not be greater than or equals to the number of children components. It was: "
                                 + index));
     }
+
+    /**
+     * Gets the children components of this component.
+     *
+     * @see Component#getChildren()
+     *
+     * @return the children components of this component
+     */
+    Stream<Component> getChildren();
 
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasOrderedComponentsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasOrderedComponentsTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.dom.Element;
+
+public class HasOrderedComponentsTest {
+
+    static class TestOrderedComponents implements HasOrderedComponents {
+
+        @Override
+        public Element getElement() {
+            return null;
+        }
+
+        @Override
+        public Stream<Component> getChildren() {
+            return null;
+        }
+
+    }
+
+    private HasOrderedComponents components = Mockito
+            .spy(TestOrderedComponents.class);
+
+    @Test
+    public void indexOf_componentIsChild_returnsIndexOfChild() {
+        Component comp = Mockito.mock(Component.class);
+        Mockito.when(components.getChildren())
+                .thenReturn(Arrays.asList(Mockito.mock(Component.class), comp,
+                        Mockito.mock(Component.class)).stream());
+
+        Assert.assertEquals(1, components.indexOf(comp));
+    }
+
+    @Test
+    public void indexOf_componentIsNotChild_returnsNegative() {
+        Component comp = Mockito.mock(Component.class);
+        Mockito.when(components.getChildren())
+                .thenReturn(Arrays.asList(Mockito.mock(Component.class),
+                        Mockito.mock(Component.class)).stream());
+
+        Assert.assertEquals(-1, components.indexOf(comp));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void indexOf_componentIsNull_throws() {
+        Mockito.when(components.getChildren()).thenReturn(Stream.empty());
+
+        components.indexOf(null);
+    }
+
+    @Test
+    public void getComponentCount_returnsChildrenSize() {
+        Mockito.when(components.getChildren())
+                .thenReturn(Arrays.asList(Mockito.mock(Component.class),
+                        Mockito.mock(Component.class)).stream());
+        Assert.assertEquals(2, components.getComponentCount());
+    }
+
+    @Test
+    public void getComponentAt_returnsComponentAtIndex() {
+        Component comp = Mockito.mock(Component.class);
+        Mockito.when(components.getChildren())
+                .thenReturn(Arrays.asList(Mockito.mock(Component.class), comp,
+                        Mockito.mock(Component.class)).stream());
+
+        Assert.assertSame(comp, components.getComponentAt(1));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getComponentAt_negativeIndex_throws() {
+        Mockito.when(components.getChildren())
+                .thenReturn(Arrays.asList(Mockito.mock(Component.class),
+                        Mockito.mock(Component.class)).stream());
+
+        components.getComponentAt(-1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getComponentAt_indexIsGreaterThanSize_throws() {
+        Mockito.when(components.getChildren())
+                .thenReturn(Stream.of(Mockito.mock(Component.class)));
+
+        components.getComponentAt(-2);
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasOrderedComponentsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasOrderedComponentsTest.java
@@ -40,8 +40,21 @@ public class HasOrderedComponentsTest {
 
     }
 
+    @Tag("div")
+    static class TestComponentContianer extends Component
+            implements HasOrderedComponents {
+
+    }
+
+    @Tag(Tag.A)
+    static class Anchor extends Component {
+
+    }
+
     private HasOrderedComponents components = Mockito
             .spy(TestOrderedComponents.class);
+
+    private TestComponentContianer contianer = new TestComponentContianer();
 
     @Test
     public void indexOf_componentIsChild_returnsIndexOfChild() {
@@ -51,6 +64,11 @@ public class HasOrderedComponentsTest {
                         Mockito.mock(Component.class)).stream());
 
         Assert.assertEquals(1, components.indexOf(comp));
+
+        contianer = new TestComponentContianer();
+        comp = new Anchor();
+        contianer.add(new Text(""), comp);
+        Assert.assertEquals(1, contianer.indexOf(comp));
     }
 
     @Test
@@ -76,6 +94,10 @@ public class HasOrderedComponentsTest {
                 .thenReturn(Arrays.asList(Mockito.mock(Component.class),
                         Mockito.mock(Component.class)).stream());
         Assert.assertEquals(2, components.getComponentCount());
+
+        contianer = new TestComponentContianer();
+        contianer.add(new Text(""), new Anchor());
+        Assert.assertEquals(2, contianer.getComponentCount());
     }
 
     @Test
@@ -86,6 +108,11 @@ public class HasOrderedComponentsTest {
                         Mockito.mock(Component.class)).stream());
 
         Assert.assertSame(comp, components.getComponentAt(1));
+
+        contianer = new TestComponentContianer();
+        comp = new Anchor();
+        contianer.add(new Text(""), comp);
+        Assert.assertSame(comp, contianer.getComponentAt(1));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -102,6 +129,6 @@ public class HasOrderedComponentsTest {
         Mockito.when(components.getChildren())
                 .thenReturn(Stream.of(Mockito.mock(Component.class)));
 
-        components.getComponentAt(-2);
+        components.getComponentAt(2);
     }
 }


### PR DESCRIPTION
* Use getChildren method directly in the HasOrderedComponents interface 
* Remove parameter

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7344)
<!-- Reviewable:end -->
