### PR TITLE
Fix for #8669 - add getLocationChangeEvent() to AfterNavigationEvent

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/AfterNavigationEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/AfterNavigationEvent.java
@@ -52,6 +52,15 @@ public class AfterNavigationEvent extends EventObject {
     }
 
     /**
+     * Get the {@link LocationChangeEvent}.
+     *
+     * @return the {@link LocationChangeEvent}, not {@code null}
+     */
+    public LocationChangeEvent getLocationChangeEvent() {
+        return event;
+    }
+
+    /**
      * Get the active chain that we have after navigation.
      *
      * @return unmodifiable list of active view chain


### PR DESCRIPTION
This fixes #8669 by adding a method to retrieve the `LocationChangeEvent` from an `AfterNavigationEvent`.