### PR TITLE
Do not force installation of compatible pnpm version when system property `vaadin.ignoreVersionChecks` is set

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -95,9 +95,9 @@ public class FrontendTools {
                     new FrontendVersion("6.11.1"),
                     new FrontendVersion("6.11.2"));
 
-    private static final String PNMP_INSTALLED_BY_NPM_FOLDER = "node_modules/pnpm/";
+    static final String PNPM_INSTALLED_BY_NPM_FOLDER = "node_modules/pnpm/";
 
-    private static final String PNMP_INSTALLED_BY_NPM = PNMP_INSTALLED_BY_NPM_FOLDER
+    static final String PNPM_INSTALLED_BY_NPM = PNPM_INSTALLED_BY_NPM_FOLDER
             + "bin/pnpm.js";
 
     private static final int SUPPORTED_NODE_MAJOR_VERSION = 10;
@@ -676,7 +676,7 @@ public class FrontendTools {
         return returnCommand;
     }
 
-    private List<String> getSuitablePnpm(String dir) {
+    List<String> getSuitablePnpm(String dir) {
         final List<String> pnpmCommand = getPnpmExecutable(dir, false);
         if (!pnpmCommand.isEmpty()) {
             // check whether globally or locally installed pnpm is new enough
@@ -690,12 +690,20 @@ public class FrontendTools {
                         && pnpmVersion.isOlderThan(BREAKING_PNPM_VERSION)) {
                     return pnpmCommand;
                 } else {
-                    getLogger().warn(String.format(
-                            "installed pnpm ('%s', version %s) is not in the compatible versions range (>=%s, <%s), installing supported version locally",
+                    getLogger().warn(
+                            "installed pnpm ('{}', version {}) is not in the compatible versions range (>={}, <{})",
                             String.join(" ", pnpmCommand),
                             pnpmVersion.getFullVersion(),
                             SUPPORTED_PNPM_VERSION.getFullVersion(),
-                            BREAKING_PNPM_VERSION.getFullVersion()));
+                            BREAKING_PNPM_VERSION.getFullVersion());
+                    if (FrontendUtils.skippingVersionCheck()) {
+                        getLogger().info("using '{}' anyway",
+                                String.join(" ", pnpmCommand));
+                        return pnpmCommand;
+                    } else {
+                        getLogger().info("installing pnpm version {} locally",
+                                SUPPORTED_PNPM_VERSION.getFullVersion());
+                    }
                 }
             } catch (UnknownVersionException e) {
                 getLogger().warn(
@@ -753,7 +761,7 @@ public class FrontendTools {
     }
 
     private Optional<File> getLocalPnpmScript(String dir) {
-        File npmInstalled = new File(dir, PNMP_INSTALLED_BY_NPM);
+        File npmInstalled = new File(dir, PNPM_INSTALLED_BY_NPM);
         if (npmInstalled.canRead()) {
             return Optional.of(npmInstalled);
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -808,17 +808,8 @@ public class FrontendUtils {
         return new CssImportData(value, id, include, themeFor);
     }
 
-    static boolean skippingVersionCheck() {
-        return "true".equalsIgnoreCase(
-                System.getProperty(PARAM_IGNORE_VERSION_CHECKS));
-    }
-
     static void validateToolVersion(String tool, FrontendVersion toolVersion,
             FrontendVersion supported, FrontendVersion shouldWork) {
-        if (skippingVersionCheck()) {
-            return;
-        }
-
         if (isVersionAtLeast(toolVersion, supported)) {
             return;
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -808,10 +808,14 @@ public class FrontendUtils {
         return new CssImportData(value, id, include, themeFor);
     }
 
+    static boolean skippingVersionCheck() {
+        return "true".equalsIgnoreCase(
+                System.getProperty(PARAM_IGNORE_VERSION_CHECKS));
+    }
+
     static void validateToolVersion(String tool, FrontendVersion toolVersion,
             FrontendVersion supported, FrontendVersion shouldWork) {
-        if ("true".equalsIgnoreCase(
-                System.getProperty(PARAM_IGNORE_VERSION_CHECKS))) {
+        if (skippingVersionCheck()) {
             return;
         }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -511,25 +511,15 @@ public class FrontendToolsTest {
     @Test
     public void getSuitablePnpm_tooNewVersionInstalledAndSkipVersionCheck_accepted()
             throws Exception {
+        tools = new FrontendTools(baseDir, () -> vaadinHomeDir,
+                "v12.10.0", new File(baseDir).toURI(), true);
         Assume.assumeFalse(
                 tools.getNodeExecutable().isEmpty());
-        String originalPropertyValue = System
-                .getProperty(FrontendUtils.PARAM_IGNORE_VERSION_CHECKS);
+
         createFakePnpm("5.5.0");
-        try {
-            System.setProperty(FrontendUtils.PARAM_IGNORE_VERSION_CHECKS,
-                    "true");
-            List<String> pnpmCommand = tools.getSuitablePnpm(baseDir);
-            Assert.assertNotEquals("expected pnpm version 5.5.0 accepted", 0,
-                    pnpmCommand.size());
-        } finally {
-            if (originalPropertyValue != null) {
-                System.setProperty(FrontendUtils.PARAM_IGNORE_VERSION_CHECKS,
-                        originalPropertyValue);
-            } else {
-                System.clearProperty(FrontendUtils.PARAM_IGNORE_VERSION_CHECKS);
-            }
-        }
+        List<String> pnpmCommand = tools.getSuitablePnpm(baseDir);
+        Assert.assertNotEquals("expected pnpm version 5.5.0 accepted", 0,
+                pnpmCommand.size());
     }
 
     private void assertNpmCommand(Supplier<String> path) throws IOException {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -17,9 +17,9 @@ package com.vaadin.flow.server.frontend;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -489,6 +489,49 @@ public class FrontendToolsTest {
         assertNpmCommand(() -> vaadinHomeDir);
     }
 
+    @Test
+    public void getSuitablePnpm_compatibleVersionInstalled_accepted() throws Exception {
+        Assume.assumeFalse(
+                tools.getNodeExecutable().isEmpty());
+        createFakePnpm("4.5.0");
+        List<String> pnpmCommand = tools.getSuitablePnpm(baseDir);
+        Assert.assertNotEquals("expected pnpm version 4.5.0 accepted", 0,
+                pnpmCommand.size());
+    }
+    @Test
+    public void getSuitablePnpm_tooNewVersionInstalled_rejected() throws Exception {
+        Assume.assumeFalse(
+                tools.getNodeExecutable().isEmpty());
+        createFakePnpm("5.5.0");
+        List<String> pnpmCommand = tools.getSuitablePnpm(baseDir);
+        Assert.assertEquals("expected pnpm version 5.5.0 rejected", 0,
+                pnpmCommand.size());
+    }
+
+    @Test
+    public void getSuitablePnpm_tooNewVersionInstalledAndSkipVersionCheck_accepted()
+            throws Exception {
+        Assume.assumeFalse(
+                tools.getNodeExecutable().isEmpty());
+        String originalPropertyValue = System
+                .getProperty(FrontendUtils.PARAM_IGNORE_VERSION_CHECKS);
+        createFakePnpm("5.5.0");
+        try {
+            System.setProperty(FrontendUtils.PARAM_IGNORE_VERSION_CHECKS,
+                    "true");
+            List<String> pnpmCommand = tools.getSuitablePnpm(baseDir);
+            Assert.assertNotEquals("expected pnpm version 5.5.0 accepted", 0,
+                    pnpmCommand.size());
+        } finally {
+            if (originalPropertyValue != null) {
+                System.setProperty(FrontendUtils.PARAM_IGNORE_VERSION_CHECKS,
+                        originalPropertyValue);
+            } else {
+                System.clearProperty(FrontendUtils.PARAM_IGNORE_VERSION_CHECKS);
+            }
+        }
+    }
+
     private void assertNpmCommand(Supplier<String> path) throws IOException {
         createStubNode(false, true, false, vaadinHomeDir);
 
@@ -527,4 +570,17 @@ public class FrontendToolsTest {
         }
     }
 
+    private void createFakePnpm(String version) throws Exception {
+        File pnpmJs = new File(baseDir, FrontendTools.PNPM_INSTALLED_BY_NPM);
+        FileUtils.forceMkdir(pnpmJs.getParentFile());
+
+        FileWriter fileWriter = new FileWriter(pnpmJs);
+        try {
+            fileWriter.write(
+                    "if (process.argv.includes('--version') || process.argv.includes('-v')) {\n"
+                            + "    console.log('" + version + "');\n" + "}\n");
+        } finally {
+            fileWriter.close();
+        }
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -116,17 +116,6 @@ public class FrontendUtilsTest {
     }
 
     @Test
-    public void validateLargerThan_ignoredWithProperty() {
-        try {
-            System.setProperty("vaadin.ignoreVersionChecks", "true");
-            FrontendUtils.validateToolVersion("test", new FrontendVersion(0, 0),
-                    new FrontendVersion(10, 2), new FrontendVersion(10, 2));
-        } finally {
-            System.clearProperty("vaadin.ignoreVersionChecks");
-        }
-    }
-
-    @Test
     public void parseValidToolVersions() throws IOException {
         Assert.assertEquals("10.11.12",
                 FrontendUtils.parseVersionString("v10.11.12"));


### PR DESCRIPTION
Fixes #8889.