### PR TITLE
Live reload on frontend changes

### DIFF
--- a/flow-client/.eslintrc.js
+++ b/flow-client/.eslintrc.js
@@ -47,11 +47,6 @@ module.exports = {
             "space-infix-ops": "off",
             "no-trailing-spaces": "off",
             "func-call-spacing": "off"
-        }}, {
-        "files": ["VaadinDevmodeGizmo.js"],
-        "rules": {
-            "max-len": "off",
-            "indent": "off"
         }}
     ]
 };

--- a/flow-client/src/main/java/com/vaadin/client/ApplicationConfiguration.java
+++ b/flow-client/src/main/java/com/vaadin/client/ApplicationConfiguration.java
@@ -359,34 +359,79 @@ public class ApplicationConfiguration {
         return exportedWebComponents;
     }
 
+    /**
+     * Gets if development mode gizmo should be added to the page.
+     *
+     * @return whether development mode gizmo should be added
+     */
     public boolean isDevmodeGizmoEnabled() {
         return devmodeGizmoEnabled;
     }
 
+    /**
+     *
+     * Sets if development mode gizmo should be added to the page.
+     *
+     * @param devmodeGizmoEnabled
+     *            whether development mode gizmo should be added
+     */
     public void setDevmodeGizmoEnabled(boolean devmodeGizmoEnabled) {
         this.devmodeGizmoEnabled = devmodeGizmoEnabled;
     }
 
+    /**
+     * Gets the URL for the live reload websocket connection
+     *
+     * @return URL for the live reload websocket connection
+     */
     public String getLiveReloadUrl() {
         return liveReloadUrl;
     }
 
+    /**
+     * Sets the URL for the live reload websocket connection
+     * 
+     * @param liveReloadUrl
+     *            URL for the live reload websocket connection
+     */
     public void setLiveReloadUrl(String liveReloadUrl) {
         this.liveReloadUrl = liveReloadUrl;
     }
 
+    /**
+     * Gets the the live reload backend technology identifier.
+     * 
+     * @return the live reload backend technology identifier
+     */
     public String getLiveReloadBackend() {
         return liveReloadBackend;
     }
 
+    /**
+     * Sets the live reload backend technology identifier.
+     * 
+     * @param liveReloadBackend
+     *            the live reload backend technology identifier
+     */
     public void setLiveReloadBackend(String liveReloadBackend) {
         this.liveReloadBackend = liveReloadBackend;
     }
 
+    /**
+     * Gets the Spring boot live reload port.
+     * 
+     * @return the Spring boot live reload port
+     */
     public String getSpringBootLiveReloadPort() {
         return springBootLiveReloadPort;
     }
 
+    /**
+     * Sets the Spring boot live reload port.
+     * 
+     * @param springBootLiveReloadPort
+     *            the Spring boot live reload port
+     */
     public void setSpringBootLiveReloadPort(String springBootLiveReloadPort) {
         this.springBootLiveReloadPort = springBootLiveReloadPort;
     }

--- a/flow-client/src/main/java/com/vaadin/client/ApplicationConfiguration.java
+++ b/flow-client/src/main/java/com/vaadin/client/ApplicationConfiguration.java
@@ -45,6 +45,11 @@ public class ApplicationConfiguration {
     private String atmosphereJSVersion;
     private String[] exportedWebComponents;
 
+    private boolean devmodeGizmoEnabled;
+    private String liveReloadUrl;
+    private String liveReloadBackend;
+    private String springBootLiveReloadPort;
+
     /**
      * Gets the id generated for the application.
      *
@@ -352,5 +357,37 @@ public class ApplicationConfiguration {
      */
     public String[] getExportedWebComponents() {
         return exportedWebComponents;
+    }
+
+    public boolean isDevmodeGizmoEnabled() {
+        return devmodeGizmoEnabled;
+    }
+
+    public void setDevmodeGizmoEnabled(boolean devmodeGizmoEnabled) {
+        this.devmodeGizmoEnabled = devmodeGizmoEnabled;
+    }
+
+    public String getLiveReloadUrl() {
+        return liveReloadUrl;
+    }
+
+    public void setLiveReloadUrl(String liveReloadUrl) {
+        this.liveReloadUrl = liveReloadUrl;
+    }
+
+    public String getLiveReloadBackend() {
+        return liveReloadBackend;
+    }
+
+    public void setLiveReloadBackend(String liveReloadBackend) {
+        this.liveReloadBackend = liveReloadBackend;
+    }
+
+    public String getSpringBootLiveReloadPort() {
+        return springBootLiveReloadPort;
+    }
+
+    public void setSpringBootLiveReloadPort(String springBootLiveReloadPort) {
+        this.springBootLiveReloadPort = springBootLiveReloadPort;
     }
 }

--- a/flow-client/src/main/java/com/vaadin/client/ApplicationConfiguration.java
+++ b/flow-client/src/main/java/com/vaadin/client/ApplicationConfiguration.java
@@ -380,7 +380,7 @@ public class ApplicationConfiguration {
     }
 
     /**
-     * Gets the URL for the live reload websocket connection
+     * Gets the URL for the live reload websocket connection.
      *
      * @return URL for the live reload websocket connection
      */
