### PR TITLE
fix: surround 404 check with spaces

### DIFF
--- a/flow-test-util/src/main/java/com/vaadin/flow/testutil/TestBenchHelpers.java
+++ b/flow-test-util/src/main/java/com/vaadin/flow/testutil/TestBenchHelpers.java
@@ -379,7 +379,7 @@ public class TestBenchHelpers extends ParallelTest {
             Predicate<String> acceptableMessagePredicate) {
         getLogEntries(Level.WARNING).forEach(logEntry -> {
             if ((Objects.equals(logEntry.getLevel(), Level.SEVERE)
-                    || logEntry.getMessage().contains("404"))
+                    || logEntry.getMessage().contains(" 404 "))
                     && !logEntry.getMessage()
                             .contains(WEB_SOCKET_CONNECTION_ERROR_PREFIX)
                     && !acceptableMessagePredicate


### PR DESCRIPTION
`checkLogsForErrors` checks if the message contains `404`, but it will match if the sequence is part of a number.

[This build for Grid](https://teamcity.vaadin.com/viewLog.html?buildId=66566&) is an example of such case.