### PR TITLE
Manage flow-jrebel-plugin version under flow-bom

### DIFF
--- a/flow-bom/pom.xml
+++ b/flow-bom/pom.xml
@@ -58,6 +58,11 @@
                 <artifactId>vaadin-material-theme</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.vaadin</groupId>
+                <artifactId>vaadin-jrebel-plugin</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>


### PR DESCRIPTION
To be able to depend on `flow-jrebel-plugin` of correct version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8123)
<!-- Reviewable:end -->
