### PR TITLE
Create vaadin json with defaults.

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -24,19 +24,20 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
-import org.apache.commons.io.FileUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
-
 import elemental.json.Json;
 import elemental.json.JsonObject;
+import elemental.json.JsonValue;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import static com.vaadin.flow.server.Constants.COMPATIBILITY_RESOURCES_FRONTEND_DEFAULT;
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 import static com.vaadin.flow.server.Constants.RESOURCES_FRONTEND_DEFAULT;
@@ -194,9 +195,9 @@ public abstract class NodeUpdater implements FallibleCommand {
             packageJson.put(DEP_NAME_KEY, DEP_NAME_DEFAULT);
             packageJson.put(DEP_LICENSE_KEY, DEP_LICENSE_DEFAULT);
         }
-        if (!packageJson.hasKey(VAADIN_DEP_KEY)) {
-            packageJson.put(VAADIN_DEP_KEY, createVaadinPackagesJson());
-        }
+
+        createVaadinPackagesJson(packageJson);
+
         return packageJson;
     }
 
@@ -223,21 +224,33 @@ public abstract class NodeUpdater implements FallibleCommand {
         return jsonContent;
     }
 
-    static JsonObject createVaadinPackagesJson() {
-        JsonObject vaadinPackages = Json.createObject();
-        vaadinPackages.put(DEPENDENCIES, Json.createObject());
-        vaadinPackages.put(DEV_DEPENDENCIES, Json.createObject());
+    static void createVaadinPackagesJson(JsonObject packageJson) {
+        JsonObject vaadinPackages = computeIfAbsent(packageJson, VAADIN_DEP_KEY,
+                Json::createObject);
 
-        // Add default dependencies
-        JsonObject dependencies = vaadinPackages.getObject(DEPENDENCIES);
-        getDefaultDependencies().forEach(dependencies::put);
+        computeIfAbsent(vaadinPackages, DEPENDENCIES,
+                () -> {
+                    final JsonObject dependencies = Json.createObject();
+                    getDefaultDependencies().forEach(dependencies::put);
+                    return dependencies;
+                });
+        computeIfAbsent(vaadinPackages, DEV_DEPENDENCIES,
+                () -> {
+                    final JsonObject devDependencies = Json.createObject();
+                    getDefaultDevDependencies().forEach(devDependencies::put);
+                    return devDependencies;
+                });
+        computeIfAbsent(vaadinPackages, HASH_KEY, () -> Json.create(""));
+    }
 
-        // Add default developmentDependencies
-        JsonObject devDependencies = vaadinPackages.getObject(DEV_DEPENDENCIES);
-        getDefaultDevDependencies().forEach(devDependencies::put);
-
-        vaadinPackages.put(HASH_KEY, "");
-        return vaadinPackages;
+    private static <T extends JsonValue> T computeIfAbsent(
+            JsonObject jsonObject, String key, Supplier<T> valueSupplier) {
+        T result = jsonObject.get(key);
+        if (result == null) {
+            result = valueSupplier.get();
+            jsonObject.put(key, result);
+        }
+        return result;
     }
 
     static Map<String, String> getDefaultDependencies() {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -196,7 +196,7 @@ public abstract class NodeUpdater implements FallibleCommand {
             packageJson.put(DEP_LICENSE_KEY, DEP_LICENSE_DEFAULT);
         }
 
-        createVaadinPackagesJson(packageJson);
+        addVaadinDefaultsToJson(packageJson);
 
         return packageJson;
     }
@@ -224,8 +224,8 @@ public abstract class NodeUpdater implements FallibleCommand {
         return jsonContent;
     }
 
-    static void createVaadinPackagesJson(JsonObject packageJson) {
-        JsonObject vaadinPackages = computeIfAbsent(packageJson, VAADIN_DEP_KEY,
+    static void addVaadinDefaultsToJson(JsonObject json) {
+        JsonObject vaadinPackages = computeIfAbsent(json, VAADIN_DEP_KEY,
                 Json::createObject);
 
         computeIfAbsent(vaadinPackages, DEPENDENCIES,

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -116,7 +116,7 @@ public class NodeUpdaterTest {
     @Test
     public void updateMainDefaultDependencies_polymerVersionIsNull_useDefault() {
         JsonObject object = Json.createObject();
-        nodeUpdater.createVaadinPackagesJson(object);
+        nodeUpdater.addVaadinDefaultsToJson(object);
         nodeUpdater.updateDefaultDependencies(object);
 
         String version = getPolymerVersion(object);
@@ -129,7 +129,7 @@ public class NodeUpdaterTest {
         JsonObject dependencies = Json.createObject();
         dependencies.put("@polymer/polymer", "4.0.0");
         object.put(NodeUpdater.DEPENDENCIES, dependencies);
-        nodeUpdater.createVaadinPackagesJson(object);
+        nodeUpdater.addVaadinDefaultsToJson(object);
 
         nodeUpdater.updateDefaultDependencies(object);
 
@@ -145,7 +145,7 @@ public class NodeUpdaterTest {
         vaadin.put("disableUsageStatistics", true);
         object.put(NodeUpdater.VAADIN_DEP_KEY, vaadin);
 
-        nodeUpdater.createVaadinPackagesJson(object);
+        nodeUpdater.addVaadinDefaultsToJson(object);
         nodeUpdater.updateDefaultDependencies(object);
 
         Assert.assertEquals("3.2.0", getPolymerVersion(object));

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -116,8 +116,7 @@ public class NodeUpdaterTest {
     @Test
     public void updateMainDefaultDependencies_polymerVersionIsNull_useDefault() {
         JsonObject object = Json.createObject();
-        object.put(nodeUpdater.VAADIN_DEP_KEY,
-                nodeUpdater.createVaadinPackagesJson());
+        nodeUpdater.createVaadinPackagesJson(object);
         nodeUpdater.updateDefaultDependencies(object);
 
         String version = getPolymerVersion(object);
@@ -130,13 +129,28 @@ public class NodeUpdaterTest {
         JsonObject dependencies = Json.createObject();
         dependencies.put("@polymer/polymer", "4.0.0");
         object.put(NodeUpdater.DEPENDENCIES, dependencies);
-        object.put(NodeUpdater.VAADIN_DEP_KEY,
-                nodeUpdater.createVaadinPackagesJson());
+        nodeUpdater.createVaadinPackagesJson(object);
 
         nodeUpdater.updateDefaultDependencies(object);
 
         String version = getPolymerVersion(object);
         Assert.assertEquals("4.0.0", version);
+    }
+
+    @Test
+    public void updateMainDefaultDependencies_vaadinIsProvidedByUser_useDefault() {
+        JsonObject object = Json.createObject();
+
+        JsonObject vaadin = Json.createObject();
+        vaadin.put("disableUsageStatistics", true);
+        object.put(NodeUpdater.VAADIN_DEP_KEY, vaadin);
+
+        nodeUpdater.createVaadinPackagesJson(object);
+        nodeUpdater.updateDefaultDependencies(object);
+
+        Assert.assertEquals("3.2.0", getPolymerVersion(object));
+        Assert.assertEquals("3.2.0", getPolymerVersion(
+                object.getObject(NodeUpdater.VAADIN_DEP_KEY)));
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/vaadin/flow/issues/7663

Make sure that in case `package.json` is configured by user with `vaadin` object, but missing `dependencies`, all `vaadin` defaults are created.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7697)
<!-- Reviewable:end -->
