### PR TITLE
Throw an exception when setting an ID to the Text component

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/Text.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Text.java
@@ -68,6 +68,13 @@ public class Text extends Component implements HasText {
         return getElement().getText();
     }
 
+    /**
+     * The method is not supported for the {@link Text} class.
+     * <p>
+     * Always throws an {@link UnsupportedOperationException}.
+     *
+     * @throws UnsupportedOperationException
+     */
     @Override
     protected <T> void set(PropertyDescriptor<T, ?> descriptor, T value) {
         throw new UnsupportedOperationException("Cannot set '"
@@ -85,7 +92,10 @@ public class Text extends Component implements HasText {
      */
     @Override
     public void setId(String id) {
-        super.setId(id);
+        throw new UnsupportedOperationException("Cannot set id '"
+                + id + "' to the " + getClass().getSimpleName()
+                + " component because it doesn't "
+                + "represent an HTML Element but a text Node on the client side.");
     }
 
     /**


### PR DESCRIPTION
Set the `Text::setId` to throw an UOE according to javadoc and to the fact it's a text node, not a DOM element.