### PR TITLE
Use pnpm instead of npm

### DIFF
--- a/flow-client/pom.xml
+++ b/flow-client/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <gwt.module>com.vaadin.ClientEngine</gwt.module>
         <gwt.module.output>${project.build.outputDirectory}/META-INF/resources/VAADIN/static/</gwt.module.output>
-        <gwt.module.style>PRETTY</gwt.module.style>
+        <gwt.module.style>OBF</gwt.module.style>
         <gwt.sdm.bindAddress>0.0.0.0</gwt.sdm.bindAddress>
     </properties>
 

--- a/flow-client/pom.xml
+++ b/flow-client/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <gwt.module>com.vaadin.ClientEngine</gwt.module>
         <gwt.module.output>${project.build.outputDirectory}/META-INF/resources/VAADIN/static/</gwt.module.output>
-        <gwt.module.style>OBF</gwt.module.style>
+        <gwt.module.style>PRETTY</gwt.module.style>
         <gwt.sdm.bindAddress>0.0.0.0</gwt.sdm.bindAddress>
     </properties>
 

--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -87,6 +87,21 @@
         </plugins>
         <pluginManagement>
             <plugins>
+                <plugin>
+                    <groupId>com.vaadin</groupId>
+                    <artifactId>flow-maven-plugin</artifactId>
+                    <version>${project.version}</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>prepare-frontend</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <pnpmEnable>true</pnpmEnable>
+                    </configuration>
+                </plugin>
                 <!-- Remove libs before ITs to avoid scan complaining about classes in multiple locations -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/flow-tests/test-ccdm/pom-production.xml
