### PR TITLE
Always lookup DOM elements inside the given context and not globally

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/ElementUtil.java
+++ b/flow-client/src/main/java/com/vaadin/client/ElementUtil.java
@@ -63,15 +63,12 @@ public class ElementUtil {
          return context.shadowRoot.getElementById(id);
        } else if (context.getElementById) {
          return context.getElementById(id);
-       } else if (context.ownerDocument && context.ownerDocument.getElementById) {
-         var e = context.ownerDocument.getElementById(id);
-         if (e && context.contains(e)) {
-           return e;
-         } else {
-           return null;
-         }
+       } else if (id && id.match("^[a-zA-Z0-9-_]*$")) {
+         // No funky characters in id so querySelector can be used directly
+         return context.querySelector("#" + id);
        } else {
-         return null;
+         // Find all elements with an id attribute and filter out the correct one
+         return Array.from(context.querySelectorAll('[id]')).find(function(e) {return e.id == id});
        }
     }-*/;
 

--- a/flow-tests/test-root-context/frontend/template-without-shadow-root-view.js
+++ b/flow-tests/test-root-context/frontend/template-without-shadow-root-view.js
@@ -17,7 +17,8 @@ class PolymerTemplateWithoutShadowRootView extends PolymerElement {
 
   static get template() {
     return html`
-      <div id="content"></div>
+      <div real="deal" id="content"></div>
+      <div id="special!#id"></div>
     `;
   }
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/PolymerTemplateWithoutShadowRootView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/template/PolymerTemplateWithoutShadowRootView.java
@@ -24,21 +24,36 @@ import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.templatemodel.TemplateModel;
 
-@Tag("template-without-shadow-root-view")
-@JsModule("./template-without-shadow-root-view.js")
 @Route(value = "com.vaadin.flow.uitest.ui.template.PolymerTemplateWithoutShadowRootView")
 @PageTitle("PolymerTemplate without a shadow root")
-public class PolymerTemplateWithoutShadowRootView
-        extends PolymerTemplate<TemplateModel> {
+public class PolymerTemplateWithoutShadowRootView extends Div {
 
-    @Id("content")
-    private Div div;
+    @JsModule("./template-without-shadow-root-view.js")
+    @Tag("template-without-shadow-root-view")
+    public static class Template extends PolymerTemplate<TemplateModel> {
+
+        @Id("content")
+        private Div div;
+        @Id("special!#id")
+        private Div specialId;
+
+        public Template() {
+            div.setText("Hello");
+            specialId.setText("Special");
+            div.addClickListener(e -> {
+                div.setText("Goodbye");
+            });
+        }
+    }
 
     public PolymerTemplateWithoutShadowRootView() {
-        div.setText("Hello");
-        div.addClickListener(e -> {
-            div.setText("Goodbye");
-        });
+        Div distractor1 = new Div();
+        Div distractor2 = new Div();
+        distractor1.setId("content");
+        distractor2.setId("content");
+        add(distractor1);
+        add(new Template());
+        add(distractor2);
     }
 
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/PolymerTemplateWithoutShadowRootIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/template/PolymerTemplateWithoutShadowRootIT.java
@@ -2,22 +2,21 @@ package com.vaadin.flow.uitest.ui.template;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.html.testbench.DivElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
-import com.vaadin.testbench.TestBenchElement;
-import com.vaadin.testbench.elementsbase.Element;
 
 public class PolymerTemplateWithoutShadowRootIT extends ChromeBrowserTest {
 
     @Test
     public void componentMappedCorrectly() {
         open();
-        DivElement content = $(DivElement.class).id("content");
-        Assert.assertEquals("Hello",content.getText());
+        DivElement content = $(DivElement.class).attribute("real", "deal")
+                .first();
+        Assert.assertEquals("Hello", content.getText());
+        DivElement special = $(DivElement.class).id("special!#id");
+        Assert.assertEquals("Special", special.getText());
         content.click();
-        Assert.assertEquals("Goodbye",content.getText());
+        Assert.assertEquals("Goodbye", content.getText());
     }
 }


### PR DESCRIPTION
This makes lookup work even if there are multiple elements with the same id defined globally

Fixes #8482

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8483)
<!-- Reviewable:end -->
