### PR TITLE
refactoring: move OSGi resource provider impl to flow-server

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/osgi/OSGiResourceProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/osgi/OSGiResourceProvider.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.flow.osgi.support;
+package com.vaadin.flow.server.osgi;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -25,7 +25,6 @@ import java.util.Objects;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.FrameworkUtil;
-import org.osgi.service.component.annotations.Component;
 
 import com.vaadin.flow.di.ResourceProvider;
 import com.vaadin.flow.server.VaadinServletService;
@@ -37,7 +36,6 @@ import com.vaadin.flow.server.VaadinServletService;
  * @since
  *
  */
-@Component(immediate = true, service = ResourceProvider.class)
 public class OSGiResourceProvider implements ResourceProvider {
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/osgi/ServletContainerInitializerExtender.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/osgi/ServletContainerInitializerExtender.java
@@ -18,7 +18,10 @@ package com.vaadin.flow.server.osgi;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
 import org.osgi.util.tracker.BundleTracker;
+
+import com.vaadin.flow.di.ResourceProvider;
 
 /**
  * Bundle activator which starts bundle tracker.
@@ -30,14 +33,21 @@ public class ServletContainerInitializerExtender implements BundleActivator {
 
     private BundleTracker<Bundle> tracker;
 
+    private ServiceRegistration<ResourceProvider> registration;
+
     @Override
     public void start(BundleContext context) throws Exception {
+        registration = context.registerService(ResourceProvider.class,
+                new OSGiResourceProvider(), null);
         tracker = new VaadinBundleTracker(context);
         tracker.open();
     }
 
     @Override
     public void stop(BundleContext context) throws Exception {
+        if (registration != null) {
+            registration.unregister();
+        }
         tracker.close();
         tracker = null;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/LookupInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/LookupInitializer.java
@@ -46,6 +46,7 @@ import com.vaadin.flow.internal.ReflectTools;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServletContext;
 import com.vaadin.flow.server.osgi.OSGiAccess;
+import com.vaadin.flow.server.osgi.OSGiResourceProvider;
 
 /**
  * Standard servlet initializer for collecting all SPI implementations.
@@ -274,7 +275,8 @@ public class LookupInitializer
                 : classes.stream()
                         .filter(ResourceProvider.class::isAssignableFrom)
                         .filter(clazz -> !ResourceProvider.class.equals(clazz)
-                                && !ResourceProviderImpl.class.equals(clazz))
+                                && !ResourceProviderImpl.class.equals(clazz)
+                                && !OSGiResourceProvider.class.equals(clazz))
                         .collect(Collectors.toSet());
     }
 

--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
@@ -67,6 +67,7 @@ public abstract class ClassesSerializableTest extends ClassFinder {
                 // Various utils with inner classes
                 ".*\\.demo\\..*", "com\\.vaadin\\..*Util(s)?(\\$\\w+)?$",
                 "com\\.vaadin\\.flow\\.osgi\\.support\\..*",
+                "com\\.vaadin\\.flow\\.server\\.osgi\\..*",
 
                 "com\\.vaadin\\.flow\\.data\\.provider\\.InMemoryDataProviderHelpers",
                 "com\\.vaadin\\.flow\\.di\\.InstantiatorFactory",
@@ -121,9 +122,6 @@ public abstract class ClassesSerializableTest extends ClassFinder {
                 "com\\.vaadin\\.flow\\.server\\.communication\\.PushHandler(\\$.*)?",
                 "com\\.vaadin\\.flow\\.server\\.communication\\.PushRequestHandler(\\$.*)?",
                 "com\\.vaadin\\.flow\\.templatemodel\\.PathLookup",
-                "com\\.vaadin\\.flow\\.server\\.osgi\\.ServletContainerInitializerExtender",
-                "com\\.vaadin\\.flow\\.server\\.osgi\\.OSGiAccess(\\$.*)?",
-                "com\\.vaadin\\.flow\\.server\\.osgi\\.VaadinBundleTracker(\\$.*)?",
                 "com\\.vaadin\\.flow\\.server\\.startup\\.ErrorNavigationTargetInitializer",
                 "com\\.vaadin\\.flow\\.server\\.startup\\.ServletVerifier",
                 "com\\.vaadin\\.flow\\.server\\.startup\\.RouteRegistryInitializer",


### PR DESCRIPTION
OSGi `ResourceProvider`  impl should be available as a service at the moment when Vaadin WAB register a servlet.
It's not possible without extra unclear config to make sure that the service is registered if it's in the `flow-osgi` : the bundle may be activated at any moment regardless of servlet registration.
The issue doesn't appear if the service is registered at the `flow-bundle`  start phase.