### PR TITLE
Make VaadinService.dependencyFilters unmodifiable

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -267,9 +267,9 @@ public abstract class VaadinService implements Serializable {
 
             requestHandlers = Collections.unmodifiableCollection(handlers);
 
-            dependencyFilters = instantiator
+            dependencyFilters = Collections.unmodifiableCollection(instantiator
                     .getDependencyFilters(event.getAddedDependencyFilters())
-                    .collect(Collectors.toList());
+                    .collect(Collectors.toList()));
             bootstrapListeners = instantiator
                     .getBootstrapListeners(event.getAddedBootstrapListeners())
                     .collect(Collectors.toList());

--- a/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
@@ -7,7 +7,13 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.io.IOUtils;


### PR DESCRIPTION
### Warning: Exposed mutable collection ([CERT](https://wiki.sei.cmu.edu/confluence/display/java/OBJ05-J.+Do+not+return+references+to+private+mutable+class+members))

Returning references to internal mutable members of a class can compromise an application's security, both by breaking encapsulation and by providing the opportunity to corrupt the internal state of the class (whether accidentally or maliciously). As a result, programs must not return references to private mutable classes.


Class: **`com.vaadin.flow.server.VaadinService`**
Scope: **singleton**
Field: **`private Iterable<DependencyFilter> VaadinService.dependencyFilters`**
Value: `(ArrayList<E>) []`
Value is read:
- **`public Iterable<DependencyFilter> VaadinService.getDependencyFilters()`**
Value is written:
- **`private void VaadinService.lambda$init$1(ServiceInitEvent, List<E>)`**
Value is returned:
- **`public Iterable<DependencyFilter> VaadinService.getDependencyFilters()`**
