### PR TITLE
Configure identity provider for a components through the Data View

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataView.java
@@ -22,6 +22,7 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.function.SerializableSupplier;
+import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.shared.Registration;
 
 /**
@@ -35,6 +36,7 @@ public abstract class AbstractDataView<T> implements DataView<T> {
 
     protected SerializableSupplier<? extends DataProvider<T, ?>> dataProviderSupplier;
     protected Component component;
+    protected ValueProvider<T, ?> identityProvider;
 
     /**
      * Creates a new instance of {@link AbstractDataView} subclass
@@ -49,9 +51,15 @@ public abstract class AbstractDataView<T> implements DataView<T> {
     public AbstractDataView(
             SerializableSupplier<? extends DataProvider<T, ?>> dataProviderSupplier,
             Component component) {
+        Objects.requireNonNull(dataProviderSupplier,
+                "DataProvider supplier cannot be null");
         this.dataProviderSupplier = dataProviderSupplier;
         this.component = component;
-        verifyDataProviderType(dataProviderSupplier.get().getClass());
+        final DataProvider<T, ?> dataProvider = dataProviderSupplier.get();
+        Objects.requireNonNull(dataProvider,
+                "Supplied DataProvider cannot be null");
+        this.identityProvider = dataProvider::getId;
+        verifyDataProviderType(dataProvider.getClass());
     }
 
     @Override
@@ -98,5 +106,12 @@ public abstract class AbstractDataView<T> implements DataView<T> {
     @Override
     public int getSize() {
         return dataProviderSupplier.get().size(new Query<>());
+    }
+
+    @Override
+    public void setIdentityProvider(ValueProvider<T, ?> identityProvider) {
+        Objects.requireNonNull(identityProvider,
+                "Item identity provider cannot be null");
+        this.identityProvider = identityProvider;
     }
 }

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataView.java
@@ -103,28 +103,28 @@ public abstract class AbstractDataView<T> implements DataView<T> {
     }
 
     @Override
-    public void setIdentityProvider(IdentityProvider<T> identityProvider) {
-        Objects.requireNonNull(identityProvider,
+    public void setIdentifierProvider(IdentifierProvider<T> identifierProvider) {
+        Objects.requireNonNull(identifierProvider,
                 "Item identity provider cannot be null");
-        ComponentUtil.setData(component, IdentityProvider.class,
-                        identityProvider);
+        ComponentUtil.setData(component, IdentifierProvider.class,
+                identifierProvider);
     }
 
     @SuppressWarnings("unchecked")
-    protected IdentityProvider<T> getIdentityProvider() {
-        IdentityProvider<T> identityProviderObject =
-                (IdentityProvider<T>) ComponentUtil
-                        .getData(component, IdentityProvider.class);
+    protected IdentifierProvider<T> getIdentifierProvider() {
+        IdentifierProvider<T> identifierProviderObject =
+                (IdentifierProvider<T>) ComponentUtil
+                        .getData(component, IdentifierProvider.class);
 
-        if (identityProviderObject == null) {
+        if (identifierProviderObject == null) {
             DataProvider<T, ?> dataProvider = dataProviderSupplier.get();
             if (dataProvider != null) {
                 return dataProvider::getId;
             } else {
-                return IdentityProvider.identity();
+                return IdentifierProvider.identity();
             }
         } else {
-            return identityProviderObject;
+            return identifierProviderObject;
         }
     }
 }

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractListDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractListDataView.java
@@ -300,7 +300,7 @@ public abstract class AbstractListDataView<T> extends AbstractDataView<T>
     }
 
     private Object getIdentifier(T item) {
-        final Object itemIdentifier = getIdentityProvider().apply(item);
+        final Object itemIdentifier = getIdentifierProvider().apply(item);
         Objects.requireNonNull(itemIdentifier,
                 "Identity provider should not return null");
         return itemIdentifier;

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractListDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractListDataView.java
@@ -300,7 +300,7 @@ public abstract class AbstractListDataView<T> extends AbstractDataView<T>
     }
 
     private Object getIdentifier(T item) {
-        final Object itemIdentifier = identityProvider.apply(item);
+        final Object itemIdentifier = getIdentityProvider().apply(item);
         Objects.requireNonNull(itemIdentifier,
                 "Identity provider should not return null");
         return itemIdentifier;

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractListDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractListDataView.java
@@ -69,7 +69,7 @@ public abstract class AbstractListDataView<T> extends AbstractDataView<T>
 
     @Override
     public Optional<T> getNextItem(T item) {
-        int index = getItemIndex(item, getDataProvider()::getId);
+        int index = getItemIndex(item);
         if (index < 0) {
             return Optional.empty();
         }
@@ -78,7 +78,7 @@ public abstract class AbstractListDataView<T> extends AbstractDataView<T>
 
     @Override
     public Optional<T> getPreviousItem(T item) {
-        int index = getItemIndex(item, getDataProvider()::getId);
+        int index = getItemIndex(item);
         if (index <= 0) {
             return Optional.empty();
         }
@@ -140,7 +140,7 @@ public abstract class AbstractListDataView<T> extends AbstractDataView<T>
 
     @Override
     public boolean contains(T item) {
-        return contains(item, getDataProvider());
+        return getItems().anyMatch(i -> equals(item, i));
     }
 
     @Override
@@ -158,7 +158,7 @@ public abstract class AbstractListDataView<T> extends AbstractDataView<T>
     @Override
     public AbstractListDataView<T> addItem(T item) {
         final ListDataProvider<T> dataProvider = getDataProvider();
-        if (!contains(item, dataProvider)) {
+        if (!contains(item)) {
             dataProvider.getItems().add(item);
             dataProvider.refreshAll();
         }
@@ -167,13 +167,6 @@ public abstract class AbstractListDataView<T> extends AbstractDataView<T>
 
     @Override
     public AbstractListDataView<T> updateItem(T item) {
-        ListDataProvider<T> dataProvider = getDataProvider();
-        return updateItem(item, i -> getIdentifier(i, dataProvider::getId));
-    }
-
-    @Override
-    public AbstractListDataView<T> updateItem(T item,
-                                SerializableFunction<T, ?> identityProvider) {
         Objects.requireNonNull(item, NULL_ITEM_ERROR_MESSAGE);
         final ListDataProvider<T> dataProvider = getDataProvider();
         Collection<T> items = dataProvider.getItems();
@@ -184,15 +177,13 @@ public abstract class AbstractListDataView<T> extends AbstractDataView<T>
                             items.getClass().getSimpleName()));
         }
 
-        final Object itemIdentifier = getIdentifier(item, identityProvider);
         final List<T> itemList = (List<T>) items;
 
-        int itemIndex = getItemIndex(item, identityProvider);
+        int itemIndex = getItemIndex(item);
 
         if (itemIndex != -1) {
             T itemToUpdate = itemList.get(itemIndex);
-            if (itemIdentifier.equals(
-                    getIdentifier(itemToUpdate, identityProvider))) {
+            if (equals(item, itemToUpdate)) {
                 itemList.set(itemIndex, item);
                 dataProvider.refreshItem(item);
             }
@@ -207,8 +198,7 @@ public abstract class AbstractListDataView<T> extends AbstractDataView<T>
             final ListDataProvider<T> dataProvider = getDataProvider();
             Collection<T> backendItems = dataProvider.getItems();
             items.stream()
-                    .filter(item ->
-                            contains(item, dataProvider))
+                    .filter(this::contains)
                     .forEach(item ->
                             removeItemIfPresent(item, dataProvider));
             backendItems.addAll(items);
@@ -298,49 +288,33 @@ public abstract class AbstractListDataView<T> extends AbstractDataView<T>
         return this;
     }
 
-    private int getItemIndex(T item,
-                             SerializableFunction<T, ?> identityProvider) {
+    private int getItemIndex(T item) {
         Objects.requireNonNull(item, NULL_ITEM_ERROR_MESSAGE);
-        final Object itemIdentifier = getIdentifier(item,
-                identityProvider);
         AtomicInteger index = new AtomicInteger(-1);
         if (!getItems().peek(t -> index.incrementAndGet())
-                .filter(t -> itemIdentifier.equals(
-                        getIdentifier(t, identityProvider)))
+                .filter(t -> equals(item, t))
                 .findFirst().isPresent()) {
             return -1;
         }
         return index.get();
     }
 
-    private Object getIdentifier(T item,
-                                 SerializableFunction<T, ?> identityProvider) {
-        Objects.requireNonNull(identityProvider,
-                "Identity provider cannot be null");
+    private Object getIdentifier(T item) {
         final Object itemIdentifier = identityProvider.apply(item);
         Objects.requireNonNull(itemIdentifier,
                 "Identity provider should not return null");
         return itemIdentifier;
     }
 
-    private boolean contains(T item, ListDataProvider<T> dataProvider) {
-        final Object itemIdentifier = getIdentifier(item, dataProvider::getId);
-        return getItems().anyMatch(i -> itemIdentifier.equals(
-                getIdentifier(i, dataProvider::getId)));
-    }
-
     private void removeItemIfPresent(T item,
                                      ListDataProvider<T> dataProvider) {
-        final Object itemIdentifier = getIdentifier(item, dataProvider::getId);
-        dataProvider.getItems().removeIf(i -> itemIdentifier.equals(
-                getIdentifier(i, dataProvider::getId)));
+        dataProvider.getItems().removeIf(i -> equals(item, i));
     }
 
-    private boolean equals(T item, T compareTo,
-                           ListDataProvider<T> dataProvider) {
-        final Object itemIdentifier = getIdentifier(item, dataProvider::getId);
-        return itemIdentifier.equals(
-                getIdentifier(compareTo, dataProvider::getId));
+    private boolean equals(T item, T compareTo) {
+        final Object itemIdentifier = getIdentifier(item);
+        return Objects.equals(itemIdentifier,
+                getIdentifier(compareTo));
     }
 
     private void addItemOnTarget(
@@ -355,11 +329,11 @@ public abstract class AbstractListDataView<T> extends AbstractDataView<T>
                             backendItems.getClass().getSimpleName()));
         }
 
-        if (equals(item, target, dataProvider)) {
+        if (equals(item, target)) {
             return;
         }
 
-        if (!contains(target, dataProvider)) {
+        if (!contains(target)) {
             throw new IllegalArgumentException(targetItemNotFoundErrorMessage);
         }
 
@@ -371,7 +345,7 @@ public abstract class AbstractListDataView<T> extends AbstractDataView<T>
          */
         removeItemIfPresent(item, dataProvider);
         itemList.add(insertItemsIndexProvider
-                .apply(getItemIndex(target, dataProvider::getId)), item);
+                .apply(getItemIndex(target)), item);
         dataProvider.refreshAll();
     }
 
