### PR TITLE
Require explicit property set for development mode transpilation

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -222,7 +222,7 @@ public final class Constants implements Serializable {
     public static final String SERVLET_PARAMETER_DEVMODE_TRANSPILE = "devmode.transpile";
 
     /**
-     * Default value of {@link Constants::SERVLET_PARAMETER_DEVMODE_TRANSPILE}.
+     * Default value of {@link #SERVLET_PARAMETER_DEVMODE_TRANSPILE}.
      */
     public static final boolean SERVLET_PARAMETER_DEVMODE_TRANSPILE_DEFAULT = false;
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -216,6 +216,17 @@ public final class Constants implements Serializable {
     public static final String SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE = "devmode.optimizeBundle";
 
     /**
+     * Boolean parameter for enabling/disabling transpilation for IE11 with the
+     * BabelMultiTargetPlugin in dev mode.
+     */
+    public static final String SERVLET_PARAMETER_DEVMODE_TRANSPILE = "devmode.transpile";
+
+    /**
+     * Default value of {@link Constants::SERVLET_PARAMETER_DEVMODE_TRANSPILE}.
+     */
+    public static final boolean SERVLET_PARAMETER_DEVMODE_TRANSPILE_DEFAULT = false;
+
+    /**
      * Configuration parameter name for enabling pnpm.
      *
      * @since 2.2

--- a/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
@@ -46,6 +46,8 @@ import org.slf4j.LoggerFactory;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.server.frontend.FrontendUtils;
 
+import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_DEVMODE_TRANSPILE;
+import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_DEVMODE_TRANSPILE_DEFAULT;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_DEVMODE_WEBPACK_ERROR_PATTERN;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_DEVMODE_WEBPACK_OPTIONS;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_DEVMODE_WEBPACK_SUCCESS_PATTERN;
@@ -146,6 +148,10 @@ public final class DevModeHandler {
         command.add("--port");
         command.add(String.valueOf(port));
         command.add("--watchDogPort=" + watchDog.getWatchDogPort());
+        if (config.getBooleanProperty(SERVLET_PARAMETER_DEVMODE_TRANSPILE,
+                SERVLET_PARAMETER_DEVMODE_TRANSPILE_DEFAULT)) {
+            command.add("--transpile-es5");
+        }
         command.addAll(Arrays.asList(config
                 .getStringProperty(SERVLET_PARAMETER_DEVMODE_WEBPACK_OPTIONS,
                         "-d --inline=false")

--- a/flow-server/src/main/java/com/vaadin/flow/server/UnsupportedBrowserHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/UnsupportedBrowserHandler.java
@@ -78,21 +78,22 @@ public class UnsupportedBrowserHandler extends SynchronizedRequestHandler {
     public boolean synchronizedHandleRequest(VaadinSession session,
                                              VaadinRequest request, VaadinResponse response) throws IOException {
 
-        // Check if the browser is supported
-        WebBrowser browser = session.getBrowser();
+        // bypass checks if cookie set
         final String cookie = request.getHeader("Cookie");
-        if (browser.isTooOldToFunctionProperly()) {
-            // bypass if cookie set
-            if (cookie == null || !cookie.contains(FORCE_LOAD_COOKIE)) {
-                writeBrowserTooOldPage(request, response);
-                return true; // request handled
-            }
+        if (cookie != null && cookie.contains(FORCE_LOAD_COOKIE)) {
+            return false;
         }
 
-        // check for trying to run ie11 in development mode, bypass if cookie set
+        // check if the browser is supported
+        WebBrowser browser = session.getBrowser();
+        if (browser.isTooOldToFunctionProperly()) {
+            writeBrowserTooOldPage(request, response);
+            return true; // request handled
+        }
+
+        // check for trying to run ie11 in development mode
         if (browser.isIE() && !session.getConfiguration().isProductionMode()
-                && session.getConfiguration().isCompatibilityMode()
-                && (cookie == null || !cookie.contains(FORCE_LOAD_COOKIE))) {
+                && session.getConfiguration().isCompatibilityMode()) {
             writeIE11InDevelopmentModePage(response);
             return true;
         }
@@ -103,8 +104,7 @@ public class UnsupportedBrowserHandler extends SynchronizedRequestHandler {
                 && !browser.isEs6Supported()
                 && !session.getConfiguration().getBooleanProperty(
                         SERVLET_PARAMETER_DEVMODE_TRANSPILE,
-                        SERVLET_PARAMETER_DEVMODE_TRANSPILE_DEFAULT)
-                && (cookie == null || !cookie.contains(FORCE_LOAD_COOKIE))) {
+                        SERVLET_PARAMETER_DEVMODE_TRANSPILE_DEFAULT)) {
             writeES5TranspilationRequiredInDevelopmentModePage(response);
             return true;
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/UnsupportedBrowserHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/UnsupportedBrowserHandler.java
@@ -89,25 +89,24 @@ public class UnsupportedBrowserHandler extends SynchronizedRequestHandler {
             }
         }
 
-        // check for trying to run ie11 in development mode
-        if (browser.isIE() && !session.getConfiguration().isProductionMode() && session.getConfiguration().isCompatibilityMode()) {
-            // bypass if cookie set
-            if (cookie == null || !cookie.contains(FORCE_LOAD_COOKIE)) {
-                writeIE11InDevelopmentModePage(response);
-                return true;
-            }
+        // check for trying to run ie11 in development mode, bypass if cookie set
+        if (browser.isIE() && !session.getConfiguration().isProductionMode()
+                && session.getConfiguration().isCompatibilityMode()
+                && (cookie == null || !cookie.contains(FORCE_LOAD_COOKIE))) {
+            writeIE11InDevelopmentModePage(response);
+            return true;
         }
 
+        // check for trying to run non-ES6 browser in dev mode without transpilation
         if (!session.getConfiguration().isCompatibilityMode()
                 && !session.getConfiguration().isProductionMode()
                 && !browser.isEs6Supported()
                 && !session.getConfiguration().getBooleanProperty(
                         SERVLET_PARAMETER_DEVMODE_TRANSPILE,
-                        SERVLET_PARAMETER_DEVMODE_TRANSPILE_DEFAULT)) {
-            if (cookie == null || !cookie.contains(FORCE_LOAD_COOKIE)) {
-                writeES5TranspilationRequiredInDevelopmentModePage(response);
-                return true;
-            }
+                        SERVLET_PARAMETER_DEVMODE_TRANSPILE_DEFAULT)
+                && (cookie == null || !cookie.contains(FORCE_LOAD_COOKIE))) {
+            writeES5TranspilationRequiredInDevelopmentModePage(response);
+            return true;
         }
 
         return false; // pass to next handler

--- a/flow-server/src/main/java/com/vaadin/flow/server/UnsupportedBrowserHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/UnsupportedBrowserHandler.java
@@ -203,8 +203,8 @@ public class UnsupportedBrowserHandler extends SynchronizedRequestHandler {
                         + "<p>To test your app with this browser, enable transpilation in development mode.</p>"
                         + "<p>Transpilation can be enabled by setting the <code>vaadin.devmode.transpile=true</code> "
                         + "property for the deployment configuration using an application or a system property.<p>"
-                        + "<p>Note that transpilation is always enabled when running the <code>build-frontend</code> Maven goal as part of a "
-                        + "production mode build.</p>"
+                        + "<p>Note that transpilation is always enabled for the <code>build-frontend</code> Maven goal, "
+                        + "which is also used when creating a production build of the application.</p>"
                         + "<p><sub><a onclick=\"document.cookie='"
                         + FORCE_LOAD_COOKIE
                         + "';window.location.reload();return false;\" href=\"#\">Continue anyway<br>"

--- a/flow-server/src/main/java/com/vaadin/flow/server/UnsupportedBrowserHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/UnsupportedBrowserHandler.java
@@ -205,6 +205,10 @@ public class UnsupportedBrowserHandler extends SynchronizedRequestHandler {
                         + "property for the deployment configuration using an application or a system property.<p>"
                         + "<p>Note that transpilation is always enabled when running the <code>build-frontend</code> Maven goal as part of a "
                         + "production mode build.</p>"
+                        + "<p><sub><a onclick=\"document.cookie='"
+                        + FORCE_LOAD_COOKIE
+                        + "';window.location.reload();return false;\" href=\"#\">Continue anyway<br>"
+                        + "(eg. if you've setup ES5 transpilation in a custom webpack configuration)</sub></p>"
                         + "</body>\n"
                         + "</html>");
         // @formatter:on

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -41,7 +41,7 @@ if (watchDogPort){
     watchDogPort = watchDogPort.substr(watchDogPrefix.length);
 }
 
-const transpile = process.argv.find(v => v.indexOf('--transpile-es5') >= 0);
+const transpile = !devMode || process.argv.find(v => v.indexOf('--transpile-es5') >= 0);
 
 const net = require('net');
 

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -41,6 +41,8 @@ if (watchDogPort){
     watchDogPort = watchDogPort.substr(watchDogPrefix.length);
 }
 
+const transpile = process.argv.find(v => v.indexOf('--transpile-es5') >= 0);
+
 const net = require('net');
 
 function setupWatchDog(){
@@ -112,10 +114,10 @@ module.exports = {
 
   module: {
     rules: [
-      { // Files that Babel has to transpile
+      ...(transpile ? [{ // Files that Babel has to transpile
         test: /\.js$/,
         use: [BabelMultiTargetPlugin.loader()]
-      },
+      }] : []),
       {
         test: /\.css$/i,
         use: ['raw-loader']
@@ -131,7 +133,7 @@ module.exports = {
     ...(devMode ? [] : [new CompressionPlugin()]),
 
     // Transpile with babel, and produce different bundles per browser
-    new BabelMultiTargetPlugin({
+    ...(transpile ? [new BabelMultiTargetPlugin({
       babel: {
         plugins: [
           // workaround for Safari 10 scope issue (https://bugs.webkit.org/show_bug.cgi?id=159270)
@@ -161,7 +163,7 @@ module.exports = {
           tagAssetsWithKey: true, // append a suffix to the file name
         }
       }
-    }),
+    })] : []),
 
     // Generates the stats file for flow `@Id` binding.
     function (compiler) {


### PR DESCRIPTION
Part of #7434. Use `BabelMultiTargetPlugin` only if the parameter `devmode.transpile` is set to true (false by default), and show an info page about this for ES6 noncompliant browsers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7453)
<!-- Reviewable:end -->
