### PR TITLE
Fix regression in @Push when running in client bootstrapping

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -1051,11 +1051,14 @@ public class UIInternals implements Serializable {
     }
 
     private void configurePush(HasElement root) {
-        Optional<Push> push = AnnotationReader.getAnnotationFor(root.getClass(),
-                Push.class);
         DeploymentConfiguration deploymentConfiguration = getSession()
                 .getService().getDeploymentConfiguration();
+        if (!deploymentConfiguration.useV14Bootstrap()) {
+            return;
+        }
         PushConfiguration pushConfiguration = ui.getPushConfiguration();
+        Optional<Push> push = AnnotationReader.getAnnotationFor(root.getClass(),
+                Push.class);
         PushMode pushMode = push.map(Push::value)
                 .orElseGet(deploymentConfiguration::getPushMode);
         pushConfiguration.setPushMode(pushMode);

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/UIInternalsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/UIInternalsTest.java
@@ -115,6 +115,8 @@ public class UIInternalsTest {
     @Test
     public void showRouteTarget_usePushConfigFromComponent() {
         PushConfiguration pushConfig = setUpInitialPush();
+        useV14Bootstrap();
+
         internals.showRouteTarget(Mockito.mock(Location.class),
                 new RouteTarget(), Collections.emptyList());
 
@@ -125,6 +127,8 @@ public class UIInternalsTest {
     @Test
     public void showRouteTarget_usePushConfigFromParentLayout() {
         PushConfiguration pushConfig = setUpInitialPush();
+        useV14Bootstrap();
+
         internals.showRouteTarget(Mockito.mock(Location.class),
                 new RouteTarget1(),
                 Collections.singletonList(new RouteTarget()));
@@ -136,6 +140,8 @@ public class UIInternalsTest {
     @Test
     public void showRouteTarget_componentHasNoPush_pushIsDisabled() {
         PushConfiguration pushConfig = setUpInitialPush();
+        useV14Bootstrap();
+
         DeploymentConfiguration deploymentConfiguration = vaadinService
                 .getDeploymentConfiguration();
         Mockito.when(deploymentConfiguration.getPushMode())
@@ -149,6 +155,16 @@ public class UIInternalsTest {
                 .setTransport(Mockito.any());
     }
 
+    @Test
+    public void showRouteTarget_clientSideBootstrap() {
+        PushConfiguration pushConfig = setUpInitialPush();
+
+        internals.showRouteTarget(Mockito.mock(Location.class),
+                new RouteTarget(), Collections.emptyList());
+
+        Mockito.verify(pushConfig, Mockito.never()).setPushMode(Mockito.any());
+    }
+
     private PushConfiguration setUpInitialPush() {
         DeploymentConfiguration config = Mockito
                 .mock(DeploymentConfiguration.class);
@@ -160,6 +176,13 @@ public class UIInternalsTest {
 
         Mockito.when(config.getPushMode()).thenReturn(PushMode.DISABLED);
         return pushConfig;
+    }
+
+    private void useV14Bootstrap() {
+        DeploymentConfiguration deploymentConfiguration = vaadinService
+                .getDeploymentConfiguration();
+        Mockito.when(deploymentConfiguration.useV14Bootstrap())
+                .thenReturn(true);
     }
 
 }

--- a/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/PushView.java
+++ b/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/PushView.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.ccdmtest;
+
+import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.Route;
+
+@Route("push")
+public class PushView extends Div {
+    public PushView() {
+        setId("pushView");
+        add(new Text("Push View"));
+    }
+
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        setId("pushedContent");
+        setText("Message pushed from server");
+        getUI().get().push();
+    }
+}

--- a/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/PushView.java
+++ b/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/PushView.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.ccdmtest;
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.router.Route;
 
 @Route("push")

--- a/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/IndexHtmlRequestHandlerIT.java
+++ b/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/IndexHtmlRequestHandlerIT.java
@@ -582,4 +582,18 @@ public class IndexHtmlRequestHandlerIT extends CCDMTest {
                 "object", executeScript(
                         "return typeof window.vaadinPush" + ".atmosphere"));
     }
+
+    @Test
+    public void should_receiveServerPushUpdates() {
+        openTestUrl("/");
+        waitForElementPresent(By.id("button3"));
+
+        findElement(By.id("pathname")).sendKeys("/push");
+        findElement(By.id("button3")).click();
+        waitForElementPresent(By.id("pushedContent"));
+
+        String content = findElement(By.id("pushedContent")).getText();
+        Assert.assertEquals("Should have content sent from server using push mechanism",
+                "Message pushed from server", content);
+    }
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/RedirectToPushIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/RedirectToPushIT.java
@@ -30,7 +30,13 @@ public class RedirectToPushIT extends ChromeBrowserTest {
 
         $(NativeButtonElement.class).first().click();
 
-        Assert.assertEquals("Push mode: AUTOMATIC",
+        // when running V15-Bootstrapping push must be configured in AppShell
+        // otherwise @Push annotation in routes are logged in startup but ignored.
+        String pushMode = Boolean.getBoolean(
+                "vaadin.useDeprecatedV14Bootstrapping") ? "AUTOMATIC"
+                        : "DISABLED";
+
+        Assert.assertEquals("Push mode: " + pushMode,
                 $(TestBenchElement.class).id("pushMode").getText());
     }
 }


### PR DESCRIPTION
Fixes #8283 
This is broken since https://github.com/vaadin/flow/pull/7838 
Problem is that in client-side routing, push mechanism only can be configured once, and it happens in the AppShell class, earlier to compute the server target route.
This fix needs to be cherry-picked in 3.1 series (v16)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8435)
<!-- Reviewable:end -->
