### PR TITLE
feat: Theme annotation should be only on AppShellConfigurator

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinAppShellInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinAppShellInitializer.java
@@ -22,7 +22,6 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRegistration;
 import javax.servlet.annotation.HandlesTypes;
 import javax.servlet.annotation.WebListener;
-
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
@@ -51,6 +50,8 @@ import com.vaadin.flow.server.PageConfigurator;
 import com.vaadin.flow.server.VaadinServlet;
 import com.vaadin.flow.server.VaadinServletContext;
 import com.vaadin.flow.server.startup.ServletDeployer.StubServletConfig;
+import com.vaadin.flow.theme.NoTheme;
+import com.vaadin.flow.theme.Theme;
 
 import static com.vaadin.flow.server.AppShellRegistry.ERROR_HEADER_NO_APP_CONFIGURATOR;
 import static com.vaadin.flow.server.AppShellRegistry.ERROR_HEADER_NO_SHELL;
@@ -64,7 +65,8 @@ import static com.vaadin.flow.server.AppShellRegistry.ERROR_HEADER_OFFENDING_PWA
  */
 @HandlesTypes({ AppShellConfigurator.class, Meta.class, Meta.Container.class,
         PWA.class, Inline.class, Inline.Container.class, Viewport.class,
-        BodySize.class, PageTitle.class, PageConfigurator.class, Push.class })
+        BodySize.class, PageTitle.class, PageConfigurator.class, Push.class,
+        Theme.class, NoTheme.class })
 // @WebListener is needed so that servlet containers know that they have to run
 // it
 @WebListener

--- a/flow-server/src/main/java/com/vaadin/flow/theme/NoTheme.java
+++ b/flow-server/src/main/java/com/vaadin/flow/theme/NoTheme.java
@@ -29,9 +29,9 @@ import java.lang.annotation.Target;
  * Flow uses the following logic to determine which theme to use for the
  * application:
  * <ul>
- * <li>If a {@link Theme} annotation is found at the root navigation level, the
+ * <li>If a {@link Theme} annotation is found on the AppShellConfigurator, the
  * theme defined by it is used.
- * <li>If a {@link NoTheme} annotation is found at the root navigation level,
+ * <li>If a {@link NoTheme} annotation is found on the AppShellConfigurator,
  * theming is disabled.
  * <li>If the <code>com.vaadin.flow.theme.lumo.Lumo</code> class is available in
  * the classpath (which comes from the vaadin-lumo-theme project), then it is

--- a/flow-server/src/main/java/com/vaadin/flow/theme/Theme.java
+++ b/flow-server/src/main/java/com/vaadin/flow/theme/Theme.java
@@ -22,9 +22,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import com.vaadin.flow.router.Route;
-import com.vaadin.flow.router.RouterLayout;
-
 /**
  * Defines that there is a theme to use and defines the theme handler
  * implementation.

--- a/flow-server/src/main/java/com/vaadin/flow/theme/Theme.java
+++ b/flow-server/src/main/java/com/vaadin/flow/theme/Theme.java
@@ -36,47 +36,27 @@ import com.vaadin.flow.router.RouterLayout;
  * By default {@code com.vaadin.flow.theme.lumo.Lumo} theme is used if it's in
  * the classpath. You may disable theming with {@link NoTheme} annotation.
  * <p>
- * {@link Theme} annotation should be added to your root navigation level,
- * {@link RouterLayout} or to the top level @{@link Route}.
+ * {@link Theme} annotation should be added to the AppShellConfigurator
+ * implementation.
  *
  * <p>
- * Defining different Themes for different views will end throwing an exception.
+ * Only a single theme can be defined and having multiple instances will throw
+ * an exception.
  *
  * <p>
- * Here are examples:
- *
- * <ul>
- * <li>On the navigation root
+ * Here is an example:
  *
  * <pre>
  * <code>
- * &#64;Route(value = "")
+ *
  * &#64;Theme(Lumo.class)
- * public class Main extends Div {
+ * public class MyAppShell implements AppShellConfigurator {
  * }
  * </code>
  * </pre>
- *
- * <li>on the top level router layout
- *
- * <pre>
- * <code>
- * &#64;Theme(MyTheme.class)
- * public class MainLayout extends Div implements RouterLayout {
- * }
- *
- * &#64;Route(value = "editor", layout = MainLayout.class)
- * public class Editor extends Div {
- * }
- * </code>
- * </pre>
- *
- * </ul>
  *
  * @see AbstractTheme
  * @see NoTheme
- * @see RouterLayout
- * @see Route
  *
  * @author Vaadin Ltd
  * @since 1.0

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/VaadinAppShellInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/VaadinAppShellInitializerTest.java
@@ -54,6 +54,8 @@ import com.vaadin.flow.server.VaadinServletContext;
 import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.shared.communication.PushMode;
 import com.vaadin.flow.shared.ui.Transport;
+import com.vaadin.flow.theme.AbstractTheme;
+import com.vaadin.flow.theme.Theme;
 
 import static com.vaadin.flow.server.DevModeHandler.getDevModeHandler;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -78,6 +80,7 @@ public class VaadinAppShellInitializerTest {
     @BodySize(height = "my-height", width = "my-width")
     @PageTitle("my-title")
     @Push(value = PushMode.MANUAL, transport = Transport.WEBSOCKET)
+    @Theme(AbstractTheme.class)
     public static class MyAppShellWithMultipleAnnotations
             implements AppShellConfigurator {
     }
@@ -91,6 +94,7 @@ public class VaadinAppShellInitializerTest {
     @BodySize(height = "my-height", width = "my-width")
     @PageTitle("my-title")
     @Push(value = PushMode.MANUAL, transport = Transport.WEBSOCKET)
+    @Theme(AbstractTheme.class)
     public static class OffendingClass {
     }
 
@@ -370,7 +374,7 @@ public class VaadinAppShellInitializerTest {
         exception.expectMessage(containsString(
                 "Found app shell configuration annotations in non"));
         exception.expectMessage(containsString(
-                "- @Meta, @Inline, @Viewport, @BodySize, @Push" + " from"));
+                "- @Meta, @Inline, @Viewport, @BodySize, @Push, @Theme" + " from"));
         classes.add(MyAppShellWithoutAnnotations.class);
         classes.add(OffendingClass.class);
         initializer.process(classes, servletContext);


### PR DESCRIPTION
If an AppShellConfigurator is available the `@Theme` annotation 
should be only defined there.

Fixes #9092