### PR TITLE
Send changes to web component after size reset

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -1001,7 +1001,7 @@ public class DataCommunicator<T> implements Serializable {
     private boolean collectChangesToSend(final Range previousActive,
             final Range effectiveRequested, Update update) {
         boolean updated = false;
-        if (assumeEmptyClient || resendEntireRange) {
+        if (assumeEmptyClient || resendEntireRange || sizeReset) {
             if (!assumeEmptyClient) {
                 /*
                  * TODO: Not necessary to clear something that would be set back


### PR DESCRIPTION
When setting a new count callback or new size estimation to a DataCommunicator, it should send the updates to a web component (client) even if the requested range not changed. For instance, if we change the count callback for ComboBox, it would be great to see the scroller size change immediately after open the dropdown. This one-liner code change provide this feature.