### PR TITLE
refactor: make web browser immutable

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -925,7 +925,7 @@ public abstract class VaadinService implements Serializable {
         storeSession(session, request.getWrappedSession());
 
         // Initial WebBrowser data comes from the request
-        session.getBrowser().updateRequestDetails(request);
+        session.setBrowser(new WebBrowser(request));
 
         session.setConfiguration(getDeploymentConfiguration());
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
@@ -208,6 +208,16 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
     }
 
     /**
+     * Set the web browser associated with this session.
+     *
+     * @return the web browser object
+     */
+    public void setBrowser(WebBrowser browser) {
+        checkHasLock();
+        this.browser = browser;
+    }
+
+    /**
      * @return The total time spent servicing requests in this session, in
      *         milliseconds.
      */

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
@@ -209,8 +209,6 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
 
     /**
      * Set the web browser associated with this session.
-     *
-     * @return the web browser object
      */
     public void setBrowser(WebBrowser browser) {
         checkHasLock();

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
@@ -209,6 +209,8 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
 
     /**
      * Set the web browser associated with this session.
+     *
+     * @param browser the web browser object
      */
     public void setBrowser(WebBrowser browser) {
         checkHasLock();

--- a/flow-server/src/main/java/com/vaadin/flow/server/WebBrowser.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/WebBrowser.java
@@ -35,11 +35,37 @@ import com.vaadin.flow.shared.BrowserDetails;
 public class WebBrowser implements Serializable {
 
     private String browserApplication = null;
-    private Locale locale;
-    private String address;
-    private boolean secureConnection;
+    private Locale locale = null;
+    private String address = null;
+    private boolean secureConnection = false;
 
-    private BrowserDetails browserDetails;
+    private BrowserDetails browserDetails = null;
+
+    /**
+     * For internal use only. Configures all properties for the initial empty state.
+     */
+    WebBrowser() {}
+
+    /**
+     * For internal use only. Configures all properties in the class according to
+     * the given information.
+     *
+     * @param request
+     *            the Vaadin request to read the information from
+     */
+    WebBrowser(VaadinRequest request) {
+        locale = request.getLocale();
+        address = request.getRemoteAddr();
+        secureConnection = request.isSecure();
+        // Headers are case insensitive according to the specification but are
+        // case sensitive in Weblogic portal...
+        String agent = request.getHeader("User-Agent");
+
+        if (agent != null) {
+            browserApplication = agent;
+            browserDetails = new BrowserDetails(agent);
+        }
+    }
 
     /**
      * Get the browser user-agent string.
@@ -288,27 +314,6 @@ public class WebBrowser implements Serializable {
             return false;
         }
         return browserDetails.isChromeOS();
-    }
-
-    /**
-     * For internal use only. Updates all properties in the class according to
-     * the given information.
-     *
-     * @param request
-     *            the Vaadin request to read the information from
-     */
-    public void updateRequestDetails(VaadinRequest request) {
-        locale = request.getLocale();
-        address = request.getRemoteAddr();
-        secureConnection = request.isSecure();
-        // Headers are case insensitive according to the specification but are
-        // case sensitive in Weblogic portal...
-        String agent = request.getHeader("User-Agent");
-
-        if (agent != null) {
-            browserApplication = agent;
-            browserDetails = new BrowserDetails(agent);
-        }
     }
 
     /**


### PR DESCRIPTION
Even though `WebBrowser` is updated only once via `com.vaadin.flow.server.VaadinService#createAndRegisterSession()`, it still has `public void updateRequestDetails()` method which may be called by the third party. `WebBrowser` instance is returned without defensive copy from `VaadinSession.getBrowser()`. This PR makes `WebBrowser` effectively immutable and removes `updateRequestDetails()` method.