### PR TITLE
Fix exported webcomponents in client-side

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
@@ -23,6 +23,8 @@ import java.lang.annotation.Annotation;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.regex.Pattern;
@@ -51,6 +53,7 @@ import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 
+import static com.vaadin.flow.server.frontend.FrontendUtils.EXPORT_CHUNK;
 import static com.vaadin.flow.shared.ApplicationConstants.CONTENT_TYPE_TEXT_JAVASCRIPT_UTF_8;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -89,11 +92,19 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
         }
     }
 
+    private static class WebComponentBootstrapPageBuilder
+            extends BootstrapPageBuilder {
+        @Override
+        protected List<String> getChunkKeys(JsonObject chunks) {
+            return Collections.singletonList(EXPORT_CHUNK);
+        }
+    }
+
     /**
      * Creates a new bootstrap handler with default page builder.
      */
     public WebComponentBootstrapHandler() {
-        super();
+        super(new WebComponentBootstrapPageBuilder());
     }
 
     /**
@@ -298,8 +309,8 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
                 || "style".equals(element.tagName())) {
             return true;
         } else {
-            // embedding context should not provide polyfill, it is left to the
-            // end-user
+            // embedding context should not provide polyfill, it is left
+            // to the end-user
             return "script".equals(element.tagName())
                     && element.attr("src").contains("webcomponents-loader.js");
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -475,7 +475,7 @@ public class FrontendUtils {
             return Collections.emptyList();
         }
 
-        try (FileReader fileReader = new FileReader(npmrc)) {
+        try (FileReader fileReader = new FileReader(npmrc)) { // NOSONAR
             List<ProxyConfig.Proxy> proxyList = new ArrayList<>(2);
             Properties properties = new Properties();
             properties.load(fileReader);
@@ -716,7 +716,7 @@ public class FrontendUtils {
                 return new File(installNode(baseDir, vaadinHome,
                         DEFAULT_NODE_VERSION, null));
             }
-        } catch (FileNotFoundException exception) {
+        } catch (FileNotFoundException exception) { // NOSONAR
             Throwable cause = exception.getCause();
             assert cause != null;
             throw new IllegalStateException(cause);
@@ -1560,7 +1560,7 @@ public class FrontendUtils {
             }
 
             return returnCommand;
-        } catch (FileNotFoundException exception) {
+        } catch (FileNotFoundException exception) { // NOSONAR
             assert exception.getCause() != null;
             throw new IllegalStateException(exception.getCause());
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -255,6 +255,11 @@ public class FrontendUtils {
     public static final String FALLBACK = "fallback";
 
     /**
+     * The entry-point key used for the exported bundle.
+     */
+    public static final String EXPORT_CHUNK = "export";
+
+    /**
      * A key in a Json object for css imports data.
      */
     public static final String CSS_IMPORTS = "cssImports";
