### PR TITLE
fix webpack problem in os windows because of path separator

### DIFF
--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -68,9 +68,10 @@ if (watchDogPort) {
 const webPackEntries = {};
 if (useClientSideIndexFileForBootstrapping) {
   webPackEntries.bundle = clientSideIndexEntryPoint;
-  // if there are vaadin exported views, add a second entry
-  const [_, dir, prefix] = /^(.*)\/(.+)\.js/.exec(fileNameOfTheFlowGeneratedMainEntryPoint);
-  if (fs.readdirSync(dir).filter(fileName => !fileName.startsWith(prefix)).length) {
+  const dirName = path.dirname(fileNameOfTheFlowGeneratedMainEntryPoint);
+  const baseName = path.basename(fileNameOfTheFlowGeneratedMainEntryPoint, '.js');
+  if (fs.readdirSync(dirName).filter(fileName => !fileName.startsWith(baseName)).length) {
+    // if there are vaadin exported views, add a second entry
     webPackEntries.export = fileNameOfTheFlowGeneratedMainEntryPoint;
   }
 } else {


### PR DESCRIPTION
Fixes #7755

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7769)
<!-- Reviewable:end -->
