### PR TITLE
test: service-worker aware live reload IT

### DIFF
--- a/flow-tests/test-live-reload/frontend/code.js
+++ b/flow-tests/test-live-reload/frontend/code.js
@@ -1,1 +1,0 @@
-/* Update to trigger Webpack */

--- a/flow-tests/test-live-reload/frontend/custom-component.ts
+++ b/flow-tests/test-live-reload/frontend/custom-component.ts
@@ -1,0 +1,10 @@
+import { customElement, html, LitElement } from 'lit-element';
+
+@customElement('custom-component')
+export class CustomComponent extends LitElement {
+  render() {
+    return html`
+      <div id="custom-div">Custom component contents</div>
+    `;
+  }
+}

--- a/flow-tests/test-live-reload/pom.xml
+++ b/flow-tests/test-live-reload/pom.xml
@@ -19,6 +19,11 @@
     <dependencies>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>flow-lit-template</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>flow-test-resources</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/flow-tests/test-live-reload/src/main/java/com/vaadin/flow/uitest/ui/AbstractLiveReloadView.java
+++ b/flow-tests/test-live-reload/src/main/java/com/vaadin/flow/uitest/ui/AbstractLiveReloadView.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import java.util.Random;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+
+public abstract class AbstractLiveReloadView extends Div {
+    public static final String INSTANCE_IDENTIFIER = "instance-identifier";
+    public static final String ATTACH_IDENTIFIER = "attach-identifier";
+
+    private static final Random random = new Random();
+
+    private Span attachIdLabel = new Span();
+
+    public AbstractLiveReloadView() {
+        getStyle().set("display", "flex");
+        getStyle().set("flex-direction", "column");
+        getStyle().set("align-items", "flex-start");
+
+        Span instanceIdLabel = new Span(Integer.toString(random.nextInt()));
+        instanceIdLabel.setId(INSTANCE_IDENTIFIER);
+        add(instanceIdLabel);
+
+        attachIdLabel.setId(ATTACH_IDENTIFIER);
+        add(attachIdLabel);
+        addAttachListener(e -> {
+            attachIdLabel.setText(Integer.toString(random.nextInt()));
+        });
+    }
+
+}

--- a/flow-tests/test-live-reload/src/main/java/com/vaadin/flow/uitest/ui/FrontendLiveReloadView.java
+++ b/flow-tests/test-live-reload/src/main/java/com/vaadin/flow/uitest/ui/FrontendLiveReloadView.java
@@ -13,29 +13,21 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package com.vaadin.flow.uitest.ui;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Random;
 
 import org.apache.commons.io.FileUtils;
 
-import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
-import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.NativeButton;
-import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.littemplate.LitTemplate;
 import com.vaadin.flow.component.page.AppShellConfigurator;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementFactory;
-import com.vaadin.flow.internal.BrowserLiveReload;
-import com.vaadin.flow.internal.BrowserLiveReloadAccess;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.PWA;
 import com.vaadin.flow.server.VaadinService;
@@ -43,13 +35,9 @@ import com.vaadin.flow.server.frontend.FrontendUtils;
 import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 
 @PWA(name = "Live Reload View", shortName = "live-reload-view")
