### PR TITLE
Simplify ValidationCallback return type

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/form/Field.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/form/Field.ts
@@ -151,7 +151,7 @@ export const field = directive(<T>(
   }
 
   const firstError = binderNode.ownErrors[0];
-  const errorMessage = firstError && firstError.validator.message || '';
+  const errorMessage = firstError && firstError.message || '';
   if (errorMessage !== fieldState.errorMessage) {
     fieldState.strategy.errorMessage = fieldState.errorMessage = errorMessage;
   }

--- a/flow-client/src/main/resources/META-INF/resources/frontend/form/Validation.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/form/Validation.ts
@@ -1,5 +1,6 @@
 /* tslint:disable:max-classes-per-file */
 
+import { Binder } from "./Binder";
 import {
   AbstractModel,
   getBinderNode,
@@ -7,7 +8,6 @@ import {
   getValue,
 } from "./Models";
 import { Required } from "./Validators";
-import {Binder} from "./Binder";
 
 export interface ValueError<T> {
   property: string | AbstractModel<any>,
@@ -31,7 +31,7 @@ export class ValidationError extends Error {
   }
 }
 
-export type ValidationCallback<T> = (value: T, binder: Binder<any, AbstractModel<T>>) => boolean | ValidationResult | Array<ValidationResult> | Promise<boolean | ValidationResult | Array<ValidationResult>>;
+export type ValidationCallback<T> = (value: T, binder: Binder<any, AbstractModel<T>>) => boolean | ValidationResult | ReadonlyArray<ValidationResult> | Promise<boolean | ValidationResult | ReadonlyArray<ValidationResult>>;
 
 export interface Validator<T> {
   validate: ValidationCallback<T>,
@@ -58,7 +58,7 @@ export async function runValidator<T>(model: AbstractModel<T>, validator: Valida
       } else if (result === true || Array.isArray(result) && result.length === 0) {
         return [];
       } else if (Array.isArray(result)) {
-        return result.map(result => ({ message: validator.message, ...result, value, validator }));
+        return result.map(result2 => ({ message: validator.message, ...result2, value, validator }));
       } else {
         return [{ message: validator.message, ...result, value, validator }];
       }

--- a/flow-client/src/main/resources/META-INF/resources/frontend/form/Validation.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/form/Validation.ts
@@ -7,6 +7,7 @@ import {
   getValue,
 } from "./Models";
 import { Required } from "./Validators";
+import {Binder} from "./Binder";
 
 export interface ValueError<T> {
   property: string | AbstractModel<any>,
@@ -30,7 +31,7 @@ export class ValidationError extends Error {
   }
 }
 
-export type ValidationCallback<T> = (value: T) => boolean | ValidationResult | Array<ValidationResult> | Promise<boolean | ValidationResult | Array<ValidationResult>>;
+export type ValidationCallback<T> = (value: T, binder: Binder<any, AbstractModel<T>>) => boolean | ValidationResult | Array<ValidationResult> | Promise<boolean | ValidationResult | Array<ValidationResult>>;
 
 export interface Validator<T> {
   validate: ValidationCallback<T>,
@@ -50,7 +51,7 @@ export async function runValidator<T>(model: AbstractModel<T>, validator: Valida
   if (!getBinderNode(model).required && !new Required().validate(value)) {
     return [];
   }
-  return (async () => validator.validate(value))()
+  return (async () => validator.validate(value, getBinderNode(model).binder))()
     .then(result => {
       if (result === false) {
         return [{ property: getName(model), value, validator, message: validator.message }];

--- a/flow-client/tsconfig.json
+++ b/flow-client/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "sourceMap": true,
     "inlineSources": true,
+    "lib": ["DOM", "ES2019.Array"],
     "module": "esNext",
     "target": "es2015",
     "moduleResolution": "node",


### PR DESCRIPTION
- `ValidationCallback` may now return a single `ValidationResult` or an array of `ValidationResult` objects which don't need to specify the `value` or `validator` properties which were needed previously when `ValueError` was used in the return type.
- `ValidationResult` may contain an optional `message` property for overriding the default error message (coming from validator) for a specific property.
- `ValueError` now also directly has a `message` property so it's slightly simpler to get the error messages when working with a list of errors.
- Update `flow-client` tsconfig to allow using `Array.flat()` etc.
- Add Binder as a parameter to `ValidationCallback`

Fixes #8552