### PR TITLE
feat: Endpoint generation based on @Deferrable

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/Connect.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Connect.ts
@@ -518,3 +518,7 @@ export class InvalidSessionMiddleware implements MiddlewareClass {
     }
   }
 }
+
+export class DeferrableResult<T> {
+  result?: T
+}

--- a/flow-server/src/main/java/com/vaadin/flow/internal/HtmlUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/HtmlUtils.java
@@ -38,6 +38,6 @@ public final class HtmlUtils {
      * @return escaped string
      */
     public static String escape(String maybeHtml) {
-        return new TextNode(maybeHtml, null).outerHtml();
+        return new TextNode(maybeHtml).outerHtml();
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/Deferrable.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/Deferrable.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.connect;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to mark the endpoint call or an endpoint method to be deferrable,
+ * meaning that when offline, the endpoint request will be cached locally.
+ *
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Deferrable {
+    
+}

--- a/flow-server/src/main/resources/com/vaadin/flow/server/connect/generator/TypeScriptApiTemplate.mustache
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/connect/generator/TypeScriptApiTemplate.mustache
@@ -37,7 +37,9 @@ So `// @ts-ignore` is used for now to mute this error. The consequences are:
 
 }}// @ts-ignore
 import client from '{{vaadinConnectDefaultClientPath}}';
