### PR TITLE
Add content type to dev-mode-not-ready response

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
@@ -241,6 +241,7 @@ public final class DevModeHandler implements RequestHandler {
             InputStream inputStream = DevModeHandler.class
                     .getResourceAsStream("dev-mode-not-ready.html");
             IOUtils.copy(inputStream, response.getOutputStream());
+            response.setContentType("text/html;charset=utf-8");
             return true;
         }
     }


### PR DESCRIPTION
If you enable Spring Security, the missing charset causes the page to either be downloaded or shown as plain text depending on the browser.