### PR TITLE
Adapt fix #8542 for #8541 to CCDM bootstrap (Flow.ts)

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.d.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.d.ts
@@ -1,1 +1,1 @@
-export const init: (serviceUrl: string, liveReloadPath: string, liveReloadBackend: string, springBootDevToolsPort: number) => HTMLElement;
+export const init: (reloadConnectionBaseUri: string, liveReloadBackend: string, springBootDevToolsPort: number) => HTMLElement;

--- a/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.js
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.js
@@ -549,8 +549,7 @@ class VaadinDevmodeGizmo extends LitElement {
       splashMessage: {type: String},
       notifications: {type: Array},
       status: {type: String},
-      serviceurl: {type: String},
-      liveReloadPath: {type: String},
+      reloadConnectionBaseUri: {type: String},
       liveReloadBackend: {type: String},
       springBootDevToolsPort: {type: Number}
     };
@@ -693,7 +692,7 @@ class VaadinDevmodeGizmo extends LitElement {
   }
 
   openDedicatedWebSocketConnection() {
-    const wsUrl = this.getDedicatedWebSocketUrl(window.location);
+    const wsUrl = this.getDedicatedWebSocketUrl();
     if (wsUrl) {
       this.connection = new WebSocket(wsUrl);
       const self = this;
@@ -705,20 +704,16 @@ class VaadinDevmodeGizmo extends LitElement {
     }
   }
 
-  getDedicatedWebSocketUrl(location) {
-    let url;
-    if (this.serviceurl) {
-      url = this.serviceurl;
-    } else if (this.liveReloadPath) {
-      url = location.protocol + '//' + location.host + '/' + this.liveReloadPath;
-    } else {
-      url = location.href;
+  getDedicatedWebSocketUrl() {
+    if (!this.reloadConnectionBaseUri) {
+      console.warn('This live reload backend requires a dedicated WS connection, but no base URL is given');
+      return null;
     }
-    if (!url.startsWith('http://') && !url.startsWith('https://')) {
+    if (!this.reloadConnectionBaseUri.startsWith('http://') && !this.reloadConnectionBaseUri.startsWith('https://')) {
       console.warn('The protocol of the url should be http or https for live reload to work.');
       return null;
     }
-    return url.replace(/^http/, 'ws') + '?v-r=push&refresh_connection';
+    return this.reloadConnectionBaseUri.replace(/^http/, 'ws') + '?v-r=push&refresh_connection';
   }
 
   getSpringBootWebSocketUrl(location) {
@@ -1013,17 +1008,14 @@ class VaadinDevmodeGizmo extends LitElement {
   }
 }
 
-const init = function(serviceUrl, liveReloadPath, liveReloadBackend, springBootDevToolsPort) {
+const init = function(reloadConnectionBaseUri, liveReloadBackend, springBootDevToolsPort) {
   if ('false' !== window.localStorage.getItem(VaadinDevmodeGizmo.ENABLED_KEY_IN_LOCAL_STORAGE)) {
     if (customElements.get('vaadin-devmode-gizmo') === undefined) {
       customElements.define('vaadin-devmode-gizmo', VaadinDevmodeGizmo);
     }
     const devmodeGizmo = document.createElement('vaadin-devmode-gizmo');
-    if (serviceUrl) {
-      devmodeGizmo.setAttribute('serviceurl', serviceUrl);
-    }
-    if (liveReloadPath) {
-      devmodeGizmo.setAttribute('liveReloadPath', liveReloadPath);
+    if (reloadConnectionBaseUri) {
+      devmodeGizmo.setAttribute('reloadConnectionBaseUri', reloadConnectionBaseUri);
     }
     if (liveReloadBackend) {
       devmodeGizmo.setAttribute('liveReloadBackend', liveReloadBackend);

--- a/flow-client/src/test/frontend/VaadinDevmodeGizmoTests.js
+++ b/flow-client/src/test/frontend/VaadinDevmodeGizmoTests.js
@@ -6,7 +6,7 @@ import { init } from "../../main/resources/META-INF/resources/frontend/VaadinDev
 describe('VaadinDevmodeGizmo', () => {
 
   it('should connect to port-hostname.gitpod.io with Spring Boot Devtools', () => {
-    let gizmo = init(undefined, '','SPRING_BOOT_DEVTOOLS', 35729);
+    let gizmo = init( 'http://localhost:8080', 'SPRING_BOOT_DEVTOOLS', 35729);
     let location = {
       'protocol': 'https',
       'hostname': 'abc-12345678-1234-1234-1234-1234567890ab.ws-eu01.gitpod.io'
@@ -15,19 +15,14 @@ describe('VaadinDevmodeGizmo', () => {
       'ws://35729-12345678-1234-1234-1234-1234567890ab.ws-eu01.gitpod.io');
   });
 
-  it('should append push target if given', () => {
-    let gizmo = init(undefined, 'context/vaadinServlet','HOTSWAP_AGENT', 35729);
-    let location = {
-      'href': 'http://localhost:8080/context/myroute',
-      'protocol': 'http:',
-      'host': 'localhost:8080',
-    };
-    assert.equal(gizmo.getDedicatedWebSocketUrl(location),
+  it('should use base URI', () => {
+    let gizmo = init('http://localhost:8080/context/vaadinServlet','HOTSWAP_AGENT', 35729);
+    assert.equal(gizmo.getDedicatedWebSocketUrl(),
       'ws://localhost:8080/context/vaadinServlet?v-r=push&refresh_connection');
   });
 
   it('should have a new message on tray when error occurs', () => {
-    let gizmo = init(undefined, '','SPRING_BOOT_DEVTOOLS', 35729);
+    let gizmo = init('http://localhost:8080','SPRING_BOOT_DEVTOOLS', 35729);
     gizmo.connection.onerror('TEST');
     let message = {
       'id': 1,

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -1086,7 +1086,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                     appConfig.put("liveReloadBackend",
                             liveReload.getBackend().toString());
                     String pushURL = session.getConfiguration().getPushURL();
-                    if (pushURL != null) {
+                    if (pushURL != null && pushURL.startsWith("context:")) {
                         appConfig.put("liveReloadPath", context
                                 .getUriResolver().resolveVaadinUri(pushURL));
                     }


### PR DESCRIPTION
Same as #8542, but computes the live reload push URI in `Flow.ts` instead of GWT code.