### PR TITLE
fix: BinderNode errors property

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/form/Field.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/form/Field.ts
@@ -150,7 +150,7 @@ export const field = directive(<T>(
     fieldState.strategy.required = fieldState.required = required;
   }
 
-  const firstError = binderNode.ownErrors[0];
+  const firstError = binderNode.ownErrors ? binderNode.ownErrors[0] : undefined;
   const errorMessage = firstError && firstError.message || '';
   if (errorMessage !== fieldState.errorMessage) {
     fieldState.strategy.errorMessage = fieldState.errorMessage = errorMessage;

--- a/flow-client/src/test/frontend/form/ValidationTests.ts
+++ b/flow-client/src/test/frontend/form/ValidationTests.ts
@@ -541,6 +541,25 @@ suite("form/Validation", () => {
       await orderView.updateComplete;
       expect(orderView.submitting.textContent).to.equal('false');
     });
+
+    // https://github.com/vaadin/flow/issues/8688
+    test("should update binder properties after submit when a field changes value", async () => {
+      try {
+        await orderView.binder.submitTo(async (item) => item);
+        expect.fail();
+      } catch (error) {
+      }
+      const errorsOnSubmit = binder.errors.length;
+
+      orderView.notes.value = 'foo';
+      await fireEvent(orderView.notes, 'change');
+      
+      const numberOfValidatorsOnNotesField = binder.for(binder.model.notes).validators.length;
+
+      if(errorsOnSubmit>=1){
+        assert.equal(errorsOnSubmit-numberOfValidatorsOnNotesField, binder.errors.length);
+      }
+    });
   });
 
 });


### PR DESCRIPTION
Fixes https://github.com/vaadin/flow/issues/8688

Make The errors property of BinderNode return it's own validation errors + validation errors from its descendants. 