### PR TITLE
fix: do not attempt to call `$server.leaveNavigation` in offline case

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
@@ -148,8 +148,8 @@ export class Flow {
       ctx: NavigationParameters,
       cmd?: PreventCommands): Promise<any> {
 
-    // server -> server or at the offline page
-    if (this.pathname === ctx.pathname || this.response === undefined) {
+    // server -> server, viewing offline stub, or browser is offline
+    if (this.pathname === ctx.pathname || this.response === undefined || !navigator.onLine) {
       return Promise.resolve({});
     }
     // 'server -> client'


### PR DESCRIPTION
Check `navigator.onLine` value before calling server. Note that when he have the
new "single source of truth" (part of #9203) for the connection state that should 
be used instead.

Fixes #9326.