### PR TITLE
IllegalStateException when running a Vaadin Spring project on WebLogic server #502

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -161,6 +161,15 @@ public class DevModeInitializer implements ServletContainerInitializer,
         }
     }
 
+    // Attribute key for storing Dev Mode Handler startup flag.
+    // If presented in Servlet Context, shows the Dev Mode Handler already
+    // started / become starting.
+    // This attribute helps to avoid Dev Mode running twice.
+    //
+    // Addresses the issue https://github.com/vaadin/spring/issues/502
+    public static final String DEV_MODE_HANDLER_ALREADY_STARTED_ATTRIBUTE =
+            "dev-mode-handler-already-started-attribute";
+
     private static final Pattern JAR_FILE_REGEX = Pattern
             .compile(".*file:(.+\\.jar).*");
 
@@ -219,11 +228,17 @@ public class DevModeInitializer implements ServletContainerInitializer,
         }
 
         initDevModeHandler(classes, context, config);
+
+        setDevModeStarted(context);
     }
 
     private boolean isVaadinServletSubClass(String className)
             throws ClassNotFoundException {
         return VaadinServlet.class.isAssignableFrom(Class.forName(className));
+    }
+
+    private void setDevModeStarted(ServletContext context) {
+        context.setAttribute(DEV_MODE_HANDLER_ALREADY_STARTED_ATTRIBUTE, true);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -186,12 +186,14 @@ public class DevModeInitializer implements ServletContainerInitializer,
                     + Constants.COMPATIBILITY_RESOURCES_FRONTEND_DEFAULT
                     + "/?$");
 
-    // Stores Dev Mode Handler startup flag.
-    // Shows if the Dev Mode Handler already started / becomes starting.
-    // This flag helps to avoid Dev Mode running twice.
+    // Attribute key for storing Dev Mode Handler startup flag.
+    // If presented in Servlet Context, shows the Dev Mode Handler already
+    // started / become starting.
+    // This attribute helps to avoid Dev Mode running twice.
     //
     // Addresses the issue https://github.com/vaadin/spring/issues/502
-    private static volatile boolean devModeAlreadyStarted = false;
+    private static final String DEV_MODE_HANDLER_ALREADY_STARTED_ATTRIBUTE =
+            "dev-mode-handler-already-started-attribute";
 
     @Override
     public void onStartup(Set<Class<?>> classes, ServletContext context)
@@ -227,12 +229,16 @@ public class DevModeInitializer implements ServletContainerInitializer,
 
         initDevModeHandler(classes, context, config);
 
-        setDevModeStarted();
+        setDevModeStarted(context);
     }
 
     private boolean isVaadinServletSubClass(String className)
             throws ClassNotFoundException {
         return VaadinServlet.class.isAssignableFrom(Class.forName(className));
+    }
+
+    private void setDevModeStarted(ServletContext context) {
+        context.setAttribute(DEV_MODE_HANDLER_ALREADY_STARTED_ATTRIBUTE, true);
     }
 
     /**
@@ -389,15 +395,14 @@ public class DevModeInitializer implements ServletContainerInitializer,
     /**
      * Shows whether {@link DevModeHandler} has been already started or not.
      *
+     * @param servletContext The servlet context, not <code>null</code>
      * @return <code>true</code> if {@link DevModeHandler} has already been started,
      *         <code>false</code> - otherwise
      */
-    public static boolean isDevModeAlreadyStarted() {
-        return devModeAlreadyStarted;
-    }
-
-    private static void setDevModeStarted() {
-        devModeAlreadyStarted = true;
+    public static boolean isDevModeAlreadyStarted(ServletContext servletContext) {
+        assert servletContext != null;
+        return servletContext.getAttribute(
+                DevModeInitializer.DEV_MODE_HANDLER_ALREADY_STARTED_ATTRIBUTE) != null;
     }
 
     private static Logger log() {

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -227,7 +227,7 @@ public class DevModeInitializer implements ServletContainerInitializer,
 
         initDevModeHandler(classes, context, config);
 
-        devModeAlreadyStarted = true;
+        setDevModeStarted();
     }
 
     private boolean isVaadinServletSubClass(String className)
@@ -387,13 +387,17 @@ public class DevModeInitializer implements ServletContainerInitializer,
     }
 
     /**
-     * Shows whether {@link DevModeHandler} has been already started or not
+     * Shows whether {@link DevModeHandler} has been already started or not.
      *
      * @return <code>true</code> if {@link DevModeHandler} has already been started,
      *         <code>false</code> - otherwise
      */
     public static boolean isDevModeAlreadyStarted() {
         return devModeAlreadyStarted;
+    }
+
+    private static void setDevModeStarted() {
+        devModeAlreadyStarted = true;
     }
 
     private static Logger log() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
@@ -334,6 +334,12 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
         assertNotNull(DevModeHandler.getDevModeHandler());
     }
 
+    @Test
+    public void onStartup_devModeAlreadyStarted_shouldBeTrueWhenStarted() throws Exception {
+        runOnStartup();
+        assertTrue(DevModeInitializer.isDevModeAlreadyStarted());
+    }
+
     private void loadingJars_allFilesExist(String resourcesFolder)
             throws IOException, ServletException {
         loadingJarsWithProtocol_allFilesExist(resourcesFolder, s -> {

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
@@ -19,8 +19,10 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.Map;
 import java.util.function.Function;
 
+import com.google.common.collect.Maps;
 import net.jcip.annotations.NotThreadSafe;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -336,8 +338,20 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
 
     @Test
     public void onStartup_devModeAlreadyStarted_shouldBeTrueWhenStarted() throws Exception {
+        final Map<String, Object> servletContextAttributes = Maps.newHashMap();
+        Mockito.doAnswer(answer -> {
+            String key = answer.getArgumentAt(0, String.class);
+            Object value = answer.getArgumentAt(1, Object.class);
+            servletContextAttributes.putIfAbsent(key, value);
+            return null;
+        })
+                .when(servletContext)
+                .setAttribute(Mockito.anyString(), Mockito.anyObject());
+        Mockito.when(servletContext.getAttribute(Mockito.anyString()))
+                .thenAnswer(answer ->
+                        servletContextAttributes.get(answer.getArgumentAt(0, String.class)));
         runOnStartup();
-        assertTrue(DevModeInitializer.isDevModeAlreadyStarted());
+        assertTrue(DevModeInitializer.isDevModeAlreadyStarted(servletContext));
     }
 
     private void loadingJars_allFilesExist(String resourcesFolder)


### PR DESCRIPTION
This modification introduces the "Dev Mode already started" flag and mainly addresses `WebLogic`+`Spring-boot` configuration (or any other configuration where `Spring-Boot` is started within a web server/servlet container), where two sequential Dev Mode runs lead to `webpack` compile failures and significant startup time increase.

Setting this flag in `DevModeInitializer` helps `DevModeServletContextListener` to identify either Dev Mode has been already started and just skip pnpm and webpack.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7990)
<!-- Reviewable:end -->
