### PR TITLE
Workaround for TestBench/Flow not waiting for the view to be rendered

### DIFF
--- a/flow-test-util/src/main/java/com/vaadin/flow/testutil/AbstractTestBenchTest.java
+++ b/flow-test-util/src/main/java/com/vaadin/flow/testutil/AbstractTestBenchTest.java
@@ -31,6 +31,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestName;
+import org.openqa.selenium.By;
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
@@ -114,6 +115,11 @@ public abstract class AbstractTestBenchTest extends TestBenchHelpers {
         String url = getTestURL(parameters);
 
         getDriver().get(url);
+        try {
+            waitForElementPresent(By.xpath("//div[@id='outlet']/*"));
+        } catch (Exception e) {
+            // This happens in one or two tests which do not actually test server side routes, e.g. IdTestIT
+        }
     }
 
     protected void openProduction(String... parameters) {
@@ -143,6 +149,11 @@ public abstract class AbstractTestBenchTest extends TestBenchHelpers {
         }
         url = url.replace("/view/", builder.toString());
         getDriver().get(url);
+        try {
+            waitForElementPresent(By.xpath("//div[@id='outlet']/*"));
+        } catch (Exception e) {
+            // This happens in one or two tests which do not actually test server side routes, e.g. IdTestIT
+        }
     }
 
     /**


### PR DESCRIPTION
This should be reverted once the real problem is fixed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7378)
<!-- Reviewable:end -->
