### PR TITLE
fix: only register endpoint request handler when endpoint presents

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/InternalConstants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/InternalConstants.java
@@ -18,7 +18,7 @@ package com.vaadin.flow.internal;
 import java.io.Serializable;
 
 /**
- * A collection of constants that are intended to be used only internally
+ * A collection of constants that are intended to be used only internally.
  */
 public final class InternalConstants implements Serializable{
     public static final String VAADIN_ENDPOINT_ENABLED = "endpoint.enabled";

--- a/flow-server/src/main/java/com/vaadin/flow/internal/InternalConstants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/InternalConstants.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.connect.internal;
+
+import java.io.Serializable;
+
+/**
+ * A collection of constants that are intended to be used only internally
+ */
+public final class InternalConstants implements Serializable{
+    public static final String VAADIN_ENDPOINT_ENABLED = "endpoint.enabled";
+
+    private InternalConstants() {
+        // prevent instantiation constants class only
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/internal/InternalConstants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/InternalConstants.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.flow.server.connect.internal;
+package com.vaadin.flow.internal;
 
 import java.io.Serializable;
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -412,6 +412,8 @@ public final class Constants implements Serializable {
     // Non-default port currently not supported (#7970)
     public static final int SPRING_BOOT_DEFAULT_LIVE_RELOAD_PORT = 35729;
 
+    public static final String VAADIN_ENDPINT_ENABLED = "endpoint.enabled";
+
     private Constants() {
         // prevent instantiation constants class only
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -412,8 +412,6 @@ public final class Constants implements Serializable {
     // Non-default port currently not supported (#7970)
     public static final int SPRING_BOOT_DEFAULT_LIVE_RELOAD_PORT = 35729;
 
-    public static final String VAADIN_ENDPINT_ENABLED = "endpoint.enabled";
-
     private Constants() {
         // prevent instantiation constants class only
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectController.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectController.java
@@ -76,7 +76,7 @@ import com.vaadin.flow.server.connect.exception.EndpointValidationException;
 import com.vaadin.flow.server.connect.exception.EndpointValidationException.ValidationErrorData;
 import com.vaadin.flow.server.startup.ServletDeployer.StubServletConfig;
 
-import static com.vaadin.flow.server.Constants.VAADIN_ENDPINT_ENABLED;
+import static com.vaadin.flow.internal.InternalConstants.VAADIN_ENDPOINT_ENABLED;
 
 /**
  * The controller that is responsible for processing Vaadin Connect requests.
@@ -97,7 +97,7 @@ import static com.vaadin.flow.server.Constants.VAADIN_ENDPINT_ENABLED;
 @RestController
 @Import({ VaadinConnectControllerConfiguration.class,
         VaadinEndpointProperties.class })
-@ConditionalOnProperty(value = VAADIN_ENDPINT_ENABLED, havingValue = "true")
+@ConditionalOnProperty(value = VAADIN_ENDPOINT_ENABLED, havingValue = "true")
 public class VaadinConnectController {
     /**
      * A qualifier to override the request and response default json mapper.

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectController.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/VaadinConnectController.java
@@ -52,6 +52,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.jackson.JacksonProperties;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Import;
@@ -75,6 +76,8 @@ import com.vaadin.flow.server.connect.exception.EndpointValidationException;
 import com.vaadin.flow.server.connect.exception.EndpointValidationException.ValidationErrorData;
 import com.vaadin.flow.server.startup.ServletDeployer.StubServletConfig;
 
+import static com.vaadin.flow.server.Constants.VAADIN_ENDPINT_ENABLED;
+
 /**
  * The controller that is responsible for processing Vaadin Connect requests.
  * Each class that is annotated with {@link Endpoint} gets its public methods
@@ -94,6 +97,7 @@ import com.vaadin.flow.server.startup.ServletDeployer.StubServletConfig;
 @RestController
 @Import({ VaadinConnectControllerConfiguration.class,
         VaadinEndpointProperties.class })
+@ConditionalOnProperty(value = VAADIN_ENDPINT_ENABLED, havingValue = "true")
 public class VaadinConnectController {
     /**
      * A qualifier to override the request and response default json mapper.

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/OpenApiObjectGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/OpenApiObjectGenerator.java
@@ -96,7 +96,7 @@ import com.vaadin.flow.server.connect.EndpointExposed;
 import com.vaadin.flow.server.connect.EndpointNameChecker;
 import com.vaadin.flow.server.connect.auth.AnonymousAllowed;
 
-import static com.vaadin.flow.server.Constants.VAADIN_ENDPINT_ENABLED;
+import static com.vaadin.flow.internal.InternalConstants.VAADIN_ENDPOINT_ENABLED;
 
 /**
  * Java parser class which scans for all {@link Endpoint} classes and
@@ -318,7 +318,7 @@ public class OpenApiObjectGenerator {
         pathItems.forEach((pathName, pathItem) -> openApiModel.getPaths()
                 .addPathItem(pathName, pathItem));
         if(!pathItems.isEmpty()){
-            System.setProperty(VAADIN_ENDPINT_ENABLED, Boolean.TRUE.toString());
+            System.setProperty(VAADIN_ENDPOINT_ENABLED, Boolean.TRUE.toString());
         }
         return SourceRoot.Callback.Result.DONT_SAVE;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/OpenApiObjectGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/connect/generator/OpenApiObjectGenerator.java
@@ -96,6 +96,8 @@ import com.vaadin.flow.server.connect.EndpointExposed;
 import com.vaadin.flow.server.connect.EndpointNameChecker;
 import com.vaadin.flow.server.connect.auth.AnonymousAllowed;
 
+import static com.vaadin.flow.server.Constants.VAADIN_ENDPINT_ENABLED;
+
 /**
  * Java parser class which scans for all {@link Endpoint} classes and
  * produces OpenApi json.
@@ -315,6 +317,9 @@ public class OpenApiObjectGenerator {
                         classOrInterfaceDeclaration, compilationUnit)));
         pathItems.forEach((pathName, pathItem) -> openApiModel.getPaths()
                 .addPathItem(pathName, pathItem));
+        if(!pathItems.isEmpty()){
+            System.setProperty(VAADIN_ENDPINT_ENABLED, Boolean.TRUE.toString());
+        }
         return SourceRoot.Callback.Result.DONT_SAVE;
     }
 


### PR DESCRIPTION
Fixes https://github.com/vaadin/flow/issues/9005

For a non-boot Spring application or a Spring Boot application with auto-configuration disabled (e.g. when using `@EnableWebMvc`), Vaadin registers a request handler with mapping `/{endpoint}/{method}`. Note the connect prefix is not added in this case, since it relies on Spring Boot auto-configuraiton.

So it's better for users who are using endpoints, we don't register the endpoint request handler.

Test is in https://github.com/vaadin/spring/pull/672