### PR TITLE
feat: offline stub for server-side views

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/OfflineStub.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/OfflineStub.ts
@@ -1,0 +1,87 @@
+import {css, html, LitElement } from 'lit-element';
+
+export class OfflineStub extends LitElement {
+
+  static get styles() {
+    return css`
+      .page {
+        font-family: -apple-system, BlinkMacSystemFont, "Roboto", "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        font-size: 1rem;
+        line-height: 1.625;
+        font-weight: 300;
+        -webkit-font-smoothing: antialiased;
+        color: hsla(214, 96%, 96%, 0.9);
+        background: hsl(214, 35%, 21%);
+        word-break: break-word;
+        padding: 0;
+        margin: 0;
+      }
+      .offline {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        z-index: 10000;
+        padding: 0 24px;
+        min-height: 100vh;
+      }
+
+      .offline .content {
+        width: 100%;
+        max-width: 50em;
+        margin: 0 auto;
+      }
+
+      .offline .content .message {
+        flex: 1;
+        box-sizing: border-box;
+        height: 100%;
+      }
+
+      .offline .content .message h2 {
+        text-align: center;
+        font-size: 1.75rem;
+        margin-bottom: 0.5em;
+        font-weight: 600;
+        color: hsl(214, 100%, 98%);
+      }
+
+      .offline .content .message p {
+        margin-top: 0.5em;
+        margin-bottom: 0.75em;
+      }
+
+      @media (min-width: 800px) {
+        .offline {
+            padding: 0 48px;
+        }
+
+        .offline .content .title h1,
+        .offline .content .message h2 {
+            text-align: left;
+        }
+
+        .offline .content .message {
+            height: auto;
+        }
+      }
+    `;
+  }
+
+  render() {
+    return html`
+      <div class="page">
+        <div class="offline">
+          <div class="content">
+            <section class="message">
+              <h2>You are offline</h2>
+              <p>This route requires an internet connection to work. You do not seem to have access to the server right now. Check your internet connection and try reloading the page to use the application.</p>
+            </section>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+}
+
+customElements.define('vaadin-offline-stub', OfflineStub);

--- a/flow-client/src/test/frontend/FlowTests.ts
+++ b/flow-client/src/test/frontend/FlowTests.ts
@@ -97,6 +97,7 @@ suite("Flow", () => {
 
   beforeEach(() => {
     delete $wnd.Vaadin;
+    Object.defineProperty(window.navigator, 'onLine', {value: true, configurable: true});
     mock.setup();
     const indicator = $wnd.document.body.querySelector('.v-loading-indicator');
     if (indicator) {
@@ -594,6 +595,56 @@ suite("Flow", () => {
     const flow = new Flow();
     const route = flow.serverSideRoutes[0];
     await route.action({pathname: "Foo/Bar.baz", search:""});
+  });
+
+  test("should show stub when navigating to server view offline", async () => {
+    stubServerRemoteFunction('foobar-123');
+    Object.defineProperty(window.navigator, 'onLine', {
+      value: false,
+      configurable: true
+    });
+    const flow = new Flow();
+    const route = flow.serverSideRoutes[0];
+    const params: NavigationParameters = {
+      pathname: 'Foo/Bar.baz',
+      search: ''
+    };
+    const view = await route.action(params);
+    assert.equal(view.tagName, 'VAADIN-OFFLINE-STUB');
+
+    // @ts-ignore
+    let onBeforeEnterReturns = await view.onBeforeEnter(params, {});
+    assert.equal(view, onBeforeEnterReturns);
+
+    // @ts-ignore
+    let onBeforeLeaveReturns = await view.onBeforeLeave(params, {});
+    assert.deepEqual({}, onBeforeLeaveReturns);
+  });
+
+  test("should show stub when navigating to server view and Flow initialization fails due to network error", async () => {
+    mock.get(/^.*\?v-r=init.*/, () => {
+      throw new Error("unable to connect");
+    });
+    const flow = new Flow();
+    const route = flow.serverSideRoutes[0];
+    const params: NavigationParameters = {
+      pathname: 'Foo/Bar.baz',
+      search: ''
+    };
+
+    const view = await route.action(params);
+    assert.equal(view.tagName, 'VAADIN-OFFLINE-STUB');
+
+    const indicator = $wnd.document.querySelector('.v-loading-indicator');
+    assert.equal('none', indicator.getAttribute('style'));
+
+    // @ts-ignore
+    let onBeforeEnterReturns = await view.onBeforeEnter(params, {});
+    assert.equal(view, onBeforeEnterReturns);
+
+    // @ts-ignore
+    let onBeforeLeaveReturns = await view.onBeforeLeave(params, {});
+    assert.deepEqual({}, onBeforeLeaveReturns);
   });
 });
 

--- a/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/OfflineServerViewIT.java
+++ b/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/OfflineServerViewIT.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package com.vaadin.flow.ccdmtest;
+
+import java.io.IOException;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.mobile.NetworkConnection;
+
+import com.vaadin.flow.testutil.ChromeDeviceTest;
+
+public class OfflineServerViewIT extends ChromeDeviceTest {
+
+    @Test
+    public void should_showOfflineStub_whenNavigatingToServerSideView()
+            throws IOException {
+        open();
+
+        waitForElementPresent(By.id("button3"));
+
+        setConnectionType(NetworkConnection.ConnectionType.AIRPLANE_MODE);
+        try {
+            findElement(By.id("pathname")).sendKeys("serverview");
+            findElement(By.id("button3")).click();
+
+            waitForElementPresent(By.tagName("vaadin-offline-stub"));
+            WebElement offlineStub = findElement(
+                    By.tagName("vaadin-offline-stub"));
+
+            Assert.assertFalse(
+                    "vaadin-offline-stub shadow root expected to contain an element with class offline",
+                    findInShadowRoot(offlineStub, By.className("offline"))
+                            .isEmpty());
+        } finally {
+            setConnectionType(NetworkConnection.ConnectionType.ALL);
+        }
+    }
+
+    @Override
+    protected String getTestPath() {
+        return "/foo";
+    }
+}


### PR DESCRIPTION
An information page, similar in style and content to the default `offline.html`, is rendered in 
when navigating to a server-side view in offline mode.

Fixes #9132.