+{{#vendorExtensions.x-vaadin-connect-deferrable}}
 import { DeferrableResult } from '@vaadin/flow-frontend/Connect';
+{{/vendorExtensions.x-vaadin-connect-deferrable}}
 {{#each imports}}
 import {{~#importAs}} {{importAs}}{{/importAs}}{{~^importAs}} {{className}}{{/importAs}} from '{{importPath}}';
 {{/each}}

--- a/flow-server/src/main/resources/com/vaadin/flow/server/connect/generator/TypeScriptApiTemplate.mustache
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/connect/generator/TypeScriptApiTemplate.mustache
@@ -37,6 +37,7 @@ So `// @ts-ignore` is used for now to mute this error. The consequences are:
 
 }}// @ts-ignore
 import client from '{{vaadinConnectDefaultClientPath}}';
+import { DeferrableResult } from '@vaadin/flow-frontend/Connect';
 {{#each imports}}
 import {{~#importAs}} {{importAs}}{{/importAs}}{{~^importAs}} {{className}}{{/importAs}} from '{{importPath}}';
 {{/each}}
@@ -52,28 +53,57 @@ import {{~#importAs}} {{importAs}}{{/importAs}}{{~^importAs}} {{className}}{{/im
  }}{{/each}}
  *{{#responses}}{{#message}} {{message}}{{/message}}{{/responses}}
  */{{/vendorExtensions.x-vaadin-connect-show-tsdoc}}
+{{#vendorExtensions.x-vaadin-connect-deferrable}}
 function _{{vendorExtensions.x-vaadin-connect-method-name}}({{!
-  }}{{#each bodyParam.vendorExtensions.x-vaadin-connect-parameters}}
-  {{name}}{{^required}}?{{/required}}: {{{getClassNameFromImports type ../../imports}}}{{#if @last}}{{! Append new line if it's the last param.}}
+ }}{{#each bodyParam.vendorExtensions.x-vaadin-connect-parameters}}
+ {{name}}{{^required}}?{{/required}}: {{{getClassNameFromImports type ../../imports}}}{{#if @last}}{{! Append new line if it's the last param.}}
+{{else}},{{! Used the `~` after if to remove extra empty line by the each loop}}{{/if~}}
+{{/each}}): Promise<DeferrableResult<{{!
+}}{{#responses}}{{#dataType}}{{{getClassNameFromImports dataType ../../../imports}}}{{/dataType}}{{^dataType}}void{{/dataType}}{{/responses}}{{!
+}}>> {
+{{=<% %>=}}
+ return new DeferrableResult(<%!
+   %>'<%vendorExtensions.x-vaadin-connect-endpoint-name%>', <%!
+   %>'<%vendorExtensions.x-vaadin-connect-method-name%>'<%!
+   %><%^bodyParams%><%!
+     %><%^authMethods%>, undefined<%/authMethods%><%!
+   %><%/bodyParams%><%!
+   %><%#bodyParams%>, {<%!
+   %><%#each bodyParam.vendorExtensions.x-vaadin-connect-parameters%><%!
+     %><%name%><%#if @last%><%else%>, <%/if%><%!
+   %><%/each%><%!
+   %>}<%/bodyParams%><%!
+   %><%^authMethods%>, {requireCredentials: false}<%/authMethods%><%!
+ %>)._request();
+}
+<%={{ }}=%>
+{{/vendorExtensions.x-vaadin-connect-deferrable}}
+{{^vendorExtensions.x-vaadin-connect-deferrable}}
+function _{{vendorExtensions.x-vaadin-connect-method-name}}({{!
+ }}{{#each bodyParam.vendorExtensions.x-vaadin-connect-parameters}}
+ {{name}}{{^required}}?{{/required}}: {{{getClassNameFromImports type ../../imports}}}{{#if @last}}{{! Append new line if it's the last param.}}
 {{else}},{{! Used the `~` after if to remove extra empty line by the each loop}}{{/if~}}
 {{/each}}): Promise<{{!
 }}{{#responses}}{{#dataType}}{{{getClassNameFromImports dataType ../../../imports}}}{{/dataType}}{{^dataType}}void{{/dataType}}{{/responses}}{{!
 }}> {
 {{=<% %>=}}
-  return client.call(<%!
-    %>'<%vendorExtensions.x-vaadin-connect-endpoint-name%>', <%!
-    %>'<%vendorExtensions.x-vaadin-connect-method-name%>'<%!
-    %><%^bodyParams%><%!
-      %><%^authMethods%>, undefined<%/authMethods%><%!
-    %><%/bodyParams%><%!
-    %><%#bodyParams%>, {<%!
-    %><%#each bodyParam.vendorExtensions.x-vaadin-connect-parameters%><%!
-      %><%name%><%#if @last%><%else%>, <%/if%><%!
-    %><%/each%><%!
-    %>}<%/bodyParams%><%!
-    %><%^authMethods%>, {requireCredentials: false}<%/authMethods%><%!
-  %>);
+ return client.call(<%!
+   %>'<%vendorExtensions.x-vaadin-connect-endpoint-name%>', <%!
+   %>'<%vendorExtensions.x-vaadin-connect-method-name%>'<%!
+   %><%^bodyParams%><%!
+     %><%^authMethods%>, undefined<%/authMethods%><%!
+   %><%/bodyParams%><%!
+   %><%#bodyParams%>, {<%!
+   %><%#each bodyParam.vendorExtensions.x-vaadin-connect-parameters%><%!
+     %><%name%><%#if @last%><%else%>, <%/if%><%!
+   %><%/each%><%!
+   %>}<%/bodyParams%><%!
+   %><%^authMethods%>, {requireCredentials: false}<%/authMethods%><%!
+ %>);
 }
+<%={{ }}=%>
+{{/vendorExtensions.x-vaadin-connect-deferrable}}
+{{=<% %>=}}
 export {_<%vendorExtensions.x-vaadin-connect-method-name%> as <%vendorExtensions.x-vaadin-connect-method-name%>};
 <%={{ }}=%>
 {{/operation}}

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/VaadinConnectControllerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/VaadinConnectControllerTest.java
@@ -46,6 +46,8 @@ import com.vaadin.flow.server.connect.auth.AnonymousAllowed;
 import com.vaadin.flow.server.connect.auth.VaadinConnectAccessChecker;
 import com.vaadin.flow.server.connect.exception.EndpointException;
 import com.vaadin.flow.server.connect.exception.EndpointValidationException;
+import com.vaadin.flow.server.connect.generator.endpoints.superclassmethods.PersonEndpoint;
+import com.vaadin.flow.server.connect.generator.endpoints.superclassmethods.PersonEndpoint.Person;
 import com.vaadin.flow.server.connect.testendpoint.BridgeMethodTestEndpoint;
 
 import static org.junit.Assert.assertEquals;
@@ -1056,6 +1058,17 @@ public class VaadinConnectControllerTest {
         assertTrue(message.contains(NullCheckerTestClass.class.getSimpleName()));
         assertTrue(message.contains(testNullMethodName));
         assertTrue(message.contains(errorMessage));
+    }
+
+    @Test
+    public void should_ReturnResult_When_CallingSuperClassMethodWithGenericTypedParameter() {
+        ResponseEntity<?> response = createVaadinController(new PersonEndpoint())
+                .serveEndpoint(PersonEndpoint.class.getSimpleName(), "update",
+                        createRequestParameters(
+                        "{\"entity\":{\"name\":\"aa\"}}"), requestMock);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("{\"name\":\"aa\"}", response.getBody());
     }
 
     private void assertEndpointInfoPresent(String responseBody) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/endpoints/deferrable/DeferrableEndpointTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/endpoints/deferrable/DeferrableEndpointTest.java
@@ -1,0 +1,19 @@
+package com.vaadin.flow.server.connect.generator.endpoints.deferrable;
+
+import java.util.Arrays;
+
+import com.vaadin.flow.server.connect.generator.endpoints.AbstractEndpointGenerationTest;
+
+import org.junit.Test;
+
+public class DeferrableEndpointTest extends AbstractEndpointGenerationTest {
+    
+    public DeferrableEndpointTest() {
+        super(Arrays.asList(WholeClassDeferrableEndpoint.class, SingleMethodDeferrableEndpoint.class));
+    }
+    
+    @Test
+    public void should_DeferrableResult_When_ASingleMethod_Or_TheWholeClass_IsMarkedAsDeferrable() {
+        verifyOpenApiObjectAndGeneratedTs();
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/endpoints/deferrable/SingleMethodDeferrableEndpoint.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/endpoints/deferrable/SingleMethodDeferrableEndpoint.java
@@ -1,0 +1,18 @@
+package com.vaadin.flow.server.connect.generator.endpoints.deferrable;
+
+import com.vaadin.flow.server.connect.Deferrable;
+import com.vaadin.flow.server.connect.Endpoint;
+
+@Endpoint
+public class SingleMethodDeferrableEndpoint {
+
+    @Deferrable
+    public String hello(String userName) {
+        return "Hello, "+userName;
+    }
+
+    public String hi(String userName) {
+        return "Hi, "+userName;
+    }
+
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/endpoints/deferrable/WholeClassDeferrableEndpoint.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/endpoints/deferrable/WholeClassDeferrableEndpoint.java
@@ -1,0 +1,17 @@
+package com.vaadin.flow.server.connect.generator.endpoints.deferrable;
+
+import com.vaadin.flow.server.connect.Deferrable;
+import com.vaadin.flow.server.connect.Endpoint;
+
+@Endpoint
+@Deferrable
+public class WholeClassDeferrableEndpoint {
+    
+    public String hello(String userName) {
+        return "Hello, "+userName;
+    }
+
+    public String hi(String userName) {
+        return "Hi, "+userName;
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/endpoints/superclassmethods/CrudEndpoint.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/generator/endpoints/superclassmethods/CrudEndpoint.java
@@ -1,10 +1,10 @@
 package com.vaadin.flow.server.connect.generator.endpoints.superclassmethods;
 
-import java.util.Optional;
-
 import com.vaadin.flow.server.connect.EndpointExposed;
+import com.vaadin.flow.server.connect.auth.AnonymousAllowed;
 
 @EndpointExposed
+@AnonymousAllowed
 public abstract class CrudEndpoint<T, ID> extends ReadOnlyEndpoint<T, ID> {
     public T update(T entity) {
         return entity;

--- a/flow-server/src/test/resources/com/vaadin/flow/server/connect/generator/endpoints/deferrable/expected-SingleMethodDeferrableEndpoint.ts
+++ b/flow-server/src/test/resources/com/vaadin/flow/server/connect/generator/endpoints/deferrable/expected-SingleMethodDeferrableEndpoint.ts
@@ -1,0 +1,23 @@
+/**
+ * This module is generated from SingleMethodDeferrableEndpoint.java
+ * All changes to this file are overridden. Please consider to make changes in the corresponding Java file if necessary.
+ * @module SingleMethodDeferrableEndpoint
+ */
+
+// @ts-ignore
+import client from './connect-client.default';
+import { DeferrableResult } from '@vaadin/flow-frontend/Connect';
+
+function _hello(
+  userName: string
+): Promise<DeferrableResult<string>> {
+  return new DeferrableResult('SingleMethodDeferrableEndpoint', 'hello', {userName})._request();
+}
+export {_hello as hello};
+
+function _hi(
+  userName: string
+): Promise<string> {
+  return client.call('SingleMethodDeferrableEndpoint', 'hi', {userName});
+}
+export {_hi as hi};

--- a/flow-server/src/test/resources/com/vaadin/flow/server/connect/generator/endpoints/deferrable/expected-WholeClassDeferrableEndpoint.ts
+++ b/flow-server/src/test/resources/com/vaadin/flow/server/connect/generator/endpoints/deferrable/expected-WholeClassDeferrableEndpoint.ts
@@ -1,0 +1,23 @@
+/**
+ * This module is generated from WholeClassDeferrableEndpoint.java
+ * All changes to this file are overridden. Please consider to make changes in the corresponding Java file if necessary.
+ * @module WholeClassDeferrableEndpoint
+ */
+
+// @ts-ignore
+import client from './connect-client.default';
+import { DeferrableResult } from '@vaadin/flow-frontend/Connect';
+
+function _hello(
+  userName: string
+): Promise<DeferrableResult<string>> {
+  return new DeferrableResult('WholeClassDeferrableEndpoint', 'hello', {userName})._request();
+}
+export {_hello as hello};
+
+function _hi(
+  userName: string
+): Promise<DeferrableResult<string>> {
+  return new DeferrableResult('WholeClassDeferrableEndpoint', 'hi', {userName})._request();
+}
+export {_hi as hi};


### PR DESCRIPTION
- When there is a @Deferrable in an Endpoint class or method, the generated function will return a `DeferrableResult` instead.
- If @Deferrable is present, the generated code is the same as before.

Note this PR only has a class definition for the `DeferrableResult`, the detail implemented will be in a separate PR