### PR TITLE
Avoid exposing `StateNode::fireAttachListeners` and StateNode::fireDetachListeners`

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateTree.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateTree.java
@@ -428,18 +428,11 @@ public class StateTree implements NodeOwner {
     }
 
     /**
-     * Prepares the tree for resynchronization by detaching all nodes,
-     * setting their internal state to not yet attached, and calling the
-     * attach listeners. The effect is that the client will receive the same
-     * changes as when the component tree was initially attached, so that it
-     * can build the DOM tree from scratch.
+     * Prepares the tree for resynchronization, meaning that the client will
+     * receive the same changes as when the component tree was initially
+     * attached, so that it can build the DOM tree from scratch.
      */
     public void prepareForResync() {
-        getRootNode().visitNodeTreeBottomUp(StateNode::fireDetachListeners);
-        getRootNode().visitNodeTree(sn -> {
-            markAsDirty(sn);
-            sn.prepareForResync();
-        });
-        getRootNode().visitNodeTreeBottomUp(sn -> sn.fireAttachListeners(true));
+        rootNode.prepareForResync();
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/StateTreeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/StateTreeTest.java
@@ -569,6 +569,7 @@ public class StateTreeTest {
         Assert.assertTrue(collectedNodes.contains(node3));
     }
 
+
     @Test
     public void prepareForResync_nodeHasAttachAndDetachListeners_treeIsDirtyAndListenersAreCalled() {
         StateNode node1 = tree.getRootNode();
@@ -583,7 +584,7 @@ public class StateTreeTest {
         tree.collectChanges(c -> {});
         Assert.assertEquals(0, tree.collectDirtyNodes().size());
 
-        tree.prepareForResync();
+        tree.getRootNode().prepareForResync();
 
         Assert.assertEquals(1, attachCount.get());
         Assert.assertEquals(1, detachCount.get());


### PR DESCRIPTION
For consistency with 2.1 and 3.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7683)
<!-- Reviewable:end -->
