### PR TITLE
chore: apply symbol renaming in model template

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/connect/generator/EntityModelTemplate.mustache
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/connect/generator/EntityModelTemplate.mustache
@@ -7,7 +7,7 @@ import {{className}}Model from '{{importPath}}Model';
 import {{{getClassNameFromImports classname ../../imports}}} from './{{{getClassNameFromImports classname ../../imports}}}';
 {{/model}}{{/models}}
 
-import {ObjectModel,StringModel,NumberModel,ArrayModel,BooleanModel,Required,ModelType,getPropertyModelSymbol} from '@vaadin/form';
+import {ObjectModel,StringModel,NumberModel,ArrayModel,BooleanModel,Required,ModelType,_getPropertyModel} from '@vaadin/form';
 
 import {Email,Null,NotNull,NotEmpty,NotBlank,AssertTrue,AssertFalse,Negative,NegativeOrZero,Positive,PositiveOrZero,Size,Past,Future,Digits,Min,Max,Pattern,DecimalMin,DecimalMax} from '@vaadin/form';
 
@@ -24,7 +24,7 @@ export default class {{{getClassNameFromImports classname ../../imports}}}Model<
 {{#vars}}
 
   get {{name}}(): {{{getModelFullType this ../../imports}}} {
-    return this[getPropertyModelSymbol]('{{name}}', {{{getModelArguments this ../../imports}}});
+    return this[_getPropertyModel]('{{name}}', {{{getModelArguments this ../../imports}}});
   }
 {{/vars}}
 }

--- a/flow-server/src/test/resources/com/vaadin/flow/server/connect/generator/tsmodel/expected-TsFormEndpoint.ts
+++ b/flow-server/src/test/resources/com/vaadin/flow/server/connect/generator/tsmodel/expected-TsFormEndpoint.ts
@@ -4,7 +4,7 @@ import MyBazModel from './MyBazModel';
 import MyEntityIdModel from './MyEntityIdModel';
 import MyEntity from './MyEntity';
 
-import {ObjectModel,StringModel,NumberModel,ArrayModel,BooleanModel,Required,ModelType,getPropertyModelSymbol} from '@vaadin/form';
+import {ObjectModel,StringModel,NumberModel,ArrayModel,BooleanModel,Required,ModelType,_getPropertyModel} from '@vaadin/form';
 
 import {Email,Null,NotNull,NotEmpty,NotBlank,AssertTrue,AssertFalse,Negative,NegativeOrZero,Positive,PositiveOrZero,Size,Past,Future,Digits,Min,Max,Pattern,DecimalMin,DecimalMax} from '@vaadin/form';
 
@@ -16,166 +16,166 @@ export default class MyEntityModel<T extends MyEntity = MyEntity> extends MyEnti
   static createEmptyValue: () => MyEntity;
 
   get assertFalse(): StringModel {
-    return this[getPropertyModelSymbol]('assertFalse', StringModel, [false, new AssertFalse()]);
+    return this[_getPropertyModel]('assertFalse', StringModel, [false, new AssertFalse()]);
   }
 
   get assertTrue(): StringModel {
-    return this[getPropertyModelSymbol]('assertTrue', StringModel, [false, new AssertTrue()]);
+    return this[_getPropertyModel]('assertTrue', StringModel, [false, new AssertTrue()]);
   }
 
   get bar(): MyBazModel {
-    return this[getPropertyModelSymbol]('bar', MyBazModel, [false]);
+    return this[_getPropertyModel]('bar', MyBazModel, [false]);
   }
 
   get baz(): ArrayModel<ModelType<MyBazModel>, MyBazModel> {
-    return this[getPropertyModelSymbol]('baz', ArrayModel, [false, MyBazModel, [false]]);
+    return this[_getPropertyModel]('baz', ArrayModel, [false, MyBazModel, [false]]);
   }
 
   get bool(): BooleanModel {
-    return this[getPropertyModelSymbol]('bool', BooleanModel, [false]);
+    return this[_getPropertyModel]('bool', BooleanModel, [false]);
   }
 
   get children(): ArrayModel<ModelType<MyEntityModel>, MyEntityModel> {
-    return this[getPropertyModelSymbol]('children', ArrayModel, [false, MyEntityModel, [false]]);
+    return this[_getPropertyModel]('children', ArrayModel, [false, MyEntityModel, [false]]);
   }
 
   get decimalMax(): NumberModel {
-    return this[getPropertyModelSymbol]('decimalMax', NumberModel, [false, new DecimalMax({value:"0.01", inclusive:false})]);
+    return this[_getPropertyModel]('decimalMax', NumberModel, [false, new DecimalMax({value:"0.01", inclusive:false})]);
   }
 
   get decimalMin(): NumberModel {
-    return this[getPropertyModelSymbol]('decimalMin', NumberModel, [false, new DecimalMin("0.01")]);
+    return this[_getPropertyModel]('decimalMin', NumberModel, [false, new DecimalMin("0.01")]);
   }
 
   get digits(): StringModel {
-    return this[getPropertyModelSymbol]('digits', StringModel, [false, new Digits({integer:5, fraction:2})]);
+    return this[_getPropertyModel]('digits', StringModel, [false, new Digits({integer:5, fraction:2})]);
   }
 
   get email(): StringModel {
-    return this[getPropertyModelSymbol]('email', StringModel, [false, new Email({message:"foo"})]);
+    return this[_getPropertyModel]('email', StringModel, [false, new Email({message:"foo"})]);
   }
 
   get entityMap(): ObjectModel<{ [key: string]: ModelType<MyBazModel>; }> {
-    return this[getPropertyModelSymbol]('entityMap', ObjectModel, [false]);
+    return this[_getPropertyModel]('entityMap', ObjectModel, [false]);
   }
 
   get entityMatrix(): ArrayModel<ModelType<ArrayModel<ModelType<MyEntityModel>, MyEntityModel>>, ArrayModel<ModelType<MyEntityModel>, MyEntityModel>> {
-    return this[getPropertyModelSymbol]('entityMatrix', ArrayModel, [false, ArrayModel, [false, MyEntityModel, [false]]]);
+    return this[_getPropertyModel]('entityMatrix', ArrayModel, [false, ArrayModel, [false, MyEntityModel, [false]]]);
   }
 
   get foo(): StringModel {
-    return this[getPropertyModelSymbol]('foo', StringModel, [false]);
+    return this[_getPropertyModel]('foo', StringModel, [false]);
   }
 
   get future(): StringModel {
-    return this[getPropertyModelSymbol]('future', StringModel, [false, new Future()]);
+    return this[_getPropertyModel]('future', StringModel, [false, new Future()]);
   }
 
   get isNull(): StringModel {
-    return this[getPropertyModelSymbol]('isNull', StringModel, [false, new Null()]);
+    return this[_getPropertyModel]('isNull', StringModel, [false, new Null()]);
   }
 
   get list(): ArrayModel<string, StringModel> {
-    return this[getPropertyModelSymbol]('list', ArrayModel, [false, StringModel, [false], new NotEmpty()]);
+    return this[_getPropertyModel]('list', ArrayModel, [false, StringModel, [false], new NotEmpty()]);
   }
 
   get localTime(): StringModel {
-    return this[getPropertyModelSymbol]('localTime', StringModel, [false]);
+    return this[_getPropertyModel]('localTime', StringModel, [false]);
   }
 
   get max(): NumberModel {
-    return this[getPropertyModelSymbol]('max', NumberModel, [false, new Max(2)]);
+    return this[_getPropertyModel]('max', NumberModel, [false, new Max(2)]);
   }
 
   get min(): NumberModel {
-    return this[getPropertyModelSymbol]('min', NumberModel, [false, new Min({value:1, message:"foo"})]);
+    return this[_getPropertyModel]('min', NumberModel, [false, new Min({value:1, message:"foo"})]);
   }
 
   get negative(): NumberModel {
-    return this[getPropertyModelSymbol]('negative', NumberModel, [false, new Negative()]);
+    return this[_getPropertyModel]('negative', NumberModel, [false, new Negative()]);
   }
 
   get negativeOrCero(): NumberModel {
-    return this[getPropertyModelSymbol]('negativeOrCero', NumberModel, [false, new NegativeOrZero()]);
+    return this[_getPropertyModel]('negativeOrCero', NumberModel, [false, new NegativeOrZero()]);
   }
 
   get notBlank(): StringModel {
-    return this[getPropertyModelSymbol]('notBlank', StringModel, [false, new NotBlank()]);
+    return this[_getPropertyModel]('notBlank', StringModel, [false, new NotBlank()]);
   }
 
   get notEmpty(): StringModel {
-    return this[getPropertyModelSymbol]('notEmpty', StringModel, [false, new NotEmpty(), new NotNull()]);
+    return this[_getPropertyModel]('notEmpty', StringModel, [false, new NotEmpty(), new NotNull()]);
   }
 
   get notNull(): StringModel {
-    return this[getPropertyModelSymbol]('notNull', StringModel, [false, new NotNull()]);
+    return this[_getPropertyModel]('notNull', StringModel, [false, new NotNull()]);
   }
 
   get nullableEntity(): MyEntityModel {
-    return this[getPropertyModelSymbol]('nullableEntity', MyEntityModel, [true]);
+    return this[_getPropertyModel]('nullableEntity', MyEntityModel, [true]);
   }
 
   get nullableList(): ArrayModel<string, StringModel> {
-    return this[getPropertyModelSymbol]('nullableList', ArrayModel, [true, StringModel, [true]]);
+    return this[_getPropertyModel]('nullableList', ArrayModel, [true, StringModel, [true]]);
   }
 
   get nullableMatrix(): ArrayModel<ModelType<ArrayModel<string, StringModel>>, ArrayModel<string, StringModel>> {
-    return this[getPropertyModelSymbol]('nullableMatrix', ArrayModel, [true, ArrayModel, [false, StringModel, [true]]]);
+    return this[_getPropertyModel]('nullableMatrix', ArrayModel, [true, ArrayModel, [false, StringModel, [true]]]);
   }
 
   get nullableString(): StringModel {
-    return this[getPropertyModelSymbol]('nullableString', StringModel, [true]);
+    return this[_getPropertyModel]('nullableString', StringModel, [true]);
   }
 
   get numberMatrix(): ArrayModel<ModelType<ArrayModel<number, NumberModel>>, ArrayModel<number, NumberModel>> {
-    return this[getPropertyModelSymbol]('numberMatrix', ArrayModel, [false, ArrayModel, [false, NumberModel, [false]]]);
+    return this[_getPropertyModel]('numberMatrix', ArrayModel, [false, ArrayModel, [false, NumberModel, [false]]]);
   }
 
   get optionalEntity(): MyEntityModel {
-    return this[getPropertyModelSymbol]('optionalEntity', MyEntityModel, [true]);
+    return this[_getPropertyModel]('optionalEntity', MyEntityModel, [true]);
   }
 
   get optionalList(): ArrayModel<string, StringModel> {
-    return this[getPropertyModelSymbol]('optionalList', ArrayModel, [true, StringModel, [true]]);
+    return this[_getPropertyModel]('optionalList', ArrayModel, [true, StringModel, [true]]);
   }
 
   get optionalMatrix(): ArrayModel<ModelType<ArrayModel<string, StringModel>>, ArrayModel<string, StringModel>> {
-    return this[getPropertyModelSymbol]('optionalMatrix', ArrayModel, [true, ArrayModel, [false, StringModel, [true]]]);
+    return this[_getPropertyModel]('optionalMatrix', ArrayModel, [true, ArrayModel, [false, StringModel, [true]]]);
   }
 
   get optionalString(): StringModel {
-    return this[getPropertyModelSymbol]('optionalString', StringModel, [true]);
+    return this[_getPropertyModel]('optionalString', StringModel, [true]);
   }
 
   get past(): StringModel {
-    return this[getPropertyModelSymbol]('past', StringModel, [false, new Past()]);
+    return this[_getPropertyModel]('past', StringModel, [false, new Past()]);
   }
 
   get pattern(): StringModel {
-    return this[getPropertyModelSymbol]('pattern', StringModel, [false, new Pattern({regexp:"\\d+\\..+"})]);
+    return this[_getPropertyModel]('pattern', StringModel, [false, new Pattern({regexp:"\\d+\\..+"})]);
   }
 
   get positive(): NumberModel {
-    return this[getPropertyModelSymbol]('positive', NumberModel, [false, new Positive()]);
+    return this[_getPropertyModel]('positive', NumberModel, [false, new Positive()]);
   }
 
   get positiveOrCero(): NumberModel {
-    return this[getPropertyModelSymbol]('positiveOrCero', NumberModel, [false, new PositiveOrZero()]);
+    return this[_getPropertyModel]('positiveOrCero', NumberModel, [false, new PositiveOrZero()]);
   }
 
   get size(): StringModel {
-    return this[getPropertyModelSymbol]('size', StringModel, [false, new Size()]);
+    return this[_getPropertyModel]('size', StringModel, [false, new Size()]);
   }
 
   get size1(): StringModel {
-    return this[getPropertyModelSymbol]('size1', StringModel, [false, new Size({min:1})]);
+    return this[_getPropertyModel]('size1', StringModel, [false, new Size({min:1})]);
   }
 
   get stringArray(): ArrayModel<string, StringModel> {
-    return this[getPropertyModelSymbol]('stringArray', ArrayModel, [false, StringModel, [false]]);
+    return this[_getPropertyModel]('stringArray', ArrayModel, [false, StringModel, [false]]);
   }
 
   get stringMap(): ObjectModel<{ [key: string]: string; }> {
-    return this[getPropertyModelSymbol]('stringMap', ObjectModel, [false]);
+    return this[_getPropertyModel]('stringMap', ObjectModel, [false]);
   }
 }


### PR DESCRIPTION
This fixes the error in the previous PR https://github.com/vaadin/flow/pull/8754 that it forgot to apply the renaming to the model template.