### PR TITLE
fix: Use ArrayList while creating ListDataProvider from items array

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataProvider.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataProvider.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.data.provider;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Objects;
@@ -291,7 +292,7 @@ public interface DataProvider<T, F> extends Serializable {
      */
     @SafeVarargs
     static <T> ListDataProvider<T> ofItems(T... items) {
-        return new ListDataProvider<>(Arrays.asList(items));
+        return new ListDataProvider<>(new ArrayList<>(Arrays.asList(items)));
     }
 
     /**

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractListDataViewTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractListDataViewTest.java
@@ -917,6 +917,37 @@ public class AbstractListDataViewTest {
         dataView.addItem("foo");
     }
 
+    @Test
+    public void createListDataProviderFromArrayOfItems_addingOneItem_itemCountShouldBeIncreasedByOne() {
+        ListDataProvider<Item> localListDataProvider = DataProvider.ofItems(
+                new Item(1L, "First"), new Item(2L, "Second")
+        );
+
+        ListDataView<Item, AbstractListDataView<Item>> listDataView =
+                new ItemListDataView(() -> localListDataProvider, component);
+
+        long itemCount = listDataView.getItemCount();
+
+        listDataView.addItem(new Item(3L, "Third"));
+        Assert.assertEquals(itemCount + 1, listDataView.getItemCount());
+    }
+
+    @Test
+    public void createListDataProviderFromArrayOfItems_removingOneItem_itemCountShouldBeDecreasedByOne() {
+        Item first = new Item(1L, "First");
+        Item second = new Item(2L, "Second");
+        ListDataProvider<Item> localListDataProvider = DataProvider.ofItems(
+                first, second);
+
+        ListDataView<Item, AbstractListDataView<Item>> listDataView =
+                new ItemListDataView(() -> localListDataProvider, component);
+
+        long itemCount = listDataView.getItemCount();
+
+        listDataView.removeItem(first);
+        Assert.assertEquals(itemCount - 1, listDataView.getItemCount());
+    }
+
     private static class ListDataViewImpl extends AbstractListDataView<String> {
 
         public ListDataViewImpl(


### PR DESCRIPTION
Wrapped the result of `Arrays.asList(T... items)` by `java.util.ArrayList` to support further add/remove operations through the `DataView` API without getting an `UnsupportedOperationException`. 

Fix: #8761 
