### PR TITLE
Live reload: construct correct push URL when both service URL (and context path) and liveReloadPath are given

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
@@ -95,7 +95,7 @@ public class ApplicationConnection {
                     "Vaadin application servlet version: " + servletVersion);
 
             if (applicationConfiguration.isDevmodeGizmoEnabled()) {
-                createDevModeGizmo(applicationConfiguration.getServiceUrl(),
+                createDevModeGizmo(applicationConfiguration.getContextRootUrl(),
                         applicationConfiguration.getLiveReloadPath(),
                         applicationConfiguration.getLiveReloadBackend(),
                         applicationConfiguration.getSpringBootDevToolsPort());
@@ -105,13 +105,13 @@ public class ApplicationConnection {
         registry.getLoadingIndicator().show();
     }
 
-    private native void createDevModeGizmo(String serviceUrl,
+    private native void createDevModeGizmo(String contextRootUrl,
             String liveReloadPath, String liveReloadBackend,
             String springBootDevToolsPort)
     /*-{
       if ($wnd.Vaadin.Flow.initDevModeGizmo !== undefined) {
         $wnd.Vaadin.Flow.devModeGizmo = $wnd.Vaadin.Flow.initDevModeGizmo(
-          serviceUrl, liveReloadPath, liveReloadBackend, springBootDevToolsPort);
+          contextRootUrl, liveReloadPath, liveReloadBackend, springBootDevToolsPort);
       } else {
         // This should normally not happen, as conditions during which
         // live-reload is disabled (configuration, production and/or

--- a/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
@@ -94,9 +94,16 @@ public class ApplicationConnection {
             Console.log(
                     "Vaadin application servlet version: " + servletVersion);
 
+            String reloadConnectionUrl;
+            if (applicationConfiguration.getLiveReloadPath() != null) {
+                reloadConnectionUrl = applicationConfiguration
+                        .getContextRootUrl()
+                        + applicationConfiguration.getLiveReloadPath();
+            } else {
+                reloadConnectionUrl = applicationConfiguration.getServiceUrl();
+            }
             if (applicationConfiguration.isDevmodeGizmoEnabled()) {
-                createDevModeGizmo(applicationConfiguration.getContextRootUrl(),
-                        applicationConfiguration.getLiveReloadPath(),
+                createDevModeGizmo(reloadConnectionUrl,
                         applicationConfiguration.getLiveReloadBackend(),
                         applicationConfiguration.getSpringBootDevToolsPort());
             }
@@ -105,13 +112,12 @@ public class ApplicationConnection {
         registry.getLoadingIndicator().show();
     }
 
-    private native void createDevModeGizmo(String contextRootUrl,
-            String liveReloadPath, String liveReloadBackend,
-            String springBootDevToolsPort)
+    private native void createDevModeGizmo(String reloadConnectionUrl,
+            String liveReloadBackend, String springBootDevToolsPort)
     /*-{
       if ($wnd.Vaadin.Flow.initDevModeGizmo !== undefined) {
         $wnd.Vaadin.Flow.devModeGizmo = $wnd.Vaadin.Flow.initDevModeGizmo(
-          contextRootUrl, liveReloadPath, liveReloadBackend, springBootDevToolsPort);
+          reloadConnectionUrl, liveReloadBackend, springBootDevToolsPort);
       } else {
         // This should normally not happen, as conditions during which
         // live-reload is disabled (configuration, production and/or

--- a/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
@@ -94,16 +94,16 @@ public class ApplicationConnection {
             Console.log(
                     "Vaadin application servlet version: " + servletVersion);
 
-            String reloadConnectionUrl;
+            String reloadConnectionBaseUri;
             if (applicationConfiguration.getLiveReloadPath() != null) {
-                reloadConnectionUrl = applicationConfiguration
+                reloadConnectionBaseUri = applicationConfiguration
                         .getContextRootUrl()
                         + applicationConfiguration.getLiveReloadPath();
             } else {
-                reloadConnectionUrl = applicationConfiguration.getServiceUrl();
+                reloadConnectionBaseUri = applicationConfiguration.getServiceUrl();
             }
             if (applicationConfiguration.isDevmodeGizmoEnabled()) {
-                createDevModeGizmo(reloadConnectionUrl,
+                createDevModeGizmo(reloadConnectionBaseUri,
                         applicationConfiguration.getLiveReloadBackend(),
                         applicationConfiguration.getSpringBootDevToolsPort());
             }
@@ -112,12 +112,12 @@ public class ApplicationConnection {
         registry.getLoadingIndicator().show();
     }
 
-    private native void createDevModeGizmo(String reloadConnectionUrl,
+    private native void createDevModeGizmo(String reloadConnectionBaseUri,
             String liveReloadBackend, String springBootDevToolsPort)
     /*-{
       if ($wnd.Vaadin.Flow.initDevModeGizmo !== undefined) {
         $wnd.Vaadin.Flow.devModeGizmo = $wnd.Vaadin.Flow.initDevModeGizmo(
-          reloadConnectionUrl, liveReloadBackend, springBootDevToolsPort);
+          reloadConnectionBaseUri, liveReloadBackend, springBootDevToolsPort);
       } else {
         // This should normally not happen, as conditions during which
         // live-reload is disabled (configuration, production and/or

--- a/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.js
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.js
@@ -549,7 +549,7 @@ class VaadinDevmodeGizmo extends LitElement {
       splashMessage: {type: String},
       notifications: {type: Array},
       status: {type: String},
-      reloadConnectionUrl: {type: String},
+      reloadConnectionBaseUri: {type: String},
       liveReloadBackend: {type: String},
       springBootDevToolsPort: {type: Number}
     };
@@ -705,15 +705,15 @@ class VaadinDevmodeGizmo extends LitElement {
   }
 
   getDedicatedWebSocketUrl(location) {
-    if (!this.reloadConnectionUrl) {
-      console.warn('This live reload backend requires a dedicated WS connection, but no URL is given');
+    if (!this.reloadConnectionBaseUri) {
+      console.warn('This live reload backend requires a dedicated WS connection, but no base URL is given');
       return null;
     }
-    if (!this.reloadConnectionUrl.startsWith('http://') && !url.startsWith('https://')) {
+    if (!this.reloadConnectionBaseUri.startsWith('http://') && !url.startsWith('https://')) {
       console.warn('The protocol of the url should be http or https for live reload to work.');
       return null;
     }
-    return this.reloadConnectionUrl.replace(/^http/, 'ws') + '?v-r=push&refresh_connection';
+    return this.reloadConnectionBaseUri.replace(/^http/, 'ws') + '?v-r=push&refresh_connection';
   }
 
   getSpringBootWebSocketUrl(location) {
@@ -1008,14 +1008,14 @@ class VaadinDevmodeGizmo extends LitElement {
   }
 }
 
-const init = function(reloadConnectionUrl, liveReloadBackend, springBootDevToolsPort) {
+const init = function(reloadConnectionBaseUri, liveReloadBackend, springBootDevToolsPort) {
   if ('false' !== window.localStorage.getItem(VaadinDevmodeGizmo.ENABLED_KEY_IN_LOCAL_STORAGE)) {
     if (customElements.get('vaadin-devmode-gizmo') === undefined) {
       customElements.define('vaadin-devmode-gizmo', VaadinDevmodeGizmo);
     }
     const devmodeGizmo = document.createElement('vaadin-devmode-gizmo');
-    if (reloadConnectionUrl) {
-      devmodeGizmo.setAttribute('reloadConnectionUrl', reloadConnectionUrl);
+    if (reloadConnectionBaseUri) {
+      devmodeGizmo.setAttribute('reloadConnectionBaseUri', reloadConnectionBaseUri);
     }
     if (liveReloadBackend) {
       devmodeGizmo.setAttribute('liveReloadBackend', liveReloadBackend);

--- a/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.js
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.js
@@ -549,7 +549,7 @@ class VaadinDevmodeGizmo extends LitElement {
       splashMessage: {type: String},
       notifications: {type: Array},
       status: {type: String},
-      serviceurl: {type: String},
+      contextRootUrl: {type: String},
       liveReloadPath: {type: String},
       liveReloadBackend: {type: String},
       springBootDevToolsPort: {type: Number}
@@ -707,12 +707,13 @@ class VaadinDevmodeGizmo extends LitElement {
 
   getDedicatedWebSocketUrl(location) {
     let url;
-    if (this.serviceurl) {
-      url = this.serviceurl;
-    } else if (this.liveReloadPath) {
-      url = location.protocol + '//' + location.host + '/' + this.liveReloadPath;
+    if (this.contextRootUrl) {
+      url = this.contextRootUrl;
     } else {
-      url = location.href;
+      url = location.protocol + '//' + location.host;
+    }
+    if (this.liveReloadPath) {
+      url = url + (url.endsWith('/') ? '' : '/') + this.liveReloadPath;
     }
     if (!url.startsWith('http://') && !url.startsWith('https://')) {
       console.warn('The protocol of the url should be http or https for live reload to work.');
@@ -1013,14 +1014,14 @@ class VaadinDevmodeGizmo extends LitElement {
   }
 }
 
-const init = function(serviceUrl, liveReloadPath, liveReloadBackend, springBootDevToolsPort) {
+const init = function(contextRootUrl, liveReloadPath, liveReloadBackend, springBootDevToolsPort) {
   if ('false' !== window.localStorage.getItem(VaadinDevmodeGizmo.ENABLED_KEY_IN_LOCAL_STORAGE)) {
     if (customElements.get('vaadin-devmode-gizmo') === undefined) {
       customElements.define('vaadin-devmode-gizmo', VaadinDevmodeGizmo);
     }
     const devmodeGizmo = document.createElement('vaadin-devmode-gizmo');
-    if (serviceUrl) {
-      devmodeGizmo.setAttribute('serviceurl', serviceUrl);
+    if (contextRootUrl) {
+      devmodeGizmo.setAttribute('contextRootUrl', contextRootUrl);
     }
     if (liveReloadPath) {
       devmodeGizmo.setAttribute('liveReloadPath', liveReloadPath);

--- a/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.js
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.js
@@ -549,8 +549,7 @@ class VaadinDevmodeGizmo extends LitElement {
       splashMessage: {type: String},
       notifications: {type: Array},
       status: {type: String},
-      contextRootUrl: {type: String},
-      liveReloadPath: {type: String},
+      reloadConnectionUrl: {type: String},
       liveReloadBackend: {type: String},
       springBootDevToolsPort: {type: Number}
     };
@@ -706,20 +705,15 @@ class VaadinDevmodeGizmo extends LitElement {
   }
 
   getDedicatedWebSocketUrl(location) {
-    let url;
-    if (this.contextRootUrl) {
-      url = this.contextRootUrl;
-    } else {
-      url = location.protocol + '//' + location.host;
+    if (!this.reloadConnectionUrl) {
+      console.warn('This live reload backend requires a dedicated WS connection, but no URL is given');
+      return null;
     }
-    if (this.liveReloadPath) {
-      url = url + (url.endsWith('/') ? '' : '/') + this.liveReloadPath;
-    }
-    if (!url.startsWith('http://') && !url.startsWith('https://')) {
+    if (!this.reloadConnectionUrl.startsWith('http://') && !url.startsWith('https://')) {
       console.warn('The protocol of the url should be http or https for live reload to work.');
       return null;
     }
-    return url.replace(/^http/, 'ws') + '?v-r=push&refresh_connection';
+    return this.reloadConnectionUrl.replace(/^http/, 'ws') + '?v-r=push&refresh_connection';
   }
 
   getSpringBootWebSocketUrl(location) {
@@ -1014,17 +1008,14 @@ class VaadinDevmodeGizmo extends LitElement {
   }
 }
 
-const init = function(contextRootUrl, liveReloadPath, liveReloadBackend, springBootDevToolsPort) {
+const init = function(reloadConnectionUrl, liveReloadBackend, springBootDevToolsPort) {
   if ('false' !== window.localStorage.getItem(VaadinDevmodeGizmo.ENABLED_KEY_IN_LOCAL_STORAGE)) {
     if (customElements.get('vaadin-devmode-gizmo') === undefined) {
       customElements.define('vaadin-devmode-gizmo', VaadinDevmodeGizmo);
     }
     const devmodeGizmo = document.createElement('vaadin-devmode-gizmo');
-    if (contextRootUrl) {
-      devmodeGizmo.setAttribute('contextRootUrl', contextRootUrl);
-    }
-    if (liveReloadPath) {
-      devmodeGizmo.setAttribute('liveReloadPath', liveReloadPath);
+    if (reloadConnectionUrl) {
+      devmodeGizmo.setAttribute('reloadConnectionUrl', reloadConnectionUrl);
     }
     if (liveReloadBackend) {
       devmodeGizmo.setAttribute('liveReloadBackend', liveReloadBackend);

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -1387,9 +1387,9 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                     appConfig.put("liveReloadBackend",
                             liveReload.getBackend().toString());
                     String pushURL = session.getConfiguration().getPushURL();
-                    if (pushURL != null) {
-                        appConfig.put("liveReloadPath", context
-                                .getUriResolver().resolveVaadinUri(pushURL));
+                    if (pushURL != null && pushURL.startsWith("context:")) {
+                        appConfig.put("liveReloadPath", context.getUriResolver()
+                                .resolveVaadinUri(pushURL));
                     }
                 }
 


### PR DESCRIPTION
Closes #8541. 

Note: Fix needs to be picked to master also, but will require some adaptation to the TS bootstrapping as the `flow-client` method for computing the URL with context root is not available there.