### PR TITLE
Do not throw for @ParentLayout w/o RouterLayout

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractRouteRegistryInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractRouteRegistryInitializer.java
@@ -37,6 +37,7 @@ import com.vaadin.flow.router.internal.RouteUtil;
 import com.vaadin.flow.server.InvalidRouteLayoutConfigurationException;
 import com.vaadin.flow.server.PWA;
 import com.vaadin.flow.server.PageConfigurator;
+import org.slf4j.LoggerFactory;
 
 /**
  * Common validation methods for route registry initializer.
@@ -187,11 +188,17 @@ public abstract class AbstractRouteRegistryInitializer implements Serializable {
             return;
         }
         if (!RouterLayout.class.isAssignableFrom(route)) {
-            throw new InvalidRouteLayoutConfigurationException(String.format(
-                    "The class '%s' should either be a '%s' or only a navigation target using"
-                            + " '%s.layout' to set the parent layout",
-                    route.getSimpleName(), RouterLayout.class.getSimpleName(),
-                    Route.class.getSimpleName()));
+            String routerLayoutSimpleName = RouterLayout.class.getSimpleName();
+            LoggerFactory
+                    .getLogger(AbstractRouteRegistryInitializer.class.getName())
+                    .error("\n\n"
+                            + "The class '{}' should either be a '{}' or only a navigation target using '{}.layout' to set the parent layout."
+                            + "\nUsing '{}' without implementing '{}' will be changed to throwing an exception in a future release.\n",
+                            route.getSimpleName(),
+                            routerLayoutSimpleName,
+                            Route.class.getSimpleName(),
+                            ParentLayout.class.getSimpleName(),
+                            routerLayoutSimpleName);
         }
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/AbstractRouteRegistryInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/AbstractRouteRegistryInitializerTest.java
@@ -55,10 +55,10 @@ public class AbstractRouteRegistryInitializerTest {
 
     }
 
-    @Test(expected = InvalidRouteLayoutConfigurationException.class)
-    public void routeAndParentLayout_notRouterLayout_throws() {
+    @Test // (expected = InvalidRouteLayoutConfigurationException.class)
+    public void routeAndParentLayout_notRouterLayout_noThrows() {
+        // this has been switched to intentionally not throw but log a warning
         initializer.validateRouteClasses(Stream.of(RouteAndParentLayout.class));
-
     }
 
     @Test


### PR DESCRIPTION
Logs an error instead, which is not very visible but prevents breaking any existing apps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8013)
<!-- Reviewable:end -->
