### PR TITLE
Do not create buildFolder in dev mode 2.2 (#7969)

### DIFF
--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -29,10 +29,12 @@ const confFolder = `${mavenOutputFolderForFlowBundledFiles}/${config}`;
 const statsFile = `${confFolder}/stats.json`;
 // make sure that build folder exists before outputting anything
 const mkdirp = require('mkdirp');
-mkdirp(buildFolder);
-mkdirp(confFolder);
 
 const devMode = process.argv.find(v => v.indexOf('webpack-dev-server') >= 0);
+
+!devMode && mkdirp(buildFolder);
+mkdirp(confFolder);
+
 let stats;
 
 const watchDogPrefix = '--watchDogPort=';


### PR DESCRIPTION
In development mode we do not use
the build folder, but creating it on
runtime may make for instance Jetty
restart due to changes in scanned packages.

Fixes #7922

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7984)
<!-- Reviewable:end -->
