### PR TITLE
Support live reload on gitpod.io

### DIFF
--- a/flow-client/src/test/frontend/VaadinDevmodeGizmoTests.js
+++ b/flow-client/src/test/frontend/VaadinDevmodeGizmoTests.js
@@ -1,0 +1,17 @@
+const { describe, it } = intern.getPlugin('interface.bdd');
+const { assert } = intern.getPlugin("chai");
+
+import { init } from "../../main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo";
+
+describe('VaadinDevmodeGizmo', () => {
+
+  it('should connect to port-hostname.gitpod.io with Spring Boot Devtools', () => {
+    let gizmo = init('', 'SPRING_BOOT_DEVTOOLS', 35729);
+    let location = {
+      'protocol': 'https',
+      'hostname': 'abc-12345678-1234-1234-1234-1234567890ab.ws-eu01.gitpod.io'
+    };
+    assert.equal(gizmo.getSpringBootWebSocketUrl(location),
+      'ws://35729-12345678-1234-1234-1234-1234567890ab.ws-eu01.gitpod.io');
+  });
+});

--- a/flow-client/webpack.tests.config.js
+++ b/flow-client/webpack.tests.config.js
@@ -4,7 +4,8 @@ module.exports = {
   mode: "development",
   entry: {
     flow: "./src/test/frontend/FlowTests.ts",
-    connect: "./src/test/frontend/ConnectTests.ts"
+    connect: "./src/test/frontend/ConnectTests.ts",
+    vaadindevmodegizmo: "./src/test/frontend/VaadinDevmodeGizmoTests.js"
   },
   output: {
     filename: "[name].spec.js",


### PR DESCRIPTION
gitpod.io maps URLs as https://port-hostname and all ports use the standard https port

Fixes #8009 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8190)
<!-- Reviewable:end -->
