### PR TITLE
Don't use the deprecated method

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/HtmlUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/HtmlUtils.java
@@ -38,6 +38,6 @@ public final class HtmlUtils {
      * @return escaped string
      */
     public static String escape(String maybeHtml) {
-        return new TextNode(maybeHtml, null).outerHtml();
+        return new TextNode(maybeHtml).outerHtml();
     }
 }


### PR DESCRIPTION
Stop using the method that was deprecated in 1.11.1

Closes #8929