@@ -391,7 +365,7 @@ public abstract class AbstractListDataView<T> extends AbstractDataView<T>
                             backendItems.getClass().getSimpleName()));
         }
 
-        if (!contains(target, dataProvider)) {
+        if (!contains(target)) {
             throw new IllegalArgumentException(targetItemNotFoundErrorMessage);
         }
 
@@ -415,13 +389,13 @@ public abstract class AbstractListDataView<T> extends AbstractDataView<T>
              * present, so as to be placed to proper position with a
              * proper order later on.
              */
-            if (equals(item, target, dataProvider)) {
+            if (equals(target, item)) {
                 containsTargetItem.set(true);
             } else {
                 removeItemIfPresent(item, dataProvider);
             }
         });
-        int targetItemIndex = getItemIndex(target, dataProvider::getId);
+        int targetItemIndex = getItemIndex(target);
 
         /*
          * If the target item is in a collection then remove it from

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataView.java
@@ -20,7 +20,6 @@ import java.io.Serializable;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.shared.Registration;
 
 /**
@@ -53,15 +52,17 @@ public interface DataView<T> extends Serializable {
      * Item may be filtered out or for lazy data not in the currently loaded
      * making it un-available.
      * <p>
-     * By default, equality between the items is determined by the identifiers
-     * provided by {@link DataProvider#getId(Object)}. Identity provider can
-     * be changed with a {@link DataView#setIdentityProvider(ValueProvider)}.
+     * By default, {@code equals} method implementation of the item is used
+     * for identity check. If a custom data provider is used,
+     * then the {@link DataProvider#getId(Object)} method is used instead.
+     * Item's custom identity can be set up with a
+     * {@link DataView#setIdentityProvider(IdentityProvider)}.
      *
      * @param item
      *         item to search for
      * @return true if item is found in the available data
      *
-     * @see #setIdentityProvider(ValueProvider)
+     * @see #setIdentityProvider(IdentityProvider)
      */
     boolean contains(T item);
 
