### PR TITLE
Add additional methods to VaadinRequest interface

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/function/ContentTypeResolver.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/ContentTypeResolver.java
@@ -18,21 +18,20 @@ package com.vaadin.flow.function;
 import java.io.Serializable;
 import java.util.function.BiFunction;
 
-import javax.servlet.ServletContext;
-
 import com.vaadin.flow.server.StreamResource;
+import com.vaadin.flow.server.VaadinService;
 
 /**
  * Content type resolver.
  * <p>
  * Allows to get content type for the given {@link StreamResource} instance
- * using the current {@link ServletContext}.
+ * using the current {@link VaadinService}.
  *
  * @author Vaadin Ltd
  * @since 1.0
  *
  */
 public interface ContentTypeResolver extends
-        BiFunction<StreamResource, ServletContext, String>, Serializable {
+        BiFunction<StreamResource, VaadinService, String>, Serializable {
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/StreamResource.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StreamResource.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.server;
 
-import javax.servlet.ServletContext;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -53,8 +51,8 @@ public class StreamResource extends AbstractStreamResource {
     private static class DefaultResolver implements ContentTypeResolver {
 
         @Override
-        public String apply(StreamResource resource, ServletContext context) {
-            return Optional.ofNullable(context.getMimeType(resource.getName()))
+        public String apply(StreamResource resource, VaadinService service) {
+            return Optional.ofNullable(service.getMimeType(resource.getName()))
                     .orElse(DEFAULT_CONTENT_TYPE);
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinRequest.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinRequest.java
@@ -25,15 +25,13 @@ import java.util.Enumeration;
 import java.util.Locale;
 import java.util.Map;
 
-import javax.servlet.ServletRequest;
 import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
 
 import com.vaadin.flow.internal.CurrentInstance;
 
 /**
  * A generic request to the server, wrapping a more specific request type, e.g.
- * HttpServletRequest.
+ * {@link javax.servlet.http.HttpServletRequest}.
  *
  * @author Vaadin Ltd
  * @since 1.0
@@ -127,7 +125,7 @@ public interface VaadinRequest {
      * Returns the portion of the request URI that indicates the context of the
      * request. The context path always comes first in a request URI.
      *
-     * @see HttpServletRequest#getContextPath()
+     * @see javax.servlet.http.HttpServletRequest#getContextPath()
      *
      * @return a String specifying the portion of the request URI that indicates
      *         the context of the request
@@ -135,11 +133,59 @@ public interface VaadinRequest {
     String getContextPath();
 
     /**
+     * Returns the part of this request's URL that calls the servlet. This path
+     * starts with a "/" character and includes either the servlet name or a
+     * path to the servlet, but does not include any extra path information or
+     * a query string.
+     *
+     * @see javax.servlet.http.HttpServletRequest#getServletPath()
+     *
+     * @return a String containing the name or path of the servlet being called,
+     *         as specified in the request URL, decoded, or an empty string if
+     *         the servlet used to process the request is matched using the
+     *         "/*" pattern.
+     */
+    String getServletPath();
+
+    /**
+     * Reconstructs the URL the client used to make the request. The returned
+     * URL contains a protocol, server name, port number, and server path, but
+     * it does not include query string parameters.
+     *
+     * @see javax.servlet.http.HttpServletRequest#getRequestURL()
+     *
+     * @return a StringBuffer object containing the reconstructed URL
+     */
+    StringBuffer getRequestURL();
+
+    /**
+     * Returns the part of this request's URL from the protocol name up to
+     * the query string in the first line of the HTTP request.
+     *
+     * @return a String containing the part of the URL from the protocol
+     *         name up to the query string
+     *
+     * @see javax.servlet.http.HttpServletRequest#getRequestURI()
+     */
+    String getRequestURI();
+
+    /**
+     * Returns the query string that is contained in the request URL after
+     * the path.
+     *
+     * @see javax.servlet.http.HttpServletRequest#getQueryString()
+     *
+     * @return a String containing the query string or <code>null</code>
+     *         if the URL contains no query string.
+     */
+    String getQueryString();
+
+    /**
      * Gets the session associated with this request, creating a new if there is
      * no session.
      *
      * @see WrappedSession
-     * @see HttpServletRequest#getSession()
+     * @see javax.servlet.http.HttpServletRequest#getSession()
      *
      * @return the wrapped session for this request
      */
@@ -155,7 +201,7 @@ public interface VaadinRequest {
      *            there's no current session
      *
      * @see WrappedSession
-     * @see HttpServletRequest#getSession(boolean)
+     * @see javax.servlet.http.HttpServletRequest#getSession(boolean)
      *
      * @return the wrapped session for this request
      */
@@ -179,7 +225,7 @@ public interface VaadinRequest {
      *
      * @return the preferred Locale
      *
-     * @see ServletRequest#getLocale()
+     * @see javax.servlet.ServletRequest#getLocale()
      */
     Locale getLocale();
 
@@ -190,7 +236,7 @@ public interface VaadinRequest {
      * @return a string containing the IP address, or <code>null</code> if the
      *         address is not available
      *
-     * @see ServletRequest#getRemoteAddr()
+     * @see javax.servlet.ServletRequest#getRemoteAddr()
      */
     String getRemoteAddr();
 
@@ -200,20 +246,20 @@ public interface VaadinRequest {
      *
      * @return a boolean indicating if the request is secure
      *
-     * @see ServletRequest#isSecure()
+     * @see javax.servlet.ServletRequest#isSecure()
      */
     boolean isSecure();
 
     /**
      * Gets the value of a request header, e.g. a http header for a
-     * {@link HttpServletRequest}.
+     * {@link javax.servlet.http.HttpServletRequest}.
      *
      * @param headerName
      *            the name of the header
      * @return the header value, or <code>null</code> if the header is not
      *         present in the request
      *
-     * @see HttpServletRequest#getHeader(String)
+     * @see javax.servlet.http.HttpServletRequest#getHeader(String)
      */
     String getHeader(String headerName);
 
@@ -234,7 +280,7 @@ public interface VaadinRequest {
      * @return an array of all the <code>Cookies</code> included with this
      *         request, or <code>null</code> if the request has no cookies
      *
-     * @see HttpServletRequest#getCookies()
+     * @see javax.servlet.http.HttpServletRequest#getCookies()
      */
     Cookie[] getCookies();
 
@@ -247,7 +293,7 @@ public interface VaadinRequest {
      * @return a string indicating the authentication scheme, or
      *         <code>null</code> if the request was not authenticated.
      *
-     * @see HttpServletRequest#getAuthType()
+     * @see javax.servlet.http.HttpServletRequest#getAuthType()
      */
     String getAuthType();
 
@@ -260,7 +306,7 @@ public interface VaadinRequest {
      * @return a String specifying the login of the user making this request, or
      *         <code>null</code> if the user login is not known.
      *
-     * @see HttpServletRequest#getRemoteUser()
+     * @see javax.servlet.http.HttpServletRequest#getRemoteUser()
      */
     String getRemoteUser();
 
@@ -273,7 +319,7 @@ public interface VaadinRequest {
      *         user making this request; <code>null</code> if the user has not
      *         been authenticated
      *
-     * @see HttpServletRequest#getUserPrincipal()
+     * @see javax.servlet.http.HttpServletRequest#getUserPrincipal()
      */
     Principal getUserPrincipal();
 
@@ -289,7 +335,7 @@ public interface VaadinRequest {
      *         to a given role; <code>false</code> if the user has not been
      *         authenticated
      *
-     * @see HttpServletRequest#isUserInRole(String)
+     * @see javax.servlet.http.HttpServletRequest#isUserInRole(String)
      */
     boolean isUserInRole(String role);
 
@@ -301,7 +347,7 @@ public interface VaadinRequest {
      * @param name
      *            a String specifying the name of the attribute to remove
      *
-     * @see ServletRequest#removeAttribute(String)
+     * @see javax.servlet.ServletRequest#removeAttribute(String)
      */
     void removeAttribute(String name);
 
@@ -313,7 +359,7 @@ public interface VaadinRequest {
      * @return an Enumeration of strings containing the names of the request's
      *         attributes
      *
-     * @see ServletRequest#getAttributeNames()
+     * @see javax.servlet.ServletRequest#getAttributeNames()
      */
     Enumeration<String> getAttributeNames();
 
@@ -326,7 +372,7 @@ public interface VaadinRequest {
      *
      * @return an Enumeration of preferred Locale objects for the client
      *
-     * @see HttpServletRequest#getLocales()
+     * @see javax.servlet.http.HttpServletRequest#getLocales()
      */
     Enumeration<Locale> getLocales();
 
@@ -339,7 +385,7 @@ public interface VaadinRequest {
      * @return a String containing the fully qualified name of the client, or
      *         <code>null</code> if the information is not available.
      *
-     * @see HttpServletRequest#getRemoteHost()
+     * @see javax.servlet.http.HttpServletRequest#getRemoteHost()
      */
     String getRemoteHost();
 
@@ -350,7 +396,7 @@ public interface VaadinRequest {
      * @return an integer specifying the port number, or -1 if the information
      *         is not available.
      *
-     * @see ServletRequest#getRemotePort()
+     * @see javax.servlet.ServletRequest#getRemotePort()
      */
     int getRemotePort();
 
@@ -362,7 +408,7 @@ public interface VaadinRequest {
      * @return a String containing the name of the character encoding, or null
      *         if the request does not specify a character encoding
      *
-     * @see ServletRequest#getCharacterEncoding()
+     * @see javax.servlet.ServletRequest#getCharacterEncoding()
      */
     String getCharacterEncoding();
 
@@ -383,7 +429,7 @@ public interface VaadinRequest {
      * @throws IOException
      *             if an input or output exception occurred
      *
-     * @see ServletRequest#getReader()
+     * @see javax.servlet.ServletRequest#getReader()
      */
     BufferedReader getReader() throws IOException;
 
@@ -394,7 +440,7 @@ public interface VaadinRequest {
      * @return a String specifying the name of the method with which this
      *         request was made
      *
-     * @see HttpServletRequest#getMethod()
+     * @see javax.servlet.http.HttpServletRequest#getMethod()
      */
     String getMethod();
 
@@ -417,7 +463,7 @@ public interface VaadinRequest {
      *         GMT, or -1 if the named header was not included with the request
      * @throws IllegalArgumentException
      *             If the header value can't be converted to a date
-     * @see HttpServletRequest#getDateHeader(String)
+     * @see javax.servlet.http.HttpServletRequest#getDateHeader(String)
      */
     long getDateHeader(String name);
 
@@ -431,7 +477,7 @@ public interface VaadinRequest {
      * @return an enumeration of all the header names sent with this request; if
      *         the request has no headers, an empty enumeration; if the
      *         implementation does not allow this method, <code>null</code>
-     * @see HttpServletRequest#getHeaderNames()
+     * @see javax.servlet.http.HttpServletRequest#getHeaderNames()
      */
     Enumeration<String> getHeaderNames();
 
@@ -457,7 +503,7 @@ public interface VaadinRequest {
      *         the request does not have any headers of that name return an
      *         empty enumeration. If the header information is not available,
      *         return <code>null</code>
-     * @see HttpServletRequest#getHeaders(String)
+     * @see javax.servlet.http.HttpServletRequest#getHeaders(String)
      */
     Enumeration<String> getHeaders(String name);
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinRequest.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinRequest.java
@@ -133,21 +133,6 @@ public interface VaadinRequest {
     String getContextPath();
 
     /**
-     * Returns the part of this request's URL that calls the servlet. This path
-     * starts with a "/" character and includes either the servlet name or a
-     * path to the servlet, but does not include any extra path information or
-     * a query string.
-     *
-     * @see javax.servlet.http.HttpServletRequest#getServletPath()
-     *
-     * @return a String containing the name or path of the servlet being called,
-     *         as specified in the request URL, decoded, or an empty string if
-     *         the servlet used to process the request is matched using the
-     *         "/*" pattern.
-     */
-    String getServletPath();
-
-    /**
      * Reconstructs the URL the client used to make the request. The returned
      * URL contains a protocol, server name, port number, and server path, but
      * it does not include query string parameters.

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinResponse.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinResponse.java
@@ -20,9 +20,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 
-import javax.servlet.ServletResponse;
 import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletResponse;
 
 import com.vaadin.flow.internal.CurrentInstance;
 
@@ -42,7 +40,7 @@ public interface VaadinResponse {
      *
      * @param statusCode
      *            the status code to set
-     * @see HttpServletResponse#setStatus(int)
+     * @see javax.servlet.http.HttpServletResponse#setStatus(int)
      *
      */
     void setStatus(int statusCode);
@@ -55,7 +53,7 @@ public interface VaadinResponse {
      * @param contentType
      *            a string specifying the MIME type of the content
      *
-     * @see ServletResponse#setContentType(String)
+     * @see javax.servlet.ServletResponse#setContentType(String)
      */
     void setContentType(String contentType);
 
@@ -68,7 +66,7 @@ public interface VaadinResponse {
      * @param value
      *            the header value.
      *
-     * @see HttpServletResponse#setHeader(String, String)
+     * @see javax.servlet.http.HttpServletResponse#setHeader(String, String)
      */
     void setHeader(String name, String value);
 
@@ -81,7 +79,7 @@ public interface VaadinResponse {
      * @param timestamp
      *            the number of milliseconds since epoch
      *
-     * @see HttpServletResponse#setDateHeader(String, long)
+     * @see javax.servlet.http.HttpServletResponse#setDateHeader(String, long)
      */
     void setDateHeader(String name, long timestamp);
 
@@ -97,7 +95,7 @@ public interface VaadinResponse {
      *             if an input or output exception occurred
      *
      * @see #getWriter()
-     * @see ServletResponse#getOutputStream()
+     * @see javax.servlet.ServletResponse#getOutputStream()
      */
     OutputStream getOutputStream() throws IOException;
 
@@ -114,7 +112,7 @@ public interface VaadinResponse {
      *             if an input or output exception occurred
      *
      * @see #getOutputStream()
-     * @see ServletResponse#getWriter()
+     * @see javax.servlet.ServletResponse#getWriter()
      */
     PrintWriter getWriter() throws IOException;
 
@@ -139,7 +137,7 @@ public interface VaadinResponse {
      * @throws IOException
      *             if an input or output exception occurs
      *
-     * @see HttpServletResponse#sendError(int, String)
+     * @see javax.servlet.http.HttpServletResponse#sendError(int, String)
      */
     void sendError(int errorCode, String message) throws IOException;
 
@@ -159,7 +157,7 @@ public interface VaadinResponse {
      * @param cookie
      *            the Cookie to return to the client
      *
-     * @see HttpServletResponse#addCookie(Cookie)
+     * @see javax.servlet.http.HttpServletResponse#addCookie(Cookie)
      */
     void addCookie(Cookie cookie);
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -16,8 +16,6 @@
 
 package com.vaadin.flow.server;
 
-import javax.servlet.Servlet;
-import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletResponse;
 
 import java.io.BufferedWriter;
@@ -472,7 +470,7 @@ public abstract class VaadinService implements Serializable {
      * @param resourceName
      *            a String specifying the name of a file
      * @return a String specifying the file's MIME type
-     * @see ServletContext#getMimeType(String)
+     * @see javax.servlet.ServletContext#getMimeType(String)
      */
     public abstract String getMimeType(String resourceName);
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
@@ -133,7 +133,7 @@ public class VaadinServletService extends VaadinService {
 
     @Override
     public String getMimeType(String resourceName) {
-        return getServlet().getServletContext().getMimeType(resourceName);
+        return getServletContext().getMimeType(resourceName);
     }
 
     @Override
@@ -233,7 +233,7 @@ public class VaadinServletService extends VaadinService {
     @Override
     public URL getStaticResource(String path) {
         try {
-            return getServlet().getServletContext().getResource(path);
+            return getServletContext().getResource(path);
         } catch (MalformedURLException e) {
             getLogger().warn("Error finding resource for '{}'", path, e);
         }
@@ -259,7 +259,7 @@ public class VaadinServletService extends VaadinService {
      *         found
      */
     public URL getResourceInServletContext(String path) {
-        ServletContext servletContext = getServlet().getServletContext();
+        ServletContext servletContext = getServletContext();
         try {
             return servletContext.getResource(path);
         } catch (MalformedURLException e) {
@@ -279,20 +279,19 @@ public class VaadinServletService extends VaadinService {
      *         found
      */
     private InputStream getResourceInServletContextAsStream(String path) {
-        ServletContext servletContext = getServlet().getServletContext();
+        ServletContext servletContext = getServletContext();
         return servletContext.getResourceAsStream(path);
     }
 
     @Override
     public String getContextRootRelativePath(VaadinRequest request) {
-        assert request instanceof VaadinServletRequest;
         // Generate location from the request by finding how many "../" should
         // be added to the servlet path before we get to the context root
 
         // Should not take pathinfo into account because the base URI refers to
         // the servlet path
 
-        String servletPath = ((VaadinServletRequest) request).getServletPath();
+        String servletPath = request.getServletPath();
         assert servletPath != null;
         if (!servletPath.endsWith("/")) {
             servletPath += "/";
@@ -300,8 +299,19 @@ public class VaadinServletService extends VaadinService {
         return HandlerHelper.getCancelingRelativePath(servletPath) + "/";
     }
 
+    /**
+     * Returns a reference to the {@link ServletContext} in which this
+     * servlet {@link #getServlet()} is running.
+     *
+     *
+     * @return the ServletContext object
+     */
+    protected ServletContext getServletContext() {
+        return getServlet().getServletContext();
+    }
+
     @Override
     protected VaadinContext constructVaadinContext() {
-        return new VaadinServletContext(getServlet().getServletContext());
+        return new VaadinServletContext(getServletContext());
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
@@ -291,7 +291,7 @@ public class VaadinServletService extends VaadinService {
         // Should not take pathinfo into account because the base URI refers to
         // the servlet path
 
-        String servletPath = request.getServletPath();
+        String servletPath = ((VaadinServletRequest)request).getServletPath();
         assert servletPath != null;
         if (!servletPath.endsWith("/")) {
             servletPath += "/";

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/FaviconHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/FaviconHandler.java
@@ -22,7 +22,6 @@ import javax.servlet.http.HttpServletResponse;
 import com.vaadin.flow.server.RequestHandler;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
-import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.server.VaadinSession;
 
 /**
@@ -39,10 +38,9 @@ public class FaviconHandler implements RequestHandler {
     @Override
     public boolean handleRequest(VaadinSession session, VaadinRequest request,
             VaadinResponse response) throws IOException {
-        VaadinServletRequest httpRequest = (VaadinServletRequest) request;
-        boolean isFavicon = httpRequest.getContextPath().isEmpty()
-                && httpRequest.getServletPath().isEmpty()
-                && "/favicon.ico".equals(httpRequest.getPathInfo());
+        boolean isFavicon = request.getContextPath().isEmpty()
+                && request.getServletPath().isEmpty()
+                && "/favicon.ico".equals(request.getPathInfo());
         if (isFavicon) {
             response.setStatus(HttpServletResponse.SC_NOT_FOUND);
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/FaviconHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/FaviconHandler.java
@@ -16,6 +16,8 @@
 package com.vaadin.flow.server.communication;
 
 import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -38,9 +40,8 @@ public class FaviconHandler implements RequestHandler {
     @Override
     public boolean handleRequest(VaadinSession session, VaadinRequest request,
             VaadinResponse response) throws IOException {
-        boolean isFavicon = request.getContextPath().isEmpty()
-                && request.getServletPath().isEmpty()
-                && "/favicon.ico".equals(request.getPathInfo());
+        String uri = URLDecoder.decode(request.getRequestURI(), StandardCharsets.UTF_8.name());
+        boolean isFavicon = uri.equals("/favicon.ico");
         if (isFavicon) {
             response.setStatus(HttpServletResponse.SC_NOT_FOUND);
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
@@ -35,7 +35,6 @@ import com.vaadin.flow.server.HandlerHelper;
 import com.vaadin.flow.server.HandlerHelper.RequestType;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
-import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.AppShellRegistry;
 import com.vaadin.flow.shared.ApplicationConstants;
@@ -84,7 +83,7 @@ public class JavaScriptBootstrapHandler extends BootstrapHandler {
     }
 
     protected String getRequestUrl(VaadinRequest request) {
-        return ((VaadinServletRequest) request).getRequestURL().toString();
+        return request.getRequestURL().toString();
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamResourceHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamResourceHandler.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.server.communication;
 
-import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
@@ -26,7 +25,7 @@ import com.vaadin.flow.server.StreamResource;
 import com.vaadin.flow.server.StreamResourceWriter;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
-import com.vaadin.flow.server.VaadinServletRequest;
+import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
 
 /**
@@ -60,10 +59,9 @@ public class StreamResourceHandler implements Serializable {
         StreamResourceWriter writer;
         session.lock();
         try {
-            ServletContext context = ((VaadinServletRequest) request)
-                    .getServletContext();
+            VaadinService service = request.getService();
             response.setContentType(streamResource.getContentTypeResolver()
-                    .apply(streamResource, context));
+                    .apply(streamResource, service));
             response.setCacheTime(streamResource.getCacheTime());
             writer = streamResource.getWriter();
             if (writer == null) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
@@ -44,7 +44,6 @@ import com.vaadin.flow.server.HandlerHelper;
 import com.vaadin.flow.server.PwaRegistry;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
-import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.webcomponent.WebComponentConfigurationRegistry;
 import com.vaadin.flow.shared.ApplicationConstants;
@@ -135,7 +134,7 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
      * @return Request's url.
      */
     protected String getRequestUrl(VaadinRequest request) {
-        return ((VaadinServletRequest) request).getRequestURL().toString();
+        return request.getRequestURL().toString();
     }
 
     @Override
@@ -422,7 +421,7 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
         String url = request.getParameter(REQ_PARAM_URL);
         // if 'url' parameter was not available, use request url
         if (url == null) {
-            url = ((VaadinServletRequest) request).getRequestURL().toString();
+            url = getRequestUrl(request);
         }
         return url
                 // +1 is to keep the trailing slash

--- a/flow-server/src/test/java/com/vaadin/flow/server/StreamResourceTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/StreamResourceTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.function.ContentTypeResolver;
-import com.vaadin.flow.server.StreamResource;
 
 public class StreamResourceTest {
 
@@ -64,9 +63,9 @@ public class StreamResourceTest {
 
     private void assertContentType(StreamResource resource,
             ContentTypeResolver resolver) {
-        ServletContext context = Mockito.mock(ServletContext.class);
-        Mockito.when(context.getMimeType("foo")).thenReturn("bar");
-        String mimeType = resolver.apply(resource, context);
+        VaadinService service = Mockito.mock(VaadinService.class);
+        Mockito.when(service.getMimeType("foo")).thenReturn("bar");
+        String mimeType = resolver.apply(resource, service);
 
         Assert.assertEquals("bar", mimeType);
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/StreamResourceHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/StreamResourceHandlerTest.java
@@ -23,6 +23,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
+import com.vaadin.flow.server.VaadinServletService;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -50,10 +51,11 @@ public class StreamResourceHandlerTest {
         ServletConfig servletConfig = new MockServletConfig();
         VaadinServlet servlet = new VaadinServlet();
         servlet.init(servletConfig);
-        VaadinService service = servlet.getService();
+        VaadinServletService service = servlet.getService();
 
         session = new AlwaysLockedVaadinSession(service);
         request = Mockito.mock(VaadinServletRequest.class);
+        Mockito.when(request.getService()).thenReturn(service);
         ServletContext context = Mockito.mock(ServletContext.class);
         Mockito.when(request.getServletContext()).thenReturn(context);
         response = Mockito.mock(VaadinServletResponse.class);

--- a/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/src/main/java/com/vaadin/flow/testnpmonlyfeatures/bytecodescanning/RemoveFallbackChunkInfo.java
+++ b/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/src/main/java/com/vaadin/flow/testnpmonlyfeatures/bytecodescanning/RemoveFallbackChunkInfo.java
@@ -15,13 +15,10 @@
  */
 package com.vaadin.flow.testnpmonlyfeatures.bytecodescanning;
 
-import javax.servlet.http.HttpServletRequest;
-
 import com.vaadin.flow.server.ServiceInitEvent;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
 import com.vaadin.flow.server.VaadinServiceInitListener;
-import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.frontend.FallbackChunk;
 
@@ -48,9 +45,7 @@ public class RemoveFallbackChunkInfo implements VaadinServiceInitListener {
 
     boolean handleRequest(VaadinSession session, VaadinRequest request,
             VaadinResponse response) {
-        VaadinServletRequest servletRequest = (VaadinServletRequest) request;
-        HttpServletRequest httpRequest = servletRequest.getHttpServletRequest();
-        String query = httpRequest.getQueryString();
+        String query = request.getQueryString();
         if ("drop-fallback".equals(query)) {
             // self check
             FallbackChunk chunk = session.getService().getContext()

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PageView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PageView.java
@@ -6,10 +6,7 @@ import com.vaadin.flow.component.html.Input;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.VaadinRequest;
-import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.uitest.servlet.ViewTestLayout;
-
-import javax.servlet.http.HttpServletRequest;
 
 @Route(value = "com.vaadin.flow.uitest.ui.PageView", layout = ViewTestLayout.class)
 public class PageView extends AbstractDivView {
@@ -43,9 +40,8 @@ public class PageView extends AbstractDivView {
             getPage().reload();
         });
 
-        VaadinServletRequest request = (VaadinServletRequest) VaadinRequest.getCurrent();
-        HttpServletRequest httpServletRequest = request.getHttpServletRequest();
-        String url = httpServletRequest.getRequestURI()
+        VaadinRequest request = VaadinRequest.getCurrent();
+        String url = request.getRequestURI()
                 .replace(PageView.class.getName(), BaseHrefView.class.getName());
 
         Div setLocationButton = new Div();

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TrackMessageSizeView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TrackMessageSizeView.java
@@ -17,15 +17,12 @@
 
 package com.vaadin.flow.uitest.ui;
 
-import javax.servlet.http.HttpServletRequest;
-
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.page.Push;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementFactory;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.VaadinRequest;
-import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.shared.ui.Transport;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -96,9 +93,7 @@ public class TrackMessageSizeView extends Div {
 
         VaadinRequest request = VaadinRequest.getCurrent();
 
-        HttpServletRequest httpServletRequest = ((VaadinServletRequest) request).getHttpServletRequest();
-
-        String jsPath = httpServletRequest.getRequestURL().toString().replace(httpServletRequest.getRequestURI(), filename);
+        String jsPath = request.getRequestURL().toString().replace(request.getRequestURI(), filename);
 
 
         String content = getFileContent(jsPath);


### PR DESCRIPTION
1. Add `getServletContext` helper method

2. Add additional methods to `VaadinRequest` interface
This helps avoid casts to `VaadinServletRequest` and allows other classes to more easily extend `VaadinRequest` and `RequestHandler`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7534)
<!-- Reviewable:end -->
