### PR TITLE
[FIX] Update links to documentation in DefaultDeploymentConfiguration

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
@@ -48,7 +48,7 @@ public class DefaultDeploymentConfiguration
             + "\nVaadin is running in DEBUG MODE.\n"
             + "In order to run your application in production mode and disable debug features, "
             + "you should enable it by setting the servlet init parameter productionMode to true.\n"
-            + "See https://vaadin.com/docs/v14/flow/production/tutorial-production-mode-basic.html "
+            + "See https://vaadin.com/docs/v15/flow/production/tutorial-production-mode-basic.html "
             + "for more information about the production mode." + SEPARATOR;
 
     public static final String WARNING_COMPATIBILITY_MODE = SEPARATOR

--- a/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
@@ -80,7 +80,7 @@ public final class DeploymentConfigurationFactory implements Serializable {
             + "'flow-build-info.json' via running 'prepare-frontend' Maven goal.";
 
     public static final String DEV_FOLDER_MISSING_MESSAGE = "Running project in development mode with no access to folder '%s'.%n"
-            + "Build project in production mode instead, see https://vaadin.com/docs/v14/flow/production/tutorial-production-mode-basic.html";
+            + "Build project in production mode instead, see https://vaadin.com/docs/v15/flow/production/tutorial-production-mode-basic.html";
     private static final Logger logger = LoggerFactory
             .getLogger(DeploymentConfigurationFactory.class);
 


### PR DESCRIPTION
Currently the link in the production mode log message point to the Vaadin 14 documentation. It should point to the v15 documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7536)
<!-- Reviewable:end -->
