### PR TITLE
lit-element as a default runtime dependency (#8351)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -261,6 +261,8 @@ public abstract class NodeUpdater implements FallibleCommand {
 
         defaults.put("@polymer/polymer", POLYMER_VERSION);
 
+        defaults.put("lit-element", "2.3.1");
+        
         return defaults;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -262,7 +262,7 @@ public abstract class NodeUpdater implements FallibleCommand {
         defaults.put("@polymer/polymer", POLYMER_VERSION);
 
         defaults.put("lit-element", "2.3.1");
-        
+
         return defaults;
     }
 

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -147,6 +147,11 @@ module.exports = {
     !devMode && new CompressionPlugin(),
     // Give some feedback when heavy builds
     devMode && new ProgressPlugin(true),
+    // Exclude DevmodeGizmo from webpack bundle when not devMode
+    !devMode && new webpack.IgnorePlugin({
+      resourceRegExp: /^\.\/VaadinDevmodeGizmo/,
+      contextRegExp: /flow-frontend$/
+    }),
 
     // Generates the stats file for flow `@Id` binding.
     function (compiler) {

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -5,6 +5,7 @@
  * This file will be overwritten on every run. Any custom changes should be made to webpack.config.js
  */
 const fs = require('fs');
+const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin');
 const CompressionPlugin = require('compression-webpack-plugin');


### PR DESCRIPTION
Part of #8351 
Add lit-element as a default runtime dependency
Exclude VaadinDevmodeGizmo.js from production webpack bundle

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8462)
<!-- Reviewable:end -->
