### PR TITLE
Add LocalTime type support in Endpoints

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/SchemaResolver.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/SchemaResolver.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.server.connect.generator;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -141,7 +142,7 @@ class SchemaResolver {
 
     private boolean isDateTimeType(ResolvedType resolvedType) {
         return resolvedType.isReferenceType()
-                && isTypeOf(resolvedType, LocalDateTime.class, Instant.class);
+                && isTypeOf(resolvedType, LocalDateTime.class, Instant.class, LocalTime.class);
     }
 
     private boolean isDateType(ResolvedType resolvedType) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/ExplicitNullableTypeCheckerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/ExplicitNullableTypeCheckerTest.java
@@ -19,6 +19,7 @@ package com.vaadin.flow.server.connect;
 import javax.annotation.Nullable;
 import java.lang.reflect.Type;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -132,6 +133,22 @@ public class ExplicitNullableTypeCheckerTest {
         Assert.assertNotNull(error);
         Assert.assertTrue(error.contains("null"));
         Assert.assertTrue(error.contains("LocalDateTime"));
+    }
+
+    @Test
+    public void should_ReturnNull_When_GivenNonNullValue_ForLocalTimeType() {
+        Assert.assertNull(explicitNullableTypeChecker
+                .checkValueForType(LocalTime.now(), LocalTime.class));
+    }
+
+    @Test
+    public void should_ReturnError_When_GivenNullValue_ForLcalTimeType() {
+        String error = explicitNullableTypeChecker.checkValueForType(null,
+                LocalTime.class);
+
+        Assert.assertNotNull(error);
+        Assert.assertTrue(error.contains("null"));
+        Assert.assertTrue(error.contains("LocalTime"));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/endpoints/AbstractEndpointGenerationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/endpoints/AbstractEndpointGenerationTest.java
@@ -33,6 +33,7 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -332,7 +333,8 @@ public abstract class AbstractEndpointGenerationTest extends AbstractEndpointGen
             } else if (actualSchema instanceof DateTimeSchema) {
                 assertTrue(Instant.class.isAssignableFrom(expectedSchemaClass)
                         || LocalDateTime.class
-                                .isAssignableFrom(expectedSchemaClass));
+                                .isAssignableFrom(expectedSchemaClass)
+                        || LocalTime.class.isAssignableFrom(expectedSchemaClass));
             } else if (actualSchema instanceof DateSchema) {
                 assertTrue(Date.class.isAssignableFrom(expectedSchemaClass)
                         || LocalDate.class

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/endpoints/datetime/DateTimeEndpoint.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/endpoints/datetime/DateTimeEndpoint.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.server.connect.generator.endpoints.datetime;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +41,10 @@ public class DateTimeEndpoint {
 
     public LocalDateTime echoLocalDateTime(LocalDateTime localDateTime) {
         return localDateTime;
+    }
+
+    public LocalTime echoLocalTime(LocalTime localTime) {
+        return localTime;
     }
 
     public List<LocalDateTime> echoListLocalDateTime(

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/tsmodel/TsFormEndpoint.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/tsmodel/TsFormEndpoint.java
@@ -94,6 +94,7 @@ public class TsFormEndpoint {
         @Digits(integer=5, fraction = 2) String digits;
         @Past LocalDate past;
         @Future LocalDate future;
+        LocalTime localTime;
         @Pattern(regexp = "\\d+\\..+") String pattern;
         List<MyEntity> children;
         String[] stringArray;

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/DateTimeConversionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/DateTimeConversionTest.java
@@ -71,6 +71,26 @@ public class DateTimeConversionTest extends BaseTypeConversionTest {
     }
     // endregion
 
+    // region LocalTime tests
+    // LocalTime uses java.time.format.DateTimeFormatter.ISO_LOCAL_DATE as
+    // default
+    // format
+
+    @Test
+    public void should_ConvertToLocalTime_When_ReceiveALocalTime() {
+        String inputTime = "\"12:12:12\"";
+        String expectedTimestamp = "\"13:12:12\"";
+        assertEqualExpectedValueWhenCallingMethod("addOneHourLocalTime",
+        inputTime, expectedTimestamp);
+    }
+
+    @Test
+    public void should_FailToConvertToLocalTime_When_ReceiveWrongFormat() {
+        String inputTime = "\"12+12+12\"";
+        assert400ResponseWhenCallingMethod("addOneHourLocalTime", inputTime);
+    }
+    // endregion
+
     // region LocalDateTime tests
     // LocalDate uses java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME as
     // default format

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/VaadinConnectTypeConversionEndpoints.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/typeconversion/VaadinConnectTypeConversionEndpoints.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.server.connect.typeconversion;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collection;
@@ -114,6 +115,10 @@ public class VaadinConnectTypeConversionEndpoints {
 
     public LocalDate addOneDayLocalDate(LocalDate value) {
         return value.plus(1, ChronoUnit.DAYS);
+    }
+
+    public LocalTime addOneHourLocalTime(LocalTime value) {
+        return value.plus(1, ChronoUnit.HOURS);
     }
 
     public LocalDateTime addOneDayOneHourLocalDateTime(LocalDateTime value) {

--- a/flow-server/src/test/resources/com/vaadin/flow/server/connect/generator/endpoints/datetime/expected-DateTimeEndpoint.ts
+++ b/flow-server/src/test/resources/com/vaadin/flow/server/connect/generator/endpoints/datetime/expected-DateTimeEndpoint.ts
@@ -35,6 +35,13 @@ function _echoLocalDate(
 }
 export {_echoLocalDate as echoLocalDate};
 
+function _echoLocalTime(
+  localTime: string
+): Promise<string> {
+  return client.call('DateTimeEndpoint', 'echoLocalTime', {localTime});
+}
+export {_echoLocalTime as echoLocalTime};
+
 function _echoLocalDateTime(
   localDateTime: string
 ): Promise<string> {

--- a/flow-server/src/test/resources/com/vaadin/flow/server/connect/generator/endpoints/datetime/expected-DateTimeEndpoint.ts
+++ b/flow-server/src/test/resources/com/vaadin/flow/server/connect/generator/endpoints/datetime/expected-DateTimeEndpoint.ts
@@ -35,19 +35,19 @@ function _echoLocalDate(
 }
 export {_echoLocalDate as echoLocalDate};
 
-function _echoLocalTime(
-  localTime: string
-): Promise<string> {
-  return client.call('DateTimeEndpoint', 'echoLocalTime', {localTime});
-}
-export {_echoLocalTime as echoLocalTime};
-
 function _echoLocalDateTime(
   localDateTime: string
 ): Promise<string> {
   return client.call('DateTimeEndpoint', 'echoLocalDateTime', {localDateTime});
 }
 export {_echoLocalDateTime as echoLocalDateTime};
+
+function _echoLocalTime(
+  localTime: string
+): Promise<string> {
+  return client.call('DateTimeEndpoint', 'echoLocalTime', {localTime});
+}
+export {_echoLocalTime as echoLocalTime};
 
 function _echoMapInstant(
   mapInstant: { [key: string]: string; }

--- a/flow-server/src/test/resources/com/vaadin/flow/server/connect/generator/tsmodel/expected-TsFormEndpoint.ts
+++ b/flow-server/src/test/resources/com/vaadin/flow/server/connect/generator/tsmodel/expected-TsFormEndpoint.ts
@@ -79,6 +79,10 @@ export default class MyEntityModel<T extends MyEntity = MyEntity> extends MyEnti
     return this[getPropertyModelSymbol]('list', ArrayModel, [false, StringModel, [false], new NotEmpty()]);
   }
 
+  get localTime(): StringModel {
+    return this[getPropertyModelSymbol]('localTime', StringModel, [false]);
+  }
+
   get max(): NumberModel {
     return this[getPropertyModelSymbol]('max', NumberModel, [false, new Max(2)]);
   }


### PR DESCRIPTION
LocalTime was an unkown type to Endpoint, which was translated to object type in TypeScript. This causes an issue when using `<vaadin-time-picker>` in a TypeScript form, as the value of `<vaadin-time-picker>` is a string. 