### PR TITLE
Remove unused response parameter in getServiceUrl

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
@@ -140,7 +140,7 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
                             + PATH_PATTERN.toString());
         }
 
-        final String serviceUrl = getServiceUrl(request, response);
+        final String serviceUrl = getServiceUrl(request);
 
         BootstrapContext context = super.createAndInitUI(WebComponentUI.class,
                 request, response, session);
@@ -196,7 +196,7 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
         HandlerHelper.setResponseNoCacheHeaders(response::setHeader,
                 response::setDateHeader);
 
-        String serviceUrl = getServiceUrl(request, response);
+        String serviceUrl = getServiceUrl(request);
 
         Document document = getPageBuilder().getBootstrapPage(context);
         writeBootstrapPage(response, document.head(), serviceUrl);
@@ -398,12 +398,9 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
      *
      * @param request
      *            the request object
-     * @param response
-     *            the response object
      * @return Service url for the given request.
      */
-    protected String getServiceUrl(VaadinRequest request,
-            VaadinResponse response) {
+    protected String getServiceUrl(VaadinRequest request) {
         // get service url from 'url' parameter
         String url = request.getParameter(REQ_PARAM_URL);
         // if 'url' parameter was not available, use request url

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandlerTest.java
@@ -56,8 +56,7 @@ public class WebComponentBootstrapHandlerTest {
         }
 
         @Override
-        protected String getServiceUrl(VaadinRequest request,
-                VaadinResponse response) {
+        protected String getServiceUrl(VaadinRequest request) {
             return "/";
         }
     }


### PR DESCRIPTION
The `VaadinResponse` parameter is unused and may confuse people thinking it could be used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7533)
<!-- Reviewable:end -->
