### PR TITLE
Accept a flow-build-info

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
@@ -27,6 +27,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -333,16 +334,20 @@ public final class DeploymentConfigurationFactory implements Serializable {
      * Check if the webpack.generated.js resources is inside 2 jars
      * (flow-server.jar and application.jar) if this is the case then we can
      * accept a build info file from inside jar with a single jar in the path.
+     * <p>
+     * Else we will accept any flow-build-info and log a warning that it may not
+     * be the correct file, but it's the best we could find.
      *
      * @param resources
-     *            flow-build-info url resource files
-     * @return flow-build-info json string or <code>null</code> if no applicable
-     *         files found
+     *            flow-build-info url resource files, not null or empty
+     * @return flow-build-info json string
      * @throws IOException
      *             exception reading stream
      */
     private static String getPossibleJarResource(List<URL> resources)
             throws IOException {
+        Objects.requireNonNull(resources);
+        assert !resources.isEmpty() : "Possible jar resource requires resources to be available.";
         URL webpackGenerated = DeploymentConfiguration.class.getClassLoader()
                 .getResource(FrontendUtils.WEBPACK_GENERATED);
         // If jar!/ exists 2 times for webpack.generated.json then we are

--- a/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
@@ -355,26 +355,22 @@ public final class DeploymentConfigurationFactory implements Serializable {
                     return FrontendUtils.streamToString(resource.openStream());
                 }
             }
-        } else {
-            URL firstResource = resources.get(0);
-            if (resources.size() > 1) {
-                String warningMessage = String.format(
-                        "Unable to fully determine correct flow-build-info.%n"
-                                + "Accepting file '%s' first match of '%s' possible.%n"
-                                + "Please verify flow-build-info file content.",
-                        firstResource.getPath(), resources.size());
-                logger.warn(warningMessage);
-            } else {
-                String debugMessage = String.format(
-                        "Unable to fully determine correct flow-build-info.%n"
-                                + "Accepting file '%s'",
-                        firstResource.getPath());
-                logger.debug(debugMessage);
-            }
-            return FrontendUtils.streamToString(firstResource.openStream());
         }
-        // No applicable resources found.
-        return null;
+        URL firstResource = resources.get(0);
+        if (resources.size() > 1) {
+            String warningMessage = String
+                    .format("Unable to fully determine correct flow-build-info.%n"
+                                    + "Accepting file '%s' first match of '%s' possible.%n"
+                                    + "Please verify flow-build-info file content.",
+                            firstResource.getPath(), resources.size());
+            logger.warn(warningMessage);
+        } else {
+            String debugMessage = String
+                    .format("Unable to fully determine correct flow-build-info.%n"
+                            + "Accepting file '%s'", firstResource.getPath());
+            logger.debug(debugMessage);
+        }
+        return FrontendUtils.streamToString(firstResource.openStream());
     }
 
     private static int countInstances(String input, String value) {


### PR DESCRIPTION
Even when we are running from inside a
jar if the paren jar doesn't contain
a flow-build-info we should accept a
found build info and log that we can't be
certain that this is the correct file.

Fixes #7579

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7607)
<!-- Reviewable:end -->
