### PR TITLE
Force size re-estimate when requested range end equals assumed size

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -541,7 +541,7 @@ public class DataCommunicator<T> implements Serializable {
              * estimated size. If there was a previous defined size used, then
              * that is kept until a reset occurs.
              */
-            if (requestedRange.contains(assumedSize)) {
+            if (requestedRange.contains(assumedSize - 1)) {
                 requestFlush();
             }
         }

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
@@ -33,6 +33,7 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.Range;
+import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinSession;
@@ -1070,6 +1071,30 @@ public class DataCommunicatorTest {
         Assert.assertEquals("Invalid count provided", 500,
                 event.getItemCount());
         Assert.assertFalse(event.isItemCountEstimated());
+    }
+
+    @Test
+    public void setDefinedSize_rangeEndEqualsAssumedSize_flushRequested() {
+        // trigger client communication in order to initialise it and avoid
+        // infinite loop inside 'requestFlush()'
+        fakeClientCommunication();
+
+        StateNode stateNode = Mockito.spy(element.getNode());
+        DataCommunicator<Item> dataCommunicator = new DataCommunicator<>(
+                dataGenerator, arrayUpdater, data -> {}, stateNode);
+        dataCommunicator.setPageSize(pageSize);
+        dataCommunicator.setDataProvider(createDataProvider(), null);
+        // Trigger flush() to set the assumedSize
+        fakeClientCommunication();
+
+        dataCommunicator.setRequestedRange(0, 100);
+        // clean flushRequest
+        fakeClientCommunication();
+
+        Mockito.reset(stateNode);
+        dataCommunicator.setDefinedSize(false);
+        // Verify that requestFlush has been invoked
+        Mockito.verify(stateNode).runWhenAttached(Mockito.anyObject());
     }
 
     @Test

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
@@ -1083,7 +1083,10 @@ public class DataCommunicatorTest {
         DataCommunicator<Item> dataCommunicator = new DataCommunicator<>(
                 dataGenerator, arrayUpdater, data -> {}, stateNode);
         dataCommunicator.setPageSize(pageSize);
+
+        // the items size returned by this data provider will be 100
         dataCommunicator.setDataProvider(createDataProvider(), null);
+
         // Trigger flush() to set the assumedSize
         fakeClientCommunication();
 
@@ -1093,8 +1096,13 @@ public class DataCommunicatorTest {
 
         Mockito.reset(stateNode);
         dataCommunicator.setDefinedSize(false);
+        fakeClientCommunication();
+
         // Verify that requestFlush has been invoked
         Mockito.verify(stateNode).runWhenAttached(Mockito.anyObject());
+
+        // Verify the estimated count is now 100 + 4 * pageSize = 300
+        Assert.assertEquals(300, dataCommunicator.getItemCount());
     }
 
     @Test


### PR DESCRIPTION
Since the `Range` is exclusive at the end, it may happen that the range end is the same as the assumed size. It that case the `flush()` would not be invoked, although it should. Requested range strategy generally speaking depends on web component and there may be the case when the component requests, for example [5700...5800] and the assumed size is already 5800. This situation reflects the case when the user scroll to the end and then he jumps to undefined size. Then it should force the size re-estimation. And thus this code change occurred.