### PR TITLE
Use fake iframe element to check reload result and replace on success.

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.js
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.js
@@ -1029,7 +1029,7 @@ class VaadinDevmodeGizmo extends LitElement {
               <input id="toggle" type="checkbox"
                   ?disabled=${this.status === VaadinDevmodeGizmo.UNAVAILABLE || this.status === VaadinDevmodeGizmo.ERROR}
                   ?checked="${this.status === VaadinDevmodeGizmo.ACTIVE}"
-                  @ch   ange=${e => this.setActive(e.target.checked)}/>
+                  @change=${e => this.setActive(e.target.checked)}/>
               <span class="slider"></span>
               <span class="live-reload-text">Live reload</span>
           </label>

--- a/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.js
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.js
@@ -660,7 +660,6 @@ class VaadinDevmodeGizmo extends LitElement {
     this.status = VaadinDevmodeGizmo.UNAVAILABLE;
     this.connection = null;
     this.nextMessageId = 1;
-    this.reloadURL = 'about:blank';
   }
 
   openWebSocketConnection() {
@@ -1060,7 +1059,7 @@ class VaadinDevmodeGizmo extends LitElement {
       : html`<span class="status-description">Live reload ${this.status} </span><span class="ahreflike">Details</span></div>`
     }
     </div>
-    <iframe style='display: none;' width='0px' height='0px' src='${window.location.href}' id='reload-frame'"></iframe>`;
+    <iframe style='display: none;' width='0px' height='0px' src='${window.location.href}' id='reload-frame'></iframe>`;
   }
 }
 

--- a/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.js
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.js
@@ -551,8 +551,7 @@ class VaadinDevmodeGizmo extends LitElement {
       status: {type: String},
       reloadConnectionBaseUri: {type: String},
       liveReloadBackend: {type: String},
-      springBootDevToolsPort: {type: Number},
-      reloadURL: {type: String}
+      springBootDevToolsPort: {type: Number}
     };
   }
 


### PR DESCRIPTION
Avoid reload() method whose usage may lead to showing a blank page
because server is not yet restarted. Instead use a fake iframe element
inside gizmo which refers to the same URL. Its window may be reloaded
safely and the result can be checked before applying it to the main
document. If reload was successful (page is initialized with Vaadin JS)
then replace the document content  with the content of iframe.

Fixes #8728