### PR TITLE
Show alert when using @PreserveOnRefresh together with live reload

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
@@ -235,7 +235,8 @@ export class Flow {
       // (server ensures this parameter is true only in dev mode)
       if (appConfig.devmodeGizmoEnabled) {
         const devmodeGizmoMod = await import('./VaadinDevmodeGizmo');
-        await devmodeGizmoMod.init(appConfig.serviceUrl, appConfig.liveReloadBackend, appConfig.springBootDevToolsPort);
+        const devmodeGizmo = await devmodeGizmoMod.init(appConfig.serviceUrl, appConfig.liveReloadBackend, appConfig.springBootDevToolsPort);
+        $wnd.Vaadin.Flow.devModeGizmo = devmodeGizmo;
       }
 
       // hide flow progress indicator

--- a/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.d.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.d.ts
@@ -1,1 +1,1 @@
-export const init: (serviceUrl: string, liveReloadBackend: string, springBootDevToolsPort: number) => void;
+export const init: (serviceUrl: string, liveReloadBackend: string, springBootDevToolsPort: number) => HTMLElement;

--- a/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.js
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.js
@@ -423,6 +423,9 @@ const init = function(serviceUrl, liveReloadBackend, springBootDevToolsPort) {
       devmodeGizmo.setAttribute('springBootDevToolsPort', springBootDevToolsPort);
     }
     document.body.appendChild(devmodeGizmo);
+    return devmodeGizmo;
+  } else {
+    return undefined;
   }
 };
 

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -34,6 +34,7 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.page.ExtendedClientDetails;
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.Pair;
 import com.vaadin.flow.internal.ReflectTools;
 import com.vaadin.flow.router.AfterNavigationEvent;
@@ -237,6 +238,7 @@ public abstract class AbstractNavigationStateRenderer
         // on the UI.
         if (preserveOnRefreshTarget) {
             setPreservedChain(chain, event);
+            warnAboutPreserveOnRefreshAndLiveReloadCombo(ui);
         }
 
         @SuppressWarnings("unchecked")
@@ -909,6 +911,17 @@ public abstract class AbstractNavigationStateRenderer
                     cache.remove(windowName);
                 }
             });
+        }
+    }
+
+    private static void warnAboutPreserveOnRefreshAndLiveReloadCombo(UI ui) {
+        // Show a warning that live-reload may work counter-intuitively
+        DeploymentConfiguration configuration = ui.getSession()
+                .getConfiguration();
+        if (!configuration.isProductionMode()
+                && configuration.isDevModeLiveReloadEnabled()) {
+            ui.getPage().executeJs(
+                    "Vaadin.Flow.devModeGizmo.showNotification('@PreserveOnRefresh: server-side instances are reused on reload')");
         }
     }
 

--- a/flow-tests/test-dev-mode/src/main/java/com/vaadin/flow/uitest/ui/frontend/PreserveOnRefreshLiveReloadView.java
+++ b/flow-tests/test-dev-mode/src/main/java/com/vaadin/flow/uitest/ui/frontend/PreserveOnRefreshLiveReloadView.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.frontend;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.PreserveOnRefresh;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+
+@Route(value = "com.vaadin.flow.uitest.ui.frontend.PreserveOnRefreshLiveReloadView", layout = ViewTestLayout.class)
+@PreserveOnRefresh
+public class PreserveOnRefreshLiveReloadView extends Div {
+}

--- a/flow-tests/test-dev-mode/src/test/java/com/vaadin/flow/uitest/ui/frontend/PreserveOnRefreshLiveReloadIT.java
+++ b/flow-tests/test-dev-mode/src/test/java/com/vaadin/flow/uitest/ui/frontend/PreserveOnRefreshLiveReloadIT.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.uitest.ui.frontend;
+
+import javax.annotation.concurrent.NotThreadSafe;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+// These tests are not parallelizable, nor should they be run at the same time
+// as other tests in the same module, due to live-reload affecting the whole
+// application
+@NotThreadSafe
+public class PreserveOnRefreshLiveReloadIT extends ChromeBrowserTest {
+
+    private static final Lock lock = new ReentrantLock();
+
+    @Before
+    @Override
+    public void setup() throws Exception {
+        lock.lock();
+        super.setup();
+    }
+
+    @After
+    public void tearDown() {
+        lock.unlock();
+    }
+
+    @Test
+    public void notificationShownWhenLoadingPreserveOnRefreshView() {
+        open();
+
+        WebElement liveReload = findElement(By.tagName("vaadin-devmode-gizmo"));
+        Assert.assertNotNull(liveReload);
+        WebElement statusDescription = findInShadowRoot(liveReload,
+                By.className("status-description")).get(0);
+        Assert.assertTrue(
+                statusDescription.getText().contains("@PreserveOnRefresh"));
+    }
+
+}


### PR DESCRIPTION
For `@PreserveOnRefresh`-annotated views, the live reload behavior is not be intuitive since the view instance is re-used on reload (for instance, modifications to the view's constructor are not reflected after live reload). 

Fixes #7819.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8070)
<!-- Reviewable:end -->
