### PR TITLE
Extract live reload ITs into separate test module

### DIFF
--- a/flow-tests/README.md
+++ b/flow-tests/README.md
@@ -76,6 +76,10 @@
   * `context://` tests for Compatibility mode
 * test-themes
   * Custom Theme tests for NPM and Compatibility modes
+* test-live-reload
+  * Tests the live reload feature in development mode. Run sequentially in their own
+    module as live reload affects all open UIs and would cause interference between 
+    parallelly executing tests.
 
 ### Common test resource modules
 

--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -289,6 +289,7 @@
                 <module>test-subcontext</module>
                 <module>test-root-ui-context</module>
                 <module>test-router-custom-context</module>
+                <module>test-live-reload</module>
 
                 <module>test-scalability</module>
                 <module>test-memory-leaks</module>

--- a/flow-tests/test-dev-mode/src/main/java/com/vaadin/flow/uitest/ui/TestingServiceInitListener.java
+++ b/flow-tests/test-dev-mode/src/main/java/com/vaadin/flow/uitest/ui/TestingServiceInitListener.java
@@ -44,13 +44,6 @@ public class TestingServiceInitListener implements VaadinServiceInitListener {
             }
             return dependencies;
         });
-
-        // just set a fake backend to trigger live-reload client-side
-        BrowserLiveReloadAccess liveReloadAccess = VaadinService.getCurrent()
-                .getInstantiator().getOrCreate(BrowserLiveReloadAccess.class);
-        BrowserLiveReload browserLiveReload = liveReloadAccess
-                .getLiveReload(VaadinService.getCurrent());
-        browserLiveReload.setBackend(BrowserLiveReload.Backend.HOTSWAP_AGENT);
     }
 
 }

--- a/flow-tests/test-live-reload/pom.xml
+++ b/flow-tests/test-live-reload/pom.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
+        <groupId>com.vaadin</groupId>
         <version>3.2-SNAPSHOT</version>
     </parent>
-    <artifactId>flow-test-dev-mode</artifactId>
-    <name>Flow tests for dev mode</name>
-    <description>
-        Tests extracted from flow-test-root-context to be run in development mode.
-    </description>
+    <artifactId>flow-test-live-reload-mode</artifactId>
+    <name>Flow tests for live reload in dev mode</name>
+
     <packaging>war</packaging>
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
@@ -25,20 +24,20 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>flow-html-components-testbench</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.vaadin</groupId>
             <artifactId>flow-test-common</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>annotations</artifactId>
+            <version>3.0.1</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <!-- Run flow plugin to build frontend -->
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
@@ -46,10 +45,36 @@
                     <productionMode>false</productionMode>
                 </configuration>
             </plugin>
-            <!-- This module is mapped to default web context -->
+            <!-- Run jetty before integration tests, and stop after -->
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
+                <configuration>
+                    <webApp>
+                        <!-- use a non-root context -->
+                        <contextPath>/context</contextPath>
+                    </webApp>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>set-system-properties</goal>
+                        </goals>
+                        <configuration>
+                            <properties>
+                                <property>
+                                    <!-- make sure live reload is enabled -->
+                                    <name>vaadin.devmode.liveReload.enabled</name>
+                                    <value>true</value>-->
+                                </property>
+                            </properties>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
@@ -88,4 +113,3 @@
         </profile>
     </profiles>
 </project>
-

--- a/flow-tests/test-live-reload/pom.xml
+++ b/flow-tests/test-live-reload/pom.xml
@@ -69,7 +69,7 @@
                                 <property>
                                     <!-- make sure live reload is enabled -->
                                     <name>vaadin.devmode.liveReload.enabled</name>
-                                    <value>true</value>-->
+                                    <value>true</value>
                                 </property>
                             </properties>
                         </configuration>

