### PR TITLE
Make the CustomInMemoryDataProvider implement listeners handling

### DIFF
--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/CustomInMemoryDataProvider.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/CustomInMemoryDataProvider.java
@@ -21,9 +21,10 @@ import java.util.stream.Stream;
 
 import com.vaadin.flow.function.SerializableComparator;
 import com.vaadin.flow.function.SerializablePredicate;
-import com.vaadin.flow.shared.Registration;
 
-public class CustomInMemoryDataProvider<T> implements InMemoryDataProvider<T> {
+public class CustomInMemoryDataProvider<T>
+        extends AbstractDataProvider<T, SerializablePredicate<T>>
+        implements InMemoryDataProvider<T> {
 
     private List<T> items;
     private SerializablePredicate<T> filter = in -> true;
@@ -41,6 +42,7 @@ public class CustomInMemoryDataProvider<T> implements InMemoryDataProvider<T> {
     @Override
     public void setFilter(SerializablePredicate<T> filter) {
         this.filter = filter;
+        refreshAll();
     }
 
     @Override
@@ -65,22 +67,5 @@ public class CustomInMemoryDataProvider<T> implements InMemoryDataProvider<T> {
             filteredStream = filteredStream.sorted(this.comparator);
         }
         return filteredStream.skip(query.getOffset()).limit(query.getLimit());
-    }
-
-    @Override
-    public void refreshItem(T item) {
-
-    }
-
-    @Override
-    public void refreshAll() {
-
-    }
-
-    @Override
-    public Registration addDataProviderListener(
-            DataProviderListener<T> listener) {
-        return () -> {
-        };
     }
 }


### PR DESCRIPTION
This changes relevant to unit tests for data view in ComboBox.
I extended `AbstractDataProvider` in order to have a real implementation of listeners handling in ComboBox unit tests.