### PR TITLE
Fix race condition in embedding tests

### DIFF
--- a/drivers.xml
+++ b/drivers.xml
@@ -2,10 +2,10 @@
 <root>
     <windows>
         <driver id="googlechrome">
-            <version id="80.0.3987.106">
+            <version id="83.0.4103.39">
                 <bitrate thirtytwobit="true" sixtyfourbit="true">
-                    <filelocation>https://chromedriver.storage.googleapis.com/80.0.3987.106/chromedriver_win32.zip</filelocation>
-                    <hash>40aeb7b0b3a3ea23a139a764b56e172f2fdb90a4</hash>
+                    <filelocation>https://chromedriver.storage.googleapis.com/83.0.4103.39/chromedriver_win32.zip</filelocation>
+                    <hash>e06f7553e68df7eec76a6fd0e1a21317807bf945</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
             </version>
@@ -13,10 +13,10 @@
     </windows>
     <linux>
         <driver id="googlechrome">
-            <version id="80.0.3987.106">
+            <version id="83.0.4103.39">
                 <bitrate sixtyfourbit="true">
-                    <filelocation>https://chromedriver.storage.googleapis.com/80.0.3987.106/chromedriver_linux64.zip</filelocation>
-                    <hash>0e8848ebca11706768fd748dd0282672acad35ac</hash>
+                    <filelocation>https://chromedriver.storage.googleapis.com/83.0.4103.39/chromedriver_linux64.zip</filelocation>
+                    <hash>fb412fdbf282ec5ceeddb2f6cf700268fde4ee44</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
             </version>
@@ -24,10 +24,10 @@
     </linux>
     <osx>
         <driver id="googlechrome">
-            <version id="80.0.3987.106">
+            <version id="83.0.4103.39">
                 <bitrate sixtyfourbit="true">
-                    <filelocation>https://chromedriver.storage.googleapis.com/80.0.3987.106/chromedriver_mac64.zip</filelocation>
-                    <hash>3b58b8039f363de3b13a8bea7d4646105fbbd177</hash>
+                    <filelocation>https://chromedriver.storage.googleapis.com/83.0.4103.39/chromedriver_mac64.zip</filelocation>
+                    <hash>5ad2f2fa798095f20a7086b1bad1047fb138fa83</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
             </version>

--- a/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/DefaultValueInitializationIT.java
+++ b/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/DefaultValueInitializationIT.java
@@ -19,9 +19,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
 
