### PR TITLE
Upgrade auto-installed Node to latest LTS and suppress some `npm install` errors

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -139,7 +139,7 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo {
 
     /**
      * The node.js version to be used when node.js is installed automatically by
-     * Vaadin, for example `"v12.16.0"`. Defaults to null which uses the
+     * Vaadin, for example `"v12.18.3"`. Defaults to null which uses the
      * Vaadin-default node version - see {@link FrontendTools} for details.
      */
     @Parameter(property = "node.version", defaultValue = FrontendTools.DEFAULT_NODE_VERSION)

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -190,7 +190,7 @@ public class FrontendTools {
      *            {@code null}
      * @param nodeVersion
      *            The node.js version to be used when node.js is installed automatically
-     *            by Vaadin, for example <code>"v12.16.0"</code>. Use
+     *            by Vaadin, for example <code>"v12.18.3"</code>. Use
      *            {@value #DEFAULT_NODE_VERSION} by default.
      * @param nodeDownloadRoot
      *            Download node.js from this URL. Handy in heavily firewalled corporate

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -57,7 +57,7 @@ import elemental.json.JsonObject;
  */
 public class FrontendTools {
 
-    public static final String DEFAULT_NODE_VERSION = "v12.16.0";
+    public static final String DEFAULT_NODE_VERSION = "v12.18.3";
 
     public static final String DEFAULT_PNPM_VERSION = "4.5.0";
 
@@ -650,6 +650,7 @@ public class FrontendTools {
         }
         returnCommand.add("--no-update-notifier");
         returnCommand.add("--no-audit");
+        returnCommand.add("--scripts-prepend-node-path=true");
 
         if (removePnpmLock) {
             // remove pnpm-lock.yaml which contains pnpm as a dependency.

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -61,7 +61,7 @@ public class FrontendTools {
 
     public static final String DEFAULT_PNPM_VERSION = "4.5.0";
 
-    public static final String INSTALL_NODE_LOCALLY = "%n  $ mvn com.github.eirslett:frontend-maven-plugin:1.7.6:install-node-and-npm -DnodeVersion=\"v12.14.0\" ";
+    public static final String INSTALL_NODE_LOCALLY = "%n  $ mvn com.github.eirslett:frontend-maven-plugin:1.10.0:install-node-and-npm -DnodeVersion=\"v12.18.3\" ";
 
     private static final String MSG_PREFIX = "%n%n======================================================================================================";
     private static final String MSG_SUFFIX = "%n======================================================================================================%n";

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -113,7 +113,7 @@ public class NodeTasks implements FallibleCommand {
 
         /**
          * The node.js version to be used when node.js is installed
-         * automatically by Vaadin, for example <code>"v12.16.0"</code>.
+         * automatically by Vaadin, for example <code>"v12.18.3"</code>.
          * Defaults to {@value FrontendTools#DEFAULT_NODE_VERSION}.
          */
         private String nodeVersion = FrontendTools.DEFAULT_NODE_VERSION;
@@ -468,7 +468,7 @@ public class NodeTasks implements FallibleCommand {
 
         /**
          * Sets the node.js version to be used when node.js is installed
-         * automatically by Vaadin, for example <code>"v12.16.0"</code>.
+         * automatically by Vaadin, for example <code>"v12.18.3"</code>.
          * Defaults to {@value FrontendTools#DEFAULT_NODE_VERSION}.
          *
          * @param nodeVersion

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -315,11 +315,6 @@ public abstract class NodeUpdater implements FallibleCommand {
         // check out https://github.com/babel/babel/issues/11488
         defaults.put("chokidar", "^3.4.0");
 
-        // macOS: fsevents 1.2.13 install script requirement
-        // https://github.com/vaadin/flow/issues/8741
-        // Remove after upgrading to webpack 5
-        defaults.put("node-gyp", "7.1.0");
-
         return defaults;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -315,6 +315,11 @@ public abstract class NodeUpdater implements FallibleCommand {
         // check out https://github.com/babel/babel/issues/11488
         defaults.put("chokidar", "^3.4.0");
 
+        // macOS: fsevents 1.2.13 install script requirement
+        // https://github.com/vaadin/flow/issues/8741
+        // Remove after upgrading to webpack 5
+        defaults.put("node-gyp", "7.1.0");
+
         return defaults;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -89,7 +89,7 @@ public class TaskRunNpmInstall implements FallibleCommand {
      *            whether vaadin home node executable has to be used
      * @param nodeVersion
      *            The node.js version to be used when node.js is installed
-     *            automatically by Vaadin, for example <code>"v12.16.0"</code>.
+     *            automatically by Vaadin, for example <code>"v12.18.3"</code>.
      *            Use {@value FrontendTools#DEFAULT_NODE_VERSION} by default.
      * @param nodeDownloadRoot
      *            Download node.js from this URL. Handy in heavily firewalled

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
@@ -118,7 +118,7 @@ public class NodeInstaller {
     }
 
     /**
-     * Set the node version to install. (given as "v12.16.0")
+     * Set the node version to install. (given as "v12.18.3")
      *
      * @param nodeVersion
      *         version string
@@ -135,11 +135,11 @@ public class NodeInstaller {
      * This should be a url or directory under which we can find a directory
      * {@link #nodeVersion} and there should then exist the archived node
      * packages.
-     * For instance for v12.16.0 we should have under nodeDownloadRoot:
-     * ./v12.6.0/node-v12.16.0-linux-x64.tar.xz
-     * ./v12.6.0/node-v12.16.0-darwin-x64.tar.gz
-     * ./v12.6.0/node-v12.16.0-win-x64.zip
-     * ./v12.6.0/node-v12.16.0-win-x86.zip
+     * For instance for v12.18.3 we should have under nodeDownloadRoot:
+     * ./v12.18.3/node-v12.18.3-linux-x64.tar.xz
+     * ./v12.18.3/node-v12.18.3-darwin-x64.tar.gz
+     * ./v12.18.3/node-v12.18.3-win-x64.zip
+     * ./v12.18.3/node-v12.18.3-win-x86.zip
      *
      * @param nodeDownloadRoot
      *         custom download root

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -194,12 +194,14 @@ public class FrontendToolsTest {
         assertThat(tools.getNodeExecutable(),
                 not(containsString(NPM_CLI_STRING)));
 
-        assertEquals(3, tools.getNpmExecutable().size());
+        assertEquals(4, tools.getNpmExecutable().size());
         assertThat(tools.getNpmExecutable().get(0), containsString("npm"));
         assertThat(tools.getNpmExecutable().get(1),
                 containsString("--no-update-notifier"));
         assertThat(tools.getNpmExecutable().get(2),
                 containsString("--no-audit"));
+        assertThat(tools.getNpmExecutable().get(2),
+                containsString("--scripts-prepend-node-path=true"));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -200,7 +200,7 @@ public class FrontendToolsTest {
                 containsString("--no-update-notifier"));
         assertThat(tools.getNpmExecutable().get(2),
                 containsString("--no-audit"));
-        assertThat(tools.getNpmExecutable().get(2),
+        assertThat(tools.getNpmExecutable().get(3),
                 containsString("--scripts-prepend-node-path=true"));
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -87,7 +87,7 @@ public class FrontendToolsTest {
     @Ignore("Ignored to lessen PRs hitting the server too often")
     public void installNode_NodeIsInstalledToTargetDirectory()
             throws FrontendUtils.UnknownVersionException {
-        String nodeExecutable = tools.installNode("v12.16.0", null);
+        String nodeExecutable = tools.installNode("v12.18.3", null);
         Assert.assertNotNull(nodeExecutable);
 
         List<String> nodeVersionCommand = new ArrayList<>();
@@ -95,7 +95,7 @@ public class FrontendToolsTest {
         nodeVersionCommand.add("--version");
         FrontendVersion node = FrontendUtils.getVersion("node",
                 nodeVersionCommand);
-        Assert.assertEquals("12.16.0", node.getFullVersion());
+        Assert.assertEquals("12.18.3", node.getFullVersion());
 
         FrontendTools newTools = new FrontendTools(vaadinHomeDir, null);
         List<String> npmVersionCommand = new ArrayList<>(
@@ -103,7 +103,7 @@ public class FrontendToolsTest {
         npmVersionCommand.add("--version");
         FrontendVersion npm = FrontendUtils.getVersion("npm",
                 npmVersionCommand);
-        Assert.assertEquals("6.13.4", npm.getFullVersion());
+        Assert.assertEquals("6.14.6", npm.getFullVersion());
 
     }
 
@@ -158,9 +158,9 @@ public class FrontendToolsTest {
     @Test
     public void installNodeFromFileSystem_NodeIsInstalledToTargetDirectory()
             throws IOException {
-        prepareNodeDownloadableZipAt(baseDir, "v12.16.0");
+        prepareNodeDownloadableZipAt(baseDir, "v12.18.3");
 
-        String nodeExecutable = tools.installNode("v12.16.0",
+        String nodeExecutable = tools.installNode("v12.18.3",
                 new File(baseDir).toPath().toUri());
         Assert.assertNotNull(nodeExecutable);
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/installer/DefaultFileDownloaderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/installer/DefaultFileDownloaderTest.java
@@ -31,7 +31,7 @@ public class DefaultFileDownloaderTest {
         Assert.assertFalse(
                 "Clean test should not contain a installation folder",
                 targetDir.exists());
-        File downloadDir = tmpDir.newFolder("v12.16.0");
+        File downloadDir = tmpDir.newFolder("v12.18.3");
         String downloadFileName = "MyDownload.zip";
 
         File archiveFile = new File(downloadDir, downloadFileName);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/installer/NodeInstallerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/installer/NodeInstallerTest.java
@@ -35,14 +35,14 @@ public class NodeInstallerTest {
             throws IOException {
         Platform platform = Platform.guess();
         String nodeExec = platform.isWindows() ? "node.exe" : "node";
-        String prefix = "node-v12.16.0-" + platform.getNodeClassifier();
+        String prefix = "node-v12.18.3-" + platform.getNodeClassifier();
 
         File targetDir = new File(baseDir + "/installation");
 
         Assert.assertFalse(
                 "Clean test should not contain a installation folder",
                 targetDir.exists());
-        File downloadDir = tmpDir.newFolder("v12.16.0");
+        File downloadDir = tmpDir.newFolder("v12.18.3");
         File archiveFile = new File(downloadDir,
                 prefix + "." + platform.getArchiveExtension());
         archiveFile.createNewFile();
@@ -86,7 +86,7 @@ public class NodeInstallerTest {
         }
 
         NodeInstaller nodeInstaller = new NodeInstaller(targetDir,
-                Collections.emptyList()).setNodeVersion("v12.16.0")
+                Collections.emptyList()).setNodeVersion("v12.18.3")
                 .setNodeDownloadRoot(new File(baseDir).toPath().toUri());
 
         try {


### PR DESCRIPTION
This PR:

1. Upgrade Node to latest LTS version (12.18.3)
2. ~Add `node-gyp` as a dev dependency (required for native compilation of `fsevents` 1 on macOS). Note that `fsevents` 1 is deprecated and is only required for `chokidar` 2 (also deprecated), which is a requirement of `webpack` 4 but is not used at runtime (`chokidar` 3 is included). Hence, fix 2 is only cosmetic: it prevents the unsightly [`spawn node-gyp EACCES`](https://github.com/vaadin/flow/issues/8741) errors, but on the flip side the native compilation increases the `npm install` time compared to the install script failing. All for no good reason.~
3. Add parameter `--scripts-prepend-node-artifact=true` to Node install [to ensure that the same node executable is used for running npm and package install scripts](https://github.com/vaadin/flow/issues/8741#issuecomment-672648787).

Related to #8741.