### PR TITLE
JavaDocs to clarify when BeforeLeave{Listener,Observer}s are not called

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -16,6 +16,7 @@
 
 package com.vaadin.flow.component;
 
+import java.net.URI;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -969,7 +970,13 @@ public class UI extends Component
      * Add a listener that will be informed when old components are detached.
      * <p>
      * Listeners will be executed before any found observers.
-     *
+     * <p>
+     * If a route target is left for reasons not under the control of the
+     * navigator (for instance using
+     * {@link com.vaadin.flow.component.page.Page#setLocation(URI)}, typing a
+     * URL into the address bar, or closing the browser), listeners are not
+     * called.
+     * 
      * @param listener
      *            the before leave listener
      * @return handler to remove the event listener

--- a/flow-server/src/main/java/com/vaadin/flow/router/BeforeLeaveListener.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/BeforeLeaveListener.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.router;
 
+import java.net.URI;
+
 import com.vaadin.flow.router.internal.BeforeLeaveHandler;
 
 /**
@@ -27,9 +29,15 @@ import com.vaadin.flow.router.internal.BeforeLeaveHandler;
  * <p>
  * During this phase there is the possibility to reroute to another navigation
  * target or to postpone the navigation (to for instance get user input).
+ * <p>
+ * If a route target is left for reasons not under the control of the navigator
+ * (for instance using
+ * {@link com.vaadin.flow.component.page.Page#setLocation(URI)}, typing a URL
+ * into the address bar, or closing the browser), listeners are not called.
  *
- * All BeforeLeaveListeners will be executed before the BeforeLeaveObservers.
- * To control the order of execution of BeforeLeaveListeners, see {@link ListenerPriority}
+ * All BeforeLeaveListeners will be executed before the BeforeLeaveObservers. To
+ * control the order of execution of BeforeLeaveListeners, see
+ * {@link ListenerPriority}
  *
  * @since 1.0
  */

--- a/flow-server/src/main/java/com/vaadin/flow/router/BeforeLeaveObserver.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/BeforeLeaveObserver.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.router;
 
+import java.net.URI;
+
 import com.vaadin.flow.router.internal.BeforeLeaveHandler;
 
 /**
@@ -24,6 +26,11 @@ import com.vaadin.flow.router.internal.BeforeLeaveHandler;
  * During this event phase there is the possibility to reroute to another
  * navigation target or to postpone the navigation (to for instance get user
  * input).
+ * <p>
+ * If a route target is left for reasons not under the control of the navigator
+ * (for instance using
+ * {@link com.vaadin.flow.component.page.Page#setLocation(URI)}, typing a URL
+ * into the address bar, or closing the browser), listeners are not called.
  *
  * @author Vaadin Ltd
  * @since 1.0


### PR DESCRIPTION
Closes #7401

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7491)
<!-- Reviewable:end -->
