### PR TITLE
Store vaadin hash to node_modules 2.1

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -198,7 +198,7 @@ public abstract class NodeUpdater implements FallibleCommand {
     }
 
     JsonObject getPackageJson(File packageFile) throws IOException {
-        JsonObject packageJson = null;
+        JsonObject packageJson = Json.createObject();
         if (packageFile.exists()) {
             String fileContent = FileUtils.readFileToString(packageFile,
                     UTF_8.name());

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCreatePackageJson.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCreatePackageJson.java
@@ -23,6 +23,7 @@ import elemental.json.Json;
 import elemental.json.JsonObject;
 
 import static com.vaadin.flow.server.frontend.TaskUpdatePackages.APP_PACKAGE_HASH;
+import static com.vaadin.flow.server.frontend.TaskUpdatePackages.HASH_KEY;
 
 /**
  * Creates the <code>package.json</code> if missing.
@@ -57,9 +58,6 @@ public class TaskCreatePackageJson extends NodeUpdater {
         try {
             modified = false;
             JsonObject mainContent = getMainPackageJson();
-            if (mainContent == null) {
-                mainContent = Json.createObject();
-            }
             modified = updateMainDefaultDependencies(mainContent,
                     polymerVersion);
             if (modified) {
@@ -69,11 +67,12 @@ public class TaskCreatePackageJson extends NodeUpdater {
                     mainContent.put(APP_PACKAGE_HASH, FORCE_INSTALL_HASH);
                 } else {
                     mainContent.put(APP_PACKAGE_HASH, "");
+                    mainContent.put(HASH_KEY, TaskUpdatePackages.calculatePackageHash(mainContent));
                 }
                 writeMainPackageFile(mainContent);
             }
             JsonObject customContent = getAppPackageJson();
-            if (customContent == null) {
+            if (customContent.keys().length == 0) {
                 customContent = Json.createObject();
                 updateAppDefaultDependencies(customContent);
                 writeAppPackageFile(customContent);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -19,16 +19,22 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.apache.commons.io.FileUtils;
+
 import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.FallibleCommand;
 
+import elemental.json.Json;
+import elemental.json.JsonObject;
+import elemental.json.impl.JsonUtil;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
+import static com.vaadin.flow.server.frontend.TaskUpdatePackages.HASH_KEY;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Run <code>npm install</code> after dependencies have been updated.
@@ -41,8 +47,13 @@ public class TaskRunNpmInstall implements FallibleCommand {
 
     private final NodeUpdater packageUpdater;
 
+    // .vaadin/vaadin.json contains local installation data inside node_modules
+    // This will hep us know to execute even when another developer has pushed
+    // a new hash to the code repository.
+    private static final String INSTALL_HASH = ".vaadin/vaadin.json";
+
     private final List<String> ignoredNodeFolders = Arrays
-            .asList(".bin",".staging");
+            .asList(".bin", ".staging", ".vaadin");
 
     /**
      * Create an instance of the command.
@@ -62,9 +73,44 @@ public class TaskRunNpmInstall implements FallibleCommand {
                     + "resolve and optionally download frontend dependencies. "
                     + "This may take a moment, please stand by...");
             runNpmInstall();
+
+            updateLocalHash();
         } else {
             packageUpdater.log().info(SKIPPING_NPM_INSTALL);
         }
+    }
+
+
+    /**
+     * Updates the local hash to node_modules.
+     * <p>
+     * This is for handling updated package to the code repository by another
+     * developer as then the hash is updated and we may just be missing one
+     * module.
+     */
+    private void updateLocalHash() {
+        try {
+            if(!packageUpdater.getMainPackageJson().hasKey(HASH_KEY)) {
+                packageUpdater.log().warn("No hash found for full package.json.");
+                return;
+            }
+            final String hash = packageUpdater.getMainPackageJson().getString(HASH_KEY);
+
+            final JsonObject localHash = Json.createObject();
+            localHash.put(HASH_KEY, hash);
+
+            final File localHashFile = getLocalHashFile();
+            FileUtils.forceMkdirParent(localHashFile);
+            String content = JsonUtil.stringify(localHash, 2) + "\n";
+            FileUtils.writeStringToFile(localHashFile, content, UTF_8.name());
+
+        } catch (IOException e) {
+            packageUpdater.log().warn("Failed to update node_modules hash.", e);
+        }
+    }
+
+    private File getLocalHashFile() {
+        return new File(packageUpdater.nodeModulesFolder, INSTALL_HASH);
     }
 
     private boolean shouldRunNpmInstall() {
@@ -76,8 +122,35 @@ public class TaskRunNpmInstall implements FallibleCommand {
             assert installedPackages != null;
             return installedPackages.length == 0
                     || (installedPackages.length == 1 && FLOW_NPM_PACKAGE_NAME
-                            .startsWith(installedPackages[0].getName()));
+                            .startsWith(installedPackages[0].getName()))
+                    ||  (installedPackages.length > 0 && isVaadinHashUpdated());
         }
+        return true;
+    }
+
+    private boolean isVaadinHashUpdated() {
+        final File localHashFile = getLocalHashFile();
+        if (!localHashFile.exists()) {
+            return true;
+        }
+        try {
+            String fileContent = FileUtils
+                    .readFileToString(localHashFile, UTF_8.name());
+            JsonObject content = Json.parse(fileContent);
+            if (content.hasKey(HASH_KEY)) {
+                final JsonObject packageJson = packageUpdater
+                        .getMainPackageJson();
+                if (packageJson == null || !packageJson.hasKey(HASH_KEY)) {
+                    return false;
+                }
+                return !content.getString(HASH_KEY)
+                        .equals(packageJson.getString(HASH_KEY));
+            }
+        } catch (IOException e) {
+            packageUpdater.log()
+                    .warn("Failed to load hashes forcing npm execution", e);
+        }
+
         return true;
     }
 
@@ -114,7 +187,7 @@ public class TaskRunNpmInstall implements FallibleCommand {
             StringBuilder toolOutput = new StringBuilder();
             try (BufferedReader reader = new BufferedReader(
                     new InputStreamReader(process.getInputStream(),
-                            StandardCharsets.UTF_8))) {
+                            UTF_8))) {
                 String stdoutLine;
                 while ((stdoutLine = reader.readLine()) != null) {
                     packageUpdater.log().debug(stdoutLine);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -27,11 +27,11 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.server.Constants;
@@ -53,6 +53,10 @@ import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 public class TaskUpdatePackages extends NodeUpdater {
 
     static final String APP_PACKAGE_HASH = "vaadinAppPackageHash";
+    static final String HASH_KEY = "hash";
+    static final String DEPENDENCIES = "dependencies";
+    static final String DEV_DEPENDENCIES = "devDependencies";
+
     private static final String VERSION = "version";
     private static final String SHRINK_WRAP = "@vaadin/vaadin-shrinkwrap";
     private boolean forceCleanUp;
@@ -102,9 +106,6 @@ public class TaskUpdatePackages extends NodeUpdater {
         try {
             Map<String, String> deps = frontDeps.getPackages();
             JsonObject packageJson = getAppPackageJson();
-            if (packageJson == null) {
-                packageJson = Json.createObject();
-            }
             boolean isModified = updatePackageJsonDependencies(packageJson,
                     deps);
             if (isModified) {
@@ -128,17 +129,7 @@ public class TaskUpdatePackages extends NodeUpdater {
      */
     private boolean checkPackageHash(JsonObject packageJson)
             throws IOException {
-        String content = "";
-        // If we have dependencies generate hash on ordered content.
-        if (packageJson.hasKey("dependencies")) {
-            JsonObject dependencies = packageJson.getObject("dependencies");
-            content = Stream.of(dependencies.keys())
-                    .map(key -> String.format("\"%s\": \"%s\"", key,
-                            dependencies.get(key).asString()))
-                    .sorted(String::compareToIgnoreCase)
-                    .collect(Collectors.joining(",\n  "));
-        }
-        return updateAppPackageHash(getHash(content));
+        return updateAppPackageHash(calculatePackageHash(packageJson));
     }
 
     private boolean updatePackageJsonDependencies(JsonObject packageJson,
@@ -269,8 +260,7 @@ public class TaskUpdatePackages extends NodeUpdater {
         return new File(npmFolder, "package-lock.json");
     }
 
-    private String getShrinkWrapVersion(JsonObject packageJson)
-            throws IOException {
+    private String getShrinkWrapVersion(JsonObject packageJson) {
         if (packageJson == null) {
             return null;
         }
@@ -284,7 +274,7 @@ public class TaskUpdatePackages extends NodeUpdater {
         return null;
     }
 
-    private String getHash(String content) {
+    private static String getHash(String content) {
         if (content.isEmpty()) {
             return content;
         }
@@ -308,12 +298,67 @@ public class TaskUpdatePackages extends NodeUpdater {
                 || !hash.equals(mainContent.getString(APP_PACKAGE_HASH));
         if (modified) {
             mainContent.put(APP_PACKAGE_HASH, hash);
+        }
+        String mainHash = calculatePackageHash(mainContent);
+        if (!mainContent.hasKey(HASH_KEY) || !mainContent.getString(HASH_KEY)
+                .equals(mainHash)) {
+            mainContent.put(HASH_KEY, mainHash);
+            modified = true;
+        }
+        if(modified) {
             writeMainPackageFile(mainContent);
         }
         return modified;
     }
 
-    private String bytesToHex(byte[] hash) {
+    /**
+     * Calculate a full hash of dependencies, devDependencies and application
+     * package.json hash.
+     *
+     * @param packageJson
+     *         package.json to create hash for
+     * @return hash for given packageJson
+     */
+    static String calculatePackageHash(JsonObject packageJson) {
+        StringBuilder hashContent = new StringBuilder();
+        final String entryFormat = "\"%s\": \"%s\"";
+        if (packageJson.hasKey(DEPENDENCIES)) {
+            JsonObject dependencies = packageJson.getObject(DEPENDENCIES);
+            hashContent.append("\"dependencies\": {");
+            String sortedDependencies = Arrays.stream(dependencies.keys())
+                    .sorted(String::compareToIgnoreCase).map(key -> String
+                            .format(entryFormat, key,
+                                    dependencies.getString(key)))
+                    .collect(Collectors.joining(",\n  "));
+            hashContent.append(sortedDependencies);
+            hashContent.append("}");
+        }
+        if (packageJson.hasKey(DEV_DEPENDENCIES)) {
+            if (hashContent.length() > 0) {
+                hashContent.append(",\n");
+            }
+            JsonObject devDependencies = packageJson
+                    .getObject(DEV_DEPENDENCIES);
+            hashContent.append("\"devDependencies\": {");
+            String sortedDevDependencies = Arrays.stream(devDependencies.keys())
+                    .sorted(String::compareToIgnoreCase).map(key -> String
+                            .format(entryFormat, key,
+                                    devDependencies.getString(key)))
+                    .collect(Collectors.joining(",\n  "));
+            hashContent.append(sortedDevDependencies);
+            hashContent.append("}");
+        }
+        if (packageJson.hasKey(APP_PACKAGE_HASH)) {
+            if (hashContent.length() > 0) {
+                hashContent.append(",\n");
+            }
+            hashContent.append(String.format(entryFormat, APP_PACKAGE_HASH,
+                    packageJson.getString(APP_PACKAGE_HASH)));
+        }
+        return getHash(hashContent.toString());
+    }
+
+    private static String bytesToHex(byte[] hash) {
         StringBuilder result = new StringBuilder();
         for (byte bit : hash) {
             String hex = Integer.toHexString(0xff & bit);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
@@ -43,6 +43,7 @@ import elemental.json.JsonValue;
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.TaskUpdatePackages.APP_PACKAGE_HASH;
+import static com.vaadin.flow.server.frontend.TaskUpdatePackages.HASH_KEY;
 import static elemental.json.impl.JsonUtil.stringify;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -439,7 +440,8 @@ public abstract class AbstractNodeUpdatePackagesTest
     }
 
     @Test
-    public void generateAppPackageJson_noDependencies_updaterIsNotModified() {
+    public void generateAppPackageJson_noDependencies_updaterIsNotModified()
+            throws IOException {
         FrontendDependencies frontendDependencies = Mockito
                 .mock(FrontendDependencies.class);
 
@@ -593,4 +595,16 @@ public abstract class AbstractNodeUpdatePackagesTest
         return packageJson;
     }
 
+    public void writeLocalHash(String hash) throws IOException {
+        final JsonObject localHash = Json.createObject();
+        localHash.put(HASH_KEY, hash);
+
+        final File localHashFile = new File(baseDir,
+                ".vaadin/vaadin.json");
+        FileUtils.forceMkdirParent(localHashFile);
+
+        FileUtils.forceMkdirParent(localHashFile);
+        String content = stringify(localHash, 2) + "\n";
+        FileUtils.writeStringToFile(localHashFile, content, UTF_8.name());
+    }
 }


### PR DESCRIPTION
Generate a full hash to mainPackageJson
and store it after npm install to
node_modules/.vaadin

Fixes #8182

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8294)
<!-- Reviewable:end -->
