### PR TITLE
Disable devmode gizmo if production bundles but no devserver

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
@@ -216,6 +216,7 @@ public class PropertyDeploymentConfiguration
     @Override
     public boolean isDevModeLiveReloadEnabled() {
         return !isProductionMode() && getBooleanProperty(
-                SERVLET_PARAMETER_DEVMODE_ENABLE_LIVE_RELOAD, true);
+                SERVLET_PARAMETER_DEVMODE_ENABLE_LIVE_RELOAD, true)
+                && enableDevServer(); // gizmo excluded from prod bundle
     }
 }


### PR DESCRIPTION
It was missed when removing the `VaadinDevmodeGizmo` module from the production bundle that it is indeed possible to run an app in dev mode using prebuilt bundles (although not recommended / supported). In this case the client side should not try to load the module.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/flow/8489)
<!-- Reviewable:end -->
