### PR TITLE
Maven plugin: exposed the settings 'node.version' and 'node.download.…

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -17,6 +17,8 @@ package com.vaadin.flow.plugin.maven;
 
 import java.io.File;
 
+import com.vaadin.flow.server.frontend.FrontendTools;
+import com.vaadin.flow.server.frontend.installer.NodeInstaller;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -86,4 +88,23 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo {
     }
 
     abstract boolean isDefaultCompatibility();
+
+    /**
+     * The node.js version to be used when node.js is installed automatically by
+     * Vaadin, for example `"v12.16.0"`. Defaults to null which uses the
+     * Vaadin-default node version - see {@link FrontendTools} for details.
+     */
+    @Parameter(property = "node.version", defaultValue = FrontendTools.DEFAULT_NODE_VERSION)
+    protected String nodeVersion;
+
+    /**
+     * Download node.js from this URL. Handy in heavily firewalled corporate
+     * environments where the node.js download can be provided from an intranet
+     * mirror. Defaults to null which will cause the downloader to use
+     * {@link NodeInstaller#DEFAULT_NODEJS_DOWNLOAD_ROOT}.
+     * <p></p>
+     * Example: <code>"https://nodejs.org/dist/"</code>.
+     */
+    @Parameter(property = "node.download.root", defaultValue = NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT)
+    protected String nodeDownloadRoot;
 }

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
@@ -33,6 +33,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.server.frontend.FrontendTools;
+import com.vaadin.flow.server.frontend.installer.NodeInstaller;
 import org.apache.maven.model.Build;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -134,6 +136,10 @@ public class BuildFrontendMojoTest {
         ReflectionUtils.setVariableValueInObject(mojo, "compatibilityMode",
                 "false");
         ReflectionUtils.setVariableValueInObject(mojo, "optimizeBundle", true);
+        ReflectionUtils.setVariableValueInObject(mojo, "nodeVersion",
+                FrontendTools.DEFAULT_NODE_VERSION);
+        ReflectionUtils.setVariableValueInObject(mojo, "nodeDownloadRoot",
+                NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT);
 
         flowPackagPath.mkdirs();
         generatedFolder.mkdirs();

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
@@ -7,6 +7,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import com.vaadin.flow.server.frontend.FrontendTools;
+import com.vaadin.flow.server.frontend.installer.NodeInstaller;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.MavenProject;
@@ -90,6 +92,10 @@ public class PrepareFrontendMojoTest {
         ReflectionUtils.setVariableValueInObject(mojo, "pnpmEnable", true);
         ReflectionUtils.setVariableValueInObject(mojo, "requireHomeNodeExec",
                 true);
+        ReflectionUtils.setVariableValueInObject(mojo, "nodeVersion",
+                FrontendTools.DEFAULT_NODE_VERSION);
+        ReflectionUtils.setVariableValueInObject(mojo, "nodeDownloadRoot",
+                NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT);
 
         Assert.assertTrue(flowPackagePath.mkdirs());
         setProject(mojo, projectBase);


### PR DESCRIPTION
…… (#8659)

* Maven plugin: exposed the settings 'node.version' and 'node.download.root'

* Use new URI() instead of URI.create(), to validate user input

* Fixed NPE in BuildFrontendMojoTest

* Refactoring: mojo initialization refactored to Maven convention