### PR TITLE
fix: update development plugins

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -299,7 +299,7 @@ public abstract class NodeUpdater implements FallibleCommand {
         defaults.put("webpack", "4.42.0");
         defaults.put("webpack-cli", "3.3.11");
         defaults.put("webpack-dev-server", "3.10.3");
-        defaults.put("copy-webpack-plugin", "5.1.1");
+        defaults.put("copy-webpack-plugin", "5.1.2");
         defaults.put("compression-webpack-plugin", "4.0.1");
         defaults.put("webpack-merge", "4.2.2");
         defaults.put("css-loader", "4.2.1");

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -298,7 +298,7 @@ public abstract class NodeUpdater implements FallibleCommand {
 
         defaults.put("webpack", "4.42.0");
         defaults.put("webpack-cli", "3.3.11");
-        defaults.put("webpack-dev-server", "3.10.3");
+        defaults.put("webpack-dev-server", "3.11.0");
         defaults.put("copy-webpack-plugin", "5.1.2");
         defaults.put("compression-webpack-plugin", "4.0.1");
         defaults.put("webpack-merge", "4.2.2");


### PR DESCRIPTION
Update the copy-webpack-plugin and webpack-dev-server due to 
found vulnerabilities in dependencies.

Fixes #9189