### PR TITLE
Backport npm/pnpm/webpack command logging feature from V15

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -67,6 +67,11 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-configuration2</artifactId>
+            <version>2.6</version>
+        </dependency>
 
         <!-- Jsoup for BootstrapHandler, Template, ... -->
         <dependency>

--- a/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
@@ -464,9 +464,12 @@ public final class DevModeHandler {
             BufferedReader reader) throws IOException {
         StringBuilder output = getOutputBuilder();
 
-        Consumer<String> info = s -> console(GREEN, s);
-        Consumer<String> error = s -> console(RED, s);
-        Consumer<String> warn = s -> console(YELLOW, s);
+        Consumer<String> info = s -> getLogger()
+                .debug(String.format(GREEN, "{}"), s);
+        Consumer<String> error = s -> getLogger()
+                .error(String.format(RED, "{}"), s);
+        Consumer<String> warn = s -> getLogger()
+                .debug(String.format(YELLOW, "{}"), s);
         Consumer<String> log = info;
         for (String line; ((line = reader.readLine()) != null);) {
             String cleanLine = line

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -41,6 +41,7 @@ import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.text.WordUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -279,6 +280,11 @@ public class FrontendUtils {
 
     private static String operatingSystem = null;
 
+    public static final String YELLOW = "\u001b[38;5;111m%s\u001b[0m";
+
+    public static final String RED = "\u001b[38;5;196m%s\u001b[0m";
+
+    public static final String GREEN = "\u001b[38;5;35m%s\u001b[0m";
     /**
      * Only static stuff here.
      */
@@ -897,6 +903,8 @@ public class FrontendUtils {
         command.add("install");
         command.add("pnpm@" + DEFAULT_PNPM_VERSION);
 
+        console(YELLOW, commandToString(baseDir, command));
+
         ProcessBuilder builder = createProcessBuilder(command);
         builder.environment().put("ADBLOCK", "1");
         builder.directory(new File(baseDir));
@@ -1204,5 +1212,39 @@ public class FrontendUtils {
                     .parse(lastModified, DateTimeFormatter.RFC_1123_DATE_TIME)
                     .toLocalDateTime();
         }
+
+    }
+
+    /**
+     * Intentionally send to console instead to log, useful when executing
+     * external processes.
+     *
+     * @param format
+     *            Format of the line to send to console, it must contain a
+     *            `%s` outlet for the message
+     * @param message
+     *            the string to show
+     */
+    @SuppressWarnings("squid:S106")
+    public static void console(String format, Object message) {
+        System.out.print(String.format(format, message));
+    }
+
+    /**
+     * Pretty prints a command line order. It split in lines adapting to 80
+     * columns, and allowing copy and paste in console. It also removes the
+     * current directory to avoid security issues in log files.
+     *
+     * @param baseDir
+     *            the current directory
+     * @param command
+     *            the command and it's arguments
+     * @return the string for printing in logs
+     */
+    public static String commandToString(String baseDir,
+                                         List<String> command) {
+        return "\n" + WordUtils
+                .wrap(String.join(" ", command).replace(baseDir, "."), 50)
+                .replace("\r", "").replace("\n", " \\ \n    ") + "\n";
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -37,6 +37,10 @@ import com.vaadin.flow.shared.util.SharedUtil;
 import elemental.json.Json;
 
 import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
+import static com.vaadin.flow.server.frontend.FrontendUtils.YELLOW;
+import static com.vaadin.flow.server.frontend.FrontendUtils.commandToString;
+import static com.vaadin.flow.server.frontend.FrontendUtils.console;
+
 import static elemental.json.impl.JsonUtil.stringify;
 
 /**
@@ -155,6 +159,9 @@ public class TaskRunNpmInstall implements FallibleCommand {
         }
         List<String> command = new ArrayList<>(executable);
         command.add("install");
+
+        console(YELLOW, commandToString(
+                packageUpdater.npmFolder.getAbsolutePath(), command));
 
         ProcessBuilder builder = FrontendUtils.createProcessBuilder(command);
         builder.environment().put("ADBLOCK", "1");

--- a/flow-tests/test-npm-only-features/test-npm-performance-regression/src/test/java/com/vaadin/flow/testnpmonlyfeatures/performanceregression/StartupPerformanceIT.java
+++ b/flow-tests/test-npm-only-features/test-npm-performance-regression/src/test/java/com/vaadin/flow/testnpmonlyfeatures/performanceregression/StartupPerformanceIT.java
@@ -30,13 +30,12 @@ public class StartupPerformanceIT {
     @Test
     public void devModeInitializerToWebpackUpIsBelow5500ms() {
         int startupTime = measureLogEntryTimeDistance(
-                "com.vaadin.flow.server.startup.DevModeInitializer - Starting dev-mode updaters in",
-                "dev-webpack.*Webpack startup and compilation completed in [0-9]+ms",
-                true);
+                "- Starting dev-mode updaters in",
+                "- (Started|Reusing) webpack-dev-server", true);
 
         int npmInstallTime = measureLogEntryTimeDistance(
-                "dev-updater - Running `pnpm install`",
-                "dev-updater - Frontend dependencies resolved successfully",
+                "- Running `pnpm install`",
+                "- Frontend dependencies resolved successfully",
                 false);
 
         int startupTimeWithoutNpmInstallTime = startupTime - npmInstallTime;


### PR DESCRIPTION
Part of #7564. Log the full commands when running `npm`/`pmpm`/`webpack` in the same way as in V15 (https://github.com/vaadin/flow/issues/7564#issuecomment-585740781) so that the user can verify that the right node is being used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7580)
<!-- Reviewable:end -->
