### PR TITLE
Deprecate UI.getRouter() and use it only as internal

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -785,6 +785,8 @@ public class UI extends Component
     /**
      * Gets the framework data object for this UI.
      *
+     * This method is for internal use only.
+     *
      * @return the framework data object
      */
     public UIInternals getInternals() {
@@ -883,7 +885,7 @@ public class UI extends Component
     public void navigate(Class<? extends Component> navigationTarget,
             RouteParameters parameters) {
         RouteConfiguration configuration = RouteConfiguration
-                .forRegistry(getRouter().getRegistry());
+                .forRegistry(getInternals().getRouter().getRegistry());
         navigate(configuration.getUrl(navigationTarget, parameters));
     }
     
@@ -929,7 +931,8 @@ public class UI extends Component
         Objects.requireNonNull(location, "Location must not be null");
         Objects.requireNonNull(queryParameters, "Query parameters must not be null");
 
-        getRouter().navigate(this, new Location(location, queryParameters),
+        getInternals().getRouter().navigate(this,
+                new Location(location, queryParameters),
                 NavigationTrigger.UI_NAVIGATE);
     }
 
@@ -937,8 +940,10 @@ public class UI extends Component
      * Gets the router used for navigating in this UI.
      *
      * @return a router
+     *
+     * @deprecated For internal use only. Will be removed in the future.
      */
-    public Router getRouter() {
+    private Router getRouter() {
         return internals.getRouter();
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -937,6 +937,17 @@ public class UI extends Component
     }
 
     /**
+     * Returns true if this UI instance supports navigation.
+     *
+     * @return true if this UI instance supports navigation, otherwise false.
+     */
+    public boolean isNavigationSupported() {
+        // By default any UI supports navigation. Override this to return false
+        // if navigation is not supported.
+        return true;
+    }
+
+    /**
      * Gets the router used for navigating in this UI.
      *
      * @return a router

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -943,7 +943,7 @@ public class UI extends Component
      *
      * @deprecated For internal use only. Will be removed in the future.
      */
-    private Router getRouter() {
+    public Router getRouter() {
         return internals.getRouter();
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -954,6 +954,7 @@ public class UI extends Component
      *
      * @deprecated For internal use only. Will be removed in the future.
      */
+    @Deprecated
     public Router getRouter() {
         return internals.getRouter();
     }

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUI.java
@@ -188,8 +188,8 @@ public class JavaScriptBootstrapUI extends UI {
             }
 
             navigationInProgress = true;
-            Optional<NavigationState>  navigationState = this.getRouter()
-                    .resolveNavigationTarget(location);
+            Optional<NavigationState> navigationState = getInternals()
+                    .getRouter().resolveNavigationTarget(location);
 
             if (navigationState.isPresent()) {
                 // Navigation can be done in server side without extra
@@ -232,8 +232,8 @@ public class JavaScriptBootstrapUI extends UI {
     private void navigateToPlaceholder(Location location) {
         if (clientViewNavigationState == null) {
             clientViewNavigationState = new NavigationStateBuilder(
-                    this.getRouter()).withTarget(ClientViewPlaceholder.class)
-                    .build();
+                    getInternals().getRouter())
+                            .withTarget(ClientViewPlaceholder.class).build();
         }
         // Passing the `clientViewLocation` to make sure that the navigation
         // events contain the correct location that we are navigating to.
@@ -246,7 +246,7 @@ public class JavaScriptBootstrapUI extends UI {
             return;
         }
         getInternals().setLastHandledNavigation(location);
-        Optional<NavigationState> navigationState = this.getRouter()
+        Optional<NavigationState> navigationState = getInternals().getRouter()
                 .resolveNavigationTarget(location);
         if (navigationState.isPresent()) {
             // There is a valid route in flow.
@@ -280,8 +280,8 @@ public class JavaScriptBootstrapUI extends UI {
 
     private void handleNavigation(Location location, NavigationState navigationState, NavigationTrigger trigger) {
         try {
-            NavigationEvent navigationEvent = new NavigationEvent(getRouter(),
-                    location, this, trigger);
+            NavigationEvent navigationEvent = new NavigationEvent(
+                    getInternals().getRouter(), location, this, trigger);
 
             JavaScriptNavigationStateRenderer clientNavigationStateRenderer = new JavaScriptNavigationStateRenderer(
                     navigationState);
@@ -300,8 +300,8 @@ public class JavaScriptBootstrapUI extends UI {
 
     private boolean handleExceptionNavigation(Location location,
             Exception exception) {
-        Optional<ErrorTargetEntry> maybeLookupResult = this.getRouter()
-                .getErrorNavigationTarget(exception);
+        Optional<ErrorTargetEntry> maybeLookupResult = getInternals()
+                .getRouter().getErrorNavigationTarget(exception);
         if (maybeLookupResult.isPresent()) {
             ErrorTargetEntry lookupResult = maybeLookupResult.get();
 
@@ -309,12 +309,12 @@ public class JavaScriptBootstrapUI extends UI {
                     lookupResult.getHandledExceptionType(), exception,
                     exception.getMessage());
             ErrorStateRenderer errorStateRenderer = new ErrorStateRenderer(
-                    new NavigationStateBuilder(this.getRouter())
+                    new NavigationStateBuilder(getInternals().getRouter())
                             .withTarget(lookupResult.getNavigationTarget())
                             .build());
 
             ErrorNavigationEvent errorNavigationEvent = new ErrorNavigationEvent(
-                    this.getRouter(), location, this,
+                    getInternals().getRouter(), location, this,
                     NavigationTrigger.CLIENT_SIDE, errorParameter);
 
             errorStateRenderer.handle(errorNavigationEvent);
@@ -343,7 +343,7 @@ public class JavaScriptBootstrapUI extends UI {
     }
 
     private void handleErrorNavigation(Location location) {
-        NavigationState errorNavigationState = this.getRouter()
+        NavigationState errorNavigationState = getInternals().getRouter()
                 .resolveRouteNotFoundNavigationTarget()
                 .orElse(getDefaultNavigationError());
         ErrorStateRenderer errorStateRenderer = new ErrorStateRenderer(
@@ -353,13 +353,13 @@ public class JavaScriptBootstrapUI extends UI {
         ErrorParameter<NotFoundException> errorParameter = new ErrorParameter<>(
                 NotFoundException.class, notFoundException);
         ErrorNavigationEvent errorNavigationEvent = new ErrorNavigationEvent(
-                this.getRouter(), location, this, NavigationTrigger.CLIENT_SIDE,
+                getInternals().getRouter(), location, this, NavigationTrigger.CLIENT_SIDE,
                 errorParameter);
         errorStateRenderer.handle(errorNavigationEvent);
     }
 
     private NavigationState getDefaultNavigationError() {
-        return new NavigationStateBuilder(this.getRouter())
+        return new NavigationStateBuilder(getInternals().getRouter())
                 .withTarget(RouteNotFoundError.class).build();
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -962,10 +962,12 @@ public class UIInternals implements Serializable {
      * when this UI was initialized.
      *
      * @return the router used for this UI, or <code>null</code> if there is no
-     *         router
+     *         router or the UI doesn't support navigation.
      */
     public Router getRouter() {
-        return getSession().getService().getRouter();
+        return ui.isNavigationSupported()
+                ? getSession().getService().getRouter()
+                : null;
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentUI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentUI.java
@@ -260,11 +260,6 @@ public class WebComponentUI extends UI {
     }
 
     @Override
-    public Router getRouter() {
-        return null;
-    }
-
-    @Override
     public void navigate(String location) {
         throw new UnsupportedOperationException(NO_NAVIGATION);
     }

--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentUI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentUI.java
@@ -260,6 +260,11 @@ public class WebComponentUI extends UI {
     }
 
     @Override
+    public Router getRouter() {
+        return null;
+    }
+
+    @Override
     public void navigate(String location) {
         throw new UnsupportedOperationException(NO_NAVIGATION);
     }

--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentUI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentUI.java
@@ -22,8 +22,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.slf4j.LoggerFactory;
-
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.DomEvent;
@@ -37,7 +35,6 @@ import com.vaadin.flow.internal.nodefeature.NodeProperties;
 import com.vaadin.flow.router.HasUrlParameter;
 import com.vaadin.flow.router.PreserveOnRefresh;
 import com.vaadin.flow.router.QueryParameters;
-import com.vaadin.flow.router.Router;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.webcomponent.WebComponentBinding;
@@ -45,8 +42,8 @@ import com.vaadin.flow.server.webcomponent.WebComponentConfigurationRegistry;
 import com.vaadin.flow.theme.AbstractTheme;
 import com.vaadin.flow.theme.Theme;
 import com.vaadin.flow.theme.ThemeDefinition;
-
 import elemental.json.JsonObject;
+import org.slf4j.LoggerFactory;
 
 /**
  * Custom UI for use with WebComponents served from the server.
@@ -260,8 +257,8 @@ public class WebComponentUI extends UI {
     }
 
     @Override
-    public Router getRouter() {
-        return null;
+    public boolean isNavigationSupported() {
+        return false;
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/router/BeforeEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/BeforeEvent.java
@@ -513,7 +513,7 @@ public abstract class BeforeEvent extends EventObject {
     private NavigationState getNavigationState(
             Class<? extends Component> target, RouteParameters parameters,
             String resolvedUrl) {
-        return new NavigationStateBuilder(ui.getRouter())
+        return new NavigationStateBuilder(ui.getInternals().getRouter())
                 .withTarget(target, parameters).withPath(resolvedUrl).build();
     }
 
@@ -704,8 +704,10 @@ public abstract class BeforeEvent extends EventObject {
         if (maybeLookupResult.isPresent()) {
             ErrorTargetEntry lookupResult = maybeLookupResult.get();
 
-            rerouteTargetState = new NavigationStateBuilder(ui.getRouter())
-                    .withTarget(lookupResult.getNavigationTarget()).build();
+            rerouteTargetState = new NavigationStateBuilder(
+                    ui.getInternals().getRouter())
+                            .withTarget(lookupResult.getNavigationTarget())
+                            .build();
             rerouteTarget = new ErrorStateRenderer(rerouteTargetState);
 
             errorParameter = new ErrorParameter<>(

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouterLink.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouterLink.java
@@ -333,7 +333,7 @@ public class RouterLink extends Component implements HasText, HasComponents,
         Router router = null;
         if (getElement().getNode().isAttached()) {
             StateTree tree = (StateTree) getElement().getNode().getOwner();
-            router = tree.getUI().getRouter();
+            router = tree.getUI().getInternals().getRouter();
         }
         if (router == null) {
             router = VaadinService.getCurrent().getRouter();

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -143,7 +143,7 @@ public abstract class AbstractNavigationStateRenderer
         final RouteTarget routeTarget = navigationState.getRouteTarget();
 
         routeLayoutTypes = routeTarget != null ? routeTarget.getParentLayouts()
-                : getRouterLayoutTypes(routeTargetType, ui.getRouter());
+                : getRouterLayoutTypes(routeTargetType, ui.getInternals().getRouter());
 
         assert routeTargetType != null;
         assert routeLayoutTypes != null;

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -1220,8 +1220,8 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
     }
 
     protected void initializeUIWithRouter(VaadinRequest request, UI ui) {
-        if (ui.getRouter() != null) {
-            ui.getRouter().initializeUI(ui, request);
+        if (ui.getInternals().getRouter() != null) {
+            ui.getInternals().getRouter().initializeUI(ui, request);
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapUtils.java
@@ -144,7 +144,7 @@ class BootstrapUtils {
             assert pathInfo.startsWith("/");
             pathInfo = pathInfo.substring(1);
         }
-        Router router = ui.getRouter();
+        Router router = ui.getInternals().getRouter();
         NavigationEvent navigationEvent = new NavigationEvent(router,
                 new Location(pathInfo,
                         QueryParameters.full(request.getParameterMap())),
@@ -275,13 +275,13 @@ class BootstrapUtils {
      *         defined, or an empty optional if no such class is available
      */
     public static Optional<Class<?>> resolvePageConfigurationHolder(UI ui,
-                                                                    VaadinRequest request) {
+            VaadinRequest request) {
         assert ui != null;
         assert request != null;
-        if (ui.getRouter() == null) {
+        if (ui.getInternals().getRouter() == null) {
             return Optional.empty();
         }
-        Optional<Class<?>> navigationTarget = ui.getRouter()
+        Optional<Class<?>> navigationTarget = ui.getInternals().getRouter()
                 .resolveNavigationTarget(request.getPathInfo(),
                         request.getParameterMap())
                 .map(BootstrapUtils::resolveTopParentLayout);
@@ -290,8 +290,8 @@ class BootstrapUtils {
         }
         // If there is no route target available then let's ask for "route not
         // found" target
-        return ui.getRouter().resolveRouteNotFoundNavigationTarget()
-                .map(state -> {
+        return ui.getInternals().getRouter()
+                .resolveRouteNotFoundNavigationTarget().map(state -> {
                     /*
                      * {@code resolveTopParentLayout} is theoretically the
                      * correct way to get the parent layout. But in fact it does

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
@@ -181,7 +181,7 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
     protected void initializeUIWithRouter(VaadinRequest request, UI ui) {
         if (request.getService().getBootstrapInitialPredicate()
                 .includeInitialUidl(request)) {
-            ui.getRouter().initializeUI(ui, request);
+            ui.getInternals().getRouter().initializeUI(ui, request);
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
@@ -143,7 +143,7 @@ public class JavaScriptBootstrapHandler extends BootstrapHandler {
             // to know that in future navigation calls
             ui.getSession().setAttribute(SERVER_ROUTING, Boolean.TRUE);
 
-            ui.getRouter().initializeUI(ui, location);
+            ui.getInternals().getRouter().initializeUI(ui, location);
         }
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/InvalidUrlTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/InvalidUrlTest.java
@@ -96,7 +96,7 @@ public class InvalidUrlTest {
             ui.getInternals().setSession(session);
 
             RouteConfiguration routeConfiguration = RouteConfiguration
-                    .forRegistry(ui.getRouter().getRegistry());
+                    .forRegistry(ui.getInternals().getRouter().getRegistry());
             routeConfiguration.update(() -> {
                 routeConfiguration.getHandledRegistry().clean();
                 Arrays.asList(UITest.RootNavigationTarget.class,
@@ -104,7 +104,7 @@ public class InvalidUrlTest {
             });
 
             ui.doInit(request, 0);
-            ui.getRouter().initializeUI(ui, request);
+            ui.getInternals().getRouter().initializeUI(ui, request);
 
             session.unlock();
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/LocationObserverTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/LocationObserverTest.java
@@ -61,25 +61,20 @@ public class LocationObserverTest {
     public static class RootComponent extends Component {
     }
 
-    public static class RouterTestUI extends MockUI {
-        final Router router;
+    public static class RouterTestMockUI extends MockUI {
 
-        public RouterTestUI(Router router) {
-            super(createMockSession());
-            this.router = router;
+        public RouterTestMockUI(Router router) {
+            super(createMockSession(router));
         }
 
-        private static VaadinSession createMockSession() {
+        private static VaadinSession createMockSession(Router router) {
             MockVaadinServletService service = new MockVaadinServletService();
             service.init();
+            service.setRouter(router);
+
             VaadinSession session = new AlwaysLockedVaadinSession(service);
             session.setConfiguration(service.getDeploymentConfiguration());
             return session;
-        }
-
-        @Override
-        public Router getRouter() {
-            return router;
         }
 
         @Override
@@ -100,7 +95,7 @@ public class LocationObserverTest {
     public void navigation_and_locale_change_should_fire_locale_change_observer()
             throws InvalidRouteConfigurationException {
         router = new Router(new TestRouteRegistry());
-        ui = new RouterTestUI(router);
+        ui = new RouterTestMockUI(router);
 
         RouteConfiguration.forRegistry(router.getRegistry()).setAnnotatedRoute(Translations.class);
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/UITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/UITest.java
@@ -217,7 +217,7 @@ public class UITest {
             ui.getInternals().setSession(session);
 
             RouteConfiguration routeConfiguration = RouteConfiguration
-                    .forRegistry(ui.getRouter().getRegistry());
+                    .forRegistry(ui.getInternals().getRouter().getRegistry());
 
             routeConfiguration.update(() -> {
                 routeConfiguration.getHandledRegistry().clean();
@@ -228,7 +228,7 @@ public class UITest {
             });
 
             ui.doInit(request, 0);
-            ui.getRouter().initializeUI(ui, request);
+            ui.getInternals().getRouter().initializeUI(ui, request);
 
             session.unlock();
 
@@ -279,12 +279,8 @@ public class UITest {
     public void navigateWithParameters_delegateToRouter() {
         final String route = "params";
         Router router = Mockito.mock(Router.class);
-        UI ui = new MockUI() {
-            @Override
-            public com.vaadin.flow.router.Router getRouter() {
-                return router;
-            }
-        };
+        UI ui = new MockUI(router);
+
         QueryParameters params = QueryParameters
                 .simple(Collections.singletonMap("test", "indeed"));
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUITest.java
@@ -290,7 +290,7 @@ public class JavaScriptBootstrapUITest  {
     @Test
     public void should_initializeUI_when_wrapperElement_null() {
         VaadinRequest request = mocks.createRequest(mocks, "/foo");
-        ui.getRouter().initializeUI(ui, request);
+        ui.getInternals().getRouter().initializeUI(ui, request);
         assertNull(ui.wrapperElement);
         // attached to body
         assertTrue(ui.getElement().toString().contains("Available routes:"));
@@ -355,8 +355,7 @@ public class JavaScriptBootstrapUITest  {
         ui = Mockito.spy(ui);
         Page page = mockPage();
 
-        UIInternals internals = Mockito.mock(UIInternals.class);
-        Mockito.when(ui.getInternals()).thenReturn(internals);
+        UIInternals internals = mockUIInternals();
 
         Mockito.when(internals.hasLastHandledLocation()).thenReturn(true);
         Location lastLocation = new Location("clean");
@@ -387,8 +386,7 @@ public class JavaScriptBootstrapUITest  {
         ui = Mockito.spy(ui);
         Page page = mockPage();
 
-        UIInternals internals = Mockito.mock(UIInternals.class);
-        Mockito.when(ui.getInternals()).thenReturn(internals);
+        UIInternals internals = mockUIInternals();
 
         Mockito.when(internals.hasLastHandledLocation()).thenReturn(true);
         Location lastLocation = new Location("clean");
@@ -514,6 +512,16 @@ public class JavaScriptBootstrapUITest  {
         Mockito.when(page.getHistory()).thenReturn(history);
 
         return page;
+    }
+
+    private UIInternals mockUIInternals() {
+        UIInternals internals = Mockito.mock(UIInternals.class);
+        Mockito.when(ui.getInternals()).thenReturn(internals);
+
+        Mockito.when(internals.getRouter())
+                .thenReturn(mocks.getService().getRouter());
+
+        return internals;
     }
 
 }

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterConfigurationUrlResolvingTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterConfigurationUrlResolvingTest.java
@@ -37,11 +37,7 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.CurrentInstance;
 import com.vaadin.flow.server.InvalidRouteConfigurationException;
-import com.vaadin.flow.server.MockVaadinServletService;
-import com.vaadin.flow.server.MockVaadinSession;
 import com.vaadin.flow.server.VaadinService;
-import com.vaadin.flow.server.VaadinSession;
-import com.vaadin.tests.util.MockUI;
 
 @NotThreadSafe
 public class RouterConfigurationUrlResolvingTest extends RoutingTestBase {
@@ -54,7 +50,7 @@ public class RouterConfigurationUrlResolvingTest extends RoutingTestBase {
     @Before
     public void init() throws NoSuchFieldException, IllegalAccessException {
         super.init();
-        ui = new RouterTestUI(router);
+        ui = new RouterTestMockUI(router);
         ui.getSession().lock();
         ui.getSession().setConfiguration(configuration);
 
@@ -677,27 +673,6 @@ public class RouterConfigurationUrlResolvingTest extends RoutingTestBase {
         public void setParameter(BeforeEvent event,
                 @com.vaadin.flow.router.WildcardParameter String parameter) {
         }
-    }
-
-    public static class RouterTestUI extends MockUI {
-        final Router router;
-
-        public RouterTestUI(Router router) {
-            super(createMockSession());
-            this.router = router;
-        }
-
-        private static VaadinSession createMockSession() {
-            MockVaadinServletService service = new MockVaadinServletService();
-            service.init();
-            return new MockVaadinSession(service);
-        }
-
-        @Override
-        public Router getRouter() {
-            return router;
-        }
-
     }
 
 }

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterLinkTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterLinkTest.java
@@ -72,13 +72,7 @@ public class RouterLinkTest extends HasCurrentService {
         });
         router = new Router(registry);
 
-        ui = new UI() {
-            @Override
-            public Router getRouter() {
-                return router;
-            }
-        };
-
+        ui = new RoutingTestBase.RouterTestUI(router);
         VaadinService service = VaadinService.getCurrent();
         Mockito.when(service.getRouter()).thenReturn(router);
     }

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
@@ -50,13 +50,9 @@ import com.vaadin.flow.router.internal.HasUrlParameterFormat;
 import com.vaadin.flow.router.internal.RouteUtil;
 import com.vaadin.flow.server.InvalidRouteConfigurationException;
 import com.vaadin.flow.server.InvalidRouteLayoutConfigurationException;
-import com.vaadin.flow.server.MockVaadinServletService;
-import com.vaadin.flow.server.MockVaadinSession;
 import com.vaadin.flow.server.VaadinService;
-import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.startup.ApplicationRouteRegistry;
 import com.vaadin.flow.shared.Registration;
-import com.vaadin.tests.util.MockUI;
 import elemental.json.Json;
 import elemental.json.JsonObject;
 import net.jcip.annotations.NotThreadSafe;
@@ -577,27 +573,6 @@ public class RouterTest extends RoutingTestBase {
         }
     }
 
-    public static class RouterTestUI extends MockUI {
-        final Router router;
-
-        public RouterTestUI(Router router) {
-            super(createMockSession());
-            this.router = router;
-        }
-
-        private static VaadinSession createMockSession() {
-            MockVaadinServletService service = new MockVaadinServletService();
-            service.init();
-            return new MockVaadinSession(service);
-        }
-
-        @Override
-        public Router getRouter() {
-            return router;
-        }
-
-    }
-
     @Route("navigationEvents")
     @Tag(Tag.DIV)
     public static class NavigationEvents extends Component {
@@ -975,7 +950,7 @@ public class RouterTest extends RoutingTestBase {
         public void beforeEnter(BeforeEnterEvent event) {
             events.add(event);
             UI ui = UI.getCurrent();
-            ui.getRouter().navigate(ui, new Location("loop"),
+            ui.getInternals().getRouter().navigate(ui, new Location("loop"),
                     NavigationTrigger.PROGRAMMATIC);
         }
     }
@@ -1605,7 +1580,7 @@ public class RouterTest extends RoutingTestBase {
     public void init() throws NoSuchFieldException, SecurityException,
             IllegalArgumentException, IllegalAccessException {
         super.init();
-        ui = new RouterTestUI(router);
+        ui = new RouterTestMockUI(router);
         ui.getSession().lock();
         ui.getSession().setConfiguration(configuration);
 

--- a/flow-server/src/test/java/com/vaadin/flow/router/RoutingTestBase.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RoutingTestBase.java
@@ -15,11 +15,18 @@
  */
 package com.vaadin.flow.router;
 
+import com.vaadin.flow.server.MockVaadinServletService;
+import com.vaadin.flow.server.MockVaadinSession;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.tests.util.MockUI;
 import org.junit.Before;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 
 public class RoutingTestBase {
 
@@ -64,17 +71,40 @@ public class RoutingTestBase {
         }
     }
 
+    public static class RouterTestMockUI extends MockUI {
+
+        public RouterTestMockUI(Router router) {
+            super(createMockSession(router));
+        }
+
+        private static VaadinSession createMockSession(Router router) {
+            MockVaadinServletService service = new MockVaadinServletService();
+            service.init();
+            service.setRouter(router);
+            return new MockVaadinSession(service);
+        }
+
+    }
+
     public static class RouterTestUI extends UI {
-        final Router router;
 
         public RouterTestUI(Router router) {
-            this.router = router;
+            super();
+
+            getInternals().setSession(createMockSession(router));
         }
 
-        @Override
-        public Router getRouter() {
-            return router;
+        private static VaadinSession createMockSession(Router router) {
+
+            VaadinSession session = Mockito.mock(VaadinSession.class);
+            VaadinService service = Mockito.mock(VaadinService.class);
+
+            Mockito.when(session.getService()).thenReturn(service);
+            Mockito.when(service.getRouter()).thenReturn(router);
+
+            return session;
         }
+
     }
 
     protected Router router;

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/ErrorStateRendererTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/ErrorStateRendererTest.java
@@ -129,16 +129,16 @@ public class ErrorStateRendererTest {
     public void handle_openNPEErrorTarget_infiniteReroute_noStackOverflow_throws() {
         UI ui = configureMocks();
 
-        NavigationState state = new NavigationStateBuilder(ui.getRouter())
+        NavigationState state = new NavigationStateBuilder(ui.getInternals().getRouter())
                 .withTarget(InfiniteLoopErrorTarget.class).build();
         ErrorStateRenderer renderer = new ErrorStateRenderer(state);
 
-        RouteConfiguration.forRegistry(ui.getRouter().getRegistry())
+        RouteConfiguration.forRegistry(ui.getInternals().getRouter().getRegistry())
                 .setAnnotatedRoute(InfiniteLoopNPEView.class);
 
         ErrorParameter<Exception> parameter = new ErrorParameter<>(
                 Exception.class, new NullPointerException());
-        ErrorNavigationEvent event = new ErrorNavigationEvent(ui.getRouter(),
+        ErrorNavigationEvent event = new ErrorNavigationEvent(ui.getInternals().getRouter(),
                 new Location("error"), ui, NavigationTrigger.CLIENT_SIDE,
                 parameter);
         // event should route to ErrorTarget whose layout forwards to NPEView
@@ -150,17 +150,17 @@ public class ErrorStateRendererTest {
     public void handle_openNPEView_infiniteReroute_noStackOverflow_throws() {
         UI ui = configureMocks();
 
-        NavigationState state = new NavigationStateBuilder(ui.getRouter())
+        NavigationState state = new NavigationStateBuilder(ui.getInternals().getRouter())
                 .withTarget(InfiniteLoopNPEView.class).build();
         NavigationStateRenderer renderer = new NavigationStateRenderer(state);
 
-        RouteConfiguration.forRegistry(ui.getRouter().getRegistry())
+        RouteConfiguration.forRegistry(ui.getInternals().getRouter().getRegistry())
                 .setAnnotatedRoute(InfiniteLoopNPEView.class);
-        ((ApplicationRouteRegistry) ui.getRouter().getRegistry())
+        ((ApplicationRouteRegistry) ui.getInternals().getRouter().getRegistry())
                 .setErrorNavigationTargets(
                         Collections.singleton(InfiniteLoopErrorTarget.class));
 
-        NavigationEvent event = new NavigationEvent(ui.getRouter(),
+        NavigationEvent event = new NavigationEvent(ui.getInternals().getRouter(),
                 new Location("npe"), ui, NavigationTrigger.CLIENT_SIDE);
         // event should route to ErrorTarget whose layout forwards to NPEView
         // which reroute to ErrorTarget and this is an infinite loop
@@ -171,7 +171,7 @@ public class ErrorStateRendererTest {
         routerLinkState.put("scrollPositionX", 0d);
         routerLinkState.put("scrollPositionY", 0d);
 
-        event = new NavigationEvent(ui.getRouter(), new Location("npe"), ui,
+        event = new NavigationEvent(ui.getInternals().getRouter(), new Location("npe"), ui,
                 NavigationTrigger.ROUTER_LINK, routerLinkState, false);
         // event should route to ErrorTarget whose layout forwards to NPEView
         // which reroute to ErrorTarget and this is an infinite loop
@@ -182,16 +182,16 @@ public class ErrorStateRendererTest {
     public void handle_errorViewLayoutForwardsToAView_viewIsNavigated() {
         UI ui = configureMocks();
 
-        NavigationState state = new NavigationStateBuilder(ui.getRouter())
+        NavigationState state = new NavigationStateBuilder(ui.getInternals().getRouter())
                 .withTarget(HappyPathErrorTarget.class).build();
         ErrorStateRenderer renderer = new ErrorStateRenderer(state);
 
-        RouteConfiguration.forRegistry(ui.getRouter().getRegistry())
+        RouteConfiguration.forRegistry(ui.getInternals().getRouter().getRegistry())
                 .setAnnotatedRoute(HappyPathViewView.class);
 
         ErrorParameter<Exception> parameter = new ErrorParameter<>(
                 Exception.class, new NullPointerException());
-        ErrorNavigationEvent event = new ErrorNavigationEvent(ui.getRouter(),
+        ErrorNavigationEvent event = new ErrorNavigationEvent(ui.getInternals().getRouter(),
                 new Location("error"), ui, NavigationTrigger.CLIENT_SIDE,
                 parameter);
         Assert.assertEquals(200, renderer.handle(event));

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
@@ -549,6 +549,7 @@ public class NavigationStateRendererTest {
     public void handle_RouterLinkTriggerNullState_IllegalStateException() {
         // given a service with instantiator
         MockVaadinServletService service = createMockServiceWithInstantiator();
+        service.setRouter(router);
 
         // given a locked session
         MockVaadinSession session = new AlwaysLockedVaadinSession(service);
@@ -563,9 +564,8 @@ public class NavigationStateRendererTest {
         MockUI ui = new MockUI(session);
 
         expectedException.expect(IllegalStateException.class);
-        renderer.handle(new NavigationEvent(new Router(new TestRouteRegistry()),
-                new Location("regular"), ui, NavigationTrigger.ROUTER_LINK,
-                null, false));
+        renderer.handle(new NavigationEvent(router, new Location("regular"), ui,
+                NavigationTrigger.ROUTER_LINK, null, false));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/BootstrapContextTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/BootstrapContextTest.java
@@ -76,7 +76,7 @@ public class BootstrapContextTest {
 
     @Test
     public void getPushAnnotation_routeTargetPresents_pushFromTheClassDefinitionIsUsed() {
-        ui.getRouter().getRegistry().setRoute("foo", MainView.class,
+        ui.getInternals().getRouter().getRegistry().setRoute("foo", MainView.class,
                 Collections.emptyList());
         Mockito.when(request.getPathInfo()).thenReturn("/foo");
 
@@ -93,7 +93,7 @@ public class BootstrapContextTest {
 
     @Test
     public void getPushAnnotation_routeTargetPresents_pushDefinedOnParentLayout_pushFromTheClassDefinitionIsUsed() {
-        ui.getRouter().getRegistry().setRoute("foo", OtherView.class,
+        ui.getInternals().getRouter().getRegistry().setRoute("foo", OtherView.class,
                 Collections.singletonList(MainView.class));
         Mockito.when(request.getPathInfo()).thenReturn("/foo");
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerDependenciesTest.java
@@ -218,7 +218,7 @@ public class BootstrapHandlerDependenciesTest {
         Mockito.when(router.getRegistry()).thenReturn(registry);
         return router;
     }
-    
+
     private TestVaadinServletService service;
     private MockServletServiceSessionSetup mocks;
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerDependenciesTest.java
@@ -8,6 +8,8 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.router.RoutingTestBase;
+import com.vaadin.tests.util.MockUI;
 import net.jcip.annotations.NotThreadSafe;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -43,29 +45,14 @@ import static org.mockito.Mockito.mock;
 public class BootstrapHandlerDependenciesTest {
     private static final String BOOTSTRAP_SCRIPT_CONTENTS = "//<![CDATA[\n";
 
-    private static class TestUI extends UI {
-
-        @Override
-        public Router getRouter() {
-            Router router = Mockito.mock(Router.class);
-            Mockito.when(router.resolveRouteNotFoundNavigationTarget())
-                    .thenReturn(Optional.empty());
-            RouteRegistry registry = Mockito.mock(RouteRegistry.class);
-            Mockito.when(router.resolveNavigationTarget(Mockito.any(),
-                    Mockito.any())).thenReturn(Optional.empty());
-            Mockito.when(router.getRegistry()).thenReturn(registry);
-            return router;
-        }
-    }
-
     @StyleSheet(value = "lazy.css", loadMode = LoadMode.LAZY)
     @StyleSheet(value = "inline.css", loadMode = LoadMode.INLINE)
     @StyleSheet("context://eager-relative.css")
     @StyleSheet("eager.css")
-    private static class UIAnnotated_LoadingOrderTest extends TestUI {
+    private static class UIAnnotated_LoadingOrderTest extends UI {
     }
 
-    private static class UIWithMethods_LoadingOrderTest extends TestUI {
+    private static class UIWithMethods_LoadingOrderTest extends UI {
         @Override
         protected void init(VaadinRequest request) {
             getPage().addJavaScript("lazy.js", LoadMode.LAZY);
@@ -80,10 +67,10 @@ public class BootstrapHandlerDependenciesTest {
 
     @JavaScript(value = "new.js", loadMode = LoadMode.LAZY)
     @JavaScript(value = "new.js")
-    private static class UIAnnotated_BothLazyAndEagerTest extends TestUI {
+    private static class UIAnnotated_BothLazyAndEagerTest extends UI {
     }
 
-    private static class UIWithMethods_BothBothLazyAndEagerTest extends TestUI {
+    private static class UIWithMethods_BothBothLazyAndEagerTest extends UI {
         @Override
         protected void init(VaadinRequest request) {
             getPage().addJavaScript("new.js", LoadMode.LAZY);
@@ -93,11 +80,11 @@ public class BootstrapHandlerDependenciesTest {
 
     @JavaScript(value = "new.js", loadMode = LoadMode.LAZY)
     @JavaScript(value = "new.js", loadMode = LoadMode.INLINE)
-    private static class UIAnnotated_BothLazyAndInlineTest extends TestUI {
+    private static class UIAnnotated_BothLazyAndInlineTest extends UI {
     }
 
     private static class UIWithMethods_BothBothLazyAndInlineTest
-            extends TestUI {
+            extends UI {
         @Override
         protected void init(VaadinRequest request) {
             getPage().addJavaScript("new.js", LoadMode.LAZY);
@@ -107,11 +94,11 @@ public class BootstrapHandlerDependenciesTest {
 
     @JavaScript(value = "new.js", loadMode = LoadMode.INLINE)
     @JavaScript(value = "new.js")
-    private static class UIAnnotated_BothInlineAndEagerTest extends TestUI {
+    private static class UIAnnotated_BothInlineAndEagerTest extends UI {
     }
 
     private static class UIWithMethods_BothBothInlineAndEagerTest
-            extends TestUI {
+            extends UI {
         @Override
         protected void init(VaadinRequest request) {
             getPage().addJavaScript("new.js", LoadMode.INLINE);
@@ -121,20 +108,20 @@ public class BootstrapHandlerDependenciesTest {
 
     @StyleSheet("1.css")
     @StyleSheet("2.css")
-    private static class UIAnnotated_ImportOrderTest_Eager extends TestUI {
+    private static class UIAnnotated_ImportOrderTest_Eager extends UI {
     }
 
     @StyleSheet(value = "1.css", loadMode = LoadMode.LAZY)
     @StyleSheet(value = "2.css", loadMode = LoadMode.LAZY)
-    private static class UIAnnotated_ImportOrderTest_Lazy extends TestUI {
+    private static class UIAnnotated_ImportOrderTest_Lazy extends UI {
     }
 
     @StyleSheet(value = "1.css", loadMode = LoadMode.INLINE)
     @StyleSheet(value = "2.css", loadMode = LoadMode.INLINE)
-    private static class UIAnnotated_ImportOrderTest_Inline extends TestUI {
+    private static class UIAnnotated_ImportOrderTest_Inline extends UI {
     }
 
-    private static class UIWithMethods_ImportOrderTest_Eager extends TestUI {
+    private static class UIWithMethods_ImportOrderTest_Eager extends UI {
         @Override
         public void init(VaadinRequest request) {
             getPage().addStyleSheet("1.css");
@@ -142,7 +129,7 @@ public class BootstrapHandlerDependenciesTest {
         }
     }
 
-    private static class UIWithMethods_ImportOrderTest_Lazy extends TestUI {
+    private static class UIWithMethods_ImportOrderTest_Lazy extends UI {
         @Override
         public void init(VaadinRequest request) {
             getPage().addJavaScript("1.js", LoadMode.LAZY);
@@ -152,7 +139,7 @@ public class BootstrapHandlerDependenciesTest {
         }
     }
 
-    private static class UIWithMethods_ImportOrderTest_Inline extends TestUI {
+    private static class UIWithMethods_ImportOrderTest_Inline extends UI {
         @Override
         public void init(VaadinRequest request) {
             getPage().addJavaScript("1.js", LoadMode.INLINE);
@@ -165,11 +152,11 @@ public class BootstrapHandlerDependenciesTest {
     @StyleSheet(value = "1.css", loadMode = LoadMode.LAZY)
     @StyleSheet(value = "2.css", loadMode = LoadMode.LAZY)
     @StyleSheet(value = "1.css", loadMode = LoadMode.LAZY)
-    private static class UIAnnotated_DuplicateDependencies_Lazy extends TestUI {
+    private static class UIAnnotated_DuplicateDependencies_Lazy extends UI {
     }
 
     private static class UIWithMethods_DuplicateDependencies_Lazy
-            extends TestUI {
+            extends UI {
         @Override
         protected void init(VaadinRequest request) {
             getPage().addStyleSheet("1.css", LoadMode.LAZY);
@@ -185,11 +172,11 @@ public class BootstrapHandlerDependenciesTest {
     @StyleSheet(value = "2.css", loadMode = LoadMode.INLINE)
     @StyleSheet(value = "1.css", loadMode = LoadMode.INLINE)
     private static class UIAnnotated_DuplicateDependencies_Inline
-            extends TestUI {
+            extends UI {
     }
 
     private static class UIWithMethods_DuplicateDependencies_Inline
-            extends TestUI {
+            extends UI {
         @Override
         protected void init(VaadinRequest request) {
             getPage().addStyleSheet("1.css", LoadMode.INLINE);
@@ -205,11 +192,11 @@ public class BootstrapHandlerDependenciesTest {
     @StyleSheet("2.css")
     @StyleSheet("1.css")
     private static class UIAnnotated_DuplicateDependencies_Eager
-            extends TestUI {
+            extends UI {
     }
 
     private static class UIWithMethods_DuplicateDependencies_Eager
-            extends TestUI {
+            extends UI {
         @Override
         protected void init(VaadinRequest request) {
             getPage().addStyleSheet("1.css");
@@ -221,6 +208,17 @@ public class BootstrapHandlerDependenciesTest {
         }
     }
 
+    private static Router createRouter() {
+        Router router = Mockito.mock(Router.class);
+        Mockito.when(router.resolveRouteNotFoundNavigationTarget())
+                .thenReturn(Optional.empty());
+        RouteRegistry registry = Mockito.mock(RouteRegistry.class);
+        Mockito.when(router.resolveNavigationTarget(Mockito.any(),
+                Mockito.any())).thenReturn(Optional.empty());
+        Mockito.when(router.getRegistry()).thenReturn(registry);
+        return router;
+    }
+    
     private TestVaadinServletService service;
     private MockServletServiceSessionSetup mocks;
 
@@ -231,6 +229,7 @@ public class BootstrapHandlerDependenciesTest {
         mocks = new MockServletServiceSessionSetup();
 
         service = mocks.getService();
+        service.setRouter(createRouter());
         TestVaadinServlet servlet = mocks.getServlet();
         for (String type : new String[] { "js", "css" }) {
             servlet.addServletContextResource("inline." + type,

--- a/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
@@ -376,7 +376,7 @@ public class BootstrapHandlerTest {
         this.request = request;
 
         ui.doInit(request, 0);
-        ui.getRouter().initializeUI(ui, request);
+        ui.getInternals().getRouter().initializeUI(ui, request);
         context = new BootstrapContext(request, null, session, ui,
                 this::contextRootRelativePath);
         ui.getInternals().setContextRoot(contextRootRelativePath(request));
@@ -396,7 +396,7 @@ public class BootstrapHandlerTest {
         this.request = request;
 
         ui.doInit(request, 0);
-        ui.getRouter().initializeUI(ui, request);
+        ui.getInternals().getRouter().initializeUI(ui, request);
         context = new BootstrapContext(request, null, session, ui,
                 this::contextRootRelativePath);
         ui.getInternals().setContextRoot(contextRootRelativePath(request));
@@ -428,7 +428,7 @@ public class BootstrapHandlerTest {
         anotherUI.getInternals().setSession(session);
         VaadinRequest vaadinRequest = createVaadinRequest();
         anotherUI.doInit(vaadinRequest, 0);
-        anotherUI.getRouter().initializeUI(anotherUI, request);
+        anotherUI.getInternals().getRouter().initializeUI(anotherUI, request);
         anotherUI.getInternals()
                 .setContextRoot(contextRootRelativePath(request));
         BootstrapContext bootstrapContext = new BootstrapContext(vaadinRequest,
@@ -1141,7 +1141,7 @@ public class BootstrapHandlerTest {
         anotherUI.getInternals().setSession(session);
         VaadinRequest vaadinRequest = createVaadinRequest();
         anotherUI.doInit(vaadinRequest, 0);
-        anotherUI.getRouter().initializeUI(anotherUI, request);
+        anotherUI.getInternals().getRouter().initializeUI(anotherUI, request);
         BootstrapContext bootstrapContext = new BootstrapContext(vaadinRequest,
                 null, session, anotherUI, this::contextRootRelativePath);
         anotherUI.getInternals()
@@ -1224,7 +1224,7 @@ public class BootstrapHandlerTest {
         anotherUI.getInternals().setSession(session);
         VaadinRequest vaadinRequest = createVaadinRequest();
         anotherUI.doInit(vaadinRequest, 0);
-        anotherUI.getRouter().initializeUI(anotherUI, request);
+        anotherUI.getInternals().getRouter().initializeUI(anotherUI, request);
         BootstrapContext bootstrapContext = new BootstrapContext(vaadinRequest,
                 null, session, anotherUI, this::contextRootRelativePath);
         anotherUI.getInternals()
@@ -1420,7 +1420,7 @@ public class BootstrapHandlerTest {
         anotherUI.getInternals().setSession(session);
         VaadinServletRequest vaadinRequest = createVaadinRequest();
         anotherUI.doInit(vaadinRequest, 0);
-        anotherUI.getRouter().initializeUI(anotherUI, request);
+        anotherUI.getInternals().getRouter().initializeUI(anotherUI, request);
         BootstrapContext bootstrapContext = new BootstrapContext(vaadinRequest,
                 null, session, anotherUI, this::contextRootRelativePath);
         anotherUI.getInternals()

--- a/flow-server/src/test/java/com/vaadin/flow/server/MockVaadinServletService.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/MockVaadinServletService.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.router.Router;
 import com.vaadin.flow.server.RequestHandler;
 import com.vaadin.flow.server.ServiceException;
 import com.vaadin.flow.server.VaadinServlet;
@@ -35,6 +36,8 @@ import com.vaadin.tests.util.MockDeploymentConfiguration;
 public class MockVaadinServletService extends VaadinServletService {
 
     private Instantiator instantiator;
+
+    private Router router;
 
     public MockVaadinServletService() {
         this(new MockDeploymentConfiguration());
@@ -54,6 +57,15 @@ public class MockVaadinServletService extends VaadinServletService {
         } catch (ServletException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public void setRouter(Router router) {
+        this.router = router;
+    }
+
+    @Override
+    public Router getRouter() {
+        return router != null ? router : super.getRouter();
     }
 
     @Override

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServiceTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServiceTest.java
@@ -277,9 +277,9 @@ public class VaadinServiceTest {
                     VaadinService.getCurrent());
 
             Router router = event.getSource().getRouter();
-            Assert.assertNotEquals("Router should be initialized", router);
+            Assert.assertNotNull("Router should be initialized", router);
 
-            Assert.assertNotEquals("registry should be initialized",
+            Assert.assertNotNull("registry should be initialized",
                     router.getRegistry());
 
             RouteConfiguration.forApplicationScope().setRoute("test",

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinSessionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinSessionTest.java
@@ -39,6 +39,8 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.tests.util.MockUI;
 import net.jcip.annotations.NotThreadSafe;
 import org.easymock.EasyMock;
 import org.junit.Assert;
@@ -77,10 +79,22 @@ public class VaadinSessionTest {
     private UI ui;
     private Lock httpSessionLock;
 
-    private static class TestUI extends UI {
+    private static class TestServlet extends VaadinServlet {
+
         @Override
-        public Router getRouter() {
-            return Mockito.mock(Router.class);
+        protected VaadinServletService createServletService(
+                DeploymentConfiguration deploymentConfiguration)
+                throws ServiceException {
+            VaadinServletService service = new VaadinServletService(this,
+                    deploymentConfiguration) {
+
+                @Override
+                public Router getRouter() {
+                    return Mockito.mock(Router.class);
+                }
+            };
+            service.init();
+            return service;
         }
     }
 
@@ -88,7 +102,7 @@ public class VaadinSessionTest {
     public void setup() throws Exception {
         httpSessionLock = new ReentrantLock();
         mockServletConfig = new MockServletConfig();
-        mockServlet = new VaadinServlet();
+        mockServlet = new TestServlet();
         mockServlet.init(mockServletConfig);
         mockService = mockServlet.getService();
 
@@ -137,7 +151,7 @@ public class VaadinSessionTest {
         session.setConfiguration(configuration);
         session.unlock();
 
-        ui = new TestUI();
+        ui = new UI();
         vaadinRequest = new VaadinServletRequest(
                 Mockito.mock(HttpServletRequest.class), mockService) {
             @Override

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/UidlWriterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/UidlWriterTest.java
@@ -308,7 +308,7 @@ public class UidlWriterTest {
         ui.getInternals().setSession(session);
 
         RouteConfiguration routeConfiguration = RouteConfiguration
-                .forRegistry(ui.getRouter().getRegistry());
+                .forRegistry(ui.getInternals().getRouter().getRegistry());
         routeConfiguration.update(() -> {
             routeConfiguration.getHandledRegistry().clean();
             routeConfiguration.setAnnotatedRoute(BaseClass.class);
@@ -328,7 +328,7 @@ public class UidlWriterTest {
                 .thenReturn(servletRequestMock);
 
         ui.doInit(vaadinRequestMock, 1);
-        ui.getRouter().initializeUI(ui, vaadinRequestMock);
+        ui.getInternals().getRouter().initializeUI(ui, vaadinRequestMock);
 
         return ui;
     }

--- a/flow-server/src/test/java/com/vaadin/tests/util/MockUI.java
+++ b/flow-server/src/test/java/com/vaadin/tests/util/MockUI.java
@@ -17,6 +17,7 @@ package com.vaadin.tests.util;
 
 import java.util.List;
 
+import com.vaadin.flow.router.Router;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.UI;
@@ -35,6 +36,10 @@ public class MockUI extends UI {
     public MockUI(VaadinSession session) {
         getInternals().setSession(session);
         setCurrent(this);
+    }
+
+    public MockUI(Router router) {
+        this(createSession(router));
     }
 
     @Override
@@ -58,8 +63,17 @@ public class MockUI extends UI {
     }
 
     private static VaadinSession createSession() {
-        VaadinSession session = new AlwaysLockedVaadinSession(
-                Mockito.mock(VaadinService.class));
+        return createSession(null);
+    }
+    
+    private static VaadinSession createSession(Router router) {
+        VaadinService service = Mockito.mock(VaadinService.class);
+
+        if (router != null) {
+            Mockito.when(service.getRouter()).thenReturn(router);
+        }
+
+        VaadinSession session = new AlwaysLockedVaadinSession(service);
         VaadinSession.setCurrent(session);
         return session;
     }


### PR DESCRIPTION
Fixes https://github.com/vaadin/flow/issues/8989

`Router.navigate` behaviour is now different than `UI.navigate` and won't update the browser history when used with `NavigationTrigger.PROGRAMMATIC`. 