### PR TITLE
Cache original index.html Document in production mode

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.server.communication;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.io.UncheckedIOException;
 
 import org.jsoup.Jsoup;
@@ -230,20 +231,26 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
 
 
     // Holds parsed index.html to avoid re-parsing on every request in production mode
-    private static final class IndexHtmlHolder {
-        private final Document indexHtmlDocument;
+    //
+    // This holder is supposed to be stored as a VaadinContext attribute
+    //
+    // Note: IndexHtmlHolder is not really serializable, but I can't come up with
+    // circumstances under which it'll break. It seems unlikely that VaadinContext
+    // will be serialized/deserialized.
+    private static final class IndexHtmlHolder implements Serializable {
+        private final transient Document indexHtmlDocument;
 
         private IndexHtmlHolder(VaadinService service) {
             try {
-                indexHtmlDocument = getIndexHtmlDocument(service);
-                indexHtmlDocument.outputSettings().prettyPrint(false);
+                this.indexHtmlDocument = getIndexHtmlDocument(service);
+                this.indexHtmlDocument.outputSettings().prettyPrint(false);
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
         }
 
         private Document getDocument() {
-            return indexHtmlDocument.clone();
+            return this.indexHtmlDocument.clone();
         }
     }
 


### PR DESCRIPTION
This PR addresses two problems for the production mode:
- The `index.html` was read and parsed via Jsoup on every request in `IndexHtmlRequestHandler`
- The resulting page was pretty printed (default behaviour of `Jsoup.parse()`