### PR TITLE
Usability and visual design improvements for devmode gizmo and notifications

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.js
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.js
@@ -956,10 +956,10 @@ class VaadinDevmodeGizmo extends LitElement {
 
   renderMessage(messageObject) {
     return html`
-      <div class="message ${messageObject.type} ${messageObject.deleted ? 'animate-out' : ''} ${messageObject.details || messageObject.link ? 'has-details' : ''}">
+      <div class="message ${messageObject.type} ${messageObject.deleted ? 'animate-out' : ''} ${messageObject.details || messageObject.link ? 'has-details' : ''}">
         <div class="message-content">
           <div class="message-heading">${messageObject.message}</div>
-          <div class="message-details" ?hidden="${!messageObject.details && !messageObject.link}">
+          <div class="message-details" ?hidden="${!messageObject.details && !messageObject.link}">
             ${messageObject.details ? html`<p>${messageObject.details}</p>` : ''}
             ${messageObject.link ? html`<a class="ahreflike" href="${messageObject.link}" target="_blank">Read more</a>` : ''}
           </div>

--- a/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.js
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.js
@@ -309,6 +309,9 @@ class VaadinDevmodeGizmo extends LitElement {
 
       .message-content {
           margin-right: 0.5rem;
+          -webkit-user-select: text;
+          -moz-user-select: text;
+          user-select: text;
       }
 
       .message .message-heading {
@@ -386,6 +389,9 @@ class VaadinDevmodeGizmo extends LitElement {
           display: flex;
           align-items: center;
           position: relative;
+          -webkit-user-select: none;
+          -moz-user-select: none;
+          user-select: none;
       }
 
       .message .persist::before {

--- a/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.js
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.js
@@ -5,87 +5,137 @@ class VaadinDevmodeGizmo extends LitElement {
   static get styles() {
     return css`
        :host {
-          --gizmo-border-radius: 1rem;
-          
-          --gizmo-green-color: hsl(145, 80%, 42%);
-          --gizmo-grey-color: hsl(0, 0%, 50%);
-          --gizmo-yellow-color: hsl(36, 100%, 61%);
-          --gizmo-red-color: hsl(3, 100%, 61%);
+         --gizmo-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+         --gizmo-font-family-monospace: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+
+          --gizmo-font-size: 0.8125rem;
+
+          --gizmo-text-color: rgba(255, 255, 255, .85);
+          --gizmo-text-color-secondary: rgba(255, 255, 255, .65);
+          --gizmo-text-color-emphasis: rgba(255, 255, 255, 1);
+
+          --gizmo-background-color-inactive: rgba(50, 50, 50, .15);
+          --gizmo-background-color-active: rgba(50, 50, 50, 0.98);
+
+          --gizmo-border-radius: 0.5rem;
+          --gizmo-box-shadow: 0 4px 12px -2px rgba(0, 0, 0, 0.4);
+
+          --gizmo-blue-hsl: 206, 100%, 70%;
+          --gizmo-blue-color: hsl(var(--gizmo-blue-hsl));
+          --gizmo-green-hsl: 145, 80%, 42%;
+          --gizmo-green-color: hsl(var(--gizmo-green-hsl));
+          --gizmo-grey-hsl: 0, 0%, 50%;
+          --gizmo-grey-color: hsl(var(--gizmo-grey-hsl));
+          --gizmo-yellow-hsl: 38, 98%, 64%;
+          --gizmo-yellow-color: hsl(var(--gizmo-yellow-hsl));
+          --gizmo-red-hsl: 355, 100%, 68%;
+          --gizmo-red-color: hsl(var(--gizmo-red-hsl));
+
+          /* Needs to be in ms, used in JavaScript as well */
+          --gizmo-transition-duration: 200ms;
+
           direction: ltr;
+          cursor: default;
+          font: normal 500 var(--gizmo-font-size)/1.125rem var(--gizmo-font-family);
+          color: var(--gizmo-text-color);
+          -webkit-user-select: none;
+          -moz-user-select: none;
+          user-select: none;
+
+          position: fixed;
+          z-index: 20000;
+          pointer-events: none;
+          bottom: 0;
+          right: 0;
+          width: 100%;
+          height: 100%;
+          display: flex;
+          flex-direction: column-reverse;
+          align-items: flex-end;
        }
 
-      .vaadin-devmode-gizmo-root > * {
-          z-index: 20000;
-      }
-
       .gizmo {
+          pointer-events: auto;
           display: flex;
           align-items: center;
-          justify-content: center;
           position: fixed;
-          right: 0;
-          bottom: 1rem;
-          height: 2rem;
-          width: auto;
-          border-top-left-radius: var(--gizmo-border-radius);
-          border-bottom-left-radius: var(--gizmo-border-radius);
-          padding-left: .5rem;
-          background-color: rgba(50,50,50,.15);
-          color: rgba(255,255,255,.8);
-          transform: translateX(calc(100% - 2rem));
-          transition: 400ms;
+          z-index: inherit;
+          right: .25rem;
+          bottom: .25rem;
+          max-width: 1.75rem;
+          border-radius: 1rem;
+          padding: .375rem;
+          box-sizing: border-box;
+          background-color: var(--gizmo-background-color-inactive);
+          color: var(--gizmo-text-color);
+          transition: var(--gizmo-transition-duration) ease-in;
+          white-space: nowrap;
+          line-height: 1rem;
       }
 
       .gizmo:hover,
       .gizmo.active {
-          transform: translateX(0);
-          background-color: rgba(50,50,50,1);
+          max-width: calc(100% - 1rem);
+          background-color: var(--gizmo-background-color-active);
+          box-shadow: var(--gizmo-box-shadow);
       }
-      
+
       .gizmo .vaadin-logo {
+          flex: none;
           pointer-events: none;
           display: inline-block;
-          width: 16px;
-          height: 16px;
+          width: 1rem;
+          height: 1rem;
           fill: #fff;
-          opacity: 1;
-          transition: 400ms;
+          transition: var(--gizmo-transition-duration);
+          transition-delay: var(--gizmo-transition-duration);
+          margin: 0;
       }
-      
+
       .gizmo:hover .vaadin-logo,
       .gizmo.active .vaadin-logo {
           opacity: 0;
-          width: 0px;
-          margin-right: 0.25em;
+          width: 0;
       }
-      
+
       .gizmo .status-blip {
+          flex: none;
           display: block;
-          width: 0.75rem;
-          height: 0.75rem;
+          width: 1rem;
+          height: 1rem;
           border-radius: 50%;
           z-index: 20001;
           background-color: var(--gizmo-green-color);
-          transform: translate(-14px, 7px) scale(.5);
-          transition: 400ms;
+          transform: translate(-0.5rem, -0.5rem) scale(0.375);
+          transition: var(--gizmo-transition-duration);
+          transition-delay: var(--gizmo-transition-duration);
       }
 
       .gizmo:hover .status-blip,
       .gizmo.active .status-blip {
           transform: translate(0, 0) scale(1);
       }
-      
+
+      .gizmo.active .vaadin-logo,
+      .gizmo.active .status-blip {
+          transition-delay: 0s;
+      }
+
+      .gizmo .status-description {
+          overflow: hidden;
+          text-overflow: ellipsis;
+      }
+
       .gizmo > * {
           margin-right: .5rem;
       }
 
       .switch {
-          position: relative;
-          display: inline-block;
-          margin-top: auto;
-          margin-bottom: auto;
-          width: 28px;
-          height: 18px;
+          display: inline-flex;
+          align-items: center;
+          margin-left: auto;
+          flex-shrink: 1;
+          min-width: 28px;
       }
 
       .switch input {
@@ -95,272 +145,358 @@ class VaadinDevmodeGizmo extends LitElement {
       }
 
       .switch .slider {
-        position: absolute;
-        cursor: pointer;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        border-radius: 18px;
-        background-color: rgba(255, 255, 255, 0.3);
-        -webkit-transition: .4s;
-        transition: .4s;
-      }
-      
-      .switch .slider:hover {
-        background-color: rgba(255, 255, 255, 0.35);
-        transition: 0ms;
+          display: block;
+          flex: none;
+          width: 28px;
+          height: 18px;
+          border-radius: 9px;
+          background-color: rgba(255, 255, 255, 0.3);
+          transition: var(--gizmo-transition-duration);
       }
 
-      .switch .slider:before {
-        position: absolute;
-        content: "";
-        height: 14px;
-        width: 14px;
-        left: 2px;
-        bottom: 2px;
-        background-color: white;
-        -webkit-transition: .4s;
-        transition: .4s;
-        border-radius: 50%;
+      .switch .slider:hover {
+          background-color: rgba(255, 255, 255, 0.35);
+          transition: none;
+      }
+
+      .switch .slider::before {
+          content: "";
+          display: block;
+          margin: 2px;
+          width: 14px;
+          height: 14px;
+          background-color: #fff;
+          transition: var(--gizmo-transition-duration);
+          border-radius: 50%;
       }
 
       .switch input:checked + .slider {
-        background-color: var(--gizmo-green-color);
+          background-color: var(--gizmo-green-color);
       }
 
-      .switch input:checked + .slider:before {
-        -webkit-transform: translateX(10px);
-        -ms-transform: translateX(10px);
-        transform: translateX(10px);
+      .switch input:checked + .slider::before {
+          transform: translateX(10px);
       }
 
-     .switch input:disabled + .slider:before {
-        background-color: var(--gizmo-grey-color);
+     .switch input:disabled + .slider::before {
+          background-color: var(--gizmo-grey-color);
+      }
+
+      .live-reload-text {
+          font-weight: 600;
+          margin-left: 0.5em;
+          flex: 1;
+          overflow: hidden;
+          text-overflow: ellipsis;
       }
 
       .window.hidden {
           opacity: 0;
-          transform: scale(0.1,0.4);
+          transform: scale(0);
+          position: absolute;
       }
 
       .window.visible {
-          transform: scale(1,1);
+          transform: none;
           opacity: 1;
+          pointer-events: auto;
       }
 
       .window.visible ~ .gizmo {
           opacity: 0;
+          pointer-events: none;
       }
 
       .window.hidden ~ .gizmo {
           opacity: 1;
+          transition-delay: 0;
+      }
+
+      .window.hidden ~ .gizmo:hover,
+      .window.hidden ~ .gizmo:hover .vaadin-logo,
+      .window.hidden ~ .gizmo:hover .status-blip {
+          transition-delay: var(--gizmo-transition-duration);
+      }
+
+      .window.visible ~ .gizmo .vaadin-logo,
+      .window.visible ~ .gizmo .status-blip {
+          transition: none;
+          opacity: 0;
       }
 
       .window {
-          position: fixed;
-          right: 1rem;
-          bottom: 1rem;
-          border-radius: .5rem;
-          width: 480px;
-          font-size: 14px;
-          background-color: rgba(50,50,50,1);
-          color: #fff;
-          transition: 400ms;
+          border-radius: var(--gizmo-border-radius);
+          overflow: hidden;
+          margin: 0.5rem;
+          width: 30rem;
+          max-width: calc(100% - 1rem);
+          max-height: calc(50vh - 1rem);
+          flex-shrink: 0;
+          background-color: var(--gizmo-background-color-active);
+          color: var(--gizmo-text-color);
+          transition: var(--gizmo-transition-duration);
           transform-origin: bottom right;
+          display: flex;
+          flex-direction: column;
+          box-shadow: var(--gizmo-box-shadow);
       }
 
-      .window-header {
+      .window-toolbar {
           display: flex;
-          justify-content: space-between; 
+          flex: none;
           align-items: center;
-          background-color: rgba(40,40,40,1);
-          border-radius: .5rem .5rem 0px 0px;
-          padding: .25rem .5rem;
+          border-bottom: 1px solid rgba(255, 255, 255, 0.14);
+          padding: .25rem .75rem;
+          white-space: nowrap;
       }
-      
-      .window-tabs {
-          display: flex;
-          justify-content: space-between; 
-          background-color: rgba(40,40,40,1);
-          border-bottom: 1px solid rgba(70,70,70,1);
-          text-align: right;
-          padding: .25rem .5rem;
-      }
-      
-      .title {
-          font-weight: 600;
-      }
-      
+
       .tab {
-          color: #ccc;
-          font-weight: 600;
-      }   
-                  
-      .ahreflike {
-          cursor: pointer;
-          font-weight: 600;
-      }
-      
-      a {
+          color: var(--gizmo-text-color-secondary);
           font-weight: 600;
       }
 
-      .live-reload-text {
-          padding: 0 .5rem 0 .25rem;
+      .ahreflike {
+          font-weight: 600;
+          color: var(--gizmo-text-color-secondary);
       }
-      
+
+      .ahreflike:hover {
+          color: var(--gizmo-text-color-emphasis);
+      }
+
       .minimize-button {
-          width: 17px;
-          height: 17px;
-          color: #fff;
+          flex: none;
+          width: 1rem;
+          height: 1rem;
+          color: inherit;
           background-color: transparent;
           border: 0;
           padding: 0;
-          margin-left: .25rem;
+          margin: 0 -.375rem 0 1rem;
           opacity: .8;
+          outline: none;
       }
-      
+
       .minimize-button:hover {
           opacity: 1;
       }
-      
+
+      .minimize-button svg {
+          max-width: 100%;
+      }
+
+      .message.information {
+          --gizmo-notification-color: var(--gizmo-blue-color);
+      }
+
       .message.warning {
           --gizmo-notification-color: var(--gizmo-yellow-color);
       }
-      
+
       .message.error {
           --gizmo-notification-color: var(--gizmo-red-color);
       }
-      
-      .message .message-content {
+
+      .message {
+          display: flex;
+          padding: .125rem .75rem .125rem 2rem;
+          background-clip: padding-box;
+      }
+
+      .message.log {
+          padding-left: 0.75rem;
+      }
+
+      .message-content {
+          margin-right: 0.5rem;
+      }
+
+      .message .message-heading {
+          position: relative;
           display: flex;
           align-items: center;
+          margin: 0.125rem 0;
       }
-      
-      .message .message-content:before {
+
+      .message.has-details .message-heading {
+          font-weight: 600;
+      }
+
+      .message .message-heading::before {
+          position: absolute;
+          margin-left: -1.5rem;
           display: inline-block;
-          color: #000;
           text-align: center;
           font-size: 0.875em;
           font-weight: 600;
-          line-height: 1.25em;
-          width: 1.25em;
-          height: 1.25em;
+          line-height: calc(1.25em - 2px);
+          width: 1rem;
+          height: 1rem;
+          box-sizing: border-box;
+          border: 1px solid transparent;
           border-radius: 50%;
-          margin-right: .5rem;
       }
 
-      .message.information .message-content:before {
+      .message.information .message-heading::before {
           content: "i";
-          color: var(--gizmo-grey-color);
-          box-shadow: inset 0 0 0 1px var(--gizmo-grey-color);
+          border-color: currentColor;
+          color: var(--gizmo-notification-color);
       }
-            
-      .message.warning .message-content:before {
+
+      .message.warning .message-heading::before,
+      .message.error .message-heading::before {
           content: "!";
+          color: var(--gizmo-background-color-active);
           background-color: var(--gizmo-notification-color);
       }
-      
-      .message.error .message-content:before {
-          content: "!";
-          background-color: var(--gizmo-notification-color);
-      }
-      
+
       .message .message-details {
-          font-size: .875em;
-          min-width: 200px;
-          padding-bottom: 4px;
-          padding-left: 1.625rem;
+          font-weight: 400;
+          color: var(--gizmo-text-color-secondary);
+          margin: 0.25rem 0;
       }
-      
-      .message .message-actions {
+
+      .message .message-details[hidden] {
+          display: none;
+      }
+
+      .message .message-details p {
+          display: inline;
+          margin: 0;
+          margin-right: 0.375em;
+          word-break: break-word;
+      }
+
+      .message .ahreflike {
+          color: var(--gizmo-notification-color, var(--gizmo-text-color));
+          text-decoration: none;
+          opacity: 0.9;
+          font-weight: 500;
+      }
+
+      .message .ahreflike:hover {
+          color: var(--gizmo-notification-color, var(--gizmo-text-color-emphasis));
+          opacity: 1;
+      }
+
+      .message .persist {
+          color: var(--gizmo-text-color-secondary);
+          white-space: nowrap;
+          margin: 0.375rem 0;
           display: flex;
-          flex-direction: row;
-          justify-content: flex-end;
-          font-size: 1em;
+          align-items: center;
+          position: relative;
       }
-      
-      .message .message-actions > *:not(:first-child) {
-          margin-left: .5rem;
+
+      .message .persist::before {
+          content: "";
+          width: 1em;
+          height: 1em;
+          border-radius: 0.2em;
+          margin-right: 0.375em;
+          background-color: rgba(255, 255, 255, 0.3);
       }
-      
-      .message .message-actions a,
-      .message .message-actions .ahreflike {
-          color: var(--gizmo-notification-color, rgba(255,255,255,.9));
-          text-decoration: none;
+
+      .message .persist:hover::before {
+          background-color: rgba(255, 255, 255, 0.4);
       }
-      
-      .message .message-actions a:hover,
-      .message .message-actions .ahreflike:hover {
-          color: var(--gizmo-notification-color, rgba(255,255,255,1));
-          text-decoration: none;
+
+      .message .persist.on::before {
+          background-color: rgba(255, 255, 255, 0.9);
       }
-      
-      .message .message-actions .dismiss-message {
-          color: rgba(255,255,255,.6);
+
+      .message .persist.on::after {
+          content: "";
+          order: -1;
+          position: absolute;
+          width: 0.75em;
+          height: 0.25em;
+          border: 2px solid var(--gizmo-background-color-active);
+          border-width: 0 0 2px 2px;
+          transform: translate(0.05em, -0.05em) rotate(-45deg) scale(0.8, 0.9);
       }
-      
-      .message .message-actions .dismiss-message:hover {
-          color: var(--gizmo-red-color);
+
+      .message .dismiss-message {
+          font-weight: 600;
+          align-self: stretch;
+          display: flex;
+          align-items: center;
+          padding: 0 0.25rem;
+          margin-left: 0.5rem;
+          color: var(--gizmo-text-color-secondary);
       }
-      
+
+      .message .dismiss-message:hover {
+          color: var(--gizmo-text-color);
+      }
+
       .notification-tray {
           display: flex;
           flex-direction: column-reverse;
           align-items: flex-end;
-          justify-content: center;
-          position: fixed;
-          right: 0;
-          bottom: 4rem;
-          height: auto;
-          width: auto;
-          padding-left: .5rem;
-      }
-      
-      .notification-tray .message {
-          background-color: rgba(50,50,50);
-          color: rgba(255,255,255,.9);
-          width: auto;
-          max-width: 400px;
-          border-top-left-radius: var(--gizmo-border-radius);
-          border-bottom-left-radius: var(--gizmo-border-radius);
-          padding-top: .25rem;
-          padding-bottom: .25rem;
-          padding-left: .75rem;
-          padding-right: .75rem;
-          margin-top: .5rem;
-          transition: 400ms;
-          transform-origin: bottom right;
-          animation: slideIn 400ms;
-      }
-      
-      .notification-tray .message.animate-out {
-        animation: slideOut forwards 400ms;
-      }
-      
-      .notification-tray .message .message-details {
-          min-width: 200px;
-          padding-bottom: 4px;
-      }
-      
-      .message-tray .message {
-          padding: .25em .75em;
-          animation: appendList 400ms ease-in;
-      }
-      
-      .message-tray .message .message-details {
-          font-size: 1em;
+          margin: 0.5rem;
       }
 
-      .message-tray .message:not(:last-of-type) {
-          border-bottom: 1px solid rgba(70,70,70,1);
+      .window.hidden + .notification-tray {
+          margin-bottom: 3rem;
       }
-      
-      .message-tray .dismiss-message {
+
+      .notification-tray .message {
+          pointer-events: auto;
+          background-color: var(--gizmo-background-color-active);
+          color: var(--gizmo-text-color);
+          max-width: 30rem;
+          box-sizing: border-box;
+          border-radius: var(--gizmo-border-radius);
+          margin-top: .5rem;
+          transition: var(--gizmo-transition-duration);
+          transform-origin: bottom right;
+          animation: slideIn var(--gizmo-transition-duration);
+          box-shadow: var(--gizmo-box-shadow);
+          padding-top: 0.25rem;
+          padding-bottom: 0.25rem;
+      }
+
+      .notification-tray .message.animate-out {
+          animation: slideOut forwards var(--gizmo-transition-duration);
+      }
+
+      .notification-tray .message .message-details {
+          max-height: 10em;
+          overflow: hidden;
+      }
+
+      .message-tray {
+          flex: auto;
+          overflow: auto;
+      }
+
+      .message-tray .message {
+          animation: appendList var(--gizmo-transition-duration) ease-in;
+          padding-left: 2.25rem;
+      }
+
+      .message-tray .message.warning {
+          background-color: hsla(var(--gizmo-yellow-hsl), 0.09);
+      }
+
+      .message-tray .message.error {
+          background-color: hsla(var(--gizmo-red-hsl), 0.09);
+      }
+
+      .message-tray .message + .message {
+          border-top: 1px solid rgba(255, 255, 255, 0.07);
+      }
+
+      .message-tray .message:last-child {
+          padding-bottom: 0.375rem;
+      }
+
+      .message-tray .dismiss-message,
+      .message-tray .persist {
           display: none;
       }
-      
+
       @keyframes slideIn {
           from {
             transform: translateX(100%);
@@ -371,7 +507,7 @@ class VaadinDevmodeGizmo extends LitElement {
             opacity: 1;
           }
       }
-      
+
       @keyframes slideOut {
           from {
             transform: translateX(0%);
@@ -382,7 +518,7 @@ class VaadinDevmodeGizmo extends LitElement {
             opacity: 0;
           }
       }
-      
+
       @keyframes appendList {
           0% {
             font-size: 0;
@@ -476,6 +612,10 @@ class VaadinDevmodeGizmo extends LitElement {
       JREBEL: 'JRebel',
       SPRING_BOOT_DEVTOOLS: 'Spring Boot Devtools'
     };
+  }
+
+  static get LOG() {
+    return 'log';
   }
 
   static get INFORMATION() {
@@ -598,6 +738,7 @@ class VaadinDevmodeGizmo extends LitElement {
     const command = json['command'];
     switch (command) {
       case 'hello': {
+        this.showMessage(VaadinDevmodeGizmo.LOG, 'Vaadin development mode initialized');
         if (this.liveReloadBackend) {
           if (VaadinDevmodeGizmo.isActive) {
             this.status = VaadinDevmodeGizmo.ACTIVE;
@@ -614,7 +755,7 @@ class VaadinDevmodeGizmo extends LitElement {
 
       case 'reload':
         if (this.status === VaadinDevmodeGizmo.ACTIVE) {
-          this.showSplashMessage('Reloading...');
+          this.showSplashMessage('Reloading…');
           const lastReload = window.sessionStorage.getItem(VaadinDevmodeGizmo.TRIGGERED_COUNT_KEY_IN_SESSION_STORAGE);
           const nextReload = lastReload ? (parseInt(lastReload) + 1) : 1;
           window.sessionStorage.setItem(VaadinDevmodeGizmo.TRIGGERED_COUNT_KEY_IN_SESSION_STORAGE, nextReload.toString());
@@ -657,6 +798,8 @@ class VaadinDevmodeGizmo extends LitElement {
       this.showSplashMessage('Automatic reload #' + count + ' finished at ' + reloaded);
       window.sessionStorage.removeItem(VaadinDevmodeGizmo.TRIGGERED_KEY_IN_SESSION_STORAGE);
     }
+
+    this.__transitionDuration = parseInt(window.getComputedStyle(this).getPropertyValue('--gizmo-transition-duration'));
   }
 
   disconnectedCallback() {
@@ -681,17 +824,21 @@ class VaadinDevmodeGizmo extends LitElement {
 
   showSplashMessage(msg) {
     this.splashMessage = msg;
-    // automatically move notification to message tray after a certain amount of time
     if (this.splashMessage != null) {
-      setTimeout(() => {
+      if (this.expanded) {
         this.demoteSplashMessage();
-      }, VaadinDevmodeGizmo.AUTO_DEMOTE_NOTIFICATION_DELAY);
+      } else {
+        // automatically move notification to message tray after a certain amount of time
+        setTimeout(() => {
+          this.demoteSplashMessage();
+        }, VaadinDevmodeGizmo.AUTO_DEMOTE_NOTIFICATION_DELAY);
+      }
     }
   }
 
   demoteSplashMessage() {
     if (this.splashMessage) {
-      this.showMessage(VaadinDevmodeGizmo.INFORMATION, this.splashMessage);
+      this.showMessage(VaadinDevmodeGizmo.LOG, this.splashMessage);
     }
     this.showSplashMessage(null);
   }
@@ -706,6 +853,12 @@ class VaadinDevmodeGizmo extends LitElement {
       link: link
     });
     this.requestUpdate();
+    this.updateComplete.then(() => {
+      // Scroll into view
+      setTimeout(() => {
+        this.shadowRoot.querySelector('.message-tray .message:last-child').scrollIntoView({behavior: 'smooth'});
+      }, this.__transitionDuration);
+    });
   }
 
   showNotification(type, msg, details = null, link = null, persistentId = null) {
@@ -717,7 +870,8 @@ class VaadinDevmodeGizmo extends LitElement {
         message: msg,
         details: details,
         link: link,
-        persistentId: persistentId
+        persistentId: persistentId,
+        dontShowAgain: false
       });
       // automatically move notification to message tray after a certain amount of time unless it contains a link
       if (link === null) {
@@ -731,13 +885,13 @@ class VaadinDevmodeGizmo extends LitElement {
     }
   }
 
-  dismissNotification(id, persistently = false) {
+  dismissNotification(id) {
     const index = this.notifications.findIndex(notification => notification.id === id);
     if (index !== -1 && !this.notifications[index].deleted) {
       const notification = this.notifications[index];
 
       // user is explicitly dismissing a notification---after that we won't bug them with it
-      if (persistently && notification.persistentId && !VaadinDevmodeGizmo.notificationDismissed(notification.persistentId)) {
+      if (notification.dontShowAgain && notification.persistentId && !VaadinDevmodeGizmo.notificationDismissed(notification.persistentId)) {
         let dismissed = window.localStorage.getItem(VaadinDevmodeGizmo.DISMISSED_NOTIFICATIONS_IN_LOCAL_STORAGE);
         if (dismissed === null) {
           dismissed = notification.persistentId;
@@ -757,7 +911,16 @@ class VaadinDevmodeGizmo extends LitElement {
           this.notifications.splice(index, 1);
           this.requestUpdate();
         }
-      }, 400);
+      }, this.__transitionDuration);
+    }
+  }
+
+  toggleDontShowAgain(id) {
+    const index = this.notifications.findIndex(notification => notification.id === id);
+    if (index !== -1 && !this.notifications[index].deleted) {
+      const notification = this.notifications[index];
+      notification.dontShowAgain = !notification.dontShowAgain;
+      this.requestUpdate();
     }
   }
 
@@ -787,69 +950,59 @@ class VaadinDevmodeGizmo extends LitElement {
 
   renderMessage(messageObject) {
     return html`
-      <div class="message ${messageObject.type} ${messageObject.deleted ? 'animate-out' : ''}" @click=${e => this.dismissNotification(messageObject.id)}>
-        <div class="message-content">${messageObject.message}</div>
-        ${messageObject.details ? html`<div class="message-details">${messageObject.details}</div>` : ''}
-        <div class="message-actions">
-            ${messageObject.link ? html`<a href="${messageObject.link}" target="_blank">Read more</a>` : ''}
-            ${messageObject.persistentId ? html`<span class="ahreflike dismiss-message" @click=${e => this.dismissNotification(messageObject.id, true)}>Don't show again</span>` : ''}
+      <div class="message ${messageObject.type} ${messageObject.deleted ? 'animate-out' : ''} ${messageObject.details || messageObject.link ? 'has-details' : ''}">
+        <div class="message-content">
+          <div class="message-heading">${messageObject.message}</div>
+          <div class="message-details" ?hidden="${!messageObject.details && !messageObject.link}">
+            ${messageObject.details ? html`<p>${messageObject.details}</p>` : ''}
+            ${messageObject.link ? html`<a class="ahreflike" href="${messageObject.link}" target="_blank">Read more</a>` : ''}
+          </div>
+          ${messageObject.persistentId ? html`<div class="persist ${messageObject.dontShowAgain ? 'on' : 'off'}" @click=${e => this.toggleDontShowAgain(messageObject.id)}>Don’t show again</div>` : ''}
         </div>
+        <div class="dismiss-message" @click=${e => this.dismissNotification(messageObject.id)}>Dismiss</div>
       </div>
       `;
   }
 
   render() {
     return html`
-      <div class="vaadin-devmode-gizmo-root">
       <div class="window ${this.expanded ? 'visible' : 'hidden'}">
-        <div class="window-header">
-          <span class="title">Vaadin Development Mode</span>
-          <button class="minimize-button" @click=${e => this.toggleExpanded()}>
-            <svg xmlns="http://www.w3.org/2000/svg" style="width: 18px; height: 18px;">
-              <g stroke="#fff" stroke-width="1.25">
-                <rect rx="5" x="0.5" y="0.5" height="16" width="16" fill-opacity="0"/>
-                <line y2="12.1" x2="12.3" y1="3.4" x1="3" />
-                <line y2="8.5" x2="12.1" y1="12.4" x1="12.8" />
-                <line y2="12.1" x2="8.7" y1="12.1" x1="12.8" />
-              </g>
+        <div class="window-toolbar">
+          <span class="tab">Log</span>
+          <label class="switch">
+              <input id="toggle" type="checkbox"
+                  ?disabled=${this.status === VaadinDevmodeGizmo.UNAVAILABLE || this.status === VaadinDevmodeGizmo.ERROR}
+                  ?checked="${this.status === VaadinDevmodeGizmo.ACTIVE}"
+                  @change=${e => this.setActive(e.target.checked)}/>
+              <span class="slider"></span>
+              <span class="live-reload-text">Live reload</span>
+          </label>
+          <button class="minimize-button" title="Minimize" @click=${e => this.toggleExpanded()}>
+            <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+              <path d="M7.25 0.75C7.25 0.335786 7.58579 0 8 0H12.25C14.3211 0 16 1.67893 16 3.75V12.25C16 14.3211 14.3211 16 12.25 16H3.75C1.67893 16 0 14.3211 0 12.25V8C0 7.58579 0.335786 7.25 0.75 7.25C1.16421 7.25 1.5 7.58579 1.5 8V12.25C1.5 13.4926 2.50736 14.5 3.75 14.5H12.25C13.4926 14.5 14.5 13.4926 14.5 12.25V3.75C14.5 2.50736 13.4926 1.5 12.25 1.5H8C7.58579 1.5 7.25 1.16421 7.25 0.75Z"/>
+              <path d="M2.96967 2.96967C3.26256 2.67678 3.73744 2.67678 4.03033 2.96967L9.5 8.43934V5.75C9.5 5.33579 9.83579 5 10.25 5C10.6642 5 11 5.33579 11 5.75V10.25C11 10.6642 10.6642 11 10.25 11H5.75C5.33579 11 5 10.6642 5 10.25C5 9.83579 5.33579 9.5 5.75 9.5H8.43934L2.96967 4.03033C2.67678 3.73744 2.67678 3.26256 2.96967 2.96967Z"/>
             </svg>
           </button>
-        </div>
-        <div class="window-tabs">
-          <span class="tab">Log</span>
-          <div>
-            <label class="switch">
-                <input id="toggle" type="checkbox"
-                    ?disabled=${this.status === VaadinDevmodeGizmo.UNAVAILABLE || this.status === VaadinDevmodeGizmo.ERROR}
-                    ?checked="${this.status === VaadinDevmodeGizmo.ACTIVE}"
-                    @change=${e => this.setActive(e.target.checked)}/>
-                <span class="slider"></span>
-            </label>
-            <span class="live-reload-text">Live-reload</span>
-          </div>
         </div>
         <div class="message-tray">
           ${this.messages.map(msg => this.renderMessage(msg))}
         </div>
       </div>
-      
+
       <div class="notification-tray">
         ${this.notifications.map(msg => this.renderMessage(msg))}
       </div>
-      
+
       <div class="gizmo ${this.splashMessage !== null ? 'active' : ''}" @click=${e => this.toggleExpanded()}>
         <svg viewBox="0 0 16 16" preserveAspectRatio="xMidYMid meet" focusable="false" class="vaadin-logo">
-          <g><title>vaadin-logo</title>
           <path d="M15.21 0.35c-0.436 0-0.79 0.354-0.79 0.79v0 0.46c0 0.5-0.32 0.85-1.070 0.85h-3.55c-1.61 0-1.73 1.19-1.8 1.83v0c-0.060-0.64-0.18-1.83-1.79-1.83h-3.57c-0.75 0-1.090-0.37-1.090-0.86v-0.45c0-0.006 0-0.013 0-0.020 0-0.425-0.345-0.77-0.77-0.77-0 0-0 0-0 0h0c-0 0-0 0-0 0-0.431 0-0.78 0.349-0.78 0.78 0 0.004 0 0.007 0 0.011v-0.001 1.32c0 1.54 0.7 2.31 2.34 2.31h3.66c1.090 0 1.19 0.46 1.19 0.9 0 0 0 0.090 0 0.13 0.048 0.428 0.408 0.758 0.845 0.758s0.797-0.33 0.845-0.754l0-0.004s0-0.080 0-0.13c0-0.44 0.1-0.9 1.19-0.9h3.61c1.61 0 2.32-0.77 2.32-2.31v-1.32c0-0.436-0.354-0.79-0.79-0.79v0z"></path>
           <path d="M11.21 7.38c-0.012-0-0.026-0.001-0.040-0.001-0.453 0-0.835 0.301-0.958 0.714l-0.002 0.007-2.21 4.21-2.3-4.2c-0.122-0.425-0.507-0.731-0.963-0.731-0.013 0-0.026 0-0.039 0.001l0.002-0c-0.012-0-0.025-0.001-0.039-0.001-0.58 0-1.050 0.47-1.050 1.050 0 0.212 0.063 0.41 0.171 0.575l-0.002-0.004 3.29 6.1c0.15 0.333 0.478 0.561 0.86 0.561s0.71-0.228 0.858-0.555l0.002-0.006 3.34-6.1c0.090-0.152 0.144-0.335 0.144-0.53 0-0.58-0.47-1.050-1.050-1.050-0.005 0-0.010 0-0.014 0h0.001z"></path>
-          </g>
         </svg>
         <span class="status-blip" style="background-color: ${this.getStatusColor()}"></span>
           ${this.splashMessage !== null
       ? html`<span class="status-description">${this.splashMessage}</span></div>`
-      : html`<span class="status-description">Live-reload ${this.status} </span><span class="ahreflike">Details</span></div>`
+      : html`<span class="status-description">Live reload ${this.status} </span><span class="ahreflike">Details</span></div>`
     }
-      </div>
     </div>`;
   }
 }


### PR DESCRIPTION
Partial redesign of the UI design. Wanted to clean up the visual hierarchy and improve the usability of the notifications (dismissing and the “don’t show again” feature).

As a disclaimer: I didn’t pay any attention to accessibility, as it looked like that wasn’t a concern previously either (color contrast, keyboard or screen reader usability). The gizmo is only usable with a mouse or a touch device, and by sighted people.

Apologies for the unnecessary white-space changes (my IDE does the formatting automatically). I didn’t bother leaving those out.

Not super happy about the code quality, but it does the job.

## Changes

- Refined typographic styles (slightly smaller overall)
- Visually detached the gizmo and notifications from the edge of the browser
- Added a blue color for “information” messages
- Added a shadow for the gizmo and notifications
- Added an explicit “Dismiss” button (previously the user could click anywhere on the notification to dismiss it)

<img width="625" alt="Frame 1" src="https://user-images.githubusercontent.com/66382/83847542-1a8fb980-a715-11ea-85e8-98cd248737fd.png">

- Moved the “Read more” link to be part of the message details
- Changed the “Don’t show again” from a button to a checkbox
- Added a “log” style message, which does not have an icon and uses the gray color

<img width="1069" alt="Frame 2" src="https://user-images.githubusercontent.com/66382/83848107-08624b00-a716-11ea-837a-41be0a6fcf59.png">

- Simplified the window layout: removed the title bar (moved the title to a message in the log)
- Redesigned minimize icon

<img width="1123" alt="Frame 3" src="https://user-images.githubusercontent.com/66382/83848291-4e1f1380-a716-11ea-8917-25c077097910.png">

- If there’s a notification at the same time as the window is open, the notification shows above the window (previously was on top of it)

<img width="1146" alt="Frame 4" src="https://user-images.githubusercontent.com/66382/83849128-9d197880-a717-11ea-9e1b-d38c995d5d7d.png">

- Allow the log window to scroll if there are many message (previously the window grew outside the browser viewport and it was impossible to minimize the window)
- In general, restricted the UI from growing outside the browser viewport (long messages, small viewports, etc.)

<img width="1099" alt="Frame 5" src="https://user-images.githubusercontent.com/66382/83848934-46ac3a00-a717-11ea-9136-d4907c623fbe.png">

