### PR TITLE
Show a notification in the UI after live reload happened (#7820)

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/LiveReload.java
+++ b/flow-client/src/main/java/com/vaadin/client/LiveReload.java
@@ -230,7 +230,7 @@ public class LiveReload {
             reloadNotificationElement.appendChild(message);
             indicator.appendChild(reloadNotificationElement);
             Browser.getDocument().getBody()
-                    .setOnfocus(this::handleOnBodyFocusEvent);
+                    .setOnclick(this::handleOnBodyFocusEvent);
         } else {
             Element message = Browser.getDocument()
                     .getElementById("vaadin-live-reload-timestamp");

--- a/flow-client/src/main/java/com/vaadin/client/LiveReload.java
+++ b/flow-client/src/main/java/com/vaadin/client/LiveReload.java
@@ -40,7 +40,7 @@ public class LiveReload {
     private static final String ENABLED_KEY_IN_STORAGE = "vaadin.live-reload.enabled";
     private static final String ACTIVE_KEY_IN_SESSION_STORAGE = "vaadin.live-reload.active";
     private static final String LAST_RELOAD_KEY_IN_STORAGE = "vaadin.live-reload.last-reload";
-    private static final String LAST_RELOAD_TEXT = "Last reload happened at ";
+    private static final String LAST_RELOAD_TEXT = "Last automatic reload happened at ";
     private static final int SPRING_DEV_TOOLS_PORT = 35729;
     private String serviceUrl;
     private int uiId;
@@ -218,8 +218,11 @@ public class LiveReload {
     }
 
     private void saveLastReloadInStorage(Date date) {
-        StorageUtil.setSessionItem(LAST_RELOAD_KEY_IN_STORAGE, date.getHours()
-                + ":" + date.getMinutes() + ":" + date.getSeconds());
+
+        StorageUtil.setSessionItem(LAST_RELOAD_KEY_IN_STORAGE,
+                buildStringWith2LeadingZeroes(date.getHours()) + ":"
+                        + buildStringWith2LeadingZeroes(date.getMinutes()) + ":"
+                        + buildStringWith2LeadingZeroes(date.getSeconds()));
     }
 
     private String getLastReloadInStorage(){
@@ -277,5 +280,13 @@ public class LiveReload {
         closeWebSocketConnection();
         Browser.getDocument().getBody().removeChild(indicator);
         StorageUtil.setLocalItem(ENABLED_KEY_IN_STORAGE, "false");
+    }
+
+    private String buildStringWith2LeadingZeroes(int number) {
+        if (number < 10) {
+            return "0" + number;
+        } else {
+            return number + "";
+        }
     }
 }

--- a/flow-client/src/main/java/com/vaadin/client/LiveReload.java
+++ b/flow-client/src/main/java/com/vaadin/client/LiveReload.java
@@ -149,7 +149,7 @@ public class LiveReload {
         Element overlay = Browser.getDocument()
                 .getElementById("vaadin-live-reload-overlay");
         overlay.setHidden(!overlay.isHidden());
-        if (lastReloadNotification != null) {
+        if (lastReloadNotification == null) {
             return;
         }
         if (!overlay.isHidden()) {

--- a/flow-client/src/main/java/com/vaadin/client/LiveReload.java
+++ b/flow-client/src/main/java/com/vaadin/client/LiveReload.java
@@ -46,7 +46,6 @@ public class LiveReload {
     private int uiId;
     private WebSocket webSocket;
     private Element indicator;
-    private Element reloadNotification;
 
     /**
      * Connects to either Spring Dev Tools Live Reload server or Flow Live
@@ -65,7 +64,7 @@ public class LiveReload {
         if (isEnabled()) {
             indicator = getOrCreateIndicator();
             if (getLastReloadInStorage() != null) {
-                reloadNotification = getOrCreateReloadNotification();
+                getOrCreateReloadNotification();
             }
             openWebSocketConnection();
         }
@@ -274,7 +273,6 @@ public class LiveReload {
 
     private void disable() {
         assert indicator != null;
-        assert reloadNotification != null;
 
         closeWebSocketConnection();
         Browser.getDocument().getBody().removeChild(indicator);

--- a/flow-tests/test-dev-mode/src/main/java/com/vaadin/flow/uitest/ui/frontend/LiveReloadView.java
+++ b/flow-tests/test-dev-mode/src/main/java/com/vaadin/flow/uitest/ui/frontend/LiveReloadView.java
@@ -16,9 +16,14 @@
 
 package com.vaadin.flow.uitest.ui.frontend;
 
+import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.internal.BrowserLiveReload;
+import com.vaadin.flow.internal.BrowserLiveReloadAccess;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 
 @Route(value = "com.vaadin.flow.uitest.ui.frontend.LiveReloadView", layout = ViewTestLayout.class)
@@ -26,6 +31,17 @@ public class LiveReloadView extends Div {
     public LiveReloadView() {
         Label label = new Label("Just a label");
         label.setId("elementId");
+        NativeButton reloadButton = new NativeButton("Trigger live reload");
+        reloadButton.addClickListener(this::handleClickLiveReload);
         add(label);
+        add(reloadButton);
+    }
+
+    private void handleClickLiveReload(ClickEvent event) {
+        BrowserLiveReloadAccess liveReload = VaadinService.getCurrent()
+                .getInstantiator().getOrCreate(BrowserLiveReloadAccess.class);
+        BrowserLiveReload browserLiveReload = liveReload
+                .getLiveReload(VaadinService.getCurrent());
+        browserLiveReload.reload();
     }
 }

--- a/flow-tests/test-dev-mode/src/main/java/com/vaadin/flow/uitest/ui/frontend/LiveReloadView.java
+++ b/flow-tests/test-dev-mode/src/main/java/com/vaadin/flow/uitest/ui/frontend/LiveReloadView.java
@@ -33,14 +33,15 @@ public class LiveReloadView extends Div {
         label.setId("elementId");
         NativeButton reloadButton = new NativeButton("Trigger live reload");
         reloadButton.addClickListener(this::handleClickLiveReload);
+        reloadButton.setId("live-reload-trigger-button");
         add(label);
         add(reloadButton);
     }
 
     private void handleClickLiveReload(ClickEvent event) {
-        BrowserLiveReloadAccess liveReload = VaadinService.getCurrent()
+        BrowserLiveReloadAccess liveReloadAccess = VaadinService.getCurrent()
                 .getInstantiator().getOrCreate(BrowserLiveReloadAccess.class);
-        BrowserLiveReload browserLiveReload = liveReload
+        BrowserLiveReload browserLiveReload = liveReloadAccess
                 .getLiveReload(VaadinService.getCurrent());
         browserLiveReload.reload();
     }

--- a/flow-tests/test-dev-mode/src/test/java/com/vaadin/flow/uitest/ui/frontend/LiveReloadIT.java
+++ b/flow-tests/test-dev-mode/src/test/java/com/vaadin/flow/uitest/ui/frontend/LiveReloadIT.java
@@ -21,6 +21,10 @@ import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
+import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.internal.BrowserLiveReload;
+import com.vaadin.flow.internal.BrowserLiveReloadAccess;
+import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
 public class LiveReloadIT extends ChromeBrowserTest {
@@ -62,5 +66,27 @@ public class LiveReloadIT extends ChromeBrowserTest {
 
         Assert.assertEquals(0,
                 findElements(By.id("vaadin-live-reload-indicator")).size());
+    }
+
+    @Test
+    public void notificationShownOnAutoReload() {
+        open();
+
+        VaadinService service = VaadinService.getCurrent();
+        Instantiator liveReload = service
+                .getInstantiator();
+        BrowserLiveReloadAccess liveReloadAccess = liveReload
+                .getOrCreate(BrowserLiveReloadAccess.class);
+        BrowserLiveReload browserLiveReload = liveReloadAccess
+                .getLiveReload(VaadinService.getCurrent());
+        browserLiveReload.reload();
+
+        WebElement reloadNotification = findElement(
+                By.id("vaadin-live-reload-notification"));
+        Assert.assertNotNull(reloadNotification);
+        Assert.assertNotNull(reloadNotification.getAttribute("hidden"));
+
+        findElement(By.tagName("body")).click();
+        Assert.assertNull(reloadNotification.getAttribute("null"));
     }
 }

--- a/flow-tests/test-dev-mode/src/test/java/com/vaadin/flow/uitest/ui/frontend/LiveReloadIT.java
+++ b/flow-tests/test-dev-mode/src/test/java/com/vaadin/flow/uitest/ui/frontend/LiveReloadIT.java
@@ -20,11 +20,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
-import com.vaadin.flow.di.Instantiator;
-import com.vaadin.flow.internal.BrowserLiveReload;
-import com.vaadin.flow.internal.BrowserLiveReloadAccess;
-import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
 public class LiveReloadIT extends ChromeBrowserTest {
@@ -72,21 +69,20 @@ public class LiveReloadIT extends ChromeBrowserTest {
     public void notificationShownOnAutoReload() {
         open();
 
-        VaadinService service = VaadinService.getCurrent();
-        Instantiator liveReload = service
-                .getInstantiator();
-        BrowserLiveReloadAccess liveReloadAccess = liveReload
-                .getOrCreate(BrowserLiveReloadAccess.class);
-        BrowserLiveReload browserLiveReload = liveReloadAccess
-                .getLiveReload(VaadinService.getCurrent());
-        browserLiveReload.reload();
+        WebElement liveReloadTrigger = findElement(
+                By.id("live-reload-trigger-button"));
+        liveReloadTrigger.click();
+
+        waitUntil(ExpectedConditions.presenceOfElementLocated(
+                By.id("vaadin-live-reload-notification")));
 
         WebElement reloadNotification = findElement(
                 By.id("vaadin-live-reload-notification"));
         Assert.assertNotNull(reloadNotification);
-        Assert.assertNotNull(reloadNotification.getAttribute("hidden"));
+        Assert.assertNull(reloadNotification.getAttribute("hidden"));
 
         findElement(By.tagName("body")).click();
-        Assert.assertNull(reloadNotification.getAttribute("null"));
+        Assert.assertNotNull(reloadNotification.getAttribute("hidden"));
+
     }
 }


### PR DESCRIPTION
(NEW)

Fix #7820
Present a notification when a Live Reload browser refresh is called, keep a timestamp in the notification about the time of the last reload.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7908)
<!-- Reviewable:end -->
