### PR TITLE
fixing error message when fails to load content of index.html (#8593)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
@@ -174,7 +174,12 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
         }
         String frontendDir = FrontendUtils.getProjectFrontendDir(
                 request.getService().getDeploymentConfiguration());
-        String indexHtmlFilePath = frontendDir + File.separatorChar + "index.html";
+        String indexHtmlFilePath;
+        if(frontendDir.endsWith(File.separator)) {
+            indexHtmlFilePath = frontendDir + "index.html";
+        } else {
+            indexHtmlFilePath = frontendDir + File.separatorChar + "index.html";
+        }
         String message = String
                 .format("Failed to load content of '%1$s'."
                         + "It is required to have '%1$s' file when "

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
@@ -39,6 +39,8 @@ import elemental.json.Json;
 import elemental.json.JsonObject;
 import elemental.json.impl.JsonUtil;
 
+import java.io.File;
+
 import static com.vaadin.flow.component.internal.JavaScriptBootstrapUI.SERVER_ROUTING;
 import static com.vaadin.flow.shared.ApplicationConstants.CONTENT_TYPE_TEXT_HTML_UTF_8;
 import static com.vaadin.flow.shared.ApplicationConstants.CSRF_TOKEN;

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
@@ -174,10 +174,11 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
         }
         String frontendDir = FrontendUtils.getProjectFrontendDir(
                 request.getService().getDeploymentConfiguration());
+        String indexHtmlFilePath = frontendDir + File.separatorChar + "index.html";
         String message = String
-                .format("Failed to load content of '%1$s%2$cindex.html'."
-                        + "It is required to have '%1$s%2$cindex.html' file when "
-                        + "using client side bootstrapping.", frontendDir, File.separatorChar);
+                .format("Failed to load content of '%1$s'."
+                        + "It is required to have '%1$s' file when "
+                        + "using client side bootstrapping.", indexHtmlFilePath);
         throw new IOException(message);
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
@@ -173,9 +173,9 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
         String frontendDir = FrontendUtils.getProjectFrontendDir(
                 request.getService().getDeploymentConfiguration());
         String message = String
-                .format("Failed to load content of '%1$sindex.html'."
-                        + "It is required to have '%1$sindex.html' file when "
-                        + "using client side bootstrapping.", frontendDir);
+                .format("Failed to load content of '%1$s%2$cindex.html'."
+                        + "It is required to have '%1$s%2$cindex.html' file when "
+                        + "using client side bootstrapping.", frontendDir, File.separatorChar);
         throw new IOException(message);
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
@@ -181,7 +181,7 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
             indexHtmlFilePath = frontendDir + File.separatorChar + "index.html";
         }
         String message = String
-                .format("Failed to load content of '%1$s'."
+                .format("Failed to load content of '%1$s'. "
                         + "It is required to have '%1$s' file when "
                         + "using client side bootstrapping.", indexHtmlFilePath);
         throw new IOException(message);

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
@@ -66,6 +66,7 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.INDEX_HTML;
 import static com.vaadin.flow.server.frontend.NodeUpdateTestUtil.createStubWebpackServer;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class IndexHtmlRequestHandlerTest {
     private MockServletServiceSessionSetup mocks;
@@ -116,6 +117,8 @@ public class IndexHtmlRequestHandlerTest {
             throws IOException {
         VaadinServletRequest vaadinServletRequest = createVaadinRequest("/");
         VaadinService vaadinService = vaadinServletRequest.getService();
+
+        // Finding index.html URL
         String indexHtmlPathInProductionMode = VAADIN_SERVLET_RESOURCES
                 + INDEX_HTML;
         URL url = vaadinService.getClassLoader().getResource(indexHtmlPathInProductionMode);
@@ -124,10 +127,11 @@ public class IndexHtmlRequestHandlerTest {
         File indexHtmlFile = new File(url.getPath());
         File indexHtmlFileTmp = new File(url.getPath() + "_tmp");
         try {
-            // rename file to simulate the absence of index.html
-            indexHtmlFile.renameTo(indexHtmlFileTmp);
+            // Renaming file to simulate the absence of index.html
+            boolean renamed = indexHtmlFile.renameTo(indexHtmlFileTmp);
+            assertTrue(renamed);
 
-            String expectedError = "Failed to load content of './frontend/index.html'." +
+            String expectedError = "Failed to load content of './frontend/index.html'. " +
                     "It is required to have './frontend/index.html' file " +
                     "when using client side bootstrapping.";
 
@@ -137,8 +141,9 @@ public class IndexHtmlRequestHandlerTest {
             indexHtmlRequestHandler.synchronizedHandleRequest(session,
                     vaadinServletRequest, response);
         } finally {
-            //restore index.html
-            indexHtmlFileTmp.renameTo(indexHtmlFile);
+            // Restoring index.html
+            boolean renamed = indexHtmlFileTmp.renameTo(indexHtmlFile);
+            assertTrue(renamed);
         }
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -118,21 +117,20 @@ public class IndexHtmlRequestHandlerTest {
 
         URL url = vaadinService.getClassLoader().getResource(indexHtmlPathInProductionMode);
 
-        try {
-            Objects.requireNonNull(url);
+        if(url != null) {
             File indexHtmlFile = new File(url.getPath());
             indexHtmlFile.delete();
-        } catch (Exception ignored) {}
+        }
 
         try {
             indexHtmlRequestHandler.synchronizedHandleRequest(session,
                     vaadinServletRequest, response);
             throw new IllegalStateException("Must not reach to this point since index.html is not found");
-        } catch (IOException iOExeption) {
+        } catch (IOException iOException) {
             String expectedError = "Failed to load content of './frontend/index.html'." +
                     "It is required to have './frontend/index.html' file " +
                     "when using client side bootstrapping.";
-            assertEquals(expectedError, iOExeption.getMessage());
+            assertEquals(expectedError, iOException.getMessage());
         }
     }
 


### PR DESCRIPTION
I have experienced the same issue #8593 
This PR is to add file separator to the error message.