### PR TITLE
Disable development mode gizmo for exported webcomponents

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -1078,7 +1078,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                     versionInfo.put("atmosphereVersion", atmosphereVersion);
                 }
                 appConfig.put("versionInfo", versionInfo);
-                appConfig.put("devmodeGizmoEnabled",
+                appConfig.put(ApplicationConstants.DEVMODE_GIZMO_ENABLED,
                         deploymentConfiguration.isDevModeLiveReloadEnabled());
                 // make configurable when fixing #7847
                 appConfig.put("springBootDevToolsPort", 35729);

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
@@ -184,6 +184,9 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
                 .map(conf -> Json.create(conf.getTag()))
                 .collect(JsonUtils.asArray());
         config.put("webcomponents", tags);
+
+        config.put(ApplicationConstants.DEVMODE_GIZMO_ENABLED, false);
+
         return context;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/shared/ApplicationConstants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/ApplicationConstants.java
@@ -193,4 +193,9 @@ public class ApplicationConstants implements Serializable {
      */
     public static final String LIVE_RELOAD_CONNECTION = "refresh_connection";
 
+    /**
+     * Boolean client configuration parameter enabling the development mode
+     * gizmo.
+     */
+    public static final String DEVMODE_GIZMO_ENABLED = "devmodeGizmoEnabled";
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandlerTest.java
@@ -155,6 +155,33 @@ public class WebComponentBootstrapHandlerTest {
     }
 
     @Test
+    public void writeBootstrapPage_devmodeGizmoIsDisabled()
+            throws IOException, ServiceException {
+        TestWebComponentBootstrapHandler handler = new TestWebComponentBootstrapHandler();
+        VaadinServletService service = new MockVaadinServletService();
+        service.init();
+        VaadinSession session = new MockVaadinSession(service);
+        session.lock();
+        session.setConfiguration(service.getDeploymentConfiguration());
+        MockDeploymentConfiguration config = (MockDeploymentConfiguration) service
+                .getDeploymentConfiguration();
+        config.setEnableDevServer(false);
+
+        VaadinServletRequest request = Mockito.mock(VaadinServletRequest.class);
+        Mockito.when(request.getService()).thenReturn(service);
+        Mockito.when(request.getServletPath()).thenReturn("/");
+        VaadinResponse response = getMockResponse(null);
+
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        Mockito.when(response.getOutputStream()).thenReturn(stream);
+
+        handler.synchronizedHandleRequest(session, request, response);
+
+        String result = stream.toString(StandardCharsets.UTF_8.name());
+        Assert.assertTrue(result.contains("\\\"devmodeGizmoEnabled\\\": false"));
+    }
+
+    @Test
     public void writeBootstrapPage_spepe()
             throws Exception {
         WebComponentBootstrapHandler handler = new WebComponentBootstrapHandler();


### PR DESCRIPTION
Development mode gizmo and live-reload logic at the moment does not support the embedded webcomponent use-case, so disable it. Fixes #7991.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/7993)
<!-- Reviewable:end -->
