### PR TITLE
Force chokidar version to ^3.4.0 (#8432)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -283,6 +283,10 @@ public abstract class NodeUpdater implements FallibleCommand {
 
         defaults.put("terser", "4.6.7");
 
+        // Forcing chokidar version for now until new babel version is available
+        // check out https://github.com/babel/babel/issues/11488
+        defaults.put("chokidar", "^3.4.0");
+
         return defaults;
     }
 

--- a/flow-server/src/main/resources/pnpmfile.js
+++ b/flow-server/src/main/resources/pnpmfile.js
@@ -34,7 +34,7 @@ function readPackage(pkg) {
     }
   }
 
-  if (pkg.dependencies.chokidar === '*') {
+  if (pkg.dependencies.chokidar) {
     pkg.dependencies.chokidar = '^3.4.0';
   }
 

--- a/flow-server/src/main/resources/pnpmfile.js
+++ b/flow-server/src/main/resources/pnpmfile.js
@@ -34,5 +34,9 @@ function readPackage(pkg) {
     }
   }
 
+  if (pkg.dependencies.chokidar === '*') {
+    pkg.dependencies.chokidar = '^3.4.0';
+  }
+
   return pkg;
 }

--- a/flow-server/src/main/resources/pnpmfile.js
+++ b/flow-server/src/main/resources/pnpmfile.js
@@ -34,6 +34,8 @@ function readPackage(pkg) {
     }
   }
 
+  // Forcing chokidar version for now until new babel version is available
+  // check out https://github.com/babel/babel/issues/11488
   if (pkg.dependencies.chokidar) {
     pkg.dependencies.chokidar = '^3.4.0';
   }


### PR DESCRIPTION
Fixes #8432 
Update pnpmfile.js to force all chokidar versions to ^3.4.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8451)
<!-- Reviewable:end -->
