### PR TITLE
Run npm install if only .staging

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -39,6 +40,9 @@ public class TaskRunNpmInstall implements FallibleCommand {
     static final String SKIPPING_NPM_INSTALL = "Skipping `npm install`.";
 
     private final NodeUpdater packageUpdater;
+
+    private final List<String> ignoredNodeFolders = Arrays
+            .asList(".bin",".staging");
 
     /**
      * Create an instance of the command.
@@ -65,8 +69,10 @@ public class TaskRunNpmInstall implements FallibleCommand {
 
     private boolean shouldRunNpmInstall() {
         if (packageUpdater.nodeModulesFolder.isDirectory()) {
+            // Ignore installation files
             File[] installedPackages = packageUpdater.nodeModulesFolder
-                    .listFiles();
+                    .listFiles(
+                            (dir, name) -> !ignoredNodeFolders.contains(name));
             assert installedPackages != null;
             return installedPackages.length == 0
                     || (installedPackages.length == 1 && FLOW_NPM_PACKAGE_NAME

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -75,6 +75,18 @@ public class TaskRunNpmInstallTest {
 
         Mockito.verify(logger).info(getRunningMsg());
     }
+    @Test
+    public void runNpmInstall_nodeModulesContainsStaging_npmInstallIsExecuted()
+            throws ExecutionFailedException {
+        File nodeModules = nodeUpdater.nodeModulesFolder;
+        nodeModules.mkdir();
+        File staging = new File(nodeModules, ".staging");
+        staging.mkdir();
+        nodeUpdater.modified = false;
+        task.execute();
+
+        Mockito.verify(logger).info(getRunningMsg());
+    }
 
     @Test
     public void runNpmInstall_nonEmptyDir_npmInstallIsNotExecuted()


### PR DESCRIPTION
If npm install has failed in the middle of
extraction only a .staging folder will
exist  in node_modules and we should
execute npm install on application startup.

Fixes #7972

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7982)
<!-- Reviewable:end -->
