### PR TITLE
Change the filter type from Void to wildcard in abstract data view test

### DIFF
--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractComponentDataViewTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractComponentDataViewTest.java
@@ -25,9 +25,6 @@ import java.util.stream.Stream;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
-import com.vaadin.flow.function.SerializableComparator;
-import com.vaadin.flow.function.SerializablePredicate;
-import com.vaadin.flow.shared.Registration;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,7 +41,7 @@ public abstract class AbstractComponentDataViewTest {
     protected List<String> items;
     protected InMemoryDataProvider<String> dataProvider;
     protected DataView<String> dataView;
-    protected HasDataView<String, Void, ? extends DataView<String>> component;
+    protected HasDataView<String, ?, ? extends DataView<String>> component;
 
     @Before
     public void init() {
@@ -89,10 +86,10 @@ public abstract class AbstractComponentDataViewTest {
         Assert.assertEquals(10, fired.get());
     }
 
-    protected abstract HasDataView<String, Void, ? extends DataView<String>> getComponent();
+    protected abstract HasDataView<String, ?, ? extends DataView<String>> getComponent();
 
-    private HasDataView<String, Void, ? extends DataView<String>> getVerifiedComponent() {
-        HasDataView<String, Void, ? extends DataView<String>> component =
+    private HasDataView<String, ?, ? extends DataView<String>> getVerifiedComponent() {
+        HasDataView<String, ?, ? extends DataView<String>> component =
                 getComponent();
         if (component instanceof Component) {
             return component;


### PR DESCRIPTION
`Void` type was erroneously set in `AbstractComponentDataViewTest`, which is not appropriate for components with an internal filter.
No changes in Grid, Select, CheckBox are needed, they just replace `?` with `Void`.