### PR TITLE
Fix log time units

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
@@ -179,7 +179,7 @@ public final class DevModeHandler {
                     commandToString(npmFolder.getAbsolutePath(), command));
         }
 
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
         processBuilder.command(command);
         try {
             webpackProcess = processBuilder


### PR DESCRIPTION
The unit used when recording start (milliseconds) is not the same as the unit used when recording end (nanoseconds), yielding erroneous timing reports in the log. Record start also in nanoseconds.