### PR TITLE
vaadin elements strategies 

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/form/Models.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/form/Models.ts
@@ -42,6 +42,7 @@ export abstract class AbstractModel<T> {
     this[keySymbol] = key;
     validators.forEach(validator => this[validatorsSymbol].add(validator));
   }
+
   toString() {
     return String(this.valueOf());
   }
@@ -76,15 +77,12 @@ export class ObjectModel<T> extends AbstractModel<T> {
     const modelInstance = new this(undefined as any, defaultValueSymbol)
     return Object.keys(modelInstance).reduce(
       (obj: any, key: keyof any) => {
-        obj[key] = (
+        (obj = (obj || {}))[key] = (
           (modelInstance as any)[key].constructor as ModelConstructor<any, AbstractModel<any>>
         ).createEmptyValue();
         return obj;
-      },
-      {}
-    );
+      }, null);
   }
-  [fromStringSymbol] = String;
 }
 
 export class ArrayModel<T, M extends AbstractModel<T>> extends AbstractModel<ReadonlyArray<T>> {

--- a/flow-client/src/main/resources/META-INF/resources/frontend/form/Validators.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/form/Validators.ts
@@ -39,7 +39,7 @@ export class NotNull extends AbstractValidator<any> {
   validate = (value: any) => !new Null().validate(value);
 }
 export class NotEmpty extends AbstractValidator<any> {
-  validate = (value: any) => new NotNull().validate(value) && !validator.isEmpty(value);
+  validate = (value: any) => new NotNull().validate(value) && value.length > 0;
 }
 export class NotBlank extends AbstractValidator<any> {
   validate = (value: any) => new NotEmpty().validate(value);

--- a/flow-client/src/test/frontend/FormValidatorTests.ts
+++ b/flow-client/src/test/frontend/FormValidatorTests.ts
@@ -42,8 +42,10 @@ from "../../main/resources/META-INF/resources/frontend/form";
   test("NotEmpty", () => {
     const validator = new NotEmpty();
     assert.isTrue(validator.validate('a'));
+    assert.isTrue(validator.validate(['a']));
     assert.isFalse(validator.validate(''));
     assert.isFalse(validator.validate(undefined));
+    assert.isFalse(validator.validate([]));
   });
 
   test("NotBlank", () => {


### PR DESCRIPTION
Fixes: https://github.com/vaadin/flow/issues/7940

    - Do not use field-conversor in object models (fix check-group value arrays)
    - Do not generate empty objects but null on createEmpty (fix clear time-picker)
    - Adding strategies for checked and selected components
    - Better stragegy selector for elements (checkbox, radio, listbox, rich-editor)
    - fix NotEmpty validator so as it can check arrays (fix check-group arrays)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8378)
<!-- Reviewable:end -->
