### PR TITLE
resovle JsModule annotation if refering inside dependency

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -153,7 +153,7 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo {
                         .useV14Bootstrap(useDeprecatedV14Bootstrapping())
                         .enablePackagesUpdate(true)
                         .useByteCodeScanner(optimizeBundle)
-                        .withFlowResourcesFolder(flowResourcesFolder)
+                        .withFlowResourcesFolder(getFlowResourcesFolder())
                         .copyResources(jarFiles)
                         .copyLocalResources(frontendResourcesDirectory)
                         .enableImportsUpdate(true)

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -55,8 +55,7 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo {
     /**
      * The directory where flow resources from jars will be copied to.
      */
-    @Parameter(defaultValue = "${project.basedir}/"
-            + DEAULT_FLOW_RESOURCES_FOLDER)
+    @Parameter(defaultValue = "${vaadin.flowResourcesFolder}")
     public File flowResourcesFolder;
 
     /**
@@ -142,4 +141,16 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo {
         return Boolean.parseBoolean(useDeprecatedV14Bootstrapping);
     }
 
+    /**
+     * Check if the plugin provides `flowResourcesFolder` or not.
+     * Default: `target/flow-frontend` folder.
+     *
+     * @return new folder if the `flowResourcesFolder` is provided.
+     */
+    public File getFlowResourcesFolder() {
+        if (flowResourcesFolder == null) {
+            return new File(DEAULT_FLOW_RESOURCES_FOLDER);
+        }
+        return flowResourcesFolder;
+    }
 }

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
@@ -56,6 +56,7 @@ import static com.vaadin.flow.server.Constants.NPM_TOKEN;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_INITIAL_UIDL;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_PRODUCTION_MODE;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_USE_V14_BOOTSTRAP;
+import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_FLOW_RESOURCES_FOLDER;
 import static com.vaadin.flow.server.frontend.FrontendUtils.TOKEN_FILE;
 
 /**
@@ -117,7 +118,7 @@ public class PrepareFrontendMojo extends FlowModeAbstractMojo {
                             .withWebpack(webpackOutputDirectory,
                                     webpackTemplate, webpackGeneratedTemplate)
                             .useV14Bootstrap(useDeprecatedV14Bootstrapping())
-                            .withFlowResourcesFolder(flowResourcesFolder)
+                            .withFlowResourcesFolder(getFlowResourcesFolder())
                             .createMissingPackageJson(true)
                             .enableImportsUpdate(false)
                             .enablePackagesUpdate(false).runNpmInstall(false);
@@ -147,6 +148,8 @@ public class PrepareFrontendMojo extends FlowModeAbstractMojo {
         buildInfo.put(SERVLET_PARAMETER_PRODUCTION_MODE, productionMode);
         buildInfo.put(SERVLET_PARAMETER_USE_V14_BOOTSTRAP,
                 useDeprecatedV14Bootstrapping());
+        buildInfo.put(SERVLET_PARAMETER_FLOW_RESOURCES_FOLDER,
+                getFlowResourcesFolder().getAbsolutePath());
         buildInfo.put(SERVLET_PARAMETER_INITIAL_UIDL, eagerServerLoad);
         buildInfo.put(NPM_TOKEN, npmFolder.getAbsolutePath());
         buildInfo.put(GENERATED_TOKEN, generatedFolder.getAbsolutePath());

--- a/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/BundleParser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/BundleParser.java
@@ -254,13 +254,8 @@ public final class BundleParser {
 
             // For polymer templates inside add-ons we will not find the sources
             // using ./ as the actual path contains
-            // "node_modules/@vaadin/flow-frontend/" instead of "./"
-            // "target/flow-frontend/" instead of "./"
-            if (name.contains(FLOW_NPM_PACKAGE_NAME) ||
-                    name.contains(DEAULT_FLOW_RESOURCES_FOLDER)) {
-                alternativeFileName = alternativeFileName.replaceFirst("\\./",
-                        "");
-            }
+            alternativeFileName = alternativeFileName.replaceFirst("\\./",
+                    "");
 
             // Remove query-string used by webpack modules like babel (e.g
             // ?babel-target=es6)

--- a/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
@@ -16,6 +16,7 @@
 
 package com.vaadin.flow.function;
 
+import java.io.File;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
@@ -29,7 +30,9 @@ import com.vaadin.flow.shared.communication.PushMode;
 
 import static com.vaadin.flow.server.Constants.POLYFILLS_DEFAULT_VALUE;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_USE_V14_BOOTSTRAP;
+import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_FLOW_RESOURCES_FOLDER;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_POLYFILLS;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEAULT_FLOW_RESOURCES_FOLDER;
 
 /**
  * A collection of properties configured at deploy time as well as a way of
@@ -54,6 +57,16 @@ public interface DeploymentConfiguration extends Serializable {
      */
     default boolean useV14Bootstrap() {
         return getBooleanProperty(SERVLET_PARAMETER_USE_V14_BOOTSTRAP, false);
+    }
+
+    /**
+     * Returns whether the plugin provides `flowResourcesFolder`.
+     *
+     * @return new folder if the `flowResourcesFolder` is provided.
+     */
+    default File flowResourcesFolder() {
+        return flowResourcesFolder(SERVLET_PARAMETER_FLOW_RESOURCES_FOLDER,
+                DEAULT_FLOW_RESOURCES_FOLDER);
     }
 
     /**
@@ -95,7 +108,7 @@ public interface DeploymentConfiguration extends Serializable {
      * the client will then wait for the predecessors of a received out-order
      * message, before considering them missing and requesting a full
      * resynchronization of the application state from the server.
-     * 
+     *
      * @return The maximum message suspension timeout
      */
     int getMaxMessageSuspendTimeout();
@@ -241,6 +254,28 @@ public interface DeploymentConfiguration extends Serializable {
                         propertyName, booleanString, parsedBoolean));
             }
         }
