### PR TITLE
Always cleanup before generating files 3.0 (#7869)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -142,6 +142,15 @@ public class TaskRunNpmInstall implements FallibleCommand {
      * `package.json` has been updated.
      */
     private void runNpmInstall() throws ExecutionFailedException {
+        // Do possible cleaning before generating any new files.
+        try {
+            cleanUp();
+        } catch (IOException exception) {
+            throw new ExecutionFailedException("Couldn't remove "
+                    + packageUpdater.nodeModulesFolder + " directory",
+                    exception);
+        }
+
         if (enablePnpm) {
             try {
                 createPnpmFile(generateVersionsJson());
@@ -153,14 +162,6 @@ public class TaskRunNpmInstall implements FallibleCommand {
                                 + "with npm by setting system variable -Dvaadin.pnpm.enable=false",
                         exception);
             }
-        }
-
-        try {
-            cleanUp();
-        } catch (IOException exception) {
-            throw new ExecutionFailedException("Couldn't remove "
-                    + packageUpdater.nodeModulesFolder + " directory",
-                    exception);
         }
 
         List<String> executable;


### PR DESCRIPTION
The used  `FileUtils.forceDelete` for some
reason doesn't note (at least on windows)
that the directory is a symbolic link
and continues to delete the directory contents.

That meant that the
generated versions.json was generated correctly
but as the symlinkcheck failed it was removed
immediately as the version changed.

Fixes #7858

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7892)
<!-- Reviewable:end -->
