### PR TITLE
Make the items collection modifiable for data view listener test

### DIFF
--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractListDataViewListenerTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractListDataViewListenerTest.java
@@ -24,6 +24,7 @@ import com.vaadin.flow.server.VaadinSession;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -38,7 +39,7 @@ public abstract class AbstractListDataViewListenerTest {
         HasListDataView<String, ? extends AbstractListDataView<String>> component =
                 getVerifiedComponent();
         AbstractListDataView<String> dataView = component
-                .setDataSource(items);
+                .setDataSource(new ArrayList<>(Arrays.asList(items)));
 
         AtomicInteger invocationCounter = new AtomicInteger(0);
 


### PR DESCRIPTION
Provide a modifiable collection to data provider in  `GridListDataViewTest.addSizeChangeListener_sizeChanged_listenersAreNotified`, since the test expects modifying the data source to get the size change events.