### PR TITLE
test: remove Theme annotation from demo helpers module

### DIFF
--- a/flow-component-demo-helpers/src/main/java/com/vaadin/flow/demo/DemoView.java
+++ b/flow-component-demo-helpers/src/main/java/com/vaadin/flow/demo/DemoView.java
@@ -37,8 +37,6 @@ import com.vaadin.flow.router.BeforeEvent;
 import com.vaadin.flow.router.HasUrlParameter;
 import com.vaadin.flow.router.OptionalParameter;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.theme.Theme;
-import com.vaadin.flow.theme.lumo.Lumo;
 
 /**
  * Base class for all the Views that demo some component.
@@ -47,7 +45,6 @@ import com.vaadin.flow.theme.lumo.Lumo;
  * @since 1.0
  */
 @Tag(Tag.DIV)
-@Theme(themeClass = Lumo.class)
 @StyleSheet("frontend/src/css/demo.css")
 @StyleSheet("frontend/src/css/prism.css")
 public abstract class DemoView extends Component


### PR DESCRIPTION
Due to https://github.com/vaadin/flow/commit/c5f531937fe99ae7b49b2a7310abfccfdc5e5bcc Theme annotation should be removed from the module so as it can be used in vaadin-flow-components demos