### PR TITLE
fix: hide loading indicator when endpoint call fails

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/Connect.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Connect.ts
@@ -352,10 +352,11 @@ export class ConnectClient {
     const fetchNext: MiddlewareNext =
       async(context: MiddlewareContext): Promise<Response> => {
         this.loading(true);
-        return fetch(context.request).then(response => {
-          this.loading(false);
-          return response;
-        });
+        try {
+          return fetch(context.request);
+        } finally {
+          this.loading(false); 
+        }
       };
 
     // Assemble the final middlewares array from internal


### PR DESCRIPTION
Fixes #8162 