### PR TITLE
Allow Vaadin plugins to configure node download URL and version (#8611)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -58,7 +58,7 @@ import elemental.json.JsonObject;
  */
 public class FrontendTools {
 
-    private static final String DEFAULT_NODE_VERSION = "v12.16.0";
+    public static final String DEFAULT_NODE_VERSION = "v12.16.0";
 
     public static final String DEFAULT_PNPM_VERSION = "4.5.0";
 
@@ -149,6 +149,9 @@ public class FrontendTools {
 
     private final FrontendToolsLocator frontendToolsLocator = new FrontendToolsLocator();
 
+    private final String nodeVersion;
+    private final URI nodeDownloadRoot;
+
     /**
      * Creates an instance of the class using the {@code baseDir} as a base
      * directory to locate the tools and the directory returned by the
@@ -167,8 +170,42 @@ public class FrontendTools {
      */
     public FrontendTools(String baseDir,
             Supplier<String> alternativeDirGetter) {
+        this(baseDir, alternativeDirGetter, DEFAULT_NODE_VERSION,
+                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT));
+    }
+
+    /**
+     * Creates an instance of the class using the {@code baseDir} as a base
+     * directory to locate the tools and the directory returned by the
+     * {@code alternativeDirGetter} as a directory to install tools if they are
+     * not found and use it as an alternative tools location.
+     * <p>
+     * If {@code alternativeDir} is {@code null} tools won't be installed.
+     *
+     *
+     * @param baseDir
+     *            the base directory to locate the tools, not {@code null}
+     * @param alternativeDirGetter
+     *            the getter for a directory where tools will be installed if
+     *            they are not found globally or in the {@code baseDir}, may be
+     *            {@code null}
+     * @param nodeVersion
+     *            The node.js version to be used when node.js is installed automatically
+     *            by Vaadin, for example <code>"v12.16.0"</code>. Use
+     *            {@value #DEFAULT_NODE_VERSION} by default.
+     * @param nodeDownloadRoot
+     *            Download node.js from this URL. Handy in heavily firewalled corporate
+     *            environments where the node.js download can be provided from an intranet
+     *            mirror. Use {@link NodeInstaller#DEFAULT_NODEJS_DOWNLOAD_ROOT} by default.
+     */
+    public FrontendTools(String baseDir,
+                         Supplier<String> alternativeDirGetter,
+                         String nodeVersion,
+                         URI nodeDownloadRoot) {
         this.baseDir = Objects.requireNonNull(baseDir);
         this.alternativeDirGetter = alternativeDirGetter;
+        this.nodeVersion = Objects.requireNonNull(nodeVersion);
+        this.nodeDownloadRoot = Objects.requireNonNull(nodeDownloadRoot);
     }
 
     /**
@@ -211,8 +248,8 @@ public class FrontendTools {
             return file.getAbsolutePath();
         } else {
             getLogger().info("Node not found in {}. Installing node {}.", dir,
-                    DEFAULT_NODE_VERSION);
-            return installNode(DEFAULT_NODE_VERSION, null);
+                    nodeVersion);
+            return installNode(nodeVersion, nodeDownloadRoot);
         }
     }
 
@@ -481,7 +518,7 @@ public class FrontendTools {
         if (file == null && installNode) {
             getLogger().info("Couldn't find {}. Installing Node and NPM to {}.",
                     cmd, getAlternativeDir());
-            return new File(installNode(DEFAULT_NODE_VERSION, null));
+            return new File(installNode(nodeVersion, nodeDownloadRoot));
         }
         if (file == null) {
             throw new IllegalStateException(String.format(NODE_NOT_FOUND));
@@ -772,5 +809,4 @@ public class FrontendTools {
     private String getAlternativeDir() {
         return alternativeDirGetter.get();
     }
-
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.server.frontend;
 
 import java.io.File;
 import java.io.Serializable;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -25,6 +26,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import com.vaadin.flow.server.ExecutionFailedException;
+import com.vaadin.flow.server.frontend.installer.NodeInstaller;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 
@@ -98,6 +100,20 @@ public class NodeTasks implements FallibleCommand {
          * Directory where generated files are written.
          */
         public final File generatedFolder;
+
+        /**
+         * The node.js version to be used when node.js is installed
+         * automatically by Vaadin, for example <code>"v12.16.0"</code>.
+         * Defaults to {@value FrontendTools#DEFAULT_NODE_VERSION}.
+         */
+        private String nodeVersion = FrontendTools.DEFAULT_NODE_VERSION;
+
+        /**
+         * Download node.js from this URL. Handy in heavily firewalled corporate
+         * environments where the node.js download can be provided from an
+         * intranet mirror. Defaults to {@link NodeInstaller#DEFAULT_NODEJS_DOWNLOAD_ROOT}.
+         */
+        private URI nodeDownloadRoot = URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT);
 
         /**
          * Create a builder instance given an specific npm folder.
@@ -377,6 +393,34 @@ public class NodeTasks implements FallibleCommand {
             additionalFrontendModules.addAll(frontendModules);
             return this;
         }
+
+        /**
+         * Sets the node.js version to be used when node.js is installed
+         * automatically by Vaadin, for example <code>"v12.16.0"</code>.
+         * Defaults to {@value FrontendTools#DEFAULT_NODE_VERSION}.
+         *
+         * @param nodeVersion
+         *            the new node version to download, not null.
+         * @return the builder, for chaining
+         */
+        public Builder withNodeVersion(String nodeVersion) {
+            this.nodeVersion = Objects.requireNonNull(nodeVersion);
+            return this;
+        }
+
+        /**
+         * Sets the download node.js URL. Handy in heavily firewalled corporate
+         * environments where the node.js download can be provided from an
+         * intranet mirror. Defaults to {@link NodeInstaller#DEFAULT_NODEJS_DOWNLOAD_ROOT}.
+         *
+         * @param nodeDownloadRoot
+         *            the new download URL to set, not null.
+         * @return the builder, for chaining
+         */
+        public Builder withNodeDownloadRoot(URI nodeDownloadRoot) {
+            this.nodeDownloadRoot = Objects.requireNonNull(nodeDownloadRoot);
+            return this;
+        }
     }
 
     private final Collection<FallibleCommand> commands = new ArrayList<>();
