### PR TITLE
Implement resynchronization of the client and server

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
@@ -229,6 +229,9 @@ public class MessageHandler {
                     + " while waiting for " + getExpectedServerId());
             lastSeenServerSyncId = serverId - 1;
             removeOldPendingMessages();
+
+            // Unregister all nodes and rebuild the state tree
+            registry.getStateTree().prepareForResync();
         }
 
         boolean locked = !responseHandlingLocks.isEmpty();

--- a/flow-client/src/main/java/com/vaadin/client/flow/StateTree.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/StateTree.java
@@ -18,14 +18,17 @@ package com.vaadin.client.flow;
 import com.vaadin.client.Console;
 import com.vaadin.client.Registry;
 import com.vaadin.client.WidgetUtil;
+import com.vaadin.client.flow.binding.ServerEventObject;
 import com.vaadin.client.flow.collection.JsArray;
 import com.vaadin.client.flow.collection.JsCollections;
 import com.vaadin.client.flow.collection.JsMap;
 import com.vaadin.client.flow.nodefeature.MapProperty;
+import com.vaadin.client.flow.nodefeature.NodeList;
 import com.vaadin.client.flow.nodefeature.NodeMap;
 import com.vaadin.flow.internal.nodefeature.NodeFeatures;
 import com.vaadin.flow.internal.nodefeature.NodeProperties;
 
+import elemental.dom.Node;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 
@@ -122,6 +125,38 @@ public class StateTree {
 
         idToNode.delete(getKey(node));
         node.unregister();
+    }
+
+    /**
+     * Unregisters all nodes except root from this tree, and clears the root's
+     * features. Use to reset the tree in preparation for rebuilding it in in a
+     * resynchronization response.
+     */
+    public void prepareForResync() {
+        idToNode.forEach((node, b) -> {
+            if (node != rootNode) {
+                final Node dom = node.getDomNode();
+                if (dom != null
+                        && ServerEventObject.getIfPresent(dom) != null) {
+                    // reject any promise waiting on this node
+                    ServerEventObject.getIfPresent(dom).rejectPromises();
+                }
+                unregisterNode(node);
+                node.setParent(null);
+            }
+        });
+        rootNode.forEachFeature((feature, featureId) -> {
+            if (feature instanceof NodeList) {
+                final NodeList nodeList = (NodeList) feature;
+                if (featureId.intValue() == NodeFeatures.ELEMENT_CHILDREN) {
+                    // splice() instead of clear() to preserve auxiliary DOM
+                    // nodes (loading indicator and <noscript>)
+                    nodeList.splice(0, nodeList.length());
+                } else {
+                    nodeList.clear();
+                }
+            }
+        });
     }
 
     /**

--- a/flow-client/src/main/java/com/vaadin/client/flow/StateTree.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/StateTree.java
@@ -18,7 +18,6 @@ package com.vaadin.client.flow;
 import com.vaadin.client.Console;
 import com.vaadin.client.Registry;
 import com.vaadin.client.WidgetUtil;
-import com.vaadin.client.flow.binding.ServerEventObject;
 import com.vaadin.client.flow.collection.JsArray;
 import com.vaadin.client.flow.collection.JsCollections;
 import com.vaadin.client.flow.collection.JsMap;
@@ -28,7 +27,6 @@ import com.vaadin.client.flow.nodefeature.NodeMap;
 import com.vaadin.flow.internal.nodefeature.NodeFeatures;
 import com.vaadin.flow.internal.nodefeature.NodeProperties;
 
-import elemental.dom.Node;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 
@@ -135,12 +133,6 @@ public class StateTree {
     public void prepareForResync() {
         idToNode.forEach((node, b) -> {
             if (node != rootNode) {
-                final Node dom = node.getDomNode();
-                if (dom != null
-                        && ServerEventObject.getIfPresent(dom) != null) {
-                    // reject any promise waiting on this node
-                    ServerEventObject.getIfPresent(dom).rejectPromises();
-                }
                 unregisterNode(node);
                 node.setParent(null);
             }

--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/ServerEventObject.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/ServerEventObject.java
@@ -226,13 +226,26 @@ public final class ServerEventObject extends JavaScriptObject {
      * @return a reference to the <code>$server</code> object in the element
      */
     public static ServerEventObject get(Element element) {
-        ServerEventObject serverObject = WidgetUtil
-                .crazyJsoCast(WidgetUtil.getJsProperty(element, "$server"));
+        ServerEventObject serverObject = getIfPresent(element);
         if (serverObject == null) {
             serverObject = (ServerEventObject) JavaScriptObject.createObject();
             WidgetUtil.setJsProperty(element, "$server", serverObject);
         }
         return serverObject;
+    }
+
+    /**
+     * Gets or creates <code>element.$server</code> for the given element, if
+     * present.
+     *
+     * @param node
+     *            the element to use
+     * @return a reference to the <code>$server</code> object in the element, or
+     *         <code>null</code> if note present.
+     */
+    public static ServerEventObject getIfPresent(Node node) {
+        return WidgetUtil
+                .crazyJsoCast(WidgetUtil.getJsProperty(node, "$server"));
     }
 
     protected static ServerEventDataExpression getOrCreateExpression(
@@ -248,4 +261,20 @@ public final class ServerEventObject extends JavaScriptObject {
 
         return expression;
     }
+
+    /**
+     * Reject all promises pending on this server object. Called during client
+     * resynchronization to free consumers of promises that are never delivered
+     * by the server.
+     */
+    public native void rejectPromises()
+    /*-{
+        var promises = this[@ServerEventObject::PROMISE_CALLBACK_NAME].promises;
+        if (promises !== undefined ) {
+            promises.forEach(function (item) {
+                item[1](Error("Client is resynchronizing"));
+            });
+        }
+    }-*/;
+
 }

