### PR TITLE
fix: declare webworker lib for sw.ts with TS triple-slash directive

### DIFF
--- a/flow-client/tsconfig.json
+++ b/flow-client/tsconfig.json
@@ -4,12 +4,6 @@
     "inlineSources": true,
     "module": "esNext",
     "target": "es2015",
-    "lib": [
-      "es2015",
-      "dom",
-      "dom.iterable",
-      "webworker"
-    ],
     "moduleResolution": "node",
     "strict": true,
     "noFallthroughCasesInSwitch": true,

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/tsconfig.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/tsconfig.json
@@ -9,12 +9,6 @@
     "inlineSources": true,
     "module": "esNext",
     "target": "es2017",
-    "lib": [
-      "es2017",
-      "dom",
-      "dom.iterable",
-      "webworker"
-    ],
     "moduleResolution": "node",
     "strict": true,
     "noFallthroughCasesInSwitch": true,

--- a/flow-server/src/main/resources/sw.ts
+++ b/flow-server/src/main/resources/sw.ts
@@ -1,3 +1,5 @@
+/// <reference lib="webworker" />
+
 importScripts('sw-runtime-resources-precache.js');
 import {skipWaiting, clientsClaim} from 'workbox-core';
 import {precacheAndRoute} from 'workbox-precaching';

--- a/flow-server/src/main/resources/tsconfig.json
+++ b/flow-server/src/main/resources/tsconfig.json
@@ -4,12 +4,6 @@
     "inlineSources": true,
     "module": "esNext",
     "target": "es2017",
-    "lib": [
-      "es2017",
-      "dom",
-      "dom.iterable",
-      "webworker"
-    ],
     "moduleResolution": "node",
     "strict": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
Revert adding lib section to tsconfig.json to avoid needing a manual upgrade step in projects.

Fixes #9144