@@ -415,8 +459,10 @@ public class NodeTasks implements FallibleCommand {
             commands.add(packageUpdater);
 
             if (builder.runNpmInstall) {
-                commands.add(new TaskRunNpmInstall(classFinder, packageUpdater,
-                        builder.enablePnpm, builder.requireHomeNodeExec));
+                commands.add(new TaskRunNpmInstall(
+                        classFinder, packageUpdater,
+                        builder.enablePnpm, builder.requireHomeNodeExec,
+                        builder.nodeVersion, builder.nodeDownloadRoot));
             }
         }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -17,7 +17,9 @@ package com.vaadin.flow.server.frontend;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 
+import com.vaadin.flow.server.frontend.installer.NodeInstaller;
 import net.jcip.annotations.NotThreadSafe;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
@@ -84,7 +86,8 @@ public class TaskRunNpmInstallTest {
 
     protected TaskRunNpmInstall createTask() {
         return new TaskRunNpmInstall(getClassFinder(), nodeUpdater, false,
-                false);
+                false, FrontendTools.DEFAULT_NODE_VERSION,
+                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT));
     }
 
     @Test
@@ -228,11 +231,14 @@ public class TaskRunNpmInstallTest {
     public void runNpmInstall_vaadinHomeNodeIsAFolder_throws()
             throws IOException, ExecutionFailedException {
         assertRunNpmInstallThrows_vaadinHomeNodeIsAFolder(new TaskRunNpmInstall(
-                getClassFinder(), nodeUpdater, false, true));
+                getClassFinder(), nodeUpdater, false, true, FrontendTools.DEFAULT_NODE_VERSION, URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT)));
         exception.expectMessage(
                 "it's either not a file or not a 'node' executable.");
         assertRunNpmInstallThrows_vaadinHomeNodeIsAFolder(new TaskRunNpmInstall(
-                getClassFinder(), nodeUpdater, false, true));
+                getClassFinder(), nodeUpdater, false, true,
+                FrontendTools.DEFAULT_NODE_VERSION,
+                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT)
+                ));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -18,8 +18,12 @@ package com.vaadin.flow.server.frontend;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
+import javax.validation.constraints.AssertTrue;
+
+import com.vaadin.flow.server.frontend.installer.NodeInstaller;
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
@@ -366,11 +370,11 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
     public void runNpmInstall_vaadinHomeNodeIsAFolder_throws()
             throws IOException, ExecutionFailedException {
         assertRunNpmInstallThrows_vaadinHomeNodeIsAFolder(new TaskRunNpmInstall(
-                getClassFinder(), getNodeUpdater(), true, true));
+                getClassFinder(), getNodeUpdater(), true, true, FrontendTools.DEFAULT_NODE_VERSION, URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT)));
         exception.expectMessage(
                 "it's either not a file or not a 'node' executable.");
         assertRunNpmInstallThrows_vaadinHomeNodeIsAFolder(new TaskRunNpmInstall(
-                getClassFinder(), getNodeUpdater(), true, true));
+                getClassFinder(), getNodeUpdater(), true, true, FrontendTools.DEFAULT_NODE_VERSION, URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT)));
     }
 
     @Test
@@ -456,12 +460,14 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
     @Override
     protected TaskRunNpmInstall createTask() {
         return new TaskRunNpmInstall(getClassFinder(), getNodeUpdater(), true,
-                false);
+                false, FrontendTools.DEFAULT_NODE_VERSION,
+                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT));
     }
 
     protected TaskRunNpmInstall createTask(String versionsContent) {
         return new TaskRunNpmInstall(getClassFinder(), getNodeUpdater(), true,
-                false) {
+                false, FrontendTools.DEFAULT_NODE_VERSION,
+                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT)) {
             @Override
             protected String generateVersionsJson() {
                 try {
@@ -479,7 +485,8 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
 
     private TaskRunNpmInstall createTaskWithDevDepsLocked(String devDepsPath) {
         return new TaskRunNpmInstall(getClassFinder(), getNodeUpdater(), true,
-                false) {
+                false, FrontendTools.DEFAULT_NODE_VERSION,
+                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT)) {
             @Override
             protected String getDevDependenciesFilePath() {
                 return devDepsPath;


### PR DESCRIPTION
* Allow Vaadin plugins to configure node download URL and version

https://github.com/vaadin/flow/issues/8603 . Currently FrontendTools nor NodeTasks.Builder
doesn't allow you to override the node.js download URL. However, in firewalled corporate
environments the node.js may be served from an intranet server.

* #8603 initialize FrontendTools and TaskRunNpmInstall fields in ctor

* #8603 add test for FrontendTools.nodeVersion and nodeDownloadRoot

* #8603 fixed javadoc

Cherry-pick of https://github.com/vaadin/flow/pull/8611 into the 2.3 branch.