### PR TITLE
CP: Compare frontend locations to vfs patterns first (#7846)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -355,23 +355,24 @@ public class DevModeInitializer implements ServletContainerInitializer,
                 Matcher dirCompatibilityMatcher = DIR_REGEX_COMPATIBILITY_FRONTEND_DEFAULT
                         .matcher(path);
                 Matcher jarVfsMatcher = VFS_FILE_REGEX.matcher(urlString);
-                if (jarMatcher.find()) {
+                Matcher dirVfsMatcher = VFS_DIRECTORY_REGEX.matcher(urlString);
+                if (jarVfsMatcher.find()) {
+                    String vfsJar = jarVfsMatcher.group(1);
+                    if (vfsJars.add(vfsJar))
+                        frontendFiles.add(
+                                getPhysicalFileOfJBossVfsJar(new URL(vfsJar)));
+                } else if (dirVfsMatcher.find()) {
+                    URL vfsDirUrl = new URL(urlString.substring(0,
+                            urlString.lastIndexOf(resourcesFolder)));
+                    frontendFiles
+                            .add(getPhysicalFileOfJBossVfsDirectory(vfsDirUrl));
+                } else if (jarMatcher.find()) {
                     frontendFiles.add(new File(jarMatcher.group(1)));
                 } else if (dirMatcher.find()) {
                     frontendFiles.add(new File(dirMatcher.group(1)));
                 } else if (dirCompatibilityMatcher.find()) {
                     frontendFiles
                             .add(new File(dirCompatibilityMatcher.group(1)));
-                } else if (jarVfsMatcher.find()) {
-                    String vfsJar = jarVfsMatcher.group(1);
-                    if (vfsJars.add(vfsJar))
-                        frontendFiles.add(
-                                getPhysicalFileOfJBossVfsJar(new URL(vfsJar)));
-                } else if (VFS_DIRECTORY_REGEX.matcher(urlString).find()) {
-                    URL vfsDirUrl = new URL(urlString.substring(0,
-                            urlString.lastIndexOf(resourcesFolder)));
-                    frontendFiles
-                            .add(getPhysicalFileOfJBossVfsDirectory(vfsDirUrl));
                 } else {
                     log().warn(
                             "Resource {} not visited because does not meet supported formats.",

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
@@ -1,13 +1,19 @@
 package com.vaadin.flow.server.startup;
 
 import javax.servlet.ServletException;
-
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.EventListener;
 import java.util.HashSet;
@@ -31,7 +37,6 @@ import com.vaadin.flow.server.frontend.FallbackChunk;
 
 import elemental.json.Json;
 import elemental.json.JsonObject;
-
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_PRODUCTION_MODE;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_REUSE_DEV_SERVER;
@@ -68,6 +73,41 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
         Visited b;
     }
 
+    public static class MockVirtualFile {
+        File file;
+
+        public List<MockVirtualFile> getChildrenRecursively() {
+            List<MockVirtualFile> files = new ArrayList<>();
+
+            File[] children = file.listFiles();
+            if (children != null) {
+                for(File child: children) {
+                    MockVirtualFile mvf = new MockVirtualFile();
+                    mvf.file = child;
+                    files.add(mvf);
+                    files.addAll(mvf.getChildrenRecursively());
+                }
+            }
+            return files;
+        }
+
+        public InputStream openStream() throws FileNotFoundException {
+            return new FileInputStream(file);
+        }
+
+        public File getPhysicalFile() {
+            return file;
+        }
+
+        public String getPathNameRelativeTo(MockVirtualFile other) {
+            return Paths.get(file.toURI()).relativize(Paths.get(other.file.toURI())).toString();
+        }
+
+        public boolean isFile() {
+            return file.isFile();
+        }
+    }
+
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
@@ -96,6 +136,33 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
             throws IOException, ServletException {
         loadingFsResources_allFilesExist("/dir-with-frontend-resources/",
                 Constants.COMPATIBILITY_RESOURCES_FRONTEND_DEFAULT);
+    }
+
+    @Test
+    public void loadingFsResources_usesVfsProtocol_allFilesExist() throws Exception {
+        String path = Paths.get("/dir-with-modern-frontend",
+                Constants.RESOURCES_FRONTEND_DEFAULT).toString();
+        MockVirtualFile virtualFile = new MockVirtualFile();
+        virtualFile.file = new File(getClass().getResource(path).toURI());
+
+        URLConnection urlConnection =  Mockito.mock(URLConnection.class);
+        Mockito.when(urlConnection.getContent()).thenReturn(virtualFile);
+
+        URL.setURLStreamHandlerFactory(protocol -> {
+            if (protocol.equals("vfs")) {
+                return new URLStreamHandler() {
+                    @Override
+                    protected URLConnection openConnection(URL u) {
+                        return urlConnection;
+                    }
+                };
+            }
+            return null;
+        });
+        URL url = new URL(Paths.get("vfs://some-non-existent-place", path).toString());
+
+        loadingFsResources_allFilesExist(Collections.singletonList(url),
+                Constants.RESOURCES_FRONTEND_DEFAULT);
     }
 
     @Test
@@ -255,7 +322,11 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
             String resourcesFolder) throws IOException, ServletException {
         List<URL> urls = Collections.singletonList(
                 getClass().getResource(resourcesRoot + resourcesFolder));
+        loadingFsResources_allFilesExist(urls, resourcesFolder);
+    }
 
+    private void loadingFsResources_allFilesExist(Collection<URL> urls,
+            String resourcesFolder) throws IOException, ServletException {
         // Create mock loader with the single jar to be found
         ClassLoader classLoader = Mockito.mock(ClassLoader.class);
         Mockito.when(classLoader.getResources(resourcesFolder))


### PR DESCRIPTION
When locating frontend resources, there are special cases for virtual file system files, so that the actual path can be resolved. With this commit, paths are tested against those patterns first, as not to risk a vfs file or directory getting caught by another pattern.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7915)
<!-- Reviewable:end -->
