### PR TITLE
Basic LitTemplate support based on LitElement for Java UIs

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/LitUtils.java
+++ b/flow-client/src/main/java/com/vaadin/client/LitUtils.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.client;
+
+import elemental.dom.Element;
+import elemental.dom.Node;
+
+/**
+ * Utils class, intended to ease working with LitElement related code on client side.
+ *
+ * @author Vaadin Ltd
+ */
+public final class LitUtils {
+
+    private LitUtils() {
+    }
+
+    /**
+     * Checks if the given element is a LitElement.
+     *
+     * @param element
+     *            the custom element
+     * @return {@code true} if the element is a Lit element, <code>false</code>
+     *         otherwise
+     */
+    public static native boolean isLitElement(Node element)
+    /*-{
+        return typeof element.update == "function" && element.updateComplete instanceof Promise && typeof element.shouldUpdate == "function" && typeof element.firstUpdated == "function";
+    }-*/;
+
+    /**
+     * Invokes the {@code runnable} when the given Lit element has been rendered
+     * at least once.
+     *
+     * @param element
+     *            the Lit element
+     * @param runnable
+     *            the command to run
+     */
+    public static native void whenRendered(Element element, Runnable runnable)
+    /*-{
+        element.updateComplete.then(
+            $entry(
+              function() {
+                runnable.@java.lang.Runnable::run(*)();
+              })
+            );
+    }-*/;
+
+}

--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
@@ -29,6 +29,7 @@ import com.vaadin.client.Console;
 import com.vaadin.client.ElementUtil;
 import com.vaadin.client.ExistingElementMap;
 import com.vaadin.client.InitialPropertiesHandler;
+import com.vaadin.client.LitUtils;
 import com.vaadin.client.PolymerUtils;
 import com.vaadin.client.WidgetUtil;
 import com.vaadin.client.flow.ConstantPool;
