### PR TITLE
Added servlet parameter maxMessageSuspendTimeout (#7706)

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/ApplicationConfiguration.java
+++ b/flow-client/src/main/java/com/vaadin/client/ApplicationConfiguration.java
@@ -34,6 +34,7 @@ public class ApplicationConfiguration {
     private int uiId;
     private ErrorMessage sessionExpiredError;
     private int heartbeatInterval;
+    private int maxMessageSuspendTimeout;
 
     private boolean productionMode;
     private boolean requestTiming;
@@ -163,6 +164,27 @@ public class ApplicationConfiguration {
      */
     public void setHeartbeatInterval(int heartbeatInterval) {
         this.heartbeatInterval = heartbeatInterval;
+    }
+
+    /**
+     * Gets the maximum message suspension delay.
+     *
+     * @return The maximum time, in milliseconds, to suspend out-of-order
+     *         messages waiting for their predecessor before resynchronizing.
+     */
+    public int getMaxMessageSuspendTimeout() {
+        return maxMessageSuspendTimeout;
+    }
+
+    /**
+     * Sets the maximum message suspension delay.
+     *
+     * @param maxMessageSuspendTimeout
+     *            The maximum time, in milliseconds, to suspend out-of-order
+     *            messages waiting for their predecessor before resynchronizing.
+     */
+    public void setMaxMessageSuspendTimeout(int maxMessageSuspendTimeout) {
+        this.maxMessageSuspendTimeout = maxMessageSuspendTimeout;
     }
 
     /**

--- a/flow-client/src/main/java/com/vaadin/client/bootstrap/Bootstrapper.java
+++ b/flow-client/src/main/java/com/vaadin/client/bootstrap/Bootstrapper.java
@@ -157,6 +157,9 @@ public class Bootstrapper implements EntryPoint {
         conf.setHeartbeatInterval(
                 jsoConfiguration.getConfigInteger("heartbeatInterval"));
 
+        conf.setMaxMessageSuspendTimeout(
+                jsoConfiguration.getConfigInteger("maxMessageSuspendTimeout"));
+
         conf.setServletVersion(jsoConfiguration.getVaadinVersion());
         conf.setAtmosphereVersion(jsoConfiguration.getAtmosphereVersion());
         conf.setAtmosphereJSVersion(jsoConfiguration.getAtmosphereJSVersion());

--- a/flow-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
@@ -58,9 +58,6 @@ public class MessageHandler {
     public static final String JSON_COMMUNICATION_PREFIX = "for(;;);[";
     public static final String JSON_COMMUNICATION_SUFFIX = "]";
 
-    /** The max timeout that response handling may be suspended. */
-    private static final int MAX_SUSPENDED_TIMEOUT = 5000;
-
     /**
      * The value of an undefined sync id.
      * <p>
@@ -263,7 +260,9 @@ public class MessageHandler {
             }
             pendingUIDLMessages.push(new PendingUIDLMessage(valueMap));
             if (!forceHandleMessage.isRunning()) {
-                forceHandleMessage.schedule(MAX_SUSPENDED_TIMEOUT);
+                int timeout = registry.getApplicationConfiguration()
+                        .getMaxMessageSuspendTimeout();
+                forceHandleMessage.schedule(timeout);
             }
             return;
         }

--- a/flow-client/src/test-gwt/java/com/vaadin/client/GwtApplicationConnectionTest.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/GwtApplicationConnectionTest.java
@@ -87,6 +87,7 @@ public class GwtApplicationConnectionTest extends ClientEngineTestBase {
     private native void mockFlowBootstrapScript(boolean webComponentMode) /*-{
         var mockCfg = {
             'heartbeatInterval' : 300,
+            'maxMessageSuspendTimeout': 5000,
             'contextRootUrl' : '../',
             'debug' : true,
             'v-uiId' : 0,

--- a/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
@@ -101,6 +101,18 @@ public interface DeploymentConfiguration extends Serializable {
     int getHeartbeatInterval();
 
     /**
+     * In certain cases, such as when combining XmlHttpRequests and push over
+     * low bandwidth connections, messages may be received out of order by the
+     * client. This property specifies the maximum time (in milliseconds) that
+     * the client will then wait for the predecessors of a received out-order
+     * message, before considering them missing and requesting a full
+     * resynchronization of the application state from the server.
+     * 
+     * @return The maximum message suspension timeout
+     */
+    int getMaxMessageSuspendTimeout();
+
+    /**
      * Returns the number of seconds that a WebComponent will wait for a
      * reconnect before removing the server-side component from memory.
      *

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -1410,6 +1410,9 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
 
             appConfig.put("heartbeatInterval",
                     deploymentConfiguration.getHeartbeatInterval());
+            
+            appConfig.put("maxMessageSuspendTimeout",
+                    deploymentConfiguration.getMaxMessageSuspendTimeout());
 
             boolean sendUrlsAsParameters = deploymentConfiguration
                     .isSendUrlsAsParameters();

--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -72,7 +72,7 @@ public final class Constants implements Serializable {
     public static final String SERVLET_PARAMETER_SYNC_ID_CHECK = "syncIdCheck";
     public static final String SERVLET_PARAMETER_SEND_URLS_AS_PARAMETERS = "sendUrlsAsParameters";
     public static final String SERVLET_PARAMETER_PUSH_SUSPEND_TIMEOUT_LONGPOLLING = "pushLongPollingSuspendTimeout";
-
+    public static final String SERVLET_PARAMETER_MAX_MESSAGE_SUSPEND_TIMEOUT = "maxMessageSuspendTimeout";
     public static final String SERVLET_PARAMETER_JSBUNDLE = "module.bundle";
     public static final String SERVLET_PARAMETER_POLYFILLS = "module.polyfills";
     public static final String POLYFILLS_DEFAULT_VALUE = "build/webcomponentsjs/webcomponents-loader.js";

--- a/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
@@ -69,6 +69,11 @@ public class DefaultDeploymentConfiguration
     public static final int DEFAULT_HEARTBEAT_INTERVAL = 300;
 
     /**
+     * Default value for {@link #getMaxMessageSuspendTimeout()} ()} = {@value} .
+     */
+    public static final int DEFAULT_MAX_MESSAGE_SUSPEND_TIMEOUT = 5000;
+
+    /**
      * Default value for {@link #getWebComponentDisconnect()} = {@value}.
      */
     public static final int DEFAULT_WEB_COMPONENT_DISCONNECT = 300;
@@ -90,6 +95,7 @@ public class DefaultDeploymentConfiguration
     private boolean compatibilityMode;
     private boolean xsrfProtectionEnabled;
     private int heartbeatInterval;
+    private int maxMessageSuspendTimeout;
     private int webComponentDisconnect;
     private boolean closeIdleSessions;
     private PushMode pushMode;
@@ -121,6 +127,7 @@ public class DefaultDeploymentConfiguration
         checkRequestTiming();
         checkXsrfProtection(log);
         checkHeartbeatInterval();
+        checkMaxMessageSuspendTimeout();
         checkWebComponentDisconnectTimeout();
         checkCloseIdleSessions();
         checkPushMode();
@@ -178,6 +185,16 @@ public class DefaultDeploymentConfiguration
     @Override
     public int getHeartbeatInterval() {
         return heartbeatInterval;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The default max message suspension time is 5000 milliseconds.
+     */
+    @Override
+    public int getMaxMessageSuspendTimeout() {
+        return maxMessageSuspendTimeout;
     }
 
     @Override
@@ -308,6 +325,21 @@ public class DefaultDeploymentConfiguration
         } catch (NumberFormatException e) {
             getLogger().warn(WARNING_HEARTBEAT_INTERVAL_NOT_NUMERIC);
             heartbeatInterval = DEFAULT_HEARTBEAT_INTERVAL;
+        }
+    }
+
+    private void checkMaxMessageSuspendTimeout() {
+        try {
+            maxMessageSuspendTimeout = getApplicationOrSystemProperty(
+                    Constants.SERVLET_PARAMETER_MAX_MESSAGE_SUSPEND_TIMEOUT,
+                    DEFAULT_MAX_MESSAGE_SUSPEND_TIMEOUT, Integer::parseInt);
+        } catch (NumberFormatException e) {
+            String warning = SEPARATOR
+                    + "\nWARNING: maxMessageSuspendInterval has been set to an illegal value."
+                    + "The default of " + DEFAULT_MAX_MESSAGE_SUSPEND_TIMEOUT
+                    + " ms will be used." + SEPARATOR;
+            getLogger().warn(warning);
+            maxMessageSuspendTimeout = DEFAULT_MAX_MESSAGE_SUSPEND_TIMEOUT;
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
@@ -186,6 +186,11 @@ public class PropertyDeploymentConfiguration
     }
 
     @Override
+    public int getMaxMessageSuspendTimeout() {
+        return DefaultDeploymentConfiguration.DEFAULT_MAX_MESSAGE_SUSPEND_TIMEOUT;
+    }
+
+    @Override
     public int getWebComponentDisconnect() {
         return DefaultDeploymentConfiguration.DEFAULT_WEB_COMPONENT_DISCONNECT;
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
@@ -99,6 +99,11 @@ public class AbstractDeploymentConfigurationTest {
         }
 
         @Override
+        public int getMaxMessageSuspendTimeout() {
+            return 0;
+        }
+
+        @Override
         public int getWebComponentDisconnect() {
             return 0;
         }

--- a/flow-server/src/test/java/com/vaadin/flow/server/DefaultDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DefaultDeploymentConfigurationTest.java
@@ -212,4 +212,23 @@ public class DefaultDeploymentConfigurationTest {
         Assert.assertFalse(config.useCompiledFrontendResources());
     }
 
+    public void maxMessageSuspendTimeout_validValue_accepted() {
+        Properties initParameters = new Properties();
+        initParameters.setProperty(
+                Constants.SERVLET_PARAMETER_MAX_MESSAGE_SUSPEND_TIMEOUT,
+                "2700");
+        DefaultDeploymentConfiguration config = createDeploymentConfig(
+                initParameters);
+        assertEquals(2700, config.getMaxMessageSuspendTimeout());
+    }
+
+    @Test
+    public void maxMessageSuspendTimeout_invalidValue_defaultValue() {
+        Properties initParameters = new Properties();
+        initParameters.setProperty(
+                Constants.SERVLET_PARAMETER_MAX_MESSAGE_SUSPEND_TIMEOUT, "kk");
+        DefaultDeploymentConfiguration config = createDeploymentConfig(
+                initParameters);
+        assertEquals(5000, config.getMaxMessageSuspendTimeout());
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/tests/util/MockDeploymentConfiguration.java
+++ b/flow-server/src/test/java/com/vaadin/tests/util/MockDeploymentConfiguration.java
@@ -17,6 +17,7 @@ public class MockDeploymentConfiguration
     private boolean compatibilityMode = false;
     private boolean xsrfProtectionEnabled = true;
     private int heartbeatInterval = 300;
+    private int maxMessageSuspendTimeout = 5000;
     private int webComponentDisconnect = 300;
     private boolean closeIdleSessions = false;
     private PushMode pushMode = PushMode.DISABLED;
@@ -85,6 +86,11 @@ public class MockDeploymentConfiguration
     @Override
     public int getHeartbeatInterval() {
         return heartbeatInterval;
+    }
+
+    @Override
+    public int getMaxMessageSuspendTimeout() {
+        return maxMessageSuspendTimeout;
     }
 
     @Override


### PR DESCRIPTION
This servlet parameter allows tuning the maximum time the client waits for receiving missing messages when it has received an out-of-order message before resynchronizing from the server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7717)
<!-- Reviewable:end -->
