### PR TITLE
Only connect to devServer when it is started

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.server;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -298,7 +297,8 @@ public final class DevModeHandler implements RequestHandler {
      */
     public boolean serveDevModeRequest(HttpServletRequest request,
             HttpServletResponse response) throws IOException {
-        if (isDevServerFailedToStart.get()) {
+        // Do not serve requests if dev server starting or failed to start.
+        if (isDevServerFailedToStart.get() || !devServerStartFuture.isDone()) {
             return false;
         }
         // Since we have 'publicPath=/VAADIN/' in webpack config,

--- a/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
@@ -208,12 +208,12 @@ public class DevModeHandlerTest {
 
     @Test
     public void webpackIsNotExecutable_throws() {
-        exception.expectCause(CoreMatchers.isA(ExecutionFailedException.class));
         // The set executable doesn't work in Windows and will always return
         // false
         boolean systemImplementsExecutable = new File(baseDir, WEBPACK_SERVER)
                 .setExecutable(false);
         if (systemImplementsExecutable) {
+            exception.expectCause(CoreMatchers.isA(ExecutionFailedException.class));
             DevModeHandler.start(configuration, npmFolder,
                     CompletableFuture.completedFuture(null)).join();
         }


### PR DESCRIPTION
Do not try to connect to the dev server
if it hasn't started yet or startup has failed.

Fixes #8858