### PR TITLE
Log webpack command executed during `build-frontend`

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -190,6 +190,9 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo {
         ProcessBuilder builder = FrontendUtils.createProcessBuilder(command)
                 .directory(project.getBasedir()).inheritIO();
         getLog().info("Running webpack ...");
+        FrontendUtils.console(FrontendUtils.YELLOW,
+                FrontendUtils.commandToString(npmFolder.getAbsolutePath(), 
+                        command));
 
         Process webpackLaunch = null;
         try {


### PR DESCRIPTION
Part of #7564. With more options to define the node location, log the webpack command also when building the production package (so that the user can ensure that the right node is being used.) Should be cherry-picked to 2.2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7582)
<!-- Reviewable:end -->