-@Route(value = "com.vaadin.flow.uitest.ui.LiveReloadView", layout = ViewTestLayout.class)
-public class LiveReloadView extends Div implements AppShellConfigurator {
-    public static final String INSTANCE_IDENTIFIER = "instance-identifier";
-    public static final String PAGE_RELOADING = "page-reloading";
-
-    public static final String JAVA_LIVE_RELOAD_TRIGGER_BUTTON = "java-live-reload-trigger-button";
-
+@Route(value = "com.vaadin.flow.uitest.ui.FrontendLiveReloadView", layout = ViewTestLayout.class)
+public class FrontendLiveReloadView extends AbstractLiveReloadView
+        implements AppShellConfigurator {
     public static final String FRONTEND_CODE_TEXT = "frontend-code-text";
     public static final String FRONTEND_CODE_UPDATE_BUTTON = "frontend-code-update-button";
     public static final String FRONTEND_CODE_RESET_BUTTON = "frontend-code-reset-button";
@@ -59,31 +47,16 @@ public class LiveReloadView extends Div implements AppShellConfigurator {
     private static final String FRONTEND_FILE = "custom-component.ts";
     private static File frontendFileBackup = null;
 
-    private static final Random random = new Random();
-    Integer instanceIdentifier = random.nextInt();
-
     @Tag("custom-component")
     @JsModule("./custom-component.ts")
     static class CustomComponent extends LitTemplate {
     }
 
-    public LiveReloadView() {
-        getStyle().set("display", "flex");
-        getStyle().set("flex-direction", "column");
-        getStyle().set("align-items", "flex-start");
-
-        Span label = new Span(Integer.toString(instanceIdentifier));
-        label.setId(INSTANCE_IDENTIFIER);
-        add(label);
-
-        NativeButton javaReloadButton = new NativeButton(
-                "Trigger Java live reload");
-        javaReloadButton.addClickListener(this::handleClickJavaLiveReload);
-        javaReloadButton.setId(JAVA_LIVE_RELOAD_TRIGGER_BUTTON);
-        add(javaReloadButton);
-
+    public FrontendLiveReloadView() {
         Element codeArea = ElementFactory.createTextarea();
         codeArea.setProperty("id", FRONTEND_CODE_TEXT);
+        codeArea.setAttribute("rows", "10");
+        codeArea.getStyle().set("width", "500px");
         getElement().appendChild(codeArea);
         File frontendFile = getFrontendFile(VaadinService.getCurrent());
         try {
@@ -111,22 +84,6 @@ public class LiveReloadView extends Div implements AppShellConfigurator {
         CustomComponent customComponent = new CustomComponent();
         customComponent.setId(CUSTOM_COMPONENT);
         add(customComponent);
-    }
-
-    // Java triggered live reload is faked as we do not have Trava JDK in test
-    private void handleClickJavaLiveReload(ClickEvent<?> event) {
-        addPageReloadingSpan();
-        BrowserLiveReloadAccess liveReloadAccess = VaadinService.getCurrent()
-                .getInstantiator().getOrCreate(BrowserLiveReloadAccess.class);
-        BrowserLiveReload browserLiveReload = liveReloadAccess
-                .getLiveReload(VaadinService.getCurrent());
-        browserLiveReload.reload();
-    }
-
-    private void addPageReloadingSpan() {
-        Span reloading = new Span("Reload triggered...");
-        reloading.setId(PAGE_RELOADING);
-        add(reloading);
     }
 
     public static void replaceFrontendFile(VaadinService vaadinService,

--- a/flow-tests/test-live-reload/src/main/java/com/vaadin/flow/uitest/ui/JavaLiveReloadView.java
+++ b/flow-tests/test-live-reload/src/main/java/com/vaadin/flow/uitest/ui/JavaLiveReloadView.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.ClickEvent;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.internal.BrowserLiveReload;
+import com.vaadin.flow.internal.BrowserLiveReloadAccess;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+@Route(value = "com.vaadin.flow.uitest.ui.JavaLiveReloadView", layout = ViewTestLayout.class)
+public class JavaLiveReloadView extends AbstractLiveReloadView {
+    public static final String JAVA_LIVE_RELOAD_TRIGGER_BUTTON = "java-live-reload-trigger-button";
+
+    public JavaLiveReloadView() {
+        NativeButton javaReloadButton = new NativeButton(
+                "Trigger Java live reload");
+        javaReloadButton.addClickListener(this::handleClickJavaLiveReload);
+        javaReloadButton.setId(JAVA_LIVE_RELOAD_TRIGGER_BUTTON);
+        add(javaReloadButton);
+    }
+
+    // Java triggered live reload is faked as we do not have Trava JDK in test
+    private void handleClickJavaLiveReload(ClickEvent<?> event) {
+        BrowserLiveReloadAccess liveReloadAccess = VaadinService.getCurrent()
+                .getInstantiator().getOrCreate(BrowserLiveReloadAccess.class);
+        BrowserLiveReload browserLiveReload = liveReloadAccess
+                .getLiveReload(VaadinService.getCurrent());
+        browserLiveReload.reload();
+    }
+}

--- a/flow-tests/test-live-reload/src/main/java/com/vaadin/flow/uitest/ui/LiveReloadView.java
+++ b/flow-tests/test-live-reload/src/main/java/com/vaadin/flow/uitest/ui/LiveReloadView.java
@@ -25,32 +25,53 @@ import java.util.Random;
 import org.apache.commons.io.FileUtils;
 
 import com.vaadin.flow.component.ClickEvent;
+import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.littemplate.LitTemplate;
+import com.vaadin.flow.component.page.AppShellConfigurator;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.ElementFactory;
 import com.vaadin.flow.internal.BrowserLiveReload;
 import com.vaadin.flow.internal.BrowserLiveReloadAccess;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.PWA;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.frontend.FrontendUtils;
 import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 
+@PWA(name = "Live Reload View", shortName = "live-reload-view")
 @Route(value = "com.vaadin.flow.uitest.ui.LiveReloadView", layout = ViewTestLayout.class)
-@JsModule("./code.js")
-public class LiveReloadView extends Div {
+public class LiveReloadView extends Div implements AppShellConfigurator {
     public static final String INSTANCE_IDENTIFIER = "instance-identifier";
     public static final String PAGE_RELOADING = "page-reloading";
 
     public static final String JAVA_LIVE_RELOAD_TRIGGER_BUTTON = "java-live-reload-trigger-button";
 
-    public static final String WEBPACK_LIVE_RELOAD_TRIGGER_BUTTON = "webpack-live-reload-trigger-button";
-    public static final String WEBPACK_LIVE_RELOAD_BREAK_BUTTON = "webpack-live-reload-break-button";
+    public static final String FRONTEND_CODE_TEXT = "frontend-code-text";
+    public static final String FRONTEND_CODE_UPDATE_BUTTON = "frontend-code-update-button";
+    public static final String FRONTEND_CODE_RESET_BUTTON = "frontend-code-reset-button";
+
+    public static final String CUSTOM_COMPONENT = "custom-component";
+
+    private static final String FRONTEND_FILE = "custom-component.ts";
+    private static File frontendFileBackup = null;
 
     private static final Random random = new Random();
     Integer instanceIdentifier = random.nextInt();
 
+    @Tag("custom-component")
+    @JsModule("./custom-component.ts")
+    static class CustomComponent extends LitTemplate {
+    }
+
     public LiveReloadView() {
+        getStyle().set("display", "flex");
+        getStyle().set("flex-direction", "column");
+        getStyle().set("align-items", "flex-start");
+
         Span label = new Span(Integer.toString(instanceIdentifier));
         label.setId(INSTANCE_IDENTIFIER);
         add(label);
@@ -61,22 +82,39 @@ public class LiveReloadView extends Div {
         javaReloadButton.setId(JAVA_LIVE_RELOAD_TRIGGER_BUTTON);
         add(javaReloadButton);
 
-        NativeButton webpackReloadButton = new NativeButton(
-                "Trigger Webpack live reload");
-        webpackReloadButton
-                .addClickListener(this::handleClickWebpackLiveReload);
-        webpackReloadButton.setId(WEBPACK_LIVE_RELOAD_TRIGGER_BUTTON);
-        add(webpackReloadButton);
+        Element codeArea = ElementFactory.createTextarea();
+        codeArea.setProperty("id", FRONTEND_CODE_TEXT);
+        getElement().appendChild(codeArea);
+        File frontendFile = getFrontendFile(VaadinService.getCurrent());
+        try {
+            String code = FileUtils.readFileToString(frontendFile,
+                    StandardCharsets.UTF_8);
+            codeArea.setText(code);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
 
-        NativeButton webpackBreakButton = new NativeButton(
-                "Insert an error in a frontend file");
-        webpackBreakButton.addClickListener(this::handleClickBreakWebpack);
-        webpackBreakButton.setId(WEBPACK_LIVE_RELOAD_BREAK_BUTTON);
-        add(webpackBreakButton);
+        Element updateFrontend = ElementFactory
+                .createButton("Replace frontend code");
+        updateFrontend.setProperty("id", FRONTEND_CODE_UPDATE_BUTTON);
+        updateFrontend.setAttribute("onclick",
+                "fetch('update_frontend', { method: 'POST', body: document.getElementById('"
+                        + FRONTEND_CODE_TEXT + "').value})");
+        getElement().appendChild(updateFrontend);
+
+        Element resetFrontend = ElementFactory
+                .createButton("Reset frontend code");
+        resetFrontend.setProperty("id", FRONTEND_CODE_RESET_BUTTON);
+        resetFrontend.setAttribute("onclick", "fetch('reset_frontend')");
+        getElement().appendChild(resetFrontend);
+
+        CustomComponent customComponent = new CustomComponent();
+        customComponent.setId(CUSTOM_COMPONENT);
+        add(customComponent);
     }
 
     // Java triggered live reload is faked as we do not have Trava JDK in test
-    private void handleClickJavaLiveReload(ClickEvent event) {
+    private void handleClickJavaLiveReload(ClickEvent<?> event) {
         addPageReloadingSpan();
         BrowserLiveReloadAccess liveReloadAccess = VaadinService.getCurrent()
                 .getInstantiator().getOrCreate(BrowserLiveReloadAccess.class);
@@ -85,33 +123,41 @@ public class LiveReloadView extends Div {
         browserLiveReload.reload();
     }
 
-    private void handleClickBreakWebpack(
-            ClickEvent<NativeButton> nativeButtonClickEvent) {
-        writeToFrontendJSFile(VaadinService.getCurrent(), "{");
-    }
-
-    // Touch a frontend file to trigger webpack reload
-    private void handleClickWebpackLiveReload(ClickEvent event) {
-        addPageReloadingSpan();
-        String js = String.format("%nconsole.log('Hello world');");
-        writeToFrontendJSFile(VaadinService.getCurrent(), js);
-    }
-
     private void addPageReloadingSpan() {
         Span reloading = new Span("Reload triggered...");
         reloading.setId(PAGE_RELOADING);
         add(reloading);
     }
 
-    public static void writeToFrontendJSFile(VaadinService vaadinService,
-                                             String text) {
-        final String projectFrontendDir = FrontendUtils.getProjectFrontendDir(
-                vaadinService.getDeploymentConfiguration());
-        File styleFile = new File(projectFrontendDir, "code.js");
+    public static void replaceFrontendFile(VaadinService vaadinService,
+                                           String code) {
+        File frontendFile = getFrontendFile(vaadinService);
         try {
-            FileUtils.write(styleFile, text, StandardCharsets.UTF_8);
+            if (frontendFileBackup==null) {
+                // make a backup so it can be restored at teardown
+                frontendFileBackup = File.createTempFile("frontend", "ts");
+                FileUtils.copyFile(frontendFile, frontendFileBackup);
+            }
+            FileUtils.write(frontendFile, code, StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    public static void resetFrontendFile(VaadinService vaadinService) {
+        if (frontendFileBackup != null) {
+            File frontendFile = getFrontendFile(vaadinService);
+            try {
+                FileUtils.copyFile(frontendFileBackup, frontendFile);
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    }
+
+    private static File getFrontendFile(VaadinService vaadinService) {
+        final String projectFrontendDir = FrontendUtils.getProjectFrontendDir(
+                vaadinService.getDeploymentConfiguration());
+        return new File(projectFrontendDir, FRONTEND_FILE);
     }
 }

--- a/flow-tests/test-live-reload/src/main/java/com/vaadin/flow/uitest/ui/PreserveOnRefreshLiveReloadView.java
+++ b/flow-tests/test-live-reload/src/main/java/com/vaadin/flow/uitest/ui/PreserveOnRefreshLiveReloadView.java
@@ -15,12 +15,11 @@
  */
 package com.vaadin.flow.uitest.ui;
 
-import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.PreserveOnRefresh;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 
 @Route(value = "com.vaadin.flow.uitest.ui.PreserveOnRefreshLiveReloadView", layout = ViewTestLayout.class)
 @PreserveOnRefresh
-public class PreserveOnRefreshLiveReloadView extends Div {
+public class PreserveOnRefreshLiveReloadView extends JavaLiveReloadView  {
 }

--- a/flow-tests/test-live-reload/src/main/java/com/vaadin/flow/uitest/ui/TestingServiceInitListener.java
+++ b/flow-tests/test-live-reload/src/main/java/com/vaadin/flow/uitest/ui/TestingServiceInitListener.java
@@ -40,13 +40,14 @@ public class TestingServiceInitListener implements VaadinServiceInitListener {
         event.addRequestHandler(
                 (RequestHandler) (session, request, response) -> {
                     if ("/reset_frontend".equals(request.getPathInfo())) {
-                        LiveReloadView
+                        FrontendLiveReloadView
                                 .resetFrontendFile(session.getService());
                         return true;
                     } else if ("/update_frontend".equals(request.getPathInfo())) {
                         String code = IOUtils.toString(request.getInputStream(),
                                 StandardCharsets.UTF_8.name());
-                        LiveReloadView.replaceFrontendFile(session.getService(), code);
+                        FrontendLiveReloadView.replaceFrontendFile(
+                                session.getService(), code);
                         return true;
                     } else {
                         return false;

--- a/flow-tests/test-live-reload/src/main/java/com/vaadin/flow/uitest/ui/TestingServiceInitListener.java
+++ b/flow-tests/test-live-reload/src/main/java/com/vaadin/flow/uitest/ui/TestingServiceInitListener.java
@@ -15,6 +15,10 @@
  */
 package com.vaadin.flow.uitest.ui;
 
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.IOUtils;
+
 import com.vaadin.flow.internal.BrowserLiveReload;
 import com.vaadin.flow.internal.BrowserLiveReloadAccess;
 import com.vaadin.flow.server.RequestHandler;
@@ -36,9 +40,13 @@ public class TestingServiceInitListener implements VaadinServiceInitListener {
         event.addRequestHandler(
                 (RequestHandler) (session, request, response) -> {
                     if ("/reset_frontend".equals(request.getPathInfo())) {
-                        LiveReloadView.writeToFrontendJSFile(
-                                session.getService(),
-                                "/* Update to trigger Webpack */\n");
+                        LiveReloadView
+                                .resetFrontendFile(session.getService());
+                        return true;
+                    } else if ("/update_frontend".equals(request.getPathInfo())) {
+                        String code = IOUtils.toString(request.getInputStream(),
+                                StandardCharsets.UTF_8.name());
+                        LiveReloadView.replaceFrontendFile(session.getService(), code);
                         return true;
                     } else {
                         return false;

--- a/flow-tests/test-live-reload/src/test/java/com/vaadin/flow/uitest/ui/AbstractLiveReloadIT.java
+++ b/flow-tests/test-live-reload/src/test/java/com/vaadin/flow/uitest/ui/AbstractLiveReloadIT.java
@@ -15,13 +15,18 @@
  */
 package com.vaadin.flow.uitest.ui;
 
-import com.vaadin.flow.testutil.ChromeBrowserTest;
+import com.vaadin.flow.testutil.ChromeDeviceTest;
 
-public abstract class AbstractLiveReloadIT extends ChromeBrowserTest {
+public abstract class AbstractLiveReloadIT extends ChromeDeviceTest {
 
     @Override
     protected String getTestPath() {
         return "/context" + super.getTestPath();
+    }
+
+    protected void open() {
+        open((String[]) null);
+        waitForServiceWorkerReady();
     }
 
 }

--- a/flow-tests/test-live-reload/src/test/java/com/vaadin/flow/uitest/ui/AbstractLiveReloadIT.java
+++ b/flow-tests/test-live-reload/src/test/java/com/vaadin/flow/uitest/ui/AbstractLiveReloadIT.java
@@ -15,9 +15,13 @@
  */
 package com.vaadin.flow.uitest.ui;
 
+import org.openqa.selenium.By;
+
 import com.vaadin.flow.testutil.ChromeDeviceTest;
 
 public abstract class AbstractLiveReloadIT extends ChromeDeviceTest {
+
+    private String initialAttachId = "";
 
     @Override
     protected String getTestPath() {
@@ -27,6 +31,17 @@ public abstract class AbstractLiveReloadIT extends ChromeDeviceTest {
     protected void open() {
         open((String[]) null);
         waitForServiceWorkerReady();
+        waitForElementPresent(
+                By.id(AbstractLiveReloadView.ATTACH_IDENTIFIER));
+        initialAttachId = findElement(
+                By.id(AbstractLiveReloadView.ATTACH_IDENTIFIER)).getText();
     }
 
+    protected void waitForLiveReload() {
+        waitUntil( d -> {
+            final String newViewId = findElement(
+                    By.id(AbstractLiveReloadView.ATTACH_IDENTIFIER)).getText();
+            return !initialAttachId.equals(newViewId);
+        });
+    }
 }

--- a/flow-tests/test-live-reload/src/test/java/com/vaadin/flow/uitest/ui/FrontendLiveReloadIT.java
+++ b/flow-tests/test-live-reload/src/test/java/com/vaadin/flow/uitest/ui/FrontendLiveReloadIT.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import net.jcip.annotations.NotThreadSafe;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+@NotThreadSafe
+public class FrontendLiveReloadIT extends AbstractLiveReloadIT {
+
+    @After
+    public void resetFrontend() {
+        executeScript("fetch('/context/view/reset_frontend')");
+    }
+
+    @Test
+    public void liveReloadOnTouchedFrontendFile() {
+        open();
+
+        // when: the frontend code is updated
+        WebElement codeField = findElement(
+                By.id(FrontendLiveReloadView.FRONTEND_CODE_TEXT));
+        String oldCode = codeField.getAttribute("value");
+        String newCode = oldCode.replace(
+                "Custom component contents", "Updated component contents");
+        codeField.clear();
+        codeField.sendKeys(newCode);
+
+        waitForElementPresent(By.id(FrontendLiveReloadView.FRONTEND_CODE_UPDATE_BUTTON));
+        WebElement liveReloadTrigger = findElement(
+                By.id(FrontendLiveReloadView.FRONTEND_CODE_UPDATE_BUTTON));
+        liveReloadTrigger.click();
+
+        // when: the page has reloaded
+        waitForLiveReload();
+
+        // then: the frontend changes are visible in the DOM
+        WebElement customComponent = findElement(
+                By.id(FrontendLiveReloadView.CUSTOM_COMPONENT));
+        WebElement embeddedDiv = findInShadowRoot(customComponent,
+                By.id("custom-div")).get(0);
+        Assert.assertEquals("Updated component contents",
+                embeddedDiv.getText());
+    }
+
+    @Test
+    public void webpackErrorIsShownAfterReloadAndHiddenAfterFix() {
+        open();
+
+        // when: a webpack error occurs during frontend file edit
+        WebElement codeField = findElement(
+                By.id(FrontendLiveReloadView.FRONTEND_CODE_TEXT));
+        String oldCode = codeField.getAttribute("value");
+        String erroneousCode = "{" + oldCode;
+        codeField.clear();
+        codeField.sendKeys(erroneousCode); // illegal TS
+        WebElement insertWebpackError = findElement(
+                By.id(FrontendLiveReloadView.FRONTEND_CODE_UPDATE_BUTTON));
+        insertWebpackError.click();
+
+        // then: an error box is shown
+        waitForElementPresent(By.className("v-system-error"));
+
+        // when: the error is corrected
+        resetFrontend();
+
+        // then: the error box is not shown and the view is reloaded
+        waitForElementNotPresent(By.className("v-system-error"));
+    }
+}

--- a/flow-tests/test-live-reload/src/test/java/com/vaadin/flow/uitest/ui/JavaLiveReloadIT.java
+++ b/flow-tests/test-live-reload/src/test/java/com/vaadin/flow/uitest/ui/JavaLiveReloadIT.java
@@ -18,23 +18,18 @@ package com.vaadin.flow.uitest.ui;
 import java.util.List;
 
 import net.jcip.annotations.NotThreadSafe;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 @NotThreadSafe
-public class LiveReloadIT extends AbstractLiveReloadIT {
-
-    @After
-    public void resetFrontend() {
-        executeScript("fetch('/context/view/reset_frontend')");
-    }
+public class JavaLiveReloadIT extends AbstractLiveReloadIT {
 
     @Test
     public void overlayShouldRender() {
         open();
+
         // Upon opening, the LiveReloadUI should show the indicator but not the
         // message window
         waitForElementPresent(By.tagName("vaadin-devmode-gizmo"));
@@ -63,10 +58,12 @@ public class LiveReloadIT extends AbstractLiveReloadIT {
     @Test
     public void splashMessageShownOnAutoReloadAndClosedOnBodyClick() {
         open();
-        waitForElementPresent(By.id(LiveReloadView.JAVA_LIVE_RELOAD_TRIGGER_BUTTON));
+
         WebElement liveReloadTrigger = findElement(
-                By.id(LiveReloadView.JAVA_LIVE_RELOAD_TRIGGER_BUTTON));
+                By.id(JavaLiveReloadView.JAVA_LIVE_RELOAD_TRIGGER_BUTTON));
         liveReloadTrigger.click();
+
+        waitForLiveReload();
 
         WebElement liveReload = findElement(By.tagName("vaadin-devmode-gizmo"));
         Assert.assertNotNull(liveReload);
@@ -105,7 +102,7 @@ public class LiveReloadIT extends AbstractLiveReloadIT {
 
         // when: live reload is triggered
         WebElement liveReloadTrigger = findElement(
-                By.id(LiveReloadView.JAVA_LIVE_RELOAD_TRIGGER_BUTTON));
+                By.id(JavaLiveReloadView.JAVA_LIVE_RELOAD_TRIGGER_BUTTON));
         liveReloadTrigger.click();
 
         // then: page is not reloaded
@@ -116,67 +113,5 @@ public class LiveReloadIT extends AbstractLiveReloadIT {
         Assert.assertFalse(
                 gizmo2.getAttribute("class").contains("active"));
         Assert.assertTrue(gizmo2.getAttribute("class").contains("gizmo"));
-    }
-
-    @Test
-    public void liveReloadOnTouchedFrontendFile() {
-        open();
-
-        final String initialViewId = findElement(
-                By.id(LiveReloadView.INSTANCE_IDENTIFIER)).getText();
-
-        // when: the frontend code is updated
-        WebElement codeField = findElement(
-                By.id(LiveReloadView.FRONTEND_CODE_TEXT));
-        String oldCode = codeField.getAttribute("value");
-        String newCode = oldCode.replace(
-                "Custom component contents", "Updated component contents");
-        codeField.clear();
-        codeField.sendKeys(newCode);
-
-        waitForElementPresent(By.id(LiveReloadView.FRONTEND_CODE_UPDATE_BUTTON));
-        WebElement liveReloadTrigger = findElement(
-                By.id(LiveReloadView.FRONTEND_CODE_UPDATE_BUTTON));
-        liveReloadTrigger.click();
-
-        // when: the page has reloaded
-        waitUntil( d -> {
-            final String newViewId = findElement(
-                    By.id(LiveReloadView.INSTANCE_IDENTIFIER)).getText();
-            return !initialViewId.equals(newViewId);
-        });
-
-        // then: the frontend changes are visible in the DOM
-        WebElement customComponent = findElement(
-                By.id(LiveReloadView.CUSTOM_COMPONENT));
-        WebElement embeddedDiv = findInShadowRoot(customComponent,
-                By.id("custom-div")).get(0);
-        Assert.assertEquals("Updated component contents",
-                embeddedDiv.getText());
-    }
-
-    @Test
-    public void webpackErrorIsShownAfterReloadAndHiddenAfterFix() {
-        open();
-
-        // when: a webpack error occurs during frontend file edit
-        WebElement codeField = findElement(
-                By.id(LiveReloadView.FRONTEND_CODE_TEXT));
-        String oldCode = codeField.getAttribute("value");
-        String erroneousCode = "{" + oldCode;
-        codeField.clear();
-        codeField.sendKeys(erroneousCode); // illegal TS
-        WebElement insertWebpackError = findElement(
-                By.id(LiveReloadView.FRONTEND_CODE_UPDATE_BUTTON));
-        insertWebpackError.click();
-
-        // then: an error box is shown
-        waitForElementPresent(By.className("v-system-error"));
-
-        // when: the error is corrected
-        resetFrontend();
-
-        // then: the error box is not shown and the view is reloaded
-        waitForElementNotPresent(By.className("v-system-error"));
     }
 }

--- a/flow-tests/test-live-reload/src/test/java/com/vaadin/flow/uitest/ui/PreserveOnRefreshLiveReloadIT.java
+++ b/flow-tests/test-live-reload/src/test/java/com/vaadin/flow/uitest/ui/PreserveOnRefreshLiveReloadIT.java
@@ -36,4 +36,22 @@ public class PreserveOnRefreshLiveReloadIT extends AbstractLiveReloadIT {
                 messageDetails.getText().contains("@PreserveOnRefresh"));
     }
 
+    @Test
+    public void viewIsPreservedOnLiveReload() {
+        open();
+
+        String instanceId0= findElement(
+                By.id(AbstractLiveReloadView.INSTANCE_IDENTIFIER)).getText();
+        WebElement liveReloadTrigger = findElement(
+                By.id(JavaLiveReloadView.JAVA_LIVE_RELOAD_TRIGGER_BUTTON));
+        liveReloadTrigger.click();
+
+        // when: the page is reloaded
+        waitForLiveReload();
+
+        // then: the same instance is rendered
+        String instanceId1 = findElement(
+                By.id(AbstractLiveReloadView.INSTANCE_IDENTIFIER)).getText();
+        Assert.assertEquals(instanceId0, instanceId1);
+    }
 }


### PR DESCRIPTION
Improvements to frontend live reload IT:
- Add PWA annotation and wait for service worker installation
- `LiveReloadIt::liveReloadOnTouchedFrontendFile` now makes a TS file change and validates that it is applied after automatic reload

Part of #9182 