### PR TITLE
Add size event firing

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -31,8 +32,11 @@ import java.util.stream.Stream;
 
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.data.provider.ArrayUpdater.Update;
 import com.vaadin.flow.data.provider.DataChangeEvent.DataRefreshEvent;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableComparator;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.ExecutionContext;
@@ -75,6 +79,7 @@ public class DataCommunicator<T> implements Serializable {
 
     // Last total size value sent to the client
     private int assumedSize;
+    private int lastSent = -1;
 
     private boolean resendEntireRange = true;
     private boolean assumeEmptyClient = true;
@@ -530,6 +535,27 @@ public class DataCommunicator<T> implements Serializable {
 
         // Phase 4: unregister passivated and updated items
         unregisterPassivatedKeys();
+
+        fireSizeEvent(assumedSize);
+    }
+
+    /**
+     * Fire a size change event if the last event was fired for a different size
+     * from the last sent one.
+     *
+     * @param dataSize
+     *         data size to send
+     */
+    private void fireSizeEvent(int dataSize) {
+        if (lastSent != dataSize) {
+            final Optional<Component> component = Element.get(stateNode)
+                    .getComponent();
+            if (component.isPresent()) {
+                ComponentUtil.fireEvent(component.get(),
+                        new SizeChangeEvent<>(component.get(), dataSize));
+            }
+            lastSent = dataSize;
+        }
     }
 
     private void flushUpdatedData() {

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/SizeChangeEvent.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/SizeChangeEvent.java
@@ -20,6 +20,8 @@ import com.vaadin.flow.component.ComponentEvent;
 
 /**
  * Event describing the data size change for a component data set.
+ * The SizeChangedEvent will fired from beforeClientResponse so changes done
+ * during the server round trip will only receive one event.
  *
  * @param <T>
  *         the event source type

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/SizeChangeListener.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/SizeChangeListener.java
@@ -18,8 +18,10 @@ package com.vaadin.flow.data.provider;
 import java.io.Serializable;
 
 /**
- * Listener interface for getting updates on data set size changes.
- *
+ * Listener interface for getting updates on data set size changes. The
+ * sizeChanged method will be called on beforeClientResponse so changes done
+ * during the server round trip will only receive one event.
+ * <p>
  * Size changes are mostly due to filtering of the data, but can also be
  * sent for changes in the dataset.
  *
@@ -31,7 +33,8 @@ public interface SizeChangeListener extends Serializable {
     /**
      * Invoked for changes in the data size.
      *
-     * @param event Component event containing new data size
+     * @param event
+     *         Component event containing new data size
      */
     void sizeChanged(SizeChangeEvent event);
 

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
@@ -338,6 +338,7 @@ public class DataCommunicatorTest {
         fakeClientCommunication();
 
         Assert.assertEquals(40, lastSet.getEnd());
+        // Assert takes into acount the inital size query for setting dataprovider.
         Mockito.verify(dataProvider, Mockito.times(2)).size(Mockito.any());
         Mockito.verify(dataProvider, Mockito.times(1)).fetch(Mockito.any());
     }

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicatorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicatorTest.java
@@ -28,13 +28,18 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.internal.UIInternals;
 import com.vaadin.flow.data.provider.CompositeDataGenerator;
 import com.vaadin.flow.data.provider.hierarchy.HierarchicalArrayUpdater.HierarchicalUpdate;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.internal.StateTree;
+import com.vaadin.flow.internal.nodefeature.ComponentMapping;
+import com.vaadin.flow.internal.nodefeature.ElementData;
 
 import elemental.json.JsonValue;
 
@@ -114,13 +119,18 @@ public class HierarchicalCommunicatorTest {
         treeData.addItems(FOLDER, LEAF);
         dataProvider = new TreeDataProvider<>(treeData);
         stateNode = Mockito.mock(StateNode.class);
+        Mockito.when(stateNode.hasFeature(Mockito.any())).thenReturn(true);
+        ComponentMapping mapping = Mockito.mock(ComponentMapping.class);
+        Mockito.when(stateNode.getFeatureIfInitialized(ComponentMapping.class)).thenReturn(
+                java.util.Optional.ofNullable(mapping));
+        Mockito.when(mapping.getComponent()).thenReturn(
+                java.util.Optional.of(new TestComponent()));
         communicator = new HierarchicalDataCommunicator<>(
                 Mockito.mock(CompositeDataGenerator.class), arrayUpdater,
                 json -> {
                 }, stateNode, () -> null);
         communicator.setDataProvider(dataProvider, null);
     }
-
     @Test
     public void folderRemoveRefreshAll() {
         testItemRemove(FOLDER, true);
@@ -192,5 +202,10 @@ public class HierarchicalCommunicatorTest {
         Assert.assertEquals("$connector.ensureHierarchy",
                 enqueueFunctions.get(0));
     }
+
+    @Tag("test")
+    public static class TestComponent extends Component {
+    }
+
 
 }


### PR DESCRIPTION
DataCommunicator now fires size
change event for the component when
data size or dataprovider changes.

Fix DataCommunicator components for #8345

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8450)
<!-- Reviewable:end -->
