### PR TITLE
Do not create buildFolder in dev mode

### DIFF
--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -33,10 +33,12 @@ const confFolder = `${mavenOutputFolderForFlowBundledFiles}/${config}`;
 const statsFile = `${confFolder}/stats.json`;
 // make sure that build folder exists before outputting anything
 const mkdirp = require('mkdirp');
-mkdirp(buildFolder);
-mkdirp(confFolder);
 
 const devMode = process.argv.find(v => v.indexOf('webpack-dev-server') >= 0);
+
+!devMode && mkdirp(buildFolder);
+mkdirp(confFolder);
+
 let stats;
 
 // Open a connection with the Java dev-mode handler in order to finish


### PR DESCRIPTION
In development mode we do not use
the build folder, but creating it on
runtime may make for instance Jetty
restart due to changes in scanned packages.

Fixes #7922

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7969)
<!-- Reviewable:end -->
