### PR TITLE
fix: AppShellConfigurator is now considered for theme endpoint

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
@@ -39,6 +39,7 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.WebComponentExporter;
 import com.vaadin.flow.component.WebComponentExporterFactory;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.component.page.AppShellConfigurator;
 import com.vaadin.flow.internal.ReflectTools;
 import com.vaadin.flow.router.HasErrorParameter;
 import com.vaadin.flow.router.Route;
@@ -234,6 +235,11 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
         for (Class<?> initListener : getFinder().getSubTypesOf(getFinder()
                 .loadClass(VaadinServiceInitListener.class.getName()))) {
             collectEndpoints(initListener);
+        }
+
+        for (Class<?> appShell : getFinder().getSubTypesOf(
+                getFinder().loadClass(AppShellConfigurator.class.getName()))) {
+            collectEndpoints(appShell);
         }
 
         for (Class<?> errorParameters : getFinder().getSubTypesOf(

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -63,6 +63,7 @@ import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.component.page.AppShellConfigurator;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.router.HasErrorParameter;
 import com.vaadin.flow.router.Route;
@@ -116,7 +117,7 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_GENERATED;
         NpmPackage.Container.class, JsModule.class, JsModule.Container.class,
         CssImport.class, CssImport.Container.class, JavaScript.class,
         JavaScript.Container.class, Theme.class, NoTheme.class,
-        HasErrorParameter.class })
+        AppShellConfigurator.class,HasErrorParameter.class })
 @WebListener
 public class DevModeInitializer
         implements ClassLoaderAwareServletContainerInitializer, Serializable,

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeClassFinderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeClassFinderTest.java
@@ -33,6 +33,7 @@ import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.component.page.AppShellConfigurator;
 import com.vaadin.flow.router.HasErrorParameter;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.SessionInitListener;
@@ -70,7 +71,8 @@ public class DevModeClassFinderTest {
             CssImport.Container.class,
             Theme.class,
             NoTheme.class,
-            HasErrorParameter.class);
+            HasErrorParameter.class,
+            AppShellConfigurator.class);
 
         for (Class<?> clz : classes) {
             assertTrue("should be a known class " + clz.getName(), knownClasses.contains(clz));


### PR DESCRIPTION
AppShellConfigurator is now also considered when
scanning for annotations and deciding theme.

Fixes #9110