### PR TITLE
Implement resynchronization of the client and server

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
@@ -229,6 +229,9 @@ public class MessageHandler {
                     + " while waiting for " + getExpectedServerId());
             lastSeenServerSyncId = serverId - 1;
             removeOldPendingMessages();
+
+            // Unregister all nodes and rebuild the state tree
+            registry.getStateTree().prepareForResync();
         }
 
         boolean locked = !responseHandlingLocks.isEmpty();

--- a/flow-client/src/main/java/com/vaadin/client/flow/StateTree.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/StateTree.java
@@ -22,6 +22,7 @@ import com.vaadin.client.flow.collection.JsArray;
 import com.vaadin.client.flow.collection.JsCollections;
 import com.vaadin.client.flow.collection.JsMap;
 import com.vaadin.client.flow.nodefeature.MapProperty;
+import com.vaadin.client.flow.nodefeature.NodeList;
 import com.vaadin.client.flow.nodefeature.NodeMap;
 import com.vaadin.flow.internal.nodefeature.NodeFeatures;
 import com.vaadin.flow.internal.nodefeature.NodeProperties;
@@ -122,6 +123,32 @@ public class StateTree {
 
         idToNode.delete(getKey(node));
         node.unregister();
+    }
+
+    /**
+     * Unregisters all nodes except root from this tree, and clears the root's
+     * features. Use to reset the tree in preparation for rebuilding it in
+     * in a resynchronization response.
+     */
+    public void prepareForResync() {
+        idToNode.forEach((node, b) -> {
+            if (node != rootNode) {
+                unregisterNode(node);
+                node.setParent(null);
+            }
+        });
+        rootNode.forEachFeature((feature, featureId) -> {
+            if (feature instanceof NodeList) {
+                final NodeList nodeList = (NodeList)feature;
+                if (featureId.intValue() == NodeFeatures.ELEMENT_CHILDREN) {
+                    // splice() instead of clear() to preserve auxilliary DOM
+                    // nodes such as loading indicator and <noscript>
+                    nodeList.splice(0, nodeList.length());
+                } else {
+                    nodeList.clear();
+                }
+            }
+        });
     }
 
     /**

--- a/flow-client/src/main/java/com/vaadin/client/flow/TreeChangeProcessor.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/TreeChangeProcessor.java
@@ -55,26 +55,12 @@ public class TreeChangeProcessor {
                 .isUpdateInProgress() : "Previous tree change processing has not completed";
         try {
             tree.setUpdateInProgress(true);
-            int length = changes.length();
-
-            JsSet<StateNode> nodes = JsCollections.set();
 
             // Attach all nodes before doing anything else
-            for (int i = 0; i < length; i++) {
-                JsonObject change = changes.getObject(i);
-                if (isAttach(change)) {
-                    int nodeId = (int) change
-                            .getNumber(JsonConstants.CHANGE_NODE);
-
-                    if (nodeId != tree.getRootNode().getId()) {
-                        StateNode node = new StateNode(nodeId, tree);
-                        tree.registerNode(node);
-                        nodes.add(node);
-                    }
-                }
-            }
+            JsSet<StateNode> nodes = processAttachChanges(tree, changes);
 
             // Then process all non-attach changes
+            int length = changes.length();
             for (int i = 0; i < length; i++) {
                 JsonObject change = changes.getObject(i);
                 if (!isAttach(change)) {
@@ -85,7 +71,25 @@ public class TreeChangeProcessor {
         } finally {
             tree.setUpdateInProgress(false);
         }
+    }
 
+    private static JsSet<StateNode> processAttachChanges(StateTree tree,
+            JsonArray changes) {
+        JsSet<StateNode> nodes = JsCollections.set();
+        int length = changes.length();
+        for (int i = 0; i < length; i++) {
+            JsonObject change = changes.getObject(i);
+            if (isAttach(change)) {
+                int nodeId = (int) change.getNumber(JsonConstants.CHANGE_NODE);
+
+                if (nodeId != tree.getRootNode().getId()) {
+                    StateNode node = new StateNode(nodeId, tree);
+                    tree.registerNode(node);
+                    nodes.add(node);
+                }
+            }
+        }
+        return nodes;
     }
 
     private static boolean isAttach(JsonObject change) {

--- a/flow-client/src/main/java/com/vaadin/client/flow/TreeChangeProcessor.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/TreeChangeProcessor.java
@@ -66,9 +66,11 @@ public class TreeChangeProcessor {
                     int nodeId = (int) change
                             .getNumber(JsonConstants.CHANGE_NODE);
 
-                    StateNode node = new StateNode(nodeId, tree);
-                    tree.registerNode(node);
-                    nodes.add(node);
+                    if (nodeId != tree.getRootNode().getId()) {
+                        StateNode node = new StateNode(nodeId, tree);
+                        tree.registerNode(node);
+                        nodes.add(node);
+                    }
                 }
             }
 

--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/ServerEventObject.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/ServerEventObject.java
@@ -275,14 +275,27 @@ public final class ServerEventObject extends JavaScriptObject {
      * @return a reference to the <code>$server</code> object in the element
      */
     public static ServerEventObject get(Element element) {
-        ServerEventObject serverObject = WidgetUtil
-                .crazyJsoCast(WidgetUtil.getJsProperty(element, "$server"));
+        ServerEventObject serverObject = getIfPresent(element);
         if (serverObject == null) {
             serverObject = (ServerEventObject) JavaScriptObject.createObject();
             serverObject.initPromiseHandler();
             WidgetUtil.setJsProperty(element, "$server", serverObject);
         }
         return serverObject;
+    }
+
+    /**
+     * Gets or creates <code>element.$server</code> for the given element, if
+     * present.
+     *
+     * @param node
+     *            the element to use
+     * @return a reference to the <code>$server</code> object in the element, or
+     *         <code>null</code> if note present.
+     */
+    public static ServerEventObject getIfPresent(Node node) {
+        return WidgetUtil
+                .crazyJsoCast(WidgetUtil.getJsProperty(node, "$server"));
     }
 
     protected static ServerEventDataExpression getOrCreateExpression(
@@ -298,4 +311,20 @@ public final class ServerEventObject extends JavaScriptObject {
 
         return expression;
     }
+
+    /**
+     * Reject all promises pending on this server object. Called during client
+     * resynchronization to free consumers of promises that are never delivered
+     * by the server.
+     */
+    public native void rejectPromises()
+    /*-{
+        var promises = this[@ServerEventObject::PROMISE_CALLBACK_NAME].promises;
+        if (promises !== undefined ) {
+            promises.forEach(function (item) {
+                item[1](Error("Client is resynchronizing"));
+            });
+        }
+    }-*/;
+
 }

