### PR TITLE
fix: custom connect client breaks endpoints mapping

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectControllerConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectControllerConfiguration.java
@@ -18,8 +18,6 @@ package com.vaadin.flow.server.connect;
 
 import java.lang.reflect.Method;
 
-import com.vaadin.flow.server.frontend.FrontendUtils;
-
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcRegistrations;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectControllerConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectControllerConfiguration.java
@@ -95,10 +95,8 @@ public class VaadinConnectControllerConfiguration {
      */
     private RequestMappingInfo prependConnectPrefixUrl(
             RequestMappingInfo mapping) {
-        String customEnpointPrefixName = FrontendUtils.getCustomEndpointPrefix();
         PatternsRequestCondition connectEndpointPattern =
                 new PatternsRequestCondition(
-                        customEnpointPrefixName != null ? customEnpointPrefixName :
                 vaadinEndpointProperties.getVaadinEndpointPrefix())
                         .combine(mapping.getPatternsCondition());
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/OpenApiSpecGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/OpenApiSpecGenerator.java
@@ -22,7 +22,6 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Properties;
 
-import com.vaadin.flow.server.frontend.FrontendUtils;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.models.OpenAPI;
 import org.apache.commons.io.FileUtils;
@@ -115,14 +114,8 @@ public class OpenApiSpecGenerator {
 
     private OpenApiConfiguration extractOpenApiConfiguration(
             Properties applicationProperties) {
-        String customEnpointPrefixName = FrontendUtils.getCustomEndpointPrefix();
         String prefix = (String) applicationProperties.getOrDefault(PREFIX,
-                customEnpointPrefixName != null
-                        ? customEnpointPrefixName
-                        : DEFAULT_PREFIX);
-        if(!prefix.startsWith(("/"))) {
-            prefix = "/" + prefix;
-        }
+                DEFAULT_PREFIX);
         String server = GeneratorUtils.removeEnd((String) applicationProperties
                 .getOrDefault(SERVER, DEFAULT_SERVER), "/");
         String serverDescription = (String) applicationProperties

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -55,7 +55,6 @@ import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_STATISTICS_JSON
 import static com.vaadin.flow.server.Constants.STATISTICS_JSON_DEFAULT;
 import static com.vaadin.flow.server.Constants.VAADIN_MAPPING;
 import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
-import static com.vaadin.flow.server.connect.generator.VaadinConnectClientGenerator.CUSTOM_CONNECT_CLIENT_NAME;
 import static java.lang.String.format;
 
 /**
@@ -1040,28 +1039,4 @@ public class FrontendUtils {
         System.out.print(format(format, message));
     }
 
-    /**
-     * Get the custom endpoint prefix
-     *      in frontend folder.
-     *
-     * @return the string for endpoint name if exists
-     */
-    public static String getCustomEndpointPrefix() {
-        File customConnectClient = new File(System.getProperty("user.dir") + "/" + FRONTEND,
-                CUSTOM_CONNECT_CLIENT_NAME);
-        String contentFile = null;
-        if (customConnectClient.exists()) {
-            try {
-                contentFile = FileUtils.readFileToString(customConnectClient, "UTF-8");
-                String temp = contentFile.substring(
-                        contentFile.indexOf("{prefix:") + 8,
-                        contentFile.indexOf("})"))
-                        .trim();
-                contentFile = temp.substring(1, temp.length() - 1);
-            } catch (IOException e) {
-                getLogger().error("Failed to read file content", e);
-            }
-        }
-        return contentFile;
-    }
 }


### PR DESCRIPTION
Presence or absence of a custom Connect client in `frontend/connect-client.ts` should not affect the URL mapping of the endpoint calls handler on the backend (the way to configure that mapping is to use the `vaadin.endpoint.prefix` application property). There is no need to parse the `connect-client.ts` and try to determine the URL mapping from there.

Earlier, when the support for a custom Connect client was added in https://github.com/vaadin/flow/pull/7944, the code that tried to determine the endpoint handler URL mapping from a custom `connect-client.ts` file had a bug that resulted in an incorrect URL mapping configuration.

This commit completely removes the link between a custom Connect client and the endpoint handler URL mapping config.

NOTE: an integration test is added to the `spring` repo, as it requires Spring to run, and the `flow` repo does not have it:  https://github.com/vaadin/spring/pull/622

Fixes #8364

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8366)
<!-- Reviewable:end -->
