### PR TITLE
test: Fix duplicate registration (#9233)

### DIFF
--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TestingServiceInitListener.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/TestingServiceInitListener.java
@@ -32,8 +32,7 @@ public class TestingServiceInitListener implements VaadinServiceInitListener {
     public static final String DYNAMICALLY_REGISTERED_ROUTE = "dynamically-registered-route";
     private static AtomicInteger initCount = new AtomicInteger();
     private static AtomicInteger requestCount = new AtomicInteger();
-    private static Set<UI> notNavigatedUis = Collections
-            .newSetFromMap(new ConcurrentHashMap<>());
+    private static Set<UI> notNavigatedUis = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     private boolean redirected;
 
@@ -42,12 +41,13 @@ public class TestingServiceInitListener implements VaadinServiceInitListener {
         event.getSource().addUIInitListener(this::handleUIInit);
         initCount.incrementAndGet();
 
-        RouteConfiguration configuration = RouteConfiguration
-                .forApplicationScope();
-        if (!configuration.isPathRegistered(DYNAMICALLY_REGISTERED_ROUTE)) {
-            configuration.setRoute(DYNAMICALLY_REGISTERED_ROUTE,
-                    DynamicallyRegisteredRoute.class);
-        }
+        RouteConfiguration configuration = RouteConfiguration.forApplicationScope();
+        // lock registry from any other updates to get registrations correctly.
+        configuration.getHandledRegistry().update(() -> {
+            if (!configuration.isPathRegistered(DYNAMICALLY_REGISTERED_ROUTE)) {
+                configuration.setRoute(DYNAMICALLY_REGISTERED_ROUTE, DynamicallyRegisteredRoute.class);
+            }
+        });
 
         event.addRequestHandler((session, request, response) -> {
             requestCount.incrementAndGet();
@@ -70,17 +70,15 @@ public class TestingServiceInitListener implements VaadinServiceInitListener {
 
     private void handleUIInit(UIInitEvent event) {
         notNavigatedUis.add(event.getUI());
-        event.getUI().addBeforeEnterListener(
-                (BeforeEnterListener & Serializable) e -> {
-                    if (e.getNavigationTarget() != null) {
-                        notNavigatedUis.remove(e.getUI());
-                    }
-                    if (!redirected && ServiceInitListenersView.class
-                            .equals(e.getNavigationTarget())) {
-                        e.rerouteTo(e.getLocation().getPath(), 22);
-                        redirected = true;
-                    }
-                });
+        event.getUI().addBeforeEnterListener((BeforeEnterListener & Serializable) e -> {
+            if (e.getNavigationTarget() != null) {
+                notNavigatedUis.remove(e.getUI());
+            }
+            if (!redirected && ServiceInitListenersView.class.equals(e.getNavigationTarget())) {
+                e.rerouteTo(e.getLocation().getPath(), 22);
+                redirected = true;
+            }
+        });
     }
 
 }


### PR DESCRIPTION
Lock the registry when registering
dynamic route in serviceInit to not have
a race where 2 inits note that path is not
registered and then try to register the route.

Fixes #9223