### PR TITLE
CP: Treat URLs with "context" and "base" schemas as external  (#8556)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/dependency/JavaScript.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/dependency/JavaScript.java
@@ -67,9 +67,18 @@ public @interface JavaScript {
      * in the browser.
      * <p>
      * Relative URLs are interpreted as relative to the configured
-     * {@code frontend} directory location. You can prefix the URL with
-     * {@code context://} to make it relative to the context path or use an
-     * absolute URL to refer to files outside the frontend directory.
+     * {@code frontend} directory location.
+     * <p>
+     * In NPM mode this URL identifies a file which will be bundled, so the file
+     * should be available to be able to bundle it. External URLs (e.g. absolute
+     * URL which has a schema like "http://") are not bundled but included into
+     * the page as standalone scripts (the same way as in compatibility mode,
+     * see below). It's applicable also for "context://" and "base://" schemas.
+     * <p>
+     * In compatibility mode the URL represents a standalone script which will
+     * be added to the page. You can prefix the URL with {@code context://} to
+     * make it relative to the context path or use an absolute URL to refer to
+     * files outside the frontend directory.
      *
      * @return a JavaScript file URL
      */

--- a/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
@@ -41,9 +41,6 @@ public class UrlUtil {
         if (url.startsWith("//")) {
             return true;
         }
-        return url.contains("://") && !(url
-                .startsWith(ApplicationConstants.CONTEXT_PROTOCOL_PREFIX)
-                || url.startsWith(ApplicationConstants.FRONTEND_PROTOCOL_PREFIX)
-                || url.startsWith(ApplicationConstants.BASE_PROTOCOL_PREFIX));
+        return url.contains("://") && !url.startsWith(ApplicationConstants.FRONTEND_PROTOCOL_PREFIX);
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/UrlUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/UrlUtilTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.internal;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class UrlUtilTest {
+
+    @Test
+    public void isExternal_URLStartsWithTwoSlashes_returnsTrue() {
+        Assert.assertTrue(UrlUtil.isExternal("//foo"));
+    }
+
+    @Test
+    public void isExternal_URLContainsAnySchemaAsPrefix_returnsTrue() {
+        Assert.assertTrue(UrlUtil.isExternal("http://foo"));
+        Assert.assertTrue(UrlUtil.isExternal("https://foo"));
+        Assert.assertTrue(UrlUtil.isExternal("context://foo"));
+        Assert.assertTrue(UrlUtil.isExternal("base://foo"));
+    }
+
+    @Test
+    public void isExternal_URLDoesnotContainSchema_returnsFalse() {
+        Assert.assertFalse(UrlUtil.isExternal("foo"));
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PlainScriptViaJavaScriptView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PlainScriptViaJavaScriptView.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.dependency.JavaScript;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "com.vaadin.flow.uitest.ui.PlainScriptViaJavaScriptView")
+@JavaScript("context://plain-script.js")
+public class PlainScriptViaJavaScriptView extends Div {
+
+}

--- a/flow-tests/test-root-context/src/main/webapp/plain-script.js
+++ b/flow-tests/test-root-context/src/main/webapp/plain-script.js
@@ -1,0 +1,4 @@
+var div = document.createElement("div");
+div.id="added-from-src-script";
+div.textContent="Hello from src script";
+document.body.insertBefore(div, document.body.firstChild);

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PlainScriptViaJavaScriptIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PlainScriptViaJavaScriptIT.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class PlainScriptViaJavaScriptIT extends ChromeBrowserTest {
+
+    @Test
+    public void contextSchemaWorksinJavaScript() {
+        open();
+
+        Assert.assertTrue(isElementPresent(By.id("added-from-src-script")));
+    }
+}


### PR DESCRIPTION
* Consider context/base schemas as external URLs

Fixes #8290