### PR TITLE
chore: create deepClean profile

### DIFF
--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -453,12 +453,11 @@
                                     <fileset>
                                         <directory>${project.basedir}</directory>
                                         <includes>
-                                            <include>frontend/main.js</include>
                                             <include>package*.json</include>
                                             <include>webpack.*.js</include>
                                             <include>types.d.ts</include>
                                             <include>tsconfig.json</include>
-                                            <include>pmpm-lock.yaml</include>
+                                            <include>pnpm-lock.yaml</include>
                                             <include>node_modules/**</include>
                                         </includes>
                                     </fileset>

--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -441,6 +441,33 @@
                 </test.excludegroup>
             </properties>
         </profile>
+        <profile>
+            <id>deepClean</id>
+            <build>
+                    <plugins>
+                        <plugin>
+                            <artifactId>maven-clean-plugin</artifactId>
+                            <version>3.1.0</version>
+                            <configuration>
+                                <filesets>
+                                    <fileset>
+                                        <directory>${project.basedir}</directory>
+                                        <includes>
+                                            <include>frontend/main.js</include>
+                                            <include>package*.json</include>
+                                            <include>webpack.*.js</include>
+                                            <include>types.d.ts</include>
+                                            <include>tsconfig.json</include>
+                                            <include>pmpm-lock.yaml</include>
+                                            <include>node_modules/**</include>
+                                        </includes>
+                                    </fileset>
+                                </filesets>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+            </build>
+        </profile>
     </profiles>
 
 </project>


### PR DESCRIPTION
Using the deepClean profile one can
clean up all the generated files and
node_modules folders from all test modules.