@@ -389,7 +389,7 @@ public class ApplicationConfiguration {
     }
 
     /**
-     * Sets the URL for the live reload websocket connection
+     * Sets the URL for the live reload websocket connection.
      * 
      * @param liveReloadUrl
      *            URL for the live reload websocket connection

--- a/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
@@ -26,6 +26,7 @@ import com.vaadin.client.communication.ReconnectDialogConfiguration;
 import com.vaadin.client.flow.RouterLinkHandler;
 import com.vaadin.client.flow.StateNode;
 import com.vaadin.client.flow.binding.Binder;
+import com.vaadin.client.flow.dom.DomApi;
 import com.vaadin.client.flow.util.NativeFunction;
 
 import elemental.client.Browser;
@@ -97,6 +98,25 @@ public class ApplicationConnection {
                     servletVersion);
             Console.log(
                     "Vaadin application servlet version: " + servletVersion);
+
+            if (applicationConfiguration.isDevmodeGizmoEnabled()
+                    && applicationConfiguration.getLiveReloadUrl() != null) {
+                Element devmodeGizmo = Browser.getDocument()
+                        .createElement("vaadin-devmode-gizmo");
+                DomApi.wrap(devmodeGizmo).setAttribute("url",
+                        applicationConfiguration.getLiveReloadUrl());
+                if (applicationConfiguration.getLiveReloadBackend() != null) {
+                    DomApi.wrap(devmodeGizmo).setAttribute("backend",
+                            applicationConfiguration.getLiveReloadBackend());
+                }
+                if (applicationConfiguration
+                        .getSpringBootLiveReloadPort() != null) {
+                    DomApi.wrap(devmodeGizmo).setAttribute(
+                            "springbootlivereloadport", applicationConfiguration
+                                    .getSpringBootLiveReloadPort());
+                }
+                DomApi.wrap(body).appendChild(devmodeGizmo);
+            }
         }
 
         registry.getLoadingIndicator().show();

--- a/flow-client/src/main/java/com/vaadin/client/bootstrap/Bootstrapper.java
+++ b/flow-client/src/main/java/com/vaadin/client/bootstrap/Bootstrapper.java
@@ -165,6 +165,15 @@ public class Bootstrapper implements EntryPoint {
                 jsoConfiguration.getConfigBoolean("requestTiming"));
         conf.setExportedWebComponents(
                 jsoConfiguration.getConfigStringArray("webcomponents"));
+
+        conf.setDevmodeGizmoEnabled(jsoConfiguration
+                .getConfigBoolean(ApplicationConstants.DEVMODE_GIZMO_ENABLED));
+        conf.setLiveReloadUrl(
+                jsoConfiguration.getConfigString("liveReloadUrl"));
+        conf.setLiveReloadBackend(
+                jsoConfiguration.getConfigString("liveReloadBackend"));
+        conf.setSpringBootLiveReloadPort(
+                jsoConfiguration.getConfigString("springBootLiveReloadPort"));
     }
 
     private static void doStartApplication(final String applicationId) {

--- a/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
@@ -9,12 +9,6 @@ interface AppConfig {
   appId: string;
   uidl: object;
   clientRouting: boolean;
-  devmodeGizmoEnabled: boolean;
-  serviceUrl: string;
-  contextRootUrl: string;
-  springBootDevToolsPort: number;
-  liveReloadBackend: string;
-  liveReloadPath: string;
 }
 
 interface AppInitResponse {
@@ -233,15 +227,6 @@ export class Flow {
         document.body.appendChild(this.container);
       }
 
-      // Load devmode gizmo, which handles live-reload connection to the server
-      // (server ensures this parameter is true only in dev mode)
-      if (appConfig.devmodeGizmoEnabled) {
-        const devmodeGizmoMod = await import('./VaadinDevmodeGizmo');
-        const devmodeGizmo = await devmodeGizmoMod.init(this.getLiveReloadConnectionBaseUri(appConfig),
-            appConfig.liveReloadBackend, appConfig.springBootDevToolsPort);
-        $wnd.Vaadin.Flow.devModeGizmo = devmodeGizmo;
-      }
-
       // hide flow progress indicator
       this.hideLoading();
     }
@@ -411,24 +396,5 @@ export class Flow {
         loading.setAttribute('style', 'none');
       }
     };
-  }
-
-  private getLiveReloadConnectionBaseUri(appConfig: AppConfig) {
-    function getAbsoluteUrl(relative: string) {
-      // Use innerHTML to obtain an absolute URL
-      const div = document.createElement("div");
-      div.innerHTML = '<a href="' + relative + '"/>';
-      return (div.firstChild as HTMLLinkElement).href;
-    }
-    let serviceUrl: string;
-    let contextRoot: string;
-    if (appConfig.serviceUrl) {
-      serviceUrl = appConfig.serviceUrl;
-      contextRoot = getAbsoluteUrl(serviceUrl + appConfig.contextRootUrl);
-    } else {
-      serviceUrl = getAbsoluteUrl(".");
-      contextRoot = getAbsoluteUrl(appConfig.contextRootUrl);
-    }
-    return appConfig.liveReloadPath ? (contextRoot + appConfig.liveReloadPath) : serviceUrl;
   }
 }

--- a/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.d.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.d.ts
@@ -1,1 +1,0 @@
-export const init: (reloadConnectionBaseUri: string, liveReloadBackend: string, springBootDevToolsPort: number) => HTMLElement;

--- a/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.ts
@@ -918,8 +918,9 @@ export class VaadinDevmodeGizmo extends LitElement {
           <span class="tab">Log</span>
           <label class="switch">
               <input id="toggle" type="checkbox"
-                  ?disabled=${this.frontendStatus === ConnectionStatus.UNAVAILABLE || this.frontendStatus === ConnectionStatus.ERROR}
-                  ?checked="${this.frontendStatus === ConnectionStatus.ACTIVE}"
+                  ?disabled=${(this.frontendStatus === ConnectionStatus.UNAVAILABLE || this.frontendStatus === ConnectionStatus.ERROR)
+                    && (this.javaStatus === ConnectionStatus.UNAVAILABLE || this.javaStatus === ConnectionStatus.ERROR)}
+                  ?checked="${this.frontendStatus === ConnectionStatus.ACTIVE || this.javaStatus === ConnectionStatus.ACTIVE}"
                   @change=${(e:any) => this.setActive(e.target.checked)}/>
               <span class="slider"></span>
               <span class="live-reload-text">Live reload</span>

--- a/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.ts
@@ -1,6 +1,8 @@
-import {LitElement, html, css} from 'lit-element';
+import {css, html, LitElement, property} from 'lit-element';
 
-class VaadinDevmodeGizmo extends LitElement {
+/* tslint:disable: no-console max-classes-per-file */
+
+export class VaadinDevmodeGizmo extends LitElement {
 
   static get styles() {
     return css`
@@ -542,151 +544,141 @@ class VaadinDevmodeGizmo extends LitElement {
     `;
   }
 
-  static get properties() {
-    return {
-      expanded: {type: Boolean, attribute: false},
-      messages: {type: Array, attribute: false},
-      splashMessage: {type: String, attribute: false},
-      notifications: {type: Array, attribute: false},
-      frontendStatus: {type: String, attribute: false},
-      javaStatus: {type: String, attribute: false},
-      url: {type: String},
-      backend: {type: String},
-      springBootLiveReloadPort: {type: Number},
-    };
-  }
+  static DISMISSED_NOTIFICATIONS_IN_LOCAL_STORAGE = 'vaadin.live-reload.dismissedNotifications';
+  static ACTIVE_KEY_IN_SESSION_STORAGE = 'vaadin.live-reload.active';
+  static TRIGGERED_KEY_IN_SESSION_STORAGE = 'vaadin.live-reload.triggered';
+  static TRIGGERED_COUNT_KEY_IN_SESSION_STORAGE = 'vaadin.live-reload.triggeredCount';
 
-  static get DISMISSED_NOTIFICATIONS_IN_LOCAL_STORAGE() {
-    return 'vaadin.live-reload.dismissedNotifications';
-  }
+  static AUTO_DEMOTE_NOTIFICATION_DELAY = 5000;
 
-  static get ACTIVE_KEY_IN_SESSION_STORAGE() {
-    return 'vaadin.live-reload.active';
-  }
-
-  static get TRIGGERED_KEY_IN_SESSION_STORAGE() {
-    return 'vaadin.live-reload.triggered';
-  }
-
-  static get TRIGGERED_COUNT_KEY_IN_SESSION_STORAGE() {
-    return 'vaadin.live-reload.triggeredCount';
-  }
-
-  static get AUTO_DEMOTE_NOTIFICATION_DELAY() {
-    return 5000;
-  }
-
-  static get HOTSWAP_AGENT() {
-    return 'HOTSWAP_AGENT';
-  }
-
-  static get JREBEL() {
-    return 'JREBEL';
-  }
-
-  static get SPRING_BOOT_DEVTOOLS() {
-    return 'SPRING_BOOT_DEVTOOLS';
-  }
-
-  static get BACKEND_DISPLAY_NAME() {
-    return {
+  static HOTSWAP_AGENT = 'HOTSWAP_AGENT';
+  static JREBEL = 'JREBEL';
+  static SPRING_BOOT_DEVTOOLS = 'SPRING_BOOT_DEVTOOLS';
+  static BACKEND_DISPLAY_NAME: Record<string,string> = {
       HOTSWAP_AGENT: 'HotswapAgent',
       JREBEL: 'JRebel',
       SPRING_BOOT_DEVTOOLS: 'Spring Boot Devtools'
-    };
-  }
-
-  static get LOG() {
-    return 'log';
-  }
-
-  static get INFORMATION() {
-    return 'information';
-  }
-
-  static get WARNING() {
-    return 'warning';
-  }
+  };
 
   static get isActive() {
-    const active = window.sessionStorage.getItem(VaadinDevmodeGizmo.ACTIVE_KEY_IN_SESSION_STORAGE);
+    const active = window.sessionStorage
+        .getItem(VaadinDevmodeGizmo.ACTIVE_KEY_IN_SESSION_STORAGE);
     return active === null || active !== 'false';
   }
 
-  static notificationDismissed(persistentId) {
-    const shown = window.localStorage.getItem(VaadinDevmodeGizmo.DISMISSED_NOTIFICATIONS_IN_LOCAL_STORAGE);
+  static notificationDismissed(persistentId: string) {
+    const shown = window.localStorage
+        .getItem(VaadinDevmodeGizmo.DISMISSED_NOTIFICATIONS_IN_LOCAL_STORAGE);
     return shown !== null && shown.includes(persistentId);
   }
 
+  @property({type: String})
+  url?: string;
+
+  @property({type: String})
+  backend?: string;
+
+  @property({type: Number})
+  springBootLiveReloadPort?: number;
+
+  @property({type: Boolean, attribute: false})
+  expanded: boolean = false;
+
+  @property({type: Array, attribute: false})
+  messages:Message[] = [];
+
+  @property({type: Object, attribute: false})
+  splashMessage?: string;
+
+  @property({type: Array, attribute: false})
+  notifications: Message[] = [];
+
+  @property({type: String, attribute: false})
+  frontendStatus: ConnectionStatus = ConnectionStatus.UNAVAILABLE;
+
+  @property({type: String, attribute: false})
+  javaStatus: ConnectionStatus = ConnectionStatus.UNAVAILABLE;
+
+  javaConnection?: Connection;
+  frontendConnection?: Connection;
+
+  nextMessageId: number = 1;
+
+  disableEventListener?: EventListener;
+
+  transitionDuration: number = 0;
+
   constructor() {
     super();
-    this.messages = [];
-    this.splashMessage = null;
-    this.notifications = [];
-    this.expanded = false;
-    this.javaConnection = null;
-    this.frontendConnection = null;
-    this.nextMessageId = 1;
   }
 
   openWebSocketConnection() {
-    self = this;
+    this.frontendStatus = ConnectionStatus.UNAVAILABLE;
+    this.javaStatus = ConnectionStatus.UNAVAILABLE;
 
-    this.frontendStatus = Connection.UNAVAILABLE;
-    this.javaStatus = Connection.UNAVAILABLE;
-
-    const onConnectionError = msg => this.showMessage(VaadinDevmodeGizmo.ERROR, msg);
+    const onConnectionError = (msg: string) => this.showMessage(MessageType.ERROR, msg);
     const onReload = () => {
-      self.showSplashMessage('Reloading…');
-      const lastReload = window.sessionStorage.getItem(VaadinDevmodeGizmo.TRIGGERED_COUNT_KEY_IN_SESSION_STORAGE);
-      const nextReload = lastReload ? (parseInt(lastReload) + 1) : 1;
-      window.sessionStorage.setItem(VaadinDevmodeGizmo.TRIGGERED_COUNT_KEY_IN_SESSION_STORAGE, nextReload.toString());
-      window.sessionStorage.setItem(VaadinDevmodeGizmo.TRIGGERED_KEY_IN_SESSION_STORAGE, 'true');
+      this.showSplashMessage('Reloading…');
+      const lastReload = window.sessionStorage.getItem(
+          VaadinDevmodeGizmo.TRIGGERED_COUNT_KEY_IN_SESSION_STORAGE);
+      const nextReload = lastReload ? (parseInt(lastReload, 10) + 1) : 1;
+      window.sessionStorage.setItem(VaadinDevmodeGizmo.TRIGGERED_COUNT_KEY_IN_SESSION_STORAGE,
+          nextReload.toString());
+      window.sessionStorage.setItem(VaadinDevmodeGizmo.TRIGGERED_KEY_IN_SESSION_STORAGE,
+          'true');
       window.location.reload();
     };
 
-    this.frontendConnection = new Connection(this.getDedicatedWebSocketUrl());
-    this.frontendConnection.onHandshake = () => {
-      self.showMessage(VaadinDevmodeGizmo.LOG, 'Vaadin development mode initialized');
+    const frontendConnection = new Connection(this.getDedicatedWebSocketUrl());
+    frontendConnection.onHandshake = () => {
+      this.showMessage(MessageType.LOG, 'Vaadin development mode initialized');
       if (!VaadinDevmodeGizmo.isActive) {
-        this.frontendConnection.setActive(false);
+        frontendConnection.setActive(false);
       }
     };
-    this.frontendConnection.onConnectionError = onConnectionError;
-    this.frontendConnection.onReload = onReload;
-    this.frontendConnection.onStatusChange = status => {
-      self.frontendStatus = status;
+    frontendConnection.onConnectionError = onConnectionError;
+    frontendConnection.onReload = onReload;
+    frontendConnection.onStatusChange = (status:ConnectionStatus) => {
+      this.frontendStatus = status;
     };
+    this.frontendConnection = frontendConnection;
 
-    if (this.backend === VaadinDevmodeGizmo.SPRING_BOOT_DEVTOOLS && this.springBootLiveReloadPort) {
-      this.javaConnection = new Connection(this.getSpringBootWebSocketUrl(window.location));
-      this.javaConnection.onHandshake = () => {
+    let javaConnection: Connection;
+    if (this.backend === VaadinDevmodeGizmo.SPRING_BOOT_DEVTOOLS
+        && this.springBootLiveReloadPort) {
+      javaConnection = new Connection(
+          this.getSpringBootWebSocketUrl(window.location));
+      javaConnection.onHandshake = () => {
         if (!VaadinDevmodeGizmo.isActive) {
-          this.javaConnection.setActive(false);
+          javaConnection.setActive(false);
         }
       };
-      this.javaConnection.onReload = onReload;
-      this.javaConnection.onConnectionError = onConnectionError;
-    } else if (this.backend) {
-      this.javaConnection = this.frontendConnection;
+      javaConnection.onReload = onReload;
+      javaConnection.onConnectionError = onConnectionError;
+    } else if (this.backend === VaadinDevmodeGizmo.JREBEL
+        || this.backend === VaadinDevmodeGizmo.HOTSWAP_AGENT) {
+      javaConnection = frontendConnection;
     } else {
-      this.javaConnection = new Connection(null);
+      javaConnection = new Connection(undefined);
     }
-    const prevOnStatusChange = this.javaConnection.onStatusChange;
-    this.javaConnection.onStatusChange = status => {
+    const prevOnStatusChange = javaConnection.onStatusChange;
+    javaConnection.onStatusChange = status => {
       prevOnStatusChange(status);
-      self.javaStatus = status;
+      this.javaStatus = status;
     };
-    const prevOnHandshake = this.javaConnection.onHandshake;
-    this.javaConnection.onHandshake = () => {
+    const prevOnHandshake = javaConnection.onHandshake;
+    javaConnection.onHandshake = () => {
       prevOnHandshake();
-      if (self.backend) {
-        self.showMessage(VaadinDevmodeGizmo.INFORMATION, 'Java live reload available: ' + VaadinDevmodeGizmo.BACKEND_DISPLAY_NAME[self.backend]);
+      if (this.backend) {
+        this.showMessage(MessageType.INFORMATION,
+            'Java live reload available: '
+            + VaadinDevmodeGizmo.BACKEND_DISPLAY_NAME[this.backend]);
       }
     };
+    this.javaConnection = javaConnection;
 
     if (!this.backend) {
-      this.showNotification(VaadinDevmodeGizmo.WARNING,
+      this.showNotification(MessageType.WARNING,
         'Java live reload unavailable',
         'Live reload for Java changes is currently not set up. Find out how to make use of this functionality to boost your workflow.',
         'https://vaadin.com/docs/live-reload',
@@ -694,26 +686,31 @@ class VaadinDevmodeGizmo extends LitElement {
     }
   }
 
-  getDedicatedWebSocketUrl() {
-    function getAbsoluteUrl(relative) {
+  getDedicatedWebSocketUrl(): string | undefined {
+    function getAbsoluteUrl(relative: string) {
       // Use innerHTML to obtain an absolute URL
       const div = document.createElement('div');
       div.innerHTML = '<a href="' + relative + '"/>';
-      return div.firstChild.href;
+      return (div.firstChild as HTMLLinkElement).href;
     }
-
-    const connectionBaseUrl = getAbsoluteUrl(this.url);
-
-    if (!connectionBaseUrl.startsWith('http://') && !connectionBaseUrl.startsWith('https://')) {
-      console.warn('The protocol of the url should be http or https for live reload to work.');
-      return null;
+    if (this.url === undefined) {
+      return undefined;
     }
-    return connectionBaseUrl.replace(/^http/, 'ws') + '?v-r=push&refresh_connection';
+    const connectionBaseUrl = getAbsoluteUrl(this.url!);
+
+    if (!connectionBaseUrl.startsWith('http://')
+        && !connectionBaseUrl.startsWith('https://')) {
+      // eslint-disable-next-line no-console
+      console.error('The protocol of the url should be http or https for live reload to work.');
+      return undefined;
+    }
+    return connectionBaseUrl.replace(/^http/, 'ws')
+        + '?v-r=push&refresh_connection';
   }
 
-  getSpringBootWebSocketUrl(location) {
+  getSpringBootWebSocketUrl(location: any) {
     const hostname = location.hostname;
-    const wsProtocol = location.protocol == 'https:' ? 'wss' : 'ws';
+    const wsProtocol = location.protocol === 'https:' ? 'wss' : 'ws';
     if (hostname.endsWith('gitpod.io')) {
       // Gitpod uses `port-url` instead of `url:port`
       const hostnameWithoutPort = hostname.replace(/.*?-/, '');
@@ -727,41 +724,50 @@ class VaadinDevmodeGizmo extends LitElement {
     super.connectedCallback();
 
     // when focus or clicking anywhere, move the splash message to the message tray
-    this.disableEventListener = e => this.demoteSplashMessage();
+    this.disableEventListener = (_:any) => this.demoteSplashMessage();
     document.body.addEventListener('focus', this.disableEventListener);
     document.body.addEventListener('click', this.disableEventListener);
     this.openWebSocketConnection();
 
-    const lastReload = window.sessionStorage.getItem(VaadinDevmodeGizmo.TRIGGERED_KEY_IN_SESSION_STORAGE);
+    const lastReload = window.sessionStorage.getItem(
+        VaadinDevmodeGizmo.TRIGGERED_KEY_IN_SESSION_STORAGE);
     if (lastReload) {
-      const count = window.sessionStorage.getItem(VaadinDevmodeGizmo.TRIGGERED_COUNT_KEY_IN_SESSION_STORAGE);
+      const count = window.sessionStorage.getItem(
+          VaadinDevmodeGizmo.TRIGGERED_COUNT_KEY_IN_SESSION_STORAGE);
       const now = new Date();
       const reloaded = ('0' + now.getHours()).slice(-2) + ':'
         + ('0' + now.getMinutes()).slice(-2) + ':'
         + ('0' + now.getSeconds()).slice(-2);
       this.showSplashMessage('Automatic reload #' + count + ' finished at ' + reloaded);
-      window.sessionStorage.removeItem(VaadinDevmodeGizmo.TRIGGERED_KEY_IN_SESSION_STORAGE);
+      window.sessionStorage.removeItem(
+          VaadinDevmodeGizmo.TRIGGERED_KEY_IN_SESSION_STORAGE);
     }
 
-    this.__transitionDuration = parseInt(window.getComputedStyle(this).getPropertyValue('--gizmo-transition-duration'));
+    this.transitionDuration = parseInt(window.getComputedStyle(this)
+        .getPropertyValue('--gizmo-transition-duration'), 10);
 
-    window.Vaadin.Flow.devModeGizmo = this;
+    if ((window as any).Vaadin && (window as any).Vaadin.Flow) {
+      (window as any).Vaadin.Flow.devModeGizmo = this;
+    }
   }
 
   disconnectedCallback() {
-    document.body.removeEventListener('focus', this.disableEventListener);
-    document.body.removeEventListener('click', this.disableEventListener);
+    if (this.disableEventListener) {
+      document.body.removeEventListener('focus', this.disableEventListener!);
+      document.body.removeEventListener('click', this.disableEventListener!);
+    }
     super.disconnectedCallback();
   }
 
   toggleExpanded() {
-    this.notifications.slice().forEach(notification => this.dismissNotification(notification.id));
+    this.notifications.slice()
+        .forEach(notification => this.dismissNotification(notification.id));
     this.expanded = !this.expanded;
   }
 
-  showSplashMessage(msg) {
+  showSplashMessage(msg: string | undefined) {
     this.splashMessage = msg;
-    if (this.splashMessage != null) {
+    if (this.splashMessage) {
       if (this.expanded) {
         this.demoteSplashMessage();
       } else {
@@ -775,97 +781,92 @@ class VaadinDevmodeGizmo extends LitElement {
 
   demoteSplashMessage() {
     if (this.splashMessage) {
-      this.showMessage(VaadinDevmodeGizmo.LOG, this.splashMessage);
+      this.showMessage(MessageType.LOG, this.splashMessage);
     }
-    this.showSplashMessage(null);
+    this.showSplashMessage(undefined);
   }
 
-  showMessage(type, msg, details = null, link = null) {
+  showMessage(type: MessageType, message: string, details?: string, link?: string) {
     const id = this.nextMessageId++;
     this.messages.push({
-      id: id,
-      type: type,
-      message: msg,
-      details: details,
-      link: link
+      id,
+      type,
+      message,
+      details,
+      link,
+      dontShowAgain: false,
+      deleted: false
     });
     this.requestUpdate();
     this.updateComplete.then(() => {
       // Scroll into view
       setTimeout(() => {
-        this.shadowRoot.querySelector('.message-tray .message:last-child').scrollIntoView({behavior: 'smooth'});
-      }, this.__transitionDuration);
+        this.shadowRoot!
+            .querySelector('.message-tray .message:last-child')!
+            .scrollIntoView({behavior: 'smooth'});
+      }, this.transitionDuration);
     });
   }
 
-  showNotification(type, msg, details = null, link = null, persistentId = null) {
-    if (persistentId === null || !VaadinDevmodeGizmo.notificationDismissed(persistentId)) {
+  showNotification(type: MessageType, message: string, details?: string, link?: string, persistentId?: string) {
+    if (persistentId === undefined || !VaadinDevmodeGizmo.notificationDismissed(persistentId!)) {
       const id = this.nextMessageId++;
       this.notifications.push({
-        id: id,
-        type: type,
-        message: msg,
-        details: details,
-        link: link,
-        persistentId: persistentId,
-        dontShowAgain: false
+        id,
+        type,
+        message,
+        details,
+        link,
+        persistentId,
+        dontShowAgain: false,
+        deleted: false
       });
       // automatically move notification to message tray after a certain amount of time unless it contains a link
-      if (link === null) {
+      if (link === undefined) {
         setTimeout(() => {
           this.dismissNotification(id);
         }, VaadinDevmodeGizmo.AUTO_DEMOTE_NOTIFICATION_DELAY);
       }
       this.requestUpdate();
     } else {
-      this.showMessage(type, msg, details, link);
+      this.showMessage(type, message, details, link);
     }
   }
 
-  dismissNotification(id) {
+  dismissNotification(id: number) {
     const index = this.findNotificationIndex(id);
     if (index !== -1 && !this.notifications[index].deleted) {
       const notification = this.notifications[index];
 
       // user is explicitly dismissing a notification---after that we won't bug them with it
-      if (notification.dontShowAgain && notification.persistentId && !VaadinDevmodeGizmo.notificationDismissed(notification.persistentId)) {
+      if (notification.dontShowAgain && notification.persistentId
+          && !VaadinDevmodeGizmo.notificationDismissed(notification.persistentId)) {
         let dismissed = window.localStorage.getItem(VaadinDevmodeGizmo.DISMISSED_NOTIFICATIONS_IN_LOCAL_STORAGE);
-        if (dismissed === null) {
-          dismissed = notification.persistentId;
-        } else {
-          dismissed = dismissed + ',' + notification.persistentId;
-        }
+        dismissed = dismissed === null ? notification.persistentId : dismissed + ',' + notification.persistentId;
         window.localStorage.setItem(VaadinDevmodeGizmo.DISMISSED_NOTIFICATIONS_IN_LOCAL_STORAGE, dismissed);
       }
 
       notification.deleted = true;
-      this.showMessage(notification.type, notification.message, notification.details, notification.link);
+      this.showMessage(notification.type, notification.message, notification.details,
+          notification.link);
 
-      const self = this;
       // give some time for the animation
       setTimeout(() => {
-        const index = self.findNotificationIndex(id);
-        if (index != -1) {
-          this.notifications.splice(index, 1);
+        const idx = this.findNotificationIndex(id);
+        if (idx !== -1) {
+          this.notifications.splice(idx, 1);
           this.requestUpdate();
         }
-      }, this.__transitionDuration);
+      }, this.transitionDuration);
     }
   }
 
-  findNotificationIndex(id) {
-      let index = -1;
-      this.notifications.some((notification, idx) => {
-          if (notification.id === id) {
-              index = idx;
-              return true;
-          }
-      });
-      return index;
+  findNotificationIndex(id: number): number {
+    return this.notifications.findIndex((notification, _) => notification.id === id);
   }
 
-  toggleDontShowAgain(id) {
-    const index = this.notifications.findIndex(notification => notification.id === id);
+  toggleDontShowAgain(id: number) {
+    const index = this.findNotificationIndex(id);
     if (index !== -1 && !this.notifications[index].deleted) {
       const notification = this.notifications[index];
       notification.dontShowAgain = !notification.dontShowAgain;
@@ -873,31 +874,28 @@ class VaadinDevmodeGizmo extends LitElement {
     }
   }
 
-  setActive(yes) {
-    this.frontendConnection.setActive(yes);
-    this.javaConnection.setActive(yes);
-    if (yes) {
-      window.sessionStorage.setItem(VaadinDevmodeGizmo.ACTIVE_KEY_IN_SESSION_STORAGE, 'true');
-    } else {
-      window.sessionStorage.setItem(VaadinDevmodeGizmo.ACTIVE_KEY_IN_SESSION_STORAGE, 'false');
-    }
+  setActive(yes: boolean) {
+    this.frontendConnection?.setActive(yes);
+    this.javaConnection?.setActive(yes);
+    window.sessionStorage.setItem(VaadinDevmodeGizmo.ACTIVE_KEY_IN_SESSION_STORAGE,
+        yes ? 'true' : 'false');
   }
 
-  getStatusColor(status) {
-    if (status === Connection.ACTIVE) {
+  getStatusColor(status: ConnectionStatus | undefined) {
+    if (status === ConnectionStatus.ACTIVE) {
       return 'var(--gizmo-green-color)';
-    } else if (status === Connection.INACTIVE) {
+    } else if (status === ConnectionStatus.INACTIVE) {
       return 'var(--gizmo-grey-color)';
-    } else if (status === Connection.UNAVAILABLE) {
+    } else if (status === ConnectionStatus.UNAVAILABLE) {
       return 'var(--gizmo-yellow-color)';
-    } else if (status === Connection.ERROR) {
+    } else if (status === ConnectionStatus.ERROR) {
       return 'var(--gizmo-red-color)';
     } else {
       return 'none';
     }
   }
 
-  renderMessage(messageObject) {
+  renderMessage(messageObject: Message) {
     return html`
       <div class="message ${messageObject.type} ${messageObject.deleted ? 'animate-out' : ''} ${messageObject.details || messageObject.link ? 'has-details' : ''}">
         <div class="message-content">
@@ -906,9 +904,9 @@ class VaadinDevmodeGizmo extends LitElement {
             ${messageObject.details ? html`<p>${messageObject.details}</p>` : ''}
             ${messageObject.link ? html`<a class="ahreflike" href="${messageObject.link}" target="_blank">Read more</a>` : ''}
           </div>
-          ${messageObject.persistentId ? html`<div class="persist ${messageObject.dontShowAgain ? 'on' : 'off'}" @click=${e => this.toggleDontShowAgain(messageObject.id)}>Don’t show again</div>` : ''}
+          ${messageObject.persistentId ? html`<div class="persist ${messageObject.dontShowAgain ? 'on' : 'off'}" @click=${() => this.toggleDontShowAgain(messageObject.id)}>Don’t show again</div>` : ''}
         </div>
-        <div class="dismiss-message" @click=${e => this.dismissNotification(messageObject.id)}>Dismiss</div>
+        <div class="dismiss-message" @click=${() => this.dismissNotification(messageObject.id)}>Dismiss</div>
       </div>
       `;
   }
@@ -920,13 +918,13 @@ class VaadinDevmodeGizmo extends LitElement {
           <span class="tab">Log</span>
           <label class="switch">
               <input id="toggle" type="checkbox"
-                  ?disabled=${this.frontendStatus === Connection.UNAVAILABLE || this.frontendStatus === Connection.ERROR}
-                  ?checked="${this.frontendStatus === Connection.ACTIVE}"
-                  @change=${e => this.setActive(e.target.checked)}/>
+                  ?disabled=${this.frontendStatus === ConnectionStatus.UNAVAILABLE || this.frontendStatus === ConnectionStatus.ERROR}
+                  ?checked="${this.frontendStatus === ConnectionStatus.ACTIVE}"
+                  @change=${(e:any) => this.setActive(e.target.checked)}/>
               <span class="slider"></span>
               <span class="live-reload-text">Live reload</span>
           </label>
-          <button class="minimize-button" title="Minimize" @click=${e => this.toggleExpanded()}>
+          <button class="minimize-button" title="Minimize" @click=${() => this.toggleExpanded()}>
             <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
               <path d="M7.25 0.75C7.25 0.335786 7.58579 0 8 0H12.25C14.3211 0 16 1.67893 16 3.75V12.25C16 14.3211 14.3211 16 12.25 16H3.75C1.67893 16 0 14.3211 0 12.25V8C0 7.58579 0.335786 7.25 0.75 7.25C1.16421 7.25 1.5 7.58579 1.5 8V12.25C1.5 13.4926 2.50736 14.5 3.75 14.5H12.25C13.4926 14.5 14.5 13.4926 14.5 12.25V3.75C14.5 2.50736 13.4926 1.5 12.25 1.5H8C7.58579 1.5 7.25 1.16421 7.25 0.75Z"/>
               <path d="M2.96967 2.96967C3.26256 2.67678 3.73744 2.67678 4.03033 2.96967L9.5 8.43934V5.75C9.5 5.33579 9.83579 5 10.25 5C10.6642 5 11 5.33579 11 5.75V10.25C11 10.6642 10.6642 11 10.25 11H5.75C5.33579 11 5 10.6642 5 10.25C5 9.83579 5.33579 9.5 5.75 9.5H8.43934L2.96967 4.03033C2.67678 3.73744 2.67678 3.26256 2.96967 2.96967Z"/>
@@ -942,13 +940,13 @@ class VaadinDevmodeGizmo extends LitElement {
         ${this.notifications.map(msg => this.renderMessage(msg))}
       </div>
 
-      <div class="gizmo ${this.splashMessage !== null ? 'active' : ''}" @click=${e => this.toggleExpanded()}>
+      <div class="gizmo ${this.splashMessage ? 'active' : ''}" @click=${() => this.toggleExpanded()}>
         <svg viewBox="0 0 16 16" preserveAspectRatio="xMidYMid meet" focusable="false" class="vaadin-logo">
           <path d="M15.21 0.35c-0.436 0-0.79 0.354-0.79 0.79v0 0.46c0 0.5-0.32 0.85-1.070 0.85h-3.55c-1.61 0-1.73 1.19-1.8 1.83v0c-0.060-0.64-0.18-1.83-1.79-1.83h-3.57c-0.75 0-1.090-0.37-1.090-0.86v-0.45c0-0.006 0-0.013 0-0.020 0-0.425-0.345-0.77-0.77-0.77-0 0-0 0-0 0h0c-0 0-0 0-0 0-0.431 0-0.78 0.349-0.78 0.78 0 0.004 0 0.007 0 0.011v-0.001 1.32c0 1.54 0.7 2.31 2.34 2.31h3.66c1.090 0 1.19 0.46 1.19 0.9 0 0 0 0.090 0 0.13 0.048 0.428 0.408 0.758 0.845 0.758s0.797-0.33 0.845-0.754l0-0.004s0-0.080 0-0.13c0-0.44 0.1-0.9 1.19-0.9h3.61c1.61 0 2.32-0.77 2.32-2.31v-1.32c0-0.436-0.354-0.79-0.79-0.79v0z"></path>
           <path d="M11.21 7.38c-0.012-0-0.026-0.001-0.040-0.001-0.453 0-0.835 0.301-0.958 0.714l-0.002 0.007-2.21 4.21-2.3-4.2c-0.122-0.425-0.507-0.731-0.963-0.731-0.013 0-0.026 0-0.039 0.001l0.002-0c-0.012-0-0.025-0.001-0.039-0.001-0.58 0-1.050 0.47-1.050 1.050 0 0.212 0.063 0.41 0.171 0.575l-0.002-0.004 3.29 6.1c0.15 0.333 0.478 0.561 0.86 0.561s0.71-0.228 0.858-0.555l0.002-0.006 3.34-6.1c0.090-0.152 0.144-0.335 0.144-0.53 0-0.58-0.47-1.050-1.050-1.050-0.005 0-0.010 0-0.014 0h0.001z"></path>
         </svg>
         <span class="status-blip" style="background: linear-gradient(to right, ${this.getStatusColor(this.frontendStatus)} 0.5rem, ${this.getStatusColor(this.javaStatus)} 0.5rem)"></span>
-          ${this.splashMessage !== null
+          ${this.splashMessage 
       ? html`<span class="status-description">${this.splashMessage}</span></div>`
       : html`<span class="status-description">Live reload (JS: ${this.frontendStatus}, Java: ${this.javaStatus}) </span><span class="ahreflike">Details</span></div>`
     }
@@ -956,48 +954,40 @@ class VaadinDevmodeGizmo extends LitElement {
   }
 }
 
+enum ConnectionStatus {
+  ACTIVE ='active',
+  INACTIVE = 'inactive',
+  UNAVAILABLE = 'unavailable',
+  ERROR = 'error'
+}
+
+// eslint-disable-next-line
 class Connection extends Object {
 
-  static get ACTIVE() {
-    return 'active';
-  }
+  static HEARTBEAT_INTERVAL = 180000;
 
-  static get INACTIVE() {
-    return 'inactive';
-  }
+  status: ConnectionStatus = ConnectionStatus.UNAVAILABLE;
+  webSocket?: WebSocket;
 
-  static get UNAVAILABLE() {
-    return 'unavailable';
-  }
-
-  static get ERROR() {
-    return 'error';
-  }
-
-  static get HEARTBEAT_INTERVAL() {
-    return 180000;
-  }
-
-  constructor(url) {
+  constructor(url?: string) {
     super();
-    this.status = Connection.UNAVAILABLE;
 
     if (url) {
       this.webSocket = new WebSocket(url);
       this.webSocket.onmessage = msg => this.handleMessage(msg);
       this.webSocket.onerror = err => this.handleError(err);
-      const self = this;
       this.webSocket.onclose = _ => {
-        if (self.status !== Connection.ERROR) {
-          self.setStatus(Connection.UNAVAILABLE);
+        if (this.status !== ConnectionStatus.ERROR) {
+          this.setStatus(ConnectionStatus.UNAVAILABLE);
         }
-        self.webSocket = null;
+        this.webSocket = undefined;
       };
     }
 
-    setInterval(function() {
-      if (self.webSocket && self.status !== Connection.ERROR && self.status !== Connection.UNAVAILABLE) {
-        self.webSocket.send('');
+    setInterval(() => {
+      if (this.webSocket && self.status !== ConnectionStatus.ERROR
+          && this.status !== ConnectionStatus.UNAVAILABLE) {
+        this.webSocket.send('');
       }
     }, Connection.HEARTBEAT_INTERVAL);
   }
@@ -1008,13 +998,13 @@ class Connection extends Object {
   onReload() {
   }
 
-  onConnectionError(msg) {
+  onConnectionError(_: string) {
   }
 
-  onStatusChange(status) {
+  onStatusChange(_: ConnectionStatus) {
   }
 
-  handleMessage(msg) {
+  handleMessage(msg: any) {
     let json;
     try {
       json = JSON.parse(msg.data);
@@ -1022,44 +1012,46 @@ class Connection extends Object {
       this.handleError(`[${e.name}: ${e.message}`);
       return;
     }
-    const command = json['command'];
+    const command = json.command;
     switch (command) {
       case 'hello': {
-        this.setStatus(Connection.ACTIVE);
-        this.onHandshake(msg);
+        this.setStatus(ConnectionStatus.ACTIVE);
+        this.onHandshake();
         break;
       }
 
       case 'reload':
-        if (this.status === Connection.ACTIVE) {
+        if (this.status === ConnectionStatus.ACTIVE) {
           this.onReload();
         }
         break;
 
       default:
-        console.warn('Unknown command received from the live reload server:', command);
+        // eslint-disable-next-line no-console
+        console.error('Unknown command received from the live reload server:', command);
     }
   }
 
-  handleError(msg) {
+  handleError(msg: any) {
+    // eslint-disable-next-line no-console
     console.error(msg);
-    this.setStatus(Connection.ERROR);
-    if (msg instanceof Event) {
+    this.setStatus(ConnectionStatus.ERROR);
+    if (msg instanceof Event && this.webSocket) {
       this.onConnectionError('Error in WebSocket connection to ' + this.webSocket.url);
     } else {
       this.onConnectionError(msg);
     }
   }
 
-  setActive(yes) {
-    if (!yes && this.status === Connection.ACTIVE) {
-      this.setStatus(Connection.INACTIVE);
-    } else if (yes && this.status === Connection.INACTIVE) {
-      this.setStatus(Connection.ACTIVE);
+  setActive(yes: boolean) {
+    if (!yes && this.status === ConnectionStatus.ACTIVE) {
+      this.setStatus(ConnectionStatus.INACTIVE);
+    } else if (yes && this.status === ConnectionStatus.INACTIVE) {
+      this.setStatus(ConnectionStatus.ACTIVE);
     }
   }
 
-  setStatus(status) {
+  setStatus(status: ConnectionStatus) {
     if (this.status !== status) {
       this.status = status;
       this.onStatusChange(status);
@@ -1067,10 +1059,24 @@ class Connection extends Object {
   }
 }
 
+enum MessageType {
+  LOG = 'log',
+  INFORMATION ='information',
+  WARNING = 'warning',
+  ERROR = 'error'
+}
+
+interface Message {
+  id: number;
+  type: MessageType;
+  message: string;
+  details?: string;
+  link?: string;
+  persistentId?: string;
+  dontShowAgain: boolean;
+  deleted: boolean;
+}
+
 if (customElements.get('vaadin-devmode-gizmo') === undefined) {
   customElements.define('vaadin-devmode-gizmo', VaadinDevmodeGizmo);
 }
-
-export {
-  VaadinDevmodeGizmo
-};

--- a/flow-client/src/test/frontend/VaadinDevmodeGizmoTests.js
+++ b/flow-client/src/test/frontend/VaadinDevmodeGizmoTests.js
@@ -35,7 +35,7 @@ describe('VaadinDevmodeGizmo', () => {
     gizmo.javaConnection.handleError('TEST');
     assert.equal(gizmo.javaStatus, 'error');
     assert.equal(gizmo.messages.length, 1);
-    assert.equal(gizmo.messages[0].type, VaadinDevmodeGizmo.ERROR);
+    assert.equal(gizmo.messages[0].type, 'error');
     assert.equal(gizmo.messages[0].message, 'TEST');
 
   });

--- a/flow-client/src/test/frontend/VaadinDevmodeGizmoTests.js
+++ b/flow-client/src/test/frontend/VaadinDevmodeGizmoTests.js
@@ -1,12 +1,15 @@
 const { describe, it } = intern.getPlugin('interface.bdd');
 const { assert } = intern.getPlugin("chai");
 
-import { init } from "../../main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo";
+import { VaadinDevmodeGizmo } from "../../main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo";
 
 describe('VaadinDevmodeGizmo', () => {
 
   it('should connect to port-hostname.gitpod.io with Spring Boot Devtools', () => {
-    let gizmo = init( 'http://localhost:8080', 'SPRING_BOOT_DEVTOOLS', 35729);
+    const gizmo = document.createElement('vaadin-devmode-gizmo');
+    gizmo.setAttribute('url', '');
+    gizmo.setAttribute('backend', 'SPRING_BOOT_DEVTOOLS');
+    gizmo.setAttribute('springBootLiveReloadPort', '35729');
     let location = {
       'protocol': 'https',
       'hostname': 'abc-12345678-1234-1234-1234-1234567890ab.ws-eu01.gitpod.io'
@@ -16,23 +19,24 @@ describe('VaadinDevmodeGizmo', () => {
   });
 
   it('should use base URI', () => {
-    let gizmo = init('http://localhost:8080/context/vaadinServlet','HOTSWAP_AGENT', 35729);
+    const gizmo = document.createElement('vaadin-devmode-gizmo');
+    gizmo.setAttribute('url', 'http://localhost:8080/context/vaadinServlet');
+    gizmo.setAttribute('backend', 'HOTSWAP_AGENT');
+
     assert.equal(gizmo.getDedicatedWebSocketUrl(),
       'ws://localhost:8080/context/vaadinServlet?v-r=push&refresh_connection');
   });
 
   it('should have a new message on tray when error occurs', () => {
-    let gizmo = init('http://localhost:8080','SPRING_BOOT_DEVTOOLS', 35729);
-    gizmo.connection.onerror('TEST');
-    let message = {
-      'id': 1,
-      'type': 'error',
-      'message': 'TEST',
-      'details': null,
-      'link': null
-    };
-    assert.equal(gizmo.status, 'error');
+    const gizmo = document.createElement('vaadin-devmode-gizmo');
+    gizmo.setAttribute('url', '');
+    gizmo.setAttribute('backend', 'HOTSWAP_AGENT');
+    gizmo.openWebSocketConnection();
+    gizmo.javaConnection.handleError('TEST');
+    assert.equal(gizmo.javaStatus, 'error');
     assert.equal(gizmo.messages.length, 1);
-    assert.deepEqual(gizmo.messages[0], message);
+    assert.equal(gizmo.messages[0].type, VaadinDevmodeGizmo.ERROR);
+    assert.equal(gizmo.messages[0].message, 'TEST');
+
   });
 });

--- a/flow-server/src/main/java/com/vaadin/flow/internal/BootstrapHandlerHelper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/BootstrapHandlerHelper.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.internal;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import com.vaadin.flow.server.HandlerHelper;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.shared.VaadinUriResolver;
+
+/**
+ * Helper methods for use in bootstrapping.
+ *
+ */
+public class BootstrapHandlerHelper implements Serializable {
+
+    /**
+     * Gets the service URL as a URL relative to the request URI.
+     *
+     * @param vaadinRequest
+     *            the request
+     * @return the relative service URL
+     */
+    public static String getServiceUrl(VaadinRequest vaadinRequest) {
+        String pathInfo = vaadinRequest.getPathInfo();
+        if (pathInfo == null) {
+            return ".";
+        } else {
+            /*
+             * Make a relative URL to the servlet by adding one ../ for each
+             * path segment in pathInfo (i.e. the part of the requested path
+             * that comes after the servlet mapping)
+             */
+            return HandlerHelper.getCancelingRelativePath(pathInfo);
+        }
+    }
+
+    /**
+     * Gets the push URL as a URL relative to the request URI.
+     *
+     * @param vaadinSession
+     *            the session
+     * @param vaadinRequest
+     *            the request
+     * @return the relative push URL
+     */
+    public static String getPushURL(VaadinSession vaadinSession,
+                                    VaadinRequest vaadinRequest) {
+        String serviceUrl = getServiceUrl(vaadinRequest);
+
+        String pushURL = vaadinSession.getConfiguration().getPushURL();
+        if (pushURL == null) {
+            pushURL = serviceUrl;
+        } else {
+            try {
+                URI uri = new URI(serviceUrl);
+                pushURL = uri.resolve(new URI(pushURL)).toASCIIString();
+            } catch (URISyntaxException exception) {
+                throw new IllegalStateException(String.format(
+                        "Can't resolve pushURL '%s' based on the service URL '%s'",
+                        pushURL, serviceUrl), exception);
+            }
+        }
+        String contextPath = vaadinRequest.getService()
+                .getContextRootRelativePath(vaadinRequest);
+
+        class UriResolver extends VaadinUriResolver {
+            public String resolveVaadinUri(String uri) {
+                return resolveVaadinUri(uri, contextPath);
+            }
+        }
+        return new UriResolver().resolveVaadinUri(pushURL);
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReload.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReload.java
@@ -34,12 +34,6 @@ public interface BrowserLiveReload {
     }
 
     /**
-     * Default live reload port as defined in Spring Boot Dev Tools.
-     */
-    // Non-default port currently not supported (#7970)
-    int SPRING_BOOT_DEFAULT_LIVE_RELOAD_PORT = 35729;
-
-    /**
      * Detects and return enabling live reload backend technology.
      * 
      * @return enabling technology, or <code>null</code> if none

--- a/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReload.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReload.java
@@ -34,7 +34,7 @@ public interface BrowserLiveReload {
     }
 
     /**
-     * Default live reload port as defined in Spring Boot Dev Tools
+     * Default live reload port as defined in Spring Boot Dev Tools.
      */
     // Non-default port currently not supported (#7970)
     int SPRING_BOOT_DEFAULT_LIVE_RELOAD_PORT = 35729;

--- a/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReload.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReload.java
@@ -34,6 +34,12 @@ public interface BrowserLiveReload {
     }
 
     /**
+     * Default live reload port as defined in Spring Boot Dev Tools
+     */
+    // Non-default port currently not supported (#7970)
+    int SPRING_BOOT_DEFAULT_LIVE_RELOAD_PORT = 35729;
+
+    /**
      * Detects and return enabling live reload backend technology.
      * 
      * @return enabling technology, or <code>null</code> if none

--- a/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReloadImpl.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReloadImpl.java
@@ -27,6 +27,8 @@ import org.atmosphere.cpr.AtmosphereResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.flow.server.DevModeHandler;
+
 /**
  * {@link BrowserLiveReload} implementation class.
  *
@@ -59,6 +61,11 @@ class BrowserLiveReloadImpl implements BrowserLiveReload {
 
     BrowserLiveReloadImpl(ClassLoader classLoader) {
         this.classLoader = classLoader;
+
+        DevModeHandler devModeHandler = DevModeHandler.getDevModeHandler();
+        if (devModeHandler != null) {
+            devModeHandler.setLiveReload(this);
+        }
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -1096,7 +1096,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                                 liveReload.getBackend().toString());
                     }
                     appConfig.put("springBootLiveReloadPort",
-                            BrowserLiveReload.SPRING_BOOT_DEFAULT_LIVE_RELOAD_PORT);
+                            Constants.SPRING_BOOT_DEFAULT_LIVE_RELOAD_PORT);
                 }
             }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -406,6 +406,12 @@ public final class Constants implements Serializable {
     @Deprecated
     public static final String SERVLET_PARAMETER_DEVMODE_ENABLE_LIVE_RELOAD = InitParameters.SERVLET_PARAMETER_DEVMODE_ENABLE_LIVE_RELOAD;
 
+    /**
+     * Default live reload port as defined in Spring Boot Dev Tools.
+     */
+    // Non-default port currently not supported (#7970)
+    public static final int SPRING_BOOT_DEFAULT_LIVE_RELOAD_PORT = 35729;
+
     private Constants() {
         // prevent instantiation constants class only
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
@@ -45,6 +45,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.internal.BrowserLiveReload;
 import com.vaadin.flow.internal.Pair;
 import com.vaadin.flow.server.communication.StreamRequestHandler;
 import com.vaadin.flow.server.frontend.FrontendTools;
@@ -108,6 +109,8 @@ public final class DevModeHandler implements RequestHandler {
     private volatile String failedOutput;
 
     private AtomicBoolean isDevServerFailedToStart = new AtomicBoolean();
+
+    private BrowserLiveReload liveReload;
 
     /**
      * The local installation path of the webpack-dev-server node script.
@@ -199,6 +202,25 @@ public final class DevModeHandler implements RequestHandler {
      */
     public static DevModeHandler getDevModeHandler() {
         return atomicHandler.get();
+    }
+
+    /**
+     * Set the live reload service instance.
+     * 
+     * @param liveReload
+     *            the live reload instance
+     */
+    public void setLiveReload(BrowserLiveReload liveReload) {
+        this.liveReload = liveReload;
+    }
+
+    /**
+     * Get the live reload service instance.
+     * 
+     * @return the live reload instance
+     */
+    public BrowserLiveReload getLiveReload() {
+        return liveReload;
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
@@ -110,7 +110,7 @@ public final class DevModeHandler implements RequestHandler {
 
     private AtomicBoolean isDevServerFailedToStart = new AtomicBoolean();
 
-    private BrowserLiveReload liveReload;
+    private transient BrowserLiveReload liveReload;
 
     /**
      * The local installation path of the webpack-dev-server node script.

--- a/flow-server/src/main/java/com/vaadin/flow/server/DevServerWatchDog.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DevServerWatchDog.java
@@ -15,12 +15,16 @@
  */
 package com.vaadin.flow.server;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.net.ServerSocket;
 import java.net.Socket;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.vaadin.flow.internal.BrowserLiveReload;
 
 /**
  * Opens a server socket which is supposed to be opened until dev mode is active
@@ -57,6 +61,17 @@ class DevServerWatchDog {
                 try {
                     Socket accept = server.accept();
                     accept.setSoTimeout(0);
+                    BufferedReader in = new BufferedReader(new InputStreamReader(accept.getInputStream()));
+                    String line;
+                    while ((line = in.readLine()) != null) {
+                        if ("reload".equals(line)) {
+                            BrowserLiveReload liveReload = DevModeHandler
+                                    .getDevModeHandler().getLiveReload();
+                            if (liveReload != null) {
+                                liveReload.reload();
+                            }
+                        }
+                    }
                 } catch (IOException e) {
                     getLogger().debug(
                             "Error occurred during accept a connection", e);

--- a/flow-server/src/main/java/com/vaadin/flow/server/DevServerWatchDog.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DevServerWatchDog.java
@@ -61,17 +61,7 @@ class DevServerWatchDog {
                 try {
                     Socket accept = server.accept();
                     accept.setSoTimeout(0);
-                    BufferedReader in = new BufferedReader(new InputStreamReader(accept.getInputStream()));
-                    String line;
-                    while ((line = in.readLine()) != null) {
-                        if ("reload".equals(line)) {
-                            BrowserLiveReload liveReload = DevModeHandler
-                                    .getDevModeHandler().getLiveReload();
-                            if (liveReload != null) {
-                                liveReload.reload();
-                            }
-                        }
-                    }
+                    enterReloadMessageReadLoop(accept);
                 } catch (IOException e) {
                     getLogger().debug(
                             "Error occurred during accept a connection", e);
@@ -94,6 +84,19 @@ class DevServerWatchDog {
             return LoggerFactory.getLogger(WatchDogServer.class);
         }
 
+        private void enterReloadMessageReadLoop(Socket accept) throws IOException{
+            BufferedReader in = new BufferedReader(new InputStreamReader(accept.getInputStream()));
+            String line;
+            while ((line = in.readLine()) != null) {
+                if ("reload".equals(line)) {
+                    BrowserLiveReload liveReload = DevModeHandler
+                            .getDevModeHandler().getLiveReload();
+                    if (liveReload != null) {
+                        liveReload.reload();
+                    }
+                }
+            }
+        }
     }
 
     private final WatchDogServer watchDogServer;

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
@@ -32,6 +32,7 @@ import com.vaadin.flow.internal.BrowserLiveReload;
 import com.vaadin.flow.internal.BrowserLiveReloadAccess;
 import com.vaadin.flow.internal.UsageStatisticsExporter;
 import com.vaadin.flow.server.AppShellRegistry;
+import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.VaadinContext;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
@@ -138,7 +139,7 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
                 devmodeGizmo.attr("backend", liveReload.getBackend().toString());
             }
             devmodeGizmo.attr("springbootlivereloadport", Integer.toString(
-                    BrowserLiveReload.SPRING_BOOT_DEFAULT_LIVE_RELOAD_PORT));
+                    Constants.SPRING_BOOT_DEFAULT_LIVE_RELOAD_PORT));
             indexDocument.body().appendChild(devmodeGizmo);
         }
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
@@ -27,11 +27,15 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.internal.BootstrapHandlerHelper;
+import com.vaadin.flow.internal.BrowserLiveReload;
+import com.vaadin.flow.internal.BrowserLiveReloadAccess;
 import com.vaadin.flow.internal.UsageStatisticsExporter;
 import com.vaadin.flow.server.AppShellRegistry;
 import com.vaadin.flow.server.VaadinContext;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
+import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.frontend.FrontendUtils;
 
@@ -103,6 +107,9 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
         // modify the page based on registered IndexHtmlRequestListener:s
         request.getService().modifyIndexHtmlResponse(indexHtmlResponse);
 
+        if (config.isDevModeLiveReloadEnabled()) {
+            addDevmodeGizmo(indexDocument, session, request);
+        }
         try {
             response.getOutputStream()
                     .write(indexDocument.html().getBytes(UTF_8));
@@ -111,6 +118,29 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
             return false;
         }
         return true;
+    }
+
+    private void addDevmodeGizmo(Document indexDocument, VaadinSession session,
+            VaadinRequest request) {
+        VaadinService service = session.getService();
+        BrowserLiveReloadAccess liveReloadAccess = service
+                .getInstantiator()
+                .getOrCreate(BrowserLiveReloadAccess.class);
+        BrowserLiveReload liveReload = liveReloadAccess != null
+                ? liveReloadAccess.getLiveReload(service)
+                : null;
+
+        if (liveReload != null) {
+            Element devmodeGizmo = new Element("vaadin-devmode-gizmo");
+            devmodeGizmo.attr("url",
+                    BootstrapHandlerHelper.getPushURL(session, request));
+            if (liveReload.getBackend() != null) {
+                devmodeGizmo.attr("backend", liveReload.getBackend().toString());
+            }
+            devmodeGizmo.attr("springbootlivereloadport", Integer.toString(
+                    BrowserLiveReload.SPRING_BOOT_DEFAULT_LIVE_RELOAD_PORT));
+            indexDocument.body().appendChild(devmodeGizmo);
+        }
     }
 
     private void addInitialFlow(JsonObject initialJson, Document indexDocument,

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
@@ -27,6 +27,7 @@ import java.util.function.Function;
 import com.vaadin.flow.component.PushConfiguration;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.internal.JavaScriptBootstrapUI;
+import com.vaadin.flow.internal.BootstrapHandlerHelper;
 import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.router.Location;
 import com.vaadin.flow.server.BootstrapHandler;
@@ -172,17 +173,7 @@ public class JavaScriptBootstrapHandler extends BootstrapHandler {
      * @return the relative service URL
      */
     protected static String getServiceUrl(VaadinRequest vaadinRequest) {
-        String pathInfo = vaadinRequest.getPathInfo();
-        if (pathInfo == null) {
-            return ".";
-        } else {
-            /*
-             * Make a relative URL to the servlet by adding one ../ for each
-             * path segment in pathInfo (i.e. the part of the requested path
-             * that comes after the servlet mapping)
-             */
-            return HandlerHelper.getCancelingRelativePath(pathInfo);
-        }
+        return BootstrapHandlerHelper.getServiceUrl(vaadinRequest);
     }
 
     private JsonObject getStats() {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -564,7 +564,8 @@ public class NodeTasks implements FallibleCommand {
                     builder.npmFolder, builder.webpackOutputDirectory,
                     builder.webpackTemplate, builder.webpackGeneratedTemplate,
                     new File(builder.generatedFolder, IMPORTS_NAME),
-                    builder.useDeprecatedV14Bootstrapping));
+                    builder.useDeprecatedV14Bootstrapping,
+                    builder.flowResourcesFolder));
         }
 
         if (builder.enableImportsUpdate) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksTest.java
@@ -100,7 +100,8 @@ public class NodeTasksTest {
                                 WEBPACK_CONFIG, WEBPACK_GENERATED)
                         .enableImportsUpdate(true).runNpmInstall(false)
                         .withEmbeddableWebComponents(false)
-                        .useV14Bootstrap(false);
+                        .useV14Bootstrap(false).withFlowResourcesFolder(
+                                new File(userDir, TARGET + "flow-frontend"));
         builder.build().execute();
         String webpackGeneratedContent = Files
                 .lines(new File(userDir, WEBPACK_GENERATED).toPath())

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateWebpackTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateWebpackTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEAULT_FLOW_RESOURCES_FOLDER;
 import static com.vaadin.flow.server.frontend.FrontendUtils.IMPORTS_NAME;
 import static com.vaadin.flow.server.frontend.FrontendUtils.TARGET;
 import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_CONFIG;
@@ -61,7 +62,8 @@ public class TaskUpdateWebpackTest extends NodeUpdateTestUtil {
         webpackUpdater = new TaskUpdateWebpack(frontendFolder, baseDir,
                 new File(baseDir, TARGET + "classes"), WEBPACK_CONFIG,
                 WEBPACK_GENERATED,
-                new File(baseDir, DEFAULT_GENERATED_DIR + IMPORTS_NAME), true);
+                new File(baseDir, DEFAULT_GENERATED_DIR + IMPORTS_NAME), true,
+                new File(baseDir, DEAULT_FLOW_RESOURCES_FOLDER));
 
         webpackConfig = new File(baseDir, WEBPACK_CONFIG);
         webpackGenerated = new File(baseDir, WEBPACK_GENERATED);
@@ -103,7 +105,8 @@ public class TaskUpdateWebpackTest extends NodeUpdateTestUtil {
         webpackUpdater = new TaskUpdateWebpack(frontendFolder, baseDir,
                 new File(baseDir, TARGET + "classes"), WEBPACK_CONFIG,
                 WEBPACK_GENERATED,
-                new File(baseDir, DEFAULT_GENERATED_DIR + IMPORTS_NAME), false);
+                new File(baseDir, DEFAULT_GENERATED_DIR + IMPORTS_NAME), false,
+                new File(baseDir, DEAULT_FLOW_RESOURCES_FOLDER));
 
         webpackUpdater.execute();
 
@@ -147,7 +150,8 @@ public class TaskUpdateWebpackTest extends NodeUpdateTestUtil {
 
         TaskUpdateWebpack newUpdater = new TaskUpdateWebpack(frontendFolder,
                 baseDir, new File(baseDir, "foo"), WEBPACK_CONFIG,
-                WEBPACK_GENERATED, new File(baseDir, "bar"), false);
+                WEBPACK_GENERATED, new File(baseDir, "bar"), false,
+                new File(baseDir, DEAULT_FLOW_RESOURCES_FOLDER));
         newUpdater.execute();
 
         assertWebpackGeneratedConfigContent("bar", "foo");
@@ -181,7 +185,8 @@ public class TaskUpdateWebpackTest extends NodeUpdateTestUtil {
                 frontendFolder, baseDir,
                 new File(baseDir, TARGET + "classes"),
                 WEBPACK_CONFIG, WEBPACK_GENERATED,
-                new File(baseDir, DEFAULT_GENERATED_DIR + IMPORTS_NAME), false);
+                new File(baseDir, DEFAULT_GENERATED_DIR + IMPORTS_NAME), false,
+                new File(baseDir, DEAULT_FLOW_RESOURCES_FOLDER));
         webpackUpdater.execute();
         String webpackGeneratedContents = Files.lines(webpackGenerated.toPath())
                 .collect(Collectors.joining("\n"));

--- a/flow-tests/test-live-reload/frontend/styles.css
+++ b/flow-tests/test-live-reload/frontend/styles.css
@@ -1,0 +1,1 @@
+/* A CSS file */

--- a/flow-tests/test-live-reload/frontend/styles.css
+++ b/flow-tests/test-live-reload/frontend/styles.css
@@ -1,1 +1,1 @@
-/* A CSS file */
+/* Initially empty CSS file, updated in test to trigger Webpack-triggered live reload */

--- a/flow-tests/test-live-reload/src/test/java/com/vaadin/flow/uitest/ui/LiveReloadIT.java
+++ b/flow-tests/test-live-reload/src/test/java/com/vaadin/flow/uitest/ui/LiveReloadIT.java
@@ -57,9 +57,9 @@ public class LiveReloadIT extends AbstractLiveReloadIT {
     @Test
     public void splashMessageShownOnAutoReloadAndClosedOnBodyClick() {
         open();
-        waitForElementPresent(By.id("live-reload-trigger-button"));
+        waitForElementPresent(By.id(LiveReloadView.JAVA_LIVE_RELOAD_TRIGGER_BUTTON));
         WebElement liveReloadTrigger = findElement(
-                By.id("live-reload-trigger-button"));
+                By.id(LiveReloadView.JAVA_LIVE_RELOAD_TRIGGER_BUTTON));
         liveReloadTrigger.click();
 
         WebElement liveReload = findElement(By.tagName("vaadin-devmode-gizmo"));
@@ -99,7 +99,7 @@ public class LiveReloadIT extends AbstractLiveReloadIT {
 
         // when: live reload is triggered
         WebElement liveReloadTrigger = findElement(
-                By.id("live-reload-trigger-button"));
+                By.id(LiveReloadView.JAVA_LIVE_RELOAD_TRIGGER_BUTTON));
         liveReloadTrigger.click();
 
         // then: page is not reloaded
@@ -112,4 +112,23 @@ public class LiveReloadIT extends AbstractLiveReloadIT {
         Assert.assertTrue(gizmo2.getAttribute("class").contains("gizmo"));
     }
 
+    @Test
+    public void liveReloadOnTouchedFrontendFile() {
+        open();
+
+        final String initialViewId = findElement(
+                By.id(LiveReloadView.INSTANCE_IDENTIFIER)).getText();
+
+        waitForElementPresent(By.id(LiveReloadView.WEBPACK_LIVE_RELOAD_TRIGGER_BUTTON));
+        WebElement liveReloadTrigger = findElement(
+                By.id(LiveReloadView.WEBPACK_LIVE_RELOAD_TRIGGER_BUTTON));
+        liveReloadTrigger.click();
+
+        waitForElementPresent(By.id(LiveReloadView.PAGE_RELOADING));
+        waitForElementNotPresent(By.id(LiveReloadView.PAGE_RELOADING));
+
+        final String newViewId = findElement(
+                By.id(LiveReloadView.INSTANCE_IDENTIFIER)).getText();
+        Assert.assertNotEquals(initialViewId, newViewId);
+    }
 }


### PR DESCRIPTION
When the webpack dev server finished recompilation, it will notify the Java server over
the watchdog connection. When the Java server notices the message, it in turn sends
the browser reload message over the dedicated live reload web socket connections.

Other changes in this commit:
- live reload now also works in V14 bootstrapping mode
- vaadin-devmode-gizmo is bundled separately

Addresses tickets #8852, #8721, #8001, #5617, #607 (and maybe others).