### PR TITLE
Do not print webpack progress output in a production build

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -195,7 +195,7 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo {
         }
 
         List<String> command = Arrays.asList(nodePath,
-                webpackExecutable.getAbsolutePath(), "--progress");
+                webpackExecutable.getAbsolutePath());
         ProcessBuilder builder = FrontendUtils.createProcessBuilder(command)
                 .directory(project.getBasedir()).inheritIO();
         getLog().info("Running webpack ...");

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -146,7 +146,7 @@ module.exports = {
     // Generate compressed bundles when not devMode
     !devMode && new CompressionPlugin(),
     // Give some feedback when heavy builds
-    new ProgressPlugin(true),
+    devMode && new ProgressPlugin(true),
 
     // Generates the stats file for flow `@Id` binding.
     function (compiler) {


### PR DESCRIPTION
Produces around 2000 rows less output in the production build.
The progress output for a CI build is not relevant and is in the way
when looking for build problems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8227)
<!-- Reviewable:end -->