--- a/flow-tests/test-live-reload/src/main/java/com/vaadin/flow/uitest/ui/LiveReloadView.java
+++ b/flow-tests/test-live-reload/src/main/java/com/vaadin/flow/uitest/ui/LiveReloadView.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.uitest.ui;
+
+import java.util.Random;
+
+import com.vaadin.flow.component.ClickEvent;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.internal.BrowserLiveReload;
+import com.vaadin.flow.internal.BrowserLiveReloadAccess;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+@Route(value = "com.vaadin.flow.uitest.ui.LiveReloadView", layout = ViewTestLayout.class)
+public class LiveReloadView extends Div {
+
+    Integer instanceIdentifier = new Random().nextInt();
+
+    public LiveReloadView() {
+        Label label = new Label(Integer.toString(instanceIdentifier));
+        label.setId("elementId");
+        NativeButton reloadButton = new NativeButton("Trigger live reload");
+        reloadButton.addClickListener(this::handleClickLiveReload);
+        reloadButton.setId("live-reload-trigger-button");
+        add(label);
+        add(reloadButton);
+    }
+
+    private void handleClickLiveReload(ClickEvent event) {
+        BrowserLiveReloadAccess liveReloadAccess = VaadinService.getCurrent()
+                .getInstantiator().getOrCreate(BrowserLiveReloadAccess.class);
+        BrowserLiveReload browserLiveReload = liveReloadAccess
+                .getLiveReload(VaadinService.getCurrent());
+        browserLiveReload.reload();
+    }
+}

--- a/flow-tests/test-live-reload/src/main/java/com/vaadin/flow/uitest/ui/PreserveOnRefreshLiveReloadView.java
+++ b/flow-tests/test-live-reload/src/main/java/com/vaadin/flow/uitest/ui/PreserveOnRefreshLiveReloadView.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.flow.uitest.ui.frontend;
+package com.vaadin.flow.uitest.ui;
 
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.PreserveOnRefresh;
@@ -21,7 +21,7 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 
 
-@Route(value = "com.vaadin.flow.uitest.ui.frontend.PreserveOnRefreshLiveReloadView", layout = ViewTestLayout.class)
+@Route(value = "com.vaadin.flow.uitest.ui.PreserveOnRefreshLiveReloadView", layout = ViewTestLayout.class)
 @PreserveOnRefresh
 public class PreserveOnRefreshLiveReloadView extends Div {
 }

--- a/flow-tests/test-live-reload/src/main/java/com/vaadin/flow/uitest/ui/TestingServiceInitListener.java
+++ b/flow-tests/test-live-reload/src/main/java/com/vaadin/flow/uitest/ui/TestingServiceInitListener.java
@@ -13,41 +13,23 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+package com.vaadin.flow.uitest.ui;
 
-package com.vaadin.flow.uitest.ui.frontend;
-
-import java.util.Random;
-
-import com.vaadin.flow.component.ClickEvent;
-import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.Label;
-import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.internal.BrowserLiveReload;
 import com.vaadin.flow.internal.BrowserLiveReloadAccess;
-import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.ServiceInitEvent;
 import com.vaadin.flow.server.VaadinService;
-import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+import com.vaadin.flow.server.VaadinServiceInitListener;
 
