### PR TITLE
Update README with branch versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,21 +6,28 @@ Vaadin Flow
 
 **For instructions about developing web applications with Vaadin Flow**, please refer to [the starter packs for Vaadin 14 with Flow](https://vaadin.com/start) or [the documentation](https://vaadin.com/docs/flow/Overview.html).
 
-To contribute, first refer to [Contribution Guide](/CONTRIBUTING.md)
-for general instructions and requirements for contributing code to Flow.
+To contribute, first refer to [Contribution Guide](/CONTRIBUTING.md) for general instructions and requirements for contributing code to Flow.
 
 Flow EAP discussion in Gitter IM at https://gitter.im/vaadin-flow/Lobby
 
 Instructions on how to set up a working environment for developing the Flow project follow below.
 
-`master` branch is the latest version (3.1) that will at some point be released in the [Vaadin platform 16.0.0](https://github.com/vaadin/platform). 
-See other branches for other framework versions:
-* 1.0 branch is Vaadin 10 LTS (Flow version 1.0)
-* 1.4 branch is for Vaadin 13 (Flow version 1.4) (End of line)
-* 2.0 branch is for Vaadin 14.0 (Flow version 2.0)
-* 2.1 branch is for Vaadin 14.1 (Flow version 2.1)
-* 2.2 branch is for upcoming Vaadin 14.2 (Flow version 2.2)
-* 3.0 branch is for Vaadin 15.0 (Flow version 3.0)
+The `master` branch is the latest version (5.0) that will at some point be released in the [Vaadin platform 18.0](https://github.com/vaadin/platform). See other branches for other framework versions:
+
+| Branch | [Platform Version](https://github.com/vaadin/platform/releases) | [Flow Version](https://github.com/vaadin/flow/releases) |
+|--------|-----------------------------------------------------------------|---------------------------------------------------------|
+|  1.0   |  10 (LTS)                                                       |  1.0                                                    |
+|  1.4   |  13.0.x (end of line)                                           |  1.4                                                    |
+|  2.0   |  14.0.x                                                         |  2.0.x                                                  |
+|  2.1   |  14.1.x                                                         |  2.1.x                                                  |
+|  2.2   |  14.2.x                                                         |  2.2.x                                                  |
+|  2.3   |  14.3.x                                                         |  2.3.x                                                  |
+|  2.4   |  14.4.x                                                         |  2.4.x                                                  |
+|  2.5   |  14.5.x (upcoming)                                              |  2.5.x                                                  |
+|  3.0   |  15.0.x                                                         |  3.0.x                                                  |
+|  3.1   |  16.0.x                                                         |  3.1.x                                                  |
+|  4.0   |  17.0.x                                                         |  4.x                                                    |
+
 
 Setting up Eclipse to Develop Flow
 =========


### PR DESCRIPTION
Updated `master` to reference version `5.0`. Added a few missing branches/versions. Updated to table format.