### PR TITLE
Store scroll position in state when entering route not found view (#8698)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -243,17 +243,15 @@ public abstract class AbstractNavigationStateRenderer
     }
 
     private void pushHistoryStateIfNeeded(NavigationEvent event, UI ui) {
-        boolean isRouterLink = NavigationTrigger.ROUTER_LINK
-                .equals(event.getTrigger());
-
         if (event instanceof ErrorNavigationEvent) {
-            // Push history in case the exception was due to route not
-            // found (#8544)
-            if (isRouterLinkNotFoundNavigationError(
-                    (ErrorNavigationEvent) event)) {
-                pushHistoryState(event);
-            }
-        } else if (isRouterLink) {
+            ErrorNavigationEvent errorEvent = (ErrorNavigationEvent) event;
+            if (isRouterLinkNotFoundNavigationError(errorEvent)) {
+                // #8544
+                event.getState().ifPresent(s -> ui.getPage().executeJs(
+                        "this.scrollPositionHandlerAfterServerNavigation($0);",
+                        s));
+            } 
+        } else if (NavigationTrigger.ROUTER_LINK.equals(event.getTrigger())) {
             /*
              * When the event trigger is a RouterLink, pushing history state
              * should be done in client-side. See
@@ -262,7 +260,6 @@ public abstract class AbstractNavigationStateRenderer
             JsonValue state = event.getState()
                     .orElseThrow(() -> new IllegalStateException(
                             "When the navigation trigger is ROUTER_LINK, event state should not be null."));
-
             ui.getPage().executeJs(
                     "this.scrollPositionHandlerAfterServerNavigation($0);",
                     state);

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/BrokenRouterLinkView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/BrokenRouterLinkView.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.uitest.ui;
 
+import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouterLink;
 
@@ -26,6 +27,10 @@ public class BrokenRouterLinkView extends AbstractDivView {
     public BrokenRouterLinkView() {
         final RouterLink routerLink = new RouterLink("Broken",
                 BrokenRouterLinkView.class);
+        Div spacer = new Div();
+        spacer.setHeight("5000px");
+        add(spacer);
+
         routerLink.getElement().setAttribute("href", "somewhere_non_existent");
         routerLink.setId(LINK_ID);
         add(routerLink);

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/BrokenRouterLinkIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/BrokenRouterLinkIT.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.uitest.ui;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -27,6 +28,9 @@ public class BrokenRouterLinkIT extends ChromeBrowserTest {
     // https://github.com/vaadin/flow/issues/8544
     @Test
     public void testRouterLink_linkIsBroken_urlIsUpdated() {
+        // enable after https://github.com/vaadin/vaadin-router/issues/43 is fixed
+        Assume.assumeFalse(isClientRouter());
+
         open();
 
         WebElement link = findElement(By.id(BrokenRouterLinkView.LINK_ID));
@@ -41,6 +45,9 @@ public class BrokenRouterLinkIT extends ChromeBrowserTest {
     // https://github.com/vaadin/flow/issues/8693
     @Test
     public void testRouterLink_visitBrokenLinkAndBack_scrollPositionIsRetained() {
+        // enable after https://github.com/vaadin/vaadin-router/issues/43 is fixed
+        Assume.assumeFalse(isClientRouter());
+
         open();
 
         executeScript("window.scrollTo(0,100)");

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/BrokenRouterLinkIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/BrokenRouterLinkIT.java
@@ -22,9 +22,9 @@ import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
-// https://github.com/vaadin/flow/issues/8544
 public class BrokenRouterLinkIT extends ChromeBrowserTest {
 
+    // https://github.com/vaadin/flow/issues/8544
     @Test
     public void testRouterLink_linkIsBroken_urlIsUpdated() {
         open();
@@ -36,6 +36,24 @@ public class BrokenRouterLinkIT extends ChromeBrowserTest {
         link.click();
 
         Assert.assertTrue(getDriver().getCurrentUrl().endsWith(href));
+    }
 
+    // https://github.com/vaadin/flow/issues/8693
+    @Test
+    public void testRouterLink_visitBrokenLinkAndBack_scrollPositionIsRetained() {
+        open();
+
+        executeScript("window.scrollTo(0,100)");
+
+        WebElement link = findElement(By.id(BrokenRouterLinkView.LINK_ID));
+        link.click();
+
+        long y0 = (Long) executeScript("return window.scrollY");
+        Assert.assertEquals(0L, y0);
+
+        getDriver().navigate().back();
+
+        long y1 = (Long) executeScript("return window.scrollY");
+        Assert.assertEquals(100L, y1);
     }
 }


### PR DESCRIPTION
Closes #8693. Disabled ITs as scroll position handling requires a [separate fix](https://github.com/vaadin/vaadin-router/issues/43) for client-side router.