### PR TITLE
CP: Compare frontend locations to vfs patterns first (#7846)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -427,7 +427,18 @@ public class DevModeInitializer implements ServletContainerInitializer,
                 Matcher dirCompatibilityMatcher = DIR_REGEX_COMPATIBILITY_FRONTEND_DEFAULT
                         .matcher(path);
                 Matcher jarVfsMatcher = VFS_FILE_REGEX.matcher(urlString);
-                if (jarMatcher.find()) {
+                Matcher dirVfsMatcher = VFS_DIRECTORY_REGEX.matcher(urlString);
+                if (jarVfsMatcher.find()) {
+                    String vfsJar = jarVfsMatcher.group(1);
+                    if (vfsJars.add(vfsJar))
+                        frontendFiles.add(
+                                getPhysicalFileOfJBossVfsJar(new URL(vfsJar)));
+                } else if (dirVfsMatcher.find()) {
+                    URL vfsDirUrl = new URL(urlString.substring(0,
+                            urlString.lastIndexOf(resourcesFolder)));
+                    frontendFiles
+                            .add(getPhysicalFileOfJBossVfsDirectory(vfsDirUrl));
+                } else if (jarMatcher.find()) {
                     frontendFiles.add(new File(jarMatcher.group(1)));
                 } else if ("zip".equalsIgnoreCase(url.getProtocol())
                         && zipProtocolJarMatcher.find()) {
@@ -437,16 +448,6 @@ public class DevModeInitializer implements ServletContainerInitializer,
                 } else if (dirCompatibilityMatcher.find()) {
                     frontendFiles
                             .add(new File(dirCompatibilityMatcher.group(1)));
-                } else if (jarVfsMatcher.find()) {
-                    String vfsJar = jarVfsMatcher.group(1);
-                    if (vfsJars.add(vfsJar))
-                        frontendFiles.add(
-                                getPhysicalFileOfJBossVfsJar(new URL(vfsJar)));
-                } else if (VFS_DIRECTORY_REGEX.matcher(urlString).find()) {
-                    URL vfsDirUrl = new URL(urlString.substring(0,
-                            urlString.lastIndexOf(resourcesFolder)));
-                    frontendFiles
-                            .add(getPhysicalFileOfJBossVfsDirectory(vfsDirUrl));
                 } else {
                     log().warn(
                             "Resource {} not visited because does not meet supported formats.",


### PR DESCRIPTION
When locating frontend resources, there are special cases for virtual file system files, so that the actual path can be resolved. With this commit, paths are tested against those patterns first, as not to risk a vfs file or directory getting caught by another pattern.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7913)
<!-- Reviewable:end -->
