### PR TITLE
Make StreamRequestHandler constructor public

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamRequestHandler.java
@@ -63,7 +63,7 @@ public class StreamRequestHandler implements RequestHandler {
         this(new StreamReceiverHandler());
     }
 
-    protected StreamRequestHandler(StreamReceiverHandler receiverHandler) {
+    public StreamRequestHandler(StreamReceiverHandler receiverHandler) {
         this.receiverHandler = receiverHandler;
     }
 


### PR DESCRIPTION
The `StreamRequestHandler` constructor which allows passing in a `StreamReceiverHandler` is currently `protected`. If you want to have a custom `StreamRequestHandler` and `StreamReceiverHandler`, this makes it difficult.

By changing the `StreamRequestHandler` constructor to `public`, it makes it easy to extend `StreamRequestHandler` with a custom `StreamReceiverHandler`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7429)
<!-- Reviewable:end -->
