### PR TITLE
test: Fix duplicate registration

### DIFF
--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TestingServiceInitListener.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TestingServiceInitListener.java
@@ -44,11 +44,13 @@ public class TestingServiceInitListener implements VaadinServiceInitListener {
 
         RouteConfiguration configuration = RouteConfiguration
                 .forApplicationScope();
-        if (!configuration
-                .isPathAvailable(DYNAMICALLY_REGISTERED_ROUTE)) {
-            configuration.setRoute(DYNAMICALLY_REGISTERED_ROUTE,
+        // lock registry from any other updates to get registrations correctly.
+        configuration.getHandledRegistry().update(() -> {
+            if (!configuration.isPathRegistered(DYNAMICALLY_REGISTERED_ROUTE)) {
+                configuration.setRoute(DYNAMICALLY_REGISTERED_ROUTE,
                     DynamicallyRegisteredRoute.class);
-        }
+            }
+        });
 
         event.addRequestHandler((session, request, response) -> {
             requestCount.incrementAndGet();


### PR DESCRIPTION
Lock the registry when registering
dynamic route in serviceInit to not have
a race where 2 inits note that path not
registered and then register the route.

Fixes #9223