### PR TITLE
Move generic element helpers out from PolymerUtils

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/ElementUtil.java
+++ b/flow-client/src/main/java/com/vaadin/client/ElementUtil.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.client;
+
+import elemental.dom.Element;
+import elemental.dom.Node;
+
+/**
+ * Utils class, intended to ease working with DOM elements on client side.
+ *
+ * @author Vaadin Ltd
+ */
+public class ElementUtil {
+
+    private ElementUtil() {
+        // Only static helpers
+    }
+
+    /**
+     * Checks whether the {@code node} has required {@code tag}.
+     *
+     * @param node
+     *            the node to check
+     * @param tag
+     *            the required tag name
+     * @return {@code true} if the node has required tag name
+     */
+    public static boolean hasTag(Node node, String tag) {
+        return node instanceof Element
+                && tag.equalsIgnoreCase(((Element) node).getTagName());
+    }
+
+    /**
+     * Searches the shadow root of the given context element for the given id or
+     * searches the light DOM if the element has no shadow root.
+     *
+     * @param context
+     *            the container element to search through
+     * @param id
+     *            the identifier of the element to search for
+     * @return the element with the given {@code id} if found, otherwise
+     *         <code>null</code>
+     */
+    public static native Element getElementById(Node context, String id)
+    /*-{
+       if (document.body.$ && document.body.$[id]) {
+         // Exported WCs add their id to body.$ and cannot be found using a real id attribute
+         return document.body.$[id];
+       } else if (context.shadowRoot) {
+         return context.shadowRoot.getElementById(id);
+       } else if (context.getElementById) {
+         return context.getElementById(id);
+       } else if (context.ownerDocument && context.ownerDocument.getElementById) {
+         var e = context.ownerDocument.getElementById(id);
+         if (e && context.contains(e)) {
+           return e;
+         } else {
+           return null;
+         }
+       } else {
+         return null;
+       }
+    }-*/;
+
+}

