### PR TITLE
Fix duplicate event listeners in TemplateRenderer

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/renderer/RendererUtil.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/renderer/RendererUtil.java
@@ -121,21 +121,19 @@ public class RendererUtil {
             Element eventOrigin, String handlerName, Consumer<T> consumer,
             Function<String, T> keyMapper) {
         ui.getInternals().getStateTree()
-                .beforeClientResponse(eventOrigin.getNode(), context -> {
-                    // vaadin.sendEventMessage is an exported function at the
-                    // client side
-                    ui.getPage().executeJs(String.format(
-                            "$0.%s = function(e) {Vaadin.Flow.clients[$1].sendEventMessage(%d, '%s', {key: e.model ? e.model.__data.item.key : e.target.__dataHost.__data.item.key})}",
-                            handlerName, eventOrigin.getNode().getId(),
-                            handlerName), eventOrigin,
-                            ui.getInternals().getAppId());
-                });
+                .beforeClientResponse(eventOrigin.getNode(), context ->
+                // sendEventMessage is an exported function at the client side
+                ui.getPage().executeJs(String.format(
+                        "$0.%s = function(e) {Vaadin.Flow.clients[$1].sendEventMessage(%d, '%s', {key: e.model ? e.model.__data.item.key : e.target.__dataHost.__data.item.key})}",
+                        handlerName, eventOrigin.getNode().getId(),
+                        handlerName), eventOrigin,
+                        ui.getInternals().getAppId()));
 
         DomListenerRegistration registration = eventOrigin.addEventListener(
                 handlerName, event -> processEventFromTemplateRenderer(event,
                         handlerName, consumer, keyMapper));
 
-        runOnceOnDetach(eventOrigin, () -> registration.remove());
+        runOnceOnDetach(eventOrigin, registration::remove);
     }
 
     private static <T> void processEventFromTemplateRenderer(DomEvent event,


### PR DESCRIPTION
in case where the element is attached several times during the same roundtrip.

Fixes vaadin/vaadin-grid-flow#837

With these changes, the event listener is added synchronously instead of `beforeClientResponse`, so that it gets removed before the next attach.

Also, fixed a minor memory leak: The detach listeners were never removed, so re-attaching a component with template renderers was accumulating redundant listeners (see the third commit).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8428)
<!-- Reviewable:end -->
