### PR TITLE
Use correct javadocs for JavaScript annotation in the master btanch.

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/dependency/JavaScript.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/dependency/JavaScript.java
@@ -24,6 +24,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.page.Page;
 import com.vaadin.flow.shared.ui.LoadMode;
 
 /**
@@ -69,16 +70,15 @@ public @interface JavaScript {
      * Relative URLs are interpreted as relative to the configured
      * {@code frontend} directory location.
      * <p>
-     * In NPM mode this URL identifies a file which will be bundled, so the file
-     * should be available to be able to bundle it. External URLs (e.g. absolute
-     * URL which has a schema like "http://") are not bundled but included into
-     * the page as standalone scripts (the same way as in compatibility mode,
-     * see below). It's applicable also for "context://" and "base://" schemas.
+     * This URL identifies a file which will be bundled, so the file should be
+     * available to be able to bundle it.
      * <p>
-     * In compatibility mode the URL represents a standalone script which will
-     * be added to the page. You can prefix the URL with {@code context://} to
-     * make it relative to the context path or use an absolute URL to refer to
-     * files outside the frontend directory.
+     * You can prefix the URL with {@code context://} to make it relative to the
+     * context path or use an absolute URL to refer to files outside the
+     * frontend directory. Such URLs are not bundled but included into the page
+     * as standalone scripts in the same way as it's done by
+     * {@link Page#addJavaScript(String)}.
+     * <p>
      *
      * @return a JavaScript file URL
      */


### PR DESCRIPTION
The `master` branch has no compatibility mode.
So it should not be mentioned.

This should be either taken with dramatic changes into `2.x` branches or should not be cherry-picked at all.