### PR TITLE
fix: fail access check when no csrf token in session

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/auth/VaadinConnectAccessChecker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/auth/VaadinConnectAccessChecker.java
@@ -139,14 +139,14 @@ public class VaadinConnectAccessChecker {
         if (!xsrfProtectionEnabled) {
             return false;
         }
+
         HttpSession session = request.getSession(false);
-        String csrfTokenInHeader = request.getHeader("X-CSRF-Token");
         if (session == null) {
-            return csrfTokenInHeader != null;
-        } else {
-            String csrfTokenInSession = (String) session.getAttribute(VaadinService.getCsrfTokenAttributeName());
-            return csrfTokenInSession == null || !csrfTokenInSession.equals(csrfTokenInHeader);
+            return false;
         }
+
+        String csrfTokenInSession = (String) session.getAttribute(VaadinService.getCsrfTokenAttributeName());
+        return csrfTokenInSession == null || !csrfTokenInSession.equals(request.getHeader("X-CSRF-Token"));
     }
 
     private boolean entityForbidden(AnnotatedElement entity,

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/auth/VaadinConnectAccessChecker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/auth/VaadinConnectAccessChecker.java
@@ -22,6 +22,7 @@ import javax.annotation.security.DenyAll;
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
@@ -138,9 +139,14 @@ public class VaadinConnectAccessChecker {
         if (!xsrfProtectionEnabled) {
             return false;
         }
-        String csrfToken = (String) request.getSession()
-                .getAttribute(VaadinService.getCsrfTokenAttributeName());
-        return csrfToken != null && !csrfToken.equals(request.getHeader("X-CSRF-Token"));
+        HttpSession session = request.getSession(false);
+        String csrfTokenInHeader = request.getHeader("X-CSRF-Token");
+        if (session == null) {
+            return csrfTokenInHeader != null;
+        } else {
+            String csrfTokenInSession = (String) session.getAttribute(VaadinService.getCsrfTokenAttributeName());
+            return csrfTokenInSession == null || !csrfTokenInSession.equals(csrfTokenInHeader);
+        }
     }
 
     private boolean entityForbidden(AnnotatedElement entity,

--- a/flow-server/src/test/java/com/vaadin/flow/server/connect/VaadinConnectControllerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/connect/VaadinConnectControllerTest.java
@@ -186,7 +186,7 @@ public class VaadinConnectControllerTest {
         HttpSession sessionMock = mock(HttpSession.class);
         when(sessionMock.getAttribute(com.vaadin.flow.server.VaadinService.getCsrfTokenAttributeName()))
                 .thenReturn("Vaadin CCDM");
-        when(requestMock.getSession()).thenReturn(sessionMock);
+        when(requestMock.getSession(false)).thenReturn(sessionMock);
     }
 
     @Test


### PR DESCRIPTION
- use `request.getSesssion(false)` instead of `request.getSesssion()` so that it won't create a new session for access check.
- fix a bug that when there is no csrf token in the session (e.g. when session is expired), it's considered valid.
- allow empty csrf token in the request header when there is no session (e.g. using curl).