### PR TITLE
fix: support Range requests with either start or end byte index omitted

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/ResponseWriter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/ResponseWriter.java
@@ -51,8 +51,8 @@ import static com.vaadin.flow.server.Constants.VAADIN_BUILD_FILES_PATH;
 public class ResponseWriter implements Serializable {
     private static final int DEFAULT_BUFFER_SIZE = 32 * 1024;
 
-    private static final Pattern RANGE_HEADER_PATTERN = Pattern.compile("^bytes=(([0-9]+-[0-9]+,?\\s*)+)$");
-    private static final Pattern BYTE_RANGE_PATTERN = Pattern.compile("([0-9]+)-([0-9]+)");
+    private static final Pattern RANGE_HEADER_PATTERN = Pattern.compile("^bytes=(([0-9]*-[0-9]*,?\\s*)+)$");
+    private static final Pattern BYTE_RANGE_PATTERN = Pattern.compile("([0-9]*)-([0-9]*)");
 
     private final int bufferSize;
     private final boolean brotliEnabled;
@@ -198,8 +198,16 @@ public class ResponseWriter implements Serializable {
 
         List<Pair<Long, Long>> ranges = new ArrayList<>();
         while (rangeMatcher.find()) {
-            final long start = Long.parseLong(rangeMatcher.group(1));
-            final long end = Long.parseLong(rangeMatcher.group(2));
+            String startGroup = rangeMatcher.group(1);
+            String endGroup = rangeMatcher.group(2);
+            if (startGroup.isEmpty() && endGroup.isEmpty()) {
+                response.setContentLengthLong(0L);
+                response.setStatus(416); // Range Not Satisfiable
+                return;
+            }
+            long start = startGroup.isEmpty() ? 0L : Long.parseLong(startGroup);
+            long end = endGroup.isEmpty() ? Long.MAX_VALUE
+                    : Long.parseLong(endGroup);
             if (end < start
                     || (resourceLength >= 0 && start >= resourceLength)) {
                 // illegal range -> 416

--- a/flow-server/src/test/java/com/vaadin/flow/internal/ResponseWriterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/ResponseWriterTest.java
@@ -375,6 +375,34 @@ public class ResponseWriterTest {
     }
 
     @Test
+    public void writeByteRangeStartOmitted() throws IOException {
+        makePathsAvailable(PATH_JS);
+        mockRequestHeaders(new Pair<>("Range", "bytes=-10"));
+        assertResponse(
+                Arrays.copyOfRange(fileJsContents, 0, 11));
+        assertResponseHeaders(
+                new Pair<>("Accept-Ranges", "bytes"),
+                new Pair<>("Content-Range",
+                        "bytes 0-10/" + fileJsContents.length));
+        Assert.assertEquals(11L, responseContentLength.get());
+        assertStatus(206);
+    }
+
+    @Test
+    public void writeByteRangeEndOmitted() throws IOException {
+        makePathsAvailable(PATH_JS);
+        mockRequestHeaders(new Pair<>("Range", "bytes=10-"));
+        assertResponse(
+                Arrays.copyOfRange(fileJsContents, 10, fileJsContents.length));
+        assertResponseHeaders(
+                new Pair<>("Accept-Ranges", "bytes"),
+                new Pair<>("Content-Range",
+                        "bytes 10-15/" + fileJsContents.length));
+        Assert.assertEquals(6L, responseContentLength.get());
+        assertStatus(206);
+    }
+
+    @Test
     public void writeByteRangePastFileSize() throws IOException {
         makePathsAvailable(PATH_JS);
         mockRequestHeaders(new Pair<>("Range", "bytes=10-100000"));

--- a/flow-server/src/test/java/com/vaadin/flow/internal/ResponseWriterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/ResponseWriterTest.java
@@ -433,6 +433,14 @@ public class ResponseWriterTest {
     }
 
     @Test
+    public void writeByteRangeBothEndsOpen() throws IOException {
+        makePathsAvailable(PATH_JS);
+        mockRequestHeaders(new Pair<>("Range", "-"));
+        assertResponse(new byte[] {});
+        assertStatus(416);
+    }
+
+    @Test
     public void writeByteRangeMultiPartSequential() throws IOException {
         makePathsAvailable(PATH_JS);
         mockRequestHeaders(new Pair<>("Range", "bytes=1-4, 5-6, 10-12"));


### PR DESCRIPTION
Supports headers of the type `Range: -123` and `Range: 123-`. This
format was accidentally omittted in the previous implementation and 
Firefox and Chromium now use it.

Fixes #9083.