### PR TITLE
Log warning instead of throwing NPE

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -549,8 +549,13 @@ public class UIInternals implements Serializable {
      */
     public void addJavaScriptInvocation(
             PendingJavaScriptInvocation invocation) {
-        session.checkHasLock();
-        pendingJsInvocations.add(invocation);
+        if (session != null) {
+            session.checkHasLock();
+            pendingJsInvocations.add(invocation);
+        } else {
+            getLogger().warn("Tried to perform a JavaScript call when session is null, this should never happen.");
+            dumpPendingJavaScriptInvocations();
+        }
     }
 
     /**


### PR DESCRIPTION
NPE thrown in addJavaScriptInvocation(..) if the session is null is not intuitive. I am proposing to log warning instead.

This is related to https://github.com/vaadin/flow/issues/9397

This PR is not fixing root cause, just making the behavior better.