### PR TITLE
fix: consider import when checking has annotation

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/GeneratorUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/GeneratorUtils.java
@@ -104,13 +104,12 @@ final class GeneratorUtils {
         return endsWith(s, p) ? s.substring(0, s.lastIndexOf(p)) : s;
     }
 
-    @SuppressWarnings("squid:S1872")
     static boolean hasAnnotation(NodeWithAnnotations<?> declaration, CompilationUnit compilationUnit,
             Class<? extends Annotation> annotation) {
         Optional<AnnotationExpr> endpointAnnotation = declaration.getAnnotationByClass(annotation);
         if (endpointAnnotation.isPresent()) {
             return compilationUnit.getImports().stream()
-                    .anyMatch(importDeclaration -> annotation.getName().equals(importDeclaration.getNameAsString()));
+                    .anyMatch(importDeclaration -> annotation.getName().equals(importDeclaration.getNameAsString())); // NOSONAR
         }
         return false;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/GeneratorUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/GeneratorUtils.java
@@ -104,6 +104,7 @@ final class GeneratorUtils {
         return endsWith(s, p) ? s.substring(0, s.lastIndexOf(p)) : s;
     }
 
+    @SuppressWarnings("squid:S1872")
     static boolean hasAnnotation(NodeWithAnnotations<?> declaration, CompilationUnit compilationUnit,
             Class<? extends Annotation> annotation) {
         Optional<AnnotationExpr> endpointAnnotation = declaration.getAnnotationByClass(annotation);

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/GeneratorUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/GeneratorUtils.java
@@ -15,7 +15,13 @@
  */
 package com.vaadin.flow.server.connect.generator;
 
+import java.lang.annotation.Annotation;
 import java.util.Arrays;
+import java.util.Optional;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.AnnotationExpr;
+import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 
 /**
  * A set of static methods used in CCDM generators, so as flow do not depend on
@@ -98,4 +104,13 @@ final class GeneratorUtils {
         return endsWith(s, p) ? s.substring(0, s.lastIndexOf(p)) : s;
     }
 
+    static boolean hasAnnotation(NodeWithAnnotations<?> declaration, CompilationUnit compilationUnit,
+            Class<? extends Annotation> annotation) {
+        Optional<AnnotationExpr> endpointAnnotation = declaration.getAnnotationByClass(annotation);
+        if (endpointAnnotation.isPresent()) {
+            return compilationUnit.getImports().stream()
+                    .anyMatch(importDeclaration -> annotation.getName().equals(importDeclaration.getNameAsString()));
+        }
+        return false;
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/OpenApiObjectGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/OpenApiObjectGenerator.java
@@ -336,7 +336,7 @@ public class OpenApiObjectGenerator {
                     .orElse(classDeclaration.getNameAsString());
             qualifiedNameToPath.put(className, storage.getPath().toString());
         });
-        if (!endpointAnnotation.isPresent()) {
+        if (!GeneratorUtils.hasAnnotation(classDeclaration, compilationUnit, Endpoint.class)) {
             nonEndpointMap.put(classDeclaration.resolve().getQualifiedName(),
                     classDeclaration);
         } else {

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/OpenApiObjectGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/OpenApiObjectGenerator.java
@@ -348,7 +348,7 @@ public class OpenApiObjectGenerator {
                 endpointsJavadoc.put(classDeclaration, "");
             }
             pathItems.putAll(createPathItems(
-                    getEndpointName(classDeclaration, endpointAnnotation.get()),
+                    getEndpointName(classDeclaration, endpointAnnotation.orElse(null)),
                     classDeclaration));
         }
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/GeneratorUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/GeneratorUtilsTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.connect.generator;
+
+import java.util.Optional;
+
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.ImportDeclaration;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.expr.AnnotationExpr;
+import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
+import com.vaadin.flow.server.connect.Endpoint;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class GeneratorUtilsTest {
+
+    @Test
+    public void should_Not_BeConsideredAsHavingAnAnnotation_When_GivenClassDoesNotHaveAnnotationDeclarationNorImport() {
+        NodeWithAnnotations<?> declarationWithoutEndpointAnnotation = Mockito.mock(NodeWithAnnotations.class);
+        CompilationUnit compilationUnitWithoutEndpointImport = Mockito.mock(CompilationUnit.class);
+
+        Mockito.doReturn(Optional.empty()).when(declarationWithoutEndpointAnnotation)
+                .getAnnotationByClass(Endpoint.class);
+        Mockito.doReturn(new NodeList<>()).when(compilationUnitWithoutEndpointImport).getImports();
+
+        Assert.assertFalse("A class without Endpoint annotation nor import should not be considered as an Endpoint",
+                GeneratorUtils.hasAnnotation(declarationWithoutEndpointAnnotation, compilationUnitWithoutEndpointImport,
+                        Endpoint.class));
+    }
+
+    @Test
+    public void should_Not_BeConsideredAsHavingAnAnnotation_When_GivenClassHavsAnnotationDeclarationButWithDifferentImport() {
+        NodeWithAnnotations<?> declarationWithEndpointAnnotation = Mockito.mock(NodeWithAnnotations.class);
+        CompilationUnit compilationUnitWithNonVaadinEndpointImport = Mockito.mock(CompilationUnit.class);
+
+        AnnotationExpr endpointAnnotation = Mockito.mock(AnnotationExpr.class);
+        Mockito.doReturn(Optional.of(endpointAnnotation)).when(declarationWithEndpointAnnotation)
+                .getAnnotationByClass(Endpoint.class);
+
+        NodeList<ImportDeclaration> imports = new NodeList<>();
+        ImportDeclaration importDeclaration = Mockito.mock(ImportDeclaration.class);
+        Mockito.doReturn("some.non.vaadin.Endpoint").when(importDeclaration).getNameAsString();
+        imports.add(importDeclaration);
+        Mockito.doReturn(imports).when(compilationUnitWithNonVaadinEndpointImport).getImports();
+
+        Assert.assertFalse("A class with a non Vaadin Endpoint should not be considered as an Endpoint",
+                GeneratorUtils.hasAnnotation(declarationWithEndpointAnnotation,
+                        compilationUnitWithNonVaadinEndpointImport, Endpoint.class));
+    }
+
+    @Test
+    public void should_BeConsideredAsHavingAnAnnotation_When_GivenClassHavsAnnotationDeclarationAndTheImport() {
+        NodeWithAnnotations<?> declarationWithEndpointAnnotation = Mockito.mock(NodeWithAnnotations.class);
+        CompilationUnit compilationUnitWithVaadinEndpointImport = Mockito.mock(CompilationUnit.class);
+
+        AnnotationExpr endpointAnnotation = Mockito.mock(AnnotationExpr.class);
+        Mockito.doReturn(Optional.of(endpointAnnotation)).when(declarationWithEndpointAnnotation)
+                .getAnnotationByClass(Endpoint.class);
+
+        NodeList<ImportDeclaration> imports = new NodeList<>();
+        ImportDeclaration importDeclaration = Mockito.mock(ImportDeclaration.class);
+        Mockito.doReturn(Endpoint.class.getName()).when(importDeclaration).getNameAsString();
+        imports.add(importDeclaration);
+        Mockito.doReturn(imports).when(compilationUnitWithVaadinEndpointImport).getImports();
+
+        Assert.assertTrue("A class with a Vaadin Endpoint should be considered as an Endpoint",
+                GeneratorUtils.hasAnnotation(declarationWithEndpointAnnotation, compilationUnitWithVaadinEndpointImport,
+                        Endpoint.class));
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/endpoints/model/NonVaadinEndpoint.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/endpoints/model/NonVaadinEndpoint.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.connect.generator.endpoints.model;
+
+import com.vaadin.flow.server.connect.generator.endpoints.model.NonVaadinEndpoint.Endpoint;
+
+@Endpoint
+public class NonVaadinEndpoint {
+
+    public String getDescription() {
+        return "Not a Vaadin Endpoint, should not generate ts models for it";
+    }
+
+    public @interface Endpoint {
+
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/vaadin/flow/issues/8743

When checking if a class has an annotation, the underlying java parser lib has a bug that only considers the annotation's simple name. So a helper method is introduced in this PR to also check if it has the correct import.