### PR TITLE
Fix RouterSessionExpirationIT OSGi failure on 2.1

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/flow/RouterLinkHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/RouterLinkHandler.java
@@ -265,7 +265,7 @@ public class RouterLinkHandler {
         // If the server tells us the session has expired, we refresh (using the
         // new location) instead.
         registry.getMessageHandler().setNextResponseSessionExpiredHandler(
-                () -> WidgetUtil.refresh());
+                () -> WidgetUtil.redirect(location));
         registry.getServerConnector().sendNavigationMessage(location,
                 stateObject, routerLinkEvent);
 


### PR DESCRIPTION
Fixes https://github.com/vaadin/flow/issues/8308

Using felix-jetty RouterSessionExpirationIT.navigationAfterSessionExpired fails due to session expired when using a router link.

https://bender.vaadin.com/viewLog.html?buildId=145588&buildTypeId=Flow_Nightly_FlowFelixJettyIntegrationTests21

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8354)
<!-- Reviewable:end -->
