### PR TITLE
Add an AbstractLazyDataView

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataView.java
@@ -25,11 +25,11 @@ import com.vaadin.flow.function.SerializableSupplier;
 import com.vaadin.flow.shared.Registration;
 
 /**
- * Abstract data view implementation which takes care of processing
- * component data size change events.
+ * Abstract data view implementation which takes care of processing component
+ * data size change events.
  *
  * @param <T>
- *         data type
+ *            data type
  */
 public abstract class AbstractDataView<T> implements DataView<T> {
 
@@ -37,14 +37,14 @@ public abstract class AbstractDataView<T> implements DataView<T> {
     protected Component component;
 
     /**
-     * Creates a new instance of {@link AbstractDataView} subclass
-     * and verifies the passed data provider is compatible with this
-     * data view implementation.
+     * Creates a new instance of {@link AbstractDataView} subclass and verifies
+     * the passed data provider is compatible with this data view
+     * implementation.
      *
      * @param dataProviderSupplier
-     *         supplier from which the DataProvider can be gotten
+     *            supplier from which the DataProvider can be gotten
      * @param component
-     *         the component that the dataView is bound to
+     *            the component that the dataView is bound to
      */
     public AbstractDataView(
             SerializableSupplier<? extends DataProvider<T, ?>> dataProviderSupplier,
@@ -70,22 +70,25 @@ public abstract class AbstractDataView<T> implements DataView<T> {
     protected abstract Class<?> getSupportedDataProviderType();
 
     /**
-     * Verifies an obtained {@link DataProvider} type is appropriate
-     * for current Data View type.
+     * Verifies an obtained {@link DataProvider} type is appropriate for current
+     * Data View type.
      *
      * @param dataProviderType
-     *         data provider type to be verified
+     *            data provider type to be verified
      * @throws IllegalStateException
-     *         if data provider type is incompatible with data view type
+     *             if data provider type is incompatible with data view type
      */
     protected final void verifyDataProviderType(Class<?> dataProviderType) {
+        // TODO https://github.com/vaadin/flow/issues/8583
         Class<?> supportedDataProviderType = getSupportedDataProviderType();
         if (!supportedDataProviderType.isAssignableFrom(dataProviderType)) {
-            final String message = String
-                    .format("%s only supports '%s' or it's subclasses, but was given a '%s'",
-                            this.getClass().getSimpleName(),
-                            supportedDataProviderType.getSimpleName(),
-                            dataProviderType.getSuperclass().getSimpleName());
+            final String message = String.format(
+                    "%s only supports '%s' or it's subclasses, but was given a '%s'."
+                            + "%nUse either 'getLazyDataView()', 'getListDatView()'"
+                            + " or getDataView() according to the used data type.",
+                    this.getClass().getSimpleName(),
+                    supportedDataProviderType.getSimpleName(),
+                    dataProviderType.getSuperclass().getSimpleName());
             throw new IllegalStateException(message);
         }
     }

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractLazyDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractLazyDataView.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.data.provider;
+
+import java.util.stream.Stream;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentEventListener;
+
+/**
+ * Abstract lazy data view implementation which handles the interaction with a
+ * data communicator.
+ * 
+ * @param <T>
+ *            the type of data
+ */
+public abstract class AbstractLazyDataView<T> extends AbstractDataView<T>
+        implements LazyDataView<T> {
+
+    private final DataCommunicator<T> dataCommunicator;
+
+    /**
+     * Creates a new instance and verifies the passed data provider is
+     * compatible with this data view implementation.
+     *
+     * @param dataCommunicator
+     *            the data communicator of the component
+     * @param component
+     *            the component
+     */
+    public AbstractLazyDataView(DataCommunicator<T> dataCommunicator,
+            Component component) {
+        super(dataCommunicator::getDataProvider, component);
+        this.dataCommunicator = dataCommunicator;
+    }
+
+    /**
+     * Returns the data communicator for the component and checks that the data
+     * provider is of the correct type.
+     * 
+     * @return the data communicator
+     */
+    protected DataCommunicator<T> getDataCommunicator() {
+        // verify that the data provider hasn't been changed to an incompatible
+        // type
+        if (dataCommunicator.getDataProvider().isInMemory()) {
+            throw new IllegalStateException(String.format(
+                    "LazyDataView cannot be used for component %s with an "
+                            + "in-memory data provider (type was %s)."
+                            + "Use a lazy data provider instead or"
+                            + " for accessing data view for in-memory data use"
+                            + " getListDataView().",
+                    component.getClass().getSimpleName(), dataCommunicator
+                            .getDataProvider().getClass().getSimpleName()));
+        }
+        return dataCommunicator;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Stream<T> getItems() {
+        if (isDefinedSize()) {
+            return getDataCommunicator().getDataProvider()
+                    .fetch(dataCommunicator.buildQuery(0,
+                            dataCommunicator.getDataSize()));
+        } else {
+            return getDataCommunicator().getDataProvider()
+                    .fetch(dataCommunicator.buildQuery(0, Integer.MAX_VALUE));
+        }
+    }
+
+    /**
+     * Gets the known size of the data. With undefined size
+     * {@link #withUndefinedSize()} this may be an estimate. <em>NOTE: usage of
+     * this method is not recommended as the size might change at any point -
+     * add a listener with the
+     * {@link #addSizeChangeListener(ComponentEventListener)} method to get
+     * notified when the data size has changed. Calling this method will also
+     * trigger a backend call when using {@link #withDefinedSize()} and the size
+     * is not known.</em>
+     * <p>
+     * If no size is yet known, like during the initial roundtrip, this may
+     * return {@code -1} as the size is determined during the "before client
+     * response"-phase.
+     * 
+     * @return the size of the data or the currently used estimated size
+     */
+    @Override
+    public int getSize() {
+        return getDataCommunicator().getDataSize();
+    }
+
+    @Override
+    protected Class<?> getSupportedDataProviderType() {
+        return BackEndDataProvider.class;
+    }
+
+    @Override
+    public void withDefinedSize(
+            CallbackDataProvider.CountCallback<T, Void> callback) {
+        getDataCommunicator().setSizeCallback(callback);
+    }
+
+    @Override
+    public void withUndefinedSize(int initialSizeEstimate) {
+        getDataCommunicator().setInitialSizeEstimate(initialSizeEstimate);
+    }
+
+    @Override
+    public void withUndefinedSize(SizeEstimateCallback<T, Void> callback) {
+        getDataCommunicator().setSizeEstimateCallback(callback);
+    }
+
+    @Override
+    public void withDefinedSize() {
+        getDataCommunicator().setDefinedSize(true);
+    }
+
+    @Override
+    public void withUndefinedSize() {
+        getDataCommunicator().setDefinedSize(false);
+    }
+
+    @Override
+    public boolean isDefinedSize() {
+        return getDataCommunicator().isDefinedSize();
+    }
+
+    @Override
+    public boolean contains(T item) {
+        return getDataCommunicator().isItemActive(item);
+    }
+
+}

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractLazyDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractLazyDataView.java
@@ -93,8 +93,8 @@ public abstract class AbstractLazyDataView<T> extends AbstractDataView<T>
      * trigger a backend call when using {@link #withDefinedSize()} and the size
      * is not known.</em>
      * <p>
-     * If no size is yet known, like during the initial roundtrip, this may
-     * return {@code -1} as the size is determined during the "before client
+     * If size is not yet known, like during the initial roundtrip, {@code 0} is
+     * returned as the size is determined during the "before client
      * response"-phase.
      * 
      * @return the size of the data or the currently used estimated size

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractLazyDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractLazyDataView.java
@@ -55,18 +55,7 @@ public abstract class AbstractLazyDataView<T> extends AbstractDataView<T>
      * @return the data communicator
      */
     protected DataCommunicator<T> getDataCommunicator() {
-        // verify that the data provider hasn't been changed to an incompatible
-        // type
-        if (dataCommunicator.getDataProvider().isInMemory()) {
-            throw new IllegalStateException(String.format(
-                    "LazyDataView cannot be used for component %s with an "
-                            + "in-memory data provider (type was %s)."
-                            + "Use a lazy data provider instead or"
-                            + " for accessing data view for in-memory data use"
-                            + " getListDataView().",
-                    component.getClass().getSimpleName(), dataCommunicator
-                            .getDataProvider().getClass().getSimpleName()));
-        }
+        verifyDataProviderType(dataCommunicator.getDataProvider().getClass());
         return dataCommunicator;
     }
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -186,6 +186,7 @@ public class DataCommunicator<T> implements Serializable {
      */
     public void reset() {
         skipSizeCheckUntilReset = false;
+        sizeReset = true;
         resendEntireRange = true;
         dataGenerator.destroyAllData();
         updatedData.clear();
@@ -258,7 +259,7 @@ public class DataCommunicator<T> implements Serializable {
         filter = initialFilter;
         clearSizeCallbacksAndState();
         definedSize = true;
-        sizeReset = false; // everything is cleared anyway
+        sizeReset = true;
 
         handleDetach();
 
@@ -300,7 +301,7 @@ public class DataCommunicator<T> implements Serializable {
         }
         // do not report a stale size or size estimate
         if (!isDefinedSize() && sizeReset) {
-            return -1;
+            return 0;
         }
         return assumedSize;
     }
@@ -409,6 +410,8 @@ public class DataCommunicator<T> implements Serializable {
     /**
      * Returns the number of pages that the size is increased when the estimated
      * end has been reached in undefined size mode.
+     * 
+     * @return the number of pages the size is increased
      */
     public int getSizeIncreasePageCount() {
         return sizeIncreasePageCount;
@@ -469,7 +472,8 @@ public class DataCommunicator<T> implements Serializable {
      * size. Any previously set size related callbacks are cleared. The new
      * estimate is only applied if it is greater than the currently
      * estimated/known size. Otherwise it is not applied until there has been a
-     * reset. <br/>
+     * reset.
+     * <p>
      * <em>NOTE:</em> it makes no sense to use an initial size estimate that is
      * less than two times the set page size (set with {@link #setPageSize(int)}
      * since this would trigger unnecessary requests immediately. On these
@@ -486,7 +490,7 @@ public class DataCommunicator<T> implements Serializable {
         clearSizeCallbacksAndState();
         this.initialSizeEstimate = initialSizeEstimate;
         definedSize = false;
-        if (!skipSizeCheckUntilReset && assumedSize < initialSizeEstimate) {
+        if (!skipSizeCheckUntilReset && requestedRange.getEnd() < initialSizeEstimate) {
             sizeReset = true;
             requestFlush();
         }

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -470,14 +470,12 @@ public class DataCommunicator<T> implements Serializable {
     /**
      * Sets the initial size estimate to use and switches component to undefined
      * size. Any previously set size related callbacks are cleared. The new
-     * estimate is only applied if it is greater than the currently
-     * estimated/known size. Otherwise it is not applied until there has been a
-     * reset.
+     * estimate is only applied if it is greater than the number of requested
+     * items. Otherwise it is not applied until there has been a reset.
      * <p>
-     * <em>NOTE:</em> it makes no sense to use an initial size estimate that is
-     * less than two times the set page size (set with {@link #setPageSize(int)}
-     * since this would trigger unnecessary requests immediately. On these
-     * cases, given estimate is discarded.
+     * <em>NOTE:</em> setting an initial size estimate that is less than two
+     * pages (set with {@link #setPageSize(int)}) can cause extra requests
+     * initially or after a reset.
      * 
      * @param initialSizeEstimate
      *            the initial size estimate to be used
@@ -490,7 +488,8 @@ public class DataCommunicator<T> implements Serializable {
         clearSizeCallbacksAndState();
         this.initialSizeEstimate = initialSizeEstimate;
         definedSize = false;
-        if (!skipSizeCheckUntilReset && requestedRange.getEnd() < initialSizeEstimate) {
+        if (!skipSizeCheckUntilReset
+                && requestedRange.getEnd() < initialSizeEstimate) {
             sizeReset = true;
             requestFlush();
         }

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataView.java
@@ -36,7 +36,9 @@ public interface DataView<T> extends Serializable {
 
     /**
      * Get the full data available to the component. Data will use set filters
-     * and sorting.
+     * and sorting. <em>NOTE: calling this method might cause a backend query
+     * that fetches all items from the backend when using a lazy data
+     * source!</em>
      *
      * @return filtered and sorted data set
      */

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataView.java
@@ -36,9 +36,11 @@ public interface DataView<T> extends Serializable {
 
     /**
      * Get the full data available to the component. Data will use set filters
-     * and sorting. <em>NOTE: calling this method might cause a backend query
+     * and sorting.
+     * <p>
+     * <em>NOTE:</em> calling this method might cause a backend query
      * that fetches all items from the backend when using a lazy data
-     * source!</em>
+     * source!
      *
      * @return filtered and sorted data set
      */

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataView.java
@@ -19,42 +19,52 @@ package com.vaadin.flow.data.provider;
 import java.io.Serializable;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.shared.Registration;
 
 /**
- * Base view interface for getting information on current
- * data set of a Component.
+ * Base view interface for getting information on current data set of a
+ * Component.
  *
  * @param <T>
- *         data type
+ *            data type
  * @since
  */
 public interface DataView<T> extends Serializable {
 
     /**
-     * Get the full data available to the component.
-     * Data will use set filters and sorting.
+     * Get the full data available to the component. Data will use set filters
+     * and sorting.
      *
      * @return filtered and sorted data set
      */
     Stream<T> getItems();
 
     /**
-     * Get the full data size with filters if any set.
+     * Get the full data size with filters if any set. As the size might change
+     * at any point, it is recommended to add a listener with the
+     * {@link #addSizeChangeListener(ComponentEventListener)} method instead to
+     * get notified when the data size has changed.
      *
      * @return filtered data size
      */
     int getSize();
 
     /**
-     * Check if item is in the current data.
-     * Item may be filtered out or for lazy data not in the currently loaded
-     * making it un-available.
+     * Check if item is in the current data. Item may be filtered out or for
+     * lazy data not in the currently loaded making it un-available.
+     * <p>
+     * <em>NOTE:</em> when the component is created and not yet added, the item
+     * might not yet be loaded, but will be loaded during the "before client
+     * response"-phase. To check if the item has been added at that point, after
+     * setting the data source to the component you need to use
+     * {@link com.vaadin.flow.component.UI#beforeClientResponse(Component, SerializableConsumer)}.
      *
      * @param item
-     *         item to search for
-     * @return true if item is found in the available data
+     *            item to search for
+     * @return {@code true} if item is found in the available data
      */
     boolean contains(T item);
 
@@ -67,7 +77,7 @@ public interface DataView<T> extends Serializable {
      * component.
      *
      * @param listener
-     *         size change listener to register
+     *            size change listener to register
      * @return registration for removing the listener
      */
     Registration addSizeChangeListener(

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/HasLazyDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/HasLazyDataView.java
@@ -29,6 +29,20 @@ import java.io.Serializable;
  */
 public interface HasLazyDataView<T, V extends LazyDataView<T>>
         extends Serializable {
+
+    @SuppressWarnings("rawtypes")
+    CallbackDataProvider.CountCallback INVALID_COUNT_CALLBACK = query -> {
+        throw new IllegalStateException(
+                "Trying to use defined size with a lazy loading component"
+                        + " without either providing a count callback for the"
+                        + "component to fetch the size of the data or a data"
+                        + "provider that implements the size query. Provide the "
+                        + "callback for fetching size with%n"
+                        + "component.getLazyDataView().withDefinedSize(CallbackDataProvider.CountCallback);"
+                        + "%nor switch to undefined size with%n"
+                        + "component.getLazyDataView().withUndefinedSize();");
+    };
+
     /**
      * Supply data lazily with a callback. This sets the component to undefined
      * size and removes any existing size estimate or callback to provide size.
@@ -42,17 +56,19 @@ public interface HasLazyDataView<T, V extends LazyDataView<T>>
      *            a query
      * @return LazyDataView instance for further configuration
      */
+    @SuppressWarnings("unchecked")
     default V setDataSource(
             CallbackDataProvider.FetchCallback<T, Void> fetchCallback) {
-        getDataCommunicator().setDataProvider(
-                DataProvider.fromCallbacks(fetchCallback, query -> -1), null);
-        getDataCommunicator().setDefinedSize(false);
-        return getLazyDataView();
+        setDataSource(DataProvider.fromCallbacks(fetchCallback,
+                INVALID_COUNT_CALLBACK));
+        V lazyDataView = getLazyDataView();
+        lazyDataView.withUndefinedSize();
+        return lazyDataView;
     }
 
     /**
-     * Supply data lazily with a callbacks. This sets the component to defined size
-     * - the given count callback is queried for the data size.
+     * Supply data lazily with a callbacks. This sets the component to defined
+     * size - the given count callback is queried for the data size.
      *
      * @param fetchCallback
      *            function that returns a stream of items from the back end for
@@ -70,18 +86,15 @@ public interface HasLazyDataView<T, V extends LazyDataView<T>>
     }
 
     /**
-     * Supply data with a {@link BackEndDataProvider} that lazy loads items from a
-     * back end. This sets the component to use defined size, provided by the
+     * Supply data with a {@link BackEndDataProvider} that lazy loads items from
+     * a backend. This sets the component to use defined size, provided by the
      * data provider {@link BackEndDataProvider#size(Query)} method.
      *
      * @param dataProvider
      *            BackendDataProvider instance
      * @return LazyDataView instance for further configuration
      */
-    default V setDataSource(BackEndDataProvider<T, Void> dataProvider) {
-        getDataCommunicator().setDataProvider(dataProvider, null);
-        return getLazyDataView();
-    }
+    V setDataSource(BackEndDataProvider<T, Void> dataProvider);
 
     /**
      * Get the LazyDataView for the component. Throws if the data is not lazy
@@ -92,12 +105,4 @@ public interface HasLazyDataView<T, V extends LazyDataView<T>>
      *             when lazy data view is not applicable
      */
     V getLazyDataView();
-
-    /**
-     * Gets the data communicator bound to the component. This method is meant
-     * for the data views and should not be called directly.
-     * 
-     * @return the data communicator for the data view
-     */
-    DataCommunicator<T> getDataCommunicator();
 }

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/HasLazyDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/HasLazyDataView.java
@@ -30,19 +30,6 @@ import java.io.Serializable;
 public interface HasLazyDataView<T, V extends LazyDataView<T>>
         extends Serializable {
 
-    @SuppressWarnings("rawtypes")
-    CallbackDataProvider.CountCallback INVALID_COUNT_CALLBACK = query -> {
-        throw new IllegalStateException(
-                "Trying to use defined size with a lazy loading component"
-                        + " without either providing a count callback for the"
-                        + "component to fetch the size of the data or a data"
-                        + "provider that implements the size query. Provide the "
-                        + "callback for fetching size with%n"
-                        + "component.getLazyDataView().withDefinedSize(CallbackDataProvider.CountCallback);"
-                        + "%nor switch to undefined size with%n"
-                        + "component.getLazyDataView().withUndefinedSize();");
-    };
-
     /**
      * Supply data lazily with a callback. This sets the component to undefined
      * size and removes any existing size estimate or callback to provide size.
@@ -56,11 +43,19 @@ public interface HasLazyDataView<T, V extends LazyDataView<T>>
      *            a query
      * @return LazyDataView instance for further configuration
      */
-    @SuppressWarnings("unchecked")
     default V setDataSource(
             CallbackDataProvider.FetchCallback<T, Void> fetchCallback) {
-        setDataSource(DataProvider.fromCallbacks(fetchCallback,
-                INVALID_COUNT_CALLBACK));
+        setDataSource(DataProvider.fromCallbacks(fetchCallback, query -> {
+            throw new IllegalStateException(
+                    "Trying to use defined size with a lazy loading component"
+                            + " without either providing a count callback for the"
+                            + "component to fetch the size of the data or a data"
+                            + "provider that implements the size query. Provide the "
+                            + "callback for fetching size with%n"
+                            + "component.getLazyDataView().withDefinedSize(CallbackDataProvider.CountCallback);"
+                            + "%nor switch to undefined size with%n"
+                            + "component.getLazyDataView().withUndefinedSize();");
+        }));
         V lazyDataView = getLazyDataView();
         lazyDataView.withUndefinedSize();
         return lazyDataView;

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/LazyDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/LazyDataView.java
@@ -26,43 +26,45 @@ public interface LazyDataView<T> extends DataView<T> {
 
     /**
      * Sets the component to use defined size with the given callback that
-     * provides the exact size for the dataset.
+     * provides the exact size for the data source.
      * <p>
      * When the component has a distinct data provider set with
      * {@link com.vaadin.flow.data.binder.HasDataProvider#setDataProvider(DataProvider)},
-     * the given callback will be queried for getting the dataset size instead
-     * of the data provider {@link DataProvider#size(Query)} method.
+     * the given callback will be queried for getting the size of the data
+     * source instead of the data provider {@link DataProvider#size(Query)}
+     * method.
      * <p>
      * Calling this method will clear any previously set initial size estimate
      * {@link #withUndefinedSize(int)} and size estimate callback
      * {@link #withUndefinedSize(SizeEstimateCallback)}.
      *
      * @param callback
-     *            the callback to use for determining dataset size, not
-     *            {@code null}
+     *            the callback to use for determining the size of the data
+     *            source, not {@code null}
      * @see #withDefinedSize()
      */
     void withDefinedSize(CallbackDataProvider.CountCallback<T, Void> callback);
 
     /**
      * Sets the component to use undefined size with the given initial size
-     * estimate of the dataset. The estimated size is used after reset occurs or
-     * filter changes. <em>The initial size estimate should not be less than the currently
-     * requested range, or it will get discarded until a reset occurs.</em>.
+     * estimate of the data source. <em>If the initial size estimate is less
+     * than the currently requested range, it will get discarded until a reset
+     * occurs.</em>. The initial size estimate shouldn't be less than two pages
+     * or it might cause extra requests after a reset.
      * <p>
      * Calling this method will clear any previously set size estimate callback
      * {@link #withUndefinedSize(SizeEstimateCallback)} or defined size callback
      * {@link #withDefinedSize(CallbackDataProvider.CountCallback)}.
      *
      * @param initialSizeEstimate
-     *            initial size estimate for the dataset
+     *            initial size estimate for the data source
      */
     void withUndefinedSize(int initialSizeEstimate);
 
     /**
      * Sets the component to use undefined size with the given callback for
-     * estimating the size of the dataset. Calling this method will clear any
-     * previously set size callback
+     * estimating the size of the data source. Calling this method will clear
+     * any previously set size callback
      * {@link #withDefinedSize(CallbackDataProvider.CountCallback)} or initial
      * size estimate {@link #withUndefinedSize(int)}.
      * <p>

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/LazyDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/LazyDataView.java
@@ -47,7 +47,8 @@ public interface LazyDataView<T> extends DataView<T> {
     /**
      * Sets the component to use undefined size with the given initial size
      * estimate of the dataset. The estimated size is used after reset occurs or
-     * filter changes.
+     * filter changes. <em>The initial size estimate should not be be small
+     * or it will get discarded immediately and cause extra requests</em>.
      * <p>
      * Calling this method will clear any previously set size estimate callback
      * {@link #withUndefinedSize(SizeEstimateCallback)} or defined size callback

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/LazyDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/LazyDataView.java
@@ -47,8 +47,8 @@ public interface LazyDataView<T> extends DataView<T> {
     /**
      * Sets the component to use undefined size with the given initial size
      * estimate of the dataset. The estimated size is used after reset occurs or
-     * filter changes. <em>The initial size estimate should not be be small
-     * or it will get discarded immediately and cause extra requests</em>.
+     * filter changes. <em>The initial size estimate should not be less than the currently
+     * requested range, or it will get discarded until a reset occurs.</em>.
      * <p>
      * Calling this method will clear any previously set size estimate callback
      * {@link #withUndefinedSize(SizeEstimateCallback)} or defined size callback

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractLazyDataViewTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractLazyDataViewTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.data.provider;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import elemental.json.JsonValue;
+
+public class AbstractLazyDataViewTest {
+
+    public static final String ITEM1 = "foo";
+
+    @Tag("test-component")
+    private static class TestComponent extends Component {
+    }
+
+    private ListDataProvider<String> badProvider;
+    private DataProvider<String, Void> dataProvider;
+    private DataCommunicator<String> dataCommunicator;
+    private AbstractLazyDataView<String> dataView;
+    private Component component;
+    private DataCommunicatorTest.MockUI ui;
+    @Mock
+    private ArrayUpdater arrayUpdater;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        component = new TestComponent();
+        ui = new DataCommunicatorTest.MockUI();
+        ui.add(component);
+
+        ArrayUpdater.Update update = new ArrayUpdater.Update() {
+
+            @Override
+            public void clear(int start, int length) {
+
+            }
+
+            @Override
+            public void set(int start, List<JsonValue> items) {
+
+            }
+
+            @Override
+            public void commit(int updateId) {
+
+            }
+        };
+
+        Mockito.when(arrayUpdater.startUpdate(Mockito.anyInt()))
+                .thenReturn(update);
+
+        badProvider = DataProvider.ofItems("foo", "bar");
+        dataProvider = DataProvider.fromCallbacks(query -> {
+            // this is a stupid limitation and could maybe be removed
+            query.getOffset();
+            query.getLimit();
+            return Stream.of(ITEM1, "bar", "baz");
+        }, query -> 3);
+        dataCommunicator = new DataCommunicator<>((item, jsonObject) -> {
+        }, arrayUpdater, null, component.getElement().getNode());
+        // need to set a lazy data provider to communicator or type check fails
+        dataCommunicator.setDataProvider(dataProvider, null);
+        dataView = new AbstractLazyDataView<String>(dataCommunicator,
+                component) {
+        };
+    }
+
+    @Test
+    public void defaults_withCorrectDataProvider_noErrors() {
+        dataCommunicator.setDataProvider(dataProvider, null);
+        Assert.assertTrue(dataView.isDefinedSize());
+        Assert.assertEquals(BackEndDataProvider.class,
+                dataView.getSupportedDataProviderType());
+        Assert.assertEquals(3, dataView.getSize());
+        // no items are activated
+        Assert.assertFalse(dataView.contains("foo"));
+
+        dataView.withUndefinedSize();
+        Assert.assertFalse(dataView.isDefinedSize());
+
+        dataView.withDefinedSize(query -> 5);
+        Assert.assertTrue(dataView.isDefinedSize());
+
+        dataView.withUndefinedSize(query -> 123);
+        Assert.assertFalse(dataView.isDefinedSize());
+
+        dataView.withDefinedSize();
+        Assert.assertTrue(dataView.isDefinedSize());
+
+        dataView.withUndefinedSize(500);
+        Assert.assertFalse(dataView.isDefinedSize());
+
+    }
+
+    // This is weird-ish behavior but kept for now
+    @Test(expected = IllegalStateException.class)
+    public void dataViewCreated_beforeSettingDataProvider_throws() {
+        // data communicator has by default an empty list data provider ->
+        // utilizing lazy data view fails
+        new AbstractLazyDataView<String>(
+                new DataCommunicator<>((item, jsonObject) -> {
+                }, null, null, component.getElement().getNode()), component) {
+        };
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void existingDataView_dataProviderIsChangedToInMemory_throws() {
+        dataCommunicator.setDataProvider(badProvider, null);
+        // any method call should be enough to trigger the check for type
+        dataView.withUndefinedSize();
+    }
+
+    @Test
+    public void contains_itemsNotFetched_canCheckForItemWithBeforeClientResponse() {
+        dataCommunicator.setRequestedRange(0, 3);
+
+        Assert.assertFalse("Item should not be loaded yet",
+                dataView.contains("foo"));
+
+        AtomicBoolean capturedContains = new AtomicBoolean(false);
+        ui.beforeClientResponse(component, executionContext -> {
+            capturedContains.set(dataView.contains(ITEM1));
+        });
+
+        fakeClientCommunication();
+
+        Assert.assertTrue("Item should be loaded", dataView.contains(ITEM1));
+        Assert.assertTrue(
+                "Item should be available during beforeClientResponse",
+                capturedContains.get());
+    }
+
+    @Test
+    public void size_withDefinedSize() {
+        Assert.assertEquals("Invalid size reported", 3, dataView.getSize());
+
+        dataView.withDefinedSize(query -> 5);
+
+        Assert.assertEquals("Invalid size reported", 5, dataView.getSize());
+    }
+
+    @Test
+    public void size_withUndefinedSize() {
+
+    }
+
+    @Test
+    public void getItems_withDefinedSize() {
+
+    }
+
+    @Test
+    public void getItems_withUndefinedSize() {
+
+    }
+
+    private void fakeClientCommunication() {
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+        ui.getInternals().getStateTree().collectChanges(ignore -> {
+        });
+    }
+}

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractLazyDataViewTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractLazyDataViewTest.java
@@ -121,7 +121,7 @@ public class AbstractLazyDataViewTest {
 
     }
 
-    // This is weird-ish behavior but kept for now
+    // TODO https://github.com/vaadin/flow/issues/8583
     @Test(expected = IllegalStateException.class)
     public void dataViewCreated_beforeSettingDataProvider_throws() {
         // data communicator has by default an empty list data provider ->

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/HasLazyDataViewTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/HasLazyDataViewTest.java
@@ -1,0 +1,58 @@
+package com.vaadin.flow.data.provider;
+
+import java.util.stream.Stream;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class HasLazyDataViewTest {
+
+    @Tag("test-component")
+    private static class TestComponent extends Component
+            implements HasLazyDataView<String, AbstractLazyDataView<String>> {
+
+        private DataCommunicator<String> dataCommunicator;
+
+        public TestComponent() {
+            dataCommunicator = new DataCommunicator<>((item, jsonObject) -> {
+            }, null, null, getElement().getNode());
+        }
+
+        @Override
+        public AbstractLazyDataView<String> setDataSource(BackEndDataProvider<String, Void> dataProvider) {
+            dataCommunicator.setDataProvider(dataProvider,null);
+            return getLazyDataView();
+        }
+
+        @Override
+        public AbstractLazyDataView<String> getLazyDataView() {
+            return new AbstractLazyDataView<String>(dataCommunicator, this) {
+            };
+        }
+    }
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test(expected = IllegalStateException.class)
+    public void setDataSourceCountCallback_switchesToDefinedSize_throwsOnSizeQuery() {
+        TestComponent testComponent = new TestComponent();
+        Assert.assertTrue(testComponent.getLazyDataView().isDefinedSize());
+
+        // uses a NOOP count callback that will throw when called
+        testComponent.setDataSource(query -> Stream.of("foo","bar","baz"));
+
+        Assert.assertFalse(testComponent.getLazyDataView().isDefinedSize());
+
+        testComponent.getLazyDataView().withDefinedSize();
+
+        expectedException.expect(IllegalStateException.class);
+        // to make things fail, just need to call size() which will trigger a size query
+        testComponent.getLazyDataView().getSize();
+    }
+
+}

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/HasLazyDataViewTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/HasLazyDataViewTest.java
@@ -38,17 +38,17 @@ public class HasLazyDataViewTest {
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void setDataSourceCountCallback_switchesToDefinedSize_throwsOnSizeQuery() {
         TestComponent testComponent = new TestComponent();
-        Assert.assertTrue(testComponent.getLazyDataView().isDefinedSize());
-
         // uses a NOOP count callback that will throw when called
         testComponent.setDataSource(query -> Stream.of("foo","bar","baz"));
 
         Assert.assertFalse(testComponent.getLazyDataView().isDefinedSize());
 
         testComponent.getLazyDataView().withDefinedSize();
+
+        Assert.assertTrue(testComponent.getLazyDataView().isDefinedSize());
 
         expectedException.expect(IllegalStateException.class);
         // to make things fail, just need to call size() which will trigger a size query


### PR DESCRIPTION
Removes the public API for data communicator. Adds unit tests for undefined
size APIs for data communicator, except for default page increase since
that is likely to still change.