-import com.vaadin.flow.testutil.ChromeBrowserTest;
-
-public class DefaultValueInitializationIT extends ChromeBrowserTest implements HasById{
+public class DefaultValueInitializationIT extends EmbeddingChromeBrowserTest
+        implements HasById {
 
     @Override
     protected String getTestPath() {

--- a/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/EmbeddedWebComponentIT.java
+++ b/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/EmbeddedWebComponentIT.java
@@ -19,10 +19,10 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
 
-import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-public class EmbeddedWebComponentIT extends ChromeBrowserTest implements HasById {
+public class EmbeddedWebComponentIT extends EmbeddingChromeBrowserTest
+        implements HasById {
 
     @Override
     protected String getTestPath() {

--- a/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/EmbeddingChromeBrowserTest.java
+++ b/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/EmbeddingChromeBrowserTest.java
@@ -1,0 +1,19 @@
+package com.vaadin.flow.webcomponent;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public abstract class EmbeddingChromeBrowserTest extends ChromeBrowserTest {
+
+    @Override
+    protected void open() {
+        super.open();
+
+        // Wait for at least one shadow root to appear. This is to avoid race
+        // conditions where the test starts before the shadow root has been
+        // attached #8329
+        this.waitUntil((driver) -> Boolean.TRUE
+                .equals(this.getCommandExecutor().executeScript(
+                        "return Array.from(document.getElementsByTagName('*')).some(x => x.shadowRoot !== null)")));
+    }
+
+}

--- a/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/EmbeddingChromeBrowserTest.java
+++ b/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/EmbeddingChromeBrowserTest.java
@@ -13,7 +13,7 @@ public abstract class EmbeddingChromeBrowserTest extends ChromeBrowserTest {
         // attached #8329
         this.waitUntil((driver) -> Boolean.TRUE
                 .equals(this.getCommandExecutor().executeScript(
-                        "return Array.from(document.getElementsByTagName('*')).some(x => x.shadowRoot !== null)")));
+                        "return Array.prototype.slice.call(document.getElementsByTagName(\"*\")).some(function (x) { return !!x.shadowRoot })")));
     }
 
 }

--- a/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/FactoryExporterIT.java
+++ b/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/FactoryExporterIT.java
@@ -20,9 +20,8 @@ import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.flow.testutil.ChromeBrowserTest;
-
-public class FactoryExporterIT extends ChromeBrowserTest implements HasById {
+public class FactoryExporterIT extends EmbeddingChromeBrowserTest
+        implements HasById {
 
     @Override
     protected String getTestPath() {

--- a/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/FireEventIT.java
+++ b/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/FireEventIT.java
@@ -21,14 +21,13 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
 import static com.vaadin.flow.webcomponent.FireEventComponent.OptionsType.Bubble_Cancel;
 import static com.vaadin.flow.webcomponent.FireEventComponent.OptionsType.Bubble_NoCancel;
 import static com.vaadin.flow.webcomponent.FireEventComponent.OptionsType.NoBubble_NoCancel;
 
-public class FireEventIT extends ChromeBrowserTest implements HasById {
+public class FireEventIT extends EmbeddingChromeBrowserTest implements HasById {
     private static final String N1 = "number1";
     private static final String N2 = "number2";
     private static final String SUM = "sum";

--- a/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/NpmOnlyIndexIT.java
+++ b/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/NpmOnlyIndexIT.java
@@ -22,10 +22,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
 
-import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-public class NpmOnlyIndexIT extends ChromeBrowserTest {
+public class NpmOnlyIndexIT extends EmbeddingChromeBrowserTest {
 
     @Override
     protected String getTestPath() {

--- a/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/PreserveOnRefreshIT.java
+++ b/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/PreserveOnRefreshIT.java
@@ -21,10 +21,10 @@ import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 
-import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-public class PreserveOnRefreshIT extends ChromeBrowserTest implements HasById {
+public class PreserveOnRefreshIT extends EmbeddingChromeBrowserTest
+        implements HasById {
     private static final String MODIFIED = "modified";
     private static final String UNMODIFIED = "unmodified";
     private static final String NO_PRESERVE = "nopreserve";

--- a/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/PushAnnotationIT.java
+++ b/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/PushAnnotationIT.java
@@ -18,10 +18,9 @@ package com.vaadin.flow.webcomponent;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-public class PushAnnotationIT extends ChromeBrowserTest {
+public class PushAnnotationIT extends EmbeddingChromeBrowserTest {
 
     @Override
     protected String getTestPath() {

--- a/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/UpdatePropertyIT.java
+++ b/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/UpdatePropertyIT.java
@@ -19,10 +19,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
 
-import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-public class UpdatePropertyIT extends ChromeBrowserTest implements HasById {
+public class UpdatePropertyIT extends EmbeddingChromeBrowserTest implements HasById {
 
     @Override
     protected String getTestPath() {

--- a/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/WebComponentIT.java
+++ b/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/WebComponentIT.java
@@ -19,10 +19,10 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
 
-import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
-public class WebComponentIT extends ChromeBrowserTest implements HasById {
+public class WebComponentIT extends EmbeddingChromeBrowserTest
+        implements HasById {
 
     @Override
     protected String getTestPath() {


### PR DESCRIPTION
Fixes #8329. With Chrome dropping native HTML imports and the compatibility mode test for embedded webcomponents relying on polyfill, a race condition had appeared where the shadowroot was not yet attached during test run. Now waits for at least one shadowroot before commencing the test. 

Update: should squash when merging.