### PR TITLE
Make handleFileUploadValidationAndData and sendUploadResponse protected

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
@@ -326,7 +326,29 @@ public class StreamReceiverHandler implements Serializable {
         sendUploadResponse(response, success);
     }
 
-    private boolean handleFileUploadValidationAndData(VaadinSession session,
+    /**
+     * Validate that stream target is in a valid state for receiving data
+     * and send stream to receiver. Handles cleanup and error in reading stream
+     *
+     * @param session
+     *         The session containing the stream variable
+     * @param inputStream
+     *         the request content input stream
+     * @param streamReceiver
+     *         the receiver containing the destination stream variable
+     * @param filename
+     *         name of the streamed file
+     * @param mimeType
+     *         file mime type
+     * @param contentLength
+     *         The length of the request content
+     * @param node
+     *         The owner of the stream
+     * @return true if upload successful, else false
+     * @throws UploadException
+     *         Thrown for illegal target node state
+     */
+    protected boolean handleFileUploadValidationAndData(VaadinSession session,
             InputStream inputStream, StreamReceiver streamReceiver,
             String filename, String mimeType, long contentLength,
             StateNode node) throws UploadException {
@@ -396,7 +418,7 @@ public class StreamReceiverHandler implements Serializable {
      * @throws IOException
      *             exception when writing to stream
      */
-    private void sendUploadResponse(VaadinResponse response, boolean success)
+    protected void sendUploadResponse(VaadinResponse response, boolean success)
             throws IOException {
         response.setContentType(
                 ApplicationConstants.CONTENT_TYPE_TEXT_HTML_UTF_8);


### PR DESCRIPTION
This allows external code extending this class to reduce copy/pasting these and other private methods.

An example of where this would be beneficial is [here in Vertx Vaadin](https://github.com/mcollovati/vertx-vaadin/blob/master/vertx-vaadin-flow-parent/vertx-vaadin-flow/src/main/java/com/github/mcollovati/vertx/vaadin/communication/StreamReceiverHandler.java).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8468)
<!-- Reviewable:end -->
