### PR TITLE
CCDM: clarify that serverSideRoutes must be the last entry

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/index.ts
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/index.ts
@@ -22,11 +22,10 @@ const {serverSideRoutes} = new Flow({
 });
 
 const routes = [
-  // Send all routes to  server-side.
-  // If you have client-side views add them above this line.
-  // For more info, please check out the 'Client-side Routing'
-  // page in `https://vaadin.com/docs/v15/flow/typescript/client-side-routing.html`
-  ...serverSideRoutes
+  // for client-side, place routes below (more info https://vaadin.com/docs/v15/flow/typescript/creating-routes.html)
+
+  // for server-side, the next magic line sends all unmatched routes:
+  ...serverSideRoutes // IMPORTANT: this must be the last entry in the array
 ];
 
 // Vaadin router needs an outlet in the index.html page to display views


### PR DESCRIPTION
Fixes https://github.com/vaadin/vaadin-connect/issues/432

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7407)
<!-- Reviewable:end -->
