### PR TITLE
fix: Sync HierarchicalDataCommunicator's expand state with client side

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
@@ -159,7 +159,7 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
                     .startUpdate(getHierarchyMapper().getRootSize());
             update.enqueue("$connector.ensureHierarchy");
 
-            Collection<T> expandedItems = getHierarchyMapper().getExpandedItems().values();
+            Collection<T> expandedItems = getHierarchyMapper().getExpandedItems();
             update.enqueue("$connector.expandItems",
                     expandedItems
                             .stream()

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
@@ -158,6 +158,19 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
             HierarchicalUpdate update = arrayUpdater
                     .startUpdate(getHierarchyMapper().getRootSize());
             update.enqueue("$connector.ensureHierarchy");
+
+            Collection<T> expandedItems = getHierarchyMapper().getExpandedItems().values();
+            update.enqueue("$connector.expandItems",
+                    expandedItems
+                            .stream()
+                            .map(getKeyMapper()::key)
+                            .map(key -> {
+                                JsonObject json = Json.createObject();
+                                json.put("key", key);
+                                return json;
+                            }).collect(
+                            JsonUtils.asArray()));
+
             requestFlush(update);
         }
     }

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchyMapper.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchyMapper.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.data.provider.hierarchy;
 
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -631,14 +632,12 @@ public class HierarchyMapper<T, F> implements Serializable {
     }
 
     /**
-     * Returns the mappings between object-ids and their corresponding items for
-     * the expanded items. Object ids are the result of applying data provider's
-     * {@code IdentifierProvider} to the items.
+     * Returns the expanded items in form of an unmodifiable collection.
      *
-     * @return an unmodifiable {@code Map} between object-ids and their
-     * items corresponding items for the expanded items.
+     * @return an unmodifiable {@code Collection<T>} containing the expanded
+     * items.
      */
-    public Map<Object, T> getExpandedItems() {
-        return Collections.unmodifiableMap(expandedItems);
+    public Collection<T> getExpandedItems() {
+        return Collections.unmodifiableCollection(expandedItems.values());
     }
 }

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicatorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicatorTest.java
@@ -15,9 +15,6 @@
  */
 package com.vaadin.flow.data.provider.hierarchy;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -34,14 +31,14 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.internal.UIInternals;
 import com.vaadin.flow.data.provider.CompositeDataGenerator;
 import com.vaadin.flow.data.provider.hierarchy.HierarchicalArrayUpdater.HierarchicalUpdate;
-import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.internal.StateTree;
 import com.vaadin.flow.internal.nodefeature.ComponentMapping;
-import com.vaadin.flow.internal.nodefeature.ElementData;
 
 import elemental.json.JsonValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class HierarchicalCommunicatorTest {
 
@@ -198,9 +195,11 @@ public class HierarchicalCommunicatorTest {
         // any data controllers
         communicator.reset();
 
-        Assert.assertEquals(1, enqueueFunctions.size());
+        Assert.assertEquals(2, enqueueFunctions.size());
         Assert.assertEquals("$connector.ensureHierarchy",
                 enqueueFunctions.get(0));
+        Assert.assertEquals("$connector.expandItems",
+                enqueueFunctions.get(1));
     }
 
     @Tag("test")


### PR DESCRIPTION
HierarchicalDataCommunicator's expanded state were not being synchronized with client side and TreeGrid's expanded nodes were being collapsed after re-attaching.  

Fixes: #9175 