### PR TITLE
Fix typo in variable DEAULT_FLOW_RESOURCES_FOLDER

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -60,7 +60,7 @@ import static com.vaadin.flow.server.Constants.CONNECT_JAVA_SOURCE_FOLDER_TOKEN;
 import static com.vaadin.flow.server.Constants.CONNECT_APPLICATION_PROPERTIES_TOKEN;
 import static com.vaadin.flow.server.Constants.CONNECT_OPEN_API_FILE_TOKEN;
 import static com.vaadin.flow.server.Constants.CONNECT_GENERATED_TS_DIR_TOKEN;
-import static com.vaadin.flow.server.frontend.FrontendUtils.DEAULT_FLOW_RESOURCES_FOLDER;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FLOW_RESOURCES_FOLDER;
 import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
 import static com.vaadin.flow.server.frontend.FrontendUtils.TOKEN_FILE;
 
@@ -154,7 +154,7 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo {
                 .map(Artifact::getFile).collect(Collectors.toSet());
 
         File flowResourcesFolder = new File(npmFolder,
-                DEAULT_FLOW_RESOURCES_FOLDER);
+                DEFAULT_FLOW_RESOURCES_FOLDER);
         final URI nodeDownloadRootURI;
         try {
             nodeDownloadRootURI = new URI(nodeDownloadRoot);

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -25,7 +25,6 @@ import org.apache.maven.plugins.annotations.Parameter;
 import com.vaadin.flow.server.Constants;
 
 import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
-import static com.vaadin.flow.server.frontend.FrontendUtils.DEAULT_FLOW_RESOURCES_FOLDER;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FRONTEND;
 
 /**

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
@@ -58,7 +58,7 @@ import static com.vaadin.flow.server.Constants.NPM_TOKEN;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_INITIAL_UIDL;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_PRODUCTION_MODE;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_USE_V14_BOOTSTRAP;
-import static com.vaadin.flow.server.frontend.FrontendUtils.DEAULT_FLOW_RESOURCES_FOLDER;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FLOW_RESOURCES_FOLDER;
 import static com.vaadin.flow.server.frontend.FrontendUtils.TOKEN_FILE;
 
 /**
@@ -121,7 +121,7 @@ public class PrepareFrontendMojo extends FlowModeAbstractMojo {
         }
         try {
             File flowResourcesFolder = new File(npmFolder,
-                    DEAULT_FLOW_RESOURCES_FOLDER);
+                    DEFAULT_FLOW_RESOURCES_FOLDER);
             NodeTasks.Builder builder = new NodeTasks.Builder(
                     getClassFinder(project), npmFolder, generatedFolder,
                     frontendDirectory)

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
@@ -61,7 +61,7 @@ import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_ENABLE_DEV_SERVER;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_PRODUCTION_MODE;
 import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
-import static com.vaadin.flow.server.frontend.FrontendUtils.DEAULT_FLOW_RESOURCES_FOLDER;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FLOW_RESOURCES_FOLDER;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
@@ -107,7 +107,7 @@ public class BuildFrontendMojoTest {
         generatedFolder = new File(npmFolder, DEFAULT_GENERATED_DIR);
         importsFile = new File(generatedFolder, IMPORTS_NAME);
         nodeModulesPath = new File(npmFolder, NODE_MODULES);
-        flowResourcesFolder = new File(npmFolder, DEAULT_FLOW_RESOURCES_FOLDER);
+        flowResourcesFolder = new File(npmFolder, DEFAULT_FLOW_RESOURCES_FOLDER);
         File frontendDirectory = new File(npmFolder, DEFAULT_FRONTEND_DIR);
 
         packageJson = new File(npmFolder, PACKAGE_JSON).getAbsolutePath();

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
@@ -35,7 +35,7 @@ import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_ENABLE_DEV_SERV
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_PRODUCTION_MODE;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_USE_V14_BOOTSTRAP;
 import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
-import static com.vaadin.flow.server.frontend.FrontendUtils.DEAULT_FLOW_RESOURCES_FOLDER;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FLOW_RESOURCES_FOLDER;
 import static com.vaadin.flow.server.frontend.FrontendUtils.TOKEN_FILE;
 import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_CONFIG;
 import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_GENERATED;
@@ -69,7 +69,7 @@ public class PrepareFrontendMojoTest {
         project = Mockito.mock(MavenProject.class);
         Mockito.when(project.getBasedir()).thenReturn(projectBase);
 
-        flowResourcesFolder = new File(projectBase, DEAULT_FLOW_RESOURCES_FOLDER);
+        flowResourcesFolder = new File(projectBase, DEFAULT_FLOW_RESOURCES_FOLDER);
         webpackConfig = new File(projectBase, WEBPACK_CONFIG).getAbsolutePath();
         packageJson = new File(projectBase, PACKAGE_JSON).getAbsolutePath();
         webpackOutputDirectory = new File(projectBase,

--- a/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/BundleParser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/polymertemplate/BundleParser.java
@@ -33,7 +33,7 @@ import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 import elemental.json.JsonType;
 
-import static com.vaadin.flow.server.frontend.FrontendUtils.DEAULT_FLOW_RESOURCES_FOLDER;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FLOW_RESOURCES_FOLDER;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
 import static elemental.json.JsonType.ARRAY;
 import static elemental.json.JsonType.OBJECT;
@@ -257,7 +257,7 @@ public final class BundleParser {
             // "node_modules/@vaadin/flow-frontend/" instead of "./"
             // "target/flow-frontend/" instead of "./"
             if (name.contains(FLOW_NPM_PACKAGE_NAME) ||
-                    name.contains(DEAULT_FLOW_RESOURCES_FOLDER)) {
+                    name.contains(DEFAULT_FLOW_RESOURCES_FOLDER)) {
                 alternativeFileName = alternativeFileName.replaceFirst("\\./",
                         "");
             }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -128,8 +128,17 @@ public class FrontendUtils {
     /**
      * Default folder for copying front-end resources present in the classpath
      * jars.
+     * @see #DEFAULT_FLOW_RESOURCES_FOLDER
      */
+    @Deprecated
     public static final String DEAULT_FLOW_RESOURCES_FOLDER = TARGET
+            + "flow-frontend";
+
+    /**
+     * Default folder for copying front-end resources present in the classpath
+     * jars.
+     */
+    public static final String DEFAULT_FLOW_RESOURCES_FOLDER = TARGET
             + "flow-frontend";
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -128,18 +128,20 @@ public class FrontendUtils {
     /**
      * Default folder for copying front-end resources present in the classpath
      * jars.
-     * @see #DEFAULT_FLOW_RESOURCES_FOLDER
      */
-    @Deprecated
-    public static final String DEAULT_FLOW_RESOURCES_FOLDER = TARGET
+    public static final String DEFAULT_FLOW_RESOURCES_FOLDER = TARGET
             + "flow-frontend";
 
     /**
      * Default folder for copying front-end resources present in the classpath
      * jars.
+     * @deprecated This is deprecated due to a typo.
+     *             Use DEFAULT_FLOW_RESOURCES_FOLDER instead.
+     * @see #DEFAULT_FLOW_RESOURCES_FOLDER
      */
-    public static final String DEFAULT_FLOW_RESOURCES_FOLDER = TARGET
-            + "flow-frontend";
+    @Deprecated
+    public static final String DEAULT_FLOW_RESOURCES_FOLDER =
+            DEFAULT_FLOW_RESOURCES_FOLDER;
 
     /**
      * Default folder name for flow generated stuff relative to the

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -93,7 +93,7 @@ import static com.vaadin.flow.server.Constants.CONNECT_JAVA_SOURCE_FOLDER_TOKEN;
 import static com.vaadin.flow.server.Constants.CONNECT_OPEN_API_FILE_TOKEN;
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE;
-import static com.vaadin.flow.server.frontend.FrontendUtils.DEAULT_FLOW_RESOURCES_FOLDER;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FLOW_RESOURCES_FOLDER;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_CONNECT_APPLICATION_PROPERTIES;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_CONNECT_GENERATED_TS_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_CONNECT_JAVA_SOURCE_FOLDER;
@@ -278,7 +278,7 @@ public class DevModeInitializer
                 System.getProperty(PARAM_FRONTEND_DIR, DEFAULT_FRONTEND_DIR));
 
         File flowResourcesFolder = new File(baseDir,
-                DEAULT_FLOW_RESOURCES_FOLDER);
+                DEFAULT_FLOW_RESOURCES_FOLDER);
 
         Builder builder = new NodeTasks.Builder(new DevModeClassFinder(classes),
                 new File(baseDir), new File(generatedDir),

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
@@ -43,7 +43,7 @@ import elemental.json.JsonObject;
 import elemental.json.JsonValue;
 
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
-import static com.vaadin.flow.server.frontend.FrontendUtils.DEAULT_FLOW_RESOURCES_FOLDER;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FLOW_RESOURCES_FOLDER;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.NodeUpdater.DEP_NAME_FLOW_DEPS;
 import static com.vaadin.flow.server.frontend.NodeUpdater.DEP_NAME_FLOW_JARS;
@@ -83,7 +83,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         baseDir = temporaryFolder.getRoot();
 
         generatedDir = new File(baseDir, DEFAULT_GENERATED_DIR);
-        resourcesDir = new File(baseDir, DEAULT_FLOW_RESOURCES_FOLDER);
+        resourcesDir = new File(baseDir, DEFAULT_FLOW_RESOURCES_FOLDER);
 
         NodeUpdateTestUtil.createStubNode(true, true, false,
                 baseDir.getAbsolutePath());

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendResourcesAreCopiedAfterCleaningTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendResourcesAreCopiedAfterCleaningTest.java
@@ -31,7 +31,7 @@ import org.junit.rules.TemporaryFolder;
 import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 
-import static com.vaadin.flow.server.frontend.FrontendUtils.DEAULT_FLOW_RESOURCES_FOLDER;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FLOW_RESOURCES_FOLDER;
 
 public class FrontendResourcesAreCopiedAfterCleaningTest {
 
@@ -66,7 +66,7 @@ public class FrontendResourcesAreCopiedAfterCleaningTest {
 
     private void assertCopiedFrontendFileAmount(int fileCount)
             throws IOException {
-        File dir = new File(npmFolder, DEAULT_FLOW_RESOURCES_FOLDER);
+        File dir = new File(npmFolder, DEFAULT_FLOW_RESOURCES_FOLDER);
         FileUtils.forceMkdir(dir);
         List<String> files = TestUtils.listFilesRecursively(dir);
 
@@ -80,7 +80,7 @@ public class FrontendResourcesAreCopiedAfterCleaningTest {
                         .getClassLoader());
         NodeTasks.Builder builder = new NodeTasks.Builder(classFinder,
                 npmFolder);
-        File resourcesFolder = new File(npmFolder, DEAULT_FLOW_RESOURCES_FOLDER);
+        File resourcesFolder = new File(npmFolder, DEFAULT_FLOW_RESOURCES_FOLDER);
         builder.withEmbeddableWebComponents(false).enableImportsUpdate(false)
                 .createMissingPackageJson(true).enableImportsUpdate(true)
                 .runNpmInstall(false).enablePackagesUpdate(true)
@@ -95,7 +95,7 @@ public class FrontendResourcesAreCopiedAfterCleaningTest {
                         .getClassLoader());
         NodeTasks.Builder builder = new NodeTasks.Builder(classFinder,
                 npmFolder);
-        File resourcesFolder = new File(npmFolder, DEAULT_FLOW_RESOURCES_FOLDER);
+        File resourcesFolder = new File(npmFolder, DEFAULT_FLOW_RESOURCES_FOLDER);
         builder.withEmbeddableWebComponents(false).enableImportsUpdate(false)
                 .createMissingPackageJson(true).enableImportsUpdate(true)
                 .runNpmInstall(false).enableNpmFileCleaning(true)

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateWebpackTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateWebpackTest.java
@@ -34,7 +34,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
-import static com.vaadin.flow.server.frontend.FrontendUtils.DEAULT_FLOW_RESOURCES_FOLDER;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FLOW_RESOURCES_FOLDER;
 import static com.vaadin.flow.server.frontend.FrontendUtils.IMPORTS_NAME;
 import static com.vaadin.flow.server.frontend.FrontendUtils.TARGET;
 import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_CONFIG;
@@ -63,7 +63,7 @@ public class TaskUpdateWebpackTest extends NodeUpdateTestUtil {
                 new File(baseDir, TARGET + "classes"), WEBPACK_CONFIG,
                 WEBPACK_GENERATED,
                 new File(baseDir, DEFAULT_GENERATED_DIR + IMPORTS_NAME), true,
-                new File(baseDir, DEAULT_FLOW_RESOURCES_FOLDER));
+                new File(baseDir, DEFAULT_FLOW_RESOURCES_FOLDER));
 
         webpackConfig = new File(baseDir, WEBPACK_CONFIG);
         webpackGenerated = new File(baseDir, WEBPACK_GENERATED);
@@ -106,7 +106,7 @@ public class TaskUpdateWebpackTest extends NodeUpdateTestUtil {
                 new File(baseDir, TARGET + "classes"), WEBPACK_CONFIG,
                 WEBPACK_GENERATED,
                 new File(baseDir, DEFAULT_GENERATED_DIR + IMPORTS_NAME), false,
-                new File(baseDir, DEAULT_FLOW_RESOURCES_FOLDER));
+                new File(baseDir, DEFAULT_FLOW_RESOURCES_FOLDER));
 
         webpackUpdater.execute();
 
@@ -151,7 +151,7 @@ public class TaskUpdateWebpackTest extends NodeUpdateTestUtil {
         TaskUpdateWebpack newUpdater = new TaskUpdateWebpack(frontendFolder,
                 baseDir, new File(baseDir, "foo"), WEBPACK_CONFIG,
                 WEBPACK_GENERATED, new File(baseDir, "bar"), false,
-                new File(baseDir, DEAULT_FLOW_RESOURCES_FOLDER));
+                new File(baseDir, DEFAULT_FLOW_RESOURCES_FOLDER));
         newUpdater.execute();
 
         assertWebpackGeneratedConfigContent("bar", "foo");
@@ -186,7 +186,7 @@ public class TaskUpdateWebpackTest extends NodeUpdateTestUtil {
                 new File(baseDir, TARGET + "classes"),
                 WEBPACK_CONFIG, WEBPACK_GENERATED,
                 new File(baseDir, DEFAULT_GENERATED_DIR + IMPORTS_NAME), false,
-                new File(baseDir, DEAULT_FLOW_RESOURCES_FOLDER));
+                new File(baseDir, DEFAULT_FLOW_RESOURCES_FOLDER));
         webpackUpdater.execute();
         String webpackGeneratedContents = Files.lines(webpackGenerated.toPath())
                 .collect(Collectors.joining("\n"));

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerClassLoaderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerClassLoaderTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
 
 import com.vaadin.flow.server.frontend.TestUtils;
 
-import static com.vaadin.flow.server.frontend.FrontendUtils.DEAULT_FLOW_RESOURCES_FOLDER;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FLOW_RESOURCES_FOLDER;
 
 public class DevModeInitializerClassLoaderTest {
 
@@ -54,7 +54,7 @@ public class DevModeInitializerClassLoaderTest {
         customLoader.close();
 
         List<String> files = TestUtils.listFilesRecursively(
-                new File(baseDir, DEAULT_FLOW_RESOURCES_FOLDER));
+                new File(baseDir, DEFAULT_FLOW_RESOURCES_FOLDER));
         Assert.assertEquals(5, files.size());
 
         Assert.assertTrue("A package.json file should be created",

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/StatsContentTest.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/StatsContentTest.java
@@ -30,7 +30,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import static com.vaadin.flow.server.frontend.FrontendUtils.DEAULT_FLOW_RESOURCES_FOLDER;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FLOW_RESOURCES_FOLDER;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FALLBACK_IMPORTS_NAME;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
@@ -96,7 +96,7 @@ public class StatsContentTest {
                 .filter(in -> in.startsWith("import"))
                 .map(in -> in.replace("import '", "")
                         .replace(FLOW_NPM_PACKAGE_NAME, String.format("../%s/",
-                                DEAULT_FLOW_RESOURCES_FOLDER))
+                                DEFAULT_FLOW_RESOURCES_FOLDER))
                         .replace("//", "/").replace("Frontend/", "./")
                         .replace("';", "")).collect(Collectors.toList());
     }


### PR DESCRIPTION
Replace DEAULT_FLOW_RESOURCES_FOLDER with DEFAULT_FLOW_RESOURCES_FOLDER, but keep the old variable as deprecated.