### PR TITLE
Fix vfs resource test

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
@@ -155,9 +155,7 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
     @Test
     public void loadingFsResources_usesVfsProtocol_allFilesExist()
             throws Exception {
-        String path = Paths
-                .get("/dir-with-modern-frontend", RESOURCES_FRONTEND_DEFAULT)
-                .toString();
+        String path = "/dir-with-modern-frontend/" + RESOURCES_FRONTEND_DEFAULT;
         MockVirtualFile virtualFile = new MockVirtualFile();
         virtualFile.file = new File(getClass().getResource(path).toURI());
 
@@ -175,8 +173,7 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
             }
             return null;
         });
-        URL url = new URL(
-                Paths.get("vfs://some-non-existent-place", path).toString());
+        URL url = new URL("vfs://some-non-existent-place" + path);
 
         loadingFsResources_allFilesExist(Collections.singletonList(url),
                 RESOURCES_FRONTEND_DEFAULT);


### PR DESCRIPTION
Fixes the loadingFsResources_usesVfsProtocol_allFilesExist
on windows as Paths.get() uses wrong separator
that doesn't work with URLs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8117)
<!-- Reviewable:end -->
