### PR TITLE
Disable live reload

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
@@ -23,7 +23,6 @@ import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.shared.communication.PushMode;
 
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_CLOSE_IDLE_SESSIONS;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_DEVMODE_ENABLE_LIVE_RELOAD;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_DISABLE_XSRF_PROTECTION;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_PRODUCTION_MODE;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_REQUEST_TIMING;
@@ -207,15 +206,12 @@ public class PropertyDeploymentConfiguration
     }
 
     /**
-     * Checks if dev mode live reload is enabled or not. It is always disabled
-     * in production mode. In development mode, it is enabled by default.
+     * DevModeLiveReload status. Disabled in 3.1
      *
-     * @return {@code true} if dev mode live reload is enabled, {@code false}
-     *         otherwise
+     * @return {@code false}
      */
     @Override
     public boolean isDevModeLiveReloadEnabled() {
-        return !isProductionMode() && getBooleanProperty(
-                SERVLET_PARAMETER_DEVMODE_ENABLE_LIVE_RELOAD, true);
+        return false;
     }
 }

--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -85,26 +85,6 @@
                     </excludes>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>properties-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>set-system-properties</goal>
-                        </goals>
-                        <configuration>
-                            <properties>
-                                <property>
-                                    <name>vaadin.devmode.liveReload.enabled
-                                    </name>
-                                    <value>false</value>
-                                </property>
-                            </properties>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>

--- a/flow-tests/test-dev-mode/pom.xml
+++ b/flow-tests/test-dev-mode/pom.xml
@@ -52,25 +52,6 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>properties-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>set-system-properties</goal>
-                        </goals>
-                        <configuration>
-                            <properties>
-                                <property>
-                                    <name>vaadin.devmode.liveReload.enabled</name>
-                                    <value>true</value>
-                                </property>
-                            </properties>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 

--- a/flow-tests/test-dev-mode/src/main/java/com/vaadin/flow/uitest/ui/TestingServiceInitListener.java
+++ b/flow-tests/test-dev-mode/src/main/java/com/vaadin/flow/uitest/ui/TestingServiceInitListener.java
@@ -50,7 +50,9 @@ public class TestingServiceInitListener implements VaadinServiceInitListener {
                 .getInstantiator().getOrCreate(BrowserLiveReloadAccess.class);
         BrowserLiveReload browserLiveReload = liveReloadAccess
                 .getLiveReload(VaadinService.getCurrent());
-        browserLiveReload.setBackend(BrowserLiveReload.Backend.HOTSWAP_AGENT);
+        if (browserLiveReload != null) {
+            browserLiveReload.setBackend(BrowserLiveReload.Backend.HOTSWAP_AGENT);
+        }
     }
 
 }

--- a/flow-tests/test-dev-mode/src/test/java/com/vaadin/flow/uitest/ui/frontend/LiveReloadIT.java
+++ b/flow-tests/test-dev-mode/src/test/java/com/vaadin/flow/uitest/ui/frontend/LiveReloadIT.java
@@ -24,6 +24,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -34,6 +35,7 @@ import com.vaadin.flow.testutil.ChromeBrowserTest;
 // as other tests in the same module, due to live-reload affecting the whole
 // application
 @NotThreadSafe
+@Ignore("Live reload is not supported in this version.")
 public class LiveReloadIT extends ChromeBrowserTest {
 
     private static final Lock lock = new ReentrantLock();

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <module>flow-tests</module>
         <module>flow-server-production-mode</module>
         <module>flow-component-demo-helpers</module>
-        <module>flow-jrebel-plugin</module>
+<!--        <module>flow-jrebel-plugin</module>-->
         <module>flow-maven-plugin</module>
         <module>flow-test-generic</module>
         <module>flow-bom</module>


### PR DESCRIPTION
Live reload is disabled from use
Also jrebel plugin will not be
released after this patch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8030)
<!-- Reviewable:end -->
