### PR TITLE
Revert 'Overload EmailValidator to accept an empty value' feature

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/validator/EmailValidator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/validator/EmailValidator.java
@@ -31,45 +31,14 @@ public class EmailValidator extends RegexpValidator {
             + "\\." + "[a-zA-Z0-9-]{2,}" // tld
             + "$";
 
-    private final boolean allowEmptyValue;
-
     /**
      * Creates a validator for checking that a string is a syntactically valid
      * e-mail address.
-     * <p>
-     * This constructor creates a validator which doesn't accept an empty string
-     * as a valid e-mail address. Use {@link #EmailValidator(String, boolean)}
-     * constructor with {@code true} as a value for the second argument to
-     * create a validator which accepts an empty string.
      *
      * @param errorMessage
      *            the message to display in case the value does not validate.
-     * @see #EmailValidator(String, boolean)
      */
     public EmailValidator(String errorMessage) {
-        this(errorMessage, false);
-    }
-
-    /**
-     * Creates a validator for checking that a string is a syntactically valid
-     * e-mail address.
-     *
-     * @param errorMessage
-     *            the message to display in case the value does not validate.
-     * @param allowEmpty
-     *            if {@code true} then an empty string passes the validation,
-     *            otherwise the validation fails
-     */
-    public EmailValidator(String errorMessage, boolean allowEmpty) {
         super(errorMessage, PATTERN, true);
-        allowEmptyValue = allowEmpty;
-    }
-
-    @Override
-    protected boolean isValid(String value) {
-        if (allowEmptyValue && value != null && value.isEmpty()) {
-            return true;
-        }
-        return super.isValid(value);
     }
 }

--- a/flow-data/src/test/java/com/vaadin/flow/data/validator/EmailValidatorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/validator/EmailValidatorTest.java
@@ -88,18 +88,6 @@ public class EmailValidatorTest extends ValidatorTestBase {
         assertPasses("johannes84@v44d1n.com", shouldNotFail());
     }
 
-    @Test
-    public void emptyString_validatorAcceptsEmptyValue_passesValidation() {
-        assertPasses("", new EmailValidator("this should not fail", true));
-    }
-
-    @Test
-    public void emptyString_validatorDoesNotAcceptsEmptyValue_validationFails() {
-        assertFails("", new EmailValidator(
-                "explcitily disallowed empty value should not be accepted",
-                false));
-    }
-
     private EmailValidator validator(String errorMessage) {
         return new EmailValidator(errorMessage);
     }


### PR DESCRIPTION
Revert 'Overload EmailValidator to accept an empty value' feature from maintenance release because it's a new feature.