### PR TITLE
Update ProxyConfig.java

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/ProxyConfig.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/ProxyConfig.java
@@ -114,7 +114,7 @@ public class ProxyConfig {
      */
     public static class Proxy implements Serializable {
         private static final Pattern PROXY_URL_REGEX = Pattern
-                .compile("(\\w+)://(([^:]+):(.*)@)?([^:]+)(:(\\d*))?");
+                .compile("(\\w+)://(([^:]+):(.*)@)?([^:]+)(:(\\d*))?(/)?");
 
         /**
          * Id of proxy.


### PR DESCRIPTION
npmrc proxy values often have / at the end (used in examples etc). For this reason we should also allow it on this regex.

Also proxies might end up being read from system level properties, it's not so easy for the team to modify these values just to allow Vaadin to work.