### PR TITLE
Push browser history state after postponed navigation proceeds

### DIFF
--- a/flow-client/pom.xml
+++ b/flow-client/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>com.vaadin</groupId>
@@ -15,7 +15,7 @@
     <properties>
         <gwt.module>com.vaadin.ClientEngine</gwt.module>
         <gwt.module.output>${project.build.outputDirectory}/META-INF/resources/VAADIN/static/</gwt.module.output>
-        <gwt.module.style>DETAILED</gwt.module.style>
+        <gwt.module.style>OBF</gwt.module.style>
         <gwt.sdm.bindAddress>0.0.0.0</gwt.sdm.bindAddress>
     </properties>
 
@@ -187,7 +187,7 @@
                     <style>${gwt.module.style}</style>
                     <htmlunit>FF38</htmlunit>
                     <testTimeOut>300</testTimeOut>
-                    <extraJvmArgs>-Xmx512m -Dvaadin.enableDevServer=true</extraJvmArgs>
+                    <extraJvmArgs>-Xmx512m -Dvaadin.enableDevServer=false</extraJvmArgs>
                 </configuration>
             </plugin>
 

--- a/flow-client/pom.xml
+++ b/flow-client/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <gwt.module>com.vaadin.ClientEngine</gwt.module>
         <gwt.module.output>${project.build.outputDirectory}/META-INF/resources/VAADIN/static/</gwt.module.output>
-        <gwt.module.style>OBF</gwt.module.style>
+        <gwt.module.style>DETAILED</gwt.module.style>
         <gwt.sdm.bindAddress>0.0.0.0</gwt.sdm.bindAddress>
     </properties>
 
@@ -187,7 +187,7 @@
                     <style>${gwt.module.style}</style>
                     <htmlunit>FF38</htmlunit>
                     <testTimeOut>300</testTimeOut>
-                    <extraJvmArgs>-Xmx512m -Dvaadin.enableDevServer=false</extraJvmArgs>
+                    <extraJvmArgs>-Xmx512m -Dvaadin.enableDevServer=true</extraJvmArgs>
                 </configuration>
             </plugin>
 

--- a/flow-client/src/main/java/com/vaadin/client/DefaultRegistry.java
+++ b/flow-client/src/main/java/com/vaadin/client/DefaultRegistry.java
@@ -66,7 +66,7 @@ public class DefaultRegistry extends Registry {
         }
 
         @Override
-        public void afterNavigation(JsonObject state) {
+        public void afterServerNavigation(JsonObject state) {
             // don't do anything
         }
     }

--- a/flow-client/src/main/java/com/vaadin/client/DefaultRegistry.java
+++ b/flow-client/src/main/java/com/vaadin/client/DefaultRegistry.java
@@ -32,6 +32,7 @@ import com.vaadin.client.flow.ExecuteJavaScriptProcessor;
 import com.vaadin.client.flow.StateTree;
 
 import elemental.events.PopStateEvent;
+import elemental.json.JsonObject;
 
 /**
  * A registry implementation used by {@link ApplicationConnection}.
@@ -60,11 +61,14 @@ public class DefaultRegistry extends Registry {
         }
 
         @Override
-        public void beforeNavigation(String newHref,
-                boolean triggersServerSideRoundtrip) {
+        public void beforeClientNavigation(String newHref) {
             // don't do anything
         }
 
+        @Override
+        public void afterNavigation(JsonObject state) {
+            // don't do anything
+        }
     }
 
     /**

--- a/flow-client/src/main/java/com/vaadin/client/ExecuteJavaScriptElementUtils.java
+++ b/flow-client/src/main/java/com/vaadin/client/ExecuteJavaScriptElementUtils.java
@@ -196,7 +196,7 @@ public final class ExecuteJavaScriptElementUtils {
     }
 
     /**
-     * Invoke {@link ScrollPositionHandler#afterNavigation(JsonObject)}.
+     * Invoke {@link ScrollPositionHandler#afterServerNavigation(JsonObject)}.
      * 
      * @param registry
      *            the registry
@@ -205,9 +205,9 @@ public final class ExecuteJavaScriptElementUtils {
      *            href of the router link that was clicked and caused this
      *            navigation
      */