@@ -805,7 +806,11 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
 
         assert context.htmlNode instanceof Element : "Unexpected html node. The node is supposed to be a custom element";
         if (NodeProperties.INJECT_BY_ID.equals(type)) {
-            if (!PolymerUtils.isReady(context.htmlNode)) {
+            if (LitUtils.isLitElement(context.htmlNode)) {
+                LitUtils.whenRendered((Element) context.htmlNode,
+                        () -> handleInjectId(context, node, object, false));
+                return;
+            } else if (!PolymerUtils.isReady(context.htmlNode)) {
                 PolymerUtils.addReadyListener((Element) context.htmlNode,
                         () -> handleInjectId(context, node, object, false));
                 return;

--- a/flow-server/src/main/java/com/vaadin/flow/component/littemplate/LitTemplate.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/littemplate/LitTemplate.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.littemplate;
+
+import java.util.stream.Stream;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.polymertemplate.Id;
+import com.vaadin.flow.component.polymertemplate.PolymerTemplate;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.internal.UsageStatistics;
+import com.vaadin.flow.server.VaadinService;
+
+/**
+ * Component which renders a LitElement template.
+ * <p>
+ * A LitElement template is defined in a JavaScript module which should be
+ * placed inside the {@literal frontend} folder and loaded using
+ * {@link JsModule @JsModule}. The tag name defined for the Lit template must be
+ * defined using {@link Tag @Tag} on this class.
+ * <p>
+ * By annotating a field using {@link Id @Id} you can map a
+ * {@link Component @Component} instance to an element in the template, marked
+ * with an {@code id} attribute which matches the field name or the optionally
+ * given value to the annotation.
+ * <p>
+ * Note that injected components will have the same limitations as with
+ * {@link PolymerTemplate}.
+ * <p>
+ * For more information about the LitElement project, see
+ * https://lit-element.polymer-project.org/
+ *
+ * @see JsModule
+ * @see Tag
+ * @see Id
+ *
+ * @author Vaadin Ltd
+ * @since
+ */
+public abstract class LitTemplate extends Component {
+
+    static {
+        UsageStatistics.markAsUsed("flow/LitTemplate", null);
+    }
+
+    /**
+     * Creates the component mapped to a LitElement.
+     */
+    protected LitTemplate() {
+        LitTemplateInitializer templateInitializer = new LitTemplateInitializer(this, VaadinService.getCurrent());
+        templateInitializer.initChildElements();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Please note that components defined using {@link Id @Id} are not child
+     * components. Only components explicitly added through methods such as
+     * {@link HasComponents#add} or {@link Element#appendChild(Element...)} are
+     * returned by this method.
+     */
+    @Override
+    public Stream<Component> getChildren() {
+        return super.getChildren();
+    }
+
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/littemplate/LitTemplateDataAnalyzer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/littemplate/LitTemplateDataAnalyzer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.littemplate;
+
+import java.io.Serializable;
+import java.util.Collections;
+
+import com.vaadin.flow.component.polymertemplate.IdCollector;
+import com.vaadin.flow.component.polymertemplate.TemplateDataAnalyzer.ParserData;
+
+/**
+ * Template data analyzer which produces immutable data required for template
+ * initializer using provided template class and a parser.
+ *
+ * @author Vaadin Ltd
+ *
+ */
+class LitTemplateDataAnalyzer implements Serializable {
+
+    private final Class<? extends LitTemplate> templateClass;
+
+    /**
+     * Create an instance of the analyzer using the {@code templateClass} and the
+     * template {@code parser}.
+     *
+     * @param templateClass a template type
+     */
+    LitTemplateDataAnalyzer(Class<? extends LitTemplate> templateClass) {
+        this.templateClass = templateClass;
+    }
+
+    /**
+     * Gets the template data for the template initializer.
+     *
+     * @return the template data
+     */
+    ParserData parseTemplate() {
+        IdCollector idExtractor = new IdCollector(templateClass, null, null);
+        idExtractor.collectInjectedIds(Collections.emptySet());
+        return new ParserData(idExtractor.getIdByField(), idExtractor.getTagById(), Collections.emptySet(),
+                Collections.emptyList());
+    }
+
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/littemplate/LitTemplateInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/littemplate/LitTemplateInitializer.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.littemplate;
+
+import java.util.function.Consumer;
+
+import com.vaadin.flow.component.polymertemplate.IdMapper;
+import com.vaadin.flow.component.polymertemplate.TemplateDataAnalyzer.ParserData;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.internal.ReflectionCache;
+import com.vaadin.flow.server.VaadinService;
+
+/**
+ * Template initialization related logic.
+ *
+ * @author Vaadin Ltd
+ *
+ */
+public class LitTemplateInitializer {
+    private static final ReflectionCache<LitTemplate, ParserData> CACHE = new ReflectionCache<>(
+            templateClass -> new LitTemplateDataAnalyzer(templateClass)
+                    .parseTemplate());
+
+    private final LitTemplate template;
+
+    private final ParserData parserData;
+
+    /**
+     * Creates a new initializer instance.
+     *
+     * @param template
+     *                     a template to initialize
+     * @param service
+     *                     the related service
+     */
+    public LitTemplateInitializer(LitTemplate template, VaadinService service) {
+        this.template = template;
+
+        boolean productionMode = service.getDeploymentConfiguration()
+                .isProductionMode();
+
+        Class<? extends LitTemplate> templateClass = template.getClass();
+
+        ParserData data = null;
+        if (productionMode) {
+            data = CACHE.get(templateClass);
+        }
+        if (data == null) {
+            data = new LitTemplateDataAnalyzer(templateClass).parseTemplate();
+        }
+        parserData = data;
+    }
+
+    /**
+     * Initializes child elements.
+     */
+    public void initChildElements() {
+        IdMapper idMapper = new IdMapper(template);
+        Consumer<Element> noOp = element -> {
+            // Nothing to do for elements
+        };
+
+        parserData.forEachInjectedField((field, id, tag) -> idMapper
+                .mapComponentOrElement(field, id, tag, noOp));
+    }
+
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/IdCollector.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/IdCollector.java
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 
 import org.jsoup.nodes.Element;
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.internal.AnnotationReader;
 
 /**
@@ -69,7 +70,7 @@ public class IdCollector {
 
     private void collectInjectedIds(Class<?> cls,
             Set<String> notInjectableElementIds) {
-        if (!AbstractTemplate.class.equals(cls.getSuperclass())) {
+        if (!Component.class.equals(cls.getSuperclass())) {
             // Parent fields
             collectInjectedIds(cls.getSuperclass(), notInjectableElementIds);
         }

--- a/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/IdMapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/IdMapper.java
@@ -38,7 +38,7 @@ public class IdMapper implements Serializable {
 
     private final HashMap<String, Element> registeredElementIdToInjected = new HashMap<>();
 
-    private AbstractTemplate<?> template;
+    private Component template;
 
     /**
      * Creates a mapper for the given template.
@@ -46,7 +46,7 @@ public class IdMapper implements Serializable {
      * @param template
      *            a template instance
      */
-    public IdMapper(AbstractTemplate<?> template) {
+    public IdMapper(Component template) {
         this.template = template;
     }
 
@@ -85,7 +85,7 @@ public class IdMapper implements Serializable {
         Class<?> fieldType = field.getType();
 
         Tag tag = fieldType.getAnnotation(Tag.class);
-        if (tag != null && !tagName.equalsIgnoreCase(tag.value())) {
+        if (tag != null && tagName != null && !tagName.equalsIgnoreCase(tag.value())) {
             String msg = String.format(
                     "Class '%s' has field '%s' whose type '%s' is annotated with "
                             + "tag '%s' but the element defined in the HTML "
@@ -93,6 +93,12 @@ public class IdMapper implements Serializable {
                     getContainerClass().getName(), field.getName(),
                     fieldType.getName(), tag.value(), id, tagName);
             throw new IllegalStateException(msg);
+        }
+        if (tag != null) {
+            // tag can be null if injecting Element
+            // tagName is the tag parsed from the template and it is null for Lit templates,
+            // which are not parsed
+            tagName = tag.value();
         }
         attachExistingElementById(tagName, id, field, beforeComponentInject);
     }

--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
@@ -138,6 +138,7 @@ public abstract class ClassesSerializableTest extends ClassFinder {
                 "com\\.vaadin\\.flow\\.component\\.HtmlContainer",
                 "com\\.vaadin\\.flow\\.component\\.polymertemplate\\.TemplateInitializer(\\$.*)?",
                 "com\\.vaadin\\.flow\\.component\\.polymertemplate\\.TemplateParser(\\$.*)?",
+                "com\\.vaadin\\.flow\\.component\\.littemplate\\.LitTemplateInitializer(\\$.*)?",
                 "com\\.vaadin\\.flow\\.dom\\.impl\\.ThemeListImpl\\$ThemeListIterator",
                 "com\\.vaadin\\.flow\\.templatemodel\\.PropertyMapBuilder(\\$.*)?",
                 "com\\.vaadin\\.flow\\.internal\\.ReflectionCache",

--- a/flow-tests/test-root-context/frontend/lit/simple-lit-template-no-shadow-root.js
+++ b/flow-tests/test-root-context/frontend/lit/simple-lit-template-no-shadow-root.js
@@ -1,0 +1,10 @@
+
+import { LitElement, html } from "lit-element";
+import { SimpleLitTemplateShadowRoot } from "./simple-lit-template-shadow-root.js";
+
+export class SimpleLitTemplateNoShadowRoot extends SimpleLitTemplateShadowRoot {
+	createRenderRoot() {
+		return this;
+	}
+}
+customElements.define("simple-lit-template-no-shadow-root", SimpleLitTemplateNoShadowRoot);

--- a/flow-tests/test-root-context/frontend/lit/simple-lit-template-shadow-root.js
+++ b/flow-tests/test-root-context/frontend/lit/simple-lit-template-shadow-root.js
@@ -1,0 +1,19 @@
+
+import { LitElement, html } from "lit-element";
+
+export class SimpleLitTemplateShadowRoot extends LitElement {
+  static get properties() {
+    return {
+      text: String
+    };
+  }
+  render() {
+    return html`
+      <button id="clientButton" @click="${e => this.$server.sayHello()}">${this.text}</button>
+
+      <button id="mappedButton"></button>
+      <div id="label"></div>
+    `;
+  }
+}
+customElements.define("simple-lit-template-shadow-root", SimpleLitTemplateShadowRoot);

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/littemplate/LitPerson.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/littemplate/LitPerson.java
@@ -1,0 +1,42 @@
+package com.vaadin.flow.uitest.ui.littemplate;
+
+public class LitPerson {
+    private int id;
+    private String firstName, lastName;
+
+    public LitPerson() {
+
+    }
+
+    public LitPerson(int id, String firstName, String lastName) {
+        super();
+        this.id = id;
+        this.firstName = firstName;
+        this.lastName = lastName;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/littemplate/SimpleLitTemplateNoShadowRootView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/littemplate/SimpleLitTemplateNoShadowRootView.java
@@ -1,0 +1,39 @@
+package com.vaadin.flow.uitest.ui.littemplate;
+
+import com.vaadin.flow.component.ClientCallable;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.littemplate.LitTemplate;
+import com.vaadin.flow.component.polymertemplate.Id;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+@Tag("simple-lit-template-no-shadow-root")
+@JsModule("lit/simple-lit-template-no-shadow-root.js")
+@NpmPackage(value = "lit-element", version = "2.1.0")
+@Route(value = "com.vaadin.flow.uitest.ui.littemplate.SimpleLitTemplateNoShadowRootView", layout = ViewTestLayout.class)
+public class SimpleLitTemplateNoShadowRootView extends LitTemplate {
+
+    @Id
+    public NativeButton mappedButton;
+    @Id
+    public Div label;
+
+    public SimpleLitTemplateNoShadowRootView() {
+        getElement().setProperty("text", "Client button");
+        mappedButton.setText("Server button");
+        mappedButton.addClickListener(e -> {
+            label.setText("Hello from server component event listener");
+        });
+
+    }
+
+    @ClientCallable
+    public void sayHello() {
+        label.setText("Hello from ClientCallable");
+    }
+
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/littemplate/SimpleLitTemplateShadowRootView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/littemplate/SimpleLitTemplateShadowRootView.java
@@ -1,0 +1,39 @@
+package com.vaadin.flow.uitest.ui.littemplate;
+
+import com.vaadin.flow.component.ClientCallable;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.littemplate.LitTemplate;
+import com.vaadin.flow.component.polymertemplate.Id;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+@Tag("simple-lit-template-shadow-root")
+@JsModule("lit/simple-lit-template-shadow-root.js")
+@NpmPackage(value = "lit-element", version = "2.1.0")
+@Route(value = "com.vaadin.flow.uitest.ui.littemplate.SimpleLitTemplateShadowRootView", layout = ViewTestLayout.class)
+public class SimpleLitTemplateShadowRootView extends LitTemplate {
+
+    @Id
+    public NativeButton mappedButton;
+    @Id
+    public Div label;
+
+    public SimpleLitTemplateShadowRootView() {
+        getElement().setProperty("text", "Client button");
+        mappedButton.setText("Server button");
+        mappedButton.addClickListener(e -> {
+            label.setText("Hello from server component event listener");
+        });
+
+    }
+
+    @ClientCallable
+    public void sayHello() {
+        label.setText("Hello from ClientCallable");
+    }
+
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/littemplate/SimpleLitTemplateNoShadowRootIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/littemplate/SimpleLitTemplateNoShadowRootIT.java
@@ -1,0 +1,15 @@
+package com.vaadin.flow.uitest.ui.littemplate;
+
+public class SimpleLitTemplateNoShadowRootIT
+        extends SimpleLitTemplateShadowRootIT {
+
+    protected String getTemplateTag() {
+        return "simple-lit-template-no-shadow-root";
+    }
+
+    @Override
+    protected boolean shouldHaveShadowRoot() {
+        return false;
+    }
+
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/littemplate/SimpleLitTemplateShadowRootIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/littemplate/SimpleLitTemplateShadowRootIT.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.littemplate;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.html.testbench.DivElement;
+import com.vaadin.flow.component.html.testbench.NativeButtonElement;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+import com.vaadin.testbench.TestBenchElement;
+
+public class SimpleLitTemplateShadowRootIT extends ChromeBrowserTest {
+
+    private TestBenchElement template;
+
+    protected String getTemplateTag() {
+        return "simple-lit-template-shadow-root";
+    }
+
+    protected boolean shouldHaveShadowRoot() {
+        return true;
+    }
+
+    public void setup() throws Exception {
+        super.setup();
+        open();
+        template = $(getTemplateTag()).first();
+    }
+
+    @Test
+    public void shadowRoot() {
+        Assert.assertEquals(shouldHaveShadowRoot(),
+                (Boolean) executeScript("return !!arguments[0].shadowRoot",
+                        template));
+    }
+
+    @Test
+    public void idMappingWorks() {
+        NativeButtonElement mappedButton = template.$(NativeButtonElement.class)
+                .id("mappedButton");
+
+        Assert.assertEquals("Server button", mappedButton.getText());
+        mappedButton.click();
+
+        DivElement label = template.$(DivElement.class).id("label");
+        Assert.assertEquals("Hello from server component event listener",
+                label.getText());
+    }
+
+    @Test
+    public void clientPropertyAndCallbackWorks() {
+        NativeButtonElement clientButton = template.$(NativeButtonElement.class)
+                .id("clientButton");
+
+        Assert.assertEquals("Client button", clientButton.getText());
+        clientButton.click();
+
+        DivElement label = template.$(DivElement.class).id("label");
+        Assert.assertEquals("Hello from ClientCallable", label.getText());
+    }
+}


### PR DESCRIPTION
Supports @Id mapping in the same way as PolymerTemplate

Contrary to PolymerTemplate, contains no special support for template in template, @Uses or a template model.
Properties of the template can be set on the server using the property API in `getElement()`

Limitations in this commit:
* The template is not parsed on the server so no attributes can be made available for mapped components
* All types of templates are allowed by default although we need to consider whether only static HTML should be accepted without an additional opt-in

Intentionally left out:
* Model support is intentionally left out as it causes problems when mixing with @Id mapping. The template should in most/all cases be used so that all UI logic is on the server (using @Id mapping) or all UI logic is in the browser (using TS). The existing PolymerTemplate model is a mix of the two.