### PR TITLE
Live-reload sends a heartbeat to keep the dedicated push channel alive

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.js
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.js
@@ -119,6 +119,10 @@ class VaadinDevmodeGizmo extends LitElement {
     return 'vaadin.live-reload.triggeredCount';
   }
 
+  static get HEARTBEAT_INTERVAL() {
+    return 180000;
+  }
+
   static get isEnabled() {
     const enabled = window.localStorage.getItem(VaadinDevmodeGizmo.ENABLED_KEY_IN_LOCAL_STORAGE);
     return enabled === null || !(enabled === 'false');
@@ -183,6 +187,11 @@ class VaadinDevmodeGizmo extends LitElement {
       self.status = VaadinDevmodeGizmo.UNAVAILABLE;
       self.connection = null;
     };
+    setInterval(function() {
+      if (self.connection !== null) {
+        self.connection.send('');
+      }
+    }, VaadinDevmodeGizmo.HEARTBEAT_INTERVAL);
   }
 
   handleMessage(msg) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PushHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PushHandler.java
@@ -482,8 +482,6 @@ public class PushHandler {
      *            The related atmosphere resources
      */
     void onConnect(AtmosphereResource resource) {
-        String refreshConnection = resource.getRequest()
-                .getParameter(ApplicationConstants.LIVE_RELOAD_CONNECTION);
         if (isLiveReloadConnection(resource)) {
             BrowserLiveReloadAccess access = service.getInstantiator()
                     .getOrCreate(BrowserLiveReloadAccess.class);

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PushHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PushHandler.java
@@ -292,7 +292,7 @@ public class PushHandler {
         // In development mode we may have a live-reload push channel
         // that should be closed.
 
-        if (service.getDeploymentConfiguration().isDevModeLiveReloadEnabled()) {
+        if (isLiveReloadConnection(resource)) {
             BrowserLiveReloadAccess access = service.getInstantiator()
                     .getOrCreate(BrowserLiveReloadAccess.class);
             BrowserLiveReload liveReload = access.getLiveReload(service);
@@ -484,9 +484,7 @@ public class PushHandler {
     void onConnect(AtmosphereResource resource) {
         String refreshConnection = resource.getRequest()
                 .getParameter(ApplicationConstants.LIVE_RELOAD_CONNECTION);
-        if (service.getDeploymentConfiguration().isDevModeLiveReloadEnabled()
-                && refreshConnection != null
-                && TRANSPORT.WEBSOCKET.equals(resource.transport())) {
+        if (isLiveReloadConnection(resource)) {
             BrowserLiveReloadAccess access = service.getInstantiator()
                     .getOrCreate(BrowserLiveReloadAccess.class);
             BrowserLiveReload liveReload = access.getLiveReload(service);
@@ -503,7 +501,20 @@ public class PushHandler {
      *            The related atmosphere resources
      */
     void onMessage(AtmosphereResource resource) {
-        callWithUi(resource, receiveCallback);
+        if (isLiveReloadConnection(resource)) {
+            getLogger().debug("Received live reload heartbeat");
+        } else {
+            callWithUi(resource, receiveCallback);
+        }
+    }
+
+
+    private boolean isLiveReloadConnection(AtmosphereResource resource) {
+        String refreshConnection = resource.getRequest()
+                .getParameter(ApplicationConstants.LIVE_RELOAD_CONNECTION);
+        return service.getDeploymentConfiguration().isDevModeLiveReloadEnabled()
+                && refreshConnection != null
+                && TRANSPORT.WEBSOCKET.equals(resource.transport());
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/PushHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/PushHandlerTest.java
@@ -79,7 +79,7 @@ public class PushHandlerTest {
     }
 
     @Test
-    public void onConnect_devMode_webscoket_refreshConnection_onConnectIsCalled_callWithUIIsNotCalled()
+    public void onConnect_devMode_websocket_refreshConnection_onConnectIsCalled_callWithUIIsNotCalled()
             throws ServiceException {
         MockVaadinServletService service = Mockito
                 .spy(MockVaadinServletService.class);
@@ -105,6 +105,34 @@ public class PushHandlerTest {
         Mockito.verify(service, Mockito.times(0)).requestStart(Mockito.any(),
                 Mockito.any());
         Mockito.verify(liveReload).onConnect(res.get());
+    }
+
+    @Test
+    public void onMessage_devMode_websocket_refreshConnection_callWithUIIsNotCalled()
+            throws ServiceException {
+        MockVaadinServletService service = Mockito
+                .spy(MockVaadinServletService.class);
+        MockDeploymentConfiguration deploymentConfiguration = (MockDeploymentConfiguration) service
+                .getDeploymentConfiguration();
+        deploymentConfiguration.setProductionMode(false);
+        deploymentConfiguration.setDevModeLiveReloadEnabled(true);
+
+        VaadinContext context = service.getContext();
+        BrowserLiveReload liveReload = BrowserLiveReloadAccessTest
+                .mockBrowserLiveReloadImpl(context);
+
+        AtomicReference<AtmosphereResource> res = new AtomicReference<>();
+        runTest(service, (handler, resource) -> {
+            AtmosphereRequest request = resource.getRequest();
+            Mockito.when(request
+                    .getParameter(ApplicationConstants.LIVE_RELOAD_CONNECTION))
+                    .thenReturn("");
+            Mockito.when(resource.transport()).thenReturn(TRANSPORT.WEBSOCKET);
+            handler.onMessage(resource);
+            res.set(resource);
+        });
+        Mockito.verify(service, Mockito.times(0)).requestStart(Mockito.any(),
+                Mockito.any());
     }
 
     @Test


### PR DESCRIPTION
Jetty closes the WS connection after 5 minutes, other servers may have other similar timeouts. Added a 3 minute interval heartbeat to keep the live-reload connection alive.
Fixes #7959

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7976)
<!-- Reviewable:end -->
