### PR TITLE
Revert "delay location.reload when session expires (#7707)"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,6 @@ flow-tests/**/package.json
 flow-tests/**/webpack*.js
 flow-tests/**/tsconfig.json
 flow-tests/**/pnpm-lock.yaml
-flow-tests/**/types.d.ts
 yarn.lock
 
 flow-client/src/main/resources/META-INF/resources/frontend/FlowClient.js

--- a/flow-client/src/main/java/com/vaadin/client/SystemErrorHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/SystemErrorHandler.java
@@ -20,8 +20,6 @@ import java.util.Set;
 
 import com.google.web.bindery.event.shared.UmbrellaException;
 
-import com.google.gwt.core.client.Scheduler;
-
 import com.vaadin.client.bootstrap.ErrorMessage;
 
 import elemental.client.Browser;
@@ -58,12 +56,8 @@ public class SystemErrorHandler {
      *            message details or null if there are no details
      */
     public void handleSessionExpiredError(String details) {
-        // Run asynchronously to guarantee that all executions in the Uidl are
-        // done (#7581)
-        Scheduler.get()
-                .scheduleDeferred(() -> handleUnrecoverableError(details,
-                        registry.getApplicationConfiguration()
-                                .getSessionExpiredError()));
+        handleUnrecoverableError(details, registry.getApplicationConfiguration()
+                .getSessionExpiredError());
     }
 
     /**

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/RouterSessionExpirationIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/RouterSessionExpirationIT.java
@@ -18,13 +18,10 @@ package com.vaadin.flow.uitest.ui;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
 public class RouterSessionExpirationIT extends ChromeBrowserTest {
-
-
 
     @Override
     protected String getTestPath() {
@@ -39,6 +36,10 @@ public class RouterSessionExpirationIT extends ChromeBrowserTest {
         String sessionId = getSessionId();
         navigateToFirstView();
         Assert.assertEquals(sessionId, getSessionId());
+
+        if (hasClientIssue("7581")) {
+            return;
+        }
 
         navigateToSesssionExpireView();
         // expired session causes page reload, after the page reload there will
@@ -87,6 +88,8 @@ public class RouterSessionExpirationIT extends ChromeBrowserTest {
 
     private void navigateTo(String linkText) {
         findElement(By.linkText(linkText)).click();
-        waitForElementPresent(By.xpath("//strong[text()='" + linkText + "']"));
+        Assert.assertNotNull(
+                findElement(By.xpath("//strong[text()='" + linkText + "']")));
+
     }
 }


### PR DESCRIPTION
This reverts commit 00934093ddb4c902e41ce4e4fc2408d2900c9d5f.

The fix in the mentioned commits results in an endless loop.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7789)
<!-- Reviewable:end -->
