### PR TITLE
fix(TypeScript): client-side form binder validation errors because of value having unused deep optional fields

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/form/BinderNode.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/form/BinderNode.ts
@@ -339,8 +339,11 @@ export class BinderNode<T, M extends AbstractModel<T>> {
         }
       }
     } else if (this.model instanceof ArrayModel) {
-      for (const childModel of this.model) {
-        yield childModel;
+      // Only iterate if optional array is initialised
+      if (this.value !== undefined) {
+        for (const childModel of this.model) {
+          yield childModel;
+        }
       }
     }
   }

--- a/flow-client/src/main/resources/META-INF/resources/frontend/form/BinderNode.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/form/BinderNode.ts
@@ -323,8 +323,15 @@ export class BinderNode<T, M extends AbstractModel<T>> {
 
   private *getChildBinderNodes(): Generator<BinderNode<any, AbstractModel<any>>> {
     if (this.model instanceof ObjectModel) {
-      if (this.value) {
-        for (const key of Object.keys(this.value)) {
+      // We need to skip all non-initialised optional fields here in order to
+      // prevent infinite recursion for circular references in the model.
+      // Here we rely on presence of keys in `defaultValue` to detect all
+      // initialised fields. The keys in `defaultValue` are defined for all
+      // non-optional fields plus those optional fields whose values were set
+      // from initial `binder.read()` or `binder.clear()` or by using a
+      // binder node (e. g., form biding) for a nested field.
+      if (this.defaultValue) {
+        for (const key of Object.keys(this.defaultValue)) {
           const childModel = (this.model as any)[key] as AbstractModel<any>;
           if (childModel) {
             yield getBinderNode(childModel);

--- a/flow-client/src/test/frontend/form/BinderTests.ts
+++ b/flow-client/src/test/frontend/form/BinderTests.ts
@@ -311,5 +311,28 @@ suite("form/Binder", () => {
       binder.for(binder.model.supervisor.supervisor);
       assert.isFalse(binder.dirty);
     });
+
+    test('should not fail validation for non-initialised object', async () => {
+      await binder.validate();
+      assert.isFalse(binder.invalid);
+
+      // Populate non-initialised optional field with data
+      binder.value = {...binder.value, supervisor: expectedEmptyEmployee};
+
+      await binder.validate();
+      assert.isFalse(binder.invalid);
+
+      // Populate non-initialised optional field with deep optional data
+      binder.value = {
+        ...binder.value,
+        supervisor: {
+          ...expectedEmptyEmployee,
+          supervisor: expectedEmptyEmployee
+        }
+      };
+
+      await binder.validate();
+      assert.isFalse(binder.invalid);
+    });
   });
 });

--- a/flow-client/src/test/frontend/form/BinderTests.ts
+++ b/flow-client/src/test/frontend/form/BinderTests.ts
@@ -250,7 +250,8 @@ suite("form/Binder", () => {
     const expectedEmptyEmployee: Employee = {
       idString: '',
       fullName: '',
-      supervisor: undefined
+      supervisor: undefined,
+      colleagues: undefined
     };
 
     beforeEach(() => {
@@ -312,7 +313,7 @@ suite("form/Binder", () => {
       assert.isFalse(binder.dirty);
     });
 
-    test('should not fail validation for non-initialised object', async () => {
+    test('should not fail validation for non-initialised object or array', async () => {
       await binder.validate();
       assert.isFalse(binder.invalid);
 

--- a/flow-client/src/test/frontend/form/TestModels.ts
+++ b/flow-client/src/test/frontend/form/TestModels.ts
@@ -136,6 +136,7 @@ export class TestModel<T extends TestEntity = TestEntity> extends ObjectModel<T>
 export interface Employee extends IdEntity {
   fullName: string;
   supervisor?: Employee;
+  colleagues?: Employee[]
 }
 export class EmployeeModel<T extends Employee = Employee> extends IdEntityModel<T> {
   static createEmptyValue: () => Employee;
@@ -146,5 +147,9 @@ export class EmployeeModel<T extends Employee = Employee> extends IdEntityModel<
 
   get supervisor(): EmployeeModel {
     return this[_getPropertyModel]('supervisor', EmployeeModel, [true]);
+  }
+
+  get colleagues() {
+    return this[_getPropertyModel]('colleagues', ArrayModel, [true, EmployeeModel, [false]]);
   }
 }


### PR DESCRIPTION
Fixes #9114