+    }
+
+    /**
+     * A shorthand of
+     * {@link DeploymentConfiguration#getApplicationOrSystemProperty(String, Object, Function)}
+     * for {@link String} type.
+     *
+     * @param propertyName
+     *            The simple of the property, in some contexts, lookup might be
+     *            performed using variations of the provided name.
+     * @param defaultValue
+     *            the default value that should be used if no value has been
+     *            defined
+     * @return the property value, or the passed default value if no property
+     *         value is found
+     */
+    default File flowResourcesFolder(String propertyName, String defaultValue) {
+        File flowFile = new File(getStringProperty(propertyName, defaultValue));
+        if (!flowFile.exists()) {
+            return new File(defaultValue);
+        }
+        return flowFile;
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -52,6 +52,7 @@ public final class Constants implements Serializable {
      * Enable it if your project is using client-side bootstrapping (CCDM).
      */
     public static final String SERVLET_PARAMETER_USE_V14_BOOTSTRAP = "useDeprecatedV14Bootstrapping";
+    public static final String SERVLET_PARAMETER_FLOW_RESOURCES_FOLDER = "flowResourcesFolder";
     public static final String SERVLET_PARAMETER_INITIAL_UIDL = "eagerServerLoad";
     public static final String SERVLET_PARAMETER_ENABLE_DEV_SERVER = "enableDevServer";
     public static final String SERVLET_PARAMETER_REUSE_DEV_SERVER = "reuseDevServer";

--- a/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
@@ -61,6 +61,7 @@ import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_REUSE_DEV_SERVE
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_USE_V14_BOOTSTRAP;
 import static com.vaadin.flow.server.Constants.VAADIN_PREFIX;
 import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
+import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_FLOW_RESOURCES_FOLDER;
 import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_TOKEN_FILE;
 import static com.vaadin.flow.server.frontend.FrontendUtils.PROJECT_BASEDIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.TOKEN_FILE;
@@ -223,6 +224,17 @@ public final class DeploymentConfigurationFactory implements Serializable {
             System.clearProperty(
                     VAADIN_PREFIX + SERVLET_PARAMETER_USE_V14_BOOTSTRAP);
         }
+
+        if (buildInfo.hasKey(SERVLET_PARAMETER_FLOW_RESOURCES_FOLDER)) {
+            initParameters.setProperty(SERVLET_PARAMETER_FLOW_RESOURCES_FOLDER,
+                    String.valueOf(buildInfo
+                            .getString(SERVLET_PARAMETER_FLOW_RESOURCES_FOLDER)));
+            // Need to be sure that we remove the system property,
+            // because it has priority in the configuration getter
+            System.clearProperty(
+                    VAADIN_PREFIX + SERVLET_PARAMETER_FLOW_RESOURCES_FOLDER);
+        }
+
         if (buildInfo.hasKey(SERVLET_PARAMETER_INITIAL_UIDL)) {
             initParameters.setProperty(SERVLET_PARAMETER_INITIAL_UIDL,
                     String.valueOf(buildInfo

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -257,9 +257,6 @@ public class DevModeInitializer implements ServletContainerInitializer,
         String frontendFolder = config.getStringProperty(PARAM_FRONTEND_DIR,
                 System.getProperty(PARAM_FRONTEND_DIR, DEFAULT_FRONTEND_DIR));
 
-        File flowResourcesFolder = new File(baseDir,
-                DEAULT_FLOW_RESOURCES_FOLDER);
-
         Builder builder = new NodeTasks.Builder(new DevModeClassFinder(classes),
                 new File(baseDir), new File(generatedDir),
                 new File(frontendFolder));
@@ -345,7 +342,7 @@ public class DevModeInitializer implements ServletContainerInitializer,
         try {
             builder.enablePackagesUpdate(true)
                     .useByteCodeScanner(useByteCodeScanner)
-                    .withFlowResourcesFolder(flowResourcesFolder)
+                    .withFlowResourcesFolder(config.flowResourcesFolder())
                     .copyResources(frontendLocations)
                     .copyLocalResources(new File(baseDir,
                             Constants.LOCAL_FRONTEND_RESOURCES_PATH))

--- a/flow-server/src/test/java/com/vaadin/flow/component/polymertemplate/BundleParserTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/polymertemplate/BundleParserTest.java
@@ -45,6 +45,13 @@ public class BundleParserTest {
     }
 
     @Test
+    public void nonLocalCustomTemplate_sourcesShouldBeFoundInTargetFolder() {
+        final String source = BundleParser.getSourceFromStatistics(
+                "./tempFolder/hello-world3.js", stats);
+        Assert.assertNotNull("Source expected in stats.json", source);
+    }
+
+    @Test
     public void frontendPrefix_sourcesShouldBeFound() {
         final String source = BundleParser.getSourceFromStatistics(
                 "./frontend/src/hello-world.js", stats);

--- a/flow-server/src/test/resources/META-INF/VAADIN/config/stats.json
+++ b/flow-server/src/test/resources/META-INF/VAADIN/config/stats.json
@@ -6,8 +6,12 @@
   },
   "modules": [
         {
-        "name": "../node_modules/@vaadin/flow-frontend/src/hello-world.js",
-        "source": "import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';\nimport '@polymer/paper-input/paper-input.js';\n\nclass HelloWorld extends PolymerElement {\n  static get template() {\n    return html`\n            <div>\n                <paper-input id=\"inputId\" value=\"{{userInput}}\"></paper-input>\n                <button id=\"helloButton\" on-click=\"sayHello\">Say hello</button>\n                <div id=\"greeting\">[[greeting]]</div>\n            </div>`;\n  }\n\n  static get is() {\n    return 'hello-world';\n  }\n\n}\n\ncustomElements.define(HelloWorld.is, HelloWorld);"
+            "name": "../node_modules/@vaadin/flow-frontend/src/hello-world.js",
+            "source": "import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';\nimport '@polymer/paper-input/paper-input.js';\n\nclass HelloWorld extends PolymerElement {\n  static get template() {\n    return html`\n            <div>\n                <paper-input id=\"inputId\" value=\"{{userInput}}\"></paper-input>\n                <button id=\"helloButton\" on-click=\"sayHello\">Say hello</button>\n                <div id=\"greeting\">[[greeting]]</div>\n            </div>`;\n  }\n\n  static get is() {\n    return 'hello-world';\n  }\n\n}\n\ncustomElements.define(HelloWorld.is, HelloWorld);"
+        },
+        {
+          "name": "../target/flow-frontend/src/hello-world2.js",
+          "source": "import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';\nimport '@polymer/paper-input/paper-input.js';\n\nclass HelloWorld extends PolymerElement {\n  static get template() {\n    return html`\n            <div>\n                <paper-input id=\"inputId\" value=\"{{userInput}}\"></paper-input>\n                <button id=\"helloButton\" on-click=\"sayHello\">Say hello</button>\n                <div id=\"greeting\">[[greeting]]</div>\n            </div>`;\n  }\n\n  static get is() {\n    return 'hello-world';\n  }\n\n}\n\ncustomElements.define(HelloWorld.is, HelloWorld);"
         },
         {
           "name": "../target/flow-frontend/src/hello-world2.js",
@@ -21,17 +25,15 @@
             "name": "./frontend/LikeableElementFaultyMethods.js",
             "source": "// Import an element\nimport '@polymer/paper-checkbox/paper-checkbox.js';\n\n// Import the PolymerElement base class and html helper\nimport {PolymerElement, html} from '@polymer/polymer';\n\n// Define an element class\nclass LikeableElement extends PolymerElement {\n\n  // Define public API properties\n  static get properties() { return { liked: Boolean }}\n\n  // Define the element's template\n  static get template() {\n    return `\n      <style>\n        :host{ \n          margin: 5px; \n        }\n      \n        .response { margin-top: 10px; } \n      </style>\n      <paper-checkbox checked=\"{{liked}}\">I like web components!</paper-checkbox>\n\n      <div id=\"test\" hidden$=\"[[!liked]]\" class=\"response\">Web components like you, too.</div>\n    `;\n  }\n}\n\n// Register the element with the browser\ncustomElements.define('likeable-element', LikeableElement);"
         }
-      ]
-      ,
-
-      "chunks" : [
-        {
-            "modules": [
-              {
-                "name": "./frontend/LikeableElement.js",
-                "source": "// Import an element\nimport '@polymer/paper-checkbox/paper-checkbox.js';\n\n// Import the PolymerElement base class and html helper\nimport {PolymerElement, html} from '@polymer/polymer';\n\n// Define an element class\nclass LikeableElement extends PolymerElement {\n\n  // Define public API properties\n  static get properties() { return { liked: Boolean }}\n\n  // Define the element's template\n  static get template() {\n    return html`\n      <style>\n        :host{ \n          margin: 5px; \n        }\n      \n        .response { margin-top: 10px; } \n      </style>\n   <div>Tag name doesn't match the JS module name</div>   <paper-checkbox checked='{{liked}}'>I like web components!</paper-checkbox>\n\n      <div id='test' hidden$='[[!liked]]' class='response'>Web components like you, too.</div>\n    `;\n  }\n}\n\n// Register the element with the browser\ncustomElements.define('likeable-element', LikeableElement);"
-              }
-            ]
-        }
-      ]
+  ],
+  "chunks" : [
+    {
+        "modules": [
+          {
+            "name": "./frontend/LikeableElement.js",
+            "source": "// Import an element\nimport '@polymer/paper-checkbox/paper-checkbox.js';\n\n// Import the PolymerElement base class and html helper\nimport {PolymerElement, html} from '@polymer/polymer';\n\n// Define an element class\nclass LikeableElement extends PolymerElement {\n\n  // Define public API properties\n  static get properties() { return { liked: Boolean }}\n\n  // Define the element's template\n  static get template() {\n    return html`\n      <style>\n        :host{ \n          margin: 5px; \n        }\n      \n        .response { margin-top: 10px; } \n      </style>\n   <div>Tag name doesn't match the JS module name</div>   <paper-checkbox checked='{{liked}}'>I like web components!</paper-checkbox>\n\n      <div id='test' hidden$='[[!liked]]' class='response'>Web components like you, too.</div>\n    `;\n  }\n}\n\n// Register the element with the browser\ncustomElements.define('likeable-element', LikeableElement);"
+          }
+        ]
+    }
+  ]
 }

--- a/flow-server/src/test/resources/META-INF/VAADIN/config/stats.json
+++ b/flow-server/src/test/resources/META-INF/VAADIN/config/stats.json
@@ -10,8 +10,12 @@
             "source": "import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';\nimport '@polymer/paper-input/paper-input.js';\n\nclass HelloWorld extends PolymerElement {\n  static get template() {\n    return html`\n            <div>\n                <paper-input id=\"inputId\" value=\"{{userInput}}\"></paper-input>\n                <button id=\"helloButton\" on-click=\"sayHello\">Say hello</button>\n                <div id=\"greeting\">[[greeting]]</div>\n            </div>`;\n  }\n\n  static get is() {\n    return 'hello-world';\n  }\n\n}\n\ncustomElements.define(HelloWorld.is, HelloWorld);"
         },
         {
-          "name": "../target/flow-frontend/src/hello-world2.js",
-          "source": "import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';\nimport '@polymer/paper-input/paper-input.js';\n\nclass HelloWorld extends PolymerElement {\n  static get template() {\n    return html`\n            <div>\n                <paper-input id=\"inputId\" value=\"{{userInput}}\"></paper-input>\n                <button id=\"helloButton\" on-click=\"sayHello\">Say hello</button>\n                <div id=\"greeting\">[[greeting]]</div>\n            </div>`;\n  }\n\n  static get is() {\n    return 'hello-world';\n  }\n\n}\n\ncustomElements.define(HelloWorld.is, HelloWorld);"
+            "name": "../target/flow-frontend/src/hello-world2.js",
+            "source": "import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';\nimport '@polymer/paper-input/paper-input.js';\n\nclass HelloWorld extends PolymerElement {\n  static get template() {\n    return html`\n            <div>\n                <paper-input id=\"inputId\" value=\"{{userInput}}\"></paper-input>\n                <button id=\"helloButton\" on-click=\"sayHello\">Say hello</button>\n                <div id=\"greeting\">[[greeting]]</div>\n            </div>`;\n  }\n\n  static get is() {\n    return 'hello-world';\n  }\n\n}\n\ncustomElements.define(HelloWorld.is, HelloWorld);"
+        },
+        {
+            "name": "../tempFolder/hello-world3.js",
+            "source": "import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';\nimport '@polymer/paper-input/paper-input.js';\n\nclass HelloWorld extends PolymerElement {\n  static get template() {\n    return html`\n            <div>\n                <paper-input id=\"inputId\" value=\"{{userInput}}\"></paper-input>\n                <button id=\"helloButton\" on-click=\"sayHello\">Say hello</button>\n                <div id=\"greeting\">[[greeting]]</div>\n            </div>`;\n  }\n\n  static get is() {\n    return 'hello-world';\n  }\n\n}\n\ncustomElements.define(HelloWorld.is, HelloWorld);"
         },
         {
           "name": "../target/flow-frontend/src/hello-world2.js",


### PR DESCRIPTION
The problem is that the source name of JS file of PolymetTemplate in statsJson is `target/flow-fronted/*`, not `@vaadin/flow-frontend/*`, so NpmTemplateParser can not get the JS source by incorrect name.

In this PR, do:
- allow `FlowModeAbstractMojo` to receive the custom `flowResourcesFolder` from user
- add a new entry parameter into deployment configuration
- `BundleParser` is considered to get the correct flowResourcesFolder when user provides another one
fixes #7752

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7844)
<!-- Reviewable:end -->