--- a/flow-client/src/test/java/com/vaadin/client/flow/StateTreeTest.java
+++ b/flow-client/src/test/java/com/vaadin/client/flow/StateTreeTest.java
@@ -326,4 +326,12 @@ public class StateTreeTest {
 
         Assert.assertFalse(tree.isActive(stateNode));
     }
+
+    @Test
+    public void treeHasChildren_prepareForResync_onlyRootRemainsRegistered() {
+        tree.registerNode(node);
+        tree.prepareForResync();
+        Assert.assertFalse(tree.getRootNode().isUnregistered());
+        Assert.assertTrue(node.isUnregistered());
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
@@ -386,6 +386,16 @@ public class StateNode implements Serializable {
     }
 
     /**
+     * Resets the node to state before it was attached to a state tree.
+     */
+    public void prepareForResync() {
+        wasAttached = false;
+        isInitialChanges = true;
+        hasBeenAttached = false;
+        hasBeenDetached = false;
+    }
+
+    /**
      * Gets the feature of the given type, creating one if necessary. This
      * method throws {@link IllegalStateException} if this node isn't configured
      * to use the desired feature. Use {@link #hasFeature(Class)} to check
@@ -779,7 +789,7 @@ public class StateNode implements Serializable {
         }
     }
 
-    private void fireAttachListeners(boolean initialAttach) {
+    void fireAttachListeners(boolean initialAttach) {
         if (attachListeners != null) {
             List<Command> copy = new ArrayList<>(attachListeners);
 
@@ -789,7 +799,7 @@ public class StateNode implements Serializable {
         forEachFeature(f -> f.onAttach(initialAttach));
     }
 
-    private void fireDetachListeners() {
+    void fireDetachListeners() {
         if (detachListeners != null) {
             List<Command> copy = new ArrayList<>(detachListeners);
 

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateTree.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateTree.java
@@ -426,4 +426,20 @@ public class StateTree implements NodeOwner {
         }
 
     }
+
+    /**
+     * Prepares the tree for resynchronization by detaching all nodes,
+     * setting their internal state to not yet attached, and calling the
+     * attach listeners. The effect is that the client will receive the same
+     * changes as when the component tree was initially attached, so that it
+     * can build the DOM tree from scratch.
+     */
+    public void prepareForResync() {
+        getRootNode().visitNodeTreeBottomUp(StateNode::fireDetachListeners);
+        getRootNode().visitNodeTree(sn -> {
+            markAsDirty(sn);
+            sn.prepareForResync();
+        });
+        getRootNode().visitNodeTreeBottomUp(sn -> sn.fireAttachListeners(true));
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
@@ -35,7 +35,6 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.internal.MessageDigestUtil;
-import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.server.ErrorEvent;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinService;
@@ -324,8 +323,16 @@ public class ServerRpcHandler implements Serializable {
                     + "indicate a bug in Vaadin platform. If you see this "
                     + "message regularly please open a bug report at "
                     + "https://github.com/vaadin/flow/issues");
-            ui.getInternals().getStateTree().getRootNode()
-                    .visitNodeTree(StateNode::markAsDirty);
+
+            // Run detach listeners and re-attach all nodes again to the
+            // state tree, in order to send changes for a full re-build of
+            // the client-side state tree in the response
+            ui.getInternals().getStateTree().prepareForResync();
+
+            // At this point, make no assumptions about which dependencies have
+            // been accepted by the client
+            ui.getInternals().getDependencyList().clearPendingSendToClient();
+
             // Signal by exception instead of return value to keep the method
             // signature for source and binary compatibility
             throw new ResynchronizationRequiredException();

--- a/flow-server/src/test/java/com/vaadin/flow/internal/StateTreeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/StateTreeTest.java
@@ -569,4 +569,24 @@ public class StateTreeTest {
         Assert.assertTrue(collectedNodes.contains(node3));
     }
 
+    @Test
+    public void prepareForResync_nodeHasAttachAndDetachListeners_treeIsDirtyAndListenersAreCalled() {
+        StateNode node1 = tree.getRootNode();
+        StateNode node2 = StateNodeTest.createEmptyNode("node2");
+        StateNodeTest.setParent(node2, node1);
+
+        AtomicInteger attachCount = new AtomicInteger();
+        node2.addAttachListener(attachCount::incrementAndGet);
+        AtomicInteger detachCount = new AtomicInteger();
+        node2.addDetachListener(detachCount::incrementAndGet);
+
+        tree.collectChanges(c -> {});
+        Assert.assertEquals(0, tree.collectDirtyNodes().size());
+
+        tree.prepareForResync();
+
+        Assert.assertEquals(1, attachCount.get());
+        Assert.assertEquals(1, detachCount.get());
+        Assert.assertEquals(2, tree.collectDirtyNodes().size());
+    }
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ResynchronizationView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ResynchronizationView.java
@@ -1,0 +1,23 @@
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.Route;
+
+/**
+ * Test for https://github.com/vaadin/flow/issues/7590
+ */
+@Route("com.vaadin.flow.uitest.ui.ResynchronizationView")
+public class ResynchronizationView extends AbstractDivView {
+    final static String ADD_BUTTON = "add";
+    final static String ADDED_CLASS = "added";
+
+    public ResynchronizationView() {
+        add(createButton("Desync and add", ADD_BUTTON, e -> {
+            final Span added = new Span("added");
+            added.addClassName(ADDED_CLASS);
+            add(added);
+            // trigger a resynchronization request on the client
+            getUI().get().getInternals().incrementServerId();
+        }));
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ResynchronizationView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ResynchronizationView.java
@@ -1,5 +1,6 @@
 package com.vaadin.flow.uitest.ui;
 
+import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.router.Route;
 
@@ -8,16 +9,45 @@ import com.vaadin.flow.router.Route;
  */
 @Route("com.vaadin.flow.uitest.ui.ResynchronizationView")
 public class ResynchronizationView extends AbstractDivView {
+    final static String ID = "ResynchronizationView";
+
     final static String ADD_BUTTON = "add";
+    final static String CALL_BUTTON = "call";
+
     final static String ADDED_CLASS = "added";
+    final static String REJECTED_CLASS = "rejected";
 
     public ResynchronizationView() {
+        setId(ID);
+
         add(createButton("Desync and add", ADD_BUTTON, e -> {
             final Span added = new Span("added");
             added.addClassName(ADDED_CLASS);
             add(added);
-            // trigger a resynchronization request on the client
-            getUI().get().getInternals().incrementServerId();
+            triggerResync();
         }));
+
+        add(createButton("Desync and call function", CALL_BUTTON, e -> {
+            // add a span to <body> for the test (not to view, since the DOM
+            // will be rebuilt on resync)
+            final String js = String.format(
+                    "document.getElementById(\"%s\").$server.clientCallable()"
+                            + ".then(_ => {})"
+                            + ".catch(_ => { document.body.innerHTML += '<span class=\"%s\">rejected</span>';});",
+                    ID, REJECTED_CLASS);
+            getUI().get().getPage().executeJs(js);
+        }));
+    }
+
+    @ClientCallable
+    public int clientCallable() {
+        triggerResync();
+        return 0;
+    }
+
+    private void triggerResync() {
+        // trigger a resynchronization request on the client
+        getUI().get().getInternals().incrementServerId();
+
     }
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ResynchronizationIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ResynchronizationIT.java
@@ -7,6 +7,10 @@ import com.vaadin.flow.testutil.ChromeBrowserTest;
 
 public class ResynchronizationIT extends ChromeBrowserTest {
 
+    /*
+     * If a component is only added in a lost message, it should be present after
+     * resynchronization.
+     */
     @Test
     public void resynchronize_componentAddedInLostMessage_appearAfterResync() {
         open();
@@ -19,6 +23,20 @@ public class ResynchronizationIT extends ChromeBrowserTest {
 
         waitUntil(driver -> findElements(
                 By.className(ResynchronizationView.ADDED_CLASS)).size() == 2);
+    }
+
+    /*
+     * If a @ClientCallable is invoked in a lost message, the promises waiting
+     * for the return value from the server should be rejected rather than
+     * remain pending.
+     */
+    @Test
+    public void resynchronize_clientCallableInvoked_promisesAreRejected() {
+        open();
+
+        findElement(By.id(ResynchronizationView.CALL_BUTTON)).click();
+
+        waitForElementPresent(By.className(ResynchronizationView.REJECTED_CLASS));
     }
 
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ResynchronizationIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ResynchronizationIT.java
@@ -1,0 +1,24 @@
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class ResynchronizationIT extends ChromeBrowserTest {
+
+    @Test
+    public void resynchronize_componentAddedInLostMessage_appearAfterResync() {
+        open();
+
+        findElement(By.id(ResynchronizationView.ADD_BUTTON)).click();
+
+        waitForElementPresent(By.className(ResynchronizationView.ADDED_CLASS));
+
+        findElement(By.id(ResynchronizationView.ADD_BUTTON)).click();
+
+        waitUntil(driver -> findElements(
+                By.className(ResynchronizationView.ADDED_CLASS)).size() == 2);
+    }
+
+}


### PR DESCRIPTION
When the server receives the resync request, run detach listeners and mark all state tree nodes as not attached. Handle the changes rebuilding the state tree from the root on the client.

Fixes #7590.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7631)
<!-- Reviewable:end -->
