### PR TITLE
fix: TreeGrid updating wrong expanded items state after setDataProvider

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
@@ -160,16 +160,18 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
             update.enqueue("$connector.ensureHierarchy");
 
             Collection<T> expandedItems = getHierarchyMapper().getExpandedItems();
-            update.enqueue("$connector.expandItems",
-                    expandedItems
-                            .stream()
-                            .map(getKeyMapper()::key)
-                            .map(key -> {
-                                JsonObject json = Json.createObject();
-                                json.put("key", key);
-                                return json;
-                            }).collect(
-                            JsonUtils.asArray()));
+            if (!expandedItems.isEmpty()) {
+                update.enqueue("$connector.expandItems",
+                        expandedItems
+                                .stream()
+                                .map(getKeyMapper()::key)
+                                .map(key -> {
+                                    JsonObject json = Json.createObject();
+                                    json.put("key", key);
+                                    return json;
+                                }).collect(
+                                JsonUtils.asArray()));
+            }
 
             requestFlush(update);
         }
@@ -240,14 +242,15 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
      */
     public <F> SerializableConsumer<F> setDataProvider(
             HierarchicalDataProvider<T, F> dataProvider, F initialFilter) {
-        SerializableConsumer<F> consumer = super.setDataProvider(dataProvider,
-                initialFilter);
-
-        // Remove old mapper
+        // Remove old mapper before super.setDataProvider(...) prevents calling
+        // reset() before clearing the already expanded items:
         if (mapper != null) {
             mapper.destroyAllData();
         }
         mapper = createHierarchyMapper(dataProvider);
+
+        SerializableConsumer<F> consumer = super.setDataProvider(dataProvider,
+                initialFilter);
 
         // Set up mapper for requests
         mapper.setBackEndSorting(getBackEndSorting());

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicatorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicatorTest.java
@@ -186,7 +186,7 @@ public class HierarchicalCommunicatorTest {
             dataProvider.refreshItem(item);
         }
 
-        int number = refreshAll ? 6 : 5;
+        int number = refreshAll ? 7 : 6;
 
         ArgumentCaptor<SerializableConsumer> attachCaptor = ArgumentCaptor
                 .forClass(SerializableConsumer.class);
@@ -221,11 +221,28 @@ public class HierarchicalCommunicatorTest {
         // any data controllers
         communicator.reset();
 
-        Assert.assertEquals(2, enqueueFunctions.size());
+        Assert.assertEquals(1, enqueueFunctions.size());
         Assert.assertEquals("$connector.ensureHierarchy",
                 enqueueFunctions.get(0));
+    }
+
+    @Test
+    public void reset_expandSomeItems_hierarchicalUpdateContainsExpandItems() {
+        enqueueFunctions.clear();
+
+        communicator.expand(ROOT);
+
+        communicator.reset();
+
+        // One expandItems for calling expand(...)
+        // One expandItems and one ensureHierarchy for calling reset()
+        Assert.assertEquals(3, enqueueFunctions.size());
         Assert.assertEquals("$connector.expandItems",
+                enqueueFunctions.get(0));
+        Assert.assertEquals("$connector.ensureHierarchy",
                 enqueueFunctions.get(1));
+        Assert.assertEquals("$connector.expandItems",
+                enqueueFunctions.get(2));
     }
 
     @Test
@@ -254,7 +271,6 @@ public class HierarchicalCommunicatorTest {
         dataCommunicator.expand("first-1");
 
         dataCommunicator.reset();
-
 
         Assert.assertTrue(enqueueFunctionsWithParams
                 .containsKey("$connector.expandItems"));

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchyMapperWithDataTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchyMapperWithDataTest.java
@@ -422,6 +422,9 @@ public class HierarchyMapperWithDataTest {
         protected Stream<TreeNode> fetchChildrenFromBackEnd(
                 HierarchicalQuery<TreeNode, Void> query) {
             if (query.getParent() == null) {
+                return Arrays.stream(new TreeNode[] {root});
+            }
+            if(query.getParent() == root) {
                 return Arrays.stream(secondLevelNodes);
             }
             return Arrays.stream(thirdLevelNodes)


### PR DESCRIPTION
`HierarchicalDataProvider`'s `reset` method was called before recreating the `HierrarchyMapper` in `setDataProvider`. This was creating wrong updates for the client side. 

Fixes: #9328 