+++ b/flow-tests/test-ccdm/pom-production.xml
@@ -52,7 +52,6 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <version>${project.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/flow-tests/test-ccdm/pom.xml
+++ b/flow-tests/test-ccdm/pom.xml
@@ -41,15 +41,6 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <version>${project.version}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>prepare-frontend</goal>
-                            <!-- Doesn't include build-frontend to simulate pure "jetty:run" -->
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <productionMode>false</productionMode>
                 </configuration>

--- a/flow-tests/test-dev-mode/pom.xml
+++ b/flow-tests/test-dev-mode/pom.xml
@@ -43,14 +43,6 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <version>${project.version}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>prepare-frontend</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <productionMode>false</productionMode>
                 </configuration>

--- a/flow-tests/test-embedding/test-embedding-generic/pom.xml
+++ b/flow-tests/test-embedding/test-embedding-generic/pom.xml
@@ -61,7 +61,6 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <version>${project.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/flow-tests/test-embedding/test-embedding-production-mode/pom.xml
+++ b/flow-tests/test-embedding/test-embedding-production-mode/pom.xml
@@ -79,7 +79,6 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <version>${project.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/flow-tests/test-embedding/test-embedding-theme-variant/pom.xml
+++ b/flow-tests/test-embedding/test-embedding-theme-variant/pom.xml
@@ -50,7 +50,6 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <version>${project.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/flow-tests/test-lumo-theme/pom.xml
+++ b/flow-tests/test-lumo-theme/pom.xml
@@ -45,7 +45,6 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <version>${project.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/flow-tests/test-material-theme/pom.xml
+++ b/flow-tests/test-material-theme/pom.xml
@@ -41,7 +41,6 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <version>${project.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/flow-tests/test-misc/pom.xml
+++ b/flow-tests/test-misc/pom.xml
@@ -40,7 +40,6 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <version>${project.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/flow-tests/test-mixed/pom-npm-production.xml
+++ b/flow-tests/test-mixed/pom-npm-production.xml
@@ -49,7 +49,6 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <version>${project.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/flow-tests/test-mixed/pom-npm.xml
+++ b/flow-tests/test-mixed/pom-npm.xml
@@ -48,15 +48,6 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <version>${project.version}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <!-- only need prepare-frontend because we run tests in dev mode -->
-                            <goal>prepare-frontend</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <productionMode>false</productionMode>
                 </configuration>

--- a/flow-tests/test-mixed/pom-pnpm-production.xml
+++ b/flow-tests/test-mixed/pom-pnpm-production.xml
@@ -49,7 +49,6 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <version>${project.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/flow-tests/test-mixed/pom.xml
+++ b/flow-tests/test-mixed/pom.xml
@@ -48,16 +48,6 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <version>${project.version}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <!-- only need prepare-frontend because we run 
-                                tests in dev mode -->
-                            <goal>prepare-frontend</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <productionMode>false</productionMode>
                 </configuration>

--- a/flow-tests/test-multi-war/test-war1/pom.xml
+++ b/flow-tests/test-multi-war/test-war1/pom.xml
@@ -24,7 +24,6 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <version>${project.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/flow-tests/test-multi-war/test-war2/pom.xml
+++ b/flow-tests/test-multi-war/test-war2/pom.xml
@@ -24,7 +24,6 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <version>${project.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/flow-tests/test-no-theme/pom.xml
+++ b/flow-tests/test-no-theme/pom.xml
@@ -78,7 +78,6 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <version>${project.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/flow-tests/test-npm-only-features/test-default-theme/pom.xml
+++ b/flow-tests/test-npm-only-features/test-default-theme/pom.xml
@@ -55,7 +55,6 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <version>${project.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-devmode.xml
+++ b/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-devmode.xml
@@ -79,14 +79,6 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <version>${project.version}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>prepare-frontend</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-prod-fallback.xml
+++ b/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-prod-fallback.xml
@@ -86,7 +86,6 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <version>${project.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-production.xml
+++ b/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-production.xml
@@ -86,7 +86,6 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <version>${project.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/flow-tests/test-npm-only-features/test-npm-custom-frontend-directory/pom.xml
+++ b/flow-tests/test-npm-only-features/test-npm-custom-frontend-directory/pom.xml
@@ -78,17 +78,9 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <version>${project.version}</version>
                 <configuration>
                     <frontendDirectory>${project.basedir}/myfrontend</frontendDirectory>
                 </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>prepare-frontend</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/flow-tests/test-npm-only-features/test-npm-no-buildmojo/pom.xml
+++ b/flow-tests/test-npm-only-features/test-npm-no-buildmojo/pom.xml
@@ -115,19 +115,9 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <version>${project.version}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>prepare-frontend</goal>
-                            <!-- removing build simulates pure jetty:run -->
-<!--                            <goal>build-frontend</goal>-->
-                        </goals>
-                        <configuration>
-                            <useDeprecatedV14Bootstrapping>true</useDeprecatedV14Bootstrapping>
-                        </configuration>
-                    </execution>
-                </executions>
+                <configuration>
+                    <useDeprecatedV14Bootstrapping>true</useDeprecatedV14Bootstrapping>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/flow-tests/test-npm-only-features/test-npm-no-buildmojo/pom.xml
+++ b/flow-tests/test-npm-only-features/test-npm-no-buildmojo/pom.xml
@@ -115,9 +115,6 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <configuration>
-                    <useDeprecatedV14Bootstrapping>true</useDeprecatedV14Bootstrapping>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/flow-tests/test-npm-only-features/test-npm-performance-regression/pom.xml
+++ b/flow-tests/test-npm-only-features/test-npm-performance-regression/pom.xml
@@ -130,14 +130,6 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <version>${project.version}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>prepare-frontend</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/flow-tests/test-pwa/pom.xml
+++ b/flow-tests/test-pwa/pom.xml
@@ -36,14 +36,6 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <version>${project.version}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>prepare-frontend</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <productionMode>false</productionMode>
                 </configuration>

--- a/flow-tests/test-root-context/pom.xml
+++ b/flow-tests/test-root-context/pom.xml
@@ -72,7 +72,6 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <version>${project.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/flow-tests/test-root-ui-context/pom.xml
+++ b/flow-tests/test-root-ui-context/pom.xml
@@ -28,14 +28,6 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <version>${project.version}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>prepare-frontend</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <productionMode>false</productionMode>
                 </configuration>

--- a/flow-tests/test-router-custom-context/pom.xml
+++ b/flow-tests/test-router-custom-context/pom.xml
@@ -59,17 +59,9 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <version>${project.version}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>prepare-frontend</goal>
-                        </goals>
-                        <configuration>
-                            <useDeprecatedV14Bootstrapping>true</useDeprecatedV14Bootstrapping>
-                        </configuration>
-                    </execution>
-                </executions>
+                <configuration>
+                    <useDeprecatedV14Bootstrapping>true</useDeprecatedV14Bootstrapping>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/flow-tests/test-router-custom-context/pom.xml
+++ b/flow-tests/test-router-custom-context/pom.xml
@@ -59,9 +59,6 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <configuration>
-                    <useDeprecatedV14Bootstrapping>true</useDeprecatedV14Bootstrapping>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/flow-tests/test-servlet/pom.xml
+++ b/flow-tests/test-servlet/pom.xml
@@ -27,14 +27,6 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <version>${project.version}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>prepare-frontend</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <productionMode>false</productionMode>
                 </configuration>

--- a/flow-tests/test-subcontext/pom.xml
+++ b/flow-tests/test-subcontext/pom.xml
@@ -33,14 +33,6 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <version>${project.version}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>prepare-frontend</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <!-- The Jetty plugin allows us to easily test the development
                 build by running jetty:run -->

--- a/flow-tests/test-themes/pom.xml
+++ b/flow-tests/test-themes/pom.xml
@@ -33,7 +33,6 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
-                <version>${project.version}</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
For Flow tests module use pnpm in
favor of npm as the npm i takes
3-5 min per module that uses it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7512)
<!-- Reviewable:end -->
