### PR TITLE
fix: fetch real type for generic typed parameter

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectController.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectController.java
@@ -403,14 +403,8 @@ public class VaadinConnectController {
                 .ok(vaadinEndpointMapper.writeValueAsString(returnValue));
     }
 
-    Type[] getJavaParameters(Method methodToInvoke, Type type) {
-        if (methodToInvoke.getGenericParameterTypes().length > 0) {
-            return Stream.of(GenericTypeReflector.getExactParameterTypes(methodToInvoke, type))
-                        .toArray(Type[]::new);
-        } else {
-            return Stream.of(methodToInvoke.getParameters()).map(Parameter::getParameterizedType)
-                        .toArray(Type[]::new);
-        }
+    Type[] getJavaParameters(Method methodToInvoke, Type classType) {
+        return Stream.of(GenericTypeReflector.getExactParameterTypes(methodToInvoke, classType)).toArray(Type[]::new);
     }
 
     private ResponseEntity<String> handleMethodExecutionError(

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectController.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectController.java
@@ -402,7 +402,7 @@ public class VaadinConnectController {
                 .ok(vaadinEndpointMapper.writeValueAsString(returnValue));
     }
 
-    Type[] getJavaParameters(Method methodToInvoke, Type classType) {
+    private Type[] getJavaParameters(Method methodToInvoke, Type classType) {
         return Stream.of(GenericTypeReflector.getExactParameterTypes(methodToInvoke, classType)).toArray(Type[]::new);
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectController.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectController.java
@@ -25,7 +25,6 @@ import javax.validation.Validator;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collection;

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/VaadinConnectControllerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/VaadinConnectControllerTest.java
@@ -1061,13 +1061,15 @@ public class VaadinConnectControllerTest {
     }
 
     @Test
-    public void should_GetRealTypeForGenericTypedMethodParameter() throws NoSuchMethodException, SecurityException {
-        Method[] methods = PersonEndpoint.class.getMethods();
-        Method udpateMethod = Stream.of(methods).filter(method->method.getName().equals("update")).findFirst().orElse(null);
-        VaadinConnectController controller = createVaadinController(TEST_ENDPOINT);
+    public void should_ReturnResult_When_CallingSuperClassMethodWithGenericTypedParameter() {
+        ResponseEntity<?> response = createVaadinController(new PersonEndpoint())
+                .serveEndpoint(PersonEndpoint.class.getSimpleName(), "update",
+                        createRequestParameters(
+                        "{\"entity\":{\"name\":\"aa\"}}"), requestMock);
 
-        assertEquals(Person.class, controller.getJavaParameters(udpateMethod, PersonEndpoint.class)[0]);
-    } 
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("{\"name\":\"aa\"}", response.getBody());
+    }
 
     private void assertEndpointInfoPresent(String responseBody) {
         assertTrue(String.format(

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/VaadinConnectControllerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/VaadinConnectControllerTest.java
@@ -46,6 +46,8 @@ import com.vaadin.flow.server.connect.auth.AnonymousAllowed;
 import com.vaadin.flow.server.connect.auth.VaadinConnectAccessChecker;
 import com.vaadin.flow.server.connect.exception.EndpointException;
 import com.vaadin.flow.server.connect.exception.EndpointValidationException;
+import com.vaadin.flow.server.connect.generator.endpoints.superclassmethods.PersonEndpoint;
+import com.vaadin.flow.server.connect.generator.endpoints.superclassmethods.PersonEndpoint.Person;
 import com.vaadin.flow.server.connect.testendpoint.BridgeMethodTestEndpoint;
 
 import static org.junit.Assert.assertEquals;
@@ -1057,6 +1059,15 @@ public class VaadinConnectControllerTest {
         assertTrue(message.contains(testNullMethodName));
         assertTrue(message.contains(errorMessage));
     }
+
+    @Test
+    public void should_GetRealTypeForGenericTypedMethodParameter() throws NoSuchMethodException, SecurityException {
+        Method[] methods = PersonEndpoint.class.getMethods();
+        Method udpateMethod = Stream.of(methods).filter(method->method.getName().equals("update")).findFirst().orElse(null);
+        VaadinConnectController controller = createVaadinController(TEST_ENDPOINT);
+
+        assertEquals(Person.class, controller.getJavaParameters(udpateMethod, PersonEndpoint.class)[0]);
+    } 
 
     private void assertEndpointInfoPresent(String responseBody) {
         assertTrue(String.format(

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/endpoints/superclassmethods/CrudEndpoint.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/endpoints/superclassmethods/CrudEndpoint.java
@@ -1,10 +1,10 @@
 package com.vaadin.flow.server.connect.generator.endpoints.superclassmethods;
 
-import java.util.Optional;
-
 import com.vaadin.flow.server.connect.EndpointExposed;
+import com.vaadin.flow.server.connect.auth.AnonymousAllowed;
 
 @EndpointExposed
+@AnonymousAllowed
 public abstract class CrudEndpoint<T, ID> extends ReadOnlyEndpoint<T, ID> {
     public T update(T entity) {
         return entity;


### PR DESCRIPTION
Fixes: #8931 

Use `GenericTypeReflector` to get the real type for generic typed parameters