### PR TITLE
Fix: router link finds anchor  element from shadow dom.

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/flow/RouterLinkHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/RouterLinkHandler.java
@@ -196,11 +196,23 @@ public class RouterLinkHandler {
             if (isAnchorElement(target)) {
                 return (AnchorElement) target;
             }
-            target = target.getParentElement();
+
+            Element parentTarget = target.getParentElement();
+
+            if (parentTarget == null) {
+                target = getShadowHostElement(target);
+            } else {
+                target = parentTarget;
+            }
         }
 
         return null;
     }
+
+    private static native Element getShadowHostElement(Element shadowChild)
+    /*-{
+        return shadowChild.getRootNode().host;
+    }-*/;
 
     private static native Element getTargetElement(Event clickEvent)
     /*-{

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/RouterLinkView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/RouterLinkView.java
@@ -1,13 +1,18 @@
 package com.vaadin.flow.uitest.ui;
 
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Anchor;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.Image;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementFactory;
+import com.vaadin.flow.dom.ShadowRoot;
 import com.vaadin.flow.router.Route;
 
+import com.vaadin.flow.router.RouterLink;
 import elemental.json.JsonObject;
 
 @Route("com.vaadin.flow.uitest.ui.RouterLinkView")
@@ -38,6 +43,8 @@ public class RouterLinkView extends AbstractDivView {
         });
 
         addImageLink();
+        
+        addShadowLink();
     }
 
     private void addImageLink() {
@@ -78,4 +85,44 @@ public class RouterLinkView extends AbstractDivView {
         return ElementFactory.createRouterLink(target, target);
     }
 
+    @Tag("shadow-component")
+    private static class ShadowComponent extends Component {
+
+        public ShadowComponent() {
+            ShadowRoot shadowRoot = this.getElement().attachShadow();
+
+            Div shadowDiv = new Div();
+            shadowDiv.setId("router-link-with-shadow-red");
+            shadowDiv.setHeight("100px");
+            shadowDiv.setWidth("300px");
+            shadowDiv.getStyle().set("background-color", "red");
+            shadowRoot.appendChild(shadowDiv.getElement());
+
+            Element slot = new Element("slot");
+            shadowRoot.appendChild(slot);
+
+            Div lightDiv = new Div();
+            lightDiv.setId("router-link-with-shadow-green");
+            lightDiv.setHeight("100px");
+            lightDiv.setWidth("300px");
+            lightDiv.getStyle().set("background-color", "green");
+            this.getElement().appendChild(lightDiv.getElement());
+        }
+
+    }
+
+    @Route("shadow")
+    public static class ShadowTargetView extends H1 {
+
+        public ShadowTargetView() {
+            super("Shadow");
+        }
+    }
+
+    private void addShadowLink() {
+        RouterLink link = new RouterLink(null, ShadowTargetView.class);
+        link.setId("router-link-with-shadow");
+        link.add(new ShadowComponent());
+        this.add(link);
+    }
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/RouterLinkIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/RouterLinkIT.java
@@ -1,10 +1,12 @@
 package com.vaadin.flow.uitest.ui;
 
+import com.vaadin.flow.testutil.TestBenchHelpers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
 
 import com.vaadin.flow.testutil.ChromeBrowserTest;
+import org.openqa.selenium.WebElement;
 
 public class RouterLinkIT extends ChromeBrowserTest {
 
@@ -77,6 +79,35 @@ public class RouterLinkIT extends ChromeBrowserTest {
         }
 
         verifyPopStateEvent("image/link");
+    }
+
+    @Test
+    public void testShadowDomRouterLink() {
+        open();
+
+        verifySamePage();
+
+        final WebElement routerLinkWithShadow = findElement(
+                By.id("router-link-with-shadow"));
+
+        final WebElement routerLinkShadowComponent = routerLinkWithShadow
+                .findElement(By.tagName("shadow-component"));
+
+        testInsideServlet(
+                findInShadowRoot(routerLinkShadowComponent,
+                        By.id("router-link-with-shadow-red")).get(0),
+                "shadow", "shadow");
+
+        testInsideServlet(findElement(By.id("router-link-with-shadow-green")),
+                "shadow", "shadow");
+    }
+
+    private void testInsideServlet(WebElement elementToClick, String popStateLocation,
+                                   String pathAfterServletMapping) {
+        elementToClick.click();
+        verifyInsideServletLocation(pathAfterServletMapping);
+        verifyPopStateEvent(popStateLocation);
+        verifySamePage();
     }
 
     private void testInsideServlet(String linkToTest, String popStateLocation,


### PR DESCRIPTION
Fix router link navigation when the click
is for an element inside a shadow dom
to which the anchor element is a parent

Fixes #3697