### PR TITLE
3.1 cherry pick

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -15,7 +15,6 @@
     <properties>
         <validation.api.version>2.0.1.Final</validation.api.version>
         <jackson.version>2.10.2</jackson.version>
-        <jackson.databind.version>2.10.2</jackson.databind.version>
         <spring.version>5.2.0.RELEASE</spring.version>
         <spring.autoconfigure.version>2.2.0.RELEASE</spring.autoconfigure.version>
         <javax.annotation.api.version>1.3.2</javax.annotation.api.version>
@@ -209,7 +208,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.databind.version}</version>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
         <!-- Needed for security annotations -->
         <dependency>

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectController.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectController.java
@@ -162,7 +162,8 @@ public class VaadinConnectController {
     }
 
     private ObjectMapper createVaadinConnectObjectMapper(ApplicationContext context) {
-        ObjectMapper objectMapper = Jackson2ObjectMapperBuilder.json().build();
+        Jackson2ObjectMapperBuilder builder = context.getBean(Jackson2ObjectMapperBuilder.class);
+        ObjectMapper objectMapper = builder.createXmlMapper(false).build();
         JacksonProperties jacksonProperties = context
                 .getBean(JacksonProperties.class);
         if (jacksonProperties.getVisibility().isEmpty()) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -34,7 +34,6 @@ import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.shared.util.SharedUtil;
 
 import elemental.json.Json;
-
 import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
 import static com.vaadin.flow.server.frontend.FrontendUtils.commandToString;
 import static elemental.json.impl.JsonUtil.stringify;
@@ -109,9 +108,11 @@ public class TaskRunNpmInstall implements FallibleCommand {
 
             File versions = new File(packageUpdater.generatedFolder,
                     "versions.json");
-            VersionsJsonConverter convert = new VersionsJsonConverter(Json
-                    .parse(IOUtils.toString(content, StandardCharsets.UTF_8)));
-            FileUtils.write(versions, stringify(convert.convert(), 2) + "\n",
+
+            VersionsJsonConverter convert = new VersionsJsonConverter(
+                    Json.parse(IOUtils.toString(content, StandardCharsets.UTF_8)),
+                    packageUpdater.getPackageJson());
+            FileUtils.write(versions, stringify(convert.getManagedVersions(), 2) + "\n",
                     StandardCharsets.UTF_8);
             Path versionsPath = versions.toPath();
             if (versions.isAbsolute()) {

--- a/flow-server/src/main/resources/pnpmfile.js
+++ b/flow-server/src/main/resources/pnpmfile.js
@@ -2,8 +2,8 @@
  * NOTICE: this is an auto-generated file
  *
  * This file has been generated for `pnpm install` task.
- * It is used to pin client side dependencies. 
- * This file will be overwritten on every run. 
+ * It is used to pin client side dependencies.
+ * This file will be overwritten on every run.
  */
 
 const fs = require('fs');
@@ -13,7 +13,7 @@ const packageJson = JSON.parse(fs.readFileSync('./package.json', 'utf-8'));
 const versionsFile = '[to-be-generated-by-flow]';
 
 if (!fs.existsSync(versionsFile)) {
-    return;
+  return;
 }
 const versions = JSON.parse(fs.readFileSync(versionsFile, 'utf-8'));
 
@@ -24,7 +24,7 @@ module.exports = {
 };
 
 function readPackage(pkg) {
-  const { dependencies } = pkg;
+  const {dependencies} = pkg;
 
   if (dependencies) {
     for (let k in versions) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/VaadinConnectControllerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/VaadinConnectControllerTest.java
@@ -38,6 +38,7 @@ import org.springframework.boot.autoconfigure.jackson.JacksonProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 
 import com.vaadin.flow.server.MockVaadinServletService;
 import com.vaadin.flow.server.VaadinService;
@@ -587,7 +588,6 @@ public class VaadinConnectControllerTest {
     }
 
     @Test
-    @Ignore("requires mockito version with plugin for final classes")
     public void should_Return500_When_MapperFailsToSerializeResponse()
             throws Exception {
         ObjectMapper mapperMock = mock(ObjectMapper.class);
@@ -630,7 +630,6 @@ public class VaadinConnectControllerTest {
     }
 
     @Test
-    @Ignore("requires mockito version with plugin for final classes")
     public void should_ThrowException_When_MapperFailsToSerializeEverything()
             throws Exception {
         ObjectMapper mapperMock = mock(ObjectMapper.class);
@@ -798,11 +797,19 @@ public class VaadinConnectControllerTest {
     public void should_Never_UseSpringObjectMapper() {
         ApplicationContext contextMock = mock(ApplicationContext.class);
         ObjectMapper mockSpringObjectMapper = mock(ObjectMapper.class);
+        ObjectMapper mockOwnObjectMapper = mock(ObjectMapper.class);
+        Jackson2ObjectMapperBuilder mockObjectMapperBuilder = mock(Jackson2ObjectMapperBuilder.class);
         JacksonProperties mockJacksonProperties = mock(JacksonProperties.class);
         when(contextMock.getBean(ObjectMapper.class))
                 .thenReturn(mockSpringObjectMapper);
         when(contextMock.getBean(JacksonProperties.class))
                 .thenReturn(mockJacksonProperties);
+        when(contextMock.getBean(Jackson2ObjectMapperBuilder.class))
+                .thenReturn(mockObjectMapperBuilder);
+        when(mockObjectMapperBuilder.createXmlMapper(false))
+                .thenReturn(mockObjectMapperBuilder);
+        when(mockObjectMapperBuilder.build())
+                .thenReturn(mockOwnObjectMapper);
         when(mockJacksonProperties.getVisibility())
                 .thenReturn(Collections.emptyMap());
         new VaadinConnectController(null,
@@ -813,8 +820,9 @@ public class VaadinConnectControllerTest {
                 mock(ServletContext.class));
 
         verify(contextMock, never()).getBean(ObjectMapper.class);
+        verify(contextMock, times(1)).getBean(Jackson2ObjectMapperBuilder.class);
         verify(contextMock, times(1)).getBean(JacksonProperties.class);
-        verify(mockSpringObjectMapper, never()).setVisibility(
+        verify(mockOwnObjectMapper, times(1)).setVisibility(
                 PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
     }
 
@@ -822,11 +830,19 @@ public class VaadinConnectControllerTest {
     public void should_NotOverrideVisibility_When_JacksonPropertiesProvideVisibility() {
         ApplicationContext contextMock = mock(ApplicationContext.class);
         ObjectMapper mockDefaultObjectMapper = mock(ObjectMapper.class);
+        ObjectMapper mockOwnObjectMapper = mock(ObjectMapper.class);
+        Jackson2ObjectMapperBuilder mockObjectMapperBuilder = mock(Jackson2ObjectMapperBuilder.class);
         JacksonProperties mockJacksonProperties = mock(JacksonProperties.class);
         when(contextMock.getBean(ObjectMapper.class))
                 .thenReturn(mockDefaultObjectMapper);
         when(contextMock.getBean(JacksonProperties.class))
                 .thenReturn(mockJacksonProperties);
+        when(contextMock.getBean(Jackson2ObjectMapperBuilder.class))
+                .thenReturn(mockObjectMapperBuilder);
+        when(mockObjectMapperBuilder.createXmlMapper(false))
+                .thenReturn(mockObjectMapperBuilder);
+        when(mockObjectMapperBuilder.build())
+                .thenReturn(mockOwnObjectMapper);
         when(mockJacksonProperties.getVisibility())
                 .thenReturn(Collections.singletonMap(PropertyAccessor.ALL,
                         JsonAutoDetect.Visibility.PUBLIC_ONLY));
@@ -838,7 +854,10 @@ public class VaadinConnectControllerTest {
                 mock(ServletContext.class));
 
         verify(contextMock, never()).getBean(ObjectMapper.class);
+        verify(contextMock, times(1)).getBean(Jackson2ObjectMapperBuilder.class);
         verify(mockDefaultObjectMapper, never()).setVisibility(
+                PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
+        verify(mockOwnObjectMapper, never()).setVisibility(
                 PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
         verify(contextMock, times(1)).getBean(JacksonProperties.class);
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/rest/BeanWithJacksonAnnotation.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/rest/BeanWithJacksonAnnotation.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.server.connect.rest;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class BeanWithJacksonAnnotation {
+    @JsonProperty("bookId")
+    private String id;
+    private String name;
+
+    @JsonProperty("name")
+    public void setFirstName(String name) {
+        this.name = name;
+    }
+
+    @JsonProperty("name")
+    public String getFirstName() {
+        return name;
+    }
+
+    @JsonProperty
+    public int getRating() {
+        return 2;
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/rest/EndpointWithRestControllerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/rest/EndpointWithRestControllerTest.java
@@ -38,6 +38,7 @@ import com.vaadin.flow.server.connect.ExplicitNullableTypeChecker;
 import com.vaadin.flow.server.connect.VaadinConnectController;
 import com.vaadin.flow.server.connect.auth.VaadinConnectAccessChecker;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
@@ -79,7 +80,7 @@ public class EndpointWithRestControllerTest {
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andReturn().getResponse().getContentAsString();
-        Assert.assertEquals("{\"name\":\"Bond\"}", result);
+        assertEquals("{\"name\":\"Bond\"}", result);
     }
 
     @Test
@@ -87,7 +88,7 @@ public class EndpointWithRestControllerTest {
     public void should_BeAbleToSerializePrivateFieldsOfABean_when_CallingFromConnectEndPoint() {
         try {
             String result = callEndpointMethod("getBeanWithPrivateFields");
-            Assert.assertEquals("{\"codeNumber\":\"007\",\"name\":\"Bond\",\"firstName\":\"James\"}", result);
+            assertEquals("{\"codeNumber\":\"007\",\"name\":\"Bond\",\"firstName\":\"James\"}", result);
         } catch (Exception e) {
             fail("failed to serialize a bean with private fields");
         }
@@ -104,6 +105,24 @@ public class EndpointWithRestControllerTest {
         } catch (Exception e) {
             fail("failed to serialize a bean with ZonedDateTime field");
         }
+    }
+
+    @Test
+    //https://github.com/vaadin/flow/issues/8067
+    public void should_RepsectJacksonAnnotation_when_serializeBean() throws Exception {
+        String result = callEndpointMethod("getBeanWithJacksonAnnotation");
+        assertEquals("{\"name\":null,\"rating\":2,\"bookId\":null}", result);
+    }
+
+    @Test
+    /**
+     * this requires jackson-datatype-jsr310, which is added as a test scope dependency.
+     * jackson-datatype-jsr310 is provided in spring-boot-starter-web, which is part of
+     * vaadin-spring-boot-starter
+     */
+    public void should_serializeLocalTimeInExpectedFormat_when_UsingSpringBoot() throws Exception{
+        String result = callEndpointMethod("getLocalTime");
+        assertEquals("\"08:00:00\"", result);
     }
 
     private String callEndpointMethod(String methodName) throws Exception {

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/rest/VaadinConnectEndpoints.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/rest/VaadinConnectEndpoints.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.server.connect.rest;
 
+import java.time.LocalTime;
 import java.time.ZonedDateTime;
 
 import com.vaadin.flow.server.connect.Endpoint;
@@ -28,6 +29,14 @@ public class VaadinConnectEndpoints {
 
     public BeanWithPrivateFields getBeanWithPrivateFields(){
         return new BeanWithPrivateFields();
+    }
+
+    public BeanWithJacksonAnnotation getBeanWithJacksonAnnotation(){
+        return new BeanWithJacksonAnnotation();
+    }
+
+    public LocalTime getLocalTime(){
+        return LocalTime.of(8, 0, 0);
     }
 
     public static class BeanWithZonedDateTimeField {

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/ArrayConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/ArrayConversionTest.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.server.connect.typeconversion;
 
 import org.junit.Test;
 
-public class ArrayConversionIT extends BaseTypeConversionIT {
+public class ArrayConversionTest extends BaseTypeConversionTest {
 
     @Test
     public void should_ConvertToArrayInt_When_ReceiveArrayInt() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/BaseTypeConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/BaseTypeConversionTest.java
@@ -42,7 +42,7 @@ import static org.mockito.Mockito.mock;
 @RunWith(SpringRunner.class)
 @WebMvcTest
 @Import(VaadinConnectTypeConversionEndpoints.class)
-public abstract class BaseTypeConversionIT {
+public abstract class BaseTypeConversionTest {
 
     private MockMvc mockMvc;
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/BeanConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/BeanConversionTest.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.server.connect.typeconversion;
 
 import org.junit.Test;
 
-public class BeanConversionIT extends BaseTypeConversionIT {
+public class BeanConversionTest extends BaseTypeConversionTest {
 
     @Test
     public void should_ConvertToBean_When_ReceiveBeanObject() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/BooleanConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/BooleanConversionTest.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.server.connect.typeconversion;
 
 import org.junit.Test;
 
-public class BooleanConversionIT extends BaseTypeConversionIT {
+public class BooleanConversionTest extends BaseTypeConversionTest {
     @Test
     public void should_ConvertToBoolean_When_ReceiveTrueOrFalse() {
         assertEqualExpectedValueWhenCallingMethod("revertBoolean", "true",

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/ByteConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/ByteConversionTest.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.server.connect.typeconversion;
 
 import org.junit.Test;
 
-public class ByteConversionIT extends BaseTypeConversionIT {
+public class ByteConversionTest extends BaseTypeConversionTest {
     @Test
     public void should_ConvertNumberToByte_When_ReceiveNumber() {
         assertEqualExpectedValueWhenCallingMethod("addOneByte", "1", "2");

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/CharacterConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/CharacterConversionTest.java
@@ -19,7 +19,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
 
-public class CharacterConversionIT extends BaseTypeConversionIT {
+public class CharacterConversionTest extends BaseTypeConversionTest {
     @Test
     public void should_ConvertToChar_When_ReceiveASingleCharOrNumber()
             throws Exception {

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/CollectionConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/CollectionConversionTest.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.server.connect.typeconversion;
 
 import org.junit.Test;
 
-public class CollectionConversionIT extends BaseTypeConversionIT {
+public class CollectionConversionTest extends BaseTypeConversionTest {
 
     @Test
     public void should_ConvertToIntegerCollection_When_ReceiveNumberArray() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/DateTimeConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/DateTimeConversionTest.java
@@ -15,10 +15,9 @@
  */
 package com.vaadin.flow.server.connect.typeconversion;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
-public class DateTimeConversionIT extends BaseTypeConversionIT {
+public class DateTimeConversionTest extends BaseTypeConversionTest {
 
     // region date tests
     @Test
@@ -58,7 +57,6 @@ public class DateTimeConversionIT extends BaseTypeConversionIT {
     // format
 
     @Test
-    @Ignore("Failing after moved to flow")
     public void should_ConvertToLocalDate_When_ReceiveALocalDate() {
         String inputDate = "\"2019-12-13\"";
         String expectedTimestamp = "\"2019-12-14\"";
@@ -77,7 +75,6 @@ public class DateTimeConversionIT extends BaseTypeConversionIT {
     // LocalDate uses java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME as
     // default format
     @Test
-    @Ignore("Failing after moved to flow")
     public void should_ConvertToLocalDateTime_When_ReceiveALocalDateTime() {
         String inputDate = "\"2019-12-13T12:12:12\"";
         String expectedTimestamp = "\"2019-12-14T13:12:12\"";

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/DoubleConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/DoubleConversionTest.java
@@ -19,7 +19,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
 
-public class DoubleConversionIT extends BaseTypeConversionIT {
+public class DoubleConversionTest extends BaseTypeConversionTest {
     @Test
     public void should_ConvertToDouble_When_ReceiveANumber() {
         assertCallMethodWithExpectedDoubleValue("addOneDouble", "1", "2.0");

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/EnumConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/EnumConversionTest.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.server.connect.typeconversion;
 
 import org.junit.Test;
 
-public class EnumConversionIT extends BaseTypeConversionIT {
+public class EnumConversionTest extends BaseTypeConversionTest {
 
     @Test
     public void should_ConvertToEnum_When_ReceiveStringWithSameName() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/FloatConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/FloatConversionTest.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.server.connect.typeconversion;
 
 import org.junit.Test;
 
-public class FloatConversionIT extends BaseTypeConversionIT {
+public class FloatConversionTest extends BaseTypeConversionTest {
     @Test
     public void should_ConvertToFloat_When_ReceiveANumber() {
         assertEqualExpectedValueWhenCallingMethod("addOneFloat", "1", "2.0");

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/IntegerConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/IntegerConversionTest.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.server.connect.typeconversion;
 
 import org.junit.Test;
 
-public class IntegerConversionIT extends BaseTypeConversionIT {
+public class IntegerConversionTest extends BaseTypeConversionTest {
 
     @Test
     public void should_ConvertNumberToInt_When_ReceiveNumberAsNumber() {
@@ -45,19 +45,18 @@ public class IntegerConversionIT extends BaseTypeConversionIT {
     }
 
     @Test
-    public void should_HandleOverflowInteger_When_ReceiveOverflowNumber() {
+    public void should_FailToConvertOverflowInteger_When_ReceiveOverflowNumber() {
         String overflowInputInteger = "2147483648";
-        assertEqualExpectedValueWhenCallingMethod("addOneInt",
-                overflowInputInteger, String.valueOf(Integer.MIN_VALUE + 1));
-        assertEqualExpectedValueWhenCallingMethod("addOneIntBoxed",
-                overflowInputInteger, String.valueOf(Integer.MIN_VALUE + 1));
+        assert400ResponseWhenCallingMethod("addOneInt",
+                overflowInputInteger);
+        assert400ResponseWhenCallingMethod("addOneIntBoxed",
+                overflowInputInteger);
 
         String underflowInputInteger = "-2147483649";
         // underflow will become MAX, then +1 in the method => MIN
-        assertEqualExpectedValueWhenCallingMethod("addOneInt",
-                underflowInputInteger, String.valueOf(Integer.MIN_VALUE));
-        assertEqualExpectedValueWhenCallingMethod("addOneIntBoxed",
-                underflowInputInteger, String.valueOf(Integer.MIN_VALUE));
+        assert400ResponseWhenCallingMethod("addOneInt", underflowInputInteger);
+        assert400ResponseWhenCallingMethod("addOneIntBoxed",
+                underflowInputInteger);
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/LongConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/LongConversionTest.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.server.connect.typeconversion;
 
 import org.junit.Test;
 
-public class LongConversionIT extends BaseTypeConversionIT {
+public class LongConversionTest extends BaseTypeConversionTest {
 
     @Test
     public void should_ConvertToLong_When_ReceiveANumber() {
@@ -78,18 +78,14 @@ public class LongConversionIT extends BaseTypeConversionIT {
     }
 
     @Test
-    public void should_HandleOverflowLong_When_ReceiveANumberOverflowOrUnderflow() {
+    public void should_FailToConvertToLong_When_ReceiveANumberOverflowOrUnderflow() {
         String overflowLong = "9223372036854775808"; // 2^63
-        assertEqualExpectedValueWhenCallingMethod("addOneLong", overflowLong,
-                String.valueOf(Long.MIN_VALUE + 1));
-        assertEqualExpectedValueWhenCallingMethod("addOneLongBoxed",
-                overflowLong, String.valueOf(Long.MIN_VALUE + 1));
+        assert400ResponseWhenCallingMethod("addOneLong", overflowLong);
+        assert400ResponseWhenCallingMethod("addOneLongBoxed", overflowLong);
 
         String underflowLong = "-9223372036854775809"; // -2^63-1
-        assertEqualExpectedValueWhenCallingMethod("addOneLong", underflowLong,
-                String.valueOf(Long.MIN_VALUE));
-        assertEqualExpectedValueWhenCallingMethod("addOneLongBoxed",
-                underflowLong, String.valueOf(Long.MIN_VALUE));
+        assert400ResponseWhenCallingMethod("addOneLong", underflowLong);
+        assert400ResponseWhenCallingMethod("addOneLongBoxed", underflowLong);
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/MapConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/MapConversionTest.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.server.connect.typeconversion;
 
 import org.junit.Test;
 
-public class MapConversionIT extends BaseTypeConversionIT {
+public class MapConversionTest extends BaseTypeConversionTest {
 
     @Test
     public void should_ConvertToMapOfString_When_ReceiveMapOfString() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/ShortConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/ShortConversionTest.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.server.connect.typeconversion;
 
 import org.junit.Test;
 
-public class ShortConversionIT extends BaseTypeConversionIT {
+public class ShortConversionTest extends BaseTypeConversionTest {
     @Test
     public void should_ConvertToShort_When_ReceiveANumber() {
         assertEqualExpectedValueWhenCallingMethod("addOneShort", "1", "2");

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/StringConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/StringConversionTest.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.server.connect.typeconversion;
 
 import org.junit.Test;
 
-public class StringConversionIT extends BaseTypeConversionIT {
+public class StringConversionTest extends BaseTypeConversionTest {
 
     @Test
     public void should_ConvertToString_When_ReceiveAString() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -32,8 +32,8 @@ import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 
 import elemental.json.Json;
 import elemental.json.JsonObject;
-
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
+import static elemental.json.impl.JsonUtil.stringify;
 
 public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
 
@@ -61,14 +61,32 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
 
         // Write package json file: dialog doesn't pin its Overlay version which
         // is transitive dependency.
+        // @formatter:off
         FileUtils.write(packageJson,
-                "{\"dependencies\": {"
-                        + "\"@vaadin/vaadin-dialog\": \"2.2.1\"}}",
+                "{"
+                       + "\"vaadin\": {"
+                         + "\"dependencies\": {"
+                           + "\"@vaadin/vaadin-dialog\": \"2.2.1\""
+                         + "}"
+                       + "},"
+                       + "\"dependencies\": {"
+                         + "\"@vaadin/vaadin-dialog\": \"2.2.1\""
+                       + "}"
+                     + "}",
                 StandardCharsets.UTF_8);
+        // @formatter:on
 
         // Platform defines a pinned version
-        TaskRunNpmInstall task = createTask(
-                "{ \"@vaadin/vaadin-overlay\":\"" + PINNED_VERSION + "\"}");
+        // @formatter:off
+        TaskRunNpmInstall task = createTask(String.format(
+                "{"
+                  + "\"vaadin-overlay\": {"
+                    + "\"npmName\": \"@vaadin/vaadin-overlay\","
+                    + "\"jsVersion\": \"%s\""
+                  + "}"
+                + "}", PINNED_VERSION));
+        // @formatter:on
+
         task.execute();
 
         File overlayPackageJson = new File(getNodeUpdater().nodeModulesFolder,
@@ -80,6 +98,186 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
                 .readFileToString(overlayPackageJson, StandardCharsets.UTF_8));
         Assert.assertEquals(PINNED_VERSION,
                 overlayPackage.getString("version"));
+    }
+
+    @Test
+    public void runPnpmInstall_userVersionNewerThanPinned_installedOverlayVersionIsNotSpecifiedByPlatform()
+            throws IOException, ExecutionFailedException {
+        File packageJson = new File(getNodeUpdater().npmFolder, PACKAGE_JSON);
+        packageJson.createNewFile();
+
+        // Write package json file
+        final String customOverlayVersion = "3.3.0";
+        // @formatter:off
+        FileUtils.write(packageJson,
+                "{"
+                        + "\"vaadin\": {"
+                          + "\"dependencies\": {"
+                            + "\"@vaadin/vaadin-dialog\": \"2.3.0\","
+                            + "\"@vaadin/vaadin-overlay\": \"" + PINNED_VERSION + "\""
+                          + "}"
+                        + "},"
+                        + "\"dependencies\": {"
+                          + "\"@vaadin/vaadin-dialog\": \"2.3.0\","
+                          + "\"@vaadin/vaadin-overlay\": \"" + customOverlayVersion + "\""
+                        + "}"
+                     + "}",
+                StandardCharsets.UTF_8);
+        // @formatter:on
+
+        // Platform defines a pinned version
+        // @formatter:off
+        TaskRunNpmInstall task = createTask(String.format(
+                "{"
+                  + "\"vaadin-overlay\": {"
+                    + "\"npmName\": \"@vaadin/vaadin-overlay\","
+                    + "\"jsVersion\": \"%s\""
+                  + "}"
+                + "}", PINNED_VERSION));
+        // @formatter:on
+
+        task.execute();
+
+        File overlayPackageJson = new File(getNodeUpdater().nodeModulesFolder,
+                "@vaadin/vaadin-overlay/package.json");
+
+        // The resulting version should be the user specified version
+        JsonObject overlayPackage = Json.parse(FileUtils
+                .readFileToString(overlayPackageJson, StandardCharsets.UTF_8));
+        Assert.assertEquals(customOverlayVersion,
+                overlayPackage.getString("version"));
+    }
+
+    @Test
+    public void runPnpmInstall_userVersionOlderThanPinned_installedOverlayVersionIsNotSpecifiedByPlatform()
+            throws IOException, ExecutionFailedException {
+        File packageJson = new File(getNodeUpdater().npmFolder, PACKAGE_JSON);
+        packageJson.createNewFile();
+
+        // Write package json file
+        final String customOverlayVersion = "3.1.0";
+
+        // @formatter:off
+        FileUtils.write(packageJson,
+                "{"
+                        + "\"vaadin\": {"
+                        + "\"dependencies\": {"
+                        + "\"@vaadin/vaadin-dialog\": \"2.3.0\","
+                        + "\"@vaadin/vaadin-overlay\": \"" + PINNED_VERSION + "\""
+                        + "}"
+                        + "},"
+                        + "\"dependencies\": {"
+                        + "\"@vaadin/vaadin-dialog\": \"2.3.0\","
+                        + "\"@vaadin/vaadin-overlay\": \"" + customOverlayVersion + "\""
+                        + "}"
+                        + "}",
+                StandardCharsets.UTF_8);
+        // @formatter:on
+
+        // Platform defines a pinned version
+        // @formatter:off
+        TaskRunNpmInstall task = createTask(String.format(
+                "{"
+                        + "\"vaadin-overlay\": {"
+                        + "\"npmName\": \"@vaadin/vaadin-overlay\","
+                        + "\"jsVersion\": \"%s\""
+                        + "}"
+                        + "}", PINNED_VERSION));
+        // @formatter:on
+        task.execute();
+
+        File overlayPackageJson = new File(getNodeUpdater().nodeModulesFolder,
+                "@vaadin/vaadin-overlay/package.json");
+
+        // The resulting version should be the user specified version
+        JsonObject overlayPackage = Json.parse(FileUtils
+                .readFileToString(overlayPackageJson, StandardCharsets.UTF_8));
+        Assert.assertEquals(customOverlayVersion,
+                overlayPackage.getString("version"));
+    }
+
+    @Test
+    public void runPnpmInstall_userDefinedVersions_versionOnlyUpdatedForNotAddedDependencies()
+            throws IOException, ExecutionFailedException {
+        File packageJson = new File(getNodeUpdater().npmFolder, PACKAGE_JSON);
+        packageJson.createNewFile();
+
+        // Write package json file
+        String loginVersion = "1.1.0-alpha1";
+        String menuVersion = "1.1.0-alpha2";
+        String notificationVersion = "1.4.0";
+        String uploadVersion = "4.2.0";
+        // @formatter:off
+        FileUtils.write(packageJson, String.format(
+                "{"
+                    + "\"vaadin\": {"
+                      + "\"dependencies\": {"
+                        + "\"@vaadin/vaadin-login\": \"%s\","
+                        + "\"@vaadin/vaadin-menu-bar\": \"%s\","
+                        + "\"@vaadin/vaadin-notification\": \"%s\","
+                        + "\"@vaadin/vaadin-upload\": \"%s\""
+                      + "}"
+                    + "},"
+                    + "\"dependencies\": {"
+                      + "\"@vaadin/vaadin-login\": \"%s\","
+                      + "\"@vaadin/vaadin-menu-bar\": \"%s\","
+                      + "\"@vaadin/vaadin-notification\": \"%s\","
+                      + "\"@vaadin/vaadin-upload\": \"%s\""
+                    + "}"
+                + "}",
+                loginVersion, "1.0.0", notificationVersion,
+                "4.0.0", loginVersion, menuVersion, notificationVersion,
+                uploadVersion), StandardCharsets.UTF_8);
+        // @formatter:on
+        // Platform defines a pinned version
+
+        String versionsLoginVersion = "1.1.0-alpha1";
+        String versionsMenuBarVersion = "1.1.0-alpha1";
+        String versionsNotificationVersion = "1.5.0-alpha1";
+        String versionsUploadVersion = "4.2.0-beta2";
+
+        // @formatter:off
+        TaskRunNpmInstall task = createTask(String.format(
+                "{"
+                    + "\"vaadin-login\": {"
+                        + "\"npmName\": \"@vaadin/vaadin-login\","
+                        + "\"jsVersion\": \"%s\""
+                    + "},"
+                    + "\"vaadin-menu-bar\": {"
+                        + "\"npmName\": \"@vaadin/vaadin-menu-bar\","
+                        + "\"jsVersion\": \"%s\""
+                    + "},"
+                    + "\"vaadin-notification\": {"
+                        + "\"npmName\": \"@vaadin/vaadin-notification\","
+                        + "\"jsVersion\": \"%s\""
+                    + "},"
+                    + "\"vaadin-upload\": {"
+                        + "\"npmName\": \"@vaadin/vaadin-upload\","
+                        + "\"jsVersion\": \"%s\""
+                    + "}"
+                + "}",
+                versionsLoginVersion, versionsMenuBarVersion,
+                versionsNotificationVersion, versionsUploadVersion));
+        // @formatter:on
+        task.execute();
+
+        verifyVersion("Login version is the same for user and platform.",
+                "vaadin-login", loginVersion);
+        verifyVersion("Menu Bar should use user defined version.",
+                "vaadin-menu-bar", menuVersion);
+        verifyVersion("Notification should use platform version.",
+                "vaadin-notification", versionsNotificationVersion);
+        verifyVersion("Upload should use user defined release version.",
+                "vaadin-upload", uploadVersion);
+    }
+
+    private void verifyVersion(String assertMessage, String packageName, String expectedVersion)
+            throws IOException {
+        File uploadJson = new File(getNodeUpdater().nodeModulesFolder,
+                String.format("@vaadin/%s/package.json", packageName));
+        final JsonObject json = Json.parse(FileUtils
+                .readFileToString(uploadJson, StandardCharsets.UTF_8));
+        Assert.assertEquals(assertMessage, expectedVersion, json.getString("version"));
     }
 
     @Override
@@ -184,10 +382,14 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
             @Override
             protected String generateVersionsJson() {
                 try {
+                    VersionsJsonConverter convert = new VersionsJsonConverter(
+                            Json.parse(versionsContent),
+                            getNodeUpdater().getPackageJson());
+
                     FileUtils.write(
                             new File(getNodeUpdater().npmFolder,
                                     "versions.json"),
-                            versionsContent, StandardCharsets.UTF_8);
+                            stringify(convert.getManagedVersions(), 2), StandardCharsets.UTF_8);
                 } catch (IOException e) {
                     throw new RuntimeException(e);
                 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/VersionsJsonConverterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/VersionsJsonConverterTest.java
@@ -16,7 +16,15 @@
 package com.vaadin.flow.server.frontend;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
+import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -32,46 +40,101 @@ public class VersionsJsonConverterTest {
 
     @Test
     public void convertPlatformVersions() throws IOException {
-        // @formatter:off
-        String json = "{\"core\": {"+
-                            "\"flow\": { "
-                            + " \"javaVersion\": \"3.0.0.alpha17\""
-                            + "}, "
-                        + " \"vaadin-progress-bar\": { "
-                            + " \"npmName\": \"@vaadin/vaadin-progress-bar\", "
-                            + "\"jsVersion\": \"1.1.2\" "
-                          + "},"
-                       + "},"  //core
-                + "\"vaadin-upload\": { "
-                    + "\"npmName\": \"@vaadin/vaadin-upload\", "
-                    + "\"jsVersion\": \"4.2.2\""
-                  + "},"+
-                    "\"iron-list\": {\n" +
-                    "            \"npmName\": \"@polymer/iron-list\",\n" +
-                    "            \"npmVersion\": \"3.0.2\",\n" +
-                    "            \"javaVersion\": \"3.0.0.beta1\",\n" +
-                    "            \"jsVersion\": \"2.0.19\"\n" +
-                    "        },"
-                    +"\"platform\": \"foo\""
-                + "}";
-        // @formatter:on
+        String versions = IOUtils.toString(getClass().getClassLoader()
+                        .getResourceAsStream("versions/versions.json"),
+                StandardCharsets.UTF_8);
+        String pkgJson = IOUtils.toString(getClass().getClassLoader()
+                        .getResourceAsStream("versions/package.json"),
+                StandardCharsets.UTF_8);
 
         VersionsJsonConverter convert = new VersionsJsonConverter(
-                Json.parse(json));
-        JsonObject conertedJson = convert.convert();
-        Assert.assertTrue(conertedJson.hasKey("@vaadin/vaadin-progress-bar"));
-        Assert.assertTrue(conertedJson.hasKey("@vaadin/vaadin-upload"));
-        Assert.assertTrue(conertedJson.hasKey("@polymer/iron-list"));
+                Json.parse(versions), Json.parse(pkgJson));
+        JsonObject convertedJson = convert.getManagedVersions();
+        Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-progress-bar"));
+        Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-upload"));
+        Assert.assertTrue(convertedJson.hasKey("@polymer/iron-list"));
 
-        Assert.assertFalse(conertedJson.hasKey("flow"));
-        Assert.assertFalse(conertedJson.hasKey("core"));
-        Assert.assertFalse(conertedJson.hasKey("platform"));
+        Assert.assertFalse(convertedJson.hasKey("flow"));
+        Assert.assertFalse(convertedJson.hasKey("core"));
+        Assert.assertFalse(convertedJson.hasKey("platform"));
 
         Assert.assertEquals("1.1.2",
-                conertedJson.getString("@vaadin/vaadin-progress-bar"));
+                convertedJson.getString("@vaadin/vaadin-progress-bar"));
         Assert.assertEquals("4.2.2",
-                conertedJson.getString("@vaadin/vaadin-upload"));
+                convertedJson.getString("@vaadin/vaadin-upload"));
         Assert.assertEquals("3.0.2",
-                conertedJson.getString("@polymer/iron-list"));
+                convertedJson.getString("@polymer/iron-list"));
+    }
+
+    @Test
+    public void convertPlatformVersions_multipleUserChanged_correctlyIgnored() throws IOException {
+        String versions = IOUtils.toString(getClass().getClassLoader()
+                        .getResourceAsStream("versions/user_versions.json"),
+                StandardCharsets.UTF_8);
+        String pkgJson = IOUtils.toString(getClass().getClassLoader()
+                        .getResourceAsStream("versions/user_package.json"),
+                StandardCharsets.UTF_8);
+
+        VersionsJsonConverter convert = new VersionsJsonConverter(
+                Json.parse(versions), Json.parse(pkgJson));
+        JsonObject convertedJson = convert.getManagedVersions();
+        List<String> expectedKeys = Arrays.asList("@vaadin/vaadin-notification",
+                "@vaadin/vaadin-overlay",
+                "@vaadin/vaadin-select",
+                "@vaadin/vaadin-split-layout",
+                "@vaadin/vaadin-tabs");
+
+        for(String key : expectedKeys) {
+            Assert.assertTrue(String.format("Key '%s' was expected, but not found", key), convertedJson.hasKey(key));
+        }
+
+        List<String> droppedKeys = Arrays.asList("flow",
+                "core",
+                "platform",
+                "@vaadin/vaadin-ordered-layout",
+                "@vaadin/vaadin-progress-bar",
+                "@vaadin/vaadin-radio-button",
+                "@vaadin/vaadin-confirm-dialog"
+                );
+        for(String key : droppedKeys) {
+            Assert.assertFalse(String.format("User managed key '%s' was found.", key), convertedJson.hasKey(key));
+        }
+
+        Map<String, String> expectedValues = new HashMap<>();
+        expectedValues.put("@vaadin/vaadin-notification", "1.4.0");
+        expectedValues.put("@vaadin/vaadin-overlay", "3.2.19");
+        expectedValues.put("@vaadin/vaadin-select", "2.1.7");
+        expectedValues.put("@vaadin/vaadin-split-layout", "4.1.1");
+        expectedValues.put("@vaadin/vaadin-tabs", "3.0.5");
+
+        for (Map.Entry<String, String> entry : expectedValues.entrySet()) {
+            Assert.assertEquals(
+                    String.format("Got wrong version for '%s'", entry.getKey()),
+                    entry.getValue(), convertedJson.getString(entry.getKey()));
+        }
+    }
+
+    @Test
+    public void missingVaadinDependencies_allDependenciesSholdBeUserHandled() throws IOException {
+        String versions = IOUtils.toString(getClass().getClassLoader()
+                        .getResourceAsStream("versions/versions.json"),
+                StandardCharsets.UTF_8);
+        String pkgJson = IOUtils.toString(getClass().getClassLoader()
+                        .getResourceAsStream("versions/no_vaadin_package.json"),
+                StandardCharsets.UTF_8);
+
+        VersionsJsonConverter convert = new VersionsJsonConverter(
+                Json.parse(versions), Json.parse(pkgJson));
+        JsonObject convertedJson = convert.getManagedVersions();
+        Assert.assertTrue(convertedJson.hasKey("@vaadin/vaadin-progress-bar"));
+        Assert.assertFalse(convertedJson.hasKey("@vaadin/vaadin-upload"));
+        Assert.assertFalse(convertedJson.hasKey("@polymer/iron-list"));
+
+        Assert.assertFalse(convertedJson.hasKey("flow"));
+        Assert.assertFalse(convertedJson.hasKey("core"));
+        Assert.assertFalse(convertedJson.hasKey("platform"));
+
+        Assert.assertEquals("1.1.2",
+                convertedJson.getString("@vaadin/vaadin-progress-bar"));
     }
 }

--- a/flow-server/src/test/resources/versions/no_vaadin_package.json
+++ b/flow-server/src/test/resources/versions/no_vaadin_package.json
@@ -1,0 +1,8 @@
+{
+  "name": "no-name",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "@polymer/iron-list": "3.0.0",
+    "@vaadin/vaadin-upload": "4.2.0"
+  }
+}

--- a/flow-server/src/test/resources/versions/package.json
+++ b/flow-server/src/test/resources/versions/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "no-name",
+  "license": "UNLICENSED",
+  "vaadin": {
+    "dependencies": {
+      "@vaadin/vaadin-upload": "4.2.2",
+      "@vaadin/vaadin-progress-bar": "1.1.2",
+      "@polymer/iron-list": "3.0.2"
+    },
+    "hash": ""
+  },
+  "dependencies": {
+    "@polymer/iron-list": "3.0.2",
+    "@vaadin/vaadin-progress-bar": "1.1.2",
+    "@vaadin/vaadin-upload": "4.2.2"
+  }
+}

--- a/flow-server/src/test/resources/versions/user_package.json
+++ b/flow-server/src/test/resources/versions/user_package.json
@@ -1,0 +1,29 @@
+{
+  "name": "no-name",
+  "license": "UNLICENSED",
+  "vaadin": {
+    "dependencies": {
+      "@vaadin/vaadin-notification": "1.4.0",
+      "@vaadin/vaadin-ordered-layout": "1.1.0",
+      "@vaadin/vaadin-overlay": "3.2.10",
+      "@vaadin/vaadin-progress-bar": "1.1.2",
+      "@vaadin/vaadin-radio-button": "1.2.6",
+      "@vaadin/vaadin-select": "2.1.2",
+      "@vaadin/vaadin-split-layout": "4.1.0",
+      "@vaadin/vaadin-tabs": "3.0.2"
+    },
+    "hash": ""
+  },
+  "dependencies": {
+    "@vaadin/vaadin-notification": "1.4.0",
+    "@vaadin/vaadin-overlay": "3.2.10",
+    "@vaadin/vaadin-select": "2.1.2",
+    "@vaadin/vaadin-split-layout": "4.1.0",
+    "@vaadin/vaadin-tabs": "3.0.2",
+
+    "@vaadin/vaadin-ordered-layout": "2.0.0",
+    "@vaadin/vaadin-progress-bar": "2.0.0",
+    "@vaadin/vaadin-radio-button": "2.0.0",
+    "@vaadin/vaadin-confirm-dialog":"1.1.4"
+  }
+}

--- a/flow-server/src/test/resources/versions/user_versions.json
+++ b/flow-server/src/test/resources/versions/user_versions.json
@@ -1,0 +1,73 @@
+{
+  "core": {
+    "flow": {
+      "javaVersion": "3.0.0.alpha17"
+    },
+    "vaadin-notification": {
+      "component": true,
+      "javaVersion": "2.0.0",
+      "jsVersion": "1.4.0",
+      "npmName": "@vaadin/vaadin-notification"
+    },
+    "vaadin-ordered-layout": {
+      "component": true,
+      "components": [
+        "Horizontal Layout",
+        "Vertical Layout",
+        "Flex Layout"
+      ],
+      "javaVersion": "2.0.0",
+      "jsVersion": "1.1.0",
+      "npmName": "@vaadin/vaadin-ordered-layout"
+    },
+    "vaadin-overlay": {
+      "jsVersion": "3.2.19",
+      "npmName": "@vaadin/vaadin-overlay",
+      "releasenotes": true
+    },
+    "vaadin-progress-bar": {
+      "component": true,
+      "javaVersion": "2.0.2",
+      "jsVersion": "1.1.2",
+      "npmName": "@vaadin/vaadin-progress-bar"
+    },
+    "vaadin-radio-button": {
+      "component": true,
+      "components": [
+        "Radio Button",
+        "Radio Button Group"
+      ],
+      "javaVersion": "2.0.4",
+      "jsVersion": "1.2.6",
+      "npmName": "@vaadin/vaadin-radio-button"
+    },
+    "vaadin-select": {
+      "component": true,
+      "javaVersion": "2.0.3",
+      "jsVersion": "2.1.7",
+      "npmName": "@vaadin/vaadin-select"
+    },
+    "vaadin-split-layout": {
+      "component": true,
+      "javaVersion": "2.0.3",
+      "jsVersion": "4.1.1",
+      "npmName": "@vaadin/vaadin-split-layout"
+    },
+    "vaadin-tabs": {
+      "component": true,
+      "javaVersion": "2.0.4",
+      "jsVersion": "3.0.5",
+      "npmName": "@vaadin/vaadin-tabs"
+    }
+  },
+  "platform": "foo",
+  "vaadin": {
+    "vaadin-confirm-dialog": {
+      "component": true,
+      "javaVersion": "2.0.3",
+      "jsVersion": "1.1.6",
+      "npmName": "@vaadin/vaadin-confirm-dialog",
+      "pro": true
+    }
+  }
+}

--- a/flow-server/src/test/resources/versions/versions.json
+++ b/flow-server/src/test/resources/versions/versions.json
@@ -1,0 +1,22 @@
+{
+  "core": {
+    "flow": {
+      "javaVersion": "3.0.0.alpha17"
+    },
+    "vaadin-progress-bar": {
+      "npmName": "@vaadin/vaadin-progress-bar",
+      "jsVersion": "1.1.2"
+    }
+  },
+  "vaadin-upload": {
+    "npmName": "@vaadin/vaadin-upload",
+    "jsVersion": "4.2.2"
+  },
+  "iron-list": {
+    "npmName": "@polymer/iron-list",
+    "npmVersion": "3.0.2",
+    "javaVersion": "3.0.0.beta1",
+    "jsVersion": "2.0.19"
+  },
+  "platform": "foo"
+}


### PR DESCRIPTION
1. Use Jackson2ObjectMapperBuilder from Spring application context to build a Jackson2ObjectMapper
2. Add jackson-datatype-jsr310 to ensure data format
3. Enable ignored tests
4. Add test for LocalTime format

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8098)
<!-- Reviewable:end -->
