### PR TITLE
Fix endpoint serialization problems

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -15,7 +15,6 @@
     <properties>
         <validation.api.version>2.0.1.Final</validation.api.version>
         <jackson.version>2.10.2</jackson.version>
-        <jackson.databind.version>2.10.2</jackson.databind.version>
         <spring.version>5.2.0.RELEASE</spring.version>
         <spring.autoconfigure.version>2.2.0.RELEASE</spring.autoconfigure.version>
         <javax.annotation.api.version>1.3.2</javax.annotation.api.version>
@@ -209,7 +208,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.databind.version}</version>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
         <!-- Needed for security annotations -->
         <dependency>
@@ -280,12 +284,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-test-autoconfigure</artifactId>
             <version>${spring.autoconfigure.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.10.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -282,6 +282,12 @@
             <version>${spring.autoconfigure.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>2.10.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <resources>

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectController.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectController.java
@@ -27,7 +27,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
-import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectController.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectController.java
@@ -27,6 +27,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
+import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -162,7 +163,8 @@ public class VaadinConnectController {
     }
 
     private ObjectMapper createVaadinConnectObjectMapper(ApplicationContext context) {
-        ObjectMapper objectMapper = Jackson2ObjectMapperBuilder.json().build();
+        Jackson2ObjectMapperBuilder builder = context.getBean(Jackson2ObjectMapperBuilder.class);
+        ObjectMapper objectMapper = builder.createXmlMapper(false).build();
         JacksonProperties jacksonProperties = context
                 .getBean(JacksonProperties.class);
         if (jacksonProperties.getVisibility().isEmpty()) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/VaadinConnectControllerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/VaadinConnectControllerTest.java
@@ -588,7 +588,6 @@ public class VaadinConnectControllerTest {
     }
 
     @Test
-    @Ignore("requires mockito version with plugin for final classes")
     public void should_Return500_When_MapperFailsToSerializeResponse()
             throws Exception {
         ObjectMapper mapperMock = mock(ObjectMapper.class);
@@ -631,7 +630,6 @@ public class VaadinConnectControllerTest {
     }
 
     @Test
-    @Ignore("requires mockito version with plugin for final classes")
     public void should_ThrowException_When_MapperFailsToSerializeEverything()
             throws Exception {
         ObjectMapper mapperMock = mock(ObjectMapper.class);

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/VaadinConnectControllerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/VaadinConnectControllerTest.java
@@ -38,6 +38,7 @@ import org.springframework.boot.autoconfigure.jackson.JacksonProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 
 import com.vaadin.flow.server.MockVaadinServletService;
 import com.vaadin.flow.server.VaadinService;
@@ -798,11 +799,19 @@ public class VaadinConnectControllerTest {
     public void should_Never_UseSpringObjectMapper() {
         ApplicationContext contextMock = mock(ApplicationContext.class);
         ObjectMapper mockSpringObjectMapper = mock(ObjectMapper.class);
+        ObjectMapper mockOwnObjectMapper = mock(ObjectMapper.class);
+        Jackson2ObjectMapperBuilder mockObjectMapperBuilder = mock(Jackson2ObjectMapperBuilder.class);
         JacksonProperties mockJacksonProperties = mock(JacksonProperties.class);
         when(contextMock.getBean(ObjectMapper.class))
                 .thenReturn(mockSpringObjectMapper);
         when(contextMock.getBean(JacksonProperties.class))
                 .thenReturn(mockJacksonProperties);
+        when(contextMock.getBean(Jackson2ObjectMapperBuilder.class))
+                .thenReturn(mockObjectMapperBuilder);
+        when(mockObjectMapperBuilder.createXmlMapper(false))
+                .thenReturn(mockObjectMapperBuilder);
+        when(mockObjectMapperBuilder.build())
+                .thenReturn(mockOwnObjectMapper);
         when(mockJacksonProperties.getVisibility())
                 .thenReturn(Collections.emptyMap());
         new VaadinConnectController(null,
@@ -813,8 +822,9 @@ public class VaadinConnectControllerTest {
                 mock(ServletContext.class));
 
         verify(contextMock, never()).getBean(ObjectMapper.class);
+        verify(contextMock, times(1)).getBean(Jackson2ObjectMapperBuilder.class);
         verify(contextMock, times(1)).getBean(JacksonProperties.class);
-        verify(mockSpringObjectMapper, never()).setVisibility(
+        verify(mockOwnObjectMapper, times(1)).setVisibility(
                 PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
     }
 
@@ -822,11 +832,19 @@ public class VaadinConnectControllerTest {
     public void should_NotOverrideVisibility_When_JacksonPropertiesProvideVisibility() {
         ApplicationContext contextMock = mock(ApplicationContext.class);
         ObjectMapper mockDefaultObjectMapper = mock(ObjectMapper.class);
+        ObjectMapper mockOwnObjectMapper = mock(ObjectMapper.class);
+        Jackson2ObjectMapperBuilder mockObjectMapperBuilder = mock(Jackson2ObjectMapperBuilder.class);
         JacksonProperties mockJacksonProperties = mock(JacksonProperties.class);
         when(contextMock.getBean(ObjectMapper.class))
                 .thenReturn(mockDefaultObjectMapper);
         when(contextMock.getBean(JacksonProperties.class))
                 .thenReturn(mockJacksonProperties);
+        when(contextMock.getBean(Jackson2ObjectMapperBuilder.class))
+                .thenReturn(mockObjectMapperBuilder);
+        when(mockObjectMapperBuilder.createXmlMapper(false))
+                .thenReturn(mockObjectMapperBuilder);
+        when(mockObjectMapperBuilder.build())
+                .thenReturn(mockOwnObjectMapper);
         when(mockJacksonProperties.getVisibility())
                 .thenReturn(Collections.singletonMap(PropertyAccessor.ALL,
                         JsonAutoDetect.Visibility.PUBLIC_ONLY));
@@ -838,7 +856,10 @@ public class VaadinConnectControllerTest {
                 mock(ServletContext.class));
 
         verify(contextMock, never()).getBean(ObjectMapper.class);
+        verify(contextMock, times(1)).getBean(Jackson2ObjectMapperBuilder.class);
         verify(mockDefaultObjectMapper, never()).setVisibility(
+                PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
+        verify(mockOwnObjectMapper, never()).setVisibility(
                 PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
         verify(contextMock, times(1)).getBean(JacksonProperties.class);
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/rest/BeanWithJacksonAnnotation.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/rest/BeanWithJacksonAnnotation.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.server.connect.rest;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class BeanWithJacksonAnnotation {
+    @JsonProperty("bookId")
+    private String id;
+    private String name;
+
+    @JsonProperty("name")
+    public void setFirstName(String name) {
+        this.name = name;
+    }
+
+    @JsonProperty("name")
+    public String getFirstName() {
+        return name;
+    }
+
+    @JsonProperty
+    public int getRating() {
+        return 2;
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/rest/EndpointWithRestControllerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/rest/EndpointWithRestControllerTest.java
@@ -38,6 +38,7 @@ import com.vaadin.flow.server.connect.ExplicitNullableTypeChecker;
 import com.vaadin.flow.server.connect.VaadinConnectController;
 import com.vaadin.flow.server.connect.auth.VaadinConnectAccessChecker;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
@@ -79,7 +80,7 @@ public class EndpointWithRestControllerTest {
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andReturn().getResponse().getContentAsString();
-        Assert.assertEquals("{\"name\":\"Bond\"}", result);
+        assertEquals("{\"name\":\"Bond\"}", result);
     }
 
     @Test
@@ -87,7 +88,7 @@ public class EndpointWithRestControllerTest {
     public void should_BeAbleToSerializePrivateFieldsOfABean_when_CallingFromConnectEndPoint() {
         try {
             String result = callEndpointMethod("getBeanWithPrivateFields");
-            Assert.assertEquals("{\"codeNumber\":\"007\",\"name\":\"Bond\",\"firstName\":\"James\"}", result);
+            assertEquals("{\"codeNumber\":\"007\",\"name\":\"Bond\",\"firstName\":\"James\"}", result);
         } catch (Exception e) {
             fail("failed to serialize a bean with private fields");
         }
@@ -104,6 +105,24 @@ public class EndpointWithRestControllerTest {
         } catch (Exception e) {
             fail("failed to serialize a bean with ZonedDateTime field");
         }
+    }
+
+    @Test
+    //https://github.com/vaadin/flow/issues/8067
+    public void should_RepsectJacksonAnnotation_when_serializeBean() throws Exception {
+        String result = callEndpointMethod("getBeanWithJacksonAnnotation");
+        assertEquals("{\"name\":null,\"rating\":2,\"bookId\":null}", result);
+    }
+
+    @Test
+    /**
+     * this requires jackson-datatype-jsr310, which is added as a test scope dependency.
+     * jackson-datatype-jsr310 is provided in spring-boot-starter-web, which is part of
+     * vaadin-spring-boot-starter
+     */
+    public void should_serializeLocalTimeInExpectedFormat_when_UsingSpringBoot() throws Exception{
+        String result = callEndpointMethod("getLocalTime");
+        assertEquals("\"08:00:00\"", result);
     }
 
     private String callEndpointMethod(String methodName) throws Exception {

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/rest/VaadinConnectEndpoints.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/rest/VaadinConnectEndpoints.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.server.connect.rest;
 
+import java.time.LocalTime;
 import java.time.ZonedDateTime;
 
 import com.vaadin.flow.server.connect.Endpoint;
@@ -28,6 +29,14 @@ public class VaadinConnectEndpoints {
 
     public BeanWithPrivateFields getBeanWithPrivateFields(){
         return new BeanWithPrivateFields();
+    }
+
+    public BeanWithJacksonAnnotation getBeanWithJacksonAnnotation(){
+        return new BeanWithJacksonAnnotation();
+    }
+
+    public LocalTime getLocalTime(){
+        return LocalTime.of(8, 0, 0);
     }
 
     public static class BeanWithZonedDateTimeField {

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/ArrayConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/ArrayConversionTest.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.server.connect.typeconversion;
 
 import org.junit.Test;
 
-public class ArrayConversionIT extends BaseTypeConversionIT {
+public class ArrayConversionTest extends BaseTypeConversionTest {
 
     @Test
     public void should_ConvertToArrayInt_When_ReceiveArrayInt() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/BaseTypeConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/BaseTypeConversionTest.java
@@ -42,7 +42,7 @@ import static org.mockito.Mockito.mock;
 @RunWith(SpringRunner.class)
 @WebMvcTest
 @Import(VaadinConnectTypeConversionEndpoints.class)
-public abstract class BaseTypeConversionIT {
+public abstract class BaseTypeConversionTest {
 
     private MockMvc mockMvc;
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/BeanConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/BeanConversionTest.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.server.connect.typeconversion;
 
 import org.junit.Test;
 
-public class BeanConversionIT extends BaseTypeConversionIT {
+public class BeanConversionTest extends BaseTypeConversionTest {
 
     @Test
     public void should_ConvertToBean_When_ReceiveBeanObject() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/BooleanConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/BooleanConversionTest.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.server.connect.typeconversion;
 
 import org.junit.Test;
 
-public class BooleanConversionIT extends BaseTypeConversionIT {
+public class BooleanConversionTest extends BaseTypeConversionTest {
     @Test
     public void should_ConvertToBoolean_When_ReceiveTrueOrFalse() {
         assertEqualExpectedValueWhenCallingMethod("revertBoolean", "true",

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/ByteConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/ByteConversionTest.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.server.connect.typeconversion;
 
 import org.junit.Test;
 
-public class ByteConversionIT extends BaseTypeConversionIT {
+public class ByteConversionTest extends BaseTypeConversionTest {
     @Test
     public void should_ConvertNumberToByte_When_ReceiveNumber() {
         assertEqualExpectedValueWhenCallingMethod("addOneByte", "1", "2");

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/CharacterConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/CharacterConversionTest.java
@@ -19,7 +19,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
 
-public class CharacterConversionIT extends BaseTypeConversionIT {
+public class CharacterConversionTest extends BaseTypeConversionTest {
     @Test
     public void should_ConvertToChar_When_ReceiveASingleCharOrNumber()
             throws Exception {

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/CollectionConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/CollectionConversionTest.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.server.connect.typeconversion;
 
 import org.junit.Test;
 
-public class CollectionConversionIT extends BaseTypeConversionIT {
+public class CollectionConversionTest extends BaseTypeConversionTest {
 
     @Test
     public void should_ConvertToIntegerCollection_When_ReceiveNumberArray() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/DateTimeConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/DateTimeConversionTest.java
@@ -15,10 +15,9 @@
  */
 package com.vaadin.flow.server.connect.typeconversion;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
-public class DateTimeConversionIT extends BaseTypeConversionIT {
+public class DateTimeConversionTest extends BaseTypeConversionTest {
 
     // region date tests
     @Test
@@ -58,7 +57,6 @@ public class DateTimeConversionIT extends BaseTypeConversionIT {
     // format
 
     @Test
-    @Ignore("Failing after moved to flow")
     public void should_ConvertToLocalDate_When_ReceiveALocalDate() {
         String inputDate = "\"2019-12-13\"";
         String expectedTimestamp = "\"2019-12-14\"";
@@ -77,7 +75,6 @@ public class DateTimeConversionIT extends BaseTypeConversionIT {
     // LocalDate uses java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME as
     // default format
     @Test
-    @Ignore("Failing after moved to flow")
     public void should_ConvertToLocalDateTime_When_ReceiveALocalDateTime() {
         String inputDate = "\"2019-12-13T12:12:12\"";
         String expectedTimestamp = "\"2019-12-14T13:12:12\"";

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/DoubleConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/DoubleConversionTest.java
@@ -19,7 +19,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
 
-public class DoubleConversionIT extends BaseTypeConversionIT {
+public class DoubleConversionTest extends BaseTypeConversionTest {
     @Test
     public void should_ConvertToDouble_When_ReceiveANumber() {
         assertCallMethodWithExpectedDoubleValue("addOneDouble", "1", "2.0");

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/EnumConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/EnumConversionTest.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.server.connect.typeconversion;
 
 import org.junit.Test;
 
-public class EnumConversionIT extends BaseTypeConversionIT {
+public class EnumConversionTest extends BaseTypeConversionTest {
 
     @Test
     public void should_ConvertToEnum_When_ReceiveStringWithSameName() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/FloatConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/FloatConversionTest.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.server.connect.typeconversion;
 
 import org.junit.Test;
 
-public class FloatConversionIT extends BaseTypeConversionIT {
+public class FloatConversionTest extends BaseTypeConversionTest {
     @Test
     public void should_ConvertToFloat_When_ReceiveANumber() {
         assertEqualExpectedValueWhenCallingMethod("addOneFloat", "1", "2.0");

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/IntegerConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/IntegerConversionTest.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.server.connect.typeconversion;
 
 import org.junit.Test;
 
-public class IntegerConversionIT extends BaseTypeConversionIT {
+public class IntegerConversionTest extends BaseTypeConversionTest {
 
     @Test
     public void should_ConvertNumberToInt_When_ReceiveNumberAsNumber() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/IntegerConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/IntegerConversionTest.java
@@ -45,19 +45,18 @@ public class IntegerConversionTest extends BaseTypeConversionTest {
     }
 
     @Test
-    public void should_HandleOverflowInteger_When_ReceiveOverflowNumber() {
+    public void should_FailToConvertOverflowInteger_When_ReceiveOverflowNumber() {
         String overflowInputInteger = "2147483648";
-        assertEqualExpectedValueWhenCallingMethod("addOneInt",
-                overflowInputInteger, String.valueOf(Integer.MIN_VALUE + 1));
-        assertEqualExpectedValueWhenCallingMethod("addOneIntBoxed",
-                overflowInputInteger, String.valueOf(Integer.MIN_VALUE + 1));
+        assert400ResponseWhenCallingMethod("addOneInt",
+                overflowInputInteger);
+        assert400ResponseWhenCallingMethod("addOneIntBoxed",
+                overflowInputInteger);
 
         String underflowInputInteger = "-2147483649";
         // underflow will become MAX, then +1 in the method => MIN
-        assertEqualExpectedValueWhenCallingMethod("addOneInt",
-                underflowInputInteger, String.valueOf(Integer.MIN_VALUE));
-        assertEqualExpectedValueWhenCallingMethod("addOneIntBoxed",
-                underflowInputInteger, String.valueOf(Integer.MIN_VALUE));
+        assert400ResponseWhenCallingMethod("addOneInt", underflowInputInteger);
+        assert400ResponseWhenCallingMethod("addOneIntBoxed",
+                underflowInputInteger);
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/LongConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/LongConversionTest.java
@@ -78,18 +78,14 @@ public class LongConversionTest extends BaseTypeConversionTest {
     }
 
     @Test
-    public void should_HandleOverflowLong_When_ReceiveANumberOverflowOrUnderflow() {
+    public void should_FailToConvertToLong_When_ReceiveANumberOverflowOrUnderflow() {
         String overflowLong = "9223372036854775808"; // 2^63
-        assertEqualExpectedValueWhenCallingMethod("addOneLong", overflowLong,
-                String.valueOf(Long.MIN_VALUE + 1));
-        assertEqualExpectedValueWhenCallingMethod("addOneLongBoxed",
-                overflowLong, String.valueOf(Long.MIN_VALUE + 1));
+        assert400ResponseWhenCallingMethod("addOneLong", overflowLong);
+        assert400ResponseWhenCallingMethod("addOneLongBoxed", overflowLong);
 
         String underflowLong = "-9223372036854775809"; // -2^63-1
-        assertEqualExpectedValueWhenCallingMethod("addOneLong", underflowLong,
-                String.valueOf(Long.MIN_VALUE));
-        assertEqualExpectedValueWhenCallingMethod("addOneLongBoxed",
-                underflowLong, String.valueOf(Long.MIN_VALUE));
+        assert400ResponseWhenCallingMethod("addOneLong", underflowLong);
+        assert400ResponseWhenCallingMethod("addOneLongBoxed", underflowLong);
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/LongConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/LongConversionTest.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.server.connect.typeconversion;
 
 import org.junit.Test;
 
-public class LongConversionIT extends BaseTypeConversionIT {
+public class LongConversionTest extends BaseTypeConversionTest {
 
     @Test
     public void should_ConvertToLong_When_ReceiveANumber() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/MapConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/MapConversionTest.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.server.connect.typeconversion;
 
 import org.junit.Test;
 
-public class MapConversionIT extends BaseTypeConversionIT {
+public class MapConversionTest extends BaseTypeConversionTest {
 
     @Test
     public void should_ConvertToMapOfString_When_ReceiveMapOfString() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/ShortConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/ShortConversionTest.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.server.connect.typeconversion;
 
 import org.junit.Test;
 
-public class ShortConversionIT extends BaseTypeConversionIT {
+public class ShortConversionTest extends BaseTypeConversionTest {
     @Test
     public void should_ConvertToShort_When_ReceiveANumber() {
         assertEqualExpectedValueWhenCallingMethod("addOneShort", "1", "2");

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/StringConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/StringConversionTest.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.server.connect.typeconversion;
 
 import org.junit.Test;
 
-public class StringConversionIT extends BaseTypeConversionIT {
+public class StringConversionTest extends BaseTypeConversionTest {
 
     @Test
     public void should_ConvertToString_When_ReceiveAString() {


### PR DESCRIPTION
1. Use `Jackson2ObjectMapperBuilder` from Spring application context to build a `Jackson2ObjectMapper`
2. Add `jackson-datatype-jsr310` to ensure data format
3. Enable ignored tests
4. Add test for LocalTime format

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8095)
<!-- Reviewable:end -->
