### PR TITLE
importing .css files into TypeScript should not require `@ts-ignore`

### DIFF
--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
@@ -199,7 +199,8 @@ public class PrepareFrontendMojoTest {
 
         assertContainsPackage(packageJsonObject.getObject("devDependencies"),
                 "webpack", "webpack-cli", "webpack-dev-server",
-                "copy-webpack-plugin", "html-webpack-plugin");
+                "copy-webpack-plugin", "html-webpack-plugin",
+                "typed-css-modules-webpack-plugin");
     }
 
     @Endpoint

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -265,6 +265,7 @@ public abstract class NodeUpdater implements FallibleCommand {
         defaults.put("compression-webpack-plugin", "3.0.1");
         defaults.put("webpack-merge", "4.2.2");
         defaults.put("raw-loader", "3.0.0");
+        defaults.put("typed-css-modules-webpack-plugin", "0.1.3");
 
         return defaults;
     }

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/tsconfig.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/tsconfig.json
@@ -17,7 +17,8 @@
     "noImplicitThis": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true
   },
   "include": [
     "frontend/**/*.ts", "frontend/index.js"

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -9,6 +9,7 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin');
 const CompressionPlugin = require('compression-webpack-plugin');
+const {TypedCssModulesPlugin} = require('typed-css-modules-webpack-plugin');
 
 const path = require('path');
 const baseDir = path.resolve(__dirname);
@@ -175,6 +176,11 @@ module.exports = {
         }
       });
     },
+
+    // generate ".css.d.ts" files
+    new TypedCssModulesPlugin({
+      globPattern: frontendFolder + '/**/*.css',
+    }),
 
     // Includes JS output bundles into "index.html"
     useClientSideIndexFileForBootstrapping && new HtmlWebpackPlugin({


### PR DESCRIPTION
importing .css files into TypeScript should not require `@ts-ignore`
fixes #6335

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7576)
<!-- Reviewable:end -->
