### PR TITLE
Add HasHelper interface

### DIFF
--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-buildtools</artifactId>
     <name>vaadin-buildhelpers</name>

--- a/flow-bom/pom.xml
+++ b/flow-bom/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-bom</artifactId>
     <packaging>pom</packaging>

--- a/flow-client/pom.xml
+++ b/flow-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-client</artifactId>
     <name>Flow Client</name>

--- a/flow-component-demo-helpers/pom.xml
+++ b/flow-component-demo-helpers/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>flow-component-demo-helpers</artifactId>

--- a/flow-data/pom.xml
+++ b/flow-data/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-data</artifactId>
     <name>Flow Data</name>

--- a/flow-dev-deps/pom.xml
+++ b/flow-dev-deps/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-dev-deps</artifactId>
     <name>Flow Development Dependencies</name>

--- a/flow-dnd/pom.xml
+++ b/flow-dnd/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>flow-project</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>flow-dnd</artifactId>

--- a/flow-html-components-testbench/pom.xml
+++ b/flow-html-components-testbench/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-html-components-testbench</artifactId>
     <name>TestBench elements for Flow HTML Components</name>

--- a/flow-html-components/pom.xml
+++ b/flow-html-components/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-html-components</artifactId>
     <name>Flow HTML Components</name>

--- a/flow-maven-plugin/pom.xml
+++ b/flow-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>

--- a/flow-migration/pom.xml
+++ b/flow-migration/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-migration</artifactId>
     <name>Flow Migration Tool</name>

--- a/flow-osgi/pom.xml
+++ b/flow-osgi/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-osgi</artifactId>
     <name>Flow OSGi Support</name>

--- a/flow-push/pom.xml
+++ b/flow-push/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-push</artifactId>
     <name>Flow Push</name>

--- a/flow-server-compatibility-mode/pom.xml
+++ b/flow-server-compatibility-mode/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-server-compatibility-mode</artifactId>
     <name>Flow Server Compatibility Mode</name>

--- a/flow-server-production-mode/pom.xml
+++ b/flow-server-production-mode/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-server-production-mode</artifactId>
     <name>Flow Server Production Mode</name>

