### PR TITLE
Store webpack dev server port in tempfile named from JVM unique constant and project folder (#8739)

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
@@ -399,9 +399,9 @@ public class IndexHtmlRequestHandlerTest {
         join.invoke(handler);
         // Ask to the DevModeHandler for the computed random port
         Method runningPort = DevModeHandler.class
-                .getDeclaredMethod("getRunningDevServerPort");
+                .getDeclaredMethod("getRunningDevServerPort", File.class);
         runningPort.setAccessible(true);
-        int port = (Integer) runningPort.invoke(handler);
+        int port = (Integer) runningPort.invoke(handler, npmFolder);
 
         // Configure webpack-dev-server tcp listener to return the `index.html`
         // content

--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -257,6 +257,7 @@
                 <module>test-subcontext</module>
                 <module>test-root-ui-context</module>
                 <module>test-router-custom-context</module>
+                <module>test-jetty-reload</module>
 
                 <module>test-scalability</module>
                 <module>test-memory-leaks</module>

--- a/flow-tests/test-jetty-reload/pom.xml
+++ b/flow-tests/test-jetty-reload/pom.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>flow-tests</artifactId>
+        <groupId>com.vaadin</groupId>
+        <version>3.1-SNAPSHOT</version>
+    </parent>
+    <artifactId>flow-test-jetty-reload</artifactId>
+    <name>Flow tests for Jetty reload in dev mode</name>
+
+    <packaging>war</packaging>
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-test-resources</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-test-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>annotations</artifactId>
+            <version>3.0.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Run flow plugin to build frontend -->
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>flow-maven-plugin</artifactId>
+                <configuration>
+                    <productionMode>false</productionMode>
+                </configuration>
+            </plugin>
+            <!-- Run jetty before integration tests, and stop after -->
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <configuration>
+                    <!-- Scan target/scantrigger in 1 second intervals -->
+                    <scanIntervalSeconds>1</scanIntervalSeconds>
+                    <scanTargetPatterns>
+                        <scanTargetPattern>
+                            <directory>${project.build.directory}</directory>
+                            <includes>
+                                <include>**/scantrigger</include>
+                            </includes>
+                        </scanTargetPattern>
+                    </scanTargetPatterns>
+                    <systemProperties>
+                        <force>true</force>
+                        <systemProperty>
+                            <name>jetty.scantrigger</name>
+                            <value>${project.build.directory}/scantrigger</value>
+                        </systemProperty>
+                        <systemProperty>
+                            <name>vaadin.reuseDevServer</name>
+                            <value>true</value>
+                        </systemProperty>
+                    </systemProperties>
+                </configuration>
+            </plugin>
+     </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>local-run</id>
+            <activation>
+                <property>
+                    <name>!test.use.hub</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.lazerycode.selenium</groupId>
+                        <artifactId>driver-binary-downloader-maven-plugin</artifactId>
+                        <version>${driver.binary.downloader.maven.plugin.version}</version>
+                        <configuration>
+                            <onlyGetDriversForHostOperatingSystem>true</onlyGetDriversForHostOperatingSystem>
+                            <rootStandaloneServerDirectory>${project.rootdir}/driver</rootStandaloneServerDirectory>
+                            <downloadedZipFileDirectory>${project.rootdir}/driver_zips</downloadedZipFileDirectory>
+                            <customRepositoryMap>${project.rootdir}/drivers.xml</customRepositoryMap>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>selenium</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/flow-tests/test-jetty-reload/src/main/java/com/vaadin/flow/uitest/ui/WebpackDevServerPortView.java
+++ b/flow-tests/test-jetty-reload/src/main/java/com/vaadin/flow/uitest/ui/WebpackDevServerPortView.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.UUID;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.DevModeHandler;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+@Route(value = "com.vaadin.flow.uitest.ui.WebpackDevServerPortView", layout = ViewTestLayout.class)
+public class WebpackDevServerPortView extends Div {
+
+    public static final String UUID_ID = "uuid";
+    public static final String WEBPACK_PORT_ID = "webpackPortId";
+    public static final String TRIGGER_RELOAD_ID = "triggerReload";
+
+    private static final UUID uuid = UUID.randomUUID();
+
+    public WebpackDevServerPortView() {
+        // Add a unique number to identify reload
+        Span unique = new Span(String.valueOf(uuid));
+        unique.setId(UUID_ID);
+        add(unique);
+
+        DevModeHandler handler = DevModeHandler.getDevModeHandler();
+        Span portSpan = new Span(String.valueOf(handler.getPort()));
+        portSpan.setId(WEBPACK_PORT_ID);
+        add(portSpan);
+
+        final NativeButton triggerButton = new NativeButton("Trigger reload",
+                event -> {
+                    try {
+                        touch(new File(
+                                System.getProperty("jetty.scantrigger")));
+                    } catch (IOException ioException) {
+                        throw new UncheckedIOException(ioException);
+                    }
+                });
+        triggerButton.setId(TRIGGER_RELOAD_ID);
+        add(triggerButton);
+    }
+
+    private static void touch(File file) throws IOException {
+        if (!file.exists()) {
+            file.createNewFile();
+        }
+        file.setLastModified(System.currentTimeMillis());
+    }
+}

--- a/flow-tests/test-jetty-reload/src/test/java/com/vaadin/flow/uitest/ui/WebpackDevServerPortIT.java
+++ b/flow-tests/test-jetty-reload/src/test/java/com/vaadin/flow/uitest/ui/WebpackDevServerPortIT.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import java.util.List;
+
+import net.jcip.annotations.NotThreadSafe;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+@NotThreadSafe
+public class WebpackDevServerPortIT extends ChromeBrowserTest {
+
+    @Test
+    public void webpackDevServerPortShouldBeReusedOnReload()
+            throws InterruptedException {
+        open();
+
+        String initialUUID = findElement(
+                By.id(WebpackDevServerPortView.UUID_ID)).getText();
+        Assert.assertEquals(36, initialUUID.length());
+
+        String initialPort = findElement(
+                By.id(WebpackDevServerPortView.WEBPACK_PORT_ID)).getText();
+        Assert.assertTrue(NumberUtils.isDigits(initialPort));
+
+        // trigger jetty reload
+        findElement(By.id(WebpackDevServerPortView.TRIGGER_RELOAD_ID)).click();
+
+        // keep refreshing until page comes back (the UUID has changed)
+        int totalWaitTime = 20000;
+        boolean reconnected = false;
+        long startTime = System.currentTimeMillis();
+        while (System.currentTimeMillis() < startTime + totalWaitTime
+                && !reconnected) {
+            Thread.sleep(2000);
+            getDriver().navigate().refresh();
+            List<WebElement> elements = findElements(
+                    By.id(WebpackDevServerPortView.UUID_ID));
+            if (!elements.isEmpty()
+                    && !elements.get(0).getText().equals(initialUUID)) {
+                reconnected = true;
+            }
+        }
+        Assert.assertTrue("unable to verify connection to new Jetty instance",
+                reconnected);
+
+        // then the port number is unchanged
+        String port = findElement(
+                By.id(WebpackDevServerPortView.WEBPACK_PORT_ID)).getText();
+        Assert.assertEquals(initialPort, port);
+
+    }
+}


### PR DESCRIPTION
This allows reusing the running Webpack dev server when Jetty reloads the application context.