--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/ServerEventObject.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/ServerEventObject.java
@@ -261,20 +261,4 @@ public final class ServerEventObject extends JavaScriptObject {
 
         return expression;
     }
-
-    /**
-     * Reject all promises pending on this server object. Called during client
-     * resynchronization to free consumers of promises that are never delivered
-     * by the server.
-     */
-    public native void rejectPromises()
-    /*-{
-        var promises = this[@ServerEventObject::PROMISE_CALLBACK_NAME].promises;
-        if (promises !== undefined ) {
-            promises.forEach(function (item) {
-                item[1](Error("Client is resynchronizing"));
-            });
-        }
-    }-*/;
-
 }

--- a/flow-client/src/test/java/com/vaadin/client/flow/StateTreeTest.java
+++ b/flow-client/src/test/java/com/vaadin/client/flow/StateTreeTest.java
@@ -326,4 +326,12 @@ public class StateTreeTest {
 
         Assert.assertFalse(tree.isActive(stateNode));
     }
+
+    @Test
+    public void treeHasChildren_prepareForResync_onlyRootRemainsRegistered() {
+        tree.registerNode(node);
+        tree.prepareForResync();
+        Assert.assertFalse(tree.getRootNode().isUnregistered());
+        Assert.assertTrue(node.isUnregistered());
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
@@ -386,13 +386,22 @@ public class StateNode implements Serializable {
     }
 
     /**
-     * Resets the node to state before it was attached to a state tree.
+     * Prepares the tree below this node for resynchronization by detaching all
+     * nodes, setting their internal state to not yet attached, and calling the
+     * attach listeners. The effect is that the client will receive the same
+     * changes as when the component tree was initially attached, so that it can
+     * build the DOM tree from scratch.
      */
     public void prepareForResync() {
-        wasAttached = false;
-        isInitialChanges = true;
-        hasBeenAttached = false;
-        hasBeenDetached = false;
+        visitNodeTreeBottomUp(StateNode::fireDetachListeners);
+        visitNodeTree(stateNode -> {
+            getOwner().markAsDirty(stateNode);
+            stateNode.wasAttached = false;
+            stateNode.isInitialChanges = true;
+            stateNode.hasBeenAttached = false;
+            stateNode.hasBeenDetached = false;
+        });
+        visitNodeTreeBottomUp(sn -> sn.fireAttachListeners(true));
     }
 
     /**
@@ -789,7 +798,7 @@ public class StateNode implements Serializable {
         }
     }
 
-    void fireAttachListeners(boolean initialAttach) {
+    private void fireAttachListeners(boolean initialAttach) {
         if (attachListeners != null) {
             List<Command> copy = new ArrayList<>(attachListeners);
 
@@ -799,7 +808,7 @@ public class StateNode implements Serializable {
         forEachFeature(f -> f.onAttach(initialAttach));
     }
 
-    void fireDetachListeners() {
+    private void fireDetachListeners() {
         if (detachListeners != null) {
             List<Command> copy = new ArrayList<>(detachListeners);
 

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
@@ -386,6 +386,16 @@ public class StateNode implements Serializable {
     }
 
     /**
+     * Resets the node to state before it was attached to a state tree.
+     */
+    public void prepareForResync() {
+        wasAttached = false;
+        isInitialChanges = true;
+        hasBeenAttached = false;
+        hasBeenDetached = false;
+    }
+
+    /**
      * Gets the feature of the given type, creating one if necessary. This
      * method throws {@link IllegalStateException} if this node isn't configured
      * to use the desired feature. Use {@link #hasFeature(Class)} to check
@@ -779,7 +789,7 @@ public class StateNode implements Serializable {
         }
     }
 
-    private void fireAttachListeners(boolean initialAttach) {
+    void fireAttachListeners(boolean initialAttach) {
         if (attachListeners != null) {
             List<Command> copy = new ArrayList<>(attachListeners);
 
@@ -789,7 +799,7 @@ public class StateNode implements Serializable {
         forEachFeature(f -> f.onAttach(initialAttach));
     }
 
-    private void fireDetachListeners() {
+    void fireDetachListeners() {
         if (detachListeners != null) {
             List<Command> copy = new ArrayList<>(detachListeners);
 

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
@@ -387,12 +387,10 @@ public class StateNode implements Serializable {
 
     /**
      * Prepares the tree below this node for resynchronization by detaching all
-     * nodes, setting their internal state to not yet attached, and calling the
-     * attach listeners. The effect is that the client will receive the same
-     * changes as when the component tree was initially attached, so that it can
-     * build the DOM tree from scratch.
+     * descendants, setting their internal state to not yet attached, and
+     * calling the attach listeners.
      */
-    public void prepareForResync() {
+    protected void prepareForResync() {
         visitNodeTreeBottomUp(StateNode::fireDetachListeners);
         visitNodeTree(stateNode -> {
             getOwner().markAsDirty(stateNode);

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateTree.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateTree.java
@@ -426,20 +426,4 @@ public class StateTree implements NodeOwner {
         }
 
     }
-
-    /**
-     * Prepares the tree for resynchronization by detaching all nodes,
-     * setting their internal state to not yet attached, and calling the
-     * attach listeners. The effect is that the client will receive the same
-     * changes as when the component tree was initially attached, so that it
-     * can build the DOM tree from scratch.
-     */
-    public void prepareForResync() {
-        getRootNode().visitNodeTreeBottomUp(StateNode::fireDetachListeners);
-        getRootNode().visitNodeTree(sn -> {
-            markAsDirty(sn);
-            sn.prepareForResync();
-        });
-        getRootNode().visitNodeTreeBottomUp(sn -> sn.fireAttachListeners(true));
-    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateTree.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateTree.java
@@ -426,4 +426,20 @@ public class StateTree implements NodeOwner {
         }
 
     }
+
+    /**
+     * Prepares the tree for resynchronization by detaching all nodes,
+     * setting their internal state to not yet attached, and calling the
+     * attach listeners. The effect is that the client will receive the same
+     * changes as when the component tree was initially attached, so that it
+     * can build the DOM tree from scratch.
+     */
+    public void prepareForResync() {
+        getRootNode().visitNodeTreeBottomUp(StateNode::fireDetachListeners);
+        getRootNode().visitNodeTree(sn -> {
+            markAsDirty(sn);
+            sn.prepareForResync();
+        });
+        getRootNode().visitNodeTreeBottomUp(sn -> sn.fireAttachListeners(true));
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateTree.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateTree.java
@@ -426,4 +426,13 @@ public class StateTree implements NodeOwner {
         }
 
     }
+
+    /**
+     * Prepares the tree for resynchronization, meaning that the client will
+     * receive the same changes as when the component tree was initially
+     * attached, so that it can build the DOM tree from scratch.
+     */
+    public void prepareForResync() {
+        rootNode.prepareForResync();
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
@@ -327,7 +327,7 @@ public class ServerRpcHandler implements Serializable {
             // Run detach listeners and re-attach all nodes again to the
             // state tree, in order to send changes for a full re-build of
             // the client-side state tree in the response
-            ui.getInternals().getStateTree().prepareForResync();
+            ui.getInternals().getStateTree().getRootNode().prepareForResync();
 
             // At this point, make no assumptions about which dependencies have
             // been accepted by the client

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
@@ -327,7 +327,7 @@ public class ServerRpcHandler implements Serializable {
             // Run detach listeners and re-attach all nodes again to the
             // state tree, in order to send changes for a full re-build of
             // the client-side state tree in the response
-            ui.getInternals().getStateTree().getRootNode().prepareForResync();
+            ui.getInternals().getStateTree().prepareForResync();
 
             // At this point, make no assumptions about which dependencies have
             // been accepted by the client

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
@@ -35,7 +35,6 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.internal.MessageDigestUtil;
-import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.server.ErrorEvent;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinService;
@@ -324,8 +323,16 @@ public class ServerRpcHandler implements Serializable {
                     + "indicate a bug in Vaadin platform. If you see this "
                     + "message regularly please open a bug report at "
                     + "https://github.com/vaadin/flow/issues");
-            ui.getInternals().getStateTree().getRootNode()
-                    .visitNodeTree(StateNode::markAsDirty);
+
+            // Run detach listeners and re-attach all nodes again to the
+            // state tree, in order to send changes for a full re-build of
+            // the client-side state tree in the response
+            ui.getInternals().getStateTree().prepareForResync();
+
+            // At this point, make no assumptions about which dependencies have
+            // been accepted by the client
+            ui.getInternals().getDependencyList().clearPendingSendToClient();
+
             // Signal by exception instead of return value to keep the method
             // signature for source and binary compatibility
             throw new ResynchronizationRequiredException();

--- a/flow-server/src/test/java/com/vaadin/flow/internal/StateNodeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/StateNodeTest.java
@@ -1132,29 +1132,6 @@ public class StateNodeTest {
         assertNodesReset(parent,child);
     }
 
-    @Test
-    public void prepareForResync_nodeHasAttachAndDetachListeners_treeIsDirtyAndListenersAreCalled() {
-        TestStateTree tree = new TestStateTree();
-
-        StateNode node1 = tree.getRootNode();
-        StateNode node2 = StateNodeTest.createEmptyNode("node2");
-        StateNodeTest.setParent(node2, node1);
-
-        AtomicInteger attachCount = new AtomicInteger();
-        node2.addAttachListener(attachCount::incrementAndGet);
-        AtomicInteger detachCount = new AtomicInteger();
-        node2.addDetachListener(detachCount::incrementAndGet);
-
-        tree.collectChanges(c -> {});
-        Assert.assertEquals(0, tree.collectDirtyNodes().size());
-
-        tree.getRootNode().prepareForResync();
-
-        Assert.assertEquals(1, attachCount.get());
-        Assert.assertEquals(1, detachCount.get());
-        Assert.assertEquals(2, tree.collectDirtyNodes().size());
-    }
-
     private void assertNodesReset(StateNode... nodes) {
         for (StateNode node : nodes) {
             Assert.assertEquals(-1, node.getId());

--- a/flow-server/src/test/java/com/vaadin/flow/internal/StateNodeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/StateNodeTest.java
@@ -1132,6 +1132,29 @@ public class StateNodeTest {
         assertNodesReset(parent,child);
     }
 
+    @Test
+    public void prepareForResync_nodeHasAttachAndDetachListeners_treeIsDirtyAndListenersAreCalled() {
+        TestStateTree tree = new TestStateTree();
+
+        StateNode node1 = tree.getRootNode();
+        StateNode node2 = StateNodeTest.createEmptyNode("node2");
+        StateNodeTest.setParent(node2, node1);
+
+        AtomicInteger attachCount = new AtomicInteger();
+        node2.addAttachListener(attachCount::incrementAndGet);
+        AtomicInteger detachCount = new AtomicInteger();
+        node2.addDetachListener(detachCount::incrementAndGet);
+
+        tree.collectChanges(c -> {});
+        Assert.assertEquals(0, tree.collectDirtyNodes().size());
+
+        tree.getRootNode().prepareForResync();
+
+        Assert.assertEquals(1, attachCount.get());
+        Assert.assertEquals(1, detachCount.get());
+        Assert.assertEquals(2, tree.collectDirtyNodes().size());
+    }
+
     private void assertNodesReset(StateNode... nodes) {
         for (StateNode node : nodes) {
             Assert.assertEquals(-1, node.getId());

--- a/flow-server/src/test/java/com/vaadin/flow/internal/StateTreeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/StateTreeTest.java
@@ -568,4 +568,26 @@ public class StateTreeTest {
         Assert.assertTrue(collectedNodes.contains(node2));
         Assert.assertTrue(collectedNodes.contains(node3));
     }
+
+
+    @Test
+    public void prepareForResync_nodeHasAttachAndDetachListeners_treeIsDirtyAndListenersAreCalled() {
+        StateNode node1 = tree.getRootNode();
+        StateNode node2 = StateNodeTest.createEmptyNode("node2");
+        StateNodeTest.setParent(node2, node1);
+
+        AtomicInteger attachCount = new AtomicInteger();
+        node2.addAttachListener(attachCount::incrementAndGet);
+        AtomicInteger detachCount = new AtomicInteger();
+        node2.addDetachListener(detachCount::incrementAndGet);
+
+        tree.collectChanges(c -> {});
+        Assert.assertEquals(0, tree.collectDirtyNodes().size());
+
+        tree.getRootNode().prepareForResync();
+
+        Assert.assertEquals(1, attachCount.get());
+        Assert.assertEquals(1, detachCount.get());
+        Assert.assertEquals(2, tree.collectDirtyNodes().size());
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/StateTreeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/StateTreeTest.java
@@ -568,25 +568,4 @@ public class StateTreeTest {
         Assert.assertTrue(collectedNodes.contains(node2));
         Assert.assertTrue(collectedNodes.contains(node3));
     }
-
-    @Test
-    public void prepareForResync_nodeHasAttachAndDetachListeners_treeIsDirtyAndListenersAreCalled() {
-        StateNode node1 = tree.getRootNode();
-        StateNode node2 = StateNodeTest.createEmptyNode("node2");
-        StateNodeTest.setParent(node2, node1);
-
-        AtomicInteger attachCount = new AtomicInteger();
-        node2.addAttachListener(attachCount::incrementAndGet);
-        AtomicInteger detachCount = new AtomicInteger();
-        node2.addDetachListener(detachCount::incrementAndGet);
-
-        tree.collectChanges(c -> {});
-        Assert.assertEquals(0, tree.collectDirtyNodes().size());
-
-        tree.prepareForResync();
-
-        Assert.assertEquals(1, attachCount.get());
-        Assert.assertEquals(1, detachCount.get());
-        Assert.assertEquals(2, tree.collectDirtyNodes().size());
-    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/StateTreeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/StateTreeTest.java
@@ -569,4 +569,24 @@ public class StateTreeTest {
         Assert.assertTrue(collectedNodes.contains(node3));
     }
 
+    @Test
+    public void prepareForResync_nodeHasAttachAndDetachListeners_treeIsDirtyAndListenersAreCalled() {
+        StateNode node1 = tree.getRootNode();
+        StateNode node2 = StateNodeTest.createEmptyNode("node2");
+        StateNodeTest.setParent(node2, node1);
+
+        AtomicInteger attachCount = new AtomicInteger();
+        node2.addAttachListener(attachCount::incrementAndGet);
+        AtomicInteger detachCount = new AtomicInteger();
+        node2.addDetachListener(detachCount::incrementAndGet);
+
+        tree.collectChanges(c -> {});
+        Assert.assertEquals(0, tree.collectDirtyNodes().size());
+
+        tree.prepareForResync();
+
+        Assert.assertEquals(1, attachCount.get());
+        Assert.assertEquals(1, detachCount.get());
+        Assert.assertEquals(2, tree.collectDirtyNodes().size());
+    }
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ResynchronizationView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ResynchronizationView.java
@@ -15,7 +15,6 @@ public class ResynchronizationView extends AbstractDivView {
     final static String CALL_BUTTON = "call";
 
     final static String ADDED_CLASS = "added";
-    final static String REJECTED_CLASS = "rejected";
 
     public ResynchronizationView() {
         setId(ID);
@@ -26,23 +25,6 @@ public class ResynchronizationView extends AbstractDivView {
             add(added);
             triggerResync();
         }));
-
-        add(createButton("Desync and call function", CALL_BUTTON, e -> {
-            // add a span to <body> for the test (not to view, since the DOM
-            // will be rebuilt on resync)
-            final String js = String.format(
-                    "document.getElementById(\"%s\").$server.clientCallable()"
-                            + ".then(_ => {})"
-                            + ".catch(_ => { document.body.innerHTML += '<span class=\"%s\">rejected</span>';});",
-                    ID, REJECTED_CLASS);
-            getUI().get().getPage().executeJs(js);
-        }));
-    }
-
-    @ClientCallable
-    public int clientCallable() {
-        triggerResync();
-        return 0;
     }
 
     private void triggerResync() {

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ResynchronizationView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ResynchronizationView.java
@@ -1,0 +1,53 @@
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.ClientCallable;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.Route;
+
+/**
+ * Test for https://github.com/vaadin/flow/issues/7590
+ */
+@Route("com.vaadin.flow.uitest.ui.ResynchronizationView")
+public class ResynchronizationView extends AbstractDivView {
+    final static String ID = "ResynchronizationView";
+
+    final static String ADD_BUTTON = "add";
+    final static String CALL_BUTTON = "call";
+
+    final static String ADDED_CLASS = "added";
+    final static String REJECTED_CLASS = "rejected";
+
+    public ResynchronizationView() {
+        setId(ID);
+
+        add(createButton("Desync and add", ADD_BUTTON, e -> {
+            final Span added = new Span("added");
+            added.addClassName(ADDED_CLASS);
+            add(added);
+            triggerResync();
+        }));
+
+        add(createButton("Desync and call function", CALL_BUTTON, e -> {
+            // add a span to <body> for the test (not to view, since the DOM
+            // will be rebuilt on resync)
+            final String js = String.format(
+                    "document.getElementById(\"%s\").$server.clientCallable()"
+                            + ".then(_ => {})"
+                            + ".catch(_ => { document.body.innerHTML += '<span class=\"%s\">rejected</span>';});",
+                    ID, REJECTED_CLASS);
+            getUI().get().getPage().executeJs(js);
+        }));
+    }
+
+    @ClientCallable
+    public int clientCallable() {
+        triggerResync();
+        return 0;
+    }
+
+    private void triggerResync() {
+        // trigger a resynchronization request on the client
+        getUI().get().getInternals().incrementServerId();
+
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ResynchronizationIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ResynchronizationIT.java
@@ -1,0 +1,42 @@
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class ResynchronizationIT extends ChromeBrowserTest {
+
+    /*
+     * If a component is only added in a lost message, it should be present after
+     * resynchronization.
+     */
+    @Test
+    public void resynchronize_componentAddedInLostMessage_appearAfterResync() {
+        open();
+
+        findElement(By.id(ResynchronizationView.ADD_BUTTON)).click();
+
+        waitForElementPresent(By.className(ResynchronizationView.ADDED_CLASS));
+
+        findElement(By.id(ResynchronizationView.ADD_BUTTON)).click();
+
+        waitUntil(driver -> findElements(
+                By.className(ResynchronizationView.ADDED_CLASS)).size() == 2);
+    }
+
+    /*
+     * If a @ClientCallable is invoked in a lost message, the promises waiting
+     * for the return value from the server should be rejected rather than
+     * remain pending.
+     */
+    @Test
+    public void resynchronize_clientCallableInvoked_promisesAreRejected() {
+        open();
+
+        findElement(By.id(ResynchronizationView.CALL_BUTTON)).click();
+
+        waitForElementPresent(By.className(ResynchronizationView.REJECTED_CLASS));
+    }
+
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ResynchronizationIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ResynchronizationIT.java
@@ -24,19 +24,4 @@ public class ResynchronizationIT extends ChromeBrowserTest {
         waitUntil(driver -> findElements(
                 By.className(ResynchronizationView.ADDED_CLASS)).size() == 2);
     }
-
-    /*
-     * If a @ClientCallable is invoked in a lost message, the promises waiting
-     * for the return value from the server should be rejected rather than
-     * remain pending.
-     */
-    @Test
-    public void resynchronize_clientCallableInvoked_promisesAreRejected() {
-        open();
-
-        findElement(By.id(ResynchronizationView.CALL_BUTTON)).click();
-
-        waitForElementPresent(By.className(ResynchronizationView.REJECTED_CLASS));
-    }
-
 }


### PR DESCRIPTION
Adapted by removing the rejection of stale promises (2.1 does not support `@ClientCallable` return values).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7668)
<!-- Reviewable:end -->
