### PR TITLE
Added servlet parameter maxMessageSuspendTimeout

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/ApplicationConfiguration.java
+++ b/flow-client/src/main/java/com/vaadin/client/ApplicationConfiguration.java
@@ -33,6 +33,7 @@ public class ApplicationConfiguration {
     private int uiId;
     private ErrorMessage sessionExpiredError;
     private int heartbeatInterval;
+    private int maxMessageSuspendTimeout;
 
     private boolean productionMode;
     private boolean requestTiming;
@@ -162,6 +163,29 @@ public class ApplicationConfiguration {
      */
     public void setHeartbeatInterval(int heartbeatInterval) {
         this.heartbeatInterval = heartbeatInterval;
+    }
+
+    /**
+     * Gets the max message suspend delay.
+     *
+     * @return The maximum time, in milliseconds, to suspend out-of-order
+     *         messages waiting for their predecessor before considering it
+     *         lost.
+     */
+    public int getMaxMessageSuspendTimeout() {
+        return maxMessageSuspendTimeout;
+    }
+
+    /**
+     * Sets the interval for heartbeat requests.
+     *
+     * @param maxMessageSuspendTimeout
+     *            The maximum time, in milliseconds, to suspend out-of-order
+     *            messages waiting for their predecessor before considering it
+     *            lost.
+     */
+    public void setMaxMessageSuspendTimeout(int maxMessageSuspendTimeout) {
+        this.maxMessageSuspendTimeout = maxMessageSuspendTimeout;
     }
 
     /**

--- a/flow-client/src/main/java/com/vaadin/client/ApplicationConfiguration.java
+++ b/flow-client/src/main/java/com/vaadin/client/ApplicationConfiguration.java
@@ -166,23 +166,21 @@ public class ApplicationConfiguration {
     }
 
     /**
-     * Gets the max message suspend delay.
+     * Gets the maximum message suspension delay.
      *
      * @return The maximum time, in milliseconds, to suspend out-of-order
-     *         messages waiting for their predecessor before considering it
-     *         lost.
+     *         messages waiting for their predecessor before resynchronizing.
      */
     public int getMaxMessageSuspendTimeout() {
         return maxMessageSuspendTimeout;
     }
 
     /**
-     * Sets the interval for heartbeat requests.
+     * Sets the maximum message suspension delay.
      *
      * @param maxMessageSuspendTimeout
      *            The maximum time, in milliseconds, to suspend out-of-order
-     *            messages waiting for their predecessor before considering it
-     *            lost.
+     *            messages waiting for their predecessor before resynchronizing.
      */
     public void setMaxMessageSuspendTimeout(int maxMessageSuspendTimeout) {
         this.maxMessageSuspendTimeout = maxMessageSuspendTimeout;

--- a/flow-client/src/main/java/com/vaadin/client/bootstrap/Bootstrapper.java
+++ b/flow-client/src/main/java/com/vaadin/client/bootstrap/Bootstrapper.java
@@ -148,6 +148,9 @@ public class Bootstrapper implements EntryPoint {
         conf.setHeartbeatInterval(
                 jsoConfiguration.getConfigInteger("heartbeatInterval"));
 
+        conf.setMaxMessageSuspendTimeout(
+                jsoConfiguration.getConfigInteger("maxMessageSuspendTimeout"));
+
         conf.setServletVersion(jsoConfiguration.getVaadinVersion());
         conf.setAtmosphereVersion(jsoConfiguration.getAtmosphereVersion());
         conf.setAtmosphereJSVersion(jsoConfiguration.getAtmosphereJSVersion());

--- a/flow-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
@@ -58,9 +58,6 @@ public class MessageHandler {
     public static final String JSON_COMMUNICATION_PREFIX = "for(;;);[";
     public static final String JSON_COMMUNICATION_SUFFIX = "]";
 
-    /** The max timeout that response handling may be suspended. */
-    private static final int MAX_SUSPENDED_TIMEOUT = 5000;
-
     /**
      * The value of an undefined sync id.
      * <p>
@@ -263,7 +260,9 @@ public class MessageHandler {
             }
             pendingUIDLMessages.push(new PendingUIDLMessage(valueMap));
             if (!forceHandleMessage.isRunning()) {
-                forceHandleMessage.schedule(MAX_SUSPENDED_TIMEOUT);
+                int timeout = registry.getApplicationConfiguration()
+                        .getMaxMessageSuspendTimeout();
+                forceHandleMessage.schedule(timeout);
             }
             return;
         }

--- a/flow-client/src/test-gwt/java/com/vaadin/client/GwtApplicationConnectionTest.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/GwtApplicationConnectionTest.java
@@ -87,6 +87,7 @@ public class GwtApplicationConnectionTest extends ClientEngineTestBase {
     private native void mockFlowBootstrapScript(boolean webComponentMode) /*-{
         var mockCfg = {
             'heartbeatInterval' : 300,
+            'maxMessageSuspendTimeout': 5000,
             'contextRootUrl' : '../',
             'debug' : true,
             'v-uiId' : 0,

--- a/flow-client/src/test/frontend/FlowTests.ts
+++ b/flow-client/src/test/frontend/FlowTests.ts
@@ -71,6 +71,7 @@ function createInitResponse(appId: string, changes = '[]', pushScript?: string):
       {
         "appConfig": {
           "heartbeatInterval" : 300,
+          "maxMessageSuspendTimeout": 5000,
           "contextRootUrl" : "../",
           "debug" : true,
           "v-uiId" : 0,

--- a/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
@@ -89,6 +89,18 @@ public interface DeploymentConfiguration extends Serializable {
     int getHeartbeatInterval();
 
     /**
+     * In certain cases, such as when combining XmlHttpRequests and push over
+     * low bandwidth connections, messages may be received out of order by the
+     * client. This property specifies the maximum time (in milliseconds) that
+     * the client will then wait for the predecessors of a received out-order
+     * message, before considering them missing and requesting a full
+     * resynchronization of the application state from the server.
+     * 
+     * @return The max message suspend timeout
+     */
+    int getMaxMessageSuspendTimeout();
+
+    /**
      * Returns the number of seconds that a WebComponent will wait for a
      * reconnect before removing the server-side component from memory.
      *

--- a/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
@@ -96,7 +96,7 @@ public interface DeploymentConfiguration extends Serializable {
      * message, before considering them missing and requesting a full
      * resynchronization of the application state from the server.
      * 
-     * @return The max message suspend timeout
+     * @return The maximum message suspension timeout
      */
     int getMaxMessageSuspendTimeout();
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -1080,6 +1080,9 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
 
             appConfig.put("heartbeatInterval",
                     deploymentConfiguration.getHeartbeatInterval());
+            
+            appConfig.put("maxMessageSuspendTimeout",
+                    deploymentConfiguration.getMaxMessageSuspendTimeout());
 
             boolean sendUrlsAsParameters = deploymentConfiguration
                     .isSendUrlsAsParameters();

--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -67,7 +67,7 @@ public final class Constants implements Serializable {
     public static final String SERVLET_PARAMETER_SYNC_ID_CHECK = "syncIdCheck";
     public static final String SERVLET_PARAMETER_SEND_URLS_AS_PARAMETERS = "sendUrlsAsParameters";
     public static final String SERVLET_PARAMETER_PUSH_SUSPEND_TIMEOUT_LONGPOLLING = "pushLongPollingSuspendTimeout";
-
+    public static final String SERVLET_PARAMETER_MAX_MESSAGE_SUSPEND_TIMEOUT = "maxMessageSuspendTimeout";
     public static final String SERVLET_PARAMETER_JSBUNDLE = "module.bundle";
     public static final String SERVLET_PARAMETER_POLYFILLS = "module.polyfills";
     public static final String POLYFILLS_DEFAULT_VALUE = "";

--- a/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
@@ -91,6 +91,11 @@ public class DefaultDeploymentConfiguration
     public static final int DEFAULT_HEARTBEAT_INTERVAL = 300;
 
     /**
+     * Default value for {@link #getMaxMessageSuspendTimeout()} ()} = {@value} .
+     */
+    public static final int DEFAULT_MAX_MESSAGE_SUSPEND_TIMEOUT = 5000;
+
+    /**
      * Default value for {@link #getWebComponentDisconnect()} = {@value}.
      */
     public static final int DEFAULT_WEB_COMPONENT_DISCONNECT = 300;
@@ -112,6 +117,7 @@ public class DefaultDeploymentConfiguration
     private boolean useDeprecatedV14Bootstrapping;
     private boolean xsrfProtectionEnabled;
     private int heartbeatInterval;
+    private int maxMessageSuspendTimeout;
     private int webComponentDisconnect;
     private boolean closeIdleSessions;
     private PushMode pushMode;
@@ -143,6 +149,7 @@ public class DefaultDeploymentConfiguration
         checkRequestTiming();
         checkXsrfProtection(log);
         checkHeartbeatInterval();
+        checkMaxMessageSuspendTimeout();
         checkWebComponentDisconnectTimeout();
         checkCloseIdleSessions();
         checkPushMode();
@@ -199,6 +206,16 @@ public class DefaultDeploymentConfiguration
     @Override
     public int getHeartbeatInterval() {
         return heartbeatInterval;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The default max message suspension time is 5000 milliseconds.
+     */
+    @Override
+    public int getMaxMessageSuspendTimeout() {
+        return maxMessageSuspendTimeout;
     }
 
     @Override
@@ -348,6 +365,21 @@ public class DefaultDeploymentConfiguration
         } catch (NumberFormatException e) {
             getLogger().warn(WARNING_HEARTBEAT_INTERVAL_NOT_NUMERIC);
             heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
+        }
+    }
+
+    private void checkMaxMessageSuspendTimeout() {
+        try {
+            maxMessageSuspendTimeout = getApplicationOrSystemProperty(
+                    Constants.SERVLET_PARAMETER_MAX_MESSAGE_SUSPEND_TIMEOUT,
+                    DEFAULT_MAX_MESSAGE_SUSPEND_TIMEOUT, Integer::parseInt);
+        } catch (NumberFormatException e) {
+            String warning = SEPARATOR
+                    + "\nWARNING: maxMessageSuspendInterval has been set to an illegal value."
+                    + "The default of " + DEFAULT_MAX_MESSAGE_SUSPEND_TIMEOUT
+                    + " ms will be used." + SEPARATOR;
+            getLogger().warn(warning);
+            maxMessageSuspendTimeout = DEFAULT_MAX_MESSAGE_SUSPEND_TIMEOUT;
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
@@ -170,6 +170,11 @@ public class PropertyDeploymentConfiguration
     }
 
     @Override
+    public int getMaxMessageSuspendTimeout() {
+        return DefaultDeploymentConfiguration.DEFAULT_MAX_MESSAGE_SUSPEND_TIMEOUT;
+    }
+
+    @Override
     public int getWebComponentDisconnect() {
         return DefaultDeploymentConfiguration.DEFAULT_WEB_COMPONENT_DISCONNECT;
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
@@ -94,6 +94,11 @@ public class AbstractDeploymentConfigurationTest {
         }
 
         @Override
+        public int getMaxMessageSuspendTimeout() {
+            return 0;
+        }
+
+        @Override
         public int getWebComponentDisconnect() {
             return 0;
         }

--- a/flow-server/src/test/java/com/vaadin/flow/server/DefaultDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DefaultDeploymentConfigurationTest.java
@@ -134,4 +134,24 @@ public class DefaultDeploymentConfigurationTest {
         assertThat(config.getPushURL(), is("foo"));
     }
 
+    @Test
+    public void maxMessageSuspendTimeout_validValue_accepted() {
+        Properties initParameters = new Properties();
+        initParameters.setProperty(
+                Constants.SERVLET_PARAMETER_MAX_MESSAGE_SUSPEND_TIMEOUT,
+                "2700");
+        DefaultDeploymentConfiguration config = createDeploymentConfig(
+                initParameters);
+        assertEquals(2700, config.getMaxMessageSuspendTimeout());
+    }
+
+    @Test
+    public void maxMessageSuspendTimeout_invalidValue_defaultValue() {
+        Properties initParameters = new Properties();
+        initParameters.setProperty(
+                Constants.SERVLET_PARAMETER_MAX_MESSAGE_SUSPEND_TIMEOUT, "kk");
+        DefaultDeploymentConfiguration config = createDeploymentConfig(
+                initParameters);
+        assertEquals(5000, config.getMaxMessageSuspendTimeout());
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/tests/util/MockDeploymentConfiguration.java
+++ b/flow-server/src/test/java/com/vaadin/tests/util/MockDeploymentConfiguration.java
@@ -17,6 +17,7 @@ public class MockDeploymentConfiguration
     private boolean useDeprecatedV14Bootstrapping = true;
     private boolean xsrfProtectionEnabled = true;
     private int heartbeatInterval = 300;
+    private int maxMessageSuspendTimeout = 5000;
     private int webComponentDisconnect = 300;
     private boolean closeIdleSessions = false;
     private PushMode pushMode = PushMode.DISABLED;
@@ -81,6 +82,11 @@ public class MockDeploymentConfiguration
     @Override
     public int getHeartbeatInterval() {
         return heartbeatInterval;
+    }
+
+    @Override
+    public int getMaxMessageSuspendTimeout() {
+        return maxMessageSuspendTimeout;
     }
 
     @Override


### PR DESCRIPTION
This servlet parameter allows tuning the maximum time the client waits for receiving missing messages when it has received an out-of-order message before resynchronizing from the server.

Part of #7658.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7706)
<!-- Reviewable:end -->
