### PR TITLE
Live-reload: Accept push target parameter `liveReloadPath`

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
@@ -13,6 +13,7 @@ interface AppConfig {
   serviceUrl: string;
   springBootDevToolsPort: number;
   liveReloadBackend: string;
+  liveReloadPath: string;
 }
 
 interface AppInitResponse {
@@ -235,7 +236,7 @@ export class Flow {
       // (server ensures this parameter is true only in dev mode)
       if (appConfig.devmodeGizmoEnabled) {
         const devmodeGizmoMod = await import('./VaadinDevmodeGizmo');
-        const devmodeGizmo = await devmodeGizmoMod.init(appConfig.serviceUrl, appConfig.liveReloadBackend, appConfig.springBootDevToolsPort);
+        const devmodeGizmo = await devmodeGizmoMod.init(appConfig.serviceUrl, appConfig.liveReloadPath, appConfig.liveReloadBackend, appConfig.springBootDevToolsPort);
         $wnd.Vaadin.Flow.devModeGizmo = devmodeGizmo;
       }
 

--- a/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.d.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.d.ts
@@ -1,1 +1,1 @@
-export const init: (serviceUrl: string, liveReloadBackend: string, springBootDevToolsPort: number) => HTMLElement;
+export const init: (serviceUrl: string, liveReloadPath: string, liveReloadBackend: string, springBootDevToolsPort: number) => HTMLElement;

--- a/flow-client/src/test/frontend/VaadinDevmodeGizmoTests.js
+++ b/flow-client/src/test/frontend/VaadinDevmodeGizmoTests.js
@@ -6,12 +6,23 @@ import { init } from "../../main/resources/META-INF/resources/frontend/VaadinDev
 describe('VaadinDevmodeGizmo', () => {
 
   it('should connect to port-hostname.gitpod.io with Spring Boot Devtools', () => {
-    let gizmo = init('', 'SPRING_BOOT_DEVTOOLS', 35729);
+    let gizmo = init(undefined, '','SPRING_BOOT_DEVTOOLS', 35729);
     let location = {
       'protocol': 'https',
       'hostname': 'abc-12345678-1234-1234-1234-1234567890ab.ws-eu01.gitpod.io'
     };
     assert.equal(gizmo.getSpringBootWebSocketUrl(location),
       'ws://35729-12345678-1234-1234-1234-1234567890ab.ws-eu01.gitpod.io');
+  });
+
+  it('should append push target if given', () => {
+    let gizmo = init(undefined, 'context/vaadinServlet','HOTSWAP_AGENT', 35729);
+    let location = {
+      'href': 'http://localhost:8080/context/myroute',
+      'protocol': 'http:',
+      'host': 'localhost:8080',
+    };
+    assert.equal(gizmo.getDedicatedWebSocketUrl(location),
+      'ws://localhost:8080/context/vaadinServlet?v-r=push&refresh_connection');
   });
 });

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -1054,7 +1054,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          * @return A non-null {@link JsonObject} with application parameters.
          */
         public JsonObject getApplicationParameters(BootstrapContext context) {
-            JsonObject appConfig = getApplicationParameters(
+            JsonObject appConfig = getApplicationParameters(context,
                     context.getRequest(), context.getSession());
 
             appConfig.put(ApplicationConstants.UI_ID_PARAMETER,
@@ -1062,7 +1062,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             return appConfig;
         }
 
-        private JsonObject getApplicationParameters(VaadinRequest request,
+        private JsonObject getApplicationParameters(BootstrapContext context, VaadinRequest request,
                 VaadinSession session) {
             DeploymentConfiguration deploymentConfiguration = session
                     .getConfiguration();
@@ -1093,6 +1093,11 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                 if (liveReload != null && liveReload.getBackend() != null) {
                     appConfig.put("liveReloadBackend",
                             liveReload.getBackend().toString());
+                    String pushURL = session.getConfiguration().getPushURL();
+                    if (pushURL != null) {
+                        appConfig.put("liveReloadPath", context
+                                .getUriResolver().resolveVaadinUri(pushURL));
+                    }
                 }
 
                 // make configurable when fixing #7847


### PR DESCRIPTION
This handles non-default paths when establishing the WebSocket connection (e.g. Vaadin Spring expects `/vaadinServlet`). Fixes #8205.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8280)
<!-- Reviewable:end -->
