### PR TITLE
Added babel plugin to transpile object literal spread { ... } syntax not supported by Edge

### DIFF
--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -133,8 +133,13 @@ module.exports = {
     // Transpile with babel, and produce different bundles per browser
     new BabelMultiTargetPlugin({
       babel: {
-        // workaround for Safari 10 scope issue (https://bugs.webkit.org/show_bug.cgi?id=159270)
-        plugins: ["@babel/plugin-transform-block-scoping"],
+        plugins: [
+          // workaround for Safari 10 scope issue (https://bugs.webkit.org/show_bug.cgi?id=159270)
+          "@babel/plugin-transform-block-scoping",
+
+          // Edge does not support spread '...' syntax in object literals (#7321)
+          "@babel/plugin-proposal-object-rest-spread"
+        ],
 
         presetOptions: {
           useBuiltIns: false // polyfills are provided from webcomponents-loader.js


### PR DESCRIPTION
Fixes #7321

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7367)
<!-- Reviewable:end -->
