### PR TITLE
Moved init parameters to new class com.vaadin.flow.server.InitParameters (#8409)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/di/DefaultInstantiator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/di/DefaultInstantiator.java
@@ -24,7 +24,7 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.i18n.I18NProvider;
 import com.vaadin.flow.internal.ReflectTools;
-import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.InvalidI18NConfigurationException;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServiceInitListener;
@@ -130,7 +130,7 @@ public class DefaultInstantiator implements Instantiator {
             return null;
         }
         return deploymentConfiguration
-                .getStringProperty(Constants.I18N_PROVIDER, null);
+                .getStringProperty(InitParameters.I18N_PROVIDER, null);
     }
 
     private <T> T create(Class<T> type) {

--- a/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
@@ -23,11 +23,12 @@ import java.util.Properties;
 import java.util.function.Function;
 
 import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.WrappedSession;
 import com.vaadin.flow.shared.communication.PushMode;
 
 import static com.vaadin.flow.server.Constants.POLYFILLS_DEFAULT_VALUE;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_POLYFILLS;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_POLYFILLS;
 
 /**
  * A collection of properties configured at deploy time as well as a way of
@@ -318,14 +319,14 @@ public interface DeploymentConfiguration extends Serializable {
 
     /**
      * Determines if webJars mechanism is enabled. It is disabled if the user
-     * have explicitly set the {@link Constants#DISABLE_WEBJARS} property to
+     * have explicitly set the {@link InitParameters#DISABLE_WEBJARS} property to
      * {@code true}, or the user have not set the property at all and the
      * {@link #useCompiledFrontendResources()} returns false.
      *
      * @return {@code true} if webJars are enabled, {@code false} otherwise
      */
     default boolean areWebJarsEnabled() {
-        return !getBooleanProperty(Constants.DISABLE_WEBJARS,
+        return !getBooleanProperty(InitParameters.DISABLE_WEBJARS,
                 useCompiledFrontendResources());
     }
 
@@ -333,14 +334,14 @@ public interface DeploymentConfiguration extends Serializable {
      * Determines if Flow should use compiled or original frontend resources.
      *
      * User can explicitly disable bundled resources usage by setting the
-     * {@link Constants#USE_ORIGINAL_FRONTEND_RESOURCES} property to
+     * {@link InitParameters#USE_ORIGINAL_FRONTEND_RESOURCES} property to
      * {@code true}.
      *
      * @return {@code true} if Flow should use compiled frontend resources.
      */
     default boolean useCompiledFrontendResources() {
         return isProductionMode() && !getBooleanProperty(
-                Constants.USE_ORIGINAL_FRONTEND_RESOURCES, false);
+                InitParameters.USE_ORIGINAL_FRONTEND_RESOURCES, false);
     }
 
     /**
@@ -349,7 +350,7 @@ public interface DeploymentConfiguration extends Serializable {
      * {@link com.vaadin.flow.server.startup.ServletDeployer} javadoc.
      *
      * User can explicitly disable automatic servlet registration by setting the
-     * {@link Constants#DISABLE_AUTOMATIC_SERVLET_REGISTRATION} property to
+     * {@link InitParameters#DISABLE_AUTOMATIC_SERVLET_REGISTRATION} property to
      * {@code true}.
      *
      * @return {@code true} if Flow should not automatically register servlets
@@ -357,7 +358,7 @@ public interface DeploymentConfiguration extends Serializable {
      */
     default boolean disableAutomaticServletRegistration() {
         return getBooleanProperty(
-                Constants.DISABLE_AUTOMATIC_SERVLET_REGISTRATION, false);
+                InitParameters.DISABLE_AUTOMATIC_SERVLET_REGISTRATION, false);
     }
 
     /**
@@ -367,21 +368,20 @@ public interface DeploymentConfiguration extends Serializable {
      *         <code>false</code> to not serve Brotli files.
      */
     default boolean isBrotli() {
-        return getBooleanProperty(Constants.SERVLET_PARAMETER_BROTLI, false);
+        return getBooleanProperty(InitParameters.SERVLET_PARAMETER_BROTLI, false);
     }
 
     default String getCompiledWebComponentsPath() {
-        return getStringProperty(Constants.COMPILED_WEB_COMPONENTS_PATH,
+        return getStringProperty(InitParameters.COMPILED_WEB_COMPONENTS_PATH,
                 "vaadin-web-components");
     }
 
     /**
      * Returns an array with polyfills to be loaded when the app is loaded.
      *
-     * The default value is
-     * <code>build/webcomponentsjs/webcomponents-loader.js</code> but it can be
-     * changed by setting the {@link Constants#SERVLET_PARAMETER_POLYFILLS} as a
-     * comma separated list of JS files to load.
+     * The default value is empty, but it can be changed by setting the
+     * {@link InitParameters#SERVLET_PARAMETER_POLYFILLS} as a comma separated list
+     * of JS files to load.
      *
      * @return polyfills to load
      */
@@ -396,7 +396,7 @@ public interface DeploymentConfiguration extends Serializable {
      * @return true if dev server should be used
      */
     default boolean enableDevServer() {
-        return getBooleanProperty(Constants.SERVLET_PARAMETER_ENABLE_DEV_SERVER,
+        return getBooleanProperty(InitParameters.SERVLET_PARAMETER_ENABLE_DEV_SERVER,
                 true);
     }
 
@@ -408,7 +408,7 @@ public interface DeploymentConfiguration extends Serializable {
      * @return true if dev server should be reused
      */
     default boolean reuseDevServer() {
-        return getBooleanProperty(Constants.SERVLET_PARAMETER_REUSE_DEV_SERVER,
+        return getBooleanProperty(InitParameters.SERVLET_PARAMETER_REUSE_DEV_SERVER,
                 true);
     }
 
@@ -447,7 +447,7 @@ public interface DeploymentConfiguration extends Serializable {
      * @since 2.2
      */
     default boolean isPnpmEnabled() {
-        return getBooleanProperty(
-                Constants.SERVLET_PARAMETER_ENABLE_PNPM, false);
+        return getBooleanProperty(InitParameters.SERVLET_PARAMETER_ENABLE_PNPM,
+                false);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/AbstractDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AbstractDeploymentConfiguration.java
@@ -31,7 +31,7 @@ public abstract class AbstractDeploymentConfiguration
 
     @Override
     public String getUIClassName() {
-        return getStringProperty(VaadinSession.UI_PARAMETER,
+        return getStringProperty(InitParameters.UI_PARAMETER,
                 UI.class.getName());
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -37,7 +37,26 @@ public final class Constants implements Serializable {
      */
     public static final String VAADIN_PREFIX = "vaadin.";
 
-    public static final String SERVLET_PARAMETER_PRODUCTION_MODE = "productionMode";
+    /**
+     * @deprecated Use {@link InitParameters#SERVLET_PARAMETER_PRODUCTION_MODE}
+     *             instead.
+     */
+    @Deprecated
+    public static final String SERVLET_PARAMETER_PRODUCTION_MODE = InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE;
+
+    /**
+     * @deprecated Use {@link InitParameters#SERVLET_PARAMETER_COMPATIBILITY_MODE}
+     *             instead.
+     */
+    @Deprecated
+    public static final String SERVLET_PARAMETER_COMPATIBILITY_MODE = InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE;
+
+    /**
+     * @deprecated Use {@link InitParameters#SERVLET_PARAMETER_COMPATIBILITY_MODE}
+     *             instead.
+     */
+    @Deprecated
+    public static final String SERVLET_PARAMETER_BOWER_MODE = InitParameters.SERVLET_PARAMETER_BOWER_MODE;
 
     // Token file keys used for defining folder paths for dev server
     public static final String NPM_TOKEN = "npmFolder";
@@ -47,42 +66,117 @@ public final class Constants implements Serializable {
     public static final String EXTERNAL_STATS_URL_TOKEN = "externalStatsUrl";
 
     /**
-     * enable it if your project is a Polymer 2.0 one, should be removed in V15
-     *
-     * @deprecated the parameter is renamed to
-     *             {@link #SERVLET_PARAMETER_COMPATIBILITY_MODE}
+     * @deprecated Use {@link InitParameters#SERVLET_PARAMETER_ENABLE_DEV_SERVER}
+     *             instead.
      */
     @Deprecated
-    public static final String SERVLET_PARAMETER_BOWER_MODE = "bowerMode";
-    /**
-     * enable it if your project is a Polymer 2.0 one, should be removed in V15
-     */
-    public static final String SERVLET_PARAMETER_COMPATIBILITY_MODE = "compatibilityMode";
-    public static final String SERVLET_PARAMETER_ENABLE_DEV_SERVER = "enableDevServer";
-    public static final String SERVLET_PARAMETER_REUSE_DEV_SERVER = "reuseDevServer";
+    public static final String SERVLET_PARAMETER_ENABLE_DEV_SERVER = InitParameters.SERVLET_PARAMETER_ENABLE_DEV_SERVER;
 
-    public static final String SERVLET_PARAMETER_REQUEST_TIMING = "requestTiming";
-    // Javadocs for VaadinService should be updated if this value is changed
-    public static final String SERVLET_PARAMETER_DISABLE_XSRF_PROTECTION = "disable-xsrf-protection";
-    public static final String SERVLET_PARAMETER_HEARTBEAT_INTERVAL = "heartbeatInterval";
-    public static final String SERVLET_PARAMETER_WEB_COMPONENT_DISCONNECT = "webComponentDisconnect";
-    public static final String SERVLET_PARAMETER_CLOSE_IDLE_SESSIONS = "closeIdleSessions";
-    public static final String SERVLET_PARAMETER_PUSH_MODE = "pushMode";
-    public static final String SERVLET_PARAMETER_PUSH_URL = "pushURL";
-    public static final String SERVLET_PARAMETER_SYNC_ID_CHECK = "syncIdCheck";
-    public static final String SERVLET_PARAMETER_SEND_URLS_AS_PARAMETERS = "sendUrlsAsParameters";
-    public static final String SERVLET_PARAMETER_PUSH_SUSPEND_TIMEOUT_LONGPOLLING = "pushLongPollingSuspendTimeout";
-    public static final String SERVLET_PARAMETER_MAX_MESSAGE_SUSPEND_TIMEOUT = "maxMessageSuspendTimeout";
-    public static final String SERVLET_PARAMETER_JSBUNDLE = "module.bundle";
-    public static final String SERVLET_PARAMETER_POLYFILLS = "module.polyfills";
+    /**
+     * @deprecated Use {@link InitParameters#SERVLET_PARAMETER_REUSE_DEV_SERVER}
+     *             instead.
+     */
+    @Deprecated
+    public static final String SERVLET_PARAMETER_REUSE_DEV_SERVER = InitParameters.SERVLET_PARAMETER_REUSE_DEV_SERVER;
+
+    /**
+     * @deprecated Use {@link InitParameters#SERVLET_PARAMETER_REQUEST_TIMING}
+     *             instead.
+     */
+    @Deprecated
+    public static final String SERVLET_PARAMETER_REQUEST_TIMING = InitParameters.SERVLET_PARAMETER_REQUEST_TIMING;
+
+    /**
+     * @deprecated Use {@link InitParameters#SERVLET_PARAMETER_DISABLE_XSRF_PROTECTION}
+     *             instead.
+     */
+    @Deprecated
+    public static final String SERVLET_PARAMETER_DISABLE_XSRF_PROTECTION = InitParameters.SERVLET_PARAMETER_DISABLE_XSRF_PROTECTION;
+
+    /**
+     * @deprecated Use {@link InitParameters#SERVLET_PARAMETER_HEARTBEAT_INTERVAL}
+     *             instead.
+     */
+    @Deprecated
+    public static final String SERVLET_PARAMETER_HEARTBEAT_INTERVAL = InitParameters.SERVLET_PARAMETER_HEARTBEAT_INTERVAL;
+
+    /**
+     * @deprecated Use {@link InitParameters#SERVLET_PARAMETER_WEB_COMPONENT_DISCONNECT}
+     *             instead.
+     */
+    @Deprecated
+    public static final String SERVLET_PARAMETER_WEB_COMPONENT_DISCONNECT = InitParameters.SERVLET_PARAMETER_WEB_COMPONENT_DISCONNECT;
+
+    /**
+     * @deprecated Use {@link InitParameters#SERVLET_PARAMETER_CLOSE_IDLE_SESSIONS}
+     *             instead.
+     */
+    @Deprecated
+    public static final String SERVLET_PARAMETER_CLOSE_IDLE_SESSIONS = InitParameters.SERVLET_PARAMETER_CLOSE_IDLE_SESSIONS;
+
+    /**
+     * @deprecated Use {@link InitParameters#SERVLET_PARAMETER_PUSH_MODE}
+     *             instead.
+     */
+    @Deprecated
+    public static final String SERVLET_PARAMETER_PUSH_MODE = InitParameters.SERVLET_PARAMETER_PUSH_MODE;
+
+    /**
+     * @deprecated Use {@link InitParameters#SERVLET_PARAMETER_PUSH_URL}
+     *             instead.
+     */
+    @Deprecated
+    public static final String SERVLET_PARAMETER_PUSH_URL = InitParameters.SERVLET_PARAMETER_PUSH_URL;
+
+    /**
+     * @deprecated Use {@link InitParameters#SERVLET_PARAMETER_SYNC_ID_CHECK}
+     *             instead.
+     */
+    @Deprecated
+    public static final String SERVLET_PARAMETER_SYNC_ID_CHECK = InitParameters.SERVLET_PARAMETER_SYNC_ID_CHECK;
+
+    /**
+     * @deprecated Use {@link InitParameters#SERVLET_PARAMETER_SEND_URLS_AS_PARAMETERS}
+     *             instead.
+     */
+    @Deprecated
+    public static final String SERVLET_PARAMETER_SEND_URLS_AS_PARAMETERS = InitParameters.SERVLET_PARAMETER_SEND_URLS_AS_PARAMETERS;
+
+    /**
+     * @deprecated Use {@link InitParameters#SERVLET_PARAMETER_PUSH_SUSPEND_TIMEOUT_LONGPOLLING}
+     *             instead.
+     */
+    @Deprecated
+    public static final String SERVLET_PARAMETER_PUSH_SUSPEND_TIMEOUT_LONGPOLLING = InitParameters.SERVLET_PARAMETER_PUSH_SUSPEND_TIMEOUT_LONGPOLLING;
+
+    /**
+     * @deprecated Use {@link InitParameters#SERVLET_PARAMETER_MAX_MESSAGE_SUSPEND_TIMEOUT}
+     *             instead.
+     */
+    @Deprecated
+    public static final String SERVLET_PARAMETER_MAX_MESSAGE_SUSPEND_TIMEOUT = InitParameters.SERVLET_PARAMETER_MAX_MESSAGE_SUSPEND_TIMEOUT;
+
+    /**
+     * @deprecated Use {@link InitParameters#SERVLET_PARAMETER_JSBUNDLE}
+     *             instead.
+     */
+    @Deprecated
+    public static final String SERVLET_PARAMETER_JSBUNDLE = InitParameters.SERVLET_PARAMETER_JSBUNDLE;
+
+    /**
+     * @deprecated Use {@link InitParameters#SERVLET_PARAMETER_POLYFILLS}
+     *             instead.
+     */
+    @Deprecated
+    public static final String SERVLET_PARAMETER_POLYFILLS = InitParameters.SERVLET_PARAMETER_POLYFILLS;
+
     public static final String POLYFILLS_DEFAULT_VALUE = "build/webcomponentsjs/webcomponents-loader.js";
 
     /**
-     * Configuration name for the parameter that determines whether Brotli
-     * compression should be used for static resources in cases when a
-     * precompressed file is available.
+     * @deprecated Use {@link InitParameters#SERVLET_PARAMETER_BROTLI} instead.
      */
-    public static final String SERVLET_PARAMETER_BROTLI = "brotli";
+    @Deprecated
+    public static final String SERVLET_PARAMETER_BROTLI = InitParameters.SERVLET_PARAMETER_BROTLI;
 
     /**
      * Configuration name for loading the ES5 adapters.
@@ -118,47 +212,44 @@ public final class Constants implements Serializable {
             + "frontend/";
 
     /**
-     * Configuration name for the parameter that determines if Flow should use
-     * webJars or not.
+     * @deprecated Use {@link InitParameters#DISABLE_WEBJARS} instead.
      */
-    public static final String DISABLE_WEBJARS = "disable.webjars";
+    @Deprecated
+    public static final String DISABLE_WEBJARS = InitParameters.DISABLE_WEBJARS;
 
     /**
-     * Configuration name for the parameter that determines if Flow should use
-     * bundled fragments or not.
+     * @deprecated Use {@link InitParameters#USE_ORIGINAL_FRONTEND_RESOURCES} instead.
      */
-    public static final String USE_ORIGINAL_FRONTEND_RESOURCES = "original.frontend.resources";
+    @Deprecated
+    public static final String USE_ORIGINAL_FRONTEND_RESOURCES = InitParameters.USE_ORIGINAL_FRONTEND_RESOURCES;
 
     /**
      * I18N provider property.
+     * @deprecated Use {@link InitParameters#I18N_PROVIDER} instead.
      */
-    public static final String I18N_PROVIDER = "i18n.provider";
+    @Deprecated
+    public static final String I18N_PROVIDER = InitParameters.I18N_PROVIDER;
 
     /**
-     * Configuration name for the parameter that determines if Flow should
-     * automatically register servlets needed for the application to work.
+     * @deprecated Use {@link InitParameters#DISABLE_AUTOMATIC_SERVLET_REGISTRATION}
+     *             instead.
      */
-    public static final String DISABLE_AUTOMATIC_SERVLET_REGISTRATION = "disable.automatic.servlet.registration";
+    @Deprecated
+    public static final String DISABLE_AUTOMATIC_SERVLET_REGISTRATION = InitParameters.DISABLE_AUTOMATIC_SERVLET_REGISTRATION;
 
     /**
-     * Configuration name for the parameter that sets the compiled web
-     * components path. The path should be the same as
-     * {@code webComponentOutputDirectoryName} in the maven plugin that
-     * transpiles ES6 code. This path is only used for generated web components
-     * (server side web components) module in case they are transpiled: web
-     * component UI imports them as dependencies.
+     * @deprecated Use {@link InitParameters#COMPILED_WEB_COMPONENTS_PATH}
+     *             instead.
      */
-    public static final String COMPILED_WEB_COMPONENTS_PATH = "compiled.web.components.path";
+    @Deprecated
+    public static final String COMPILED_WEB_COMPONENTS_PATH = InitParameters.COMPILED_WEB_COMPONENTS_PATH;
 
     /**
-     * Configuration name for the WebPack profile statistics json file to use to
-     * determine template contents.
-     * <p>
-     * File needs to be available either for the ClassLoader as a resource, or
-     * as a static web resource. By default it returns the value in
-     * {@link Constants#STATISTICS_JSON_DEFAULT}
+     * @deprecated Use {@link InitParameters#SERVLET_PARAMETER_STATISTICS_JSON}
+     *             instead.
      */
-    public static final String SERVLET_PARAMETER_STATISTICS_JSON = "statistics.file.path";
+    @Deprecated
+    public static final String SERVLET_PARAMETER_STATISTICS_JSON = InitParameters.SERVLET_PARAMETER_STATISTICS_JSON;
 
     /**
      * Default path for the WebPack profile statistics json file. It can be
@@ -184,65 +275,65 @@ public final class Constants implements Serializable {
     public static final String RESOURCES_FRONTEND_DEFAULT = "META-INF/frontend";
 
     /**
-     * Configuration name for the time waiting for webpack output success or
-     * error pattern defined in
-     * {@link Constants#SERVLET_PARAMETER_DEVMODE_WEBPACK_SUCCESS_PATTERN} and
-     * {@link Constants#SERVLET_PARAMETER_DEVMODE_WEBPACK_ERROR_PATTERN}
-     * parameters.
+     * @deprecated Use {@link InitParameters#SERVLET_PARAMETER_DEVMODE_WEBPACK_TIMEOUT}
+     *             instead.
      */
-    public static final String SERVLET_PARAMETER_DEVMODE_WEBPACK_TIMEOUT = "devmode.webpack.output.pattern.timeout";
+    @Deprecated
+    public static final String SERVLET_PARAMETER_DEVMODE_WEBPACK_TIMEOUT = InitParameters.SERVLET_PARAMETER_DEVMODE_WEBPACK_TIMEOUT;
 
     /**
-     * Configuration name for the pattern used to inspect the webpack output to
-     * assure it is up and running. Default value is defined in
-     * {@link DevModeHandler} as the <code>: Compiled</code> expression.
+     * @deprecated Use {@link InitParameters#SERVLET_PARAMETER_DEVMODE_WEBPACK_SUCCESS_PATTERN}
+     *             instead.
      */
-    public static final String SERVLET_PARAMETER_DEVMODE_WEBPACK_SUCCESS_PATTERN = "devmode.webpack.output.success.pattern";
+    @Deprecated
+    public static final String SERVLET_PARAMETER_DEVMODE_WEBPACK_SUCCESS_PATTERN = InitParameters.SERVLET_PARAMETER_DEVMODE_WEBPACK_SUCCESS_PATTERN;
 
     /**
-     * Configuration name for the pattern used to inspect the webpack output to
-     * detecting when compilation failed. Default value is defined in
-     * {@link DevModeHandler} as the <code>: Failed</code> expression.
+     * @deprecated Use {@link InitParameters#SERVLET_PARAMETER_DEVMODE_WEBPACK_ERROR_PATTERN}
+     *             instead.
      */
-    public static final String SERVLET_PARAMETER_DEVMODE_WEBPACK_ERROR_PATTERN = "devmode.webpack.output.error.pattern";
+    @Deprecated
+    public static final String SERVLET_PARAMETER_DEVMODE_WEBPACK_ERROR_PATTERN = InitParameters.SERVLET_PARAMETER_DEVMODE_WEBPACK_ERROR_PATTERN;
 
     /**
-     * Configuration name for adding extra options to the webpack-dev-server.
+     * @deprecated Use {@link InitParameters#SERVLET_PARAMETER_DEVMODE_WEBPACK_OPTIONS}
+     *             instead.
      */
-    public static final String SERVLET_PARAMETER_DEVMODE_WEBPACK_OPTIONS = "devmode.webpack.options";
+    @Deprecated
+    public static final String SERVLET_PARAMETER_DEVMODE_WEBPACK_OPTIONS = InitParameters.SERVLET_PARAMETER_DEVMODE_WEBPACK_OPTIONS;
 
     /**
-     * Boolean parameter for enabling/disabling bytecode scanning in dev mode.
-     * If enabled, entry points are scanned for reachable frontend resources. If
-     * disabled, all classes on the classpath are scanned.
+     * @deprecated Use {@link InitParameters#SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE}
+     *             instead.
      */
-    public static final String SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE = "devmode.optimizeBundle";
+    @Deprecated
+    public static final String SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE = InitParameters.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE;
 
     /**
-     * Boolean parameter for enabling/disabling transpilation for IE11 with the
-     * BabelMultiTargetPlugin in dev mode.
+     * @deprecated Use {@link InitParameters#SERVLET_PARAMETER_DEVMODE_TRANSPILE}
+     *             instead.
      */
-    public static final String SERVLET_PARAMETER_DEVMODE_TRANSPILE = "devmode.transpile";
+    @Deprecated
+    public static final String SERVLET_PARAMETER_DEVMODE_TRANSPILE = InitParameters.SERVLET_PARAMETER_DEVMODE_TRANSPILE;
 
     /**
-     * Default value of {@link #SERVLET_PARAMETER_DEVMODE_TRANSPILE}.
+     * Default value of {@link InitParameters#SERVLET_PARAMETER_DEVMODE_TRANSPILE}.
      */
     public static final boolean SERVLET_PARAMETER_DEVMODE_TRANSPILE_DEFAULT = false;
 
     /**
-     * Configuration parameter name for enabling pnpm.
-     *
-     * @since 2.2
+     * @deprecated Use {@link InitParameters#SERVLET_PARAMETER_ENABLE_PNPM}
+     *             instead.
      */
-    public static final String SERVLET_PARAMETER_ENABLE_PNPM = "pnpm.enable";
+    @Deprecated
+    public static final String SERVLET_PARAMETER_ENABLE_PNPM = InitParameters.SERVLET_PARAMETER_ENABLE_PNPM;
 
     /**
-     * Configuration parameter name for requiring node executable installed in
-     * home directory.
-     *
-     * @since
+     * @deprecated Use {@link InitParameters#REQUIRE_HOME_NODE_EXECUTABLE}
+     *             instead.
      */
-    public static final String REQUIRE_HOME_NODE_EXECUTABLE = "require.home.node";
+    @Deprecated
+    public static final String REQUIRE_HOME_NODE_EXECUTABLE = InitParameters.REQUIRE_HOME_NODE_EXECUTABLE;
 
     /**
      * The path used in the vaadin servlet for handling static resources.
@@ -374,11 +465,11 @@ public final class Constants implements Serializable {
     public static final String VAADIN_VERSIONS_JSON = "vaadin_versions.json";
 
     /**
-     * Configuration parameter name for enabling live reload.
-     *
-     * @since
+     * @deprecated Use {@link InitParameters#SERVLET_PARAMETER_DEVMODE_ENABLE_LIVE_RELOAD}
+     *             instead.
      */
-    public static final String SERVLET_PARAMETER_DEVMODE_ENABLE_LIVE_RELOAD = "devmode.liveReload.enabled";
+    @Deprecated
+    public static final String SERVLET_PARAMETER_DEVMODE_ENABLE_LIVE_RELOAD = InitParameters.SERVLET_PARAMETER_DEVMODE_ENABLE_LIVE_RELOAD;
 
     private Constants() {
         // prevent instantiation constants class only

--- a/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
@@ -285,7 +285,7 @@ public class DefaultDeploymentConfiguration
      */
     private void checkProductionMode(boolean log) {
         productionMode = getBooleanProperty(
-                Constants.SERVLET_PARAMETER_PRODUCTION_MODE, false);
+                InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE, false);
         if (log) {
             if (productionMode) {
                 info.add("Vaadin is running in production mode.");
@@ -306,15 +306,17 @@ public class DefaultDeploymentConfiguration
      */
     private void checkCompatibilityMode(boolean loggWarning) {
         boolean explicitlySet = false;
-        if (getStringProperty(Constants.SERVLET_PARAMETER_BOWER_MODE,
+        if (getStringProperty(
+                InitParameters.SERVLET_PARAMETER_BOWER_MODE,
                 null) != null) {
             compatibilityMode = getBooleanProperty(
-                    Constants.SERVLET_PARAMETER_BOWER_MODE, false);
+                    InitParameters.SERVLET_PARAMETER_BOWER_MODE, false);
             explicitlySet = true;
         } else if (getStringProperty(
-                Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE, null) != null) {
+                InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE,
+                null) != null) {
             compatibilityMode = getBooleanProperty(
-                    Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE, false);
+                    InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE, false);
             explicitlySet = true;
         }
 
@@ -339,7 +341,7 @@ public class DefaultDeploymentConfiguration
      */
     private void checkRequestTiming() {
         requestTiming = getBooleanProperty(
-                Constants.SERVLET_PARAMETER_REQUEST_TIMING, !productionMode);
+                InitParameters.SERVLET_PARAMETER_REQUEST_TIMING, !productionMode);
     }
 
     /**
@@ -347,7 +349,7 @@ public class DefaultDeploymentConfiguration
      */
     private void checkXsrfProtection(boolean loggWarning) {
         xsrfProtectionEnabled = !getBooleanProperty(
-                Constants.SERVLET_PARAMETER_DISABLE_XSRF_PROTECTION, false);
+                InitParameters.SERVLET_PARAMETER_DISABLE_XSRF_PROTECTION, false);
         if (!xsrfProtectionEnabled && loggWarning) {
             warnings.add(WARNING_XSRF_PROTECTION_DISABLED);
         }
@@ -356,7 +358,7 @@ public class DefaultDeploymentConfiguration
     private void checkHeartbeatInterval() {
         try {
             heartbeatInterval = getApplicationOrSystemProperty(
-                    Constants.SERVLET_PARAMETER_HEARTBEAT_INTERVAL,
+                    InitParameters.SERVLET_PARAMETER_HEARTBEAT_INTERVAL,
                     DEFAULT_HEARTBEAT_INTERVAL, Integer::parseInt);
         } catch (NumberFormatException e) {
             warnings.add(WARNING_HEARTBEAT_INTERVAL_NOT_NUMERIC);
@@ -367,7 +369,7 @@ public class DefaultDeploymentConfiguration
     private void checkMaxMessageSuspendTimeout() {
         try {
             maxMessageSuspendTimeout = getApplicationOrSystemProperty(
-                    Constants.SERVLET_PARAMETER_MAX_MESSAGE_SUSPEND_TIMEOUT,
+                    InitParameters.SERVLET_PARAMETER_MAX_MESSAGE_SUSPEND_TIMEOUT,
                     DEFAULT_MAX_MESSAGE_SUSPEND_TIMEOUT, Integer::parseInt);
         } catch (NumberFormatException e) {
             String warning = "WARNING: maxMessageSuspendInterval has been set to an illegal value."
@@ -381,7 +383,7 @@ public class DefaultDeploymentConfiguration
     private void checkWebComponentDisconnectTimeout() {
         try {
             webComponentDisconnect = getApplicationOrSystemProperty(
-                    Constants.SERVLET_PARAMETER_WEB_COMPONENT_DISCONNECT,
+                    InitParameters.SERVLET_PARAMETER_WEB_COMPONENT_DISCONNECT,
                     DEFAULT_WEB_COMPONENT_DISCONNECT, Integer::parseInt);
 
         } catch (NumberFormatException e) {
@@ -392,14 +394,14 @@ public class DefaultDeploymentConfiguration
 
     private void checkCloseIdleSessions() {
         closeIdleSessions = getBooleanProperty(
-                Constants.SERVLET_PARAMETER_CLOSE_IDLE_SESSIONS,
+                InitParameters.SERVLET_PARAMETER_CLOSE_IDLE_SESSIONS,
                 DEFAULT_CLOSE_IDLE_SESSIONS);
     }
 
     private void checkPushMode() {
         try {
             pushMode = getApplicationOrSystemProperty(
-                    Constants.SERVLET_PARAMETER_PUSH_MODE, PushMode.DISABLED,
+                    InitParameters.SERVLET_PARAMETER_PUSH_MODE, PushMode.DISABLED,
                     stringMode -> Enum.valueOf(PushMode.class,
                             stringMode.toUpperCase()));
         } catch (IllegalArgumentException e) {
@@ -409,18 +411,18 @@ public class DefaultDeploymentConfiguration
     }
 
     private void checkPushURL() {
-        pushURL = getStringProperty(Constants.SERVLET_PARAMETER_PUSH_URL, "");
+        pushURL = getStringProperty(InitParameters.SERVLET_PARAMETER_PUSH_URL, "");
     }
 
     private void checkSyncIdCheck() {
         syncIdCheck = getBooleanProperty(
-                Constants.SERVLET_PARAMETER_SYNC_ID_CHECK,
+                InitParameters.SERVLET_PARAMETER_SYNC_ID_CHECK,
                 DEFAULT_SYNC_ID_CHECK);
     }
 
     private void checkSendUrlsAsParameters() {
         sendUrlsAsParameters = getBooleanProperty(
-                Constants.SERVLET_PARAMETER_SEND_URLS_AS_PARAMETERS,
+                InitParameters.SERVLET_PARAMETER_SEND_URLS_AS_PARAMETERS,
                 DEFAULT_SEND_URLS_AS_PARAMETERS);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
@@ -50,10 +50,10 @@ import static com.vaadin.flow.server.Constants.EXTERNAL_STATS_URL;
 import static com.vaadin.flow.server.Constants.EXTERNAL_STATS_URL_TOKEN;
 import static com.vaadin.flow.server.Constants.FRONTEND_TOKEN;
 import static com.vaadin.flow.server.Constants.NPM_TOKEN;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_ENABLE_DEV_SERVER;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_PRODUCTION_MODE;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_REUSE_DEV_SERVER;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_ENABLE_DEV_SERVER;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_REUSE_DEV_SERVER;
 import static com.vaadin.flow.server.Constants.VAADIN_PREFIX;
 import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
 import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_TOKEN_FILE;
@@ -276,18 +276,18 @@ public final class DeploymentConfigurationFactory implements Serializable {
         // read dev mode properties from the token and set init parameter only
         // if it's not yet set
         if (initParameters
-                .getProperty(Constants.SERVLET_PARAMETER_ENABLE_PNPM) == null
-                && buildInfo.hasKey(Constants.SERVLET_PARAMETER_ENABLE_PNPM)) {
-            initParameters.setProperty(Constants.SERVLET_PARAMETER_ENABLE_PNPM,
+                .getProperty(InitParameters.SERVLET_PARAMETER_ENABLE_PNPM) == null
+                && buildInfo.hasKey(InitParameters.SERVLET_PARAMETER_ENABLE_PNPM)) {
+            initParameters.setProperty(InitParameters.SERVLET_PARAMETER_ENABLE_PNPM,
                     String.valueOf(buildInfo.getBoolean(
-                            Constants.SERVLET_PARAMETER_ENABLE_PNPM)));
+                            InitParameters.SERVLET_PARAMETER_ENABLE_PNPM)));
         }
         if (initParameters
-                .getProperty(Constants.REQUIRE_HOME_NODE_EXECUTABLE) == null
-                && buildInfo.hasKey(Constants.REQUIRE_HOME_NODE_EXECUTABLE)) {
-            initParameters.setProperty(Constants.REQUIRE_HOME_NODE_EXECUTABLE,
+                .getProperty(InitParameters.REQUIRE_HOME_NODE_EXECUTABLE) == null
+                && buildInfo.hasKey(InitParameters.REQUIRE_HOME_NODE_EXECUTABLE)) {
+            initParameters.setProperty(InitParameters.REQUIRE_HOME_NODE_EXECUTABLE,
                     String.valueOf(buildInfo.getBoolean(
-                            Constants.REQUIRE_HOME_NODE_EXECUTABLE)));
+                            InitParameters.REQUIRE_HOME_NODE_EXECUTABLE)));
         }
     }
 
@@ -495,7 +495,7 @@ public final class DeploymentConfigurationFactory implements Serializable {
 
         if (enclosingClass != null
                 && UI.class.isAssignableFrom(enclosingClass)) {
-            initParameters.put(VaadinSession.UI_PARAMETER,
+            initParameters.put(InitParameters.UI_PARAMETER,
                     enclosingClass.getName());
         }
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
@@ -45,12 +45,12 @@ import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.server.frontend.FrontendTools;
 import com.vaadin.flow.server.frontend.FrontendUtils;
 
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_DEVMODE_TRANSPILE;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_DEVMODE_TRANSPILE_DEFAULT;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_DEVMODE_WEBPACK_ERROR_PATTERN;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_DEVMODE_WEBPACK_OPTIONS;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_DEVMODE_WEBPACK_SUCCESS_PATTERN;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_DEVMODE_WEBPACK_TIMEOUT;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_TRANSPILE;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_WEBPACK_ERROR_PATTERN;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_WEBPACK_OPTIONS;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_WEBPACK_SUCCESS_PATTERN;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_WEBPACK_TIMEOUT;
 import static com.vaadin.flow.server.frontend.FrontendUtils.GREEN;
 import static com.vaadin.flow.server.frontend.FrontendUtils.RED;
 import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_CONFIG;
@@ -147,7 +147,7 @@ public final class DevModeHandler {
         tools.validateNodeAndNpmVersion();
 
         boolean useHomeNodeExec = config.getBooleanProperty(
-                Constants.REQUIRE_HOME_NODE_EXECUTABLE, false);
+                InitParameters.REQUIRE_HOME_NODE_EXECUTABLE, false);
 
         String nodeExec = null;
         if (useHomeNodeExec) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server;
+
+import java.io.Serializable;
+
+import com.vaadin.flow.component.UI;
+
+/**
+ * Constants for all servlet init parameters. Keeping them in a separate class
+ * allows using reflection to expose the parameters in the Spring add-on.
+ *
+ * <p>
+ * Note: do not add other constants than String constants representing init
+ * parameters here.
+ *
+ * @author Vaadin Ltd
+ * @since
+ */
+public class InitParameters implements Serializable {
+
+    /**
+     * The name of the parameter that is by default used in e.g. web.xml to
+     * define the name of the default {@link UI} class.
+     */
+    // javadoc in UI should be updated if this value is changed
+    public static final String UI_PARAMETER = "UI";
+
+    public static final String SERVLET_PARAMETER_PRODUCTION_MODE = "productionMode";
+
+    /**
+     * enable it if your project is a Polymer 2.0 one, should be removed in V15
+     */
+    public static final String SERVLET_PARAMETER_COMPATIBILITY_MODE = "compatibilityMode";
+
+    /**
+     * enable it if your project is a Polymer 2.0 one, should be removed in V15
+     *
+     * @deprecated the parameter is renamed to
+     *             {@link #SERVLET_PARAMETER_COMPATIBILITY_MODE}
+     */
+    @Deprecated
+    public static final String SERVLET_PARAMETER_BOWER_MODE = "bowerMode";
+
+    public static final String SERVLET_PARAMETER_ENABLE_DEV_SERVER = "enableDevServer";
+    public static final String SERVLET_PARAMETER_REUSE_DEV_SERVER = "reuseDevServer";
+    public static final String SERVLET_PARAMETER_REQUEST_TIMING = "requestTiming";
+    // Javadocs for VaadinService should be updated if this value is changed
+    public static final String SERVLET_PARAMETER_DISABLE_XSRF_PROTECTION = "disable-xsrf-protection";
+    public static final String SERVLET_PARAMETER_HEARTBEAT_INTERVAL = "heartbeatInterval";
+    public static final String SERVLET_PARAMETER_WEB_COMPONENT_DISCONNECT = "webComponentDisconnect";
+    public static final String SERVLET_PARAMETER_CLOSE_IDLE_SESSIONS = "closeIdleSessions";
+    public static final String SERVLET_PARAMETER_PUSH_MODE = "pushMode";
+    public static final String SERVLET_PARAMETER_PUSH_URL = "pushURL";
+    public static final String SERVLET_PARAMETER_SYNC_ID_CHECK = "syncIdCheck";
+    public static final String SERVLET_PARAMETER_SEND_URLS_AS_PARAMETERS = "sendUrlsAsParameters";
+    public static final String SERVLET_PARAMETER_PUSH_SUSPEND_TIMEOUT_LONGPOLLING = "pushLongPollingSuspendTimeout";
+    public static final String SERVLET_PARAMETER_MAX_MESSAGE_SUSPEND_TIMEOUT = "maxMessageSuspendTimeout";
+    public static final String SERVLET_PARAMETER_JSBUNDLE = "module.bundle";
+    public static final String SERVLET_PARAMETER_POLYFILLS = "module.polyfills";
+
+    /**
+     * Configuration name for the parameter that determines whether Brotli
+     * compression should be used for static resources in cases when a
+     * precompressed file is available.
+     */
+    public static final String SERVLET_PARAMETER_BROTLI = "brotli";
+
+    /**
+     * Configuration name for the WebPack profile statistics json file to use to
+     * determine template contents.
+     * <p>
+     * File needs to be available either for the ClassLoader as a resource, or
+     * as a static web resource. By default it returns the value in
+     * {@link Constants#STATISTICS_JSON_DEFAULT}
+     */
+    public static final String SERVLET_PARAMETER_STATISTICS_JSON = "statistics.file.path";
+
+    /**
+     * Configuration name for the time waiting for webpack output success or
+     * error pattern defined in
+     * {@link Constants#SERVLET_PARAMETER_DEVMODE_WEBPACK_SUCCESS_PATTERN} and
+     * {@link Constants#SERVLET_PARAMETER_DEVMODE_WEBPACK_ERROR_PATTERN}
+     * parameters.
+     */
+    public static final String SERVLET_PARAMETER_DEVMODE_WEBPACK_TIMEOUT = "devmode.webpack.output.pattern.timeout";
+
+    /**
+     * Configuration name for the pattern used to inspect the webpack output to
+     * assure it is up and running. Default value is defined in
+     * {@link DevModeHandler} as the <code>: Compiled</code> expression.
+     */
+    public static final String SERVLET_PARAMETER_DEVMODE_WEBPACK_SUCCESS_PATTERN = "devmode.webpack.output.success.pattern";
+
+    /**
+     * Configuration name for the pattern used to inspect the webpack output to
+     * detecting when compilation failed. Default value is defined in
+     * {@link DevModeHandler} as the <code>: Failed</code> expression.
+     */
+    public static final String SERVLET_PARAMETER_DEVMODE_WEBPACK_ERROR_PATTERN = "devmode.webpack.output.error.pattern";
+
+    /**
+     * Configuration name for adding extra options to the webpack-dev-server.
+     */
+    public static final String SERVLET_PARAMETER_DEVMODE_WEBPACK_OPTIONS = "devmode.webpack.options";
+
+    /**
+     * Boolean parameter for enabling/disabling bytecode scanning in dev mode.
+     * If enabled, entry points are scanned for reachable frontend resources. If
+     * disabled, all classes on the classpath are scanned.
+     */
+    public static final String SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE = "devmode.optimizeBundle";
+
+    /**
+     * Configuration parameter name for enabling pnpm.
+     *
+     * @since 2.2
+     */
+    public static final String SERVLET_PARAMETER_ENABLE_PNPM = "pnpm.enable";
+
+    /**
+     * Configuration parameter name for enabling live reload.
+     *
+     * @since
+     */
+    public static final String SERVLET_PARAMETER_DEVMODE_ENABLE_LIVE_RELOAD = "devmode.liveReload.enabled";
+
+    /**
+     * I18N provider property.
+     */
+    public static final String I18N_PROVIDER = "i18n.provider";
+
+    /**
+     * Configuration name for the parameter that determines if Flow should
+     * automatically register servlets needed for the application to work.
+     */
+    public static final String DISABLE_AUTOMATIC_SERVLET_REGISTRATION = "disable.automatic.servlet.registration";
+
+    /**
+     * Configuration parameter name for requiring node executable installed in
+     * home directory.
+     *
+     * @since
+     */
+    public static final String REQUIRE_HOME_NODE_EXECUTABLE = "require.home.node";
+
+    /**
+     * Configuration name for the parameter that sets the compiled web
+     * components path. The path should be the same as
+     * {@code webComponentOutputDirectoryName} in the maven plugin that
+     * transpiles ES6 code. This path is only used for generated web components
+     * (server side web components) module in case they are transpiled: web
+     * component UI imports them as dependencies.
+     */
+    public static final String COMPILED_WEB_COMPONENTS_PATH = "compiled.web.components.path";
+
+    /**
+     * Configuration name for the parameter that determines if Flow should use
+     * webJars or not.
+     */
+    public static final String DISABLE_WEBJARS = "disable.webjars";
+
+    /**
+     * Configuration name for the parameter that determines if Flow should use
+     * bundled fragments or not.
+     */
+    public static final String USE_ORIGINAL_FRONTEND_RESOURCES = "original.frontend.resources";
+
+    /**
+     * Boolean parameter for enabling/disabling transpilation for IE11 with the
+     * BabelMultiTargetPlugin in dev mode.
+     */
+    public static final String SERVLET_PARAMETER_DEVMODE_TRANSPILE = "devmode.transpile";
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
@@ -22,14 +22,15 @@ import java.util.function.Function;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.shared.communication.PushMode;
 
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_BOWER_MODE;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_CLOSE_IDLE_SESSIONS;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_DEVMODE_ENABLE_LIVE_RELOAD;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_DISABLE_XSRF_PROTECTION;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_PRODUCTION_MODE;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_REQUEST_TIMING;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_SEND_URLS_AS_PARAMETERS;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_SYNC_ID_CHECK;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_BOWER_MODE;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_CLOSE_IDLE_SESSIONS;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_ENABLE_LIVE_RELOAD;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DISABLE_XSRF_PROTECTION;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_REQUEST_TIMING;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_SEND_URLS_AS_PARAMETERS;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_SYNC_ID_CHECK;
 import static com.vaadin.flow.server.Constants.VAADIN_PREFIX;
 
 /**
@@ -159,7 +160,7 @@ public class PropertyDeploymentConfiguration
         String bower = getStringProperty(SERVLET_PARAMETER_BOWER_MODE, null);
         if (bower == null) {
             return getBooleanProperty(
-                    Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE, false);
+                    SERVLET_PARAMETER_COMPATIBILITY_MODE, false);
         }
         return isBowerMode();
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/UnsupportedBrowserHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/UnsupportedBrowserHandler.java
@@ -18,7 +18,7 @@ package com.vaadin.flow.server;
 import java.io.IOException;
 import java.io.Writer;
 
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_DEVMODE_TRANSPILE;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_TRANSPILE;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_DEVMODE_TRANSPILE_DEFAULT;
 
 /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletConfiguration.java
@@ -73,7 +73,7 @@ public @interface VaadinServletConfiguration {
      *
      * @see DeploymentConfiguration#isProductionMode()
      */
-    @InitParameterName(Constants.SERVLET_PARAMETER_PRODUCTION_MODE)
+    @InitParameterName(InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE)
     boolean productionMode();
 
     /**
@@ -81,7 +81,7 @@ public @interface VaadinServletConfiguration {
      *
      * @return the UI class
      */
-    @InitParameterName(VaadinSession.UI_PARAMETER)
+    @InitParameterName(InitParameters.UI_PARAMETER)
     Class<? extends UI> ui() default UI.class;
 
     /**
@@ -93,7 +93,7 @@ public @interface VaadinServletConfiguration {
      *
      * @see DeploymentConfiguration#getHeartbeatInterval()
      */
-    @InitParameterName(Constants.SERVLET_PARAMETER_HEARTBEAT_INTERVAL)
+    @InitParameterName(InitParameters.SERVLET_PARAMETER_HEARTBEAT_INTERVAL)
     int heartbeatInterval() default DefaultDeploymentConfiguration.DEFAULT_HEARTBEAT_INTERVAL;
 
     /**
@@ -107,7 +107,7 @@ public @interface VaadinServletConfiguration {
      *
      * @see DeploymentConfiguration#isCloseIdleSessions()
      */
-    @InitParameterName(Constants.SERVLET_PARAMETER_CLOSE_IDLE_SESSIONS)
+    @InitParameterName(InitParameters.SERVLET_PARAMETER_CLOSE_IDLE_SESSIONS)
     boolean closeIdleSessions() default DefaultDeploymentConfiguration.DEFAULT_CLOSE_IDLE_SESSIONS;
 
     /**
@@ -118,7 +118,7 @@ public @interface VaadinServletConfiguration {
      *
      * @see DeploymentConfiguration#disableAutomaticServletRegistration()
      */
-    @InitParameterName(Constants.DISABLE_AUTOMATIC_SERVLET_REGISTRATION)
+    @InitParameterName(InitParameters.DISABLE_AUTOMATIC_SERVLET_REGISTRATION)
     boolean disableAutomaticServletRegistration() default false;
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
@@ -71,11 +71,10 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
     private static final String SESSION_NOT_LOCKED_MESSAGE = "Cannot access state in VaadinSession or UI without locking the session.";
 
     /**
-     * The name of the parameter that is by default used in e.g. web.xml to
-     * define the name of the default {@link UI} class.
+     * @deprecated Use {@link InitParameters#UI_PARAMETER} instead.
      */
-    // javadoc in UI should be updated if this value is changed
-    public static final String UI_PARAMETER = "UI";
+    @Deprecated
+    public static final String UI_PARAMETER = InitParameters.UI_PARAMETER;
 
     /**
      * Configuration for the session.

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PushRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PushRequestHandler.java
@@ -35,9 +35,9 @@ import org.atmosphere.util.VoidAnnotationProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.HandlerHelper;
 import com.vaadin.flow.server.HandlerHelper.RequestType;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.RequestHandler;
 import com.vaadin.flow.server.ServiceException;
 import com.vaadin.flow.server.SessionExpiredHandler;
@@ -102,7 +102,7 @@ public class PushRequestHandler
         }
         pushHandler.setLongPollingSuspendTimeout(
                 atmosphere.getAtmosphereConfig().getInitParameter(
-                        Constants.SERVLET_PARAMETER_PUSH_SUSPEND_TIMEOUT_LONGPOLLING,
+                        InitParameters.SERVLET_PARAMETER_PUSH_SUSPEND_TIMEOUT_LONGPOLLING,
                         -1));
         for (AtmosphereHandlerWrapper handlerWrapper : atmosphere
                 .getAtmosphereHandlers().values()) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -51,7 +51,7 @@ import com.vaadin.flow.server.frontend.FallbackChunk.CssImportData;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_STATISTICS_JSON;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_STATISTICS_JSON;
 import static com.vaadin.flow.server.Constants.STATISTICS_JSON_DEFAULT;
 import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/osgi/OSGiAccess.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/osgi/OSGiAccess.java
@@ -49,7 +49,7 @@ import com.vaadin.flow.internal.AnnotationReader;
 import com.vaadin.flow.internal.ReflectTools;
 import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.router.HasErrorParameter;
-import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.startup.ClassLoaderAwareServletContainerInitializer;
 
 /**
@@ -113,7 +113,7 @@ public final class OSGiAccess {
         public String getInitParameter(String name) {
             // OSGi is supported in compatibiity mode only. So set it by default
             // for every ServletContainerInitializer
-            if (Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE.equals(name)) {
+            if (InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE.equals(name)) {
                 return Boolean.TRUE.toString();
             }
             return null;
@@ -122,7 +122,7 @@ public final class OSGiAccess {
         @Override
         public Enumeration<String> getInitParameterNames() {
             return Collections.enumeration(Collections.singletonList(
-                    Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE));
+                    InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE));
         }
 
         @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/BundleFilterFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/BundleFilterFactory.java
@@ -31,7 +31,7 @@ import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.WebBrowser;
 import com.vaadin.flow.shared.ApplicationConstants;
@@ -93,7 +93,7 @@ public class BundleFilterFactory implements Serializable {
                                 + " Otherwise, you can skip this error either by disabling production mode, or by setting the servlet parameter '%s=true'.",
                         FLOW_BUNDLE_MANIFEST,
                         browser.isEs6Supported() ? "ES6" : "ES5",
-                        Constants.USE_ORIGINAL_FRONTEND_RESOURCES));
+                        InitParameters.USE_ORIGINAL_FRONTEND_RESOURCES));
             }
             return Optional.of(Json.parse(IOUtils.toString(bundleManifestStream,
                     StandardCharsets.UTF_8)));

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -66,6 +66,7 @@ import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.DevModeHandler;
 import com.vaadin.flow.server.ExecutionFailedException;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.UIInitListener;
 import com.vaadin.flow.server.VaadinContext;
 import com.vaadin.flow.server.VaadinServiceInitListener;
@@ -84,7 +85,7 @@ import elemental.json.Json;
 import elemental.json.JsonObject;
 
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_FRONTEND_DIR;
@@ -299,7 +300,7 @@ public class DevModeInitializer
         boolean enablePnpm = config.isPnpmEnabled();
 
         boolean useHomeNodeExec = config.getBooleanProperty(
-                Constants.REQUIRE_HOME_NODE_EXECUTABLE, false);
+                InitParameters.REQUIRE_HOME_NODE_EXECUTABLE, false);
 
         VaadinContext vaadinContext = new VaadinServletContext(context);
         JsonObject tokenFileData = Json.createObject();

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletDeployer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletDeployer.java
@@ -34,9 +34,9 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.DeploymentConfigurationFactory;
 import com.vaadin.flow.server.FrontendVaadinServlet;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.VaadinConfig;
 import com.vaadin.flow.server.VaadinConfigurationException;
 import com.vaadin.flow.server.VaadinContext;
@@ -61,7 +61,7 @@ import com.vaadin.flow.server.webcomponent.WebComponentConfigurationRegistry;
  * <li>Frontend files servlet, mapped to '/frontend/*' <br>
  * The servlet is registered when the application is started in the development
  * mode or has
- * {@link com.vaadin.flow.server.Constants#USE_ORIGINAL_FRONTEND_RESOURCES}
+ * {@link InitParameters#USE_ORIGINAL_FRONTEND_RESOURCES}
  * parameter set to {@code true}.</li>
  * <li>Static files servlet, mapped to '/VAADIN/static' responsible to resolve
  * files placed in the '[webcontext]/VAADIN/static' folder or in the
@@ -73,7 +73,7 @@ import com.vaadin.flow.server.webcomponent.WebComponentConfigurationRegistry;
  * <p>
  * In addition to the rules above, a servlet won't be registered, if any servlet
  * had been mapped to the same path already or if
- * {@link com.vaadin.flow.server.Constants#DISABLE_AUTOMATIC_SERVLET_REGISTRATION}
+ * {@link InitParameters#DISABLE_AUTOMATIC_SERVLET_REGISTRATION}
  * system property is set to {@code true}.
  *
  * @author Vaadin Ltd
@@ -264,7 +264,7 @@ public class ServletDeployer implements ServletContextListener {
             createServletIfNotExists(context, "frontendFilesServlet",
                     FrontendVaadinServlet.class, "/frontend/*",
                     Collections.singletonMap(
-                            Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE,
+                            InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE,
                             Boolean.TRUE.toString()));
         }
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/webjar/WebJarServer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webjar/WebJarServer.java
@@ -26,7 +26,7 @@ import java.util.regex.Pattern;
 
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.ResponseWriter;
-import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.shared.ApplicationConstants;
 
 /**
@@ -35,7 +35,7 @@ import com.vaadin.flow.shared.ApplicationConstants;
  * <p>
  * By default, webJars are enabled for development mode and disabled for
  * production mode. There is a way to override this behavior by setting
- * {@link Constants#DISABLE_WEBJARS} param.
+ * {@link InitParameters#DISABLE_WEBJARS} param.
  *
  * @author Vaadin Ltd
  * @since 1.0.

--- a/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
@@ -37,7 +37,7 @@ public class AbstractDeploymentConfigurationTest {
     @Test
     public void getUIClass_returnsUIParameterPropertyValue() {
         String ui = UUID.randomUUID().toString();
-        DeploymentConfiguration config = getConfig(VaadinSession.UI_PARAMETER,
+        DeploymentConfiguration config = getConfig(InitParameters.UI_PARAMETER,
                 ui);
         Assert.assertEquals("Unexpected UI class configuration option value",
                 ui, config.getUIClassName());

--- a/flow-server/src/test/java/com/vaadin/flow/server/CustomUIClassLoaderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/CustomUIClassLoaderTest.java
@@ -59,9 +59,9 @@ public class CustomUIClassLoaderTest extends TestCase {
 
     private static DeploymentConfiguration createConfigurationMock() {
         Properties properties = new Properties();
-        properties.put(Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE,
+        properties.put(InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE,
                 Boolean.FALSE.toString());
-        properties.put(VaadinSession.UI_PARAMETER, MyUI.class.getName());
+        properties.put(InitParameters.UI_PARAMETER, MyUI.class.getName());
         return new DefaultDeploymentConfiguration(CustomUIClassLoaderTest.class,
                 properties);
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/DefaultDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DefaultDeploymentConfigurationTest.java
@@ -38,7 +38,7 @@ public class DefaultDeploymentConfigurationTest {
 
     {
         DEFAULT_PARAMS.setProperty(
-                Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE,
+                InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE,
                 Boolean.TRUE.toString());
     }
 
@@ -73,7 +73,7 @@ public class DefaultDeploymentConfigurationTest {
     public void booleanValueReadIgnoreTheCase_true() {
         Properties initParameters = new Properties(DEFAULT_PARAMS);
         initParameters.setProperty(
-                Constants.SERVLET_PARAMETER_SEND_URLS_AS_PARAMETERS, "tRUe");
+                InitParameters.SERVLET_PARAMETER_SEND_URLS_AS_PARAMETERS, "tRUe");
 
         DefaultDeploymentConfiguration config = createDeploymentConfig(
                 initParameters);
@@ -86,7 +86,7 @@ public class DefaultDeploymentConfigurationTest {
     public void booleanValueReadIgnoreTheCase_false() {
         Properties initParameters = new Properties(DEFAULT_PARAMS);
         initParameters.setProperty(
-                Constants.SERVLET_PARAMETER_SEND_URLS_AS_PARAMETERS, "FaLsE");
+                InitParameters.SERVLET_PARAMETER_SEND_URLS_AS_PARAMETERS, "FaLsE");
 
         DefaultDeploymentConfiguration config = createDeploymentConfig(
                 initParameters);
@@ -100,7 +100,7 @@ public class DefaultDeploymentConfigurationTest {
     public void booleanValueRead_emptyIsTrue() {
         Properties initParameters = new Properties(DEFAULT_PARAMS);
         initParameters.setProperty(
-                Constants.SERVLET_PARAMETER_SEND_URLS_AS_PARAMETERS, "");
+                InitParameters.SERVLET_PARAMETER_SEND_URLS_AS_PARAMETERS, "");
 
         DefaultDeploymentConfiguration config = createDeploymentConfig(
                 initParameters);
@@ -113,7 +113,7 @@ public class DefaultDeploymentConfigurationTest {
     public void booleanValueRead_exceptionOnNonBooleanValue() {
         Properties initParameters = new Properties(DEFAULT_PARAMS);
         initParameters.setProperty(
-                Constants.SERVLET_PARAMETER_SEND_URLS_AS_PARAMETERS,
+                InitParameters.SERVLET_PARAMETER_SEND_URLS_AS_PARAMETERS,
                 "incorrectValue");
 
         createDeploymentConfig(initParameters);
@@ -183,7 +183,7 @@ public class DefaultDeploymentConfigurationTest {
     @Test
     public void pushUrl() {
         Properties initParameters = new Properties(DEFAULT_PARAMS);
-        initParameters.setProperty(Constants.SERVLET_PARAMETER_PUSH_URL, "foo");
+        initParameters.setProperty(InitParameters.SERVLET_PARAMETER_PUSH_URL, "foo");
 
         DefaultDeploymentConfiguration config = createDeploymentConfig(
                 initParameters);
@@ -205,7 +205,7 @@ public class DefaultDeploymentConfigurationTest {
         Properties initParameters = new Properties(DEFAULT_PARAMS);
         initParameters.setProperty(Constants.SERVLET_PARAMETER_PRODUCTION_MODE,
                 "true");
-        initParameters.setProperty(Constants.USE_ORIGINAL_FRONTEND_RESOURCES,
+        initParameters.setProperty(InitParameters.USE_ORIGINAL_FRONTEND_RESOURCES,
                 "true");
         DefaultDeploymentConfiguration config = createDeploymentConfig(
                 initParameters);
@@ -215,7 +215,7 @@ public class DefaultDeploymentConfigurationTest {
     public void maxMessageSuspendTimeout_validValue_accepted() {
         Properties initParameters = new Properties();
         initParameters.setProperty(
-                Constants.SERVLET_PARAMETER_MAX_MESSAGE_SUSPEND_TIMEOUT,
+                InitParameters.SERVLET_PARAMETER_MAX_MESSAGE_SUSPEND_TIMEOUT,
                 "2700");
         DefaultDeploymentConfiguration config = createDeploymentConfig(
                 initParameters);
@@ -226,7 +226,7 @@ public class DefaultDeploymentConfigurationTest {
     public void maxMessageSuspendTimeout_invalidValue_defaultValue() {
         Properties initParameters = new Properties();
         initParameters.setProperty(
-                Constants.SERVLET_PARAMETER_MAX_MESSAGE_SUSPEND_TIMEOUT, "kk");
+                InitParameters.SERVLET_PARAMETER_MAX_MESSAGE_SUSPEND_TIMEOUT, "kk");
         DefaultDeploymentConfiguration config = createDeploymentConfig(
                 initParameters);
         assertEquals(5000, config.getMaxMessageSuspendTimeout());

--- a/flow-server/src/test/java/com/vaadin/flow/server/DeploymentConfigurationFactoryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DeploymentConfigurationFactoryTest.java
@@ -35,7 +35,7 @@ import com.vaadin.flow.server.frontend.FallbackChunk;
 import com.vaadin.flow.server.frontend.FallbackChunk.CssImportData;
 import com.vaadin.flow.server.frontend.FrontendUtils;
 
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_PRODUCTION_MODE;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE;
 import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
 import static com.vaadin.flow.server.DeploymentConfigurationFactory.DEV_FOLDER_MISSING_MESSAGE;
 import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_TOKEN_FILE;
@@ -82,7 +82,7 @@ public class DeploymentConfigurationFactoryTest {
         FileUtils.writeLines(tokenFile, Arrays.asList("{", "}"));
         contextMock = mock(ServletContext.class);
 
-        defaultServletParams.put(Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE,
+        defaultServletParams.put(InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE,
                 Boolean.FALSE.toString());
         defaultServletParams.put(PARAM_TOKEN_FILE, tokenFile.getPath());
     }
@@ -166,7 +166,7 @@ public class DeploymentConfigurationFactoryTest {
                 defaultServletParams);
         servletConfigParams.put(SERVLET_PARAMETER_PRODUCTION_MODE,
                 Boolean.toString(overridingProductionModeValue));
-        servletConfigParams.put(Constants.SERVLET_PARAMETER_HEARTBEAT_INTERVAL,
+        servletConfigParams.put(InitParameters.SERVLET_PARAMETER_HEARTBEAT_INTERVAL,
                 Integer.toString(overridingHeartbeatIntervalValue));
 
         DeploymentConfiguration config = DeploymentConfigurationFactory
@@ -194,7 +194,7 @@ public class DeploymentConfigurationFactoryTest {
                 defaultServletParams);
         servletContextParams.put(SERVLET_PARAMETER_PRODUCTION_MODE,
                 Boolean.toString(overridingProductionModeValue));
-        servletContextParams.put(Constants.SERVLET_PARAMETER_HEARTBEAT_INTERVAL,
+        servletContextParams.put(InitParameters.SERVLET_PARAMETER_HEARTBEAT_INTERVAL,
                 Integer.toString(overridingHeartbeatIntervalValue));
 
         DeploymentConfiguration config = DeploymentConfigurationFactory
@@ -222,7 +222,7 @@ public class DeploymentConfigurationFactoryTest {
                 defaultServletParams);
         servletConfigParams.put(SERVLET_PARAMETER_PRODUCTION_MODE,
                 Boolean.toString(servletConfigProductionModeValue));
-        servletConfigParams.put(Constants.SERVLET_PARAMETER_HEARTBEAT_INTERVAL,
+        servletConfigParams.put(InitParameters.SERVLET_PARAMETER_HEARTBEAT_INTERVAL,
                 Integer.toString(servletConfigHeartbeatIntervalValue));
 
         boolean servletContextProductionModeValue = false;
@@ -231,7 +231,7 @@ public class DeploymentConfigurationFactoryTest {
         Map<String, String> servletContextParams = new HashMap<>();
         servletContextParams.put(SERVLET_PARAMETER_PRODUCTION_MODE,
                 Boolean.toString(servletContextProductionModeValue));
-        servletContextParams.put(Constants.SERVLET_PARAMETER_HEARTBEAT_INTERVAL,
+        servletContextParams.put(InitParameters.SERVLET_PARAMETER_HEARTBEAT_INTERVAL,
                 Integer.toString(servletContextHeartbeatIntervalValue));
 
         DeploymentConfiguration config = DeploymentConfigurationFactory
@@ -267,7 +267,7 @@ public class DeploymentConfigurationFactoryTest {
         DeploymentConfigurationFactory.createDeploymentConfiguration(
                 VaadinServlet.class,
                 createVaadinConfigMock(Collections.singletonMap(
-                        Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE,
+                        InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE,
                         Boolean.FALSE.toString()), emptyMap()));
     }
 
@@ -277,7 +277,7 @@ public class DeploymentConfigurationFactoryTest {
         Map<String, String> map = new HashMap<>();
         map.put(FrontendUtils.PROJECT_BASEDIR,
                 temporaryFolder.getRoot().getAbsolutePath());
-        map.put(Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE,
+        map.put(InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE,
                 Boolean.FALSE.toString());
 
         File webPack = new File(temporaryFolder.getRoot().getAbsolutePath(),
@@ -301,7 +301,7 @@ public class DeploymentConfigurationFactoryTest {
         Map<String, String> map = new HashMap<>();
         map.put(FrontendUtils.PROJECT_BASEDIR,
                 temporaryFolder.getRoot().getAbsolutePath());
-        map.put(Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE,
+        map.put(InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE,
                 Boolean.FALSE.toString());
 
         File webPack = new File(temporaryFolder.getRoot().getAbsolutePath(),
@@ -529,12 +529,12 @@ public class DeploymentConfigurationFactoryTest {
                 .singletonMap(PARAM_TOKEN_FILE, tokenFile.getPath()));
 
         Assert.assertEquals(Boolean.TRUE.toString(), config.getInitParameters()
-                .getProperty(Constants.SERVLET_PARAMETER_ENABLE_PNPM));
+                .getProperty(InitParameters.SERVLET_PARAMETER_ENABLE_PNPM));
         Assert.assertEquals(Boolean.TRUE.toString(), config.getInitParameters()
-                .getProperty(Constants.REQUIRE_HOME_NODE_EXECUTABLE));
+                .getProperty(InitParameters.REQUIRE_HOME_NODE_EXECUTABLE));
         Assert.assertNull("Optimized bundle should not leak to devmode",
                 config.getInitParameters().getProperty(
-                        Constants.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE));
+                        InitParameters.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE));
     }
 
     @Test
@@ -549,22 +549,22 @@ public class DeploymentConfigurationFactoryTest {
                 .singletonMap(PARAM_TOKEN_FILE, tokenFile.getPath()));
 
         config.getInitParameters().setProperty(
-                Constants.SERVLET_PARAMETER_ENABLE_PNPM,
+                InitParameters.SERVLET_PARAMETER_ENABLE_PNPM,
                 Boolean.FALSE.toString());
         config.getInitParameters().setProperty(
-                Constants.REQUIRE_HOME_NODE_EXECUTABLE,
+                InitParameters.REQUIRE_HOME_NODE_EXECUTABLE,
                 Boolean.FALSE.toString());
         config.getInitParameters().setProperty(
-                Constants.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE,
+                InitParameters.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE,
                 Boolean.FALSE.toString());
 
         Assert.assertEquals(Boolean.FALSE.toString(), config.getInitParameters()
-                .getProperty(Constants.SERVLET_PARAMETER_ENABLE_PNPM));
+                .getProperty(InitParameters.SERVLET_PARAMETER_ENABLE_PNPM));
         Assert.assertEquals(Boolean.FALSE.toString(), config.getInitParameters()
-                .getProperty(Constants.REQUIRE_HOME_NODE_EXECUTABLE));
+                .getProperty(InitParameters.REQUIRE_HOME_NODE_EXECUTABLE));
         Assert.assertEquals(Boolean.FALSE.toString(),
                 config.getInitParameters().getProperty(
-                        Constants.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE));
+                        InitParameters.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE));
     }
 
     private DeploymentConfiguration createConfig(Map<String, String> map)

--- a/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
@@ -48,7 +48,7 @@ import org.mockito.Mockito;
 import com.vaadin.flow.server.frontend.FrontendUtils;
 import com.vaadin.tests.util.MockDeploymentConfiguration;
 
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_DEVMODE_WEBPACK_TIMEOUT;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_WEBPACK_TIMEOUT;
 import static com.vaadin.flow.server.DevModeHandler.WEBPACK_SERVER;
 import static com.vaadin.flow.server.frontend.NodeUpdateTestUtil.WEBPACK_TEST_OUT_FILE;
 import static com.vaadin.flow.server.frontend.NodeUpdateTestUtil.createStubWebpackServer;
@@ -299,7 +299,7 @@ public class DevModeHandlerTest {
             FileUtils.forceMkdir(node);
 
             configuration.setApplicationOrSystemProperty(
-                    Constants.REQUIRE_HOME_NODE_EXECUTABLE,
+                    InitParameters.REQUIRE_HOME_NODE_EXECUTABLE,
                     Boolean.TRUE.toString());
             DevModeHandler.start(configuration, npmFolder);
         } finally {
@@ -318,14 +318,14 @@ public class DevModeHandlerTest {
         Mockito.doAnswer(invocation -> ctx).when(cfg).getServletContext();
 
         List<String> paramNames = new ArrayList<>();
-        paramNames.add(Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE);
+        paramNames.add(InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE);
         paramNames.add(FrontendUtils.PARAM_TOKEN_FILE);
 
         Mockito.doAnswer(invocation -> Collections.enumeration(paramNames))
                 .when(cfg).getInitParameterNames();
         Mockito.doAnswer(invocation -> Boolean.FALSE.toString()).when(cfg)
                 .getInitParameter(
-                        Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE);
+                        InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE);
 
         File tokenFile = new File(temporaryFolder.getRoot(),
                 "flow-build-info.json");

--- a/flow-server/src/test/java/com/vaadin/flow/server/I18NProviderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/I18NProviderTest.java
@@ -41,7 +41,7 @@ public class I18NProviderTest {
 
     {
         DEFAULT_PARAMS.setProperty(
-                Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE,
+                InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE,
                 Boolean.TRUE.toString());
     }
 
@@ -58,7 +58,7 @@ public class I18NProviderTest {
     public void property_defined_should_init_registy_with_provider()
             throws ServletException, ServiceException {
         Properties initParams = new Properties(DEFAULT_PARAMS);
-        initParams.setProperty(Constants.I18N_PROVIDER,
+        initParams.setProperty(InitParameters.I18N_PROVIDER,
                 TestProvider.class.getName());
 
         initServletAndService(initParams);
@@ -72,7 +72,7 @@ public class I18NProviderTest {
     public void with_defined_provider_locale_should_be_the_available_one()
             throws ServletException, ServiceException {
         Properties initParams = new Properties(DEFAULT_PARAMS);
-        initParams.setProperty(Constants.I18N_PROVIDER,
+        initParams.setProperty(InitParameters.I18N_PROVIDER,
                 TestProvider.class.getName());
 
         initServletAndService(initParams);

--- a/flow-server/src/test/java/com/vaadin/flow/server/InitParametersTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/InitParametersTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class InitParametersTest {
+    @Test
+    public void publicMembersAreStringConstants() {
+        for (Field field : InitParameters.class.getDeclaredFields()) {
+            int modifiers = field.getModifiers();
+            if (Modifier.isPublic(modifiers)) {
+                Assert.assertEquals(
+                        String.format("field '%s' expected String", field.getName()),
+                        String.class, field.getType());
+                Assert.assertTrue(
+                        String.format("field '%s' expected static", field.getName()),
+                        Modifier.isStatic(modifiers));
+                Assert.assertTrue(
+                        String.format("field '%s' expected final", field.getName()),
+                        Modifier.isFinal(modifiers));
+            }
+        }
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/MockServletConfig.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/MockServletConfig.java
@@ -32,7 +32,7 @@ public class MockServletConfig implements ServletConfig {
     private static final Properties DEFAULT_PROPERTIES = new Properties();
     {
         DEFAULT_PROPERTIES.setProperty(
-                Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE,
+                InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE,
                 Boolean.TRUE.toString());
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
@@ -47,7 +47,7 @@ import org.mockito.Mockito;
 import com.vaadin.flow.function.DeploymentConfiguration;
 
 import static com.vaadin.flow.server.Constants.POLYFILLS_DEFAULT_VALUE;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_STATISTICS_JSON;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_STATISTICS_JSON;
 import static com.vaadin.flow.server.Constants.STATISTICS_JSON_DEFAULT;
 import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/UnsupportedBrowserHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/UnsupportedBrowserHandlerTest.java
@@ -11,7 +11,7 @@ import org.mockito.Mockito;
 
 import com.vaadin.tests.util.MockDeploymentConfiguration;
 
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_DEVMODE_TRANSPILE;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_TRANSPILE;
 
 public class UnsupportedBrowserHandlerTest {
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletConfigTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletConfigTest.java
@@ -40,9 +40,9 @@ public class VaadinServletConfigTest {
                 .setAttribute(Mockito.anyString(), Mockito.any());
 
         properties = new HashMap<>();
-        properties.put(Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE, "false");
-        properties.put(Constants.SERVLET_PARAMETER_PRODUCTION_MODE, "true");
-        properties.put(Constants.SERVLET_PARAMETER_ENABLE_DEV_SERVER, "false");
+        properties.put(InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE, "false");
+        properties.put(InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE, "true");
+        properties.put(InitParameters.SERVLET_PARAMETER_ENABLE_DEV_SERVER, "false");
 
         Mockito.when(servletConfig.getInitParameterNames())
                 .thenReturn(Collections.enumeration(properties.keySet()));

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletConfigurationTest.java
@@ -45,10 +45,10 @@ public class VaadinServletConfigurationTest {
     @Test
     public void testValuesFromAnnotation() throws ServletException {
         Properties servletInitParams = new Properties();
-        servletInitParams.setProperty(Constants.USE_ORIGINAL_FRONTEND_RESOURCES,
+        servletInitParams.setProperty(InitParameters.USE_ORIGINAL_FRONTEND_RESOURCES,
                 Boolean.TRUE.toString());
         servletInitParams.setProperty(
-                Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE,
+                InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE,
                 Boolean.TRUE.toString());
 
         TestServlet servlet = new TestServlet();
@@ -75,15 +75,15 @@ public class VaadinServletConfigurationTest {
 
         Properties servletInitParams = new Properties();
         servletInitParams.setProperty(
-                Constants.SERVLET_PARAMETER_SEND_URLS_AS_PARAMETERS,
+                InitParameters.SERVLET_PARAMETER_SEND_URLS_AS_PARAMETERS,
                 Boolean.toString(expectedBoolean));
         servletInitParams.setProperty(
-                Constants.SERVLET_PARAMETER_HEARTBEAT_INTERVAL,
+                InitParameters.SERVLET_PARAMETER_HEARTBEAT_INTERVAL,
                 Integer.toString(expectedInt));
-        servletInitParams.setProperty(Constants.USE_ORIGINAL_FRONTEND_RESOURCES,
+        servletInitParams.setProperty(InitParameters.USE_ORIGINAL_FRONTEND_RESOURCES,
                 Boolean.TRUE.toString());
         servletInitParams.setProperty(
-                Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE,
+                InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE,
                 Boolean.TRUE.toString());
 
         TestServlet servlet = new TestServlet();

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletContextTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletContextTest.java
@@ -45,9 +45,9 @@ public class VaadinServletContextTest {
                 .setAttribute(Mockito.anyString(), Mockito.any());
 
         properties = new HashMap<>();
-        properties.put(Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE, "false");
-        properties.put(Constants.SERVLET_PARAMETER_PRODUCTION_MODE, "true");
-        properties.put(Constants.SERVLET_PARAMETER_ENABLE_DEV_SERVER, "false");
+        properties.put(InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE, "false");
+        properties.put(InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE, "true");
+        properties.put(InitParameters.SERVLET_PARAMETER_ENABLE_DEV_SERVER, "false");
 
         Mockito.when(servletContext.getInitParameterNames())
                 .thenReturn(Collections.enumeration(properties.keySet()));

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -39,7 +39,7 @@ import org.mockito.Mockito;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.server.VaadinService;
 
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_STATISTICS_JSON;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_STATISTICS_JSON;
 import static com.vaadin.flow.server.Constants.STATISTICS_JSON_DEFAULT;
 import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
 import static org.junit.Assert.assertFalse;

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/BundleFilterFactoryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/BundleFilterFactoryTest.java
@@ -37,6 +37,7 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.DependencyFilter.FilterContext;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.MockServletServiceSessionSetup;
 import com.vaadin.flow.shared.ApplicationConstants;
 import com.vaadin.flow.shared.ui.Dependency;
@@ -111,7 +112,7 @@ public class BundleFilterFactoryTest {
     @Test
     public void when_bundle_disabled_doesnt_fail() {
         mocks.getDeploymentConfiguration().setApplicationOrSystemProperty(
-                Constants.USE_ORIGINAL_FRONTEND_RESOURCES, "true");
+                InitParameters.USE_ORIGINAL_FRONTEND_RESOURCES, "true");
         new BundleFilterFactory().createFilters(mocks.getService()).count();
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
@@ -32,13 +32,18 @@ import org.mockito.Mockito;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.DevModeHandler;
+
 import com.vaadin.flow.server.frontend.FallbackChunk;
 import com.vaadin.flow.server.frontend.FrontendUtils;
 
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_PRODUCTION_MODE;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_REUSE_DEV_SERVER;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_ENABLE_PNPM;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_REUSE_DEV_SERVER;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -249,8 +254,7 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
 
     @Test
     public void shouldUseByteCodeScannerIfPropertySet() throws Exception {
-        initParams.put(Constants.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE,
-                "true");
+        initParams.put(SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE, "true");
         DevModeInitializer devModeInitializer = new DevModeInitializer();
         final Set<Class<?>> classes = new HashSet<>();
         classes.add(NotVisitedWithDeps.class);
@@ -288,14 +292,14 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
                 .thenReturn(Collections.emptyMap());
         Mockito.when(servletContext.getInitParameterNames()).thenReturn(
                 Collections.enumeration(new HashSet<>(
-                        Arrays.asList(Constants.SERVLET_PARAMETER_ENABLE_PNPM,
+                        Arrays.asList(InitParameters.SERVLET_PARAMETER_ENABLE_PNPM,
                                 FrontendUtils.PROJECT_BASEDIR))));
         Mockito.when(
                 servletContext.getInitParameter(FrontendUtils.PROJECT_BASEDIR))
                 .thenReturn(initParams.get(FrontendUtils.PROJECT_BASEDIR));
         Mockito.when(
-                servletContext.getInitParameter(Constants.SERVLET_PARAMETER_ENABLE_PNPM))
-                .thenReturn(initParams.get(Constants.SERVLET_PARAMETER_ENABLE_PNPM));
+                servletContext.getInitParameter(InitParameters.SERVLET_PARAMETER_ENABLE_PNPM))
+                .thenReturn(initParams.get(InitParameters.SERVLET_PARAMETER_ENABLE_PNPM));
         devModeInitializer.onStartup(classes, servletContext);
         assertNotNull(DevModeHandler.getDevModeHandler());
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTestBase.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTestBase.java
@@ -21,6 +21,7 @@ import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.VaadinServlet;
 import com.vaadin.flow.server.DevModeHandler;
 import com.vaadin.flow.server.DevModeHandlerTest;
@@ -30,9 +31,9 @@ import com.vaadin.flow.server.frontend.NodeUpdater;
 import elemental.json.Json;
 import elemental.json.JsonObject;
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_PRODUCTION_MODE;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_REUSE_DEV_SERVER;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_REUSE_DEV_SERVER;
 import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_CONFIG;
 import static com.vaadin.flow.server.frontend.NodeUpdateTestUtil.createStubNode;
 import static com.vaadin.flow.server.frontend.NodeUpdateTestUtil.createStubWebpackServer;
@@ -79,7 +80,8 @@ public class DevModeInitializerTestBase {
 
         initParams = new HashMap<>();
         initParams.put(FrontendUtils.PROJECT_BASEDIR, baseDir);
-        initParams.put(Constants.SERVLET_PARAMETER_ENABLE_PNPM, enablePnpm.toString());
+        initParams.put(InitParameters.SERVLET_PARAMETER_ENABLE_PNPM,
+                enablePnpm.toString());
 
         Mockito.when(vaadinServletRegistration.getInitParameters())
                 .thenReturn(initParams);

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/ServletDeployerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/ServletDeployerTest.java
@@ -29,7 +29,7 @@ import com.vaadin.flow.component.WebComponentExporter;
 import com.vaadin.flow.component.webcomponent.WebComponent;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteConfiguration;
-import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.VaadinServlet;
 import com.vaadin.flow.server.webcomponent.WebComponentConfigurationRegistry;
 
@@ -119,7 +119,7 @@ public class ServletDeployerTest {
                 getServletRegistration("testServlet", TestServlet.class,
                         singletonList("/test/*"),
                         singletonMap(
-                                Constants.DISABLE_AUTOMATIC_SERVLET_REGISTRATION,
+                                InitParameters.DISABLE_AUTOMATIC_SERVLET_REGISTRATION,
                                 "true"))));
 
         assertMappingsCount(0, 0);
@@ -152,14 +152,14 @@ public class ServletDeployerTest {
             throws Exception {
         dynamicMockCheck = registration -> EasyMock
                 .expect(registration.setInitParameters(Collections.singletonMap(
-                        Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE,
+                        InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE,
                         Boolean.TRUE.toString())))
                 .andReturn(null).once();
         deployer.contextInitialized(getContextEvent(true, true,
                 getServletRegistration("testServlet", TestVaadinServlet.class,
                         singletonList("/test/*"),
                         Collections.singletonMap(
-                                Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE,
+                                InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE,
                                 "true"))));
 
         assertMappingsCount(1, 1);
@@ -173,7 +173,7 @@ public class ServletDeployerTest {
                 getServletRegistration("testServlet", TestServlet.class,
                         singletonList("/test/*"),
                         singletonMap(
-                                Constants.SERVLET_PARAMETER_PRODUCTION_MODE,
+                                InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE,
                                 "true"))));
 
         assertMappingsCount(1, 1);
@@ -193,17 +193,17 @@ public class ServletDeployerTest {
     public void frontendServletIsRegisteredWhenAtLeastOneServletHasDevelopmentAndCompatibilityMode()
             throws Exception {
         Map<String, String> productionMode = new HashMap<>();
-        productionMode.put(Constants.SERVLET_PARAMETER_PRODUCTION_MODE, "true");
-        productionMode.put(Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE,
+        productionMode.put(InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE, "true");
+        productionMode.put(InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE,
                 "true");
 
         Map<String, String> devMode = new HashMap<>();
-        devMode.put(Constants.SERVLET_PARAMETER_PRODUCTION_MODE, "false");
-        devMode.put(Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE, "true");
+        devMode.put(InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE, "false");
+        devMode.put(InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE, "true");
 
         dynamicMockCheck = registration -> EasyMock
                 .expect(registration.setInitParameters(Collections.singletonMap(
-                        Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE,
+                        InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE,
                         Boolean.TRUE.toString())))
                 .andReturn(null).once();
 
@@ -221,14 +221,14 @@ public class ServletDeployerTest {
     public void frontendServletIsNotRegisteredWhenNoServletsHaveDevelopmentAndCompatibilityMode()
             throws Exception {
         Map<String, String> params = new HashMap<>();
-        params.put(Constants.SERVLET_PARAMETER_PRODUCTION_MODE, "false");
-        params.put(Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE, "false");
+        params.put(InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE, "false");
+        params.put(InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE, "false");
         deployer.contextInitialized(getContextEvent(
                 true, true,
                 getServletRegistration("testServlet1", TestVaadinServlet.class,
                         singletonList("/test1/*"),
                         singletonMap(
-                                Constants.SERVLET_PARAMETER_PRODUCTION_MODE,
+                                InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE,
                                 "true")),
                 getServletRegistration("testServlet2", TestVaadinServlet.class,
                         singletonList("/test2/*"), params)));
@@ -240,13 +240,13 @@ public class ServletDeployerTest {
     public void frontendServletIsRegisteredInProductionModeIfOriginalFrontendResourcesAreUsed()
             throws Exception {
         Map<String, String> params = new HashMap<>();
-        params.put(Constants.SERVLET_PARAMETER_PRODUCTION_MODE, "true");
-        params.put(Constants.USE_ORIGINAL_FRONTEND_RESOURCES, "true");
-        params.put(Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE, "true");
+        params.put(InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE, "true");
+        params.put(InitParameters.USE_ORIGINAL_FRONTEND_RESOURCES, "true");
+        params.put(InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE, "true");
 
         dynamicMockCheck = registration -> EasyMock
                 .expect(registration.setInitParameters(Collections.singletonMap(
-                        Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE,
+                        InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE,
                         Boolean.TRUE.toString())))
                 .andReturn(null).once();
         deployer.contextInitialized(
@@ -262,7 +262,7 @@ public class ServletDeployerTest {
             throws Exception {
         dynamicMockCheck = registration -> EasyMock
                 .expect(registration.setInitParameters(Collections.singletonMap(
-                        Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE,
+                        InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE,
                         Boolean.TRUE.toString())))
                 .andReturn(null).once();
 
@@ -270,7 +270,7 @@ public class ServletDeployerTest {
                 getServletRegistration("test", TestServlet.class,
                         singletonList("/*"),
                         Collections.singletonMap(
-                                Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE,
+                                InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE,
                                 "true"))));
 
         assertMappingsCount(1, 1);
@@ -427,7 +427,7 @@ public class ServletDeployerTest {
                 getServletRegistration("testServlet", TestServlet.class,
                         singletonList("/test/*"),
                         singletonMap(
-                                Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE,
+                                InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE,
                                 Boolean.toString(compatibilityMode)))));
 
         assertMappingsCount(0, 0);

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/VerifyBrowserVersionIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/VerifyBrowserVersionIT.java
@@ -25,7 +25,7 @@ public class VerifyBrowserVersionIT extends ChromeBrowserTest {
             // Chrome version does not necessarily match the desired version
             // because of auto updates...
             browserIdentifier = getExpectedUserAgentString(
-                    getDesiredCapabilities()) + "81";
+                    getDesiredCapabilities()) + "83";
         } else if (BrowserUtil.isFirefox(getDesiredCapabilities())) {
             browserIdentifier = getExpectedUserAgentString(
                     getDesiredCapabilities()) + "58";


### PR DESCRIPTION
Collecting the init parameters in a dedicated class allows using reflection to collect them.
This allows exposing them in the Spring add-on without maintaining two lists of parameters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8423)
<!-- Reviewable:end -->
