### PR TITLE
Don't stub npm as pnpm should be installed

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -407,7 +407,7 @@ public class FrontendTools {
                         Collections.singletonList(pkgJson.toJson()));
                 JsonObject lockJson = Json.createObject();
                 lockJson.put("lockfileVersion", 1);
-                FileUtils.writeLines(new File(baseDir, "package-lock.json"),
+                FileUtils.writeLines(new File(dir, "package-lock.json"),
                         Collections.singletonList(lockJson.toJson()));
             } catch (IOException e) {
                 getLogger().warn("Couldn't create temporary package.json");
@@ -665,7 +665,7 @@ public class FrontendTools {
         command.add("pnpm@" + DEFAULT_PNPM_VERSION);
 
         if (getLogger().isDebugEnabled()) {
-            getLogger().debug(FrontendUtils.commandToString(baseDir, command));
+            getLogger().debug(FrontendUtils.commandToString(dir, command));
         }
 
         ProcessBuilder builder = FrontendUtils.createProcessBuilder(command);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
@@ -82,7 +82,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         generatedDir = new File(baseDir, DEFAULT_GENERATED_DIR);
         resourcesDir = new File(baseDir, DEAULT_FLOW_RESOURCES_FOLDER);
 
-        NodeUpdateTestUtil.createStubNode(true, true,
+        NodeUpdateTestUtil.createStubNode(true, true, false,
                 baseDir.getAbsolutePath());
 
         packageCreator = new TaskGeneratePackageJson(baseDir, generatedDir, resourcesDir);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -436,7 +436,7 @@ public class FrontendToolsTest {
         Assume.assumeFalse(
                 "Skipping test on windows until a fake node.exe that isn't caught by Window defender can be created.",
                 FrontendUtils.isWindows());
-        createStubNode(true, true, baseDir);
+        createStubNode(true, true, false, baseDir);
 
         assertNodeCommand(() -> baseDir);
     }
@@ -454,7 +454,7 @@ public class FrontendToolsTest {
         Assume.assumeFalse(
                 "Skipping test on windows until a fake node.exe that isn't caught by Window defender can be created.",
                 FrontendUtils.isWindows());
-        createStubNode(false, true, baseDir);
+        createStubNode(false, true, false, baseDir);
 
         assertNpmCommand(() -> baseDir);
     }
@@ -468,7 +468,7 @@ public class FrontendToolsTest {
     }
 
     private void assertNpmCommand(Supplier<String> path) throws IOException {
-        createStubNode(false, true, vaadinHomeDir);
+        createStubNode(false, true, false, vaadinHomeDir);
 
         assertThat(tools.getNodeExecutable(), containsString("node"));
         assertThat(tools.getNodeExecutable(),
@@ -480,7 +480,7 @@ public class FrontendToolsTest {
     }
 
     private void assertNodeCommand(Supplier<String> path) throws IOException {
-        createStubNode(true, true, vaadinHomeDir);
+        createStubNode(true, true, false, vaadinHomeDir);
 
         assertThat(tools.getNodeExecutable(), containsString(DEFAULT_NODE));
         assertThat(tools.getNodeExecutable(), containsString(path.get()));

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateTestUtil.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateTestUtil.java
@@ -74,7 +74,7 @@ public class NodeUpdateTestUtil {
     // Creates stub versions of `node` and `npm` in the ./node folder as
     // frontend-maven-plugin does
     // Also creates a stub version of webpack-devmode-server
-    public static void createStubNode(boolean stubNode, boolean stubNpm,
+    public static void createStubNode(boolean stubNode, boolean stubNpm, boolean stubPnpm,
             String baseDir) throws IOException {
 
         if (stubNpm) {
@@ -84,7 +84,8 @@ public class NodeUpdateTestUtil {
             FileUtils.writeStringToFile(npmCli,
                     "process.argv.includes('--version') && console.log('5.6.0');",
                     StandardCharsets.UTF_8);
-
+        }
+        if(stubPnpm) {
             File ppmCli = new File(baseDir, "node_modules/pnpm/bin/pnpm.js");
             FileUtils.forceMkdirParent(ppmCli);
             FileUtils.writeStringToFile(ppmCli,

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateTestUtil.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateTestUtil.java
@@ -88,8 +88,10 @@ public class NodeUpdateTestUtil {
             File ppmCli = new File(baseDir, "node_modules/pnpm/bin/pnpm.js");
             FileUtils.forceMkdirParent(ppmCli);
             FileUtils.writeStringToFile(ppmCli,
-                    "process.argv.includes('--version') && console.log('4.1.0');",
+                    "process.argv.includes('--version') && console.log('4.5.0');",
                     StandardCharsets.UTF_8);
+            File yaml = new File(baseDir, "node_modules/.modules.yaml");
+            FileUtils.writeStringToFile(yaml, "", StandardCharsets.UTF_8);
         }
         if (stubNode) {
             File node = new File(baseDir,

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateWebpackTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateWebpackTest.java
@@ -55,7 +55,7 @@ public class TaskUpdateWebpackTest extends NodeUpdateTestUtil {
         baseDir = temporaryFolder.getRoot();
         frontendFolder = new File(baseDir, "frontend");
 
-        NodeUpdateTestUtil.createStubNode(true, true,
+        NodeUpdateTestUtil.createStubNode(true, true, false,
                 baseDir.getAbsolutePath());
 
         webpackUpdater = new TaskUpdateWebpack(frontendFolder, baseDir,

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
@@ -9,6 +9,7 @@ import java.net.URLConnection;
 import java.net.URLStreamHandler;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.EventListener;
 import java.util.HashSet;
@@ -274,12 +275,16 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
         DevModeInitializer devModeInitializer = new DevModeInitializer();
         Mockito.when(servletContext.getServletRegistrations())
                 .thenReturn(Collections.emptyMap());
-        Mockito.when(servletContext.getInitParameterNames())
-                .thenReturn(Collections.enumeration(
-                        Collections.singleton(FrontendUtils.PROJECT_BASEDIR)));
+        Mockito.when(servletContext.getInitParameterNames()).thenReturn(
+                Collections.enumeration(new HashSet<>(
+                        Arrays.asList(Constants.SERVLET_PARAMETER_ENABLE_PNPM,
+                                FrontendUtils.PROJECT_BASEDIR))));
         Mockito.when(
                 servletContext.getInitParameter(FrontendUtils.PROJECT_BASEDIR))
                 .thenReturn(initParams.get(FrontendUtils.PROJECT_BASEDIR));
+        Mockito.when(
+                servletContext.getInitParameter(Constants.SERVLET_PARAMETER_ENABLE_PNPM))
+                .thenReturn(initParams.get(Constants.SERVLET_PARAMETER_ENABLE_PNPM));
         devModeInitializer.onStartup(classes, servletContext);
         assertNotNull(DevModeHandler.getDevModeHandler());
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTestBase.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTestBase.java
@@ -67,8 +67,9 @@ public class DevModeInitializerTestBase {
 
         temporaryFolder.create();
         baseDir = temporaryFolder.getRoot().getPath();
+        Boolean enablePnpm = Boolean.TRUE;
 
-        createStubNode(false, true, baseDir);
+        createStubNode(false, true, enablePnpm, baseDir);
         createStubWebpackServer("Compiled", 500, baseDir);
 
         servletContext = Mockito.mock(ServletContext.class);
@@ -80,7 +81,7 @@ public class DevModeInitializerTestBase {
 
         initParams = new HashMap<>();
         initParams.put(FrontendUtils.PROJECT_BASEDIR, baseDir);
-        initParams.put(Constants.SERVLET_PARAMETER_ENABLE_PNPM, "true");
+        initParams.put(Constants.SERVLET_PARAMETER_ENABLE_PNPM, enablePnpm.toString());
 
         Mockito.when(vaadinServletRegistration.getInitParameters())
                 .thenReturn(initParams);

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTestBase.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTestBase.java
@@ -68,7 +68,7 @@ public class DevModeInitializerTestBase {
         temporaryFolder.create();
         baseDir = temporaryFolder.getRoot().getPath();
 
-        createStubNode(false, true, baseDir);
+        createStubNode(false, false, baseDir);
         createStubWebpackServer("Compiled", 500, baseDir);
 
         servletContext = Mockito.mock(ServletContext.class);

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTestBase.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTestBase.java
@@ -68,7 +68,7 @@ public class DevModeInitializerTestBase {
         temporaryFolder.create();
         baseDir = temporaryFolder.getRoot().getPath();
 
-        createStubNode(false, false, baseDir);
+        createStubNode(false, true, baseDir);
         createStubWebpackServer("Compiled", 500, baseDir);
 
         servletContext = Mockito.mock(ServletContext.class);


### PR DESCRIPTION
We should install pnpm, but with a stubbed
npm no pnpm will be installed to .vaadin
and the test will fail trying to execute pnpm.

Fixes #7848

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7909)
<!-- Reviewable:end -->