-    public static void scrollPositionHandlerAfterNavigation(Registry registry,
-            JsonObject state) {
-        registry.getScrollPositionHandler().afterNavigation(state);
+    public static void scrollPositionHandlerAfterServerNavigation(
+            Registry registry, JsonObject state) {
+        registry.getScrollPositionHandler().afterServerNavigation(state);
     }
 
     private static native boolean isPropertyDefined(Node node, String property)

--- a/flow-client/src/main/java/com/vaadin/client/ExecuteJavaScriptElementUtils.java
+++ b/flow-client/src/main/java/com/vaadin/client/ExecuteJavaScriptElementUtils.java
@@ -28,6 +28,7 @@ import com.vaadin.flow.internal.nodefeature.NodeFeatures;
 
 import elemental.dom.Element;
 import elemental.dom.Node;
+import elemental.json.JsonObject;
 
 /**
  * Utility class which handles javascript execution context (see
@@ -192,6 +193,21 @@ public final class ExecuteJavaScriptElementUtils {
             return fromMap;
         }
         return existingId;
+    }
+
+    /**
+     * Invoke {@link ScrollPositionHandler#afterNavigation(JsonObject)}.
+     * 
+     * @param registry
+     *            the registry
+     * @param state
+     *            includes scroll position of the previous page and the complete
+     *            href of the router link that was clicked and caused this
+     *            navigation
+     */
+    public static void scrollPositionHandlerAfterNavigation(Registry registry,
+            JsonObject state) {
+        registry.getScrollPositionHandler().afterNavigation(state);
     }
 
     private static native boolean isPropertyDefined(Node node, String property)

--- a/flow-client/src/main/java/com/vaadin/client/ScrollPositionHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/ScrollPositionHandler.java
@@ -288,7 +288,7 @@ public class ScrollPositionHandler {
         // move to page top only if there is no fragment so scroll position
         // doesn't bounce around
         if (!newHref.contains("#")) {
-            setScrollPosition(new double[] { 0, 0 });
+            resetScroll();
         }
 
         currentHistoryIndex++;
@@ -320,15 +320,15 @@ public class ScrollPositionHandler {
 
     /**
      * Store scroll positions when there has been navigation triggered by a
-     * click on a link element and a server round-trip is needed. This method is
-     * called after server-side part is done.
+     * click on a link element and a server round-trip was needed. This method
+     * is called after server-side part is done.
      *
      * @param state
      *            includes scroll position of the previous page and the complete
      *            href of the router link that was clicked and caused this
      *            navigation
      */
-    public void afterNavigation(JsonObject state) {
+    public void afterServerNavigation(JsonObject state) {
         if (!state.hasKey("scrollPositionX") || !state.hasKey("scrollPositionY")
                 || !state.hasKey("href"))
             throw new IllegalStateException(
@@ -408,6 +408,11 @@ public class ScrollPositionHandler {
        }
     }-*/;
 
+    /**
+     * Gets the scroll position of the page as an array.
+     * 
+     * @return an array containing scroll position x (left) and y (top) in order
+     */
     public static native double[] getScrollPosition()
     /*-{
         if ($wnd.Vaadin.Flow.getScrollPosition) {

--- a/flow-client/src/main/java/com/vaadin/client/flow/ExecuteJavaScriptProcessor.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/ExecuteJavaScriptProcessor.java
@@ -34,8 +34,7 @@ import elemental.json.JsonValue;
 
 /**
  * Processes the result of
- * {@link Page#executeJs(String, java.io.Serializable...)} on the
- * client.
+ * {@link Page#executeJs(String, java.io.Serializable...)} on the client.
  *
  * @author Vaadin Ltd
  * @since 1.0
@@ -208,6 +207,7 @@ public class ExecuteJavaScriptProcessor {
               return node;
           };
           object.$appId = this.@ExecuteJavaScriptProcessor::getAppId()().replace(/-\d+$/, '');
+          object.registry = this.@ExecuteJavaScriptProcessor::registry;
           object.attachExistingElement = function(parent, previousSibling, tagName, id){
               @com.vaadin.client.ExecuteJavaScriptElementUtils::attachExistingElement(*)(object.getNode(parent), previousSibling, tagName, id);
           };
@@ -217,6 +217,9 @@ public class ExecuteJavaScriptProcessor {
           object.registerUpdatableModelProperties = function(element, properties){
               @com.vaadin.client.ExecuteJavaScriptElementUtils::registerUpdatableModelProperties(*)(object.getNode(element), properties);
           };
-          return object;
+          object.scorllPositionHandlerBeforeNavigation = function(state) {
+              @com.vaadin.client.ExecuteJavaScriptElementUtils::scrollPositionHandlerAfterNavigation(*)(object.registry, state);
+          }
+        return object;
     }-*/;
 }

--- a/flow-client/src/main/java/com/vaadin/client/flow/ExecuteJavaScriptProcessor.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/ExecuteJavaScriptProcessor.java
@@ -217,8 +217,8 @@ public class ExecuteJavaScriptProcessor {
           object.registerUpdatableModelProperties = function(element, properties){
               @com.vaadin.client.ExecuteJavaScriptElementUtils::registerUpdatableModelProperties(*)(object.getNode(element), properties);
           };
-          object.scorllPositionHandlerBeforeNavigation = function(state) {
-              @com.vaadin.client.ExecuteJavaScriptElementUtils::scrollPositionHandlerAfterNavigation(*)(object.registry, state);
+          object.scrollPositionHandlerAfterServerNavigation = function(state) {
+              @com.vaadin.client.ExecuteJavaScriptElementUtils::scrollPositionHandlerAfterServerNavigation(*)(object.registry, state);
           }
         return object;
     }-*/;

--- a/flow-client/src/main/java/com/vaadin/client/flow/RouterLinkHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/RouterLinkHandler.java
@@ -18,6 +18,7 @@ package com.vaadin.client.flow;
 import java.util.Objects;
 
 import com.vaadin.client.Registry;
+import com.vaadin.client.ScrollPositionHandler;
 import com.vaadin.client.URIResolver;
 import com.vaadin.client.WidgetUtil;
 import com.vaadin.flow.shared.ApplicationConstants;
@@ -28,6 +29,8 @@ import elemental.events.Event;
 import elemental.events.EventTarget;
 import elemental.events.MouseEvent;
 import elemental.html.AnchorElement;
+import elemental.json.Json;
+import elemental.json.JsonObject;
 
 /**
  * Handler for click events originating from application navigation link
@@ -84,6 +87,12 @@ public class RouterLinkHandler {
         // round trip but need to store the scroll positions since browser adds
         // another history state
         if (isInsidePageNavigation(anchor)) {
+            // there is no pop state if the hashes are exactly the same
+            String currentHash = Browser.getDocument().getLocation().getHash();
+            if (!currentHash.equals(anchor.getHash())) {
+                registry.getScrollPositionHandler().beforeClientNavigation(href);
+            }
+
             // the browser triggers a fragment change & pop state event
             registry.getScrollPositionHandler()
                     .setIgnoreScrollRestorationOnNextPopStateEvent(true);
@@ -111,7 +120,18 @@ public class RouterLinkHandler {
             location = location.split("#", 2)[0];
         }
 
-        sendServerNavigationEvent(registry, location, null, true);
+        JsonObject state = createNavigationEventState(href);
+
+        sendServerNavigationEvent(registry, location, state, true);
+    }
+
+    private static JsonObject createNavigationEventState(String href) {
+        double[] scrollPosition = ScrollPositionHandler.getScrollPosition();
+        JsonObject state = Json.createObject();
+        state.put("href", href);
+        state.put("scrollPositionX", scrollPosition[0]);
+        state.put("scrollPositionY", scrollPosition[1]);
+        return state;
     }
 
     /**

--- a/flow-client/src/main/java/com/vaadin/client/flow/RouterLinkHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/RouterLinkHandler.java
@@ -84,12 +84,6 @@ public class RouterLinkHandler {
         // round trip but need to store the scroll positions since browser adds
         // another history state
         if (isInsidePageNavigation(anchor)) {
-            // there is no pop state if the hashes are exactly the same
-            String currentHash = Browser.getDocument().getLocation().getHash();
-            if (!currentHash.equals(anchor.getHash())) {
-                registry.getScrollPositionHandler().beforeNavigation(href,
-                        false);
-            }
             // the browser triggers a fragment change & pop state event
             registry.getScrollPositionHandler()
                     .setIgnoreScrollRestorationOnNextPopStateEvent(true);
@@ -116,7 +110,6 @@ public class RouterLinkHandler {
             // don't send hash to server
             location = location.split("#", 2)[0];
         }
-        registry.getScrollPositionHandler().beforeNavigation(href, true);
 
         sendServerNavigationEvent(registry, location, null, true);
     }

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -890,13 +890,6 @@ public class UI extends Component
         }
 
         Location navigationLocation = new Location(location, queryParameters);
-        if (!internals.hasLastHandledLocation()
-                || !navigationLocation.getPathWithQueryParameters()
-                        .equals(internals.getLastHandledLocation()
-                                .getPathWithQueryParameters())) {
-            // Enable navigating back
-            getPage().getHistory().pushState(null, navigationLocation);
-        }
         getRouter().navigate(this, navigationLocation,
                 NavigationTrigger.PROGRAMMATIC);
     }

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -69,6 +69,9 @@ import com.vaadin.flow.theme.Theme;
 import com.vaadin.flow.theme.ThemeDefinition;
 import com.vaadin.flow.theme.ThemeUtil;
 
+import elemental.json.Json;
+import elemental.json.JsonObject;
+
 /**
  * The topmost component in any component hierarchy. There is one UI for every
  * Vaadin instance in a browser window. A UI may either represent an entire
@@ -890,8 +893,9 @@ public class UI extends Component
         }
 
         Location navigationLocation = new Location(location, queryParameters);
+        JsonObject navigationState = Json.createObject();
         getRouter().navigate(this, navigationLocation,
-                NavigationTrigger.PROGRAMMATIC);
+                NavigationTrigger.PROGRAMMATIC, navigationState);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -893,9 +893,8 @@ public class UI extends Component
         }
 
         Location navigationLocation = new Location(location, queryParameters);
-        JsonObject navigationState = Json.createObject();
         getRouter().navigate(this, navigationLocation,
-                NavigationTrigger.PROGRAMMATIC, navigationState);
+                NavigationTrigger.UI_NAVIGATE);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -69,9 +69,6 @@ import com.vaadin.flow.theme.Theme;
 import com.vaadin.flow.theme.ThemeDefinition;
 import com.vaadin.flow.theme.ThemeUtil;
 
-import elemental.json.Json;
-import elemental.json.JsonObject;
-
 /**
  * The topmost component in any component hierarchy. There is one UI for every
  * Vaadin instance in a browser window. A UI may either represent an entire

--- a/flow-server/src/main/java/com/vaadin/flow/router/ErrorNavigationEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/ErrorNavigationEvent.java
@@ -72,7 +72,7 @@ s     */
     public ErrorNavigationEvent(Router router, Location location, UI ui,
             NavigationTrigger trigger, ErrorParameter<?> errorParameter,
             JsonValue state) {
-        super(router, location, ui, trigger, state);
+        super(router, location, ui, trigger, state, false);
 
         this.errorParameter = errorParameter;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/router/ErrorNavigationEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/ErrorNavigationEvent.java
@@ -17,6 +17,8 @@ package com.vaadin.flow.router;
 
 import com.vaadin.flow.component.UI;
 
+import elemental.json.JsonValue;
+
 /**
  * Event object with data related to error navigation.
  *
@@ -45,6 +47,32 @@ public class ErrorNavigationEvent extends NavigationEvent {
     public ErrorNavigationEvent(Router router, Location location, UI ui,
             NavigationTrigger trigger, ErrorParameter<?> errorParameter) {
         super(router, location, ui, trigger);
+
+        this.errorParameter = errorParameter;
+    }
+
+    /**
+     * Creates a new navigation event.
+     *
+     * @param router
+     *            the router handling the navigation, not {@code null}
+     * @param location
+     *            the new location, not {@code null}
+     * @param ui
+     *            the UI in which the navigation occurs, not {@code null}
+     * @param trigger
+     *            the type of user action that triggered this navigation event,
+     *            not {@code null}
+     * @param errorParameter
+     *            parameter containing navigation error information
+     * @param state
+     *            includes navigation state info including for example the
+     *            scroll position and the complete href of the RouterLink
+s     */
+    public ErrorNavigationEvent(Router router, Location location, UI ui,
+            NavigationTrigger trigger, ErrorParameter<?> errorParameter,
+            JsonValue state) {
+        super(router, location, ui, trigger, state);
 
         this.errorParameter = errorParameter;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/router/NavigationEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/NavigationEvent.java
@@ -76,37 +76,15 @@ public class NavigationEvent extends EventObject {
      * @param state
      *            includes navigation state info including for example the
      *            scroll position and the complete href of the RouterLink
-     */
-    public NavigationEvent(Router router, Location location, UI ui,
-            NavigationTrigger trigger, JsonValue state) {
-        this(router, location, ui, trigger);
-
-        this.state = state;
-    }
-
-    /**
-     * Creates a new navigation event.
-     *
-     * @param router
-     *            the router handling the navigation, not {@code null}
-     * @param location
-     *            the new location, not {@code null}
-     * @param ui
-     *            the UI in which the navigation occurs, not {@code null}
-     * @param trigger
-     *            the type of user action that triggered this navigation event,
-     *            not {@code null}
-     * @param state
-     *            includes navigation state info including for example the
-     *            scroll position and the complete href of the RouterLink
      * @param forwardTo
      *            indicates if this event is created as a result of
      *            {@link BeforeEvent#forwardTo} or not
      */
     public NavigationEvent(Router router, Location location, UI ui,
             NavigationTrigger trigger, JsonValue state, boolean forwardTo) {
-        this(router, location, ui, trigger, state);
+        this(router, location, ui, trigger);
 
+        this.state = state;
         this.forwardTo = forwardTo;
     }
 
@@ -144,9 +122,8 @@ public class NavigationEvent extends EventObject {
     }
 
     /**
-     * Gets navigation state. It may have been captured on client-side. It may
-     * contain info like the scroll position and the complete href of the
-     * RouterLink.
+     * Gets navigation state. It contains for example the scroll position and
+     * the complete href of the RouterLink that triggers this navigation.
      * 
      * @return the navigation state
      */

--- a/flow-server/src/main/java/com/vaadin/flow/router/NavigationEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/NavigationEvent.java
@@ -16,8 +16,11 @@
 package com.vaadin.flow.router;
 
 import java.util.EventObject;
+import java.util.Optional;
 
 import com.vaadin.flow.component.UI;
+
+import elemental.json.JsonValue;
 
 /**
  * Event object with data related to navigation.
@@ -29,6 +32,8 @@ public class NavigationEvent extends EventObject {
     private final Location location;
     private final UI ui;
     private final NavigationTrigger trigger;
+    private boolean forward = false;
+    private JsonValue state = null;
 
     /**
      * Creates a new navigation event.
@@ -54,6 +59,55 @@ public class NavigationEvent extends EventObject {
         this.location = location;
         this.ui = ui;
         this.trigger = trigger;
+    }
+
+    /**
+     * Creates a new navigation event.
+     *
+     * @param router
+     *            the router handling the navigation, not {@code null}
+     * @param location
+     *            the new location, not {@code null}
+     * @param ui
+     *            the UI in which the navigation occurs, not {@code null}
+     * @param trigger
+     *            the type of user action that triggered this navigation event,
+     *            not {@code null}
+     * @param state
+     *            includes navigation state info including for example the
+     *            scroll position and the complete href of the RouterLink
+     */
+    public NavigationEvent(Router router, Location location, UI ui,
+            NavigationTrigger trigger, JsonValue state) {
+        this(router, location, ui, trigger);
+
+        this.state = state;
+    }
+
+    /**
+     * Creates a new navigation event.
+     *
+     * @param router
+     *            the router handling the navigation, not {@code null}
+     * @param location
+     *            the new location, not {@code null}
+     * @param ui
+     *            the UI in which the navigation occurs, not {@code null}
+     * @param trigger
+     *            the type of user action that triggered this navigation event,
+     *            not {@code null}
+     * @param state
+     *            includes navigation state info including for example the
+     *            scroll position and the complete href of the RouterLink
+     * @param forward
+     *            indicates if this event is created as a result of
+     *            {@link BeforeEvent#forwardTo} or not
+     */
+    public NavigationEvent(Router router, Location location, UI ui,
+            NavigationTrigger trigger, JsonValue state, boolean forward) {
+        this(router, location, ui, trigger, state);
+
+        this.forward = forward;
     }
 
     @Override
@@ -87,5 +141,26 @@ public class NavigationEvent extends EventObject {
      */
     public NavigationTrigger getTrigger() {
         return trigger;
+    }
+
+    /**
+     * Gets navigation state info including for example the scroll position and
+     * the complete href of the RouterLink
+     * 
+     * @return the navigation state
+     */
+    public Optional<JsonValue> getState() {
+        return state == null ? Optional.empty() : Optional.of(state);
+    }
+
+    /**
+     * Checks whether this event is created as a result of
+     * {@link BeforeEvent#forwardTo} or not
+     * 
+     * @return {@code true} if this event is created as a result calling
+     *         {@link BeforeEvent#forwardTo}, {@code false} otherwise
+     */
+    public boolean isForward() {
+        return forward;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/NavigationEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/NavigationEvent.java
@@ -145,7 +145,7 @@ public class NavigationEvent extends EventObject {
 
     /**
      * Gets navigation state info including for example the scroll position and
-     * the complete href of the RouterLink
+     * the complete href of the RouterLink.
      * 
      * @return the navigation state
      */
@@ -155,7 +155,7 @@ public class NavigationEvent extends EventObject {
 
     /**
      * Checks whether this event is created as a result of
-     * {@link BeforeEvent#forwardTo} or not
+     * {@link BeforeEvent#forwardTo} or not.
      * 
      * @return {@code true} if this event is created as a result calling
      *         {@link BeforeEvent#forwardTo}, {@code false} otherwise

--- a/flow-server/src/main/java/com/vaadin/flow/router/NavigationEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/NavigationEvent.java
@@ -32,7 +32,7 @@ public class NavigationEvent extends EventObject {
     private final Location location;
     private final UI ui;
     private final NavigationTrigger trigger;
-    private boolean forward = false;
+    private boolean forwardTo = false;
     private JsonValue state = null;
 
     /**
@@ -99,15 +99,15 @@ public class NavigationEvent extends EventObject {
      * @param state
      *            includes navigation state info including for example the
      *            scroll position and the complete href of the RouterLink
-     * @param forward
+     * @param forwardTo
      *            indicates if this event is created as a result of
      *            {@link BeforeEvent#forwardTo} or not
      */
     public NavigationEvent(Router router, Location location, UI ui,
-            NavigationTrigger trigger, JsonValue state, boolean forward) {
+            NavigationTrigger trigger, JsonValue state, boolean forwardTo) {
         this(router, location, ui, trigger, state);
 
-        this.forward = forward;
+        this.forwardTo = forwardTo;
     }
 
     @Override
@@ -144,8 +144,9 @@ public class NavigationEvent extends EventObject {
     }
 
     /**
-     * Gets navigation state info including for example the scroll position and
-     * the complete href of the RouterLink.
+     * Gets navigation state. It may have been captured on client-side. It may
+     * contain info like the scroll position and the complete href of the
+     * RouterLink.
      * 
      * @return the navigation state
      */
@@ -160,7 +161,7 @@ public class NavigationEvent extends EventObject {
      * @return {@code true} if this event is created as a result calling
      *         {@link BeforeEvent#forwardTo}, {@code false} otherwise
      */
-    public boolean isForward() {
-        return forward;
+    public boolean isForwardTo() {
+        return forwardTo;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/NavigationTrigger.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/NavigationTrigger.java
@@ -48,7 +48,7 @@ public enum NavigationTrigger {
     HISTORY,
 
     /**
-     * Navigation was triggered programmatically.
+     * Navigation was triggered programmatically via forward/reroute action.
      */
     PROGRAMMATIC,
 

--- a/flow-server/src/main/java/com/vaadin/flow/router/NavigationTrigger.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/NavigationTrigger.java
@@ -49,8 +49,12 @@ public enum NavigationTrigger {
 
     /**
      * Navigation was triggered programmatically.
-     *
-     * @see UI#navigate(String, QueryParameters)
      */
-    PROGRAMMATIC
+    PROGRAMMATIC,
+
+    /**
+     * Navigation was triggered via
+     * {@link UI#navigate(String, QueryParameters)}. It's for internal use only.
+     */
+    UI_NAVIGATE
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/Router.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/Router.java
@@ -221,7 +221,7 @@ public class Router implements Serializable {
                 return handleNavigation(ui, location, trigger, state);
             } catch (Exception exception) {
                 return handleExceptionNavigation(ui, location, exception,
-                        trigger);
+                        trigger, state);
             } finally {
                 ui.getInternals().clearLastHandledNavigation();
             }
@@ -239,7 +239,7 @@ public class Router implements Serializable {
     }
 
     private int handleNavigation(UI ui, Location location,
-                                 NavigationTrigger trigger, JsonValue state) {
+            NavigationTrigger trigger, JsonValue state) {
         NavigationState newState = getRouteResolver()
                 .resolve(new ResolveRequest(this, location));
         if (newState != null) {
@@ -267,7 +267,7 @@ public class Router implements Serializable {
     }
 
     private int handleExceptionNavigation(UI ui, Location location,
-            Exception exception, NavigationTrigger trigger) {
+            Exception exception, NavigationTrigger trigger, JsonValue state) {
         Optional<ErrorTargetEntry> maybeLookupResult = getErrorNavigationTarget(
                 exception);
 
@@ -283,7 +283,7 @@ public class Router implements Serializable {
                             .build());
 
             ErrorNavigationEvent navigationEvent = new ErrorNavigationEvent(
-                    this, location, ui, trigger, errorParameter);
+                    this, location, ui, trigger, errorParameter, state);
 
             return handler.handle(navigationEvent);
         } else {

--- a/flow-server/src/main/java/com/vaadin/flow/router/Router.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/Router.java
@@ -188,7 +188,6 @@ public class Router implements Serializable {
         ui.getSession().checkHasLock();
 
         if (handleNavigationForLocation(ui, location)) {
-            ui.getInternals().setLastHandledNavigation(location);
 
             try {
                 return handleNavigation(ui, location, trigger);

--- a/flow-server/src/main/java/com/vaadin/flow/router/Router.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/Router.java
@@ -187,12 +187,11 @@ public class Router implements Serializable {
     }
 
     /**
-     * Navigates the given UI to the given location.
+     * Navigates the given UI to the given location. For internal use only.
      * <p>
-     * This method just shows the given {@code location} on the page and doesn't
-     * update the browser location (and page history). Use the
-     * {@link UI#navigate(String, QueryParameters)} method if you want to update
-     * the browser location as well.
+     * This method pushes to the browser history if the <code>trigger</code> is
+     * <code>ROUTER_LINK</code> or if it's called from
+     * {@link UI#navigate(String, QueryParameters)}.
      *
      * @param ui
      *            the UI to update, not <code>null</code>

--- a/flow-server/src/main/java/com/vaadin/flow/router/Router.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/Router.java
@@ -190,8 +190,8 @@ public class Router implements Serializable {
      * Navigates the given UI to the given location. For internal use only.
      * <p>
      * This method pushes to the browser history if the <code>trigger</code> is
-     * <code>ROUTER_LINK</code> or if it's called from
-     * {@link UI#navigate(String, QueryParameters)}.
+     * {@link NavigationTrigger#ROUTER_LINK} or
+     * {@link NavigationTrigger#UI_NAVIGATE}.
      *
      * @param ui
      *            the UI to update, not <code>null</code>
@@ -243,7 +243,7 @@ public class Router implements Serializable {
                 .resolve(new ResolveRequest(this, location));
         if (newState != null) {
             NavigationEvent navigationEvent = new NavigationEvent(this,
-                    location, ui, trigger, state);
+                    location, ui, trigger, state, false);
 
             NavigationHandler handler = new NavigationStateRenderer(newState);
             return handler.handle(navigationEvent);
@@ -253,7 +253,7 @@ public class Router implements Serializable {
                     .resolve(new ResolveRequest(this, slashToggledLocation));
             if (slashToggledState != null) {
                 NavigationEvent navigationEvent = new NavigationEvent(this,
-                        slashToggledLocation, ui, trigger, state);
+                        slashToggledLocation, ui, trigger, state, false);
 
                 NavigationHandler handler = new InternalRedirectHandler(
                         slashToggledLocation);

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -58,6 +58,8 @@ import com.vaadin.flow.router.Router;
 import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.server.VaadinSession;
 
+import elemental.json.JsonValue;
+
 /**
  * Base class for navigation handlers that target a navigation state.
  *
@@ -260,7 +262,7 @@ public abstract class AbstractNavigationStateRenderer
     }
 
     private void pushHistoryStateIfNeeded(NavigationEvent event, UI ui) {
-        if(event instanceof ErrorNavigationEvent) {
+        if (event instanceof ErrorNavigationEvent) {
             return;
         }
 
@@ -270,14 +272,14 @@ public abstract class AbstractNavigationStateRenderer
              * should be done in client-side. See
              * ScrollPositionHandler#afterNavigation(JsonObject).
              */
-            if (!event.getState().isPresent())
-                throw new IllegalStateException(
-                        "When the navigation trigger is ROUTER_LINK, event state should not be null.");
+            JsonValue state = event.getState()
+                    .orElseThrow(() -> new IllegalStateException(
+                            "When the navigation trigger is ROUTER_LINK, event state should not be null."));
 
             ui.getPage().executeJs(
-                    "this.scorllPositionHandlerBeforeNavigation($0);",
-                    event.getState().get());
-        } else if (!event.isForward()
+                    "this.scrollPositionHandlerAfterServerNavigation($0);",
+                    state);
+        } else if (!event.isForwardTo()
                 && (!ui.getInternals().hasLastHandledLocation()
                         || !event.getLocation().getPathWithQueryParameters()
                                 .equals(ui.getInternals()

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -285,7 +285,11 @@ public abstract class AbstractNavigationStateRenderer
                                 .equals(ui.getInternals()
                                         .getLastHandledLocation()
                                         .getPathWithQueryParameters()))) {
-            if (NavigationTrigger.PROGRAMMATIC.equals(event.getTrigger())) {
+
+            // If the trigger is PROGRAMMATIC, we push history state if only the
+            // event state is provided. See UI#navigate(String, QueryParameters)
+            if (NavigationTrigger.PROGRAMMATIC.equals(event.getTrigger())
+                    && event.getState().isPresent()) {
                 // Enable navigating back
                 ui.getPage().getHistory().pushState(null, event.getLocation());
             }

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -180,6 +180,16 @@ public abstract class AbstractNavigationStateRenderer
             }
         }
 
+        if (!ui.getInternals().hasLastHandledLocation()
+                || !event.getLocation().getPathWithQueryParameters()
+                .equals(ui.getInternals().getLastHandledLocation()
+                        .getPathWithQueryParameters())) {
+            // Enable navigating back
+            ui.getPage().getHistory().pushState(null, event.getLocation());
+
+            ui.getInternals().setLastHandledNavigation(event.getLocation());
+        }
+
         final ArrayList<HasElement> chain;
 
         if (isPreserveOnRefreshTarget(routeTargetType, routeLayoutTypes)) {

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -260,6 +260,9 @@ public abstract class AbstractNavigationStateRenderer
     }
 
     private void pushHistoryStateIfNeeded(NavigationEvent event, UI ui) {
+        if(event instanceof ErrorNavigationEvent) {
+            return;
+        }
 
         if (NavigationTrigger.ROUTER_LINK.equals(event.getTrigger())) {
             /*

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -213,6 +213,11 @@ public abstract class AbstractNavigationStateRenderer
         notifyNavigationTarget(componentInstance, event,
                 beforeNavigationActivating, locationChangeEvent);
 
+        // If the navigation is postponed, using BeforeLeaveEvent#postpone,
+        // pushing history state shouldn't be done. So, it's done here to make
+        // sure that when history state is pushed the navigation is not
+        // postponed.
+        // See https://github.com/vaadin/flow/issues/3619 for more info.
         pushHistoryStateIfNeeded(event, ui);
 
         if (beforeNavigationActivating.hasRerouteTarget()) {
@@ -286,10 +291,7 @@ public abstract class AbstractNavigationStateRenderer
                                         .getLastHandledLocation()
                                         .getPathWithQueryParameters()))) {
 
-            // If the trigger is PROGRAMMATIC, we push history state if only the
-            // event state is provided. See UI#navigate(String, QueryParameters)
-            if (NavigationTrigger.PROGRAMMATIC.equals(event.getTrigger())
-                    && event.getState().isPresent()) {
+            if (NavigationTrigger.UI_NAVIGATE.equals(event.getTrigger())) {
                 // Enable navigating back
                 ui.getPage().getHistory().pushState(null, event.getLocation());
             }

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.router.internal;
 
+import javax.servlet.http.HttpServletResponse;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -25,8 +26,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import javax.servlet.http.HttpServletResponse;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
@@ -180,21 +179,11 @@ public abstract class AbstractNavigationStateRenderer
             }
         }
 
-        if (!ui.getInternals().hasLastHandledLocation()
-                || !event.getLocation().getPathWithQueryParameters()
-                .equals(ui.getInternals().getLastHandledLocation()
-                        .getPathWithQueryParameters())) {
-            // Enable navigating back
-            ui.getPage().getHistory().pushState(null, event.getLocation());
-
-            ui.getInternals().setLastHandledNavigation(event.getLocation());
-        }
-
         final ArrayList<HasElement> chain;
 
         if (isPreserveOnRefreshTarget(routeTargetType, routeLayoutTypes)) {
-            final Optional<ArrayList<HasElement>> maybeChain =
-                    createOrRehandlePreserveOnRefreshComponent(event);
+            final Optional<ArrayList<HasElement>> maybeChain = createOrRehandlePreserveOnRefreshComponent(
+                    event);
             if (!maybeChain.isPresent()) {
                 return HttpServletResponse.SC_OK;
             } else {
@@ -221,6 +210,8 @@ public abstract class AbstractNavigationStateRenderer
 
         notifyNavigationTarget(componentInstance, event,
                 beforeNavigationActivating, locationChangeEvent);
+
+        pushHistoryStateIfNeeded(event, ui);
 
         if (beforeNavigationActivating.hasRerouteTarget()) {
             return reroute(event, beforeNavigationActivating);
@@ -266,6 +257,36 @@ public abstract class AbstractNavigationStateRenderer
                 afterNavigationHandlers);
 
         return statusCode;
+    }
+
+    private void pushHistoryStateIfNeeded(NavigationEvent event, UI ui) {
+
+        if (NavigationTrigger.ROUTER_LINK.equals(event.getTrigger())) {
+            /*
+             * When the event trigger is a RouterLink, pushing history state
+             * should be done in client-side. See
+             * ScrollPositionHandler#afterNavigation(JsonObject).
+             */
+            if (!event.getState().isPresent())
+                throw new IllegalStateException(
+                        "When the navigation trigger is ROUTER_LINK, event state should not be null.");
+
+            ui.getPage().executeJs(
+                    "this.scorllPositionHandlerBeforeNavigation($0);",
+                    event.getState().get());
+        } else if (!event.isForward()
+                && (!ui.getInternals().hasLastHandledLocation()
+                        || !event.getLocation().getPathWithQueryParameters()
+                                .equals(ui.getInternals()
+                                        .getLastHandledLocation()
+                                        .getPathWithQueryParameters()))) {
+            if (NavigationTrigger.PROGRAMMATIC.equals(event.getTrigger())) {
+                // Enable navigating back
+                ui.getPage().getHistory().pushState(null, event.getLocation());
+            }
+
+            ui.getInternals().setLastHandledNavigation(event.getLocation());
+        }
     }
 
     /**
@@ -316,9 +337,8 @@ public abstract class AbstractNavigationStateRenderer
     private ArrayList<HasElement> createChain(NavigationEvent event) {
         final Class<? extends Component> routeTargetType = navigationState
                 .getNavigationTarget();
-        final List<Class<? extends RouterLayout>> routeLayoutTypes =
-                getRouterLayoutTypes(routeTargetType,
-                        event.getUI().getRouter());
+        final List<Class<? extends RouterLayout>> routeLayoutTypes = getRouterLayoutTypes(
+                routeTargetType, event.getUI().getRouter());
 
         final ArrayList<HasElement> chain = new ArrayList<>();
         chain.add(getRouteTarget(routeTargetType, event));
@@ -453,7 +473,8 @@ public abstract class AbstractNavigationStateRenderer
                 .getUrlBase(targetType)
                 .orElseThrow(() -> new IllegalStateException(String.format(
                         "The target component '%s' has no registered route",
-                        targetType))), event.getLocation().getQueryParameters());
+                        targetType))),
+                event.getLocation().getQueryParameters());
 
         if (beforeNavigation.hasForwardTarget()) {
             List<String> segments = new ArrayList<>(location.getSegments());
@@ -462,16 +483,16 @@ public abstract class AbstractNavigationStateRenderer
         }
 
         return new NavigationEvent(event.getSource(), location, event.getUI(),
-                NavigationTrigger.PROGRAMMATIC);
+                NavigationTrigger.PROGRAMMATIC, null, true);
     }
 
     /**
      * Creates a new instance of the target component for the route when the
      * target class is annotated with @PreserveOnRefresh. It checks if there
-     * exists a cached component of the route location in the current window.
-     * If retrieving the window name requires another round-trip, schedule it
-     * and make a new call to the handle {@link #handle(NavigationEvent)} in
-     * the callback. In this case, this method returns {@link Optional#empty()}.
+     * exists a cached component of the route location in the current window. If
+     * retrieving the window name requires another round-trip, schedule it and
+     * make a new call to the handle {@link #handle(NavigationEvent)} in the
+     * callback. In this case, this method returns {@link Optional#empty()}.
      */
     private Optional<ArrayList<HasElement>> createOrRehandlePreserveOnRefreshComponent(
             NavigationEvent event) {
@@ -486,8 +507,8 @@ public abstract class AbstractNavigationStateRenderer
                 // We may have a cached instance for this location, but we
                 // need to retrieve the window name before we can determine
                 // this, so execute a client-side request.
-                ui.getPage().retrieveExtendedClientDetails(details ->
-                        handle(event));
+                ui.getPage().retrieveExtendedClientDetails(
+                        details -> handle(event));
                 return Optional.empty();
             } else {
                 // We can immediately create the new component instance and
@@ -504,12 +525,12 @@ public abstract class AbstractNavigationStateRenderer
         } else {
             final String windowName = ui.getInternals()
                     .getExtendedClientDetails().getWindowName();
-            final Optional<ArrayList<HasElement>> maybePreserved =
-                    getPreservedChain(session, windowName, event.getLocation());
+            final Optional<ArrayList<HasElement>> maybePreserved = getPreservedChain(
+                    session, windowName, event.getLocation());
             if (maybePreserved.isPresent()) {
                 // Re-use preserved chain for this route
                 chain = maybePreserved.get();
-                final HasElement root = chain.get(chain.size()-1);
+                final HasElement root = chain.get(chain.size() - 1);
                 final Component component = (Component) chain.get(0);
                 final Optional<UI> maybePrevUI = component.getUI();
 
@@ -518,8 +539,8 @@ public abstract class AbstractNavigationStateRenderer
 
                 // Transfer all remaining UI child elements (typically dialogs
                 // and notifications) to the new UI
-                maybePrevUI.ifPresent(prevUi ->
-                        moveElementsToNewUI(prevUi, ui));
+                maybePrevUI
+                        .ifPresent(prevUi -> moveElementsToNewUI(prevUi, ui));
             } else {
                 // Instantiate new chain for the route
                 chain = createChain(event);
@@ -582,14 +603,12 @@ public abstract class AbstractNavigationStateRenderer
             Class<? extends Component> routeTargetType,
             List<Class<? extends RouterLayout>> routeLayoutTypes) {
         return routeTargetType.isAnnotationPresent(PreserveOnRefresh.class)
-                || routeLayoutTypes.stream().anyMatch(layoutType ->
-                layoutType.isAnnotationPresent(PreserveOnRefresh.class)
-        );
+                || routeLayoutTypes.stream().anyMatch(layoutType -> layoutType
+                        .isAnnotationPresent(PreserveOnRefresh.class));
     }
 
     private void moveElementsToNewUI(UI prevUi, UI newUi) {
-        final List<Element> uiChildren = prevUi.getElement()
-                .getChildren()
+        final List<Element> uiChildren = prevUi.getElement().getChildren()
                 .collect(Collectors.toList());
         uiChildren.forEach(element -> {
             element.removeFromTree();
@@ -598,31 +617,30 @@ public abstract class AbstractNavigationStateRenderer
     }
 
     // maps window.name to (location, chain)
-    private static class PreservedComponentCache extends
-            HashMap<String, Pair<String, ArrayList<HasElement>>> {
+    private static class PreservedComponentCache
+            extends HashMap<String, Pair<String, ArrayList<HasElement>>> {
     }
 
     static boolean hasPreservedChain(VaadinSession session) {
-        final PreservedComponentCache cache =
-                session.getAttribute(PreservedComponentCache.class);
-        return cache!=null && !cache.isEmpty();
+        final PreservedComponentCache cache = session
+                .getAttribute(PreservedComponentCache.class);
+        return cache != null && !cache.isEmpty();
     }
 
-    static boolean hasPreservedChainOfLocation(
-            VaadinSession session, Location location) {
-        final PreservedComponentCache cache =
-                session.getAttribute(PreservedComponentCache.class);
-        return cache != null &&
-                cache.values().stream().anyMatch(entry ->
-                        entry.getFirst().equals(location.getPath()));
+    static boolean hasPreservedChainOfLocation(VaadinSession session,
+            Location location) {
+        final PreservedComponentCache cache = session
+                .getAttribute(PreservedComponentCache.class);
+        return cache != null && cache.values().stream()
+                .anyMatch(entry -> entry.getFirst().equals(location.getPath()));
     }
 
     static Optional<ArrayList<HasElement>> getPreservedChain(
             VaadinSession session, String windowName, Location location) {
-        final PreservedComponentCache cache =
-                session.getAttribute(PreservedComponentCache.class);
-        if (cache!=null && cache.containsKey(windowName) &&
-                cache.get(windowName).getFirst().equals(location.getPath())) {
+        final PreservedComponentCache cache = session
+                .getAttribute(PreservedComponentCache.class);
+        if (cache != null && cache.containsKey(windowName) && cache
+                .get(windowName).getFirst().equals(location.getPath())) {
             return Optional.of(cache.get(windowName).getSecond());
         } else {
             return Optional.empty();
@@ -630,17 +648,15 @@ public abstract class AbstractNavigationStateRenderer
     }
 
     static void setPreservedChain(VaadinSession session, String windowName,
-                                  Location location,
-                                  ArrayList<HasElement> chain) {
-        PreservedComponentCache cache =
-                session.getAttribute(PreservedComponentCache.class);
+            Location location, ArrayList<HasElement> chain) {
+        PreservedComponentCache cache = session
+                .getAttribute(PreservedComponentCache.class);
         if (cache == null) {
             cache = new PreservedComponentCache();
         }
         cache.put(windowName, new Pair<>(location.getPath(), chain));
         session.setAttribute(PreservedComponentCache.class, cache);
     }
-
 
     private static void clearAllPreservedChains(UI ui) {
         final VaadinSession session = ui.getSession();
@@ -650,8 +666,8 @@ public abstract class AbstractNavigationStateRenderer
             ui.getPage().retrieveExtendedClientDetails(details -> {
                 final String windowName = ui.getInternals()
                         .getExtendedClientDetails().getWindowName();
-                final PreservedComponentCache cache =
-                        session.getAttribute(PreservedComponentCache.class);
+                final PreservedComponentCache cache = session
+                        .getAttribute(PreservedComponentCache.class);
                 if (cache != null) {
                     cache.remove(windowName);
                 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/InternalRedirectHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/InternalRedirectHandler.java
@@ -19,6 +19,7 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.router.Location;
 import com.vaadin.flow.router.NavigationEvent;
 import com.vaadin.flow.router.NavigationHandler;
+import com.vaadin.flow.router.NavigationTrigger;
 import com.vaadin.flow.router.Router;
 
 /**
@@ -47,8 +48,11 @@ public class InternalRedirectHandler implements NavigationHandler {
         UI ui = event.getUI();
         Router router = event.getSource();
 
-        ui.getPage().getHistory().replaceState(null, target);
+        if (NavigationTrigger.PAGE_LOAD.equals(event.getTrigger())) {
+            ui.getPage().getHistory().replaceState(null, target);
+        }
 
-        return router.navigate(ui, target, event.getTrigger());
+        return router.navigate(ui, target, event.getTrigger(),
+                event.getState().orElse(null));
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/UITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/UITest.java
@@ -253,7 +253,7 @@ public class UITest {
         ui.navigate(route, params);
 
         Mockito.verify(router).navigate(Matchers.eq(ui), location.capture(),
-                Matchers.eq(NavigationTrigger.PROGRAMMATIC));
+                Matchers.eq(NavigationTrigger.UI_NAVIGATE));
 
         Location value = location.getValue();
         Assert.assertEquals(route, value.getPath());

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
@@ -75,6 +75,9 @@ import com.vaadin.tests.util.MockUI;
 
 import net.jcip.annotations.NotThreadSafe;
 
+import elemental.json.Json;
+import elemental.json.JsonObject;
+
 @NotThreadSafe
 public class RouterTest extends RoutingTestBase {
 
@@ -3006,8 +3009,12 @@ public class RouterTest extends RoutingTestBase {
         Assert.assertEquals(NavigationTrigger.PROGRAMMATIC,
                 FileNotFound.trigger);
 
+        JsonObject state = Json.createObject();
+        state.put("href", "router_link");
+        state.put("scrollPositionX", 0d);
+        state.put("scrollPositionY", 0d);
         router.navigate(ui, new Location("router_link"),
-                NavigationTrigger.ROUTER_LINK);
+                NavigationTrigger.ROUTER_LINK, state);
 
         Assert.assertEquals(NavigationTrigger.ROUTER_LINK,
                 FileNotFound.trigger);

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
@@ -15,11 +15,7 @@
  */
 package com.vaadin.flow.router;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-
+import javax.servlet.http.HttpServletResponse;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,8 +30,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import javax.servlet.http.HttpServletResponse;
-
+import net.jcip.annotations.NotThreadSafe;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -73,10 +68,12 @@ import com.vaadin.flow.theme.AbstractTheme;
 import com.vaadin.flow.theme.Theme;
 import com.vaadin.tests.util.MockUI;
 
-import net.jcip.annotations.NotThreadSafe;
-
 import elemental.json.Json;
 import elemental.json.JsonObject;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 @NotThreadSafe
 public class RouterTest extends RoutingTestBase {
@@ -2481,7 +2478,6 @@ public class RouterTest extends RoutingTestBase {
         Assert.assertEquals(MyTheme.class, themeObject.getClass());
     }
 
-
     @Test
     public void theme_is_not_gotten_from_the_super_class_when_in_npm_mode()
             throws InvalidRouteConfigurationException, Exception {
@@ -3166,7 +3162,8 @@ public class RouterTest extends RoutingTestBase {
         RouteChildWithParameter.events.clear();
         ui.navigate(RouteChildWithParameter.class, "foobar");
 
-        BeforeEnterEvent beforeEnterEvent = (BeforeEnterEvent) RouteChildWithParameter.events.get(0);
+        BeforeEnterEvent beforeEnterEvent = (BeforeEnterEvent) RouteChildWithParameter.events
+                .get(0);
         Assert.assertEquals(
                 "There is not exactly one layout in the layout chain", 1,
                 beforeEnterEvent.getLayouts().size());
@@ -3176,7 +3173,8 @@ public class RouterTest extends RoutingTestBase {
         RouteChildWithParameter.events.clear();
         ui.navigate(LoneRoute.class);
 
-        BeforeLeaveEvent beforeLeaveEvent = (BeforeLeaveEvent) RouteChildWithParameter.events.get(0);
+        BeforeLeaveEvent beforeLeaveEvent = (BeforeLeaveEvent) RouteChildWithParameter.events
+                .get(0);
         Assert.assertEquals(
                 "There is not exactly one layout in the layout chain", 1,
                 beforeLeaveEvent.getLayouts().size());
@@ -3186,49 +3184,58 @@ public class RouterTest extends RoutingTestBase {
 
     @Test
     public void optional_parameter_non_existing_route()
-    throws InvalidRouteConfigurationException {
+            throws InvalidRouteConfigurationException {
         OptionalParameter.events.clear();
         Mockito.when(configuration.isProductionMode()).thenReturn(false);
         setNavigationTargets(OptionalParameter.class);
 
         String locationString = "optional/doesnotExist/parameter";
-        router.navigate(
-            ui, new Location(locationString), NavigationTrigger.PROGRAMMATIC);
+        router.navigate(ui, new Location(locationString),
+                NavigationTrigger.PROGRAMMATIC);
 
-        String exceptionText1 =
-             String.format("Could not navigate to '%s'", locationString);
+        String exceptionText1 = String.format("Could not navigate to '%s'",
+                locationString);
 
-        String exceptionText2 =
-            String.format("Reason: Couldn't find route for '%s'", locationString);
+        String exceptionText2 = String
+                .format("Reason: Couldn't find route for '%s'", locationString);
 
-        String exceptionText3 =
-            "<li><a href=\"optional\">optional (supports optional parameter)</a></li>";
+        String exceptionText3 = "<li><a href=\"optional\">optional (supports optional parameter)</a></li>";
 
-        assertExceptionComponent(
-            RouteNotFoundError.class, exceptionText1, exceptionText2, exceptionText3);
+        assertExceptionComponent(RouteNotFoundError.class, exceptionText1,
+                exceptionText2, exceptionText3);
     }
 
     @Test
     public void without_optional_parameter()
-    throws InvalidRouteConfigurationException {
+            throws InvalidRouteConfigurationException {
         OptionalParameter.events.clear();
         Mockito.when(configuration.isProductionMode()).thenReturn(false);
         setNavigationTargets(WithoutOptionalParameter.class);
 
         String locationString = "optional";
-        router.navigate(
-            ui, new Location(locationString), NavigationTrigger.PROGRAMMATIC);
+        router.navigate(ui, new Location(locationString),
+                NavigationTrigger.PROGRAMMATIC);
 
-        String exceptionText1 =
-             String.format("Could not navigate to '%s'", locationString);
+        String exceptionText1 = String.format("Could not navigate to '%s'",
+                locationString);
 
-        String exceptionText2 =
-            String.format("Reason: Couldn't find route for '%s'", locationString);
+        String exceptionText2 = String
+                .format("Reason: Couldn't find route for '%s'", locationString);
 
         String exceptionText3 = "<li>optional (requires parameter)</li>";
 
-        assertExceptionComponent(
-            RouteNotFoundError.class, exceptionText1, exceptionText2, exceptionText3);
+        assertExceptionComponent(RouteNotFoundError.class, exceptionText1,
+                exceptionText2, exceptionText3);
+    }
+
+    @Test
+    public void navigate_withState_() {
+        setNavigationTargets(RootNavigationTarget.class);
+
+        RootNavigationTarget.events.clear();
+        router.navigate(ui, new Location(""), NavigationTrigger.PROGRAMMATIC);
+        Assert.assertEquals(1, RootNavigationTarget.events.size());
+
     }
 
     private void setNavigationTargets(

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.router.internal;
 
+import javax.servlet.ServletContext;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -23,11 +24,12 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
-import javax.servlet.ServletContext;
-
+import net.jcip.annotations.NotThreadSafe;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
@@ -36,6 +38,7 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.page.ExtendedClientDetails;
+import com.vaadin.flow.component.page.History;
 import com.vaadin.flow.component.page.Page;
 import com.vaadin.flow.component.page.PendingJavaScriptResult;
 import com.vaadin.flow.dom.Element;
@@ -61,12 +64,17 @@ import com.vaadin.tests.util.AlwaysLockedVaadinSession;
 import com.vaadin.tests.util.MockDeploymentConfiguration;
 import com.vaadin.tests.util.MockUI;
 
-import net.jcip.annotations.NotThreadSafe;
+import elemental.json.Json;
+import elemental.json.JsonObject;
+import elemental.json.JsonValue;
 
 @NotThreadSafe
 public class NavigationStateRendererTest {
 
     Router router;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     @Before
     public void init() {
@@ -191,8 +199,8 @@ public class NavigationStateRendererTest {
         MockUI ui = new MockUI(session) {
             final Page page = new Page(this) {
                 @Override
-                public PendingJavaScriptResult executeJs(
-                        String expression, Serializable... params) {
+                public PendingJavaScriptResult executeJs(String expression,
+                        Serializable... params) {
                     jsInvoked.set(true);
                     return super.executeJs(expression, params);
                 }
@@ -205,8 +213,7 @@ public class NavigationStateRendererTest {
         };
 
         // when a navigation event reaches the renderer
-        renderer.handle(new NavigationEvent(
-                new Router(new TestRouteRegistry()),
+        renderer.handle(new NavigationEvent(new Router(new TestRouteRegistry()),
                 new Location("preserved"), ui, NavigationTrigger.PAGE_LOAD));
 
         // then client-side JS was invoked
@@ -224,8 +231,8 @@ public class NavigationStateRendererTest {
 
         // given a UI that contain a window name ROOT.123
         MockUI ui1 = new MockUI(session);
-        ExtendedClientDetails details =
-                Mockito.mock(ExtendedClientDetails.class);
+        ExtendedClientDetails details = Mockito
+                .mock(ExtendedClientDetails.class);
         Mockito.when(details.getWindowName()).thenReturn("ROOT.123");
         ui1.getInternals().setExtendedClientDetails(details);
 
@@ -235,14 +242,13 @@ public class NavigationStateRendererTest {
 
         // when a navigation event reaches the renderer
         renderer1.handle(new NavigationEvent(
-                new Router(new TestRouteRegistry()),
-                new Location("preserved"), ui1, NavigationTrigger.PAGE_LOAD));
+                new Router(new TestRouteRegistry()), new Location("preserved"),
+                ui1, NavigationTrigger.PAGE_LOAD));
 
         // then the session has a cached record of the view
         Assert.assertTrue("Session expected to have cached view",
                 AbstractNavigationStateRenderer.getPreservedChain(session,
-                        "ROOT.123", new Location("preserved"))
-                        .isPresent());
+                        "ROOT.123", new Location("preserved")).isPresent());
 
         // given the recently instantiated view
         final Component view = (Component) ui1.getInternals()
@@ -258,12 +264,12 @@ public class NavigationStateRendererTest {
 
         // when another navigation targets the same location
         renderer2.handle(new NavigationEvent(
-                new Router(new TestRouteRegistry()),
-                new Location("preserved"), ui2, NavigationTrigger.PAGE_LOAD));
+                new Router(new TestRouteRegistry()), new Location("preserved"),
+                ui2, NavigationTrigger.PAGE_LOAD));
 
         // then the same view is routed to
-        Assert.assertEquals("Expected same view",
-                view, ui1.getInternals().getActiveRouterTargetsChain().get(0));
+        Assert.assertEquals("Expected same view", view,
+                ui1.getInternals().getActiveRouterTargetsChain().get(0));
 
         // given yet another new UI with the same window name
         MockUI ui3 = new MockUI(session);
@@ -275,8 +281,8 @@ public class NavigationStateRendererTest {
 
         // when a navigation event targets that other location
         renderer3.handle(new NavigationEvent(
-                new Router(new TestRouteRegistry()),
-                new Location("regular"), ui2, NavigationTrigger.PAGE_LOAD));
+                new Router(new TestRouteRegistry()), new Location("regular"),
+                ui2, NavigationTrigger.PAGE_LOAD));
 
         // then session no longer has a cached record at location "preserved"
         Assert.assertFalse("Session expected to not have cached view",
@@ -299,9 +305,9 @@ public class NavigationStateRendererTest {
 
         // given the session has a cache of PreservedView at this location
         final PreservedView view = new PreservedView();
-        AbstractNavigationStateRenderer.setPreservedChain(session,
-                "ROOT.123", new Location("preserved"),
-               new ArrayList<>(Arrays.asList(view)));
+        AbstractNavigationStateRenderer.setPreservedChain(session, "ROOT.123",
+                new Location("preserved"),
+                new ArrayList<>(Arrays.asList(view)));
 
         // given an old UI that contains the component and an extra element
         MockUI ui0 = new MockUI(session);
@@ -311,14 +317,13 @@ public class NavigationStateRendererTest {
 
         // given a new UI after a refresh with the same window name
         MockUI ui1 = new MockUI(session);
-        ExtendedClientDetails details =
-                Mockito.mock(ExtendedClientDetails.class);
+        ExtendedClientDetails details = Mockito
+                .mock(ExtendedClientDetails.class);
         Mockito.when(details.getWindowName()).thenReturn("ROOT.123");
         ui1.getInternals().setExtendedClientDetails(details);
 
         // when a navigation event reaches the renderer
-        renderer.handle(new NavigationEvent(
-                new Router(new TestRouteRegistry()),
+        renderer.handle(new NavigationEvent(new Router(new TestRouteRegistry()),
                 new Location("preserved"), ui1, NavigationTrigger.PAGE_LOAD));
 
         // then both the view element and the other element are expected to be
@@ -361,9 +366,7 @@ public class NavigationStateRendererTest {
         NavigationStateRenderer renderer = new NavigationStateRenderer(
                 new NavigationStateBuilder(router)
                         .withTarget(PreservedNestedView.class)
-                        .withPath("preservedNested")
-                        .build()
-        );
+                        .withPath("preservedNested").build());
         router.getRegistry().setRoute("preservedNested",
                 PreservedNestedView.class,
                 Arrays.asList(PreservedLayout.class));
@@ -371,41 +374,39 @@ public class NavigationStateRendererTest {
         // given the session has a cache of PreservedNestedView at this location
         final PreservedLayout layout = new PreservedLayout();
         final PreservedNestedView nestedView = new PreservedNestedView();
-        AbstractNavigationStateRenderer.setPreservedChain(session,
-                "ROOT.123", new Location("preservedNested"),
-                new ArrayList<>(Arrays.asList(nestedView,layout)));
+        AbstractNavigationStateRenderer.setPreservedChain(session, "ROOT.123",
+                new Location("preservedNested"),
+                new ArrayList<>(Arrays.asList(nestedView, layout)));
 
         // given a UI that contain a window name ROOT.123
         MockUI ui = new MockUI(session);
-        ExtendedClientDetails details =
-                Mockito.mock(ExtendedClientDetails.class);
+        ExtendedClientDetails details = Mockito
+                .mock(ExtendedClientDetails.class);
         Mockito.when(details.getWindowName()).thenReturn("ROOT.123");
         ui.getInternals().setExtendedClientDetails(details);
 
         // when a navigation event reaches the renderer
-        renderer.handle(new NavigationEvent(
-                router,
-                new Location("preservedNested"), ui,
-                NavigationTrigger.PAGE_LOAD));
+        renderer.handle(
+                new NavigationEvent(router, new Location("preservedNested"), ui,
+                        NavigationTrigger.PAGE_LOAD));
 
         // then the view and the router layout are preserved
-        Assert.assertEquals("Expected same view",
-                nestedView,
+        Assert.assertEquals("Expected same view", nestedView,
                 ui.getInternals().getActiveRouterTargetsChain().get(0));
-        Assert.assertEquals("Expected same router layout",
-                layout,
+        Assert.assertEquals("Expected same router layout", layout,
                 ui.getInternals().getActiveRouterTargetsChain().get(1));
     }
 
     @Route(value = "preservedLayout")
     @Tag("div")
     private static class PreservedLayout extends Component
-            implements RouterLayout{
-        PreservedLayout() {}
+            implements RouterLayout {
+        PreservedLayout() {
+        }
     }
 
     @PreserveOnRefresh
-    @Route(value = "preservedNested", layout= PreservedLayout.class)
+    @Route(value = "preservedNested", layout = PreservedLayout.class)
     private static class PreservedNestedView extends Text {
         PreservedNestedView() {
             super("");
@@ -431,5 +432,280 @@ public class NavigationStateRendererTest {
     private NavigationState navigationStateFromTarget(
             Class<? extends Component> target) {
         return new NavigationStateBuilder(router).withTarget(target).build();
+    }
+
+    @Test
+    public void handle_RouterLinkTrigger_scrollPositionHandlerAfterServerNavigationIsInvoked() {
+        // given a service with instantiator
+        MockVaadinServletService service = createMockServiceWithInstantiator();
+
+        // given a locked session
+        MockVaadinSession session = new AlwaysLockedVaadinSession(service);
+        session.setConfiguration(new MockDeploymentConfiguration());
+
+        // given a NavigationStateRenderer mapping to RegularView
+        new NavigationStateBuilder(router).withTarget(RegularView.class)
+                .build();
+        NavigationStateRenderer renderer = new NavigationStateRenderer(
+                navigationStateFromTarget(RegularView.class));
+
+        // given a UI with an instrumented Page that records JS invocations
+        AtomicBoolean jsInvoked = new AtomicBoolean(false);
+        List<String> jsExpressions = new ArrayList<>();
+        MockUI ui = new MockUI(session) {
+            final Page page = new Page(this) {
+                @Override
+                public PendingJavaScriptResult executeJs(String expression,
+                        Serializable... params) {
+                    jsInvoked.set(true);
+                    jsExpressions.add(expression);
+                    return super.executeJs(expression, params);
+                }
+            };
+
+            @Override
+            public Page getPage() {
+                return page;
+            }
+        };
+
+        JsonObject state = Json.createObject();
+        state.put("href", "view/regular");
+        state.put("scrollPositionX", 0.0);
+        state.put("scrollPositionY", 0.0);
+
+        renderer.handle(new NavigationEvent(new Router(new TestRouteRegistry()),
+                new Location("preserved"), ui, NavigationTrigger.ROUTER_LINK,
+                state));
+
+        // then client-side JS was invoked
+        Assert.assertTrue("Expected JS invocation", jsInvoked.get());
+        Assert.assertTrue(jsExpressions.stream()
+                .anyMatch(expression -> expression.contains(
+                        "scrollPositionHandlerAfterServerNavigation")));
+    }
+
+    @Test()
+    public void handle_RouterLinkTriggerNullState_IllegalStateException() {
+        // given a service with instantiator
+        MockVaadinServletService service = createMockServiceWithInstantiator();
+
+        // given a locked session
+        MockVaadinSession session = new AlwaysLockedVaadinSession(service);
+        session.setConfiguration(new MockDeploymentConfiguration());
+
+        // given a NavigationStateRenderer mapping to RegularView
+        new NavigationStateBuilder(router).withTarget(RegularView.class)
+                .build();
+        NavigationStateRenderer renderer = new NavigationStateRenderer(
+                navigationStateFromTarget(RegularView.class));
+
+        MockUI ui = new MockUI(session);
+
+        expectedException.expect(IllegalStateException.class);
+        renderer.handle(new NavigationEvent(new Router(new TestRouteRegistry()),
+                new Location("regular"), ui, NavigationTrigger.ROUTER_LINK,
+                null));
+    }
+
+    @Test
+    public void handle_isForwardTo_noPushState() {
+        // given a service with instantiator
+        MockVaadinServletService service = createMockServiceWithInstantiator();
+
+        // given a locked session
+        MockVaadinSession session = new AlwaysLockedVaadinSession(service);
+        session.setConfiguration(new MockDeploymentConfiguration());
+
+        // given a NavigationStateRenderer mapping to RegularView
+        new NavigationStateBuilder(router).withTarget(RegularView.class)
+                .build();
+        NavigationStateRenderer renderer = new NavigationStateRenderer(
+                navigationStateFromTarget(RegularView.class));
+
+        // given a UI with an instrumented Page that records
+        // getHistory().pushState calls
+        AtomicBoolean pushStateCalled = new AtomicBoolean(false);
+        MockUI ui = new MockUI(session) {
+            final Page page = new Page(this) {
+                final History history = new History(getUI().get()) {
+                    @Override
+                    public void pushState(JsonValue state, Location location) {
+                        pushStateCalled.set(true);
+                    }
+                };
+
+                @Override
+                public History getHistory() {
+                    return history;
+                }
+            };
+
+            @Override
+            public Page getPage() {
+                return page;
+            }
+        };
+
+        renderer.handle(new NavigationEvent(new Router(new TestRouteRegistry()),
+                new Location("regular"), ui, NavigationTrigger.PROGRAMMATIC,
+                null, true));
+
+        Assert.assertFalse("No pushState invocation is expected.",
+                pushStateCalled.get());
+    }
+
+    @Test
+    public void handle_programmaticTriggerWithState_pushStateIsCalled() {
+        // given a service with instantiator
+        MockVaadinServletService service = createMockServiceWithInstantiator();
+
+        // given a locked session
+        MockVaadinSession session = new AlwaysLockedVaadinSession(service);
+        session.setConfiguration(new MockDeploymentConfiguration());
+
+        // given a NavigationStateRenderer mapping to RegularView
+        new NavigationStateBuilder(router).withTarget(RegularView.class)
+                .build();
+        NavigationStateRenderer renderer = new NavigationStateRenderer(
+                navigationStateFromTarget(RegularView.class));
+
+        // given a UI with an instrumented Page that records
+        // getHistory().pushState calls
+        AtomicBoolean pushStateCalled = new AtomicBoolean(false);
+        List<Location> pushStateLocations = new ArrayList<>();
+        MockUI ui = new MockUI(session) {
+            final Page page = new Page(this) {
+                final History history = new History(getUI().get()) {
+                    @Override
+                    public void pushState(JsonValue state, Location location) {
+                        pushStateCalled.set(true);
+                        pushStateLocations.add(location);
+                    }
+                };
+
+                @Override
+                public History getHistory() {
+                    return history;
+                }
+            };
+
+            @Override
+            public Page getPage() {
+                return page;
+            }
+        };
+
+        JsonObject state = Json.createObject();
+
+        renderer.handle(new NavigationEvent(new Router(new TestRouteRegistry()),
+                new Location("regular"), ui, NavigationTrigger.PROGRAMMATIC,
+                state));
+
+        Assert.assertTrue("pushState invocation is expected.",
+                pushStateCalled.get());
+        Assert.assertTrue(pushStateLocations.stream()
+                .anyMatch(location -> location.getPath().equals("regular")));
+    }
+
+    @Test
+    public void handle_programmaticTriggerWithNullState_pushStateIsNotCalled() {
+        // given a service with instantiator
+        MockVaadinServletService service = createMockServiceWithInstantiator();
+
+        // given a locked session
+        MockVaadinSession session = new AlwaysLockedVaadinSession(service);
+        session.setConfiguration(new MockDeploymentConfiguration());
+
+        // given a NavigationStateRenderer mapping to RegularView
+        new NavigationStateBuilder(router).withTarget(RegularView.class)
+                .build();
+        NavigationStateRenderer renderer = new NavigationStateRenderer(
+                navigationStateFromTarget(RegularView.class));
+
+        // given a UI with an instrumented Page that records
+        // getHistory().pushState calls
+        AtomicBoolean pushStateCalled = new AtomicBoolean(false);
+        MockUI ui = new MockUI(session) {
+            final Page page = new Page(this) {
+                final History history = new History(getUI().get()) {
+                    @Override
+                    public void pushState(JsonValue state, Location location) {
+                        pushStateCalled.set(true);
+                    }
+                };
+
+                @Override
+                public History getHistory() {
+                    return history;
+                }
+            };
+
+            @Override
+            public Page getPage() {
+                return page;
+            }
+        };
+
+        renderer.handle(new NavigationEvent(new Router(new TestRouteRegistry()),
+                new Location("regular"), ui, NavigationTrigger.PROGRAMMATIC,
+                null));
+
+        Assert.assertFalse("pushState being called is not expected.",
+                pushStateCalled.get());
+    }
+
+    @Test
+    public void handle_programmaticTriggerRepeatedLocation_pushStateIsNotCalled() {
+        // given a service with instantiator
+        MockVaadinServletService service = createMockServiceWithInstantiator();
+
+        // given a locked session
+        MockVaadinSession session = new AlwaysLockedVaadinSession(service);
+        session.setConfiguration(new MockDeploymentConfiguration());
+
+        // given a NavigationStateRenderer mapping to RegularView
+        new NavigationStateBuilder(router).withTarget(RegularView.class)
+                .build();
+        NavigationStateRenderer renderer = new NavigationStateRenderer(
+                navigationStateFromTarget(RegularView.class));
+
+        // given a UI with an instrumented Page that records
+        // getHistory().pushState calls
+        AtomicBoolean pushStateCalled = new AtomicBoolean(false);
+        MockUI ui = new MockUI(session) {
+            final Page page = new Page(this) {
+                final History history = new History(getUI().get()) {
+                    @Override
+                    public void pushState(JsonValue state, Location location) {
+                        pushStateCalled.set(true);
+                    }
+                };
+
+                @Override
+                public History getHistory() {
+                    return history;
+                }
+            };
+
+            @Override
+            public Page getPage() {
+                return page;
+            }
+        };
+
+        JsonObject state = Json.createObject();
+        renderer.handle(new NavigationEvent(new Router(new TestRouteRegistry()),
+                new Location("regular"), ui, NavigationTrigger.PROGRAMMATIC,
+                state));
+
+        pushStateCalled.set(false);
+
+        renderer.handle(new NavigationEvent(new Router(new TestRouteRegistry()),
+                new Location("regular"), ui, NavigationTrigger.PROGRAMMATIC,
+                state));
+
+        Assert.assertFalse("pushState being called is not expected.",
+                pushStateCalled.get());
     }
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PostponeProceedView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PostponeProceedView.java
@@ -15,8 +15,11 @@
  */
 package com.vaadin.flow.uitest.ui;
 
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.router.BeforeLeaveEvent;
 import com.vaadin.flow.router.BeforeLeaveEvent.ContinueNavigationAction;
 import com.vaadin.flow.router.BeforeLeaveObserver;
@@ -26,6 +29,7 @@ import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 
 @Route(value = "com.vaadin.flow.uitest.ui.PostponeProceedView", layout = ViewTestLayout.class)
 public class PostponeProceedView extends Div implements BeforeLeaveObserver {
+    private ContinueNavigationAction continueNavigationAction;
 
     @Route(value = "com.vaadin.flow.uitest.ui.PostponeProceedView.ProceedResultView", layout = ViewTestLayout.class)
     public static class ProceedResultView extends Div {
@@ -36,16 +40,47 @@ public class PostponeProceedView extends Div implements BeforeLeaveObserver {
         }
     }
 
+    @Route(value = "com.vaadin.flow.uitest.ui.PostponeProceedView.DelayedProceedTargetView", layout = ViewTestLayout.class)
+    public static class DelayedProceedTargetView extends Div {
+        public DelayedProceedTargetView() {
+            Label label = new Label("Delayed Proceed Target View");
+            label.setId("target");
+            add(label);
+        }
+    }
+
     public PostponeProceedView() {
         RouterLink link = new RouterLink("Navigate to another view",
                 ProceedResultView.class);
         link.setId("link");
-        add(link);
+        add(link, new Paragraph());
+
+        RouterLink delayedProceedLink = new RouterLink(
+                "Navigate to another view with delayed proceed",
+                DelayedProceedTargetView.class);
+        delayedProceedLink.setId("delayedProceedLink");
+
+        NativeButton postponedNavigateButton = new NativeButton(
+                "Postponed navigate", event -> UI.getCurrent()
+                        .navigate(DelayedProceedTargetView.class));
+        postponedNavigateButton.setId("postponedNavigateButton");
+
+        NativeButton proceedButton = new NativeButton("proceed",
+                event -> continueNavigationAction.proceed());
+        proceedButton.setId("proceedButton");
+
+        add(delayedProceedLink, new Paragraph(), postponedNavigateButton,
+                new Paragraph(), proceedButton);
     }
 
     @Override
     public void beforeLeave(BeforeLeaveEvent event) {
-        ContinueNavigationAction action = event.postpone();
-        action.proceed();
+        if (event.getNavigationTarget() == ProceedResultView.class) {
+            continueNavigationAction = event.postpone();
+            continueNavigationAction.proceed();
+        } else if (event
+                .getNavigationTarget() == DelayedProceedTargetView.class) {
+            continueNavigationAction = event.postpone();
+        }
     }
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/RouterLinkView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/RouterLinkView.java
@@ -1,10 +1,14 @@
 package com.vaadin.flow.uitest.ui;
 
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Anchor;
+import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Image;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementFactory;
 import com.vaadin.flow.router.Route;
+
+import elemental.json.JsonObject;
 
 @Route("com.vaadin.flow.uitest.ui.RouterLinkView")
 public class RouterLinkView extends AbstractDivView {
@@ -13,9 +17,11 @@ public class RouterLinkView extends AbstractDivView {
         Element bodyElement = getElement();
         bodyElement.getStyle().set("margin", "1em");
 
-        Element location = ElementFactory.createDiv("no location").setAttribute("id", "location");
+        Element location = ElementFactory.createDiv("no location")
+                .setAttribute("id", "location");
 
-        Element queryParams = ElementFactory.createDiv("no queryParams").setAttribute("id", "queryParams");
+        Element queryParams = ElementFactory.createDiv("no queryParams")
+                .setAttribute("id", "queryParams");
 
         bodyElement.appendChild(location, new Element("p"));
         bodyElement.appendChild(queryParams, new Element("p"));
@@ -24,7 +30,11 @@ public class RouterLinkView extends AbstractDivView {
 
         getPage().getHistory().setHistoryStateChangeHandler(e -> {
             location.setText(e.getLocation().getPath());
-            queryParams.setText(e.getLocation().getQueryParameters().getQueryString());
+            queryParams.setText(
+                    e.getLocation().getQueryParameters().getQueryString());
+            if (e.getState().isPresent())
+                UI.getCurrent().getPage().getHistory().pushState(null,
+                        ((JsonObject) e.getState().get()).getString("href"));
         });
 
         addImageLink();
@@ -46,16 +56,22 @@ public class RouterLinkView extends AbstractDivView {
     protected void addLinks() {
         getElement().appendChild(
                 // inside servlet mapping
-                ElementFactory.createDiv("inside this servlet"), ElementFactory.createRouterLink("", "empty"),
-                new Element("p"), createRouterLink("foo"), new Element("p"), createRouterLink("foo/bar"),
-                new Element("p"), createRouterLink("./foobar"), new Element("p"), createRouterLink("./foobar?what=not"),
-                new Element("p"), createRouterLink("./foobar?what=not#fragment"), new Element("p"),
-                createRouterLink("/view/baz"), new Element("p"),
+                ElementFactory.createDiv("inside this servlet"),
+                ElementFactory.createRouterLink("", "empty"), new Element("p"),
+                createRouterLink("foo"), new Element("p"),
+                createRouterLink("foo/bar"), new Element("p"),
+                createRouterLink("./foobar"), new Element("p"),
+                createRouterLink("./foobar?what=not"), new Element("p"),
+                createRouterLink("./foobar?what=not#fragment"),
+                new Element("p"), createRouterLink("/view/baz"),
+                new Element("p"),
                 // outside
-                ElementFactory.createDiv("outside this servlet"), createRouterLink("/run"), new Element("p"),
+                ElementFactory.createDiv("outside this servlet"),
+                createRouterLink("/run"), new Element("p"),
                 createRouterLink("/foo/bar"), new Element("p"),
                 // external
-                ElementFactory.createDiv("external"), createRouterLink("http://example.net/"));
+                ElementFactory.createDiv("external"),
+                createRouterLink("http://example.net/"));
     }
 
     private Element createRouterLink(String target) {

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/NavigationTriggerIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/NavigationTriggerIT.java
@@ -28,32 +28,51 @@ import com.vaadin.flow.testutil.ChromeBrowserTest;
 public class NavigationTriggerIT extends ChromeBrowserTest {
     @Test
     public void testNavigationTriggers() {
-        open();
+        String url = getTestURL() + "/abc/";
+        getDriver().get(url);
+
         assertMessageCount(1);
-        assertLastMessage("/", NavigationTrigger.PAGE_LOAD);
+        assertLastMessage("/abc", NavigationTrigger.PAGE_LOAD, "abc");
+        Assert.assertEquals("The trailing '/' from the URL should be removed.",
+                url.substring(0, url.length() - 1),
+                getDriver().getCurrentUrl());
 
         findElement(By.id("routerlink")).click();
         assertMessageCount(2);
-        assertLastMessage("/routerlink", NavigationTrigger.ROUTER_LINK);
+        assertLastMessage("/routerlink", NavigationTrigger.ROUTER_LINK,
+                "routerlink");
 
         findElement(By.id("navigate")).click();
         assertMessageCount(3);
-        assertLastMessage("/navigate", NavigationTrigger.UI_NAVIGATE);
+        assertLastMessage("/navigate", NavigationTrigger.UI_NAVIGATE,
+                "navigate");
 
         getDriver().navigate().back();
         assertMessageCount(4);
-        assertLastMessage("/routerlink", NavigationTrigger.HISTORY);
+        assertLastMessage("/routerlink", NavigationTrigger.HISTORY,
+                "routerlink");
 
         getDriver().navigate().forward();
         assertMessageCount(5);
-        assertLastMessage("/navigate", NavigationTrigger.HISTORY);
+        assertLastMessage("/navigate", NavigationTrigger.HISTORY, "navigate");
+
+        findElement(By.id("forwardButton")).click();
+        assertMessageCount(6);
+        assertLastMessage("/forwarded", NavigationTrigger.PROGRAMMATIC,
+                "forwarded");
+
+        findElement(By.id("rerouteButton")).click();
+        assertMessageCount(7);
+        assertLastMessage("/", NavigationTrigger.PROGRAMMATIC, "rerouted");
     }
 
-    private void assertLastMessage(String path, NavigationTrigger trigger) {
+    private void assertLastMessage(String path, NavigationTrigger trigger,
+            String parameter) {
         List<WebElement> messages = getMessages();
         String lastMessageText = messages.get(messages.size() - 1).getText();
 
-        Assert.assertEquals(NavigationTriggerView.buildMessage(path, trigger),
+        Assert.assertEquals(
+                NavigationTriggerView.buildMessage(path, trigger, parameter),
                 lastMessageText);
     }
 

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/NavigationTriggerIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/NavigationTriggerIT.java
@@ -38,7 +38,7 @@ public class NavigationTriggerIT extends ChromeBrowserTest {
 
         findElement(By.id("navigate")).click();
         assertMessageCount(3);
-        assertLastMessage("/navigate", NavigationTrigger.PROGRAMMATIC);
+        assertLastMessage("/navigate", NavigationTrigger.UI_NAVIGATE);
 
         getDriver().navigate().back();
         assertMessageCount(4);

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PostponeProceedIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PostponeProceedIT.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.uitest.ui;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
 
@@ -23,11 +24,68 @@ import com.vaadin.flow.testutil.ChromeBrowserTest;
 public class PostponeProceedIT extends ChromeBrowserTest {
 
     @Test
-    public void proceedPosponedNavigationImmidiately_navigationIsDone() {
+    public void proceedPostponedNavigationImmediately_navigationIsDone() {
         open();
 
         findElement(By.id("link")).click();
 
-        waitUntil(dirver -> isElementPresent(By.id("target")));
+        waitUntil(driver -> isElementPresent(By.id("target")));
+        Assert.assertTrue(String.format(
+                "After proceed, the URL in the address bar should ends with %s. But, it was %s",
+                PostponeProceedView.ProceedResultView.class.getSimpleName(),
+                getDriver().getCurrentUrl()),
+                getDriver().getCurrentUrl()
+                        .endsWith(PostponeProceedView.ProceedResultView.class
+                                .getSimpleName()));
+    }
+
+    @Test
+    public void proceedPostponedNavigationWithRouterLink_withDelay_urlIsChangedAfterProceed() {
+        open();
+
+        String url = driver.getCurrentUrl();
+
+        findElement(By.id("delayedProceedLink")).click();
+
+        Assert.assertTrue(isElementPresent(By.id("delayedProceedLink")));
+        Assert.assertTrue(!isElementPresent(By.id("target")));
+        Assert.assertEquals(url, driver.getCurrentUrl());
+
+        findElement(By.id("proceedButton")).click();
+
+        waitUntil(driver -> isElementPresent(By.id("target")));
+        Assert.assertTrue(String.format(
+                "After proceed, the URL in the address bar should ends with %s. But, it was %s",
+                PostponeProceedView.DelayedProceedTargetView.class
+                        .getSimpleName(),
+                getDriver().getCurrentUrl()),
+                getDriver().getCurrentUrl().endsWith(
+                        PostponeProceedView.DelayedProceedTargetView.class
+                                .getSimpleName()));
+    }
+
+    @Test
+    public void proceedPostponedNavigationWithUINavigate_withDelay_urlIsChangedAfterProceed() {
+        open();
+
+        String url = driver.getCurrentUrl();
+
+        findElement(By.id("postponedNavigateButton")).click();
+
+        Assert.assertTrue(isElementPresent(By.id("postponedNavigateButton")));
+        Assert.assertTrue(!isElementPresent(By.id("target")));
+        Assert.assertEquals(url, driver.getCurrentUrl());
+
+        findElement(By.id("proceedButton")).click();
+
+        waitUntil(driver -> isElementPresent(By.id("target")));
+        Assert.assertTrue(String.format(
+                "After proceed, the URL in the address bar should ends with %s. But, it was %s",
+                PostponeProceedView.DelayedProceedTargetView.class
+                        .getSimpleName(),
+                getDriver().getCurrentUrl()),
+                getDriver().getCurrentUrl().endsWith(
+                        PostponeProceedView.DelayedProceedTargetView.class
+                                .getSimpleName()));
     }
 }

--- a/flow-tests/test-root-ui-context/src/main/java/com/vaadin/flow/uitest/servlet/ApplicationRunnerServlet.java
+++ b/flow-tests/test-root-ui-context/src/main/java/com/vaadin/flow/uitest/servlet/ApplicationRunnerServlet.java
@@ -15,6 +15,12 @@
  */
 package com.vaadin.flow.uitest.servlet;
 
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
@@ -36,13 +42,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,6 +62,8 @@ import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.server.VaadinServletService;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.uitest.servlet.CustomDeploymentConfiguration.Conf;
+
+import elemental.json.JsonValue;
 
 @WebServlet(asyncSupported = true, urlPatterns = { "/*" })
 public class ApplicationRunnerServlet extends VaadinServlet {
@@ -283,7 +284,7 @@ public class ApplicationRunnerServlet extends VaadinServlet {
                 Router router = new Router(getRouteRegistry()) {
                     @Override
                     public int navigate(UI ui, Location location,
-                            NavigationTrigger trigger) {
+                            NavigationTrigger trigger, JsonValue state) {
                         ui.getPage().getHistory().pushState(null, location);
                         return HttpServletResponse.SC_OK;
                     }

--- a/flow-tests/test-root-ui-context/src/main/java/com/vaadin/flow/uitest/servlet/ApplicationRunnerServlet.java
+++ b/flow-tests/test-root-ui-context/src/main/java/com/vaadin/flow/uitest/servlet/ApplicationRunnerServlet.java
@@ -284,6 +284,7 @@ public class ApplicationRunnerServlet extends VaadinServlet {
                     @Override
                     public int navigate(UI ui, Location location,
                             NavigationTrigger trigger) {
+                        ui.getPage().getHistory().pushState(null, location);
                         return HttpServletResponse.SC_OK;
                     }
                 };


### PR DESCRIPTION
Part of #3619, fix items 1 and 2 from https://github.com/vaadin/flow/issues/3619#issuecomment-613389430

* Push browser history state after navigation is certain because in case
of `postpone` the URL in the address bar is changed too early and the 
navigation process might not proceed
* Remove adding to history state from `RouterLinkHandler` as the 
server-side does the same job at the correct time

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8125)
<!-- Reviewable:end -->
