### PR TITLE
Instantiate AppShell with Instantiator

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/AppShellRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AppShellRegistry.java
@@ -34,7 +34,6 @@ import com.vaadin.flow.component.page.Meta;
 import com.vaadin.flow.component.page.Push;
 import com.vaadin.flow.component.page.TargetElement;
 import com.vaadin.flow.component.page.Viewport;
-import com.vaadin.flow.internal.ReflectTools;
 import com.vaadin.flow.router.PageTitle;
 
 import static com.vaadin.flow.server.startup.AbstractAnnotationValidator.getClassAnnotations;
@@ -244,7 +243,7 @@ public class AppShellRegistry implements Serializable {
     public void modifyIndexHtml(Document document, VaadinRequest request) {
         AppShellSettings settings = createSettings();
         if (appShellClass != null) {
-            ReflectTools.createInstance(appShellClass).configurePage(settings);
+            VaadinService.getCurrent().getInstantiator().getOrCreate(appShellClass).configurePage(settings);
         }
 
         settings.getHeadElements(Position.PREPEND).forEach(


### PR DESCRIPTION
Fixes: https://github.com/vaadin/spring/issues/564
Instantiate AppShell with Instantiator, so that one can inject into AppShell.
Test is in the Spring Addon repo https://github.com/vaadin/spring/pull/652