### PR TITLE
Refactor initializers to take VaadinContext instead of ServletContext

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/AnnotationValidator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/AnnotationValidator.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.server.startup;
 
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
 import javax.servlet.annotation.HandlesTypes;
 
 import java.util.Arrays;
@@ -26,6 +24,7 @@ import java.util.Set;
 import com.vaadin.flow.component.page.BodySize;
 import com.vaadin.flow.component.page.Inline;
 import com.vaadin.flow.component.page.Viewport;
+import com.vaadin.flow.server.VaadinContext;
 
 /**
  * Validation class that is run during servlet container initialization which
@@ -35,11 +34,10 @@ import com.vaadin.flow.component.page.Viewport;
  */
 @HandlesTypes({ Viewport.class, BodySize.class, Inline.class })
 public class AnnotationValidator extends AbstractAnnotationValidator
-        implements ClassLoaderAwareServletContainerInitializer {
+        implements VaadinContextStartupInitializer {
 
     @Override
-    public void process(Set<Class<?>> classSet, ServletContext servletContext)
-            throws ServletException {
+    public void load(Set<Class<?>> classSet, VaadinContext context) {
         validateClasses(classSet);
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ApplicationRouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ApplicationRouteRegistry.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.server.startup;
 
-import javax.servlet.ServletContext;
-
 import java.io.Serializable;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -46,7 +44,6 @@ import com.vaadin.flow.router.internal.PathUtil;
 import com.vaadin.flow.router.internal.RouteTarget;
 import com.vaadin.flow.server.PWA;
 import com.vaadin.flow.server.VaadinContext;
-import com.vaadin.flow.server.VaadinServletContext;
 
 /**
  * Registry for holding navigation target components found on servlet
@@ -100,14 +97,14 @@ public class ApplicationRouteRegistry extends AbstractRouteRegistry {
     }
 
     /**
-     * Gets the route registry for the given Vaadin context. If the Vaadin
-     * context has no route registry, a new instance is created and assigned to
+     * Gets the <tt>RouteRegistry</tt> for the given {@link VaadinContext}. If the
+     * {@link VaadinContext} has no <tt>RouteRegistry</tt>, a new instance is created and assigned to
      * the context.
      *
      * @param context
-     *            the vaadin context for which to get a route registry, not
+     *            the {@link VaadinContext} for which to get a <tt>RouteRegistry</tt>, not
      *            <code>null</code>
-     * @return a registry instance for the given servlet context, not
+     * @return an  for the given {@link VaadinContext}, not
      *         <code>null</code>
      */
     public static ApplicationRouteRegistry getInstance(VaadinContext context) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ClassLoaderAwareServletContainerInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ClassLoaderAwareServletContainerInitializer.java
@@ -48,7 +48,7 @@ public interface ClassLoaderAwareServletContainerInitializer
     @Override
     default void onStartup(Set<Class<?>> set, ServletContext context)
             throws ServletException {
-        // see DeferredServletContextIntializers
+        // see DeferredServletContextInitializers
         DeferredServletContextInitializers.Initializer deferredInitializer = ctx -> {
             ClassLoader webClassLoader = ctx.getClassLoader();
             ClassLoader classLoader = getClass().getClassLoader();
@@ -92,7 +92,8 @@ public interface ClassLoaderAwareServletContainerInitializer
                         .filter(method -> !method.isDefault()
                                 && !method.isSynthetic())
                         .findFirst().get().getName();
-                Method operation = Stream.of(initializer.getDeclaredMethods())
+
+                Method operation = Stream.of(initializer.getMethods())
                         .filter(method -> method.getName()
                                 .equals(processMethodName))
                         .findFirst().get();
@@ -113,9 +114,9 @@ public interface ClassLoaderAwareServletContainerInitializer
                     DeferredServletContextInitializers initializers = vaadinContext
                             .getAttribute(
                                     DeferredServletContextInitializers.class,
-                                    () -> new DeferredServletContextInitializers());
+                                    DeferredServletContextInitializers::new);
                     initializers.addInitializer(
-                            ctx -> deferredInitializer.init(ctx));
+                            deferredInitializer);
                     return;
                 }
             }
@@ -136,23 +137,23 @@ public interface ClassLoaderAwareServletContainerInitializer
      * Implement this method instead of {@link #onStartup(Set, ServletContext)}
      * to handle classes accessible by different classloaders.
      *
-     * @param set
+     * @param classSet
      *            the Set of application classes that extend, implement, or have
      *            been annotated with the class types specified by the
-     *            {@link javax.servlet.annotation.HandlesTypes HandlesTypes}
-     *            annotation, or <tt>null</tt> if there are no matches, or this
-     *            <tt>ServletContainerInitializer</tt> has not been annotated
+     *            <tt>javax.servlet.annotation.HandlesTypes</tt> annotation,
+     *            or <tt>null</tt> if there are no matches, or this
+     *            {@link ServletContainerInitializer} has not been annotated
      *            with <tt>HandlesTypes</tt>
      *
      * @param ctx
-     *            the <tt>ServletContext</tt> of the web application that is
-     *            being started and in which the classes contained in <tt>c</tt>
+     *            the {@link ServletContext} of the web application that is
+     *            being started and in which the classes contained in <tt>set</tt>
      *            were found
      *
      * @throws ServletException
-     *             if an error has occurred
+     *            if an error has occurred
      *
      * @see #onStartup(Set, ServletContext)
      */
-    void process(Set<Class<?>> set, ServletContext ctx) throws ServletException;
+    void process(Set<Class<?>> classSet, ServletContext ctx) throws ServletException;
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DeferredServletContextInitializers.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DeferredServletContextInitializers.java
@@ -52,7 +52,7 @@ class DeferredServletContextInitializers {
          * {@code context}.
          * 
          * @param context
-         *            a ServletContext for the initializer
+         *            a {@link ServletContext} for the initializer
          * @throws ServletException
          *             thrown if the initializer throws an exception
          */
@@ -75,7 +75,7 @@ class DeferredServletContextInitializers {
      * Runs all collected initializers.
      * 
      * @param context
-     *            a ServletContext for initializers
+     *            a {@link ServletContext} for initializers
      * @throws ServletException
      *             thrown if some initializer throws an exception
      */

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ErrorNavigationTargetInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ErrorNavigationTargetInitializer.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.server.startup;
 
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
 import javax.servlet.annotation.HandlesTypes;
 
 import java.util.HashSet;
@@ -25,7 +23,7 @@ import java.util.stream.Collectors;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.router.HasErrorParameter;
-import com.vaadin.flow.server.VaadinServletContext;
+import com.vaadin.flow.server.VaadinContext;
 
 /**
  * Servlet initializer for collecting all available error handler navigation
@@ -35,12 +33,11 @@ import com.vaadin.flow.server.VaadinServletContext;
  */
 @HandlesTypes(HasErrorParameter.class)
 public class ErrorNavigationTargetInitializer
-        implements ClassLoaderAwareServletContainerInitializer {
+        implements VaadinContextStartupInitializer {
 
     @SuppressWarnings("unchecked")
     @Override
-    public void process(Set<Class<?>> classSet, ServletContext servletContext)
-            throws ServletException {
+    public void load(Set<Class<?>> classSet, VaadinContext context) {
         if (classSet == null) {
             classSet = new HashSet<>();
         }
@@ -51,7 +48,7 @@ public class ErrorNavigationTargetInitializer
                 .collect(Collectors.toSet());
 
         ApplicationRouteRegistry
-                .getInstance(new VaadinServletContext(servletContext))
+                .getInstance(context)
                 .setErrorNavigationTargets(routes);
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/RouteRegistryInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/RouteRegistryInitializer.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.server.startup;
 
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
 import javax.servlet.annotation.HandlesTypes;
 
 import java.util.Set;
@@ -29,7 +27,7 @@ import com.vaadin.flow.router.RouteAlias;
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.flow.server.AmbiguousRouteConfigurationException;
 import com.vaadin.flow.server.InvalidRouteConfigurationException;
-import com.vaadin.flow.server.VaadinServletContext;
+import com.vaadin.flow.server.VaadinContext;
 
 /**
  * Servlet initializer for collecting all available {@link Route}s on startup.
@@ -38,12 +36,10 @@ import com.vaadin.flow.server.VaadinServletContext;
  */
 @HandlesTypes({ Route.class, RouteAlias.class })
 public class RouteRegistryInitializer extends AbstractRouteRegistryInitializer
-        implements ClassLoaderAwareServletContainerInitializer {
+        implements VaadinContextStartupInitializer {
 
     @Override
-    public void process(Set<Class<?>> classSet, ServletContext servletContext)
-            throws ServletException {
-        VaadinServletContext context = new VaadinServletContext(servletContext);
+    public void load(Set<Class<?>> classSet, VaadinContext context) throws VaadinInitializerException {
         try {
             if (classSet == null) {
                 ApplicationRouteRegistry routeRegistry = ApplicationRouteRegistry
@@ -65,7 +61,7 @@ public class RouteRegistryInitializer extends AbstractRouteRegistryInitializer
             routeRegistry.setPwaConfigurationClass(validatePwaClass(
                     routes.stream().map(clazz -> (Class<?>) clazz)));
         } catch (InvalidRouteConfigurationException irce) {
-            throw new ServletException(
+            throw new VaadinInitializerException(
                     "Exception while registering Routes on servlet startup",
                     irce);
         }
@@ -101,5 +97,4 @@ public class RouteRegistryInitializer extends AbstractRouteRegistryInitializer
         }
         return false;
     }
-
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletDeployer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletDeployer.java
@@ -255,7 +255,7 @@ public class ServletDeployer implements ServletContextListener {
      * servlet automatically but don't use this class for that.
      *
      * @param servletContext
-     *            the deployed servlet context
+     *            the deployed {@link ServletContext}
      * @param servletAutomaticallyCreated
      *            whether the servlet was automatically created
      * @since

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletVerifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletVerifier.java
@@ -30,8 +30,9 @@ import java.util.Set;
  * @since 1.0
  */
 public class ServletVerifier implements ClassLoaderAwareServletContainerInitializer {
+
     @Override
-    public void process(Set<Class<?>> c, ServletContext ctx)
+    public void process(Set<Class<?>> classSet, ServletContext ctx)
             throws ServletException {
         verifyServletVersion();
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinContextStartupInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinContextStartupInitializer.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.startup;
+
+import com.vaadin.flow.server.VaadinContext;
+import com.vaadin.flow.server.VaadinServletContext;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import java.io.Serializable;
+import java.util.Set;
+
+/**
+ * Provides a mechanism to load initializers via {@link VaadinContext}.
+ *
+ * @since
+ */
+public interface VaadinContextStartupInitializer extends
+        ClassLoaderAwareServletContainerInitializer,
+        Serializable {
+
+    /**
+     * Handle initializer using {@link VaadinContext}.
+     *
+     * @param classSet
+     *            the Set of application classes that extend, implement, or have
+     *            been annotated with the class types specified by the
+     *            {@link javax.servlet.annotation.HandlesTypes}
+     *            annotation, or <tt>null</tt> if there are no matches, or this
+     *            initializer has not been annotated with <tt>HandlesTypes</tt>
+     *
+     * @param context
+     *            the {@link VaadinContext} to use with initializer
+     *
+     * @throws VaadinInitializerException
+     *            if an error has occurred
+     */
+    void load(Set<Class<?>> classSet, VaadinContext context) throws VaadinInitializerException;
+
+    /**
+     *
+     * {@inheritDoc}
+     *
+     * @deprecated Use {@link #load(Set, VaadinContext)} instead
+     *             by wrapping {@link ServletContext} with {@link VaadinServletContext}.
+     *
+     */
+    @Override
+    @Deprecated
+    default void process(Set<Class<?>> classSet, ServletContext ctx) throws ServletException {
+        try {
+            load(classSet, new VaadinServletContext(ctx));
+        } catch (VaadinInitializerException e) {
+            throw new ServletException(e);
+        }
+    }
+
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinInitializerException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinInitializerException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.startup;
+
+/**
+ * Exception indicating an issue during Vaadin initialization.
+ *
+ * @since
+ */
+public class VaadinInitializerException extends Exception {
+
+    /**
+     * Constructs a new exception with the specified detail message.
+     *
+     * @param message
+     *            the detail message. The detail message is saved for later
+     *            retrieval by the {@link #getMessage()} method.
+     */
+    public VaadinInitializerException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and
+     * cause.
+     *
+     * @param  message the detail message (which is saved for later retrieval
+     *         by the {@link #getMessage()} method).
+     * @param  cause the cause (which is saved for later retrieval by the
+     *         {@link #getCause()} method).  (A <tt>null</tt> value is
+     *         permitted, and indicates that the cause is nonexistent or
+     *         unknown.)
+     */
+    public VaadinInitializerException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/WebComponentConfigurationRegistryInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/WebComponentConfigurationRegistryInitializer.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.server.startup;
 
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
 import javax.servlet.annotation.HandlesTypes;
 
 import java.util.Collections;
@@ -33,7 +31,7 @@ import com.vaadin.flow.component.WebComponentExporterFactory;
 import com.vaadin.flow.component.webcomponent.WebComponentConfiguration;
 import com.vaadin.flow.internal.CustomElementNameValidator;
 import com.vaadin.flow.server.InvalidCustomElementNameException;
-import com.vaadin.flow.server.VaadinServletContext;
+import com.vaadin.flow.server.VaadinContext;
 import com.vaadin.flow.server.webcomponent.WebComponentConfigurationRegistry;
 import com.vaadin.flow.server.webcomponent.WebComponentExporterUtils;
 
@@ -48,23 +46,22 @@ import com.vaadin.flow.server.webcomponent.WebComponentExporterUtils;
  */
 @HandlesTypes({ WebComponentExporter.class, WebComponentExporterFactory.class })
 public class WebComponentConfigurationRegistryInitializer
-        implements ClassLoaderAwareServletContainerInitializer {
+        implements VaadinContextStartupInitializer {
 
     @Override
     @SuppressWarnings("rawtypes")
-    public void process(Set<Class<?>> set, ServletContext servletContext)
-            throws ServletException {
+    public void load(Set<Class<?>> classSet, VaadinContext context) throws VaadinInitializerException {
         WebComponentConfigurationRegistry instance = WebComponentConfigurationRegistry
-                .getInstance(new VaadinServletContext(servletContext));
+                .getInstance(context);
 
-        if (set == null || set.isEmpty()) {
+        if (classSet == null || classSet.isEmpty()) {
             instance.setConfigurations(Collections.emptySet());
             return;
         }
 
         try {
             Set<WebComponentExporterFactory> factories = WebComponentExporterUtils
-                    .getFactories(set);
+                    .getFactories(classSet);
             Set<WebComponentConfiguration<? extends Component>> configurations = constructConfigurations(
                     factories);
 
@@ -73,7 +70,7 @@ public class WebComponentConfigurationRegistryInitializer
 
             instance.setConfigurations(configurations);
         } catch (Exception e) {
-            throw new ServletException(
+            throw new VaadinInitializerException(
                     String.format("%s failed to collect %s implementations!",
                             WebComponentConfigurationRegistryInitializer.class
                                     .getSimpleName(),

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/WebComponentExporterAwareValidator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/WebComponentExporterAwareValidator.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.server.startup;
 
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
 import javax.servlet.annotation.HandlesTypes;
 
 import java.util.Arrays;
@@ -28,6 +26,7 @@ import com.googlecode.gentyref.GenericTypeReflector;
 
 import com.vaadin.flow.component.WebComponentExporter;
 import com.vaadin.flow.component.page.Push;
+import com.vaadin.flow.server.VaadinContext;
 
 /**
  * Checks that specific annotations are not configured wrong.
@@ -40,11 +39,10 @@ import com.vaadin.flow.component.page.Push;
 @HandlesTypes(Push.class)
 public class WebComponentExporterAwareValidator
         extends AbstractAnnotationValidator
-        implements ClassLoaderAwareServletContainerInitializer {
+        implements VaadinContextStartupInitializer {
 
     @Override
-    public void process(Set<Class<?>> classSet, ServletContext servletContext)
-            throws ServletException {
+    public void load(Set<Class<?>> classSet, VaadinContext context) {
         validateClasses(classSet);
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/AnnotationValidatorTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/AnnotationValidatorTest.java
@@ -1,11 +1,12 @@
 package com.vaadin.flow.server.startup;
 
 import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
 
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.server.VaadinContext;
+import com.vaadin.flow.server.VaadinServletContext;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -31,12 +32,12 @@ public class AnnotationValidatorTest {
     public ExpectedException expectedEx = ExpectedException.none();
 
     private AnnotationValidator annotationValidator;
-    private ServletContext servletContext;
+    private VaadinContext vaadinContext;
 
     @Before
     public void init() {
         annotationValidator = new AnnotationValidator();
-        servletContext = Mockito.mock(ServletContext.class);
+        vaadinContext = new VaadinServletContext(Mockito.mock(ServletContext.class));
     }
 
     @Tag(Tag.DIV)
@@ -80,13 +81,13 @@ public class AnnotationValidatorTest {
 
     @Test
     public void onStartUp_all_failing_anotations_are_reported()
-            throws ServletException {
+            throws VaadinInitializerException {
         try {
-            annotationValidator.process(Stream
+            annotationValidator.load(Stream
                     .of(InlineViewportWithParent.class,
                             BodySizeViewportWithParent.class,
                             ViewPortViewportWithParent.class)
-                    .collect(Collectors.toSet()), servletContext);
+                    .collect(Collectors.toSet()), vaadinContext);
             Assert.fail("No exception was thrown for faulty setup.");
         } catch (InvalidApplicationConfigurationException iace) {
             String errorMessage = iace.getMessage();
@@ -109,24 +110,24 @@ public class AnnotationValidatorTest {
 
     @Test
     public void onStartUp_all_failing_annotations_are_marked_for_class()
-            throws ServletException {
+            throws VaadinInitializerException {
         expectedEx.expect(InvalidApplicationConfigurationException.class);
         expectedEx.expectMessage(ERROR_MESSAGE_BEGINNING + String.format(
                 NON_PARENT, FailingMultiAnnotation.class.getName(),
                 "@" + BodySize.class.getSimpleName() + ", "
                         + "@" + Inline.class.getSimpleName()));
 
-        annotationValidator.process(Stream.of(FailingMultiAnnotation.class)
-                .collect(Collectors.toSet()), servletContext);
+        annotationValidator.load(Stream.of(FailingMultiAnnotation.class)
+                .collect(Collectors.toSet()), vaadinContext);
 
         Assert.fail("No exception was thrown for faulty setup.");
     }
 
     @Test
     public void onStartUp_no_exception_is_thrown_for_correctly_setup_classes()
-            throws ServletException {
+            throws VaadinInitializerException {
         annotationValidator
-                .process(Stream.of(MultiAnnotation.class, AbstractMain.class)
-                        .collect(Collectors.toSet()), servletContext);
+                .load(Stream.of(MultiAnnotation.class, AbstractMain.class)
+                        .collect(Collectors.toSet()), vaadinContext);
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
@@ -1,7 +1,5 @@
 package com.vaadin.flow.server.startup;
 
-import javax.servlet.ServletException;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -23,6 +21,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
+import com.vaadin.flow.server.VaadinServletContext;
 import net.jcip.annotations.NotThreadSafe;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -122,32 +121,32 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
 
     @Test
     public void loadingJars_useModernResourcesFolder_allFilesExist()
-            throws IOException, ServletException {
+            throws IOException, VaadinInitializerException {
         loadingJars_allFilesExist(RESOURCES_FRONTEND_DEFAULT);
     }
 
     @Test
     public void loadingZipProtocolJars_useModernResourcesFolder_allFilesExist()
-            throws IOException, ServletException {
+            throws IOException, VaadinInitializerException {
         loadingZipProtocolJars_allFilesExist(RESOURCES_FRONTEND_DEFAULT);
     }
 
     @Test
     public void loadingJars_useObsoleteResourcesFolder_allFilesExist()
-            throws IOException, ServletException {
+            throws IOException, VaadinInitializerException {
         loadingJars_allFilesExist(COMPATIBILITY_RESOURCES_FRONTEND_DEFAULT);
     }
 
     @Test
     public void loadingFsResources_useModernResourcesFolder_allFilesExist()
-            throws IOException, ServletException {
+            throws IOException, VaadinInitializerException {
         loadingFsResources_allFilesExist("/dir-with-modern-frontend/",
                 RESOURCES_FRONTEND_DEFAULT);
     }
 
     @Test
     public void loadingFsResources_useObsoleteResourcesFolder_allFilesExist()
-            throws IOException, ServletException {
+            throws IOException, VaadinInitializerException {
         loadingFsResources_allFilesExist("/dir-with-frontend-resources/",
                 COMPATIBILITY_RESOURCES_FRONTEND_DEFAULT);
     }
@@ -426,7 +425,7 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
         servletContextAttributes.put(Lookup.class.getName(), lookup);
 
         process();
-        assertTrue(DevModeInitializer.isDevModeAlreadyStarted(servletContext));
+        assertTrue(DevModeInitializer.isDevModeAlreadyStarted(new VaadinServletContext(servletContext)));
     }
 
     @Test(expected = IllegalStateException.class)
@@ -495,7 +494,7 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
     }
 
     private void loadingJars_allFilesExist(String resourcesFolder)
-            throws IOException, ServletException {
+            throws IOException, VaadinInitializerException {
         loadingJarsWithProtocol_allFilesExist(resourcesFolder, s -> {
             try {
                 return new URL("jar:" + s);
@@ -506,7 +505,7 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
     }
 
     private void loadingZipProtocolJars_allFilesExist(String resourcesFolder)
-            throws IOException, ServletException {
+            throws IOException, VaadinInitializerException {
         final URLStreamHandler dummyZipHandler = new URLStreamHandler() {
 
             @Override
@@ -527,7 +526,7 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
 
     private void loadingJarsWithProtocol_allFilesExist(String resourcesFolder,
             Function<String, URL> urlBuilder)
-            throws IOException, ServletException {
+            throws IOException, VaadinInitializerException {
         // Create jar urls with the given urlBuilder for test
         String urlPath = this.getClass().getResource("/").toString()
                 .replace("target/test-classes/", "")
@@ -555,14 +554,14 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
     }
 
     private void loadingFsResources_allFilesExist(String resourcesRoot,
-            String resourcesFolder) throws IOException, ServletException {
+            String resourcesFolder) throws IOException, VaadinInitializerException {
         List<URL> urls = Collections.singletonList(
                 getClass().getResource(resourcesRoot + resourcesFolder));
         loadingFsResources_allFilesExist(urls, resourcesFolder);
     }
 
     private void loadingFsResources_allFilesExist(Collection<URL> urls,
-            String resourcesFolder) throws IOException, ServletException {
+            String resourcesFolder) throws IOException, VaadinInitializerException {
         // Create mock loader with the single jar to be found
         ClassLoader classLoader = Mockito.mock(ClassLoader.class);
         Mockito.when(classLoader.getResources(resourcesFolder))


### PR DESCRIPTION
This PR primarily addresses #5735 but I believe it also solves #2775.

This provides a good step towards allowing external libraries to reduce the dependency on `servlet-api` (see #4613). 

- Added 2 files:
	- `VaadinInitializerException` - a `RuntimeException`
    - `VaadinContextInitializer` - an interface which is implemented by `AnnotationValidator`, `ConnectEndpointsValidator`, `ErrorNavigationTargetInitializer`, `RouteRegisteryInitializer`, `WebComponentConfigurationRegistryInitializer`, `WebComponentExporterAwareValidator`

	For the above 2 files that I added, I picked names that I thought made sense but they can change as need be.

- Refactored initializers to wrap `ServletContext` with `VaadinServletContext`.

	I marked the methods accepting `ServletContext` as deprecated. I think we should do this and encourage people to use the new methods by wrapping `ServletContext` with `VaadinServletContext`.

Questions
1. Should `VaadinInitializerException` extend a `RuntimeException` or `Exception`?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8469)
<!-- Reviewable:end -->