--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-server</artifactId>
     <name>Flow Server</name>

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasHelper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasHelper.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component;
+
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import com.vaadin.flow.dom.Element;
+
+/**
+ * Mixin interface for field components that have helper text as property and
+ * slots for inserting components.
+ *
+ * @author Vaadin Ltd
+ */
+public interface HasHelper extends HasElement {
+  /**
+   * String used for the helper text.
+   *
+   * @return the {@code helperText} property from the web component
+   */
+  default String getHelperText() {
+    return getElement().getProperty("helperText");
+  }
+
+  /**
+   * <p>
+   * String used for the helper text.
+   * </p>
+   * 
+   * <p>
+   * In case both {@link #setHelperText(String)} and
+   * {@link #setHelperComponent(Component)} are used, only the element defined
+   * by {@link #setHelperComponent(Component)} will be visible, regardless of
+   * the order on which they are defined.
+   * </p>
+   *
+   * @param helperText
+   *            the String value to set
+   */
+  default void setHelperText(String helperText) {
+    getElement().setProperty("helperText", helperText);
+  }
+  /**
+   * Adds the given component into helper slot of component, replacing any
+   * existing helper component.
+   * 
+   * @param component
+   *            the component to set, can be {@code null} to remove existing
+   *            helper component
+   * 
+   * @see #setHelperText(String)
+   */
+  default void setHelperComponent(Component component) {
+    getElement().getChildren()
+      .filter(child -> "helper".equals(child.getAttribute("slot")))
+      .collect(Collectors.toList())
+      .forEach(getElement()::removeChild);
+
+    if (component != null) {
+        component.getElement().setAttribute("slot", "helper");
+        getElement().appendChild(component.getElement());
+    }
+  }
+
+  /**
+   * Gets the component in the helper slot of this field.
+   * 
+   * @return the helper component of this field, or {@code null} if no helper
+   *         component has been set
+   * @see #setHelperComponent(Component)
+   */
+  default Component getHelperComponent() {
+    Optional<Element> element = getElement().getChildren()
+      .filter(child -> "helper".equals(child.getAttribute("slot")))
+      .findFirst();
+    if (element.isPresent()) {
+      return element.get().getComponent().orElse(null);
+    }
+    return null;
+  }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasHelperTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasHelperTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HasHelperTest {
+
+    @Tag("div")
+    public static class HasHelperComponent extends Component implements HasHelper {
+    }
+
+    @Test
+    public void setHelperText() {
+        final HasHelperComponent c = new HasHelperComponent();
+        c.setHelperText("helper");
+        Assert.assertEquals("helper", c.getHelperText());
+    }
+
+    @Test
+    public void setHelperComponent() {
+        final HasHelperComponent c = new HasHelperComponent();
+        final HasHelperComponent slotted = new HasHelperComponent();
+        c.setHelperComponent(slotted);
+        Assert.assertEquals(slotted, c.getHelperComponent());
+    }
+
+    @Test
+    public void removeHelperText() {
+        final HasHelperComponent c = new HasHelperComponent();
+        c.setHelperText("helper");
+        Assert.assertEquals("helper", c.getHelperText());
+
+        c.setHelperText(null);
+        Assert.assertNull(c.getHelperText());
+    }
+
+    @Test
+    public void removeHelperComponent() {
+        final HasHelperComponent c = new HasHelperComponent();
+        final HasHelperComponent slotted = new HasHelperComponent();
+
+        c.setHelperComponent(slotted);
+        Assert.assertEquals(slotted, c.getHelperComponent());
+
+        c.setHelperComponent(null);
+        Assert.assertNull(c.getHelperComponent());
+    }
+}

--- a/flow-test-generic/pom.xml
+++ b/flow-test-generic/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>flow-project</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flow-test-util/pom.xml
+++ b/flow-test-util/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>flow-test-util</artifactId>

--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-tests</artifactId>
     <name>Flow tests</name>

--- a/flow-tests/servlet-containers/felix-jetty/pom.xml
+++ b/flow-tests/servlet-containers/felix-jetty/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-servlet-containers-test</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>flow-test-felix-jetty-server</artifactId>

--- a/flow-tests/servlet-containers/pom.xml
+++ b/flow-tests/servlet-containers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-servlet-containers-test</artifactId>
     <name>flow-servlet-containers-test</name>

--- a/flow-tests/servlet-containers/tomcat85/pom.xml
+++ b/flow-tests/servlet-containers/tomcat85/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-servlet-containers-test</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-tomcat85-server</artifactId>
     <name>Flow Tomcat 8.5 Test</name>

--- a/flow-tests/servlet-containers/tomcat9/pom.xml
+++ b/flow-tests/servlet-containers/tomcat9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-servlet-containers-test</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-tomcat9-server</artifactId>
     <name>Flow Tomcat 9 Test</name>

--- a/flow-tests/test-common/pom.xml
+++ b/flow-tests/test-common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-common</artifactId>
     <name>Flow common test UI classes</name>

--- a/flow-tests/test-dev-mode/pom.xml
+++ b/flow-tests/test-dev-mode/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-dev-mode</artifactId>
     <name>Flow tests for dev mode</name>

--- a/flow-tests/test-embedding/embedding-test-assets/pom.xml
+++ b/flow-tests/test-embedding/embedding-test-assets/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>test-embedding</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flow-tests/test-embedding/pom.xml
+++ b/flow-tests/test-embedding/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flow-tests</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flow-tests/test-embedding/test-embedding-generic-compatibility/pom.xml
+++ b/flow-tests/test-embedding/test-embedding-generic-compatibility/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>test-embedding</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-embedding-generic-compatibility</artifactId>
     <name>Flow Embedding, generic tests, compatibility</name>

--- a/flow-tests/test-embedding/test-embedding-generic/pom.xml
+++ b/flow-tests/test-embedding/test-embedding-generic/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>test-embedding</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-embedding-generic</artifactId>
     <name>Flow Embedding, generic tests</name>

--- a/flow-tests/test-embedding/test-embedding-production-mode-compatibility/pom.xml
+++ b/flow-tests/test-embedding/test-embedding-production-mode-compatibility/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>test-embedding</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-embedding-production-compatibility</artifactId>
     <name>Flow Embedding, production tests, compatibility</name>

--- a/flow-tests/test-embedding/test-embedding-production-mode/pom.xml
+++ b/flow-tests/test-embedding/test-embedding-production-mode/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>test-embedding</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-embedding-production</artifactId>
     <name>Flow Embedding, production tests</name>

--- a/flow-tests/test-embedding/test-embedding-theme-variant-compatibility/pom.xml
+++ b/flow-tests/test-embedding/test-embedding-theme-variant-compatibility/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>test-embedding</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-embedding-theme-variant-compatibility</artifactId>
     <name>Flow Embedding, theme variant, compatibility</name>

--- a/flow-tests/test-embedding/test-embedding-theme-variant/pom.xml
+++ b/flow-tests/test-embedding/test-embedding-theme-variant/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>test-embedding</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-embedding-theme-variant</artifactId>
     <name>Flow Embedding, theme variant</name>

--- a/flow-tests/test-frontend-production-custom-context/pom.xml
+++ b/flow-tests/test-frontend-production-custom-context/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>test-frontend-custom-context</artifactId>
     <name>Flow Frontend Resources on custom context test under Production Mode</name>

--- a/flow-tests/test-live-reload/pom.xml
+++ b/flow-tests/test-live-reload/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>flow-tests</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-live-reload-mode</artifactId>
     <name>Flow tests for live reload in dev mode</name>

--- a/flow-tests/test-lumo-theme/pom.xml
+++ b/flow-tests/test-lumo-theme/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-lumo-theme</artifactId>
     <name>Flow Lumo theme tests</name>

--- a/flow-tests/test-material-theme/pom.xml
+++ b/flow-tests/test-material-theme/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-material-theme</artifactId>
     <name>Flow Material theme tests</name>

--- a/flow-tests/test-memory-leaks/pom.xml
+++ b/flow-tests/test-memory-leaks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-memory-leaks</artifactId>
     <name>Flow memory leak tests</name>

--- a/flow-tests/test-misc/pom-bower.xml
+++ b/flow-tests/test-misc/pom-bower.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>flow-tests</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-misc-test-bower</artifactId>
     <name>Flow Miscelaneous tests in bower</name>

--- a/flow-tests/test-misc/pom.xml
+++ b/flow-tests/test-misc/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>flow-tests</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-misc-test</artifactId>
     <name>Flow Miscelaneous tests in npm</name>

--- a/flow-tests/test-mixed/pom-bower-devmode.xml
+++ b/flow-tests/test-mixed/pom-bower-devmode.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>flow-tests</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-bower-dev-mode</artifactId>
     <name>Flow tests in bower and development mode</name>

--- a/flow-tests/test-mixed/pom-bower-production.xml
+++ b/flow-tests/test-mixed/pom-bower-production.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>flow-tests</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-bower-prod-mode</artifactId>
     <name>Flow tests in bower and production mode</name>

--- a/flow-tests/test-mixed/pom-npm-production.xml
+++ b/flow-tests/test-mixed/pom-npm-production.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>flow-tests</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-npm-production</artifactId>
     <name>Flow tests in npm and production mode</name>

--- a/flow-tests/test-mixed/pom-npm.xml
+++ b/flow-tests/test-mixed/pom-npm.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>flow-tests</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-npm-dev-mode</artifactId>
     <name>Flow tests in npm and development mode</name>

--- a/flow-tests/test-mixed/pom-pnpm-production.xml
+++ b/flow-tests/test-mixed/pom-pnpm-production.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>flow-tests</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-pnpm-production</artifactId>
     <name>Flow tests in pnpm and production mode</name>

--- a/flow-tests/test-mixed/pom.xml
+++ b/flow-tests/test-mixed/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>flow-tests</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-pnpm-dev-mode</artifactId>
     <name>Flow tests in pnpm and development mode</name>

--- a/flow-tests/test-multi-war/deployment/pom.xml
+++ b/flow-tests/test-multi-war/deployment/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>flow-test-multi-war</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-multi-war-bundle</artifactId>
     <name>Bundle testing multiple war deployment</name>

--- a/flow-tests/test-multi-war/pom.xml
+++ b/flow-tests/test-multi-war/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>flow-tests</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-multi-war</artifactId>
     <name>Flow tests with more than one war deployed at the same time</name>

--- a/flow-tests/test-multi-war/test-war1/pom.xml
+++ b/flow-tests/test-multi-war/test-war1/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>flow-test-multi-war</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-multi-war1</artifactId>
     <name>First war for multi war tests</name>

--- a/flow-tests/test-multi-war/test-war2/pom.xml
+++ b/flow-tests/test-multi-war/test-war2/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>flow-test-multi-war</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-multi-war2</artifactId>
     <name>First war for multi war tests</name>

--- a/flow-tests/test-npm-only-features/pom.xml
+++ b/flow-tests/test-npm-only-features/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flow-tests</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flow-tests/test-npm-only-features/test-default-theme/pom.xml
+++ b/flow-tests/test-npm-only-features/test-default-theme/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flow-test-npm-only-features</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-devmode.xml
+++ b/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-devmode.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flow-test-npm-only-features</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-prod-fallback.xml
+++ b/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-prod-fallback.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flow-test-npm-only-features</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-production.xml
+++ b/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-production.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flow-test-npm-only-features</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flow-tests/test-npm-only-features/test-npm-custom-frontend-directory/pom.xml
+++ b/flow-tests/test-npm-only-features/test-npm-custom-frontend-directory/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flow-test-npm-only-features</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flow-tests/test-npm-only-features/test-npm-general/pom.xml
+++ b/flow-tests/test-npm-only-features/test-npm-general/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-test-npm-only-features</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flow-tests/test-npm-only-features/test-npm-no-buildmojo/pom.xml
+++ b/flow-tests/test-npm-only-features/test-npm-no-buildmojo/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flow-test-npm-only-features</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flow-tests/test-npm-only-features/test-npm-performance-regression/pom.xml
+++ b/flow-tests/test-npm-only-features/test-npm-performance-regression/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>flow-test-npm-only-features</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/flow-tests/test-pwa/pom.xml
+++ b/flow-tests/test-pwa/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>flow-tests</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-pwa</artifactId>
     <name>Flow tests for PWA annotation</name>

--- a/flow-tests/test-resources/pom.xml
+++ b/flow-tests/test-resources/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-resources</artifactId>
     <name>Flow Test Resources</name>

--- a/flow-tests/test-root-context/pom-npm.xml
+++ b/flow-tests/test-root-context/pom-npm.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-root-context-npm</artifactId>
     <name>Flow root context tests in NPM dev mode</name>

--- a/flow-tests/test-root-context/pom.xml
+++ b/flow-tests/test-root-context/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-root-context</artifactId>
     <name>Flow root context tests</name>

--- a/flow-tests/test-root-ui-context/pom.xml
+++ b/flow-tests/test-root-ui-context/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-root-ui-context</artifactId>
     <name>Flow root ui context tests</name>

--- a/flow-tests/test-router-custom-context/pom.xml
+++ b/flow-tests/test-router-custom-context/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>test-router-custom-context</artifactId>
     <name>Flow Router on custom context test</name>

--- a/flow-tests/test-scalability/pom.xml
+++ b/flow-tests/test-scalability/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-scalability</artifactId>
     <name>Flow scalability tests</name>

--- a/flow-tests/test-servlet/pom.xml
+++ b/flow-tests/test-servlet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-servlet</artifactId>
     <name>Flow servlet registration test</name>

--- a/flow-tests/test-subcontext/pom.xml
+++ b/flow-tests/test-subcontext/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-subcontext</artifactId>
     <name>Flow tests mapped for /context</name>

--- a/flow-tests/test-themes/pom-npm.xml
+++ b/flow-tests/test-themes/pom-npm.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-themes-npm</artifactId>
     <name>Flow themes tests in NPM mode</name>

--- a/flow-tests/test-themes/pom.xml
+++ b/flow-tests/test-themes/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-themes</artifactId>
     <name>Flow themes tests</name>

--- a/flow-theme-integrations/lumo/pom.xml
+++ b/flow-theme-integrations/lumo/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-theme-integrations</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-lumo-theme</artifactId>

--- a/flow-theme-integrations/material/pom.xml
+++ b/flow-theme-integrations/material/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-theme-integrations</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-material-theme</artifactId>

--- a/flow-theme-integrations/pom.xml
+++ b/flow-theme-integrations/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow-theme-integrations</artifactId>
     <name>Parent project for Flow themes</name>

--- a/flow/pom.xml
+++ b/flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>2.3-SNAPSHOT</version>
+        <version>2.4-SNAPSHOT</version>
     </parent>
     <artifactId>flow</artifactId>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>flow-project</artifactId>
     <name>Flow</name>
     <packaging>pom</packaging>
-    <version>2.3-SNAPSHOT</version>
+    <version>2.4-SNAPSHOT</version>
 
     <parent>
         <groupId>com.vaadin</groupId>


### PR DESCRIPTION
On this PR:
- Add `HasHelper` interface to be used for field components that have a "helper" feature (such as `TextField`)
- The interface contains getters and setters with default implementation for text and component APIs
- Tests for the methods
- The PR also bumps minor to `2.4` which is where this feature expected to be added

It's going to merged first to a `feature/hashelper` branch, so we can start implementing this feature across our components depending on flow at `2.4.hashelper-SNAPSHOT`.

This PR relevant part is on this commit: https://github.com/vaadin/flow/pull/8532/commits/4269f349ed5f53a90c95f26eb16a468ee08aa3b2.

[This a PR](https://github.com/vaadin/vaadin-radio-button-flow/pull/140/files) to demonstrate how the feature is going to be used.

Fix https://github.com/vaadin/components-team-tasks/issues/541.