### PR TITLE
Allow Vaadin plugins to configure node download URL and version

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -57,7 +57,7 @@ import elemental.json.JsonObject;
  */
 public class FrontendTools {
 
-    private static final String DEFAULT_NODE_VERSION = "v12.16.0";
+    public static final String DEFAULT_NODE_VERSION = "v12.16.0";
 
     public static final String DEFAULT_PNPM_VERSION = "4.5.0";
 
@@ -148,20 +148,8 @@ public class FrontendTools {
 
     private final FrontendToolsLocator frontendToolsLocator = new FrontendToolsLocator();
 
-    /**
-     * The node.js version to be used when node.js is installed automatically
-     * by Vaadin, for example <code>"v12.16.0"</code>. Defaults to
-     * {@value #DEFAULT_NODE_VERSION}.
-     */
-    public String nodeVersion = DEFAULT_NODE_VERSION;
-
-    /**
-     * Download node.js from this URL. Handy in heavily firewalled corporate
-     * environments where the node.js download can be provided from an intranet
-     * mirror. Defaults to null which will cause the downloader to use
-     * {@link NodeInstaller#DEFAULT_NODEJS_DOWNLOAD_ROOT}.
-     */
-    public URI nodeDownloadRoot = null;
+    private final String nodeVersion;
+    private final URI nodeDownloadRoot;
 
     /**
      * Creates an instance of the class using the {@code baseDir} as a base
@@ -181,8 +169,42 @@ public class FrontendTools {
      */
     public FrontendTools(String baseDir,
             Supplier<String> alternativeDirGetter) {
+        this(baseDir, alternativeDirGetter, DEFAULT_NODE_VERSION,
+                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT));
+    }
+
+    /**
+     * Creates an instance of the class using the {@code baseDir} as a base
+     * directory to locate the tools and the directory returned by the
+     * {@code alternativeDirGetter} as a directory to install tools if they are
+     * not found and use it as an alternative tools location.
+     * <p>
+     * If {@code alternativeDir} is {@code null} tools won't be installed.
+     *
+     *
+     * @param baseDir
+     *            the base directory to locate the tools, not {@code null}
+     * @param alternativeDirGetter
+     *            the getter for a directory where tools will be installed if
+     *            they are not found globally or in the {@code baseDir}, may be
+     *            {@code null}
+     * @param nodeVersion
+     *            The node.js version to be used when node.js is installed automatically
+     *            by Vaadin, for example <code>"v12.16.0"</code>. Use
+     *            {@value #DEFAULT_NODE_VERSION} by default.
+     * @param nodeDownloadRoot
+     *            Download node.js from this URL. Handy in heavily firewalled corporate
+     *            environments where the node.js download can be provided from an intranet
+     *            mirror. Use {@link NodeInstaller#DEFAULT_NODEJS_DOWNLOAD_ROOT} by default.
+     */
+    public FrontendTools(String baseDir,
+                         Supplier<String> alternativeDirGetter,
+                         String nodeVersion,
+                         URI nodeDownloadRoot) {
         this.baseDir = Objects.requireNonNull(baseDir);
         this.alternativeDirGetter = alternativeDirGetter;
+        this.nodeVersion = Objects.requireNonNull(nodeVersion);
+        this.nodeDownloadRoot = Objects.requireNonNull(nodeDownloadRoot);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -149,6 +149,21 @@ public class FrontendTools {
     private final FrontendToolsLocator frontendToolsLocator = new FrontendToolsLocator();
 
     /**
+     * The node.js version to be used when node.js is installed automatically
+     * by Vaadin, for example <code>"v12.16.0"</code>. Defaults to
+     * {@value #DEFAULT_NODE_VERSION}.
+     */
+    public String nodeVersion = DEFAULT_NODE_VERSION;
+
+    /**
+     * Download node.js from this URL. Handy in heavily firewalled corporate
+     * environments where the node.js download can be provided from an intranet
+     * mirror. Defaults to null which will cause the downloader to use
+     * {@link NodeInstaller#DEFAULT_NODEJS_DOWNLOAD_ROOT}.
+     */
+    public URI nodeDownloadRoot = null;
+
+    /**
      * Creates an instance of the class using the {@code baseDir} as a base
      * directory to locate the tools and the directory returned by the
      * {@code alternativeDirGetter} as a directory to install tools if they are
@@ -210,8 +225,8 @@ public class FrontendTools {
             return file.getAbsolutePath();
         } else {
             getLogger().info("Node not found in {}. Installing node {}.", dir,
-                    DEFAULT_NODE_VERSION);
-            return installNode(DEFAULT_NODE_VERSION, null);
+                    nodeVersion);
+            return installNode(nodeVersion, nodeDownloadRoot);
         }
     }
 
@@ -459,7 +474,7 @@ public class FrontendTools {
         if (file == null && installNode) {
             getLogger().info("Couldn't find {}. Installing Node and NPM to {}.",
                     cmd, getAlternativeDir());
-            return new File(installNode(DEFAULT_NODE_VERSION, null));
+            return new File(installNode(nodeVersion, nodeDownloadRoot));
         }
         if (file == null) {
             throw new IllegalStateException(String.format(NODE_NOT_FOUND));
@@ -750,5 +765,4 @@ public class FrontendTools {
     private String getAlternativeDir() {
         return alternativeDirGetter.get();
     }
-
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -18,12 +18,14 @@ package com.vaadin.flow.server.frontend;
 
 import java.io.File;
 import java.io.Serializable;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Set;
 
 import com.vaadin.flow.server.ExecutionFailedException;
+import com.vaadin.flow.server.frontend.installer.NodeInstaller;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 
@@ -108,6 +110,21 @@ public class NodeTasks implements FallibleCommand {
          * Is in client-side bootstrapping mode.
          */
         private boolean useDeprecatedV14Bootstrapping;
+
+        /**
+         * The node.js version to be used when node.js is installed
+         * automatically by Vaadin, for example <code>"v12.16.0"</code>.
+         * Defaults to null which uses the default node version.
+         */
+        public String nodeVersion = null;
+
+        /**
+         * Download node.js from this URL. Handy in heavily firewalled corporate
+         * environments where the node.js download can be provided from an
+         * intranet mirror. Defaults to null which will cause the downloader
+         * to use {@link NodeInstaller#DEFAULT_NODEJS_DOWNLOAD_ROOT}.
+         */
+        public URI nodeDownloadRoot = null;
 
         /**
          * Create a builder instance given an specific npm folder.
@@ -496,8 +513,12 @@ public class NodeTasks implements FallibleCommand {
             commands.add(packageUpdater);
 
             if (builder.runNpmInstall) {
-                commands.add(new TaskRunNpmInstall(classFinder, packageUpdater,
-                        builder.enablePnpm, builder.requireHomeNodeExec));
+                final TaskRunNpmInstall task = new TaskRunNpmInstall(
+                        classFinder, packageUpdater,
+                        builder.enablePnpm, builder.requireHomeNodeExec);
+                task.nodeVersion = builder.nodeVersion;
+                task.nodeDownloadRoot = builder.nodeDownloadRoot;
+                commands.add(task);
             }
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -116,14 +116,14 @@ public class NodeTasks implements FallibleCommand {
          * automatically by Vaadin, for example <code>"v12.16.0"</code>.
          * Defaults to {@value FrontendTools#DEFAULT_NODE_VERSION}.
          */
-        public String nodeVersion = FrontendTools.DEFAULT_NODE_VERSION;
+        private String nodeVersion = FrontendTools.DEFAULT_NODE_VERSION;
 
         /**
          * Download node.js from this URL. Handy in heavily firewalled corporate
          * environments where the node.js download can be provided from an
          * intranet mirror. Defaults to {@link NodeInstaller#DEFAULT_NODEJS_DOWNLOAD_ROOT}.
          */
-        public URI nodeDownloadRoot = URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT);
+        private URI nodeDownloadRoot = URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT);
 
         /**
          * Create a builder instance given an specific npm folder.
@@ -463,6 +463,26 @@ public class NodeTasks implements FallibleCommand {
          */
         public Builder withHomeNodeExecRequired(boolean requireHomeNodeExec) {
             this.requireHomeNodeExec = requireHomeNodeExec;
+            return this;
+        }
+
+        /**
+         * The node.js version to be used when node.js is installed
+         * automatically by Vaadin, for example <code>"v12.16.0"</code>.
+         * Defaults to {@value FrontendTools#DEFAULT_NODE_VERSION}.
+         */
+        public Builder withNodeVersion(String nodeVersion) {
+            this.nodeVersion = Objects.requireNonNull(nodeVersion);
+            return this;
+        }
+
+        /**
+         * Download node.js from this URL. Handy in heavily firewalled corporate
+         * environments where the node.js download can be provided from an
+         * intranet mirror. Defaults to {@link NodeInstaller#DEFAULT_NODEJS_DOWNLOAD_ROOT}.
+         */
+        public Builder withNodeDownloadRoot(URI nodeDownloadRoot) {
+            this.nodeDownloadRoot = Objects.requireNonNull(nodeDownloadRoot);
             return this;
         }
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -114,17 +114,16 @@ public class NodeTasks implements FallibleCommand {
         /**
          * The node.js version to be used when node.js is installed
          * automatically by Vaadin, for example <code>"v12.16.0"</code>.
-         * Defaults to null which uses the default node version.
+         * Defaults to {@value FrontendTools#DEFAULT_NODE_VERSION}.
          */
-        public String nodeVersion = null;
+        public String nodeVersion = FrontendTools.DEFAULT_NODE_VERSION;
 
         /**
          * Download node.js from this URL. Handy in heavily firewalled corporate
          * environments where the node.js download can be provided from an
-         * intranet mirror. Defaults to null which will cause the downloader
-         * to use {@link NodeInstaller#DEFAULT_NODEJS_DOWNLOAD_ROOT}.
+         * intranet mirror. Defaults to {@link NodeInstaller#DEFAULT_NODEJS_DOWNLOAD_ROOT}.
          */
-        public URI nodeDownloadRoot = null;
+        public URI nodeDownloadRoot = URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT);
 
         /**
          * Create a builder instance given an specific npm folder.
@@ -513,12 +512,10 @@ public class NodeTasks implements FallibleCommand {
             commands.add(packageUpdater);
 
             if (builder.runNpmInstall) {
-                final TaskRunNpmInstall task = new TaskRunNpmInstall(
+                commands.add(new TaskRunNpmInstall(
                         classFinder, packageUpdater,
-                        builder.enablePnpm, builder.requireHomeNodeExec);
-                task.nodeVersion = builder.nodeVersion;
-                task.nodeDownloadRoot = builder.nodeDownloadRoot;
-                commands.add(task);
+                        builder.enablePnpm, builder.requireHomeNodeExec,
+                        builder.nodeVersion, builder.nodeDownloadRoot));
             }
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -467,9 +467,13 @@ public class NodeTasks implements FallibleCommand {
         }
 
         /**
-         * The node.js version to be used when node.js is installed
+         * Sets the node.js version to be used when node.js is installed
          * automatically by Vaadin, for example <code>"v12.16.0"</code>.
          * Defaults to {@value FrontendTools#DEFAULT_NODE_VERSION}.
+         *
+         * @param nodeVersion
+         *            the new node version to download, not null.
+         * @return the builder, for chaining
          */
         public Builder withNodeVersion(String nodeVersion) {
             this.nodeVersion = Objects.requireNonNull(nodeVersion);
@@ -477,9 +481,13 @@ public class NodeTasks implements FallibleCommand {
         }
 
         /**
-         * Download node.js from this URL. Handy in heavily firewalled corporate
+         * Sets the download node.js URL. Handy in heavily firewalled corporate
          * environments where the node.js download can be provided from an
          * intranet mirror. Defaults to {@link NodeInstaller#DEFAULT_NODEJS_DOWNLOAD_ROOT}.
+         *
+         * @param nodeDownloadRoot
+         *            the new download URL to set, not null.
+         * @return the builder, for chaining
          */
         public Builder withNodeDownloadRoot(URI nodeDownloadRoot) {
             this.nodeDownloadRoot = Objects.requireNonNull(nodeDownloadRoot);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.server.frontend;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -25,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import com.vaadin.flow.server.frontend.installer.NodeInstaller;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 
@@ -67,6 +69,21 @@ public class TaskRunNpmInstall implements FallibleCommand {
     private final boolean enablePnpm;
     private final boolean requireHomeNodeExec;
     private final ClassFinder classFinder;
+
+    /**
+     * The node.js version to be used when node.js is installed automatically by
+     * Vaadin, for example <code>"v12.16.0"</code>. Defaults to null which uses
+     * the Vaadin-default node version - see {@link FrontendTools} for details.
+     */
+    public String nodeVersion = null;
+
+    /**
+     * Download node.js from this URL. Handy in heavily firewalled corporate
+     * environments where the node.js download can be provided from an intranet
+     * mirror. Defaults to null which will cause the downloader to use
+     * {@link NodeInstaller#DEFAULT_NODEJS_DOWNLOAD_ROOT}.
+     */
+    public URI nodeDownloadRoot = null;
 
     /**
      * Create an instance of the command.
@@ -306,6 +323,10 @@ public class TaskRunNpmInstall implements FallibleCommand {
 
         FrontendTools tools = new FrontendTools(baseDir,
                 () -> FrontendUtils.getVaadinHomeDirectory().getAbsolutePath());
+        if (nodeVersion != null) {
+            tools.nodeVersion = nodeVersion;
+        }
+        tools.nodeDownloadRoot = nodeDownloadRoot;
         try {
             if (requireHomeNodeExec) {
                 tools.forceAlternativeNodeExecutable();
@@ -428,5 +449,4 @@ public class TaskRunNpmInstall implements FallibleCommand {
             }
         }
     }
-
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import com.vaadin.flow.server.frontend.installer.NodeInstaller;
 import org.apache.commons.io.FileUtils;
@@ -70,20 +71,8 @@ public class TaskRunNpmInstall implements FallibleCommand {
     private final boolean requireHomeNodeExec;
     private final ClassFinder classFinder;
 
-    /**
-     * The node.js version to be used when node.js is installed automatically by
-     * Vaadin, for example <code>"v12.16.0"</code>. Defaults to null which uses
-     * the Vaadin-default node version - see {@link FrontendTools} for details.
-     */
-    public String nodeVersion = null;
-
-    /**
-     * Download node.js from this URL. Handy in heavily firewalled corporate
-     * environments where the node.js download can be provided from an intranet
-     * mirror. Defaults to null which will cause the downloader to use
-     * {@link NodeInstaller#DEFAULT_NODEJS_DOWNLOAD_ROOT}.
-     */
-    public URI nodeDownloadRoot = null;
+    private final String nodeVersion;
+    private final URI nodeDownloadRoot;
 
     /**
      * Create an instance of the command.
@@ -97,13 +86,24 @@ public class TaskRunNpmInstall implements FallibleCommand {
      *            whether PNPM should be used instead of NPM
      * @param requireHomeNodeExec
      *            whether vaadin home node executable has to be used
+     * @param nodeVersion
+     *            The node.js version to be used when node.js is installed automatically
+     *            by Vaadin, for example <code>"v12.16.0"</code>. Use
+     *            {@value FrontendTools#DEFAULT_NODE_VERSION} by default.
+     * @param nodeDownloadRoot
+     *            Download node.js from this URL. Handy in heavily firewalled corporate
+     *            environments where the node.js download can be provided from an intranet
+     *            mirror. Use {@link NodeInstaller#DEFAULT_NODEJS_DOWNLOAD_ROOT} by default.
      */
     TaskRunNpmInstall(ClassFinder classFinder, NodeUpdater packageUpdater,
-            boolean enablePnpm, boolean requireHomeNodeExec) {
+            boolean enablePnpm, boolean requireHomeNodeExec,
+            String nodeVersion, URI nodeDownloadRoot) {
         this.classFinder = classFinder;
         this.packageUpdater = packageUpdater;
         this.enablePnpm = enablePnpm;
         this.requireHomeNodeExec = requireHomeNodeExec;
+        this.nodeVersion = Objects.requireNonNull(nodeVersion);
+        this.nodeDownloadRoot = Objects.requireNonNull(nodeDownloadRoot);
     }
 
     @Override
@@ -322,11 +322,8 @@ public class TaskRunNpmInstall implements FallibleCommand {
         String baseDir = packageUpdater.npmFolder.getAbsolutePath();
 
         FrontendTools tools = new FrontendTools(baseDir,
-                () -> FrontendUtils.getVaadinHomeDirectory().getAbsolutePath());
-        if (nodeVersion != null) {
-            tools.nodeVersion = nodeVersion;
-        }
-        tools.nodeDownloadRoot = nodeDownloadRoot;
+                () -> FrontendUtils.getVaadinHomeDirectory().getAbsolutePath(),
+                nodeVersion, nodeDownloadRoot);
         try {
             if (requireHomeNodeExec) {
                 tools.forceAlternativeNodeExecutable();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -17,7 +17,9 @@ package com.vaadin.flow.server.frontend;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 
+import com.vaadin.flow.server.frontend.installer.NodeInstaller;
 import net.jcip.annotations.NotThreadSafe;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
@@ -85,7 +87,8 @@ public class TaskRunNpmInstallTest {
 
     protected TaskRunNpmInstall createTask() {
         return new TaskRunNpmInstall(getClassFinder(), nodeUpdater, false,
-                false);
+                false, FrontendTools.DEFAULT_NODE_VERSION,
+                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT));
     }
 
     @Test
@@ -230,7 +233,10 @@ public class TaskRunNpmInstallTest {
         exception.expectMessage(
                 "it's either not a file or not a 'node' executable.");
         assertRunNpmInstallThrows_vaadinHomeNodeIsAFolder(new TaskRunNpmInstall(
-                getClassFinder(), nodeUpdater, false, true));
+                getClassFinder(), nodeUpdater, false, true,
+                FrontendTools.DEFAULT_NODE_VERSION,
+                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT)
+                ));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -18,9 +18,12 @@ package com.vaadin.flow.server.frontend;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
 import javax.validation.constraints.AssertTrue;
+
+import com.vaadin.flow.server.frontend.installer.NodeInstaller;
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
@@ -134,7 +137,9 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         exception.expectMessage(
                 "it's either not a file or not a 'node' executable.");
         assertRunNpmInstallThrows_vaadinHomeNodeIsAFolder(new TaskRunNpmInstall(
-                getClassFinder(), getNodeUpdater(), true, true));
+                getClassFinder(), getNodeUpdater(), true, true,
+                FrontendTools.DEFAULT_NODE_VERSION,
+                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT)));
     }
 
     @Test
