### PR TITLE
Parse Html contents as a body fragment

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/component/HTMLTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HTMLTest.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -123,6 +124,20 @@ public class HTMLTest {
 
         Assert.assertEquals("<audio controls></audio>",
                 html.getElement().getOuterHTML());
+    }
+
+    @Test
+    public void styleElementAsString_elementIsUsed() {
+        Html html = new Html("<style></style>");
+        Assert.assertEquals("style", html.getElement().getTag());
+    }
+
+    @Test
+
+    public void styleElementAsStream_elementIsUsed() {
+        Html html = new Html(new ByteArrayInputStream(
+                "<style></style>".getBytes(StandardCharsets.UTF_8)));
+        Assert.assertEquals("style", html.getElement().getTag());
     }
 
 }


### PR DESCRIPTION
Regular parsing puts some top-level elements in the head rather than the
body, causing them to be ignored when we use the contents of the body.
Parsing as a body fragment avoids this problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7466)
<!-- Reviewable:end -->
