### PR TITLE
Restore deprecated API for executing JS

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -128,6 +128,25 @@ public class Page implements Serializable {
 
     private ResizeEventReceiver resizeReceiver;
 
+    /**
+     * Callback method for canceling executable javascript set with
+     * {@link Page#executeJs(String, Serializable...)}.
+     *
+     * @deprecated superseded by {@link PendingJavaScriptResult}
+     */
+    @FunctionalInterface
+    @Deprecated
+    public interface ExecutionCanceler extends Serializable {
+        /**
+         * Cancel the javascript execution, if it was not yet sent to the
+         * browser for execution.
+         *
+         * @return <code>true</code> if the execution was canceled,
+         *         <code>false</code> if not
+         */
+        boolean cancelExecution();
+    }
+
     private final UI ui;
     private final History history;
 
@@ -282,6 +301,42 @@ public class Page implements Serializable {
      */
     public void addDynamicImport(String expression) {
         addDependency(new Dependency(Type.DYNAMIC_IMPORT, expression));
+    }
+
+    // When updating JavaDocs here, keep in sync with Element.executeJavaScript
+    /**
+     * Asynchronously runs the given JavaScript expression in the browser. The
+     * given parameters will be available to the expression as variables named
+     * <code>$0</code>, <code>$1</code>, and so on. Supported parameter types
+     * are:
+     * <ul>
+     * <li>{@link String}
+     * <li>{@link Integer}
+     * <li>{@link Double}
+     * <li>{@link Boolean}
+     * <li>{@link JsonValue}
+     * <li>{@link Element} (will be sent as <code>null</code> if the server-side
+     * element instance is not attached when the invocation is sent to the
+     * client)
+     * </ul>
+     * Note that the parameter variables can only be used in contexts where a
+     * JavaScript variable can be used. You should for instance do
+     * <code>'prefix' + $0</code> instead of <code>'prefix$0'</code> and
+     * <code>value[$0]</code> instead of <code>value.$0</code> since JavaScript
+     * variables aren't evaluated inside strings or property names.
+     *
+     * @param expression
+     *            the JavaScript expression to invoke
+     * @param parameters
+     *            parameters to pass to the expression
+     * @return a callback for canceling the execution if not yet sent to browser
+     * @deprecated Use {@link #executeJs(String,Serializable...)} instead since
+     *             it also allows getting return value back.
+     */
+    @Deprecated
+    public ExecutionCanceler executeJavaScript(String expression,
+            Serializable... parameters) {
+        return executeJs(expression, parameters);
     }
 
     // When updating JavaDocs here, keep in sync with Element.executeJavaScript

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/PendingJavaScriptResult.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/PendingJavaScriptResult.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.component.page;
 import java.io.Serializable;
 import java.util.concurrent.CompletableFuture;
 
+import com.vaadin.flow.component.page.Page.ExecutionCanceler;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.JsonCodec;
 
@@ -40,7 +41,8 @@ import elemental.json.JsonValue;
  * @author Vaadin Ltd
  * @since 2.0
  */
-public interface PendingJavaScriptResult extends Serializable {
+public interface PendingJavaScriptResult
+        extends Serializable, ExecutionCanceler {
 
     /**
      * Exception used when a {@link CompletableFuture} returned from
@@ -66,6 +68,7 @@ public interface PendingJavaScriptResult extends Serializable {
      * @return <code>true</code> if the execution was canceled,
      *         <code>false</code> if not
      */
+    @Override
     boolean cancelExecution();
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -1553,6 +1553,35 @@ public class Element extends Node<Element> {
     /**
      * Calls the given function on the element with the given arguments.
      * <p>
+     * The function will be called after all pending DOM updates have completed,
+     * at the same time that {@link Page#executeJs(String, Serializable...)}
+     * calls are invoked.
+     * <p>
+     * If the element is not attached, the function call will be deferred until
+     * the element is attached.
+     *
+     * @see JsonCodec JsonCodec for supported argument types
+     *
+     * @param functionName
+     *            the name of the function to call, may contain dots to indicate
+     *            a function on a property.
+     * @param arguments
+     *            the arguments to pass to the function. Must be of a type
+     *            supported by the communication mechanism, as defined by
+     *            {@link JsonCodec}
+     *
+     * @deprecated Use {@link #callJsFunction(String,Serializable...)} instead
+     *             since it also allows getting return value back.
+     */
+    @Deprecated
+    public void callFunction(String functionName, Serializable... arguments) {
+        // Ignore return value
+        callJsFunction(functionName, arguments);
+    }
+
+    /**
+     * Calls the given function on the element with the given arguments.
+     * <p>
      * It is possible to get access to the return value of the execution by
      * registering a handler with the returned pending result. If no handler is
      * registered, the return value will be ignored.
@@ -1591,6 +1620,43 @@ public class Element extends Node<Element> {
 
         return scheduleJavaScriptInvocation("return $0." + functionName + "("
                 + paramPlaceholderString + ")", jsParameters);
+    }
+
+    // When updating JavaDocs here, keep in sync with Page.executeJavaScript
+    /**
+     * Asynchronously runs the given JavaScript expression in the browser in the
+     * context of this element. This element will be available to the expression
+     * as <code>this</code>. The given parameters will be available as variables
+     * named <code>$0</code>, <code>$1</code>, and so on. Supported parameter
+     * types are:
+     * <ul>
+     * <li>{@link String}
+     * <li>{@link Integer}
+     * <li>{@link Double}
+     * <li>{@link Boolean}
+     * <li>{@link JsonValue}
+     * <li>{@link Element} (will be sent as <code>null</code> if the server-side
+     * element instance is not attached when the invocation is sent to the
+     * client)
+     * </ul>
+     * Note that the parameter variables can only be used in contexts where a
+     * JavaScript variable can be used. You should for instance do
+     * <code>'prefix' + $0</code> instead of <code>'prefix$0'</code> and
+     * <code>value[$0]</code> instead of <code>value.$0</code> since JavaScript
+     * variables aren't evaluated inside strings or property names.
+     *
+     * @param expression
+     *            the JavaScript expression to invoke
+     * @param parameters
+     *            parameters to pass to the expression
+     * @deprecated Use {@link #executeJs(String,Serializable...)} instead since
+     *             it also allows getting return value back.
+     */
+    @Deprecated
+    public void executeJavaScript(String expression,
+            Serializable... parameters) {
+        // Ignore return value
+        executeJs(expression, parameters);
     }
 
     // When updating JavaDocs here, keep in sync with Page.executeJavaScript


### PR DESCRIPTION
Removal of the deprecated methods for executing JS would cause lots of
otherwise compatible add-ons to stop working. Updating those add-ons to
use the new API would instead make it so that the same version of the
add-on cannot be used with both Vaadin 10 and Vaadin 15. For these
reasons, these three methods are restored as simple shorthands that
delegate to the non-deprecated methods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7353)
<!-- Reviewable:end -->
