### PR TITLE
Fix hierarchy for HasHierarchicalDataProvider

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HasHierarchicalDataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HasHierarchicalDataProvider.java
@@ -15,20 +15,18 @@
  */
 package com.vaadin.flow.data.provider.hierarchy;
 
-import java.util.Arrays;
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.vaadin.flow.data.binder.HasDataProvider;
 import com.vaadin.flow.data.provider.DataProvider;
 import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.function.ValueProvider;
 
 /**
  * A generic interface for hierarchical listing components that use a data
- * provider for showing data.
+ * provider for showing hierarchical data.
  *
  * @author Vaadin Ltd
  *
@@ -36,7 +34,7 @@ import com.vaadin.flow.function.ValueProvider;
  *            the item data type
  * @since 1.2
  */
-public interface HasHierarchicalDataProvider<T> extends HasDataProvider<T> {
+public interface HasHierarchicalDataProvider<T> extends Serializable {
 
     public HierarchicalDataProvider<T, SerializablePredicate<T>> getDataProvider();
 
@@ -157,108 +155,27 @@ public interface HasHierarchicalDataProvider<T> extends HasDataProvider<T> {
     }
 
     /**
-     * Sets the data items of this component provided as a collection.
+     * Sets the data provider for this listing. The data provider is queried for
+     * displayed items as needed.
      * <p>
-     * The provided items are wrapped into a {@link TreeDataProvider} backed by
-     * a flat {@link TreeData} structure. The data provider instance is used as
-     * a parameter for the {@link #setDataProvider(DataProvider)} method. It
-     * means that the items collection can be accessed later on via
-     * {@link #getTreeData()}:
-     *
-     * <pre>
-     * <code>
-     * HasHierarchicalDataProvider&lt;String&gt; treeGrid = new TreeGrid&lt;&gt;();
-     * treeGrid.setItems(Arrays.asList("a","b"));
-     * ...
-     *
-     * TreeData&lt;String&gt; data = treeGrid.getTreeData();
-     * </code>
-     * </pre>
-     * <p>
-     * The returned {@link TreeData} instance may be used as-is to add, remove
-     * or modify items in the hierarchy. These modifications to the object are
-     * not automatically reflected back to the TreeGrid. Items modified should
-     * be refreshed with {@link HierarchicalDataProvider#refreshItem(Object)}
-     * and when adding or removing items
-     * {@link HierarchicalDataProvider#refreshAll()} should be called.
-     *
-     * @param items
-     *            the data items to display, not {@code null}
+     * <em>NOTE:</em> This method is here for backwards compatibility, but the
+     * implementation for it will most likely throw if the data provider is not
+     * a {@link HierarchicalDataProvider}.
+     * 
+     * @param dataProvider
+     *            the data provider, not null
+     * @deprecated Use {@link #setDataProvider(HierarchicalDataProvider)}
+     *             instead as the data should be hierarchical
      */
-    @Override
-    public default void setItems(Collection<T> items) {
-        Objects.requireNonNull(items, "Given collection may not be null");
-        setDataProvider(new TreeDataProvider<>(
-                new TreeData<T>().addItems(null, items)));
-    }
+    @Deprecated
+    void setDataProvider(DataProvider<T, ?> dataProvider);
 
     /**
-     * Sets the data items of this component provided as a stream.
-     * <p>
-     * The provided items are wrapped into a {@link TreeDataProvider} backed by
-     * a flat {@link TreeData} structure. The data provider instance is used as
-     * a parameter for the {@link #setDataProvider(DataProvider)} method. It
-     * means that the items collection can be accessed later on via
-     * {@link #getTreeData()}:
-     *
-     * <pre>
-     * <code>
-     * HasHierarchicalDataProvider&lt;String&gt; treeGrid = new TreeGrid&lt;&gt;();
-     * treeGrid.setItems(Stream.of("a","b"));
-     * ...
-     *
-     * TreeData&lt;String&gt; data = treeGrid.getTreeData();
-     * </code>
-     * </pre>
-     * <p>
-     * The returned {@link TreeData} instance may be used as-is to add, remove
-     * or modify items in the hierarchy. These modifications to the object are
-     * not automatically reflected back to the TreeGrid. Items modified should
-     * be refreshed with {@link HierarchicalDataProvider#refreshItem(Object)}
-     * and when adding or removing items
-     * {@link HierarchicalDataProvider#refreshAll()} should be called.
-     *
-     * @param items
-     *            the data items to display, not {@code null}
+     * Sets the hierarchical data provider for this listing. The data provider
+     * provides the items and the hierarchy as needed.
+     * 
+     * @param hierarchicalDataProvider
+     *            the hierarchical data provider to use, not {@code null}
      */
-    @Override
-    public default void setItems(Stream<T> items) {
-        Objects.requireNonNull(items, "Given stream may not be null");
-        setItems(items.collect(Collectors.toList()));
-    }
-
-    /**
-     * Sets the data items of this listing.
-     * <p>
-     * The provided items are wrapped into a {@link TreeDataProvider} backed by
-     * a flat {@link TreeData} structure. The data provider instance is used as
-     * a parameter for the {@link #setDataProvider(DataProvider)} method. It
-     * means that the items collection can be accessed later on via
-     * {@link #getTreeData()}:
-     *
-     * <pre>
-     * <code>
-     * TreeGrid&lt;String&gt; treeGrid = new TreeGrid&lt;&gt;();
-     * treeGrid.setItems("a","b");
-     * ...
-     *
-     * TreeData&lt;String&gt; data = treeGrid.getTreeData();
-     * </code>
-     * </pre>
-     * <p>
-     * The returned {@link TreeData} instance may be used as-is to add, remove
-     * or modify items in the hierarchy. These modifications to the object are
-     * not automatically reflected back to the TreeGrid. Items modified should
-     * be refreshed with {@link HierarchicalDataProvider#refreshItem(Object)}
-     * and when adding or removing items
-     * {@link HierarchicalDataProvider#refreshAll()} should be called.
-     *
-     * @param items
-     *            the data items to display, not {@code null}
-     */
-    @Override
-    public default void setItems(@SuppressWarnings("unchecked") T... items) {
-        Objects.requireNonNull(items, "Given items may not be null");
-        setItems(Arrays.asList(items));
-    }
+    void setDataProvider(HierarchicalDataProvider<T, ?> hierarchicalDataProvider);
 }

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HasHierarchicalDataProviderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HasHierarchicalDataProviderTest.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.data.provider.hierarchy;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.data.provider.CallbackDataProvider;
+import com.vaadin.flow.data.provider.DataProvider;
+import com.vaadin.flow.data.provider.DataView;
+import com.vaadin.flow.data.provider.HasDataView;
+import com.vaadin.flow.data.provider.IdentifierProvider;
+import com.vaadin.flow.data.provider.LazyDataView;
+import com.vaadin.flow.data.provider.ListDataView;
+import com.vaadin.flow.data.provider.SizeChangeEvent;
+import com.vaadin.flow.data.provider.SortDirection;
+import com.vaadin.flow.function.SerializableComparator;
+import com.vaadin.flow.function.SerializablePredicate;
+import com.vaadin.flow.function.ValueProvider;
+import com.vaadin.flow.shared.Registration;
+import org.junit.Test;
+
+public class HasHierarchicalDataProviderTest {
+
+    interface TestLazyDataView extends LazyDataView<String> {
+
+    }
+
+    interface TestListDataView extends ListDataView<String, TestListDataView> {
+
+    }
+
+    interface TestDataView extends DataView<String> {
+
+    }
+
+    // This is just to verify that the hierarchy is possible for tree grid
+    public static class TestHierarchicalComponent implements TestLazyDataView,
+            TestListDataView, HasHierarchicalDataProvider<String>,
+            HasDataView<String, TestDataView> {
+        @Override
+        public void setRowCountCallback(
+                CallbackDataProvider.CountCallback<String, Void> callback) {
+
+        }
+
+        @Override
+        public void setRowCountFromDataProvider() {
+
+        }
+
+        @Override
+        public void setRowCountEstimate(int rowCountEstimate) {
+
+        }
+
+        @Override
+        public int getRowCountEstimate() {
+            return 0;
+        }
+
+        @Override
+        public void setRowCountEstimateIncrease(int rowCountEstimateIncrease) {
+
+        }
+
+        @Override
+        public int getRowCountEstimateIncrease() {
+            return 0;
+        }
+
+        @Override
+        public void setRowCountUnknown() {
+
+        }
+
+        @Override
+        public Optional<String> getNextItem(String item) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> getPreviousItem(String item) {
+            return Optional.empty();
+        }
+
+        @Override
+        public TestListDataView addItem(String item) {
+            return null;
+        }
+
+        @Override
+        public TestListDataView addItemAfter(String item, String after) {
+            return null;
+        }
+
+        @Override
+        public TestListDataView addItemBefore(String item, String before) {
+            return null;
+        }
+
+        @Override
+        public TestListDataView updateItem(String item) {
+            return null;
+        }
+
+        @Override
+        public TestListDataView addItems(Collection<String> items) {
+            return null;
+        }
+
+        @Override
+        public TestListDataView addItemsAfter(Collection<String> items,
+                String after) {
+            return null;
+        }
+
+        @Override
+        public TestListDataView addItemsBefore(Collection<String> items,
+                String before) {
+            return null;
+        }
+
+        @Override
+        public TestListDataView removeItem(String item) {
+            return null;
+        }
+
+        @Override
+        public TestListDataView removeItems(Collection<String> items) {
+            return null;
+        }
+
+        @Override
+        public TestListDataView setFilter(
+                SerializablePredicate<String> filter) {
+            return null;
+        }
+
+        @Override
+        public TestListDataView addFilter(
+                SerializablePredicate<String> filter) {
+            return null;
+        }
+
+        @Override
+        public TestListDataView removeFilters() {
+            return null;
+        }
+
+        @Override
+        public TestListDataView setSortComparator(
+                SerializableComparator<String> sortComparator) {
+            return null;
+        }
+
+        @Override
+        public TestListDataView addSortComparator(
+                SerializableComparator<String> sortComparator) {
+            return null;
+        }
+
+        @Override
+        public TestListDataView removeSorting() {
+            return null;
+        }
+
+        @Override
+        public <V1 extends Comparable<? super V1>> TestListDataView setSortOrder(
+                ValueProvider<String, V1> valueProvider,
+                SortDirection sortDirection) {
+            return null;
+        }
+
+        @Override
+        public <V1 extends Comparable<? super V1>> TestListDataView addSortOrder(
+                ValueProvider<String, V1> valueProvider,
+                SortDirection sortDirection) {
+            return null;
+        }
+
+        @Override
+        public Stream<String> getItems() {
+            return null;
+        }
+
+        @Override
+        public int getSize() {
+            return 0;
+        }
+
+        @Override
+        public boolean contains(String item) {
+            return false;
+        }
+
+        @Override
+        public Registration addSizeChangeListener(
+                ComponentEventListener<SizeChangeEvent<?>> listener) {
+            return null;
+        }
+
+        @Override
+        public void setIdentifierProvider(
+                IdentifierProvider<String> identifierProvider) {
+
+        }
+
+        @Override
+        public HierarchicalDataProvider<String, SerializablePredicate<String>> getDataProvider() {
+            return null;
+        }
+
+        @Override
+        public void setDataProvider(DataProvider<String, ?> dataProvider) {
+
+        }
+
+        @Override
+        public void setDataProvider(
+                HierarchicalDataProvider<String, ?> hierarchicalDataProvider) {
+
+        }
+
+        @Override
+        public TestDataView setItems(DataProvider<String, ?> dataProvider) {
+            return null;
+        }
+
+        @Override
+        public TestDataView getDataView() {
+            return null;
+        }
+    }
+
+    @Test
+    public void testDataView_componentHierachyIsPossible() {
+        new TestHierarchicalComponent();
+    }
+
+}


### PR DESCRIPTION
HasHierarchicalDataProvider cannot extend HasDataProvider anymore.
Removes "flat data" API from HasHierarchicalDataProvider so it does not
cause compile errors for tree grid which extends grid and implements
HasHierarchicalDataProvider. This is a breaking change.

Grid part in https://github.com/vaadin/vaadin-grid-flow/pull/1057

Part of vaadin/vaadin-grid-flow#1027