### PR TITLE
chore: rename class to align with other generator tasks

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -460,7 +460,7 @@ public class NodeTasks implements FallibleCommand {
         }
 
         if (builder.createMissingPackageJson) {
-            TaskCreatePackageJson packageCreator = new TaskCreatePackageJson(
+            TaskGeneratePackageJson packageCreator = new TaskGeneratePackageJson(
                     builder.npmFolder, builder.generatedFolder,
                     builder.flowResourcesFolder);
             commands.add(packageCreator);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGeneratePackageJson.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGeneratePackageJson.java
@@ -19,7 +19,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
-import elemental.json.Json;
 import elemental.json.JsonObject;
 
 import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
@@ -30,7 +29,7 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
  *
  * @since 2.0
  */
-public class TaskCreatePackageJson extends NodeUpdater {
+public class TaskGeneratePackageJson extends NodeUpdater {
 
     /**
      * Create an instance of the updater given all configurable parameters.
@@ -43,7 +42,7 @@ public class TaskCreatePackageJson extends NodeUpdater {
      *            folder where flow resources taken from jars will be placed.
      *            default)
      */
-    TaskCreatePackageJson(File npmFolder, File generatedPath, File flowResourcesPath) {
+    TaskGeneratePackageJson(File npmFolder, File generatedPath, File flowResourcesPath) {
         super(null, null, npmFolder, generatedPath, flowResourcesPath);
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
@@ -61,7 +61,7 @@ public abstract class AbstractNodeUpdatePackagesTest
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     private TaskUpdatePackages packageUpdater;
-    private TaskCreatePackageJson packageCreator;
+    private TaskGeneratePackageJson packageCreator;
     private File baseDir;
     private File generatedDir;
     private File resourcesDir;
@@ -85,7 +85,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         NodeUpdateTestUtil.createStubNode(true, true,
                 baseDir.getAbsolutePath());
 
-        packageCreator = new TaskCreatePackageJson(baseDir, generatedDir, resourcesDir);
+        packageCreator = new TaskGeneratePackageJson(baseDir, generatedDir, resourcesDir);
 
         classFinder = getClassFinder();
         packageUpdater = new TaskUpdatePackages(classFinder,

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskCopyFrontendFilesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskCopyFrontendFilesTest.java
@@ -68,7 +68,7 @@ public class TaskCopyFrontendFilesTest extends NodeUpdateTestUtil {
 
     @Test
     public void should_createPackageJson() throws IOException {
-        TaskCreatePackageJson task = new TaskCreatePackageJson(npmFolder, generatedFolder, frontendDepsFolder);
+        TaskGeneratePackageJson task = new TaskGeneratePackageJson(npmFolder, generatedFolder, frontendDepsFolder);
         task.execute();
         Assert.assertTrue(new File(npmFolder, PACKAGE_JSON).exists());
         Assert.assertFalse(new File(generatedFolder, PACKAGE_JSON).exists());

--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
@@ -185,7 +185,7 @@ public abstract class ClassesSerializableTest {
                 "com\\.vaadin\\.flow\\.server\\.frontend\\.NodeUpdater",
                 "com\\.vaadin\\.flow\\.server\\.frontend\\.TaskCopyFrontendFiles",
                 "com\\.vaadin\\.flow\\.server\\.frontend\\.TaskCopyLocalFrontendFiles",
-                "com\\.vaadin\\.flow\\.server\\.frontend\\.TaskCreatePackageJson",
+                "com\\.vaadin\\.flow\\.server\\.frontend\\.TaskGeneratePackageJson",
                 "com\\.vaadin\\.flow\\.server\\.frontend\\.TaskRunNpmInstall",
                 "com\\.vaadin\\.flow\\.server\\.frontend\\.TaskUpdateImports(\\$.*)?",
                 "com\\.vaadin\\.flow\\.server\\.frontend\\.TaskUpdatePackages",


### PR DESCRIPTION
Other class use the `Generate` word instead of Create, let's align names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7616)
<!-- Reviewable:end -->
