### PR TITLE
Cherry Pick: Fix the dependency of DevModeInitializer on ServletRegistration (#7709)

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/DeploymentConfigurationFactoryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DeploymentConfigurationFactoryTest.java
@@ -2,7 +2,6 @@ package com.vaadin.flow.server;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
@@ -226,8 +226,7 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
         Assert.assertFalse(generatedOpenApiJson.exists());
         DevModeInitializer devModeInitializer = new DevModeInitializer();
         devModeInitializer.onStartup(classes, servletContext);
-        Assert.assertTrue(
-                "Should generate OpenAPI spec if Endpoint is used.",
+        Assert.assertTrue("Should generate OpenAPI spec if Endpoint is used.",
                 generatedOpenApiJson.exists());
     }
 
@@ -266,6 +265,16 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
         devModeInitializer.onStartup(classes, servletContext);
         assertTrue(ts1.exists());
         assertTrue(ts2.exists());
+    }
+
+    @Test
+    public void onStartup_emptyServletRegistrations_shouldCreateDevModeHandler()
+            throws Exception {
+        DevModeInitializer devModeInitializer = new DevModeInitializer();
+        Mockito.when(servletContext.getServletRegistrations())
+                .thenReturn(Collections.emptyMap());
+        devModeInitializer.onStartup(classes, servletContext);
+        assertNotNull(DevModeHandler.getDevModeHandler());
     }
 
     private void loadingJars_allFilesExist(String resourcesFolder)
@@ -350,5 +359,4 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
         assertTrue("Resource doesn't load from given path",
                 locations.get(0).exists());
     }
-
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
@@ -271,24 +271,18 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
     @Test
     public void onStartup_emptyServletRegistrations_shouldCreateDevModeHandler()
             throws Exception {
-        System.setProperty(
-                Constants.VAADIN_PREFIX + FrontendUtils.PROJECT_BASEDIR,
-                initParams.get(FrontendUtils.PROJECT_BASEDIR));
-
         DevModeInitializer devModeInitializer = new DevModeInitializer();
         Mockito.when(servletContext.getServletRegistrations())
                 .thenReturn(Collections.emptyMap());
+        Mockito.when(servletContext.getInitParameterNames())
+                .thenReturn(Collections.enumeration(
+                        Collections.singleton(FrontendUtils.PROJECT_BASEDIR)));
+        Mockito.when(
+                servletContext.getInitParameter(FrontendUtils.PROJECT_BASEDIR))
+                .thenReturn(initParams.get(FrontendUtils.PROJECT_BASEDIR));
         devModeInitializer.onStartup(classes, servletContext);
         assertNotNull(DevModeHandler.getDevModeHandler());
     }
-
-    @Override
-    public void teardown() throws Exception, SecurityException {
-        super.teardown();
-        System.clearProperty(
-                Constants.VAADIN_PREFIX + FrontendUtils.PROJECT_BASEDIR);
-    }
-
 
     private void loadingJars_allFilesExist(String resourcesFolder)
             throws IOException, ServletException {

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
@@ -30,6 +30,7 @@ import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.DevModeHandler;
 import com.vaadin.flow.server.connect.generator.VaadinConnectClientGenerator;
 import com.vaadin.flow.server.frontend.FallbackChunk;
+import com.vaadin.flow.server.frontend.FrontendUtils;
 
 import static com.vaadin.flow.server.Constants.COMPATIBILITY_RESOURCES_FRONTEND_DEFAULT;
 import static com.vaadin.flow.server.Constants.CONNECT_JAVA_SOURCE_FOLDER_TOKEN;
@@ -270,12 +271,24 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
     @Test
     public void onStartup_emptyServletRegistrations_shouldCreateDevModeHandler()
             throws Exception {
+        System.setProperty(
+                Constants.VAADIN_PREFIX + FrontendUtils.PROJECT_BASEDIR,
+                initParams.get(FrontendUtils.PROJECT_BASEDIR));
+
         DevModeInitializer devModeInitializer = new DevModeInitializer();
         Mockito.when(servletContext.getServletRegistrations())
                 .thenReturn(Collections.emptyMap());
         devModeInitializer.onStartup(classes, servletContext);
         assertNotNull(DevModeHandler.getDevModeHandler());
     }
+
+    @Override
+    public void teardown() throws Exception, SecurityException {
+        super.teardown();
+        System.clearProperty(
+                Constants.VAADIN_PREFIX + FrontendUtils.PROJECT_BASEDIR);
+    }
+
 
     private void loadingJars_allFilesExist(String resourcesFolder)
             throws IOException, ServletException {


### PR DESCRIPTION
* Fix the dependency of DevModeInitializer on ServletRegistration

* Use VaadinServlet registration if present in DevModeInitializer

(cherry picked from commit d693b4755109dff139363ab167e186ec80d77b87)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7743)
<!-- Reviewable:end -->
