### PR TITLE
chore: add @ts-ignore to DeferrableResult import

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/connect/generator/TypeScriptApiTemplate.mustache
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/connect/generator/TypeScriptApiTemplate.mustache
@@ -38,6 +38,7 @@ So `// @ts-ignore` is used for now to mute this error. The consequences are:
 }}// @ts-ignore
 import client from '{{vaadinConnectDefaultClientPath}}';
 {{#vendorExtensions.x-vaadin-connect-deferrable}}
+// @ts-ignore
 import { DeferrableResult } from '@vaadin/flow-frontend/Connect';
 {{/vendorExtensions.x-vaadin-connect-deferrable}}
 {{#each imports}}

--- a/flow-server/src/test/resources/com/vaadin/flow/server/connect/generator/endpoints/deferrable/expected-SingleMethodDeferrableEndpoint.ts
+++ b/flow-server/src/test/resources/com/vaadin/flow/server/connect/generator/endpoints/deferrable/expected-SingleMethodDeferrableEndpoint.ts
@@ -6,6 +6,7 @@
 
 // @ts-ignore
 import client from './connect-client.default';
+// @ts-ignore
 import { DeferrableResult } from '@vaadin/flow-frontend/Connect';
 
 function _hello(

--- a/flow-server/src/test/resources/com/vaadin/flow/server/connect/generator/endpoints/deferrable/expected-WholeClassDeferrableEndpoint.ts
+++ b/flow-server/src/test/resources/com/vaadin/flow/server/connect/generator/endpoints/deferrable/expected-WholeClassDeferrableEndpoint.ts
@@ -6,6 +6,7 @@
 
 // @ts-ignore
 import client from './connect-client.default';
+// @ts-ignore
 import { DeferrableResult } from '@vaadin/flow-frontend/Connect';
 
 function _hello(


### PR DESCRIPTION
Add @ts-ignore to the DeferrableResult import in the generated ts files, as it might not be used.