### PR TITLE
Removing deprecated parameter from DataNode constructor

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -898,7 +898,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             // https://developer.mozilla.org/en/docs/Web/HTML/Element/script
             Element wrapper = createJavaScriptElement(null, false);
             wrapper.appendChild(
-                    new DataNode(javaScriptContents, wrapper.baseUri()));
+                    new DataNode(javaScriptContents));
             return wrapper;
         }
 


### PR DESCRIPTION
If you use container (such as the latest Wilfdly) which forces to use significantly newer version of Jsoup than Vaadin depends to, this can cause a problem as deprecated method as been removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8325)
<!-- Reviewable:end -->
