### PR TITLE
Maintain one AtmosphereResource per live-reload connection in BrowserLiveReload

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReload.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReload.java
@@ -30,17 +30,27 @@ public interface BrowserLiveReload {
      * Sets the web socket connection resource when it's established.
      *
      * @param resource
-     *            a web socket connection resource
+     *            a web socket connection resource, not <code>null</code>.
      */
     void onConnect(AtmosphereResource resource);
 
     /**
-     * Removes the web socket connection resource.
+     * Removes the web socket connection resource, not <code>null</code>.
      *
      * @param resource
      *            a web socket connection resource
      */
     void onDisconnect(AtmosphereResource resource);
+
+    /**
+     * Returns whether the passed connection is a browser live-reload
+     * connection.
+     * 
+     * @param resource
+     *            a web socket connection resource,  not <code>null</code>.
+     * @return whether the web socket connection is for live-reload
+     */
+    boolean isLiveReload(AtmosphereResource resource);
 
     /**
      * Requests reload via the resource provided via

--- a/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReload.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReload.java
@@ -35,8 +35,17 @@ public interface BrowserLiveReload {
     void onConnect(AtmosphereResource resource);
 
     /**
+     * Removes the web socket connection resource.
+     *
+     * @param resource
+     *            a web socket connection resource
+     */
+    void onDisconnect(AtmosphereResource resource);
+
+    /**
      * Requests reload via the resource provided via
      * {@link #onConnect(AtmosphereResource)} call.
      */
     void reload();
+
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReloadImpl.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReloadImpl.java
@@ -50,18 +50,17 @@ class BrowserLiveReloadImpl implements BrowserLiveReload {
     @Override
     public void onDisconnect(AtmosphereResource resource) {
         if (!atmosphereResources.remove(resource)) {
+            String uuid = resource.uuid();
             getLogger().warn(
                     "Push connection {} is not a live-reload connection or already closed",
-                    resource.uuid());
+                    uuid);
         }
     }
 
     @Override
     public void reload() {
-        atmosphereResources.forEach(resource -> {
-            resource.getBroadcaster().broadcast("{\"command\": \"reload\"}",
-                    resource);
-        });
+        atmosphereResources.forEach(resource -> resource.getBroadcaster()
+                .broadcast("{\"command\": \"reload\"}", resource));
     }
 
     private static Logger getLogger() {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PushHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PushHandler.java
@@ -343,9 +343,21 @@ public class PushHandler {
             String id = resource.uuid();
 
             if (pushConnection == null) {
-                getLogger().warn(
-                        "Could not find push connection to close: {} with transport {}",
-                        id, resource.transport());
+                /*
+                 * In development mode we may have a live-reload push channel
+                 * that should be closed.
+                 */
+                if (!service.getDeploymentConfiguration().isProductionMode()) {
+                    BrowserLiveReloadAccess access = service.getInstantiator()
+                            .getOrCreate(BrowserLiveReloadAccess.class);
+                    BrowserLiveReload liveReload = access
+                            .getLiveReload(service);
+                    liveReload.onDisconnect(resource);
+                } else {
+                    getLogger().warn(
+                            "Could not find push connection to close: {} with transport {}",
+                            id, resource.transport());
+                }
             } else {
                 if (!pushMode.isEnabled()) {
                     /*

--- a/flow-server/src/test/java/com/vaadin/flow/internal/BrowserLiveReloadImplTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/BrowserLiveReloadImplTest.java
@@ -71,4 +71,18 @@ public class BrowserLiveReloadImplTest {
 
         Mockito.verifyZeroInteractions(broadcaster);
     }
+
+    @Test
+    public void reload_resourceIsDisconnected_reloadCommandIsNotSent() {
+        AtmosphereResource resource = Mockito.mock(AtmosphereResource.class);
+        Broadcaster broadcaster = Mockito.mock(Broadcaster.class);
+        Mockito.when(resource.getBroadcaster()).thenReturn(broadcaster);
+        reload.onConnect(resource);
+        Mockito.reset(broadcaster);
+        reload.onDisconnect(resource);
+
+        reload.reload();
+
+        Mockito.verifyZeroInteractions(broadcaster);
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/BrowserLiveReloadImplTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/BrowserLiveReloadImplTest.java
@@ -38,21 +38,27 @@ public class BrowserLiveReloadImplTest {
 
         Mockito.verify(resource).suspend(-1);
 
-        Mockito.verify(broadcaster).broadcast("{\"command\": \"hello\"}");
+        Mockito.verify(broadcaster).broadcast("{\"command\": \"hello\"}",
+                resource);
     }
 
     @Test
-    public void reload_resourceIsSet_sendReloadCommand() {
-        AtmosphereResource resource = Mockito.mock(AtmosphereResource.class);
+    public void reload_twoConnections_sendReloadCommand() {
+        AtmosphereResource resource1 = Mockito.mock(AtmosphereResource.class);
+        AtmosphereResource resource2 = Mockito.mock(AtmosphereResource.class);
         Broadcaster broadcaster = Mockito.mock(Broadcaster.class);
-        Mockito.when(resource.getBroadcaster()).thenReturn(broadcaster);
+        Mockito.when(resource1.getBroadcaster()).thenReturn(broadcaster);
+        Mockito.when(resource2.getBroadcaster()).thenReturn(broadcaster);
 
-        reload.onConnect(resource);
+        reload.onConnect(resource1);
+        reload.onConnect(resource2);
 
         reload.reload();
 
         Mockito.verify(broadcaster).broadcast("{\"command\": \"reload\"}",
-                resource);
+                resource1);
+        Mockito.verify(broadcaster).broadcast("{\"command\": \"reload\"}",
+                resource2);
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/internal/BrowserLiveReloadImplTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/BrowserLiveReloadImplTest.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.internal;
 
 import org.atmosphere.cpr.AtmosphereResource;
 import org.atmosphere.cpr.Broadcaster;
+import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -36,8 +37,8 @@ public class BrowserLiveReloadImplTest {
 
         reload.onConnect(resource);
 
+        Assert.assertTrue(reload.isLiveReload(resource));
         Mockito.verify(resource).suspend(-1);
-
         Mockito.verify(broadcaster).broadcast("{\"command\": \"hello\"}",
                 resource);
     }
@@ -49,9 +50,10 @@ public class BrowserLiveReloadImplTest {
         Broadcaster broadcaster = Mockito.mock(Broadcaster.class);
         Mockito.when(resource1.getBroadcaster()).thenReturn(broadcaster);
         Mockito.when(resource2.getBroadcaster()).thenReturn(broadcaster);
-
         reload.onConnect(resource1);
         reload.onConnect(resource2);
+        Assert.assertTrue(reload.isLiveReload(resource1));
+        Assert.assertTrue(reload.isLiveReload(resource2));
 
         reload.reload();
 
@@ -66,6 +68,7 @@ public class BrowserLiveReloadImplTest {
         AtmosphereResource resource = Mockito.mock(AtmosphereResource.class);
         Broadcaster broadcaster = Mockito.mock(Broadcaster.class);
         Mockito.when(resource.getBroadcaster()).thenReturn(broadcaster);
+        Assert.assertFalse(reload.isLiveReload(resource));
 
         reload.reload();
 
@@ -78,8 +81,10 @@ public class BrowserLiveReloadImplTest {
         Broadcaster broadcaster = Mockito.mock(Broadcaster.class);
         Mockito.when(resource.getBroadcaster()).thenReturn(broadcaster);
         reload.onConnect(resource);
+        Assert.assertTrue(reload.isLiveReload(resource));
         Mockito.reset(broadcaster);
         reload.onDisconnect(resource);
+        Assert.assertFalse(reload.isLiveReload(resource));
 
         reload.reload();
 


### PR DESCRIPTION
Fixes 1) reload of multiple UIs simultaneously and 2) erroneously sending `hello` message over regular push channel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7860)
<!-- Reviewable:end -->
