### PR TITLE
expose the original Java exception message in VaadinConnectError

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/Connect.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Connect.ts
@@ -76,19 +76,12 @@ export class VaadinConnectError extends Error {
   detail?: any;
 
   /**
-   * An original exception error message.
-   */
-  originalErrorMessage: string;
-
-  /**
    * @param message the `message` property value
    * @param type the `type` property value
    * @param detail the `detail` property value
    */
   constructor(message: string, type?: string, detail?: any) {
-    super(
-      `Message: '${message}', additional details: '${JSON.stringify(detail)}'`);
-    this.originalErrorMessage = message;
+    super(message);
     this.type = type;
     this.detail = detail;
   }

--- a/flow-client/src/main/resources/META-INF/resources/frontend/Connect.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Connect.ts
@@ -76,6 +76,11 @@ export class VaadinConnectError extends Error {
   detail?: any;
 
   /**
+   * An original exception error message.
+   */
+  originalErrorMessage: string;
+
+  /**
    * @param message the `message` property value
    * @param type the `type` property value
    * @param detail the `detail` property value
@@ -83,6 +88,7 @@ export class VaadinConnectError extends Error {
   constructor(message: string, type?: string, detail?: any) {
     super(
       `Message: '${message}', additional details: '${JSON.stringify(detail)}'`);
+    this.originalErrorMessage = message;
     this.type = type;
     this.detail = detail;
   }

--- a/flow-client/src/test/frontend/ConnectTests.ts
+++ b/flow-client/src/test/frontend/ConnectTests.ts
@@ -189,7 +189,7 @@ describe('ConnectClient', () => {
         await client.call('FooEndpoint', 'vaadinException');
       } catch (err) {
         expect(err).to.be.instanceOf(VaadinConnectError);
-        expect(err).to.have.property('message').that.is.string(expectedObject.message);
+        expect(err).to.have.property('originalErrorMessage').that.is.string(expectedObject.message);
         expect(err).to.have.property('type').that.is.string(expectedObject.type);
         expect(err).to.have.deep.property('detail', expectedObject.detail);
       }

--- a/flow-client/src/test/frontend/ConnectTests.ts
+++ b/flow-client/src/test/frontend/ConnectTests.ts
@@ -189,7 +189,7 @@ describe('ConnectClient', () => {
         await client.call('FooEndpoint', 'vaadinException');
       } catch (err) {
         expect(err).to.be.instanceOf(VaadinConnectError);
-        expect(err).to.have.property('originalErrorMessage').that.is.string(expectedObject.message);
+        expect(err).to.have.property('message').that.is.string(expectedObject.message);
         expect(err).to.have.property('type').that.is.string(expectedObject.type);
         expect(err).to.have.deep.property('detail', expectedObject.detail);
       }


### PR DESCRIPTION
expose the original Java exception message in VaadinConnectError
fiexs #7162

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7479)
<!-- Reviewable:end -->
