### PR TITLE
Disable Live Reload in compatibility mode

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
@@ -109,8 +109,15 @@ public class ApplicationConnection {
             String liveReloadPath, String liveReloadBackend,
             String springBootDevToolsPort)
     /*-{
-      $wnd.Vaadin.Flow.devModeGizmo = $wnd.Vaadin.Flow.initDevModeGizmo(
-        serviceUrl, liveReloadPath, liveReloadBackend, springBootDevToolsPort);
+      if ($wnd.Vaadin.Flow.initDevModeGizmo !== undefined) {
+        $wnd.Vaadin.Flow.devModeGizmo = $wnd.Vaadin.Flow.initDevModeGizmo(
+          serviceUrl, liveReloadPath, liveReloadBackend, springBootDevToolsPort);
+      } else {
+        // This should normally not happen, as conditions during which
+        // live-reload is disabled (configuration, production and/or
+        // compatibility mode) are detected on the server side.
+        console.warn('Live reload UI not available');
+      }
     }-*/;
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
@@ -231,7 +231,8 @@ public class PropertyDeploymentConfiguration
      */
     @Override
     public boolean isDevModeLiveReloadEnabled() {
-        return !isProductionMode() && getBooleanProperty(
-                SERVLET_PARAMETER_DEVMODE_ENABLE_LIVE_RELOAD, true);
+        return !isProductionMode() && !isCompatibilityMode()
+                && getBooleanProperty(
+                        SERVLET_PARAMETER_DEVMODE_ENABLE_LIVE_RELOAD, true);
     }
 }


### PR DESCRIPTION
The Live Reload UI is not available in compatibility mode. Part of #8388.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8396)
<!-- Reviewable:end -->
