### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@
             <dependency>
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy</artifactId>
-                <version>1.10.9</version>
+                <version>1.10.8</version>
             </dependency>
 
 


### PR DESCRIPTION
net.bytebuddy:byte-buddy:1.10.9 -> 1.10.8 as possibly missing in BOM of spring for latest 2.2.6.RELEASE such version 1.10.9

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8214)
<!-- Reviewable:end -->
