### PR TITLE
Don't use preserve on refresh logic in case of the same UI

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.router.internal;
 
 import javax.servlet.http.HttpServletResponse;
+
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -59,6 +60,7 @@ import com.vaadin.flow.router.RouteParameters;
 import com.vaadin.flow.router.Router;
 import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.server.VaadinSession;
+
 import elemental.json.JsonValue;
 
 /**
@@ -80,7 +82,6 @@ public abstract class AbstractNavigationStateRenderer
     private Postpone postponed = null;
 
     private LocationChangeEvent locationChangeEvent = null;
-
 
     /**
      * Creates a new renderer for the given navigation state.
@@ -237,8 +238,6 @@ public abstract class AbstractNavigationStateRenderer
                 new AfterNavigationEvent(locationChangeEvent),
                 afterNavigationHandlers);
 
-
-
         return statusCode;
     }
 
@@ -277,7 +276,8 @@ public abstract class AbstractNavigationStateRenderer
 
     protected void pushHistoryState(NavigationEvent event) {
         // Enable navigating back
-        event.getUI().getPage().getHistory().pushState(null, event.getLocation());
+        event.getUI().getPage().getHistory().pushState(null,
+                event.getLocation());
     }
 
     protected boolean shouldPushHistoryState(NavigationEvent event) {
@@ -779,6 +779,10 @@ public abstract class AbstractNavigationStateRenderer
                 final HasElement root = chain.get(chain.size() - 1);
                 final Component component = (Component) chain.get(0);
                 final Optional<UI> maybePrevUI = component.getUI();
+
+                if (maybePrevUI.isPresent() && maybePrevUI.get().equals(ui)) {
+                    return Optional.of(chain);
+                }
 
                 // Remove the top-level component from the tree
                 root.getElement().removeFromTree();


### PR DESCRIPTION
setPreservedChain doesn't store Location in the cache but only a path.
This is logically correct for the router functionality since routing
considers only path and not parameters. But the same view (and same UI)
should not trigger preserve on refresh logic if they only differ with a
parameter.

Fixes #8605