### PR TITLE
Quiet down logs for deployment

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
@@ -45,37 +45,34 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.TARGET;
 public class DefaultDeploymentConfiguration
         extends PropertyDeploymentConfiguration {
 
-    private static final String SEPARATOR = "\n=======================================================================";
-    private static final String HEADER = "\n=================== Vaadin DeploymentConfiguration ====================\n";
+    public static final String NOT_PRODUCTION_MODE_INFO = "\nVaadin is running in DEBUG MODE.\n"
+            + "When deploying application for production, remember to disable debug features. See more from https://vaadin.com/docs/";
 
-    public static final String NOT_PRODUCTION_MODE_INFO = " Vaadin is running in DEBUG MODE.\n"
-            + " When deploying application for production, remember to disable debug features. See more from https://vaadin.com/docs/";
+    public static final String NOT_PRODUCTION_MODE_WARNING = "\nWARNING: Vaadin is running in DEBUG MODE with debug features enabled, but with a prebuild frontend bundle (production ready).\n"
+            + "When deploying application for production, disable debug features by enabling production mode!\n"
+            + "See more from https://vaadin.com/docs/v14/flow/production/tutorial-production-mode-basic.html";
 
-    public static final String NOT_PRODUCTION_MODE_WARNING = " WARNING: Vaadin is running in DEBUG MODE with debug features enabled, but with a prebuild frontend bundle (production ready).\n"
-            + " When deploying application for production, disable debug features by enabling production mode!\n"
-            + " See more from https://vaadin.com/docs/v14/flow/production/tutorial-production-mode-basic.html";
-
-    public static final String WARNING_V14_BOOTSTRAP = " Using deprecated Vaadin 14 bootstrap mode.\n"
-            + " Client-side views written in TypeScript are not supported. Vaadin 15+ enables client-side and server-side views.\n"
-            + " See https://vaadin.com/docs/v15/flow/typescript/starting-the-app.html for more information.";
+    public static final String WARNING_V14_BOOTSTRAP = "Using deprecated Vaadin 14 bootstrap mode.\n"
+            + "Client-side views written in TypeScript are not supported. Vaadin 15+ enables client-side and server-side views.\n"
+            + "See https://vaadin.com/docs/v15/flow/typescript/starting-the-app.html for more information.";
 
     // not a warning anymore, but keeping variable name to avoid breaking anything
-    public static final String WARNING_V15_BOOTSTRAP = "%n Using Vaadin 15+ bootstrap mode.%n %s%n %s";
+    public static final String WARNING_V15_BOOTSTRAP = "Using Vaadin 15+ bootstrap mode.%n %s%n %s";
 
-    private static final String DEPLOYMENT_WARNINGS = " Following issues were discovered with deployment configuration:";
+    private static final String DEPLOYMENT_WARNINGS = "Following issues were discovered with deployment configuration:";
 
-    public static final String WARNING_XSRF_PROTECTION_DISABLED = " WARNING: Cross-site request forgery protection is disabled!";
+    public static final String WARNING_XSRF_PROTECTION_DISABLED = "WARNING: Cross-site request forgery protection is disabled!";
 
-    public static final String WARNING_HEARTBEAT_INTERVAL_NOT_NUMERIC = " WARNING: heartbeatInterval has been set to a non integer value."
+    public static final String WARNING_HEARTBEAT_INTERVAL_NOT_NUMERIC = "WARNING: heartbeatInterval has been set to a non integer value."
             + "\n The default of 5min will be used.";
 
-    public static final String WARNING_PUSH_MODE_NOT_RECOGNIZED = " WARNING: pushMode has been set to an unrecognized value.\n"
-            + " The permitted values are \"disabled\", \"manual\",\n"
-            + " and \"automatic\". The default of \"disabled\" will be used.";
+    public static final String WARNING_PUSH_MODE_NOT_RECOGNIZED = "WARNING: pushMode has been set to an unrecognized value.\n"
+            + "The permitted values are \"disabled\", \"manual\",\n"
+            + "and \"automatic\". The default of \"disabled\" will be used.";
 
-    private static final String INDEX_NOT_FOUND = " '%s' is not found from '%s'.%n"
-            + " Generating a default one in '%s%s'. "
-            + " Move it to the '%s' folder if you want to customize it.";
+    private static final String INDEX_NOT_FOUND = "'%s' is not found from '%s'.%n"
+            + "Generating a default one in '%s%s'. "
+            + "Move it to the '%s' folder if you want to customize it.";
 
     /**
      * Default value for {@link #getHeartbeatInterval()} = {@value} .
@@ -159,18 +156,13 @@ public class DefaultDeploymentConfiguration
         Logger logger = LoggerFactory.getLogger(getClass().getName());
 
         if (!warnings.isEmpty()) {
-            warnings.add(0, HEADER);
-            warnings.add(1, DEPLOYMENT_WARNINGS);
-            warnings.add("\n");
+            warnings.add(0, DEPLOYMENT_WARNINGS);
             // merging info messages to warnings for now
             warnings.addAll(info);
-            warnings.add(SEPARATOR);
             if (logger.isWarnEnabled()) {
                 logger.warn(String.join("\n", warnings));
             }
         } else if (!info.isEmpty()) {
-            info.add(0, HEADER);
-            info.add(SEPARATOR);
             if (logger.isInfoEnabled()) {
                 logger.info(String.join("\n", info));
             }

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletDeployer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletDeployer.java
@@ -74,7 +74,6 @@ import org.slf4j.LoggerFactory;
  */
 public class ServletDeployer implements ServletContextListener {
     private static final String SKIPPING_AUTOMATIC_SERVLET_REGISTRATION_BECAUSE = "Skipping automatic servlet registration because";
-    private static final String SEPARATOR = "=======================================================================";
 
     private enum VaadinServletCreation {
         NO_CREATION, SERVLET_EXISTS, SERVLET_CREATED;
@@ -262,12 +261,11 @@ public class ServletDeployer implements ServletContextListener {
     }
 
     /**
-     * Prints to sysout a notification to the user that the application is to be
-     * opened in the browser.
+     * Prints to sysout a notification to the user that the application has been deployed.
      * <p>
      * This method is public so that it can be called in add-ons that map
      * servlet automatically but don't use this class for that.
-     * 
+     *
      * @param servletContext
      *            the deployed servlet context
      * @param servletAutomaticallyCreated
@@ -282,16 +280,14 @@ public class ServletDeployer implements ServletContextListener {
             String contextPath = servletContext.getContextPath();
             contextPath = contextPath.isEmpty() ? "/" : contextPath;
 
-            String url = String.format("http://localhost:8080%s", contextPath);
             FrontendUtils.console(FrontendUtils.BRIGHT_BLUE, String.format(
-                    "%n%s%n%n Vaadin application has started in DEBUG MODE and is available by opening %s in the browser.%n%n NOTE: the server HTTP port may vary - see server log output.%n%n%s%n",
-                    SEPARATOR, url, SEPARATOR));
+                    "Vaadin application has been deployed and started to the context path \"%s\".%n",
+                    contextPath));
         } else {
             // if the user has mapped their own servlet, they will know where to
             // find it
             FrontendUtils.console(FrontendUtils.BRIGHT_BLUE, String.format(
-                    "%n%s%n%nVaadin application has started in DEBUG MODE and is available in the browser.%n%n%s%n",
-                    SEPARATOR, SEPARATOR));
+                    "Vaadin application has been deployed and started.%n"));
         }
     }
 


### PR DESCRIPTION
Removes highlighting blocks, extra whitespace and changes output block
about application start up to a oneliner.

Fixes #8404, #8395
Related to #8104

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8471)
<!-- Reviewable:end -->
