### PR TITLE
Fix exact item count resolving if scrolled far

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataView.java
@@ -62,7 +62,7 @@ public abstract class AbstractDataView<T> implements DataView<T> {
     @Override
     public Registration addItemCountChangeListener(
             ComponentEventListener<ItemCountChangeEvent<?>> listener) {
-        Objects.requireNonNull(listener, "SizeChangeListener cannot be null");
+        Objects.requireNonNull(listener, "ItemCountChangeListener cannot be null");
         return ComponentUtil.addListener(component, ItemCountChangeEvent.class,
                 (ComponentEventListener) listener);
     }

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -110,7 +110,7 @@ public class DataCommunicator<T> implements Serializable {
     private int itemCountEstimate = -1;
     private int itemCountEstimateIncrease = -1;
     private boolean definedSize = true;
-    private boolean skipSizeCheckUntilReset;
+    private boolean skipCountIncreaseUntilReset;
     private boolean sizeReset;
     private int pageSize;
 
@@ -183,7 +183,7 @@ public class DataCommunicator<T> implements Serializable {
      * It effectively resends all available data.
      */
     public void reset() {
-        skipSizeCheckUntilReset = false;
+        skipCountIncreaseUntilReset = false;
         sizeReset = true;
         resendEntireRange = true;
         dataGenerator.destroyAllData();
@@ -429,7 +429,7 @@ public class DataCommunicator<T> implements Serializable {
         }
         this.countCallback = countCallback;
         definedSize = true;
-        skipSizeCheckUntilReset = false;
+        skipCountIncreaseUntilReset = false;
         // there is no reset but we need to get the defined size
         sizeReset = true;
         requestFlush();
@@ -457,7 +457,7 @@ public class DataCommunicator<T> implements Serializable {
         this.itemCountEstimate = itemCountEstimate;
         this.countCallback = null;
         definedSize = false;
-        if (!skipSizeCheckUntilReset
+        if (!skipCountIncreaseUntilReset
                 && requestedRange.getEnd() < itemCountEstimate) {
             sizeReset = true;
             requestFlush();
@@ -477,8 +477,8 @@ public class DataCommunicator<T> implements Serializable {
     }
 
     /**
-     * Sets the item count estimate increase to use and switches the component to
-     * undefined size if not yet used. Any previously set count callback is
+     * Sets the item count estimate increase to use and switches the component
+     * to undefined size if not yet used. Any previously set count callback is
      * cleared. The step is used the next time that the count is adjusted.
      * <em>NOTE:</em> the increase should be greater than the
      * {@link #setPageSize(int)} or it may cause bad performance.
@@ -517,8 +517,8 @@ public class DataCommunicator<T> implements Serializable {
      * count callback. Calling with value {@code true} will use the
      * {@link DataProvider#size(Query)} for getting the size. Calling with
      * {@code false} will use whatever has been set with
-     * {@link #setItemCountEstimate(int)} and increase the count when needed with
-     * {@link #setItemCountEstimateIncrease(int)}.
+     * {@link #setItemCountEstimate(int)} and increase the count when needed
+     * with {@link #setItemCountEstimateIncrease(int)}.
      * 
      * @param definedSize
      *            {@code true} for defined size, {@code false} for undefined
@@ -528,7 +528,7 @@ public class DataCommunicator<T> implements Serializable {
         if (this.definedSize != definedSize) {
             this.definedSize = definedSize;
             countCallback = null;
-            skipSizeCheckUntilReset = false;
+            skipCountIncreaseUntilReset = false;
             if (definedSize) {
                 // Always fetch explicit count from data provider
                 requestFlush();
@@ -734,7 +734,11 @@ public class DataCommunicator<T> implements Serializable {
     }
 
     private void requestFlush() {
-        if (flushRequest == null) {
+        requestFlush(false);
+    }
+
+    private void requestFlush(boolean forced) {
+        if (flushRequest == null || forced) {
             flushRequest = context -> {
                 if (!context.isClientSideInitialized()) {
                     reset();
@@ -771,7 +775,8 @@ public class DataCommunicator<T> implements Serializable {
         // With defined size the backend is only queried when necessary
         if (definedSize && (resendEntireRange || sizeReset)) {
             assumedSize = getDataProviderSize();
-        } else if (!definedSize && (!skipSizeCheckUntilReset || sizeReset)) {
+        } else if (!definedSize
+                && (!skipCountIncreaseUntilReset || sizeReset)) {
             // with undefined size, size estimate is checked when scrolling down
             updateUndefinedSize();
         }
@@ -792,7 +797,20 @@ public class DataCommunicator<T> implements Serializable {
                 // the end has been reached
                 assumedSize = requestedRange.getStart()
                         + activation.getActiveKeys().size();
-                skipSizeCheckUntilReset = true;
+                skipCountIncreaseUntilReset = true;
+                /*
+                 * If the fetch query returned 0 items, it means that the user
+                 * has scrolled past the end of the exact item count. Instead of
+                 * returning 0 items to the client and letting it incrementally
+                 * request for the previous pages, we'll cancel this flush and
+                 * tweak the requested range and flush again.
+                 */
+                if (assumedSize != 0 && activation.getActiveKeys().size() == 0) {
+                    int delta = requestedRange.length();
+                    requestedRange = requestedRange.offsetBy(-delta);
+                    requestFlush(true); // to avoid recursiveness
+                    return;
+                }
             }
             effectiveRequested = requestedRange
                     .restrictTo(Range.withLength(0, assumedSize));
@@ -832,7 +850,9 @@ public class DataCommunicator<T> implements Serializable {
                     .getComponent();
             if (component.isPresent()) {
                 ComponentUtil.fireEvent(component.get(),
-                        new ItemCountChangeEvent<>(component.get(), itemCount));
+                        new ItemCountChangeEvent<>(component.get(), itemCount,
+                                !(isDefinedSize()
+                                        || skipCountIncreaseUntilReset)));
             }
             lastSent = itemCount;
         }

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -805,7 +805,7 @@ public class DataCommunicator<T> implements Serializable {
                  * request for the previous pages, we'll cancel this flush and
                  * tweak the requested range and flush again.
                  */
-                if (assumedSize != 0 && activation.getActiveKeys().size() == 0) {
+                if (assumedSize != 0 && activation.getActiveKeys().isEmpty()) {
                     int delta = requestedRange.length();
                     requestedRange = requestedRange.offsetBy(-delta);
                     requestFlush(true); // to avoid recursiveness

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataView.java
@@ -74,12 +74,19 @@ public interface DataView<T> extends Serializable {
     void refreshItem(T item);
 
     /**
-     * Add an item count change listener that is fired when the item
-     * count changes. This can happen for instance when filtering the data set.
+     * Add an item count change listener that is fired when the item count
+     * changes. This can happen for instance when filtering the items.
      * <p>
-     * Item count change listener is bound to the component and will be
-     * retained even if the data changes by setting of a new items or
+     * Item count change listener is bound to the component and will be retained
+     * even if the data changes by setting of a new items or
      * {@link DataProvider} to component.
+     * <p>
+     * <em>NOTE:</em> when the component supports lazy loading (implements
+     * {@link HasLazyDataView}) and a count callback has not been provided, an
+     * estimate of the item count is used and increased until the actual count
+     * has been reached. When the estimate is used, the event is fired with the
+     * {@link ItemCountChangeEvent#isItemCountEstimated()} returning
+     * {@code true}.
      *
      * @param listener
      *            item count change listener to register

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/ItemCountChangeEvent.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/ItemCountChangeEvent.java
@@ -19,12 +19,12 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 
 /**
- * Event describing the item count change for a component.
- * The {@link ItemCountChangeEvent} will fired during the "before client
+ * Event describing the item count change for a component. The
+ * {@link ItemCountChangeEvent} will fired during the "before client
  * response"-phase, so changes done during the server round trip will only
- * receive one event.
- * For example, this code will trigger only one event, although there are
- * two methods called which cause the item count change:
+ * receive one event. For example, this code will trigger only one event,
+ * although there are two methods called which cause the item count change:
+ * 
  * <pre>
  * {@code
  * dataView.addItemCountChangeListener(listener);
@@ -33,30 +33,52 @@ import com.vaadin.flow.component.ComponentEvent;
  * }
  * </pre>
  *
- * @param <T> the event source type
+ * @param <T>
+ *            the event source type
  * @since
  */
-public class ItemCountChangeEvent<T extends Component> extends ComponentEvent<T> {
-    private int itemCount;
+public class ItemCountChangeEvent<T extends Component>
+        extends ComponentEvent<T> {
+    private final int itemCount;
+    private final boolean itemCountEstimated;
 
     /**
      * Creates a new event using the given source and indicator whether the
      * event originated from the client side or the server side.
      *
-     * @param source    the source component
-     * @param itemCount new items count
+     * @param source
+     *            the source component
+     * @param itemCount
+     *            new items count
      */
-    public ItemCountChangeEvent(T source, int itemCount) {
+    public ItemCountChangeEvent(T source, int itemCount, boolean itemCountEstimated) {
         super(source, false);
         this.itemCount = itemCount;
+        this.itemCountEstimated = itemCountEstimated;
     }
 
     /**
-     * Get the new items count for the component data.
+     * Get the new item count for the component.
      *
      * @return items count
      */
     public int getItemCount() {
         return itemCount;
+    }
+
+    /**
+     * Returns whether the item count {@link #getItemCount()} is an estimate or
+     * the exact count. An estimate is used when items are fetched lazily from
+     * the backend and the count callback has not been provided. See further
+     * details from {@link LazyDataView#setItemCountEstimate(int)}.
+     * <p>
+     * <em>NOTE:</em> this only applies for components that do lazy loading from
+     * the backend and implement {@link HasLazyDataView}.
+     * 
+     * @return {@code true} when the count is an estimate, {@code false} when
+     *         the count is exact
+     */
+    public boolean isItemCountEstimated() {
+        return itemCountEstimated;
     }
 }

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/ItemCountChangeEvent.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/ItemCountChangeEvent.java
@@ -50,6 +50,8 @@ public class ItemCountChangeEvent<T extends Component>
      *            the source component
      * @param itemCount
      *            new items count
+     * @param itemCountEstimated
+     *            whether item count is an estimate
      */
     public ItemCountChangeEvent(T source, int itemCount, boolean itemCountEstimated) {
         super(source, false);

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractComponentDataViewTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractComponentDataViewTest.java
@@ -84,7 +84,7 @@ public abstract class AbstractComponentDataViewTest {
                 event -> fired.compareAndSet(0, event.getItemCount()));
 
         ComponentUtil.fireEvent((Component) component,
-                new ItemCountChangeEvent<>((Component) component, 10));
+                new ItemCountChangeEvent<>((Component) component, 10, false));
 
         Assert.assertEquals(10, fired.get());
     }

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractDataViewTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractDataViewTest.java
@@ -83,7 +83,7 @@ public class AbstractDataViewTest {
                 event -> fired.compareAndSet(0, event.getItemCount()));
 
         ComponentUtil
-                .fireEvent(component, new ItemCountChangeEvent<>(component, 10));
+                .fireEvent(component, new ItemCountChangeEvent<>(component, 10, false));
 
         Assert.assertEquals(10, fired.get());
     }

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractListDataViewListenerTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractListDataViewListenerTest.java
@@ -111,6 +111,7 @@ public abstract class AbstractListDataViewListenerTest {
         dataView.addItemCountChangeListener(event -> {
             Assert.assertEquals("Unexpected item count", 1,
                     event.getItemCount());
+            Assert.assertFalse(event.isItemCountEstimated());
             invocationChecker.set(true);
         });
 


### PR DESCRIPTION
Adds isCountEstimated() to ItemCountChangeEvent.

If item count estimate allows the user to scroll way past the exact count,
DataCommunicator will now resolve the exact count immediately instead of
returning 0 items and new size to the client, which would have to keep
requesting items until the end was reached.

Fixes #8643