@@ -504,7 +509,7 @@ public class FrontendUtils {
         if (noproxy != null) {
             noproxy = noproxy.replaceAll(",", "|");
         }
-        
+
         String httpsProxyUrl = getNonNull(
                 System.getProperty(SYSTEM_HTTPS_PROXY_PROPERTY_KEY),
                 System.getProperty(

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -26,7 +26,7 @@ const clientSideIndexEntryPoint = '[to-be-generated-by-flow]';
 const build = 'build';
 // public path for resources, must match the request used in flow to get the /build/stats.json file
 const config = 'config';
-// folder for outputting index.[ts/js] bundle, etc.
+// folder for outputting vaadin-bundle and other fragments
 const buildFolder = `${mavenOutputFolderForFlowBundledFiles}/${build}`;
 // folder for outputting stats.json
 const confFolder = `${mavenOutputFolderForFlowBundledFiles}/${config}`;
@@ -64,6 +64,19 @@ if (watchDogPort) {
   runWatchDog();
 }
 
+// Compute the entries that webpack have to visit
+const webPackEntries = {};
+if (useClientSideIndexFileForBootstrapping) {
+  webPackEntries.bundle = clientSideIndexEntryPoint;
+  // if there are vaadin exported views, add a second entry
+  const [_, dir, prefix] = /^(.*)\/(.+)\.js/.exec(fileNameOfTheFlowGeneratedMainEntryPoint);
+  if (fs.readdirSync(dir).filter(fileName => !fileName.startsWith(prefix)).length) {
+    webPackEntries.export = fileNameOfTheFlowGeneratedMainEntryPoint;
+  }
+} else {
+  webPackEntries.bundle = fileNameOfTheFlowGeneratedMainEntryPoint;
+}
+
 exports = {
   frontendFolder: `${frontendFolder}`,
   buildFolder: `${buildFolder}`,
@@ -73,9 +86,7 @@ exports = {
 module.exports = {
   mode: 'production',
   context: frontendFolder,
-  entry: {
-    bundle: useClientSideIndexFileForBootstrapping ? clientSideIndexEntryPoint : fileNameOfTheFlowGeneratedMainEntryPoint
-  },
+  entry: webPackEntries,
 
   output: {
     filename: `${build}/vaadin-[name]-[contenthash].cache.js`,
@@ -174,7 +185,8 @@ module.exports = {
     // Includes JS output bundles into "index.html"
     useClientSideIndexFileForBootstrapping && new HtmlWebpackPlugin({
       template: clientSideIndexHTML,
-      inject: 'head'
+      inject: 'head',
+      chunks: ['bundle']
     }),
     useClientSideIndexFileForBootstrapping && new ScriptExtHtmlWebpackPlugin({
       defaultAttribute: 'defer'

--- a/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
@@ -996,7 +996,7 @@ public class BootstrapHandlerTest {
                         .anyMatch(element -> element
                                 .equals("<script type=\"module\" src=\"./"
                                         + VAADIN_MAPPING
-                                        + "build/index-1111.cache.js\" data-app-id=\""
+                                        + "build/vaadin-bundle-1111.cache.js\" data-app-id=\""
                                         + testUI.getInternals().getAppId()
                                         + "\" crossorigin></script>")));
     }
@@ -1231,6 +1231,7 @@ public class BootstrapHandlerTest {
                 .setContextRoot(contextRootRelativePath(request));
 
         Document page = pageBuilder.getBootstrapPage(bootstrapContext);
+
         Element head = page.head();
         Assert.assertTrue(
                 head.outerHtml().contains("mode = " + productionMode));
@@ -1342,6 +1343,8 @@ public class BootstrapHandlerTest {
         Document page = pageBuilder.getBootstrapPage(bootstrapContext);
 
         Elements scripts = page.head().getElementsByTag("script");
+        scripts.forEach(s -> System.err.println(s.outerHtml()));
+
         Element element = scripts.stream()
                 .filter(elem -> elem.attr("src").equals("//module.js"))
                 .findFirst().get();
@@ -1349,9 +1352,30 @@ public class BootstrapHandlerTest {
 
         Element bundle = scripts.stream()
                 .filter(el -> el.attr("src")
-                        .equals("./VAADIN/build/index-1111.cache.js"))
+                        .equals("./VAADIN/build/vaadin-bundle-1111.cache.js"))
                 .findFirst().get();
         Assert.assertFalse(bundle.hasAttr("defer"));
+    }
+
+    @Test
+    public void getBootstrapPage_removesExportScript()
+            throws ServiceException {
+        initUI(testUI);
+
+        BootstrapContext bootstrapContext = new BootstrapContext(request, null,
+                session, testUI, this::contextRootRelativePath);
+        Document page = pageBuilder.getBootstrapPage(bootstrapContext);
+
+        Elements scripts = page.head().getElementsByTag("script");
+
+        Assert.assertTrue(scripts.stream()
+                .filter(el -> el.attr("src")
+                        .equals("./VAADIN/build/vaadin-bundle-1111.cache.js"))
+                .findFirst().isPresent());
+        Assert.assertFalse(scripts.stream()
+                .filter(el -> el.attr("src")
+                        .equals("./VAADIN/build/vaadin-export-2222.cache.js"))
+                .findFirst().isPresent());
     }
 
     @Test // #7158

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandlerTest.java
@@ -154,6 +154,25 @@ public class WebComponentBootstrapHandlerTest {
                 CoreMatchers.not(CoreMatchers.containsString("baz")));
     }
 
+    @Test
+    public void writeBootstrapPage_spepe()
+            throws Exception {
+        WebComponentBootstrapHandler handler = new WebComponentBootstrapHandler();
+
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+
+        Element head = new Document("").normalise().head();
+
+        VaadinResponse response = getMockResponse(stream);
+        handler.writeBootstrapPage("", response, head, "");
+
+        String resultingScript = stream.toString(StandardCharsets.UTF_8.name());
+
+
+        System.err.println(resultingScript);
+
+    }
+
     private VaadinResponse getMockResponse(ByteArrayOutputStream stream) throws IOException {
         VaadinResponse response = Mockito.mock(VaadinResponse.class);
         VaadinService service = Mockito.mock(VaadinService.class);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -375,7 +375,8 @@ public class FrontendUtilsTest {
         String statsAssetsByChunkName = FrontendUtils
                 .getStatsAssetsByChunkName(service);
 
-        Assert.assertEquals("{" + "\"index\": \"build/index-1111.cache.js\"}",
+        Assert.assertEquals(
+                "{\"bundle\": \"build/vaadin-bundle-1111.cache.js\",\"export\": \"build/vaadin-export-2222.cache.js\"}",
                 statsAssetsByChunkName);
     }
 
@@ -387,7 +388,8 @@ public class FrontendUtilsTest {
         String statsAssetsByChunkName = FrontendUtils
                 .getStatsAssetsByChunkName(service);
 
-        Assert.assertEquals("{" + "\"index\": \"build/index-1111.cache.js\"}",
+        Assert.assertEquals(
+                "{\"bundle\": \"build/vaadin-bundle-1111.cache.js\"}",
                 statsAssetsByChunkName);
     }
 

--- a/flow-server/src/test/resources/InvalidStats.json
+++ b/flow-server/src/test/resources/InvalidStats.json
@@ -8,7 +8,7 @@
   "publicPath": "",
   "outputPath": "/Volumes/Framework/updates/skeleton-starter-flow/src/main/webapp/frontend/dist",
   "assetsByChunkName" :{
-    "index": "build/index-1111.cache.js",,
+    "index": "build/vaadin-bundle-1111.cache.js",,
     "extraObject" :{
 
     }

--- a/flow-server/src/test/resources/META-INF/VAADIN/config/stats.json
+++ b/flow-server/src/test/resources/META-INF/VAADIN/config/stats.json
@@ -1,11 +1,12 @@
 {
   "hash": "64bb80639ef116681818",
   "assetsByChunkName" :{
-    "index": "build/index-1111.cache.js"
+    "bundle": "build/vaadin-bundle-1111.cache.js",
+    "export": "build/vaadin-export-2222.cache.js"
   },
   "modules": [
         {
-        "name": "../node_modules/@vaadin/flow-frontend/src/hello-world.js", 
+        "name": "../node_modules/@vaadin/flow-frontend/src/hello-world.js",
         "source": "import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';\nimport '@polymer/paper-input/paper-input.js';\n\nclass HelloWorld extends PolymerElement {\n  static get template() {\n    return html`\n            <div>\n                <paper-input id=\"inputId\" value=\"{{userInput}}\"></paper-input>\n                <button id=\"helloButton\" on-click=\"sayHello\">Say hello</button>\n                <div id=\"greeting\">[[greeting]]</div>\n            </div>`;\n  }\n\n  static get is() {\n    return 'hello-world';\n  }\n\n}\n\ncustomElements.define(HelloWorld.is, HelloWorld);"
         },
         {
@@ -18,7 +19,7 @@
         }
       ]
       ,
-      
+
       "chunks" : [
         {
             "modules": [
@@ -28,5 +29,5 @@
               }
             ]
         }
-      ] 
+      ]
 }

--- a/flow-server/src/test/resources/MissFormatStats.json
+++ b/flow-server/src/test/resources/MissFormatStats.json
@@ -7,7 +7,7 @@
   "builtAt": 1549540586721,
   "publicPath": "",
   "outputPath": "/Volumes/Framework/updates/skeleton-starter-flow/src/main/webapp/frontend/dist",
-  "assetsByChunkName" :{    "index": "build/index-1111.cache.js"
+  "assetsByChunkName" :{    "bundle": "build/vaadin-bundle-1111.cache.js"
      },
   "assets": [
     {

--- a/flow-server/src/test/resources/ValidStats.json
+++ b/flow-server/src/test/resources/ValidStats.json
@@ -8,7 +8,8 @@
   "publicPath": "",
   "outputPath": "/Volumes/Framework/updates/skeleton-starter-flow/src/main/webapp/frontend/dist",
   "assetsByChunkName" :{
-    "index": "build/index-1111.cache.js"
+    "bundle": "build/vaadin-bundle-1111.cache.js",
+    "export": "build/vaadin-export-2222.cache.js"
   },
   "assets": [
     {

--- a/flow-tests/test-embedding/pom.xml
+++ b/flow-tests/test-embedding/pom.xml
@@ -32,8 +32,6 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <!-- please remove after https://github.com/vaadin/flow/issues/7559 is fixed -->
-        <vaadin.useDeprecatedV14Bootstrapping>true</vaadin.useDeprecatedV14Bootstrapping>
     </properties>
 
     <modules>

--- a/flow-tests/test-multi-war/pom.xml
+++ b/flow-tests/test-multi-war/pom.xml
@@ -13,8 +13,6 @@
     <packaging>pom</packaging>
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <!-- please remove after https://github.com/vaadin/flow/issues/7559 is fixed -->
-        <vaadin.useDeprecatedV14Bootstrapping>true</vaadin.useDeprecatedV14Bootstrapping>
     </properties>
 
     <modules>


### PR DESCRIPTION
Fixes #7559

This PR modifies the `webpack.generated.js` in order to visit two entry points
when there are flow views exported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7614)
<!-- Reviewable:end -->
