### PR TITLE
8488 3.1 cherry-pick  (Import custom Connect client with a relative path)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateConnect.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateConnect.java
@@ -63,7 +63,7 @@ public class TaskGenerateConnect extends AbstractTaskConnectGenerator {
     @Override
     public void execute() throws ExecutionFailedException {
         File customConnectClient = new File(frontendDirectory, CUSTOM_CONNECT_CLIENT_NAME);
-        String customName = customConnectClient.exists() ? customConnectClient.getPath() : null;
+        String customName = customConnectClient.exists() ? ("../" + CUSTOM_CONNECT_CLIENT_NAME) : null;
         if (VaadinConnectTsGenerator.launch(openApi, outputFolder, customName)) {
             new VaadinConnectClientGenerator(readApplicationProperties())
                     .generateVaadinConnectClientFile(connectClientFile.toPath());

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateConnectTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateConnectTest.java
@@ -9,7 +9,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class TaskGenerateConnectTest {
@@ -86,13 +88,7 @@ public class TaskGenerateConnectTest {
 
         String outputEndpoinTs1 = FileUtils.readFileToString(ts1, "UTF-8");
         String outputEndpoinTs2 = FileUtils.readFileToString(ts2, "UTF-8");
-        assertTrue(outputEndpoinTs1
-                .contains("import client from '"
-                        + customConnectClient.getPath()
-                        .replaceFirst("[.][^.]+$", "") + "'"));
-        assertTrue(outputEndpoinTs2
-                .contains("import client from '"
-                        + customConnectClient.getPath()
-                        .replaceFirst("[.][^.]+$", "") + "'"));
+        assertThat(outputEndpoinTs1, containsString("import client from '../connect-client'"));
+        assertThat(outputEndpoinTs1, containsString("import client from '../connect-client'"));
     }
 }


### PR DESCRIPTION
This commit fixes the TypeScript generator so that when a custom Connect client exists, it is imported into the generated TypeScript endpoint wrappers with a relative path (`../connect-client`) instead of an absolute path (`C:/Users/me/work/my-app/frontend/connect-client`).

(cherry picked from commit 8325a1fed04ab9f2855eba658dec33309671e19b / PR #8488)