### PR TITLE
Mock System.getProperty in DevModeHandlerTest using PowerMock

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -282,6 +282,14 @@
             <version>${spring.autoconfigure.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
@@ -46,6 +46,7 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -70,6 +71,7 @@ import static org.mockito.Mockito.mock;
 @NotThreadSafe
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({System.class, DevModeHandler.class, FileUtils.class})
+@PowerMockIgnore({"sun.net.*", "com.sun.*"})
 @SuppressWarnings("restriction")
 public class DevModeHandlerTest {
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>flow-project</artifactId>
@@ -64,7 +64,8 @@
         <flow.release.repo.url>
             https://maven.vaadin.com/vaadin-prereleases/
         </flow.release.repo.url>
-        <flow.deployment.repo.id>${flow.snapshot.repo.id}</flow.deployment.repo.id>
+        <flow.deployment.repo.id>${flow.snapshot.repo.id}
+        </flow.deployment.repo.id>
         <flow.deployment.repo.url>
             ${flow.snapshot.repo.url}
         </flow.deployment.repo.url>
@@ -92,6 +93,7 @@
         <hibernate.validator.version>6.0.1.Final</hibernate.validator.version>
         <slf4j.version>1.7.25</slf4j.version>
         <polymer.version>2.6.1</polymer.version>
+        <powermock.version>1.7.4</powermock.version>
 
         <!-- Plugins -->
         <driver.binary.downloader.maven.plugin.version>1.0.17
@@ -115,11 +117,14 @@
         <!-- Used in OSGi manifests -->
         <jsoup.version>1.12.1</jsoup.version>
         <!-- Note that this should be kept in sync with the class Constants -->
-        <atmosphere.runtime.version>2.4.30.slf4jvaadin1</atmosphere.runtime.version>
+        <atmosphere.runtime.version>2.4.30.slf4jvaadin1
+        </atmosphere.runtime.version>
 
         <!-- OSGi -->
         <!-- Note: the parserVersion value is set by build-helper-maven-plugin -->
-        <osgi.bundle.version>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}</osgi.bundle.version>
+        <osgi.bundle.version>
+            ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}
+        </osgi.bundle.version>
         <bnd.version>3.3.0</bnd.version>
         <osgi.core.version>6.0.0</osgi.core.version>
         <osgi.compendium.version>6.0.0</osgi.compendium.version>
@@ -262,6 +267,18 @@
                 <groupId>org.easymock</groupId>
                 <artifactId>easymock</artifactId>
                 <version>3.4</version>
+            </dependency>
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-module-junit4</artifactId>
+                <version>${powermock.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-api-mockito</artifactId>
+                <version>${powermock.version}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -447,7 +464,8 @@
                     <dependencies>
                         <dependency>
                             <groupId>de.skuzzle.enforcer</groupId>
-                            <artifactId>restrict-imports-enforcer-rule</artifactId>
+                            <artifactId>restrict-imports-enforcer-rule
+                            </artifactId>
                             <version>0.8.0</version>
                         </dependency>
                     </dependencies>
@@ -461,9 +479,10 @@
                             <configuration>
                                 <rules>
                                     <restrictImports
-                                        implementation="de.skuzzle.enforcer.restrictimports.RestrictImports">
+                                            implementation="de.skuzzle.enforcer.restrictimports.RestrictImports">
                                         <reason>Use SLF4j for logging</reason>
-                                        <bannedImport>java.util.logging.**</bannedImport>
+                                        <bannedImport>java.util.logging.**
+                                        </bannedImport>
                                     </restrictImports>
                                 </rules>
                             </configuration>
@@ -640,8 +659,11 @@
                         </plugin>
                         <plugin>
                             <groupId>com.lazerycode.selenium</groupId>
-                            <artifactId>driver-binary-downloader-maven-plugin</artifactId>
-                            <version>${driver.binary.downloader.maven.plugin.version}</version>
+                            <artifactId>driver-binary-downloader-maven-plugin
+                            </artifactId>
+                            <version>
+                                ${driver.binary.downloader.maven.plugin.version}
+                            </version>
                             <dependencies>
                                 <dependency>
                                     <groupId>javax.xml.bind</groupId>


### PR DESCRIPTION
This is an example of how to get rid of calling `System.setProperty` in tests using PowerMock.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7785)
<!-- Reviewable:end -->
