### PR TITLE
chore: apply symbol renaming in model template

### DIFF
--- a/flow-client/src/test-gwt/java/com/vaadin/client/communication/MessageHandlerTest.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/communication/MessageHandlerTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.client.communication;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.vaadin.client.ClientEngineTestBase;
+import com.vaadin.client.ValueMap;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ *
+ * @author Vaadin Ltd
+ * @since 1.0
+ */
+public class MessageHandlerTest extends ClientEngineTestBase{
+
+    @Test
+    public void unwrapValidJson() {
+        MessageHandler messageHandler = Mockito.mock(MessageHandler.class);
+        ValueMap json = (ValueMap)JavaScriptObject.createObject();
+        
+        Mockito.doCallRealMethod().when(messageHandler).handleJSON(Mockito.any());
+        messageHandler.handleJSON((ValueMap)json);
+        Assert.assertTrue(true);
+    }
+}

--- a/flow-server/src/main/resources/com/vaadin/flow/server/connect/generator/EntityModelTemplate.mustache
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/connect/generator/EntityModelTemplate.mustache
@@ -7,7 +7,7 @@ import {{className}}Model from '{{importPath}}Model';
 import {{{getClassNameFromImports classname ../../imports}}} from './{{{getClassNameFromImports classname ../../imports}}}';
 {{/model}}{{/models}}
 
-import {ObjectModel,StringModel,NumberModel,ArrayModel,BooleanModel,Required,ModelType,getPropertyModelSymbol} from '@vaadin/form';
+import {ObjectModel,StringModel,NumberModel,ArrayModel,BooleanModel,Required,ModelType,_getPropertyModel} from '@vaadin/form';
 
 import {Email,Null,NotNull,NotEmpty,NotBlank,AssertTrue,AssertFalse,Negative,NegativeOrZero,Positive,PositiveOrZero,Size,Past,Future,Digits,Min,Max,Pattern,DecimalMin,DecimalMax} from '@vaadin/form';
 
@@ -24,7 +24,7 @@ export default class {{{getClassNameFromImports classname ../../imports}}}Model<
 {{#vars}}
 
   get {{name}}(): {{{getModelFullType this ../../imports}}} {
-    return this[getPropertyModelSymbol]('{{name}}', {{{getModelArguments this ../../imports}}});
+    return this[_getPropertyModel]('{{name}}', {{{getModelArguments this ../../imports}}});
   }
 {{/vars}}
 }


### PR DESCRIPTION
This fixes the error in the previous PR https://github.com/vaadin/flow/pull/8754 that it forgot to apply the renaming to the model template.