--- a/flow-client/src/main/java/com/vaadin/client/PolymerUtils.java
+++ b/flow-client/src/main/java/com/vaadin/client/PolymerUtils.java
@@ -394,7 +394,10 @@ public final class PolymerUtils {
      *            HTML element to check
      * @return {@code true} if the {@code htmlNode} can become a polymer 2
      *         element
+     * 
+     * @deprecated This is not in use anywhere and can be removed
      */
+    @Deprecated
     public static native boolean mayBePolymerElement(Element htmlNode)
     /*-{
         return $wnd.customElements && htmlNode.localName.indexOf('-') > -1;
@@ -411,7 +414,10 @@ public final class PolymerUtils {
      *
      * @see <a href=
      *      "https://developer.mozilla.org/en-US/docs/Web/Web_Components/Shadow_DOM">https://developer.mozilla.org/en-US/docs/Web/Web_Components/Shadow_DOM</a>
+     * 
+     * @deprecated This is not in use anywhere and can be removed
      */
+    @Deprecated
     public static native Node searchForElementInShadowRoot(
             ShadowRoot shadowRoot, String cssQuery)
     /*-{
@@ -429,7 +435,10 @@ public final class PolymerUtils {
      *
      * @see <a href=
      *      "http://html5index.org/Shadow%20DOM%20-%20ShadowRoot.html">http://html5index.org/Shadow%20DOM%20-%20ShadowRoot.html</a>
+     * 
+     * @deprecated This is not in use anywhere and can be removed
      */
+    @Deprecated
     public static native Node getElementInShadowRootById(ShadowRoot shadowRoot,
             String id)
     /*-{
@@ -446,7 +455,11 @@ public final class PolymerUtils {
      *            the identifier of the element to search for
      * @return the element with the given {@code id} inside the shadow root of
      *         the parent
+     * @deprecated This is Polymer specific. Use
+     *             {@link ElementUtil#getElementById(Node, String)} for the
+     *             generic version
      */
+    @Deprecated
     public static native Element getDomElementById(Node shadowRootParent,
             String id)
     /*-{
@@ -475,7 +488,11 @@ public final class PolymerUtils {
      * @param tag
      *            the required tag name
      * @return {@code true} if the node has required tag name
+     * 
+     * @deprecated Use the generic {@link ElementUtil#hasTag(Node, String)}
+     *             instead
      */
+    @Deprecated
     public static boolean hasTag(Node node, String tag) {
         return node instanceof Element
                 && tag.equalsIgnoreCase(((Element) node).getTagName());

--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
@@ -21,6 +21,7 @@ import java.util.function.Supplier;
 
 import com.vaadin.client.Command;
 import com.vaadin.client.Console;
+import com.vaadin.client.ElementUtil;
 import com.vaadin.client.ExistingElementMap;
 import com.vaadin.client.InitialPropertiesHandler;
 import com.vaadin.client.PolymerUtils;
@@ -812,8 +813,8 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
                 return;
             }
 
-            Element existingElement = PolymerUtils
-                    .getDomElementById(context.htmlNode, id);
+            Element existingElement = ElementUtil
+                    .getElementById(context.htmlNode, id);
             if (verifyAttachedElement(existingElement, node, id, address,
                     context)) {
                 if (!reactivePhase) {
@@ -870,7 +871,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
             failure = true;
             Console.warn(ELEMENT_ATTACH_ERROR_PREFIX + address
                     + " is not found. The requested tag name is '" + tag + "'");
-        } else if (!PolymerUtils.hasTag(element, tag)) {
+        } else if (!ElementUtil.hasTag(element, tag)) {
             failure = true;
             Console.warn(ELEMENT_ATTACH_ERROR_PREFIX + address
                     + " has the wrong tag name '" + element.getTagName()

--- a/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtBasicElementBinderTest.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtBasicElementBinderTest.java
@@ -1341,9 +1341,7 @@ public class GwtBasicElementBinderTest extends GwtPropertyElementBinderTest {
         addVirtualChild(node, childNode, NodeProperties.INJECT_BY_ID,
                 Json.create(childId));
 
-        Element shadowRoot = Browser.getDocument().createElement("div");
-
-        WidgetUtil.setJsProperty(element, "root", shadowRoot);
+        Element shadowRoot = addShadowRootElement(element);
 
         List<Integer> expectedAfterBindingFeatures = Arrays.asList(
                 NodeFeatures.POLYMER_SERVER_EVENT_HANDLERS,
@@ -1838,6 +1836,9 @@ public class GwtBasicElementBinderTest extends GwtPropertyElementBinderTest {
         var shadowRoot = $doc.createElement("div");
         element.shadowRoot = shadowRoot;
         element.root = shadowRoot;
+        shadowRoot.getElementById = function (id) {
+            return shadowRoot.querySelector("#"+id.replace("@","\\@"));
+        };
         return shadowRoot;
     }-*/;
 

--- a/flow-tests/test-root-context/frontend/template-without-shadow-root-view.js
+++ b/flow-tests/test-root-context/frontend/template-without-shadow-root-view.js
@@ -1,0 +1,25 @@
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { html } from '@polymer/polymer/lib/utils/html-tag.js';
+
+class PolymerTemplateWithoutShadowRootView extends PolymerElement {
+  _attachDom(dom) {
+    // Do not create a shadow root
+    this.appendChild(dom);
+  }
+
+  static get properties() {
+    return {
+    };
+  }
+  static get is() {
+    return 'template-without-shadow-root-view';
+  }
+
+  static get template() {
+    return html`
+      <div id="content"></div>
+    `;
+  }
+}
+
+customElements.define(PolymerTemplateWithoutShadowRootView.is, PolymerTemplateWithoutShadowRootView);

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/PolymerTemplateWithoutShadowRootView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/PolymerTemplateWithoutShadowRootView.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.template;
+
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.polymertemplate.Id;
+import com.vaadin.flow.component.polymertemplate.PolymerTemplate;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.templatemodel.TemplateModel;
+
+@Tag("template-without-shadow-root-view")
+@JsModule("./template-without-shadow-root-view.js")
+@Route(value = "com.vaadin.flow.uitest.ui.template.PolymerTemplateWithoutShadowRootView")
+@PageTitle("PolymerTemplate without a shadow root")
+public class PolymerTemplateWithoutShadowRootView
+        extends PolymerTemplate<TemplateModel> {
+
+    @Id("content")
+    private Div div;
+
+    public PolymerTemplateWithoutShadowRootView() {
+        div.setText("Hello");
+        div.addClickListener(e -> {
+            div.setText("Goodbye");
+        });
+    }
+
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/PolymerTemplateWithoutShadowRootIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/PolymerTemplateWithoutShadowRootIT.java
@@ -1,0 +1,23 @@
+package com.vaadin.flow.uitest.ui.template;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.component.html.testbench.DivElement;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+public class PolymerTemplateWithoutShadowRootIT extends ChromeBrowserTest {
+
+    @Test
+    public void componentMappedCorrectly() {
+        open();
+        DivElement content = $(DivElement.class).id("content");
+        Assert.assertEquals("Hello",content.getText());
+        content.click();
+        Assert.assertEquals("Goodbye",content.getText());
+    }
+}


### PR DESCRIPTION
* Adds test to see that PolymerTemplates without shadow roots still work

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7797)
<!-- Reviewable:end -->
