### PR TITLE
Fix a random fail test for 2.2 branch

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/PendingJavaScriptInvocationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/PendingJavaScriptInvocationTest.java
@@ -339,6 +339,9 @@ public class PendingJavaScriptInvocationTest {
             JsonObject value = Json.createObject();
             invocation.complete(value);
 
+            executor.shutdown();
+            executor.awaitTermination(100, TimeUnit.MILLISECONDS);
+
             Assert.assertEquals("All futures should be done", futures.size(),
                     futures.stream().filter(Future::isDone).count());
 


### PR DESCRIPTION
Fixes the PendingJavaScriptInvocationTest which fails randomly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7414)
<!-- Reviewable:end -->
