### PR TITLE
chore: update jackson version to avoid failures with spring

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -14,8 +14,8 @@
 
     <properties>
         <validation.api.version>2.0.1.Final</validation.api.version>
-        <jackson.version>2.9.10</jackson.version>
-        <jackson.databind.version>2.9.10.2</jackson.databind.version>
+        <jackson.version>2.10.2</jackson.version>
+        <jackson.databind.version>2.10.2</jackson.databind.version>
         <spring.version>5.2.0.RELEASE</spring.version>
         <spring.autoconfigure.version>2.2.0.RELEASE</spring.autoconfigure.version>
         <javax.annotation.api.version>1.3.2</javax.annotation.api.version>


### PR DESCRIPTION
Spring version used in vaadin-spring depends on a higher version of jackson
This is needed in order to fix spring tests in MPR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7529)
<!-- Reviewable:end -->
