### PR TITLE
Support for disabling Win-specific tests in CI

### DIFF
--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -23,6 +23,9 @@
             concurrent running of test modules. -->
         <server.port>8888</server.port>
         <server.stop.port>8889</server.stop.port>
+        <!-- This property is needed to allow some Win-specific IT tests -->
+        <!-- to be disabled via system property in CI until they got fixed-->
+        <exclude.windows.failed.it.tests></exclude.windows.failed.it.tests>
     </properties>
 
     <dependencies>
@@ -82,6 +85,7 @@
                     <excludes>
                         <exclude>**/*$*</exclude>
                         <exclude>${exclude.it.tests}</exclude>
+                        <exclude>${exclude.windows.failed.it.tests}</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,10 @@
         <osgi.compendium.version>6.0.0</osgi.compendium.version>
 
         <maven.test.skip>false</maven.test.skip>
+
+        <!-- This property is needed to allow some Win-specific unit tests -->
+        <!-- to be disabled via system property in CI until they got fixed-->
+        <exclude.windows.failed.tests></exclude.windows.failed.tests>
     </properties>
 
     <repositories>
@@ -485,6 +489,9 @@
                     <configuration>
                         <trimStackTrace>false</trimStackTrace>
                         <reuseForks>false</reuseForks>
+                        <excludes>
+                            <exclude>${exclude.windows.failed.tests}</exclude>
+                        </excludes>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
These introduced properties allows to disable the Windows failed tests in Bender build, and to fix them gradually.