### PR TITLE
Retain binary compatibility for listenOn method

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -267,7 +267,7 @@ public class ShortcutRegistration implements Registration, Serializable {
      * @return this <code>ShortcutRegistration</code>
      */
     public ShortcutRegistration listenOn(Component listenOnComponent) {
-        listenOn(new Component[]{listenOnComponent);
+        listenOn(new Component[]{listenOnComponent});
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -267,7 +267,7 @@ public class ShortcutRegistration implements Registration, Serializable {
      * @return this <code>ShortcutRegistration</code>
      */
     public ShortcutRegistration listenOn(Component listenOnComponent) {
-        listenOn(new Component[]{listenOnComponent});
+        return listenOn(new Component[]{listenOnComponent});
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -253,11 +253,26 @@ public class ShortcutRegistration implements Registration, Serializable {
         setLifecycleOwner(component);
         return this;
     }
+    
+    /**
+     * Fluently define the component to listen for shortcuts on. Calling this
+     * method will remove any previous listeners.
+     * <p>
+     * This method only exists to retain backwards compatibility after support
+     * for listening on multiple components was added with the method
+     * {@link #listenOn(Component...)}.
+     *
+     * @param listenOnComponent
+     *            components to listen for the shortcut on. Must not be null.
+     * @return this <code>ShortcutRegistration</code>
+     */
+    public ShortcutRegistration listenOn(Component listenOnComponent) {
+        listenOn(new Component[]{listenOnComponent);
+    }
 
     /**
-     * Fluently define the {@link Component} onto which the shortcut's listener
-     * is bound. Calling this method will remove the previous listener from the
-     * {@code component} it was bound to.
+     * Fluently define the components to listen for shortcuts on. Calling this
+     * method will remove any previous listeners.
      *
      * @param listenOnComponents
      *            {@code Component}s onto which the shortcut listeners are


### PR DESCRIPTION
Adding support for listening for shortcuts on multiple components #7339 broke binary compatibility.
This is problematic for any addon that would now need a new release on top of Flow 2.2.
Fixed the weirdly formulated javadocs.

Fixes vaadin/vaadin-button-flow#162