### PR TITLE
Overrides crucial method so that it can be used in demo code

### DIFF
--- a/flow-component-demo-helpers/src/main/java/com/vaadin/flow/demo/DemoView.java
+++ b/flow-component-demo-helpers/src/main/java/com/vaadin/flow/demo/DemoView.java
@@ -70,8 +70,8 @@ public abstract class DemoView extends Component
         }
         addClassName("demo-view");
         navBar.addClassName("demo-nav");
-        add(navBar);
-        add(container);
+        HasComponents.super.add(navBar);
+        HasComponents.super.add(container);
 
         populateSources();
         initView();
@@ -288,5 +288,12 @@ public abstract class DemoView extends Component
         return String.format(
                 variantPresent ? "Remove '%s' variant" : "Add '%s' variant",
                 variantName);
+    }
+
+    /**
+     * No-op method so that we can use the line <code>add(Component)</code> in vaadin.com demos.
+     */
+    public void add(Component... components) {
+    	// No-op
     }
 }


### PR DESCRIPTION
The 'add' method is crucial for component demos, and we want to include it in all demo code. this PR makes the actual method a no-op so that demos aren't messed up by adding the method call.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8198)
<!-- Reviewable:end -->