-@Route(value = "com.vaadin.flow.uitest.ui.frontend.LiveReloadView", layout = ViewTestLayout.class)
-public class LiveReloadView extends Div {
-
-    Integer instanceIdentifier = new Random().nextInt();
-
-    public LiveReloadView() {
-        Label label = new Label(Integer.toString(instanceIdentifier));
-        label.setId("elementId");
-        NativeButton reloadButton = new NativeButton("Trigger live reload");
-        reloadButton.addClickListener(this::handleClickLiveReload);
-        reloadButton.setId("live-reload-trigger-button");
-        add(label);
-        add(reloadButton);
-    }
-
-    private void handleClickLiveReload(ClickEvent event) {
+public class TestingServiceInitListener implements VaadinServiceInitListener {
+    @Override
+    public void serviceInit(ServiceInitEvent event) {
+        // just set a fake backend to trigger live-reload client-side
         BrowserLiveReloadAccess liveReloadAccess = VaadinService.getCurrent()
                 .getInstantiator().getOrCreate(BrowserLiveReloadAccess.class);
         BrowserLiveReload browserLiveReload = liveReloadAccess
                 .getLiveReload(VaadinService.getCurrent());
-        browserLiveReload.reload();
+        browserLiveReload.setBackend(BrowserLiveReload.Backend.HOTSWAP_AGENT);
     }
+
 }

--- a/flow-tests/test-live-reload/src/main/resources/META-INF/services/com.vaadin.flow.server.VaadinServiceInitListener
+++ b/flow-tests/test-live-reload/src/main/resources/META-INF/services/com.vaadin.flow.server.VaadinServiceInitListener
@@ -1,0 +1,1 @@
+com.vaadin.flow.uitest.ui.TestingServiceInitListener

--- a/flow-tests/test-live-reload/src/test/java/com/vaadin/flow/uitest/ui/AbstractLiveReloadIT.java
+++ b/flow-tests/test-live-reload/src/test/java/com/vaadin/flow/uitest/ui/AbstractLiveReloadIT.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public abstract class AbstractLiveReloadIT extends ChromeBrowserTest {
+
+    @Override
+    protected String getTestPath() {
+        return "/context" + super.getTestPath();
+    }
+
+}

--- a/flow-tests/test-live-reload/src/test/java/com/vaadin/flow/uitest/ui/LiveReloadIT.java
+++ b/flow-tests/test-live-reload/src/test/java/com/vaadin/flow/uitest/ui/LiveReloadIT.java
@@ -13,22 +13,19 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
+package com.vaadin.flow.uitest.ui;
 
-package com.vaadin.flow.uitest.ui.frontend;
-
-import net.jcip.annotations.NotThreadSafe;
 import java.util.List;
 
+import net.jcip.annotations.NotThreadSafe;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
-
-import com.vaadin.flow.testutil.ChromeBrowserTest;
+import org.openqa.selenium.html5.WebStorage;
 
 @NotThreadSafe
-public class LiveReloadIT extends ChromeBrowserTest {
+public class LiveReloadIT extends AbstractLiveReloadIT {
 
     @Test
     public void overlayShouldRender() {
@@ -59,24 +56,9 @@ public class LiveReloadIT extends ChromeBrowserTest {
     }
 
     @Test
-    @Ignore
     public void overlayShouldNotBeRenderedAfterDisable() {
         open();
-        waitForElementPresent(By.tagName("vaadin-devmode-gizmo"));
-        WebElement liveReload = findElement(By.tagName("vaadin-devmode-gizmo"));
-        liveReload.click();
-
-        WebElement liveReloadIcon = findInShadowRoot(liveReload,
-                By.className("gizmo")).get(0);
-        liveReloadIcon.click();
-
-        WebElement button = findInShadowRoot(liveReload, By.id("disable"))
-                .get(0);
-        button.click();
-
-        Assert.assertEquals(0,
-                findElements(By.tagName("vaadin-devmode-gizmo")).size());
-
+        disableLiveReloadInLocalStorage();
         driver.navigate().refresh();
 
         Assert.assertEquals(0,
@@ -84,22 +66,12 @@ public class LiveReloadIT extends ChromeBrowserTest {
     }
 
     @Test
-    @Ignore
     public void liveReloadShouldNotTriggerAfterDisable() {
         open();
-        waitForElementPresent(By.tagName("vaadin-devmode-gizmo"));
-        WebElement liveReload = findElement(By.tagName("vaadin-devmode-gizmo"));
-        liveReload.click();
+        disableLiveReloadInLocalStorage();
+        driver.navigate().refresh();
 
         String instanceId = findElement(By.id("elementId")).getText();
-
-        WebElement liveReloadIcon = findInShadowRoot(liveReload,
-                By.className("gizmo")).get(0);
-        liveReloadIcon.click();
-
-        WebElement button = findInShadowRoot(liveReload, By.id("disable"))
-                .get(0);
-        button.click();
 
         WebElement liveReloadTrigger = findElement(
                 By.id("live-reload-trigger-button"));
@@ -166,5 +138,10 @@ public class LiveReloadIT extends ChromeBrowserTest {
         Assert.assertFalse(
                 gizmo2.getAttribute("class").contains("active"));
         Assert.assertTrue(gizmo2.getAttribute("class").contains("gizmo"));
+    }
+
+    private void disableLiveReloadInLocalStorage() {
+        ((WebStorage) getDriver()).getLocalStorage()
+                .setItem("vaadin.live-reload.enabled", "false");
     }
 }

--- a/flow-tests/test-live-reload/src/test/java/com/vaadin/flow/uitest/ui/LiveReloadIT.java
+++ b/flow-tests/test-live-reload/src/test/java/com/vaadin/flow/uitest/ui/LiveReloadIT.java
@@ -22,7 +22,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.html5.WebStorage;
 
 @NotThreadSafe
 public class LiveReloadIT extends AbstractLiveReloadIT {
@@ -53,33 +52,6 @@ public class LiveReloadIT extends AbstractLiveReloadIT {
         WebElement window2 = findInShadowRoot(liveReload, By.className("gizmo"))
                 .get(0);
         Assert.assertTrue(window2.isDisplayed());
-    }
-
-    @Test
-    public void overlayShouldNotBeRenderedAfterDisable() {
-        open();
-        disableLiveReloadInLocalStorage();
-        driver.navigate().refresh();
-
-        Assert.assertEquals(0,
-                findElements(By.tagName("vaadin-devmode-gizmo")).size());
-    }
-
-    @Test
-    public void liveReloadShouldNotTriggerAfterDisable() {
-        open();
-        disableLiveReloadInLocalStorage();
-        driver.navigate().refresh();
-
-        String instanceId = findElement(By.id("elementId")).getText();
-
-        WebElement liveReloadTrigger = findElement(
-                By.id("live-reload-trigger-button"));
-        liveReloadTrigger.click();
-
-        String instanceId2 = findElement(By.id("elementId")).getText();
-
-        Assert.assertEquals(instanceId, instanceId2);
     }
 
     @Test
@@ -140,8 +112,4 @@ public class LiveReloadIT extends AbstractLiveReloadIT {
         Assert.assertTrue(gizmo2.getAttribute("class").contains("gizmo"));
     }
 
-    private void disableLiveReloadInLocalStorage() {
-        ((WebStorage) getDriver()).getLocalStorage()
-                .setItem("vaadin.live-reload.enabled", "false");
-    }
 }

--- a/flow-tests/test-live-reload/src/test/java/com/vaadin/flow/uitest/ui/PreserveOnRefreshLiveReloadIT.java
+++ b/flow-tests/test-live-reload/src/test/java/com/vaadin/flow/uitest/ui/PreserveOnRefreshLiveReloadIT.java
@@ -13,20 +13,16 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
-package com.vaadin.flow.uitest.ui.frontend;
+package com.vaadin.flow.uitest.ui;
 
 import net.jcip.annotations.NotThreadSafe;
-
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.flow.testutil.ChromeBrowserTest;
-
 @NotThreadSafe
-public class PreserveOnRefreshLiveReloadIT extends ChromeBrowserTest {
+public class PreserveOnRefreshLiveReloadIT extends AbstractLiveReloadIT {
 
     @Test
     public void notificationShownWhenLoadingPreserveOnRefreshView() {


### PR DESCRIPTION
Live reload tests must never execute in parallel with other tests since they will trigger a reload
in all open UIs, interfere with concurrently running tests. Having them in a separate test module
makes them more isolated. Also test with non-root context.

Fixes #8296 (and possibly #8310).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8324)
<!-- Reviewable:end -->
