### PR TITLE
Fix priority order of npmrc files

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -405,9 +405,9 @@ public class FrontendTools {
 
         proxyList.addAll(readProxySettingsFromSystemProperties());
         proxyList.addAll(
-                readProxySettingsFromNpmrcFile("project .npmrc", projectNpmrc));
-        proxyList.addAll(
                 readProxySettingsFromNpmrcFile("user .npmrc", userNpmrc));
+        proxyList.addAll(
+                readProxySettingsFromNpmrcFile("project .npmrc", projectNpmrc));
         proxyList.addAll(readProxySettingsFromEnvironmentVariables());
 
         return proxyList;


### PR DESCRIPTION
I assume the order of things on this method define the priority. As Proxy and ProxyConfig doesn't have any priority logic.

If/when that's the case the order is wrong. Project file should have higher priority than User file.

https://docs.npmjs.com/configuring-npm/npmrc.html