### PR TITLE
fix: TS form validators import and missing return in submit()

### DIFF
--- a/flow-client/package.json
+++ b/flow-client/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "lit-html": "^1.2.1",
-    "@types/validator": "10.11.3",
-    "validator": "12.0.0"
+    "@types/validator": "13.1.0",
+    "validator": "13.1.17"
   }
 }

--- a/flow-client/src/main/resources/META-INF/resources/frontend/form/Binder.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/form/Binder.ts
@@ -146,8 +146,8 @@ export class Binder<T, M extends AbstractModel<T>> extends BinderNode<T, M> {
    * It's a no-op if the onSubmit callback is undefined.
    */
   async submit(): Promise<T|void>{
-    if(this[_onSubmit]!==undefined){
-      this.submitTo(this[_onSubmit]);
+    if (this[_onSubmit] !== undefined) {
+      return this.submitTo(this[_onSubmit]);
     }
   }
 

--- a/flow-client/src/main/resources/META-INF/resources/frontend/form/Validators.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/form/Validators.ts
@@ -1,16 +1,15 @@
 /* tslint:disable:max-classes-per-file */
 
-import * as isAfter from 'validator/lib/isAfter';
-import * as isBefore from 'validator/lib/isBefore';
-import * as isBoolean from 'validator/lib/isBoolean';
-import * as isDecimal from 'validator/lib/isDecimal';
-import * as isEmail from 'validator/lib/isEmail';
-// @ts-ignore (vlukashov: have not investigated why, but for the `isFloat` module the d.ts file is not accurate)
-import {default as isFloat} from 'validator/lib/isFloat';
-import * as isLength from 'validator/lib/isLength';
-import * as isNumeric from 'validator/lib/isNumeric';
-import * as matches from 'validator/lib/matches';
-import * as toFloat from 'validator/lib/toFloat';
+import isAfter from 'validator/es/lib/isAfter';
+import isBefore from 'validator/es/lib/isBefore';
+import isBoolean from 'validator/es/lib/isBoolean';
+import isDecimal from 'validator/es/lib/isDecimal';
+import isEmail from 'validator/es/lib/isEmail';
+import isFloat from 'validator/es/lib/isFloat';
+import isLength from 'validator/es/lib/isLength';
+import isNumeric from 'validator/es/lib/isNumeric';
+import matches from 'validator/es/lib/matches';
+import toFloat from 'validator/es/lib/toFloat';
 import { Validator } from './Validation';
 
 interface ValidatorAttributes {
@@ -57,7 +56,7 @@ export class Required<T> extends AbstractValidator<T> {
   }
 }
 
-function _asValidatorAttributes(attrs: ValueNumberAttributes | number | string | PatternAttributes | string | RegExp) {
+function _asValidatorAttributes(attrs: ValueNumberAttributes | number | string | PatternAttributes | RegExp) {
   return typeof attrs === 'object' ? attrs : {};
 }
 
@@ -219,7 +218,7 @@ export class Size extends AbstractValidator<string> {
     if (this.min && this.min > 0 && !new Required().validate(value)) {
       return false;
     }
-    return isLength(value, this.min, this.max);
+    return isLength(value, { min: this.min, max: this.max });
   }
 }
 

--- a/flow-client/src/main/resources/META-INF/resources/frontend/form/index.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/form/index.ts
@@ -9,5 +9,5 @@ $wnd.Vaadin = $wnd.Vaadin || {};
 $wnd.Vaadin.registrations = $wnd.Vaadin.registrations || [];
 $wnd.Vaadin.registrations.push({
   is: '@vaadin/form',
-  version: /* updated-by-script */ '5.0-SNAPSHOT'
+  version: /* updated-by-script */ '6.0-SNAPSHOT'
 });

--- a/flow-client/src/test/frontend/form/ValidationTests.ts
+++ b/flow-client/src/test/frontend/form/ValidationTests.ts
@@ -118,13 +118,19 @@ suite("form/Validation", () => {
 
   suite('submitTo', () => {
     test("should be able to call submit() if onSubmit is pre configured", async () => {
-      const binder = new Binder(view, OrderModel, {
+      const binder = new Binder(view, TestModel, {
         onSubmit: async () => {}
       });
       const binderSubmitToSpy = sinon.spy(binder, 'submitTo');
       await binder.submit();
       sinon.assert.calledOnce(binderSubmitToSpy);
     });
+
+    test("should return the result of the endpoint call when calling submit()", async () => {
+      const binder = new Binder(view, TestModel, {onSubmit: async (testEntity) => testEntity});
+      const result = await binder.submit();
+      assert.deepEqual(result, binder.value);
+    })
 
     test("should throw on validation failure", async () => {
       try {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -307,8 +307,8 @@ public abstract class NodeUpdater implements FallibleCommand {
         defaults.put("lit-css-loader", "0.0.4");
         defaults.put("lit-element", "2.3.1");
         defaults.put("lit-html", "1.2.1");
-        defaults.put("@types/validator", "10.11.3");
-        defaults.put("validator", "12.0.0");
+        defaults.put("@types/validator", "13.1.0");
+        defaults.put("validator", "13.1.17");
 
         // Forcing chokidar version for now until new babel version is available
         // check out https://github.com/babel/babel/issues/11488


### PR DESCRIPTION
Related to #9341 
- Update validator version
- Use tree-shakeable ES imports for TS form validators
- Add missing `return` in the `submit()` method