### PR TITLE
Fixed: flow-server now closes resources properly when parsing java classes

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendAnnotatedClassVisitor.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendAnnotatedClassVisitor.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.server.frontend.scanner;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -70,10 +71,11 @@ final class FrontendAnnotatedClassVisitor extends ClassVisitor {
             return;
         }
         try {
-            ClassReader cr;
             URL url = finder.getResource(name.replace(".", "/") + ".class");
-            cr = new ClassReader(url.openStream());
-            cr.accept(this, 0);
+            try (InputStream is = url.openStream()) {
+                ClassReader cr = new ClassReader(is);
+                cr.accept(this, 0);
+            }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.server.frontend.scanner;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Modifier;
 import java.net.URL;
@@ -463,8 +464,10 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
 
         FrontendClassVisitor visitor = new FrontendClassVisitor(className,
                 endPoint, themeScope);
-        ClassReader cr = new ClassReader(url.openStream());
-        cr.accept(visitor, ClassReader.EXPAND_FRAMES);
+        try (InputStream is = url.openStream()) {
+            ClassReader cr = new ClassReader(is);
+            cr.accept(visitor, ClassReader.EXPAND_FRAMES);
+        }
 
         // all classes visited by the scanner, used for performance (#5933)
         visited.add(className);


### PR DESCRIPTION
The problem is that the `ClassReader(InputStream)` constructor doesn't close the input stream itself, which is then left open hanging. This is especially troublesome for Gradle Plugin since the opened input stream is left hanging in the Gradle Daemon, which can stay around for hours. This could be a possible cause for https://github.com/vaadin/vaadin-gradle-plugin/issues/81

This PR needs to be cherry-picked to 4.0 and also 2.3 branches.