### PR TITLE
Add peer dependency forcing mechanism to VersionsJsonFilter (#8545)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonFilter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonFilter.java
@@ -48,6 +48,8 @@ class VersionsJsonFilter {
         for (String key : versions.keys()) {
             if (!userManagedDependencies.hasKey(key)) {
                 json.put(key, versions.getString(key));
+            } else {
+                json.put(key, userManagedDependencies.getString(key));
             }
         }
         return json;

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -21,8 +21,6 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
-import javax.validation.constraints.AssertTrue;
-
 import com.vaadin.flow.server.frontend.installer.NodeInstaller;
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.CoreMatchers;
@@ -89,7 +87,7 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
     }
 
     @Test
-    public void generateVersionsJson_userVersionNewerThanPinned_installedOverlayVersionIsNotPinned()
+    public void generateVersionsJson_userVersionNewerThanPinned_intalledOverlayVersionIsUserVersion()
             throws IOException, ExecutionFailedException {
         File packageJson = new File(getNodeUpdater().npmFolder, PACKAGE_JSON);
         packageJson.createNewFile();
@@ -141,11 +139,20 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
                      + "}", StandardCharsets.UTF_8);
         // @formatter:on
 
-        verifyVersionIsNotPinned(versions, devDeps);
+        JsonObject versionsJson = getGeneratedVersionsContent(versions, devDeps);
+        Assert.assertEquals("Generated versions json should have 2 keys",
+                2,
+                versionsJson.keys().length);
+        Assert.assertEquals("Overlay should be pinned to user version",
+                customOverlayVersion,
+                versionsJson.getString("@vaadin/vaadin-overlay"));
+        Assert.assertEquals("Notification should be pinned to user version",
+                "1.4.0",
+                versionsJson.getString("@vaadin/vaadin-notification"));
     }
 
     @Test
-    public void generateVersionsJson_userVersionOlderThanPinned_installedOverlayVersionIsNotPinned()
+    public void generateVersionsJson_userVersionOlderThanPinned_installedOverlayPinnedVersionIsUserVersion()
             throws IOException {
         File packageJson = new File(getNodeUpdater().npmFolder, PACKAGE_JSON);
         packageJson.createNewFile();
@@ -197,7 +204,16 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
                      + "}", StandardCharsets.UTF_8);
         // @formatter:on
 
-        verifyVersionIsNotPinned(versions, devDeps);
+        JsonObject versionsJson = getGeneratedVersionsContent(versions, devDeps);
+        Assert.assertEquals("Generated versions json should have 2 keys",
+                2,
+                versionsJson.keys().length);
+        Assert.assertEquals("Overlay should be pinned to user version",
+                customOverlayVersion,
+                versionsJson.getString("@vaadin/vaadin-overlay"));
+        Assert.assertEquals("Notification should be pinned to user version",
+                "1.3.9",
+                versionsJson.getString("@vaadin/vaadin-notification"));
     }
 
     @Test
@@ -280,13 +296,15 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         Assert.assertEquals("Login version is the same for user and platform.",
                 loginVersion,
                 generatedVersions.getString("@vaadin/vaadin-login"));
-        Assert.assertFalse("Menu Bar should not be pinned.",
-                generatedVersions.hasKey("@vaadin/vaadin-menu-bar"));
+        Assert.assertEquals("Menu Bar should be pinned to user version.",
+                menuVersion,
+                generatedVersions.getString("@vaadin/vaadin-menu-bar"));
         Assert.assertEquals("Notification version should use platform",
                 versionsNotificationVersion,
                 generatedVersions.getString("@vaadin/vaadin-notification"));
-        Assert.assertFalse("Upload should not be pinned.",
-                generatedVersions.hasKey("@vaadin/vaadin-upload"));
+        Assert.assertEquals("Upload should be pinned to user version.",
+                uploadVersion,
+                generatedVersions.getString("@vaadin/vaadin-upload"));
         Assert.assertEquals("Button version should use dev dependency", "2.2.2",
                 generatedVersions.getString("@vaadin/vaadin-button"));
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/VersionsJsonFilterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/VersionsJsonFilterTest.java
@@ -86,8 +86,8 @@ public class VersionsJsonFilterTest {
         JsonObject filteredJson = filter
                 .getFilteredVersions(Json.parse(versions));
         Assert.assertTrue(filteredJson.hasKey("@vaadin/vaadin-progress-bar"));
-        Assert.assertFalse(filteredJson.hasKey("@vaadin/vaadin-upload"));
-        Assert.assertFalse(filteredJson.hasKey("@polymer/iron-list"));
+        Assert.assertTrue(filteredJson.hasKey("@vaadin/vaadin-upload"));
+        Assert.assertTrue(filteredJson.hasKey("@polymer/iron-list"));
 
         Assert.assertEquals("1.1.2",
                 filteredJson.getString("@vaadin/vaadin-progress-bar"));
@@ -120,9 +120,7 @@ public class VersionsJsonFilterTest {
                     filteredJson.hasKey(key));
         }
 
-        List<String> droppedKeys = Arrays.asList("flow", "core", "platform",
-                "@vaadin/vaadin-ordered-layout", "@vaadin/vaadin-progress-bar",
-                "@vaadin/vaadin-radio-button", "@vaadin/vaadin-confirm-dialog");
+        List<String> droppedKeys = Arrays.asList("flow", "core", "platform");
         for (String key : droppedKeys) {
             Assert.assertFalse(
                     String.format("User managed key '%s' was found.", key),


### PR DESCRIPTION
* Update VersionJsonFilter to use forced dependencies

* Update TaskRunPnpmInstallTest

Update tests to correctly test new expectations for PnpmInstall stage

* Update VersionJsonFilterTest

Change VersionJsonFilterTest in order to accomodate new behaviour when filtering versions