### PR TITLE
Fix DevModeInitializerTest.onStartup_emptyServletRegistrations_shouldCreateDevModeHandler

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
@@ -271,24 +271,18 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
     @Test
     public void onStartup_emptyServletRegistrations_shouldCreateDevModeHandler()
             throws Exception {
-        System.setProperty(
-                Constants.VAADIN_PREFIX + FrontendUtils.PROJECT_BASEDIR,
-                initParams.get(FrontendUtils.PROJECT_BASEDIR));
-
         DevModeInitializer devModeInitializer = new DevModeInitializer();
         Mockito.when(servletContext.getServletRegistrations())
                 .thenReturn(Collections.emptyMap());
+        Mockito.when(servletContext.getInitParameterNames())
+                .thenReturn(Collections.enumeration(
+                        Collections.singleton(FrontendUtils.PROJECT_BASEDIR)));
+        Mockito.when(
+                servletContext.getInitParameter(FrontendUtils.PROJECT_BASEDIR))
+                .thenReturn(initParams.get(FrontendUtils.PROJECT_BASEDIR));
         devModeInitializer.onStartup(classes, servletContext);
         assertNotNull(DevModeHandler.getDevModeHandler());
     }
-
-    @Override
-    public void teardown() throws Exception, SecurityException {
-        super.teardown();
-        System.clearProperty(
-                Constants.VAADIN_PREFIX + FrontendUtils.PROJECT_BASEDIR);
-    }
-
 
     private void loadingJars_allFilesExist(String resourcesFolder)
             throws IOException, ServletException {

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
@@ -30,6 +30,7 @@ import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.DevModeHandler;
 import com.vaadin.flow.server.connect.generator.VaadinConnectClientGenerator;
 import com.vaadin.flow.server.frontend.FallbackChunk;
+import com.vaadin.flow.server.frontend.FrontendUtils;
 
 import static com.vaadin.flow.server.Constants.COMPATIBILITY_RESOURCES_FRONTEND_DEFAULT;
 import static com.vaadin.flow.server.Constants.CONNECT_JAVA_SOURCE_FOLDER_TOKEN;
@@ -270,12 +271,24 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
     @Test
     public void onStartup_emptyServletRegistrations_shouldCreateDevModeHandler()
             throws Exception {
+        System.setProperty(
+                Constants.VAADIN_PREFIX + FrontendUtils.PROJECT_BASEDIR,
+                initParams.get(FrontendUtils.PROJECT_BASEDIR));
+
         DevModeInitializer devModeInitializer = new DevModeInitializer();
         Mockito.when(servletContext.getServletRegistrations())
                 .thenReturn(Collections.emptyMap());
         devModeInitializer.onStartup(classes, servletContext);
         assertNotNull(DevModeHandler.getDevModeHandler());
     }
+
+    @Override
+    public void teardown() throws Exception, SecurityException {
+        super.teardown();
+        System.clearProperty(
+                Constants.VAADIN_PREFIX + FrontendUtils.PROJECT_BASEDIR);
+    }
+
 
     private void loadingJars_allFilesExist(String resourcesFolder)
             throws IOException, ServletException {


### PR DESCRIPTION
The test created `webpack.config.js`, `webpack.generated.js` in the `flow-server` directory because `project.baseDir` was unknown. It's fixed by this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7751)
<!-- Reviewable:end -->
