### PR TITLE
Revert "Fix Export-Package of bnd.bnd in fllow-dnd (#7291)"

### DIFF
--- a/flow-dnd/bnd.bnd
+++ b/flow-dnd/bnd.bnd
@@ -4,4 +4,5 @@ Bundle-Version: ${osgi.bundle.version}
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-License: http://www.apache.org/licenses/LICENSE-2.0
 Import-Package: *
-Export-Package: com.vaadin.flow.component.dnd.internal.*, com.vaadin.flow.component.dnd,com.vaadin.flow.component.dnd.osgi
+Export-Package: !com.vaadin.flow.component.dnd.internal*,\
+        com.vaadin.flow.component.dnd*;-noimport:=true


### PR DESCRIPTION
This reverts commit 99ba50dd.
See https://github.com/vaadin/flow/pull/7291#issuecomment-574609287 and https://github.com/vaadin/vaadin-grid-flow/pull/863

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7361)
<!-- Reviewable:end -->
