### PR TITLE
Simpler CSS import for TS views and CSS @import support

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -304,7 +304,9 @@ public abstract class NodeUpdater implements FallibleCommand {
         defaults.put("compression-webpack-plugin", "3.1.0");
         defaults.put("progress-webpack-plugin", "0.0.24");
         defaults.put("webpack-merge", "4.2.2");
-        defaults.put("raw-loader", "4.0.0");
+        defaults.put("css-loader", "4.2.1");
+        defaults.put("extract-loader", "5.1.0");
+        defaults.put("lit-css-loader", "0.0.3");
         defaults.put("lit-element", "2.3.1");
         defaults.put("lit-html", "1.2.1");
         defaults.put("@types/validator", "10.11.3");

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -135,7 +135,7 @@ module.exports = {
       },
       {
         test: /\.css$/i,
-        use: ['raw-loader']
+        use: ['lit-css-loader', 'extract-loader', 'css-loader']
       }
     ]
   },


### PR DESCRIPTION
This modifies the default webpack loader configuration for all *.css files. Instead of the previous `raw-loader` only, this will use a loader chain of `['lit-css-loader', 'extract-loader', 'css-loader']`.

`lit-css-loader` gives us a nice DX of importing styles to TS views like this:
```ts
import styles from './list-view.css';

@customElement('list-view')
export class ListView extends LitElement {
  static styles = [Lumo, styles];
```

`css-loader` gives the additional benefit of resolving CSS `@import "file.css";` syntax in CSS files. This is a new features that works both for TS views and also when using `@CssImport()` annotation in Java.

`extract-loader` is needed in the middle to convert the JS output of `css-loader` into a plain CSS string.