### PR TITLE
Run npm install if only .staging

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -53,7 +53,7 @@ public class TaskRunNpmInstall implements FallibleCommand {
     private final NodeUpdater packageUpdater;
 
     private final List<String> ignoredNodeFolders = Arrays.asList(".bin",
-            "pnpm", ".ignored_pnpm", ".pnpm", MODULES_YAML);
+            "pnpm", ".ignored_pnpm", ".pnpm", ".staging", MODULES_YAML);
     private final boolean enablePnpm;
 
     private final ClassFinder classFinder;

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -87,6 +87,18 @@ public class TaskRunNpmInstallTest {
 
         Mockito.verify(logger).info(getRunningMsg());
     }
+    @Test
+    public void runNpmInstall_nodeModulesContainsStaging_npmInstallIsExecuted()
+            throws ExecutionFailedException {
+        File nodeModules = getNodeUpdater().nodeModulesFolder;
+        nodeModules.mkdir();
+        File staging = new File(nodeModules, ".staging");
+        staging.mkdir();
+        nodeUpdater.modified = false;
+        task.execute();
+
+        Mockito.verify(logger).info(getRunningMsg());
+    }
 
     @Test
     public void runNpmInstall_toolIsChanged_nodeModulesIsRemoved()


### PR DESCRIPTION
If npm install has failed in the middle of
extraction only a .staging folder will
exist  in node_modules and we should
execute npm install on application startup.

Fixes #7972

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7983)
<!-- Reviewable:end -->
