### PR TITLE
Improve error messages for detaching embedded Flow

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/dom/ElementUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/ElementUtil.java
@@ -266,11 +266,16 @@ public class ElementUtil {
      * Ensure the virtual child is removed from its parent.
      * 
      * @param element
-     *            the element to remove as a virtual child
+     *            the element to remove as a virtual child, not {@code null}
      */
     public static void removeVirtualChildFromParent(Element element) {
-        assert(element.isVirtualChild());
         Element parent = element.getParent();
+        if (parent == null) {
+            throw new IllegalStateException("Virtual element has been detached from parent already");
+        }
+        if (!element.isVirtualChild()) {
+            throw new IllegalArgumentException("Element is not a virtual child");
+        }
         if (parent.getNode().hasFeature(VirtualChildrenList.class)) {
             VirtualChildrenList childrenList = parent.getNode()
                     .getFeature(VirtualChildrenList.class);
@@ -278,7 +283,7 @@ public class ElementUtil {
                     .indexOf(element.getNode());
             if (index == -1) {
                 throw new IllegalArgumentException(
-                        "Failing to clean-up an embedded Flow web component, parent UI doesn't contain it as a virtual child.");
+                        "Given element is not a virtual child to its current parent.");
             }
             childrenList.remove(index);
         }

--- a/flow-server/src/test/java/com/vaadin/flow/component/webcomponent/WebComponentWrapperTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/webcomponent/WebComponentWrapperTest.java
@@ -205,6 +205,10 @@ public class WebComponentWrapperTest {
         Assert.assertFalse(
                 "Wrapper should have been disconnected also on the server",
                 wrapper.getParent().isPresent());
+
+        // the hearbeat listener should be disconnected
+        // -> another fake heartbeat won't trigger the listener and cause errors
+        internals.setLastHeartbeatTimestamp(System.currentTimeMillis() + 1200);
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementUtilTest.java
@@ -84,4 +84,28 @@ public class ElementUtilTest {
         ElementUtil.setComponent(e, c2);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void removeVirtualChild_notVirtual_errors() {
+        Element child = ElementFactory.createAnchor();
+        Element parent = ElementFactory.createDiv();
+        parent.appendChild(child);
+
+        ElementUtil.removeVirtualChildFromParent(child);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void removeVirtualChild_detachedTwice_errorSecondTime() {
+        Element child = ElementFactory.createAnchor();
+        Element parent = ElementFactory.createDiv();
+        parent.appendVirtualChild(child);
+
+        Assert.assertTrue(child.isVirtualChild());
+
+        ElementUtil.removeVirtualChildFromParent(child);
+
+        Assert.assertFalse(child.isVirtualChild());
+        
+        ElementUtil.removeVirtualChildFromParent(child);
+    }
+
 }


### PR DESCRIPTION
Previous errors and messages made very little sense when encountered.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7708)
<!-- Reviewable:end -->
