### PR TITLE
Add zip protocol support to DevModeInitializer

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -162,7 +162,9 @@ public class DevModeInitializer implements ServletContainerInitializer,
     private static final Pattern JAR_FILE_REGEX = Pattern
             .compile(".*file:(.+\\.jar).*");
 
-    // Weblogic uses zip protocol
+    // Path of jar files in a URL with zip protocol doesn't start with "zip:"
+    // nor "file:". It contains only the path of the file.
+    // Weblogic uses zip protocol.
     private static final Pattern ZIP_PROTOCOL_JAR_FILE_REGEX = Pattern
             .compile("(.+\\.jar).*");
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -162,6 +162,10 @@ public class DevModeInitializer implements ServletContainerInitializer,
     private static final Pattern JAR_FILE_REGEX = Pattern
             .compile(".*file:(.+\\.jar).*");
 
+    // Weblogic uses zip protocol
+    private static final Pattern ZIP_PROTOCOL_JAR_FILE_REGEX = Pattern
+            .compile("(.+\\.jar).*");
+
     private static final Pattern VFS_FILE_REGEX = Pattern
             .compile("(vfs:/.+\\.jar).*");
 
@@ -394,12 +398,17 @@ public class DevModeInitializer implements ServletContainerInitializer,
                 String path = URLDecoder.decode(url.getPath(),
                         StandardCharsets.UTF_8.name());
                 Matcher jarMatcher = JAR_FILE_REGEX.matcher(path);
+                Matcher zipProtocolJarMatcher = ZIP_PROTOCOL_JAR_FILE_REGEX
+                        .matcher(path);
                 Matcher dirMatcher = DIR_REGEX_FRONTEND_DEFAULT.matcher(path);
                 Matcher dirCompatibilityMatcher = DIR_REGEX_COMPATIBILITY_FRONTEND_DEFAULT
                         .matcher(path);
                 Matcher jarVfsMatcher = VFS_FILE_REGEX.matcher(urlString);
                 if (jarMatcher.find()) {
                     frontendFiles.add(new File(jarMatcher.group(1)));
+                } else if ("zip".equalsIgnoreCase(url.getProtocol())
+                        && zipProtocolJarMatcher.find()) {
+                    frontendFiles.add(new File(zipProtocolJarMatcher.group(1)));
                 } else if (dirMatcher.find()) {
                     frontendFiles.add(new File(dirMatcher.group(1)));
                 } else if (dirCompatibilityMatcher.find()) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
@@ -3,7 +3,10 @@ package com.vaadin.flow.server.startup;
 import javax.servlet.ServletException;
 import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -11,6 +14,7 @@ import java.util.EventListener;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 
 import net.jcip.annotations.NotThreadSafe;
 import org.junit.Assert;
@@ -76,6 +80,12 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
     public void loadingJars_useModernResourcesFolder_allFilesExist()
             throws IOException, ServletException {
         loadingJars_allFilesExist(RESOURCES_FRONTEND_DEFAULT);
+    }
+
+    @Test
+    public void loadingZipProtocolJars_useModernResourcesFolder_allFilesExist()
+            throws IOException, ServletException {
+        loadingZipProtocolJars_allFilesExist(RESOURCES_FRONTEND_DEFAULT);
     }
 
     @Test
@@ -260,11 +270,43 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
 
     private void loadingJars_allFilesExist(String resourcesFolder)
             throws IOException, ServletException {
-        // Create jar urls for test
-        URL jar = new URL("jar:"
-                + this.getClass().getResource("/").toString()
-                        .replace("target/test-classes/", "")
-                + "src/test/resources/with%20space/jar-with-frontend-resources.jar!/META-INF/resources/frontend");
+        loadingJarsWithProtocol_allFilesExist(resourcesFolder, s -> {
+            try {
+                return new URL("jar:" + s);
+            } catch (MalformedURLException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    private void loadingZipProtocolJars_allFilesExist(String resourcesFolder)
+            throws IOException, ServletException {
+        final URLStreamHandler dummyZipHandler = new URLStreamHandler() {
+
+            @Override
+            protected URLConnection openConnection(URL u) throws IOException {
+                return null;
+            }
+        };
+
+        loadingJarsWithProtocol_allFilesExist(resourcesFolder, s -> {
+            try {
+                return new URL("zip", "", -1, s.replaceFirst("file:", ""),
+                        dummyZipHandler);
+            } catch (MalformedURLException e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    private void loadingJarsWithProtocol_allFilesExist(String resourcesFolder,
+            Function<String, URL> urlBuilder)
+            throws IOException, ServletException {
+        // Create jar urls with the given urlBuilder for test
+        String urlPath = this.getClass().getResource("/").toString()
+                .replace("target/test-classes/", "")
+                + "src/test/resources/with%20space/jar-with-frontend-resources.jar!/META-INF/resources/frontend";
+        URL jar = urlBuilder.apply(urlPath);
         List<URL> urls = new ArrayList<>();
         urls.add(jar);
 


### PR DESCRIPTION
Weblogic uses zip protocol for addressing jar files. To enable run-on-server for it, Flow should support zip protocol in DevModeInitializer. 
Fixes #7530

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7585)
<!-- Reviewable:end -->