@@ -87,5 +88,5 @@ public interface DataView<T> extends Serializable {
      * @param identityProvider
      *           function that returns the non-null identifier for a given item
      */
-    void setIdentityProvider(ValueProvider<T, ?> identityProvider);
+    void setIdentityProvider(IdentityProvider<T> identityProvider);
 }

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataView.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.shared.Registration;
 
 /**
@@ -51,10 +52,16 @@ public interface DataView<T> extends Serializable {
      * Check if item is in the current data.
      * Item may be filtered out or for lazy data not in the currently loaded
      * making it un-available.
+     * <p>
+     * By default, equality between the items is determined by the identifiers
+     * provided by {@link DataProvider#getId(Object)}. Identity provider can
+     * be changed with a {@link DataView#setIdentityProvider(ValueProvider)}.
      *
      * @param item
      *         item to search for
      * @return true if item is found in the available data
+     *
+     * @see #setIdentityProvider(ValueProvider)
      */
     boolean contains(T item);
 
@@ -72,4 +79,13 @@ public interface DataView<T> extends Serializable {
      */
     Registration addSizeChangeListener(
             ComponentEventListener<SizeChangeEvent<?>> listener);
+
+    /**
+     * Sets identity provider to be used for getting item identifier and
+     * compare the items using that identifier.
+     *
+     * @param identityProvider
+     *           function that returns the non-null identifier for a given item
+     */
+    void setIdentityProvider(ValueProvider<T, ?> identityProvider);
 }

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataView.java
@@ -56,13 +56,13 @@ public interface DataView<T> extends Serializable {
      * for identity check. If a custom data provider is used,
      * then the {@link DataProvider#getId(Object)} method is used instead.
      * Item's custom identity can be set up with a
-     * {@link DataView#setIdentityProvider(IdentityProvider)}.
+     * {@link DataView#setIdentifierProvider(IdentifierProvider)}.
      *
      * @param item
      *         item to search for
      * @return true if item is found in the available data
      *
-     * @see #setIdentityProvider(IdentityProvider)
+     * @see #setIdentifierProvider(IdentifierProvider)
      */
     boolean contains(T item);
 
@@ -85,8 +85,8 @@ public interface DataView<T> extends Serializable {
      * Sets identity provider to be used for getting item identifier and
      * compare the items using that identifier.
      *
-     * @param identityProvider
+     * @param identifierProvider
      *           function that returns the non-null identifier for a given item
      */
-    void setIdentityProvider(IdentityProvider<T> identityProvider);
+    void setIdentifierProvider(IdentifierProvider<T> identifierProvider);
 }

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/IdentifierProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/IdentifierProvider.java
@@ -19,23 +19,22 @@ package com.vaadin.flow.data.provider;
 import com.vaadin.flow.function.ValueProvider;
 
 /**
- * A callback interface that provides the identifier for a data items stored
- * in {@link DataProvider}.
+ * A callback interface that is used to provide the identifier of an item.
  *
  * @param <T>
- *            the type of the data item
+ *            the type of the item
  * @since
  */
 @FunctionalInterface
-public interface IdentityProvider<T> extends ValueProvider<T, Object> {
+public interface IdentifierProvider<T> extends ValueProvider<T, Object> {
     /**
-     * Returns a value provider that always returns its input argument.
+     * Returns an identifier provider that always returns its input argument.
      *
      * @param <T>
      *            the type of the input and output objects to the function
      * @return a function that always returns its input argument
      */
-    static <T> IdentityProvider<T> identity() {
+    static <T> IdentifierProvider<T> identity() {
         return t -> t;
     }
 }

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/IdentityProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/IdentityProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.data.provider;
+
+import com.vaadin.flow.function.ValueProvider;
+
+/**
+ * A callback interface that provides the identifier for a data items stored
+ * in {@link DataProvider}.
+ *
+ * @param <T>
+ *            the type of the data item
+ * @since
+ */
+@FunctionalInterface
+public interface IdentityProvider<T> extends ValueProvider<T, Object> {
+    /**
+     * Returns a value provider that always returns its input argument.
+     *
+     * @param <T>
+     *            the type of the input and output objects to the function
+     * @return a function that always returns its input argument
+     */
+    static <T> IdentityProvider<T> identity() {
+        return t -> t;
+    }
+}

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/ListDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/ListDataView.java
@@ -124,8 +124,9 @@ public interface ListDataView<T, V extends ListDataView<T, ?>>
      * Finds an item equal to {@code item} in the non-filtered data set
      * and replaces it with {@code item}.
      * <p>
-     * Equality between the items is determined by the identifiers
-     * provided by {@link DataProvider#getId(Object)}.
+     * By default, equality between the items is determined by the identifiers
+     * provided by {@link DataProvider#getId(Object)}. Identity provider can
+     * be changed with a {@link DataView#setIdentityProvider(ValueProvider)}.
      *
      * @param item
      *         item containing updated state
@@ -136,32 +137,9 @@ public interface ListDataView<T, V extends ListDataView<T, ?>>
      * @throws IllegalArgumentException
      *         if collection is not a list
      *
-     * @see #updateItem(Object, SerializableFunction)
+     * @see #setIdentityProvider(ValueProvider)
      */
     V updateItem(T item);
-
-    /**
-     * Finds an item equal to {@code item} in the non-filtered data set
-     * and replaces it with {@code item}.
-     * <p>
-     * Equality between the items is determined by the identifiers
-     * provided by {@code identityProvider}.
-     *
-     * @param item
-     *         item containing updated state
-     * @param identityProvider
-     *         callback that transforms {@code item} object into identifier
-     *         object which is used to determine the equality between items.
-     * @return this ListDataView instance
-     *
-     * @throws UnsupportedOperationException
-     *         if backing collection doesn't support modification
-     * @throws IllegalArgumentException
-     *         if collection is not a list
-     *
-     * @see #updateItem(Object)
-     */
-    V updateItem(T item, SerializableFunction<T, ?> identityProvider);
 
     /**
      * Adds multiple items to the data list.

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/ListDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/ListDataView.java
@@ -127,7 +127,7 @@ public interface ListDataView<T, V extends ListDataView<T, ?>>
      * for identity check. If a custom data provider is used,
      * then the {@link DataProvider#getId(Object)} method is used instead.
      * Item's custom identity can be set up with a
-     * {@link DataView#setIdentityProvider(IdentityProvider)}.
+     * {@link DataView#setIdentifierProvider(IdentifierProvider)}.
      *
      * @param item
      *         item containing updated state
@@ -138,7 +138,7 @@ public interface ListDataView<T, V extends ListDataView<T, ?>>
      * @throws IllegalArgumentException
      *         if collection is not a list
      *
-     * @see #setIdentityProvider(IdentityProvider)
+     * @see #setIdentifierProvider(IdentifierProvider)
      */
     V updateItem(T item);
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/ListDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/ListDataView.java
@@ -123,9 +123,11 @@ public interface ListDataView<T, V extends ListDataView<T, ?>>
      * Finds an item equal to {@code item} in the non-filtered data set
      * and replaces it with {@code item}.
      * <p>
-     * By default, equality between the items is determined by the identifiers
-     * provided by {@link DataProvider#getId(Object)}. Identity provider can
-     * be changed with a {@link DataView#setIdentityProvider(ValueProvider)}.
+     * By default, {@code equals} method implementation of the item is used
+     * for identity check. If a custom data provider is used,
+     * then the {@link DataProvider#getId(Object)} method is used instead.
+     * Item's custom identity can be set up with a
+     * {@link DataView#setIdentityProvider(IdentityProvider)}.
      *
      * @param item
      *         item containing updated state
@@ -136,7 +138,7 @@ public interface ListDataView<T, V extends ListDataView<T, ?>>
      * @throws IllegalArgumentException
      *         if collection is not a list
      *
-     * @see #setIdentityProvider(ValueProvider)
+     * @see #setIdentityProvider(IdentityProvider)
      */
     V updateItem(T item);
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/ListDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/ListDataView.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.data.provider;
 
 import com.vaadin.flow.function.SerializableComparator;
-import com.vaadin.flow.function.SerializableFunction;
 import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.function.ValueProvider;
 

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractDataViewTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractDataViewTest.java
@@ -82,7 +82,7 @@ public class AbstractDataViewTest {
     }
 
     @Test
-    public void setIdentityProvider_defaultIdentity_equalsIsUsed() {
+    public void setIdentifierProvider_defaultIdentity_equalsIsUsed() {
         Assert.assertTrue(dataView.contains(
                 new Item(1L, "first")));
         Assert.assertFalse(dataView.contains(
@@ -92,7 +92,7 @@ public class AbstractDataViewTest {
     }
 
     @Test
-    public void setIdentityProvider_dataProviderIdentity_getIdIsUsed() {
+    public void setIdentifierProvider_dataProviderIdentity_getIdIsUsed() {
         dataProvider = new CustomIdentityItemDataProvider(items);
 
         Assert.assertTrue(dataView.contains(
@@ -104,8 +104,8 @@ public class AbstractDataViewTest {
     }
 
     @Test
-    public void setIdentityProvider_customIdentityProvider_customIdentityProviderIsUsed() {
-        dataView.setIdentityProvider(Item::getValue);
+    public void setIdentifierProvider_customIdentifierProvider_customIdentifierProviderIsUsed() {
+        dataView.setIdentifierProvider(Item::getValue);
 
         Assert.assertTrue(dataView.contains(
                 new Item(1L, "first")));
@@ -116,7 +116,7 @@ public class AbstractDataViewTest {
     }
 
     @Test
-    public void setIdentityProvider_dataProviderHasChanged_newDataProviderIsUsed() {
+    public void setIdentifierProvider_dataProviderHasChanged_newDataProviderIsUsed() {
         Assert.assertFalse(dataView.contains(
                 new Item(1L, "non present")));
 
@@ -132,11 +132,11 @@ public class AbstractDataViewTest {
     }
 
     @Test
-    public void setIdentityProvider_dataProviderHasChanged_identityProviderRetained() {
+    public void setIdentifierProvider_dataProviderHasChanged_identifierProviderRetained() {
         Assert.assertFalse(dataView.contains(
                 new Item(4L, "non present", "description1")));
 
-        dataView.setIdentityProvider(Item::getDescription);
+        dataView.setIdentifierProvider(Item::getDescription);
 
         Assert.assertTrue(dataView.contains(
                 new Item(4L, "non present", "description1")));
@@ -166,11 +166,11 @@ public class AbstractDataViewTest {
 
         @Override
         public boolean contains(Item item) {
-            IdentityProvider<Item> identityProvider =
-                    getIdentityProvider();
+            IdentifierProvider<Item> identifierProvider =
+                    getIdentifierProvider();
             return getItems().anyMatch(i -> Objects.equals(
-                    identityProvider.apply(item),
-                    identityProvider.apply(i)));
+                    identifierProvider.apply(item),
+                    identifierProvider.apply(i)));
         }
     }
 

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractDataViewTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractDataViewTest.java
@@ -19,9 +19,11 @@ package com.vaadin.flow.data.provider;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.tests.data.bean.Item;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,18 +35,22 @@ import com.vaadin.flow.function.SerializableSupplier;
 
 public class AbstractDataViewTest {
 
-    private Collection<String> items;
+    private Collection<Item> items;
 
-    private ListDataProvider<String> dataProvider;
+    private ListDataProvider<Item> dataProvider;
 
-    private AbstractDataView<String> dataView;
+    private AbstractDataView<Item> dataView;
 
     private Component component;
 
     @Before
     public void init() {
 
-        items = new ArrayList<>(Arrays.asList("first", "middle", "last"));
+        items = new ArrayList<>(Arrays.asList(
+                new Item(1L, "first", "description1"),
+                new Item(2L, "middle", "description2"),
+                new Item(3L, "last", "description3")
+        ));
         dataProvider = DataProvider.ofCollection(items);
         component = new TestComponent();
         dataView = new DataViewImpl(() -> dataProvider, component);
@@ -52,7 +58,7 @@ public class AbstractDataViewTest {
 
     @Test
     public void getAllItems_noFiltersSet_allItemsObtained() {
-        Stream<String> allItems = dataView.getItems();
+        Stream<Item> allItems = dataView.getItems();
         Assert.assertArrayEquals("Unexpected data set", items.toArray(),
                 allItems.toArray());
     }
@@ -75,14 +81,80 @@ public class AbstractDataViewTest {
         Assert.assertEquals(10, fired.get());
     }
 
+    @Test
+    public void setIdentityProvider_defaultIdentity_equalsIsUsed() {
+        Assert.assertTrue(dataView.contains(
+                new Item(1L, "first")));
+        Assert.assertFalse(dataView.contains(
+                new Item(1L, "non present")));
+        Assert.assertFalse(dataView.contains(
+                new Item(4L, "first")));
+    }
+
+    @Test
+    public void setIdentityProvider_dataProviderIdentity_getIdIsUsed() {
+        dataProvider = new CustomIdentityItemDataProvider(items);
+
+        Assert.assertTrue(dataView.contains(
+                new Item(1L, "first")));
+        Assert.assertTrue(dataView.contains(
+                new Item(1L, "non present")));
+        Assert.assertFalse(dataView.contains(
+                new Item(4L, "first")));
+    }
+
+    @Test
+    public void setIdentityProvider_customIdentityProvider_customIdentityProviderIsUsed() {
+        dataView.setIdentityProvider(Item::getValue);
+
+        Assert.assertTrue(dataView.contains(
+                new Item(1L, "first")));
+        Assert.assertFalse(dataView.contains(
+                new Item(1L, "non present")));
+        Assert.assertTrue(dataView.contains(
+                new Item(4L, "first")));
+    }
+
+    @Test
+    public void setIdentityProvider_dataProviderHasChanged_newDataProviderIsUsed() {
+        Assert.assertFalse(dataView.contains(
+                new Item(1L, "non present")));
+
+        dataProvider = new CustomIdentityItemDataProvider(items);
+
+        Assert.assertTrue(dataView.contains(
+                new Item(1L, "non present")));
+
+        dataProvider = DataProvider.ofCollection(items);
+
+        Assert.assertFalse(dataView.contains(
+                new Item(1L, "non present")));
+    }
+
+    @Test
+    public void setIdentityProvider_dataProviderHasChanged_identityProviderRetained() {
+        Assert.assertFalse(dataView.contains(
+                new Item(4L, "non present", "description1")));
+
+        dataView.setIdentityProvider(Item::getDescription);
+
+        Assert.assertTrue(dataView.contains(
+                new Item(4L, "non present", "description1")));
+
+        dataProvider = new CustomIdentityItemDataProvider(items);
+
+        Assert.assertTrue(dataView.contains(
+                new Item(4L, "non present", "description1")));
+    }
+
     @Tag("test-component")
     private static class TestComponent extends Component {
     }
 
-    private static class DataViewImpl extends AbstractDataView<String> {
+    private static class DataViewImpl extends AbstractDataView<Item> {
 
         public DataViewImpl(
-                SerializableSupplier<DataProvider<String, ?>> dataProviderSupplier,
+                SerializableSupplier<DataProvider<Item, ?>> dataProviderSupplier,
                 Component component) {
             super(dataProviderSupplier, component);
         }
@@ -93,8 +165,25 @@ public class AbstractDataViewTest {
         }
 
         @Override
-        public boolean contains(String item) {
-            return getItems().anyMatch(item::equals);
+        public boolean contains(Item item) {
+            IdentityProvider<Item> identityProvider =
+                    getIdentityProvider();
+            return getItems().anyMatch(i -> Objects.equals(
+                    identityProvider.apply(item),
+                    identityProvider.apply(i)));
+        }
+    }
+
+    static class CustomIdentityItemDataProvider
+            extends ListDataProvider<Item> {
+
+        public CustomIdentityItemDataProvider(Collection<Item> items) {
+            super(items);
+        }
+
+        @Override
+        public Object getId(Item item) {
+            return item.getId();
         }
     }
 }

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractListDataViewTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractListDataViewTest.java
@@ -764,9 +764,9 @@ public class AbstractListDataViewTest {
         ItemListDataView dataView = new ItemListDataView(
                 () -> dataProvider, null);
 
+        dataView.setIdentityProvider(Item::getId);
         dataView.updateItem(
-                new Item(1L, "updatedValue", "updatedDescr"),
-                Item::getId);
+                new Item(1L, "updatedValue", "updatedDescr"));
 
         Optional<Item> firstItem =
                 items.stream().filter(i -> i.getId() == 1L).findFirst();

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractListDataViewTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractListDataViewTest.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.google.common.primitives.Chars;
+import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.tests.data.bean.Item;
 import org.junit.Assert;
@@ -48,11 +49,14 @@ public class AbstractListDataViewTest {
 
     private AbstractListDataView<String> dataView;
 
+    private Component component;
+
     @Before
     public void init() {
         items = new ArrayList<>(Arrays.asList("first", "middle", "last"));
         dataProvider = DataProvider.ofCollection(items);
-        dataView = new ListDataViewImpl(() -> dataProvider, null);
+        component = new TestComponent();
+        dataView = new ListDataViewImpl(() -> dataProvider, component);
     }
 
     @Test
@@ -126,7 +130,7 @@ public class AbstractListDataViewTest {
     @Test
     public void addSortComparator_twoComparatorsAdded_itemsSortedByCompositeComparator() {
         dataProvider = DataProvider.ofItems("b3", "a2", "a1");
-        dataView = new ListDataViewImpl(() -> dataProvider, null);
+        dataView = new ListDataViewImpl(() -> dataProvider, component);
         dataView.addSortComparator((s1, s2) ->
                 Chars.compare(s1.charAt(0), s2.charAt(0)));
         Assert.assertEquals("Unexpected data set order (comparator 1)",
@@ -251,7 +255,7 @@ public class AbstractListDataViewTest {
         exceptionRule.expectMessage("Requested index 5 on empty data.");
 
         dataProvider = DataProvider.ofCollection(Collections.emptyList());
-        dataView = new ListDataViewImpl(() -> dataProvider, null);
+        dataView = new ListDataViewImpl(() -> dataProvider, component);
         dataView.validateItemIndex(5);
     }
 
@@ -589,7 +593,7 @@ public class AbstractListDataViewTest {
 
         final ListDataProvider<String> stringListDataProvider =
                 new ListDataProvider<>(items);
-        dataView = new ListDataViewImpl(() -> stringListDataProvider, null);
+        dataView = new ListDataViewImpl(() -> stringListDataProvider, component);
 
         dataView.addItemBefore("newItem", "item2");
     }
@@ -623,7 +627,7 @@ public class AbstractListDataViewTest {
 
         final ListDataProvider<String> stringListDataProvider =
                 new ListDataProvider<>(items);
-        dataView = new ListDataViewImpl(() -> stringListDataProvider, null);
+        dataView = new ListDataViewImpl(() -> stringListDataProvider, component);
 
         dataView.addItemsAfter(Collections.singleton("newItem"), "item1");
     }
@@ -640,7 +644,7 @@ public class AbstractListDataViewTest {
 
         final ListDataProvider<String> stringListDataProvider =
                 new ListDataProvider<>(items);
-        dataView = new ListDataViewImpl(() -> stringListDataProvider, null);
+        dataView = new ListDataViewImpl(() -> stringListDataProvider, component);
 
         dataView.addItemsBefore(Collections.singleton("newItem"), "item1");
     }
@@ -693,7 +697,7 @@ public class AbstractListDataViewTest {
         ListDataProvider<Item> dataProvider = DataProvider.ofCollection(items);
 
         ItemListDataView dataView = new ItemListDataView(
-                () -> dataProvider, null);
+                () -> dataProvider, component);
 
         dataView.updateItem(
                 new Item(1L, "updatedValue", "updatedDescr"));
@@ -716,7 +720,7 @@ public class AbstractListDataViewTest {
         ListDataProvider<Item> dataProvider = DataProvider.ofCollection(items);
 
         ItemListDataView dataView = new ItemListDataView(
-                () -> dataProvider, null);
+                () -> dataProvider, component);
 
         dataView.updateItem(
                 new Item(1L, "value1", "updatedDescr"));
@@ -737,10 +741,10 @@ public class AbstractListDataViewTest {
         Collection<Item> items = getTestItems();
 
         ListDataProvider<Item> dataProvider = new
-                CustomIdentityItemDataProvider(items);
+                AbstractDataViewTest.CustomIdentityItemDataProvider(items);
 
         ItemListDataView dataView = new ItemListDataView(
-                () -> dataProvider, null);
+                () -> dataProvider, component);
 
         dataView.updateItem(
                 new Item(1L, "updatedValue", "updatedDescr"));
@@ -762,7 +766,7 @@ public class AbstractListDataViewTest {
         ListDataProvider<Item> dataProvider = DataProvider.ofCollection(items);
 
         ItemListDataView dataView = new ItemListDataView(
-                () -> dataProvider, null);
+                () -> dataProvider, component);
 
         dataView.setIdentityProvider(Item::getId);
         dataView.updateItem(
@@ -787,19 +791,6 @@ public class AbstractListDataViewTest {
         }
     }
 
-    private static class CustomIdentityItemDataProvider
-            extends ListDataProvider<Item> {
-
-        public CustomIdentityItemDataProvider(Collection<Item> items) {
-            super(items);
-        }
-
-        @Override
-        public Object getId(Item item) {
-            return item.getId();
-        }
-    }
-
     private static class ItemListDataView extends AbstractListDataView<Item> {
 
         public ItemListDataView(
@@ -814,5 +805,9 @@ public class AbstractListDataViewTest {
                 new Item(1L, "value1", "descr1"),
                 new Item(2L, "value2", "descr2"),
                 new Item(3L, "value3", "descr3")));
+    }
+
+    @Tag("test-component")
+    private static class TestComponent extends Component {
     }
 }

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractListDataViewTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractListDataViewTest.java
@@ -760,7 +760,7 @@ public class AbstractListDataViewTest {
     }
 
     @Test
-    public void updateItem_identityProvider_updatesExistingItem() {
+    public void updateItem_identifierProvider_updatesExistingItem() {
         Collection<Item> items = getTestItems();
 
         ListDataProvider<Item> dataProvider = DataProvider.ofCollection(items);
@@ -768,7 +768,7 @@ public class AbstractListDataViewTest {
         ItemListDataView dataView = new ItemListDataView(
                 () -> dataProvider, component);
 
-        dataView.setIdentityProvider(Item::getId);
+        dataView.setIdentifierProvider(Item::getId);
         dataView.updateItem(
                 new Item(1L, "updatedValue", "updatedDescr"));
 

--- a/flow-data/src/test/java/com/vaadin/flow/tests/data/bean/Item.java
+++ b/flow-data/src/test/java/com/vaadin/flow/tests/data/bean/Item.java
@@ -24,7 +24,11 @@ public class Item {
     private String description;
 
     public Item(long id) {
-        this.id = id;
+        this(id, null);
+    }
+
+    public Item(long id, String value) {
+        this(id, value, null);
     }
 
     public Item(long id, String value, String description) {


### PR DESCRIPTION
Custom identity provider now could be set globally through DataView interface and this also will affect the components.

See components PRs:
- https://github.com/vaadin/vaadin-select-flow/pull/82
- https://github.com/vaadin/vaadin-checkbox-flow/pull/155
- https://github.com/vaadin/vaadin-grid-flow/pull/1044