### PR TITLE
Change PWA javadocs to reflect phase out of Install Prompt

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/PWA.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PWA.java
@@ -48,6 +48,12 @@ import java.lang.annotation.Target;
  * {@literal manifest.webmanifest}. Same applies for service worker and generated
  * icons.
  *
+ * <b>
+ * NOTE: PWA Install Prompt feature will be removed in future versions since this
+ * feature was only supported by Chromium-based browsers, in favour of a more
+ * uniform implementation and experience for all browsers.
+ * </b>
+ *
  * @since 1.2
  *
  * @see <a href=


### PR DESCRIPTION
Part of #8038
Change javadoc in order to call attention on the phase out of PWA Install Prompt

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8240)
<!-- Reviewable:end -->