@@ -450,12 +455,14 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
     @Override
     protected TaskRunNpmInstall createTask() {
         return new TaskRunNpmInstall(getClassFinder(), getNodeUpdater(), true,
-                false);
+                false, FrontendTools.DEFAULT_NODE_VERSION,
+                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT));
     }
 
     protected TaskRunNpmInstall createTask(String versionsContent) {
         return new TaskRunNpmInstall(getClassFinder(), getNodeUpdater(), true,
-                false) {
+                false, FrontendTools.DEFAULT_NODE_VERSION,
+                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT)) {
             @Override
             protected String generateVersionsJson() {
                 try {
@@ -473,7 +480,8 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
 
     private TaskRunNpmInstall createTaskWithDevDepsLocked(String devDepsPath) {
         return new TaskRunNpmInstall(getClassFinder(), getNodeUpdater(), true,
-                false) {
+                false, FrontendTools.DEFAULT_NODE_VERSION,
+                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT)) {
             @Override
             protected String getDevDependenciesFilePath() {
                 return devDepsPath;


### PR DESCRIPTION
Currently FrontendTools nor NodeTasks.Builder
doesn't allow you to override the node.js download URL. However, in firewalled corporate
environments the node.js may be served from an intranet server.

Fixes #8603

The PR should be also merged into the 2.3 branch so that it will be present in Vaadin 14.3.