### PR TITLE
Deprecate enableInstallPrompt() method (#8038)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/PWA.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PWA.java
@@ -172,7 +172,10 @@ public @interface PWA {
      * required from Chrome 68 upwards.
      *
      * @return are pwa -install prompt resources injected.
+     *
+     * @deprecated Feature being phased out and removed in Flow 3.2.
      */
+    @Deprecated
     boolean enableInstallPrompt() default true;
 
 }


### PR DESCRIPTION
Deprecates PWA `enableInstallPrompt` method from Flow (#8038)

Add `@Deprecated` tag and `@deprecated` javadoc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8167)
<!-- Reviewable:end -->
