### PR TITLE
Add HasHelper interface

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/HasHelper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasHelper.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component;
+
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import com.vaadin.flow.dom.Element;
+
+/**
+ * Mixin interface for field components that have helper text as property and
+ * slots for inserting components.
+ *
+ * @author Vaadin Ltd
+ */
+public interface HasHelper extends HasElement {
+  /**
+   * String used for the helper text.
+   *
+   * @return the {@code helperText} property from the web component
+   */
+  default String getHelperText() {
+    return getElement().getProperty("helperText");
+  }
+
+  /**
+   * <p>
+   * String used for the helper text.
+   * </p>
+   * 
+   * <p>
+   * In case both {@link #setHelperText(String)} and
+   * {@link #setHelperComponent(Component)} are used, only the element defined
+   * by {@link #setHelperComponent(Component)} will be visible, regardless of
+   * the order on which they are defined.
+   * </p>
+   *
+   * @param helperText
+   *            the String value to set
+   */
+  default void setHelperText(String helperText) {
+    getElement().setProperty("helperText", helperText);
+  }
+  /**
+   * Adds the given component into helper slot of component, replacing any
+   * existing helper component.
+   * 
+   * @param component
+   *            the component to set, can be {@code null} to remove existing
+   *            helper component
+   * 
+   * @see #setHelperText(String)
+   */
+  default void setHelperComponent(Component component) {
+    getElement().getChildren()
+      .filter(child -> "helper".equals(child.getAttribute("slot")))
+      .collect(Collectors.toList())
+      .forEach(getElement()::removeChild);
+
+    if (component != null) {
+        component.getElement().setAttribute("slot", "helper");
+        getElement().appendChild(component.getElement());
+    }
+  }
+
+  /**
+   * Gets the component in the helper slot of this field.
+   * 
+   * @return the helper component of this field, or {@code null} if no helper
+   *         component has been set
+   * @see #setHelperComponent(Component)
+   */
+  default Component getHelperComponent() {
+    Optional<Element> element = getElement().getChildren()
+      .filter(child -> "helper".equals(child.getAttribute("slot")))
+      .findFirst();
+    if (element.isPresent()) {
+      return element.get().getComponent().orElse(null);
+    }
+    return null;
+  }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasHelper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasHelper.java
@@ -59,7 +59,9 @@ public interface HasHelper extends HasElement {
   }
   /**
    * Adds the given component into helper slot of component, replacing any
-   * existing helper component.
+   * existing helper component. It adds the component adjacent to the field that
+   * can be used, e.g., to inform to the users which values it expects. Example:
+   * a component that shows the password strength for the PasswordField.
    * 
    * @param component
    *            the component to set, can be {@code null} to remove existing

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasHelper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasHelper.java
@@ -25,6 +25,7 @@ import com.vaadin.flow.dom.Element;
  * slots for inserting components.
  *
  * @author Vaadin Ltd
+ * @since 2.4
  */
 public interface HasHelper extends HasElement {
   /**
@@ -38,7 +39,9 @@ public interface HasHelper extends HasElement {
 
   /**
    * <p>
-   * String used for the helper text.
+   * String used for the helper text. It shows a text adjacent to the field that
+   * can be used, e.g., to inform to the users which values it expects. Example:
+   * a text "The password must contain numbers" for the PasswordField.
    * </p>
    * 
    * <p>
@@ -67,8 +70,8 @@ public interface HasHelper extends HasElement {
   default void setHelperComponent(Component component) {
     getElement().getChildren()
       .filter(child -> "helper".equals(child.getAttribute("slot")))
-      .collect(Collectors.toList())
-      .forEach(getElement()::removeChild);
+      .findAny()
+      .ifPresent(getElement()::removeChild);
 
     if (component != null) {
         component.getElement().setAttribute("slot", "helper");
@@ -84,12 +87,11 @@ public interface HasHelper extends HasElement {
    * @see #setHelperComponent(Component)
    */
   default Component getHelperComponent() {
-    Optional<Element> element = getElement().getChildren()
+    Optional<Component> component = getElement().getChildren()
       .filter(child -> "helper".equals(child.getAttribute("slot")))
-      .findFirst();
-    if (element.isPresent()) {
-      return element.get().getComponent().orElse(null);
-    }
-    return null;
+      .map(Element::getComponent)
+      .findFirst().orElse(Optional.empty());
+
+    return component.orElse(null);
   }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasHelper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasHelper.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.component;
 
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import com.vaadin.flow.dom.Element;
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasHelperTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasHelperTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HasHelperTest {
+
+    @Tag("div")
+    public static class HasHelperComponent extends Component implements HasHelper {
+    }
+
+    @Test
+    public void setHelperText() {
+        final HasHelperComponent c = new HasHelperComponent();
+        c.setHelperText("helper");
+        Assert.assertEquals("helper", c.getHelperText());
+    }
+
+    @Test
+    public void setHelperComponent() {
+        final HasHelperComponent c = new HasHelperComponent();
+        final HasHelperComponent slotted = new HasHelperComponent();
+        c.setHelperComponent(slotted);
+        Assert.assertEquals(slotted, c.getHelperComponent());
+    }
+
+    @Test
+    public void removeHelperText() {
+        final HasHelperComponent c = new HasHelperComponent();
+        c.setHelperText("helper");
+        Assert.assertEquals("helper", c.getHelperText());
+
+        c.setHelperText(null);
+        Assert.assertNull(c.getHelperText());
+    }
+
+    @Test
+    public void removeHelperComponent() {
+        final HasHelperComponent c = new HasHelperComponent();
+        final HasHelperComponent slotted = new HasHelperComponent();
+
+        c.setHelperComponent(slotted);
+        Assert.assertEquals(slotted, c.getHelperComponent());
+
+        c.setHelperComponent(null);
+        Assert.assertNull(c.getHelperComponent());
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasHelperTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasHelperTest.java
@@ -25,6 +25,18 @@ public class HasHelperTest {
     }
 
     @Test
+    public void getHelperText() {
+        final HasHelperComponent c = new HasHelperComponent();
+        Assert.assertNull(c.getHelperText());
+    }
+
+    @Test
+    public void getHelperComponent() {
+        final HasHelperComponent c = new HasHelperComponent();
+        Assert.assertNull(c.getHelperComponent());
+    }
+
+    @Test
     public void setHelperText() {
         final HasHelperComponent c = new HasHelperComponent();
         c.setHelperText("helper");


### PR DESCRIPTION
On this PR:

- Add HasHelper interface to be used for field components that have a "helper" feature (such as TextField)
- The interface contains getters and setters with default implementation for text and component APIs
- Tests for the methods

Fix #8871 