### PR TITLE
feat: support deferrable endpoint request

### DIFF
--- a/flow-client/package.json
+++ b/flow-client/package.json
@@ -28,11 +28,13 @@
   ],
   "devDependencies": {
     "@types/sinon": "^9.0.0",
+    "@types/uuid": "8.3.0",
     "abort-controller": "^2.0.0",
     "chai": "^4.2.0",
     "eslint": "^5.8.0",
     "eslint-config-vaadin": "^0.2.7",
     "fetch-mock": "^7.3.0",
+    "idb-keyval": "3.2.0",
     "intern": "^4.4.3",
     "lit-element": "^2.3.1",
     "node-fetch": "^2.3.0",
@@ -43,6 +45,7 @@
     "tslint-config-prettier": "^1.18.0",
     "tslint-eslint-rules": "^5.4.0",
     "typescript": "^3.8.3",
+    "uuid": "8.0.0",
     "webpack": "^4.39.1",
     "webpack-cli": "^3.3.6",
     "xhr-mock": "^2.5.0"

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -315,6 +315,10 @@ public abstract class NodeUpdater implements FallibleCommand {
         // check out https://github.com/babel/babel/issues/11488
         defaults.put("chokidar", "^3.4.0");
 
+        defaults.put("idb-keyval", "3.2.0");
+        defaults.put("uuid", "8.0.0");
+        defaults.put("@types/uuid", "8.0.0");
+
         return defaults;
     }
 

--- a/flow-server/src/main/resources/com/vaadin/flow/server/connect/generator/TypeScriptApiTemplate.mustache
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/connect/generator/TypeScriptApiTemplate.mustache
@@ -64,7 +64,7 @@ function _{{vendorExtensions.x-vaadin-connect-method-name}}({{!
 }}{{#responses}}{{#dataType}}{{{getClassNameFromImports dataType ../../../imports}}}{{/dataType}}{{^dataType}}void{{/dataType}}{{/responses}}{{!
 }}>> {
 {{=<% %>=}}
- return new DeferrableResult(<%!
+ return client.deferrableCall(<%!
    %>'<%vendorExtensions.x-vaadin-connect-endpoint-name%>', <%!
    %>'<%vendorExtensions.x-vaadin-connect-method-name%>'<%!
    %><%^bodyParams%><%!
@@ -76,7 +76,7 @@ function _{{vendorExtensions.x-vaadin-connect-method-name}}({{!
    %><%/each%><%!
    %>}<%/bodyParams%><%!
    %><%^authMethods%>, {requireCredentials: false}<%/authMethods%><%!
- %>)._request();
+ %>);
 }
 <%={{ }}=%>
 {{/vendorExtensions.x-vaadin-connect-deferrable}}

--- a/flow-server/src/test/resources/com/vaadin/flow/server/connect/generator/endpoints/deferrable/expected-SingleMethodDeferrableEndpoint.ts
+++ b/flow-server/src/test/resources/com/vaadin/flow/server/connect/generator/endpoints/deferrable/expected-SingleMethodDeferrableEndpoint.ts
@@ -11,7 +11,7 @@ import { DeferrableResult } from '@vaadin/flow-frontend/Connect';
 function _hello(
   userName: string
 ): Promise<DeferrableResult<string>> {
-  return new DeferrableResult('SingleMethodDeferrableEndpoint', 'hello', {userName})._request();
+  return client.deferrableCall('SingleMethodDeferrableEndpoint', 'hello', {userName});
 }
 export {_hello as hello};
 

--- a/flow-server/src/test/resources/com/vaadin/flow/server/connect/generator/endpoints/deferrable/expected-WholeClassDeferrableEndpoint.ts
+++ b/flow-server/src/test/resources/com/vaadin/flow/server/connect/generator/endpoints/deferrable/expected-WholeClassDeferrableEndpoint.ts
@@ -11,13 +11,13 @@ import { DeferrableResult } from '@vaadin/flow-frontend/Connect';
 function _hello(
   userName: string
 ): Promise<DeferrableResult<string>> {
-  return new DeferrableResult('WholeClassDeferrableEndpoint', 'hello', {userName})._request();
+  return client.deferrableCall('WholeClassDeferrableEndpoint', 'hello', {userName});
 }
 export {_hello as hello};
 
 function _hi(
   userName: string
 ): Promise<DeferrableResult<string>> {
-  return new DeferrableResult('WholeClassDeferrableEndpoint', 'hi', {userName})._request();
+  return client.deferrableCall('WholeClassDeferrableEndpoint', 'hi', {userName});
 }
 export {_hi as hi};


### PR DESCRIPTION
fixes #8950 
- Add client.deferrableCall() which allows caching the endpoint request when offline
- Generated endpoints will call `client.deferrableCall()` if a `@Deferrable` annotion is detected (#8951)
- Use a IndexedDB helper `"idb-keyval": "3.2.0"` for easier indexedDB manipulation
- Use an uuid helper `"uuid": "8.0.0"` for generating uuid