### PR TITLE
Fix incorrectly using deploymentConfiguration directly

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -2316,7 +2316,7 @@ public abstract class VaadinService implements Serializable {
      */
     public BootstrapInitialPredicate getBootstrapInitialPredicate() {
         if (bootstrapInitialPredicate == null) {
-            bootstrapInitialPredicate = request -> deploymentConfiguration
+            bootstrapInitialPredicate = request -> getDeploymentConfiguration()
                     .isEagerServerLoad();
         }
         return bootstrapInitialPredicate;


### PR DESCRIPTION
If `deploymentConfiguration` is used directly, it causes issues when the no-args constructor is used. Per the Javadoc, `deploymentConfiguration` should never be used and `#getDeploymentConfiguration()` should be used instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7535)
<!-- Reviewable:end -->
