### PR TITLE
Clear previous request if it exists when it is not needed anymore

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
@@ -810,7 +810,8 @@ public class MessageHandler {
         this.nextResponseSessionExpiredHandler = nextResponseSessionExpiredHandler;
     }
 
-    public void onResynchronize() {
+    // Called by MessageSender when resyncronize starts
+    protected void onResynchronize() {
         resyncInProgress = true;
     }
 }

--- a/flow-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
@@ -558,6 +558,11 @@ public class MessageHandler {
     }
 
     private void forceMessageHandling() {
+        // Clear previous request if it exists. Otherwise resyncrhonize can trigger
+        // "Trying to start a new request while another is active" exception and fail.
+        if (registry.getRequestResponseTracker().hasActiveRequest()) {
+            registry.getRequestResponseTracker().endRequest();
+        }
         if (!responseHandlingLocks.isEmpty()) {
             // Lock which was never release -> bug in locker or things just
             // too slow


### PR DESCRIPTION
Clear previous request if it exists. Otherwise resyncrhonize can trigger "Trying to start a new request while another is active" exception and fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7437)
<!-- Reviewable:end -->
