### PR TITLE
Remove devmode widget inclusion from TS

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
@@ -230,14 +230,7 @@ export class Flow {
         this.container.style.display = 'none';
         document.body.appendChild(this.container);
       }
-
-      // Load devmode gizmo, which handles live-reload connection to the server
-      // (server ensures this parameter is true only in dev mode)
-      if (appConfig.devmodeGizmoEnabled) {
-        const devmodeGizmoMod = await import('./VaadinDevmodeGizmo');
-        await devmodeGizmoMod.init(appConfig.serviceUrl, appConfig.liveReloadBackend, appConfig.springBootDevToolsPort);
-      }
-
+      
       // hide flow progress indicator
       this.hideLoading();
     }


### PR DESCRIPTION
To prevent it from being included to the compiled client JS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8045)
<!-- Reviewable:end -->
