### PR TITLE
fix: don't clear node if cannot handle resync msg

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
@@ -275,7 +275,7 @@ public class MessageHandler {
          * It seems that the reason is that `connectClient` is removed 
          * from the rootNode(<body> element) during a resync and not added back.
          */
-        if(isResynchronize(valueMap)){
+        if (isResynchronize(valueMap)) {
             // Unregister all nodes and rebuild the state tree
             registry.getStateTree().prepareForResync();
         }

--- a/flow-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
@@ -264,6 +264,17 @@ public class MessageHandler {
             return;
         }
 
+        /**
+         * Should only prepare resync after the 
+         * if (locked || !isNextExpectedMessage(serverId)) {...}
+         * since stateTree.repareForResync() will remove the nodes,
+         * and if locked is true, it will return without handling 
+         * the message, thus won't adding nodes back. 
+         * 
+         * This is related to https://github.com/vaadin/flow/issues/8699
+         * It seems that the reason is that `connectClient` is removed 
+         * from the rootNode(<body> element) during a resync and not added back.
+         */
         if(isResynchronize(valueMap)){
             // Unregister all nodes and rebuild the state tree
             registry.getStateTree().prepareForResync();

--- a/flow-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
@@ -226,9 +226,6 @@ public class MessageHandler {
                     + " while waiting for " + getExpectedServerId());
             lastSeenServerSyncId = serverId - 1;
             removeOldPendingMessages();
-
-            // Unregister all nodes and rebuild the state tree
-            registry.getStateTree().prepareForResync();
         }
 
         boolean locked = !responseHandlingLocks.isEmpty();
@@ -265,6 +262,11 @@ public class MessageHandler {
                 forceHandleMessage.schedule(timeout);
             }
             return;
+        }
+
+        if(isResynchronize(valueMap)){
+            // Unregister all nodes and rebuild the state tree
+            registry.getStateTree().prepareForResync();
         }
 
         double start = Duration.currentTimeMillis();


### PR DESCRIPTION
This tries to fix https://github.com/vaadin/flow/issues/8699. 

There clearly is a logic error in the resync handling, under `if (isResynchronize(valueMap) && !isNextExpectedMessage(serverId))` condition. it will prepare for resync, thus remove all the nodes in the statetree, which will remove the 2 `@ClientCallable` methods in `JavaScriptBootStrapUI` (`connectClient` and `leaveNavigation`). 

But then if `boolean locked = !responseHandlingLocks.isEmpty();` is true, it will return, leaving `flowRoot.$server.connectClient` undefined in `Flow.ts`. Thus when user tries to navigate to any other view, which seems the reason to lead the error in #8699. 

But I don't know how to reliably reproduce the situation so couldn't come up with a test, even a unit test is hard to write.
