### PR TITLE
fix a flaky test in VaadinConnectControllerTest

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/VaadinConnectControllerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/VaadinConnectControllerTest.java
@@ -420,7 +420,7 @@ public class VaadinConnectControllerTest {
     }
 
     @Test
-    public void should_bePossibeToGetPrincipalInEndpoint() throws InterruptedException {
+    public void should_bePossibeToGetPrincipalInEndpoint() {
         VaadinService.setCurrent(service);
         when(principal.getName()).thenReturn("foo");
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/VaadinConnectControllerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/VaadinConnectControllerTest.java
@@ -74,6 +74,11 @@ public class VaadinConnectControllerTest {
     private static final Method TEST_VALIDATION_METHOD;
     private HttpServletRequest requestMock;
     private Principal principal;
+    /**
+     * Make the server a field instance to prevent it from garbage collected,
+     * which could fail unit test randomly.
+     */
+    private MockVaadinServletService service = new MockVaadinServletService();
 
     static {
         TEST_METHOD = Stream.of(TEST_ENDPOINT.getClass().getDeclaredMethods())
@@ -415,8 +420,7 @@ public class VaadinConnectControllerTest {
     }
 
     @Test
-    public void should_bePossibeToGetPrincipalInEndpoint() {
-        MockVaadinServletService service = new MockVaadinServletService();
+    public void should_bePossibeToGetPrincipalInEndpoint() throws InterruptedException {
         VaadinService.setCurrent(service);
         when(principal.getName()).thenReturn("foo");
 


### PR DESCRIPTION
The test `VaadinConnectControllerTest.should_bePossibeToGetPrincipalInEndpoint` fails randomly in CI, the reason seems to be that the `MockVaadinServletService service` is garbage collected before the endpoint invocation. 
Change `MockVaadinServletService service` to be a field instance to prevent the garbage collection from happening.