### PR TITLE
Update master to 4.1-SNAPSHOT

### DIFF
--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-buildtools</artifactId>
     <name>vaadin-buildhelpers</name>

--- a/flow-bom/pom.xml
+++ b/flow-bom/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-bom</artifactId>
     <packaging>pom</packaging>

--- a/flow-client/pom.xml
+++ b/flow-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-client</artifactId>
     <name>Flow Client</name>

--- a/flow-client/src/main/resources/META-INF/resources/frontend/form/index.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/form/index.ts
@@ -9,5 +9,5 @@ $wnd.Vaadin = $wnd.Vaadin || {};
 $wnd.Vaadin.registrations = $wnd.Vaadin.registrations || [];
 $wnd.Vaadin.registrations.push({
   is: '@vaadin/form',
-  version: /* updated-by-script */ '4.0-SNAPSHOT'
+  version: /* updated-by-script */ '4.1-SNAPSHOT'
 });

--- a/flow-component-demo-helpers/pom.xml
+++ b/flow-component-demo-helpers/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>flow-component-demo-helpers</artifactId>

--- a/flow-data/pom.xml
+++ b/flow-data/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-data</artifactId>
     <name>Flow Data</name>

--- a/flow-dev-deps/pom.xml
+++ b/flow-dev-deps/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-dev-deps</artifactId>
     <name>Flow Development Dependencies</name>

--- a/flow-dnd/pom.xml
+++ b/flow-dnd/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>flow-project</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>flow-dnd</artifactId>

--- a/flow-html-components-testbench/pom.xml
+++ b/flow-html-components-testbench/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-html-components-testbench</artifactId>
     <name>TestBench elements for Flow HTML Components</name>

--- a/flow-html-components/pom.xml
+++ b/flow-html-components/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-html-components</artifactId>
     <name>Flow HTML Components</name>

--- a/flow-maven-plugin/pom.xml
+++ b/flow-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>

--- a/flow-push/pom.xml
+++ b/flow-push/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-push</artifactId>
     <name>Flow Push</name>

--- a/flow-server-production-mode/pom.xml
+++ b/flow-server-production-mode/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-server-production-mode</artifactId>
     <name>Flow Server Production Mode</name>

--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-server</artifactId>
     <name>Flow Server</name>

--- a/flow-test-generic/pom.xml
+++ b/flow-test-generic/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>flow-project</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flow-test-util/pom.xml
+++ b/flow-test-util/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>flow-test-util</artifactId>

--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-tests</artifactId>
     <name>Flow tests</name>

--- a/flow-tests/servlet-containers/pom.xml
+++ b/flow-tests/servlet-containers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-servlet-containers-test</artifactId>
     <name>flow-servlet-containers-test</name>

--- a/flow-tests/servlet-containers/tomcat85/pom.xml
+++ b/flow-tests/servlet-containers/tomcat85/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-servlet-containers-test</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-tomcat85-server</artifactId>
     <name>Flow Tomcat 8.5 Test</name>

--- a/flow-tests/servlet-containers/tomcat9/pom.xml
+++ b/flow-tests/servlet-containers/tomcat9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-servlet-containers-test</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-tomcat9-server</artifactId>
     <name>Flow Tomcat 9 Test</name>

--- a/flow-tests/test-ccdm/pom-production.xml
+++ b/flow-tests/test-ccdm/pom-production.xml
@@ -5,13 +5,13 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>flow-test-ccdm-prod</artifactId>
     <name>Flow CCDM tests (production mode)</name>
-    <version>4.0-SNAPSHOT</version>
+    <version>4.1-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <properties>

--- a/flow-tests/test-ccdm/pom.xml
+++ b/flow-tests/test-ccdm/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>test-ccdm</artifactId>
     <name>Flow CCDM tests (dev mode)</name>
-    <version>4.0-SNAPSHOT</version>
+    <version>4.1-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <properties>

--- a/flow-tests/test-common/pom.xml
+++ b/flow-tests/test-common/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-common</artifactId>
     <name>Flow common test UI classes</name>

--- a/flow-tests/test-dev-mode/pom.xml
+++ b/flow-tests/test-dev-mode/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-dev-mode</artifactId>
     <name>Flow tests for dev mode</name>

--- a/flow-tests/test-embedding/embedding-test-assets/pom.xml
+++ b/flow-tests/test-embedding/embedding-test-assets/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>test-embedding</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flow-tests/test-embedding/pom.xml
+++ b/flow-tests/test-embedding/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flow-tests</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flow-tests/test-embedding/test-embedding-generic/pom.xml
+++ b/flow-tests/test-embedding/test-embedding-generic/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>test-embedding</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-embedding-generic</artifactId>
     <name>Flow Embedding, generic tests</name>

--- a/flow-tests/test-embedding/test-embedding-production-mode/pom.xml
+++ b/flow-tests/test-embedding/test-embedding-production-mode/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>test-embedding</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-embedding-production</artifactId>
     <name>Flow Embedding, production tests</name>

--- a/flow-tests/test-embedding/test-embedding-theme-variant/pom.xml
+++ b/flow-tests/test-embedding/test-embedding-theme-variant/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>test-embedding</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-embedding-theme-variant</artifactId>
     <name>Flow Embedding, theme variant</name>

--- a/flow-tests/test-jetty-reload/pom.xml
+++ b/flow-tests/test-jetty-reload/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>flow-tests</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-jetty-reload</artifactId>
     <name>Flow tests for Jetty reload in dev mode</name>

--- a/flow-tests/test-live-reload/pom.xml
+++ b/flow-tests/test-live-reload/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>flow-tests</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-live-reload-mode</artifactId>
     <name>Flow tests for live reload in dev mode</name>

--- a/flow-tests/test-lumo-theme/pom.xml
+++ b/flow-tests/test-lumo-theme/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-lumo-theme</artifactId>
     <name>Flow Lumo theme tests</name>

--- a/flow-tests/test-material-theme/pom.xml
+++ b/flow-tests/test-material-theme/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-material-theme</artifactId>
     <name>Flow Material theme tests</name>

--- a/flow-tests/test-memory-leaks/pom.xml
+++ b/flow-tests/test-memory-leaks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-memory-leaks</artifactId>
     <name>Flow memory leak tests</name>

--- a/flow-tests/test-misc/pom.xml
+++ b/flow-tests/test-misc/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>flow-tests</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-misc-test</artifactId>
     <name>Flow Miscelaneous tests in npm</name>

--- a/flow-tests/test-mixed/pom-npm-production.xml
+++ b/flow-tests/test-mixed/pom-npm-production.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>flow-tests</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-npm-production</artifactId>
     <name>Flow tests in npm and production mode</name>

--- a/flow-tests/test-mixed/pom-npm.xml
+++ b/flow-tests/test-mixed/pom-npm.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>flow-tests</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-npm-dev-mode</artifactId>
     <name>Flow tests in npm and development mode</name>

--- a/flow-tests/test-mixed/pom-pnpm-production.xml
+++ b/flow-tests/test-mixed/pom-pnpm-production.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>flow-tests</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-pnpm-production</artifactId>
     <name>Flow tests in pnpm and production mode</name>

--- a/flow-tests/test-mixed/pom.xml
+++ b/flow-tests/test-mixed/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>flow-tests</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-pnpm-dev-mode</artifactId>
     <name>Flow tests in pnpm and development mode</name>

--- a/flow-tests/test-multi-war/deployment/pom.xml
+++ b/flow-tests/test-multi-war/deployment/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>flow-test-multi-war</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-multi-war-bundle</artifactId>
     <name>Bundle testing multiple war deployment</name>

--- a/flow-tests/test-multi-war/pom.xml
+++ b/flow-tests/test-multi-war/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>flow-tests</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-multi-war</artifactId>
     <name>Flow tests with more than one war deployed at the same time</name>

--- a/flow-tests/test-multi-war/test-war1/pom.xml
+++ b/flow-tests/test-multi-war/test-war1/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>flow-test-multi-war</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-multi-war1</artifactId>
     <name>First war for multi war tests</name>

--- a/flow-tests/test-multi-war/test-war2/pom.xml
+++ b/flow-tests/test-multi-war/test-war2/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>flow-test-multi-war</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-multi-war2</artifactId>
     <name>First war for multi war tests</name>

--- a/flow-tests/test-no-theme/pom.xml
+++ b/flow-tests/test-no-theme/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-no-theme</artifactId>
     <name>Flow tests for no theme in NPM mode</name>

--- a/flow-tests/test-npm-only-features/pom.xml
+++ b/flow-tests/test-npm-only-features/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flow-tests</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flow-tests/test-npm-only-features/test-default-theme/pom.xml
+++ b/flow-tests/test-npm-only-features/test-default-theme/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flow-test-npm-only-features</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-devmode.xml
+++ b/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-devmode.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flow-test-npm-only-features</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-prod-fallback.xml
+++ b/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-prod-fallback.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flow-test-npm-only-features</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-production.xml
+++ b/flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-production.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flow-test-npm-only-features</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flow-tests/test-npm-only-features/test-npm-custom-frontend-directory/pom.xml
+++ b/flow-tests/test-npm-only-features/test-npm-custom-frontend-directory/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flow-test-npm-only-features</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flow-tests/test-npm-only-features/test-npm-general/pom.xml
+++ b/flow-tests/test-npm-only-features/test-npm-general/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-test-npm-only-features</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flow-tests/test-npm-only-features/test-npm-no-buildmojo/pom.xml
+++ b/flow-tests/test-npm-only-features/test-npm-no-buildmojo/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>flow-test-npm-only-features</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/flow-tests/test-npm-only-features/test-npm-performance-regression/pom.xml
+++ b/flow-tests/test-npm-only-features/test-npm-performance-regression/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>flow-test-npm-only-features</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/flow-tests/test-pwa/pom.xml
+++ b/flow-tests/test-pwa/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>flow-tests</artifactId>
         <groupId>com.vaadin</groupId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-pwa</artifactId>
     <name>Flow tests for PWA annotation</name>

--- a/flow-tests/test-resources/pom.xml
+++ b/flow-tests/test-resources/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-resources</artifactId>
     <name>Flow Test Resources</name>

--- a/flow-tests/test-root-context/pom.xml
+++ b/flow-tests/test-root-context/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-root-context-npm</artifactId>
     <name>Flow root context tests in NPM dev mode</name>

--- a/flow-tests/test-root-ui-context/pom.xml
+++ b/flow-tests/test-root-ui-context/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-root-ui-context</artifactId>
     <name>Flow root ui context tests</name>

--- a/flow-tests/test-router-custom-context/pom.xml
+++ b/flow-tests/test-router-custom-context/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>test-router-custom-context</artifactId>
     <name>Flow Router on custom context test</name>

--- a/flow-tests/test-scalability/pom.xml
+++ b/flow-tests/test-scalability/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-scalability</artifactId>
     <name>Flow scalability tests</name>

--- a/flow-tests/test-servlet/pom.xml
+++ b/flow-tests/test-servlet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-servlet</artifactId>
     <name>Flow servlet registration test</name>

--- a/flow-tests/test-subcontext/pom.xml
+++ b/flow-tests/test-subcontext/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-subcontext</artifactId>
     <name>Flow tests mapped for /context</name>

--- a/flow-tests/test-themes/pom.xml
+++ b/flow-tests/test-themes/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-tests</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-themes-npm</artifactId>
     <name>Flow themes tests in NPM mode</name>

--- a/flow-theme-integrations/lumo/pom.xml
+++ b/flow-theme-integrations/lumo/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-theme-integrations</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-lumo-theme</artifactId>

--- a/flow-theme-integrations/material/pom.xml
+++ b/flow-theme-integrations/material/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-theme-integrations</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-material-theme</artifactId>

--- a/flow-theme-integrations/pom.xml
+++ b/flow-theme-integrations/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow-theme-integrations</artifactId>
     <name>Parent project for Flow themes</name>

--- a/flow/pom.xml
+++ b/flow/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>flow-project</artifactId>
-        <version>4.0-SNAPSHOT</version>
+        <version>4.1-SNAPSHOT</version>
     </parent>
     <artifactId>flow</artifactId>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>flow-project</artifactId>
     <name>Flow</name>
     <packaging>pom</packaging>
-    <version>4.0-SNAPSHOT</version>
+    <version>4.1-SNAPSHOT</version>
 
     <parent>
         <groupId>com.vaadin</groupId>


### PR DESCRIPTION
Some client-side features to be done this week, require to be included in `4.1`, rather than `4.0`. So this PR is for preparing `4.1` series.