### PR TITLE
fix race-condition in IT-Tests

### DIFF
--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/InternalErrorIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/InternalErrorIT.java
@@ -84,6 +84,7 @@ public class InternalErrorIT extends ChromeBrowserTest {
         getDriver().navigate().refresh();
 
         clickButton(UPDATE);
+        waitUntil(driver -> isMessageUpdated());
         clickButton(CLOSE_SESSION);
 
         // Just click on any button to make a request after killing the session


### PR DESCRIPTION
Tests on `flow-tests/test-root-context` it work on my setup only 3 of 10 times.

every other time failed with `enableSessionExpiredNotification_sessionExpired_notificationShown` :
That is not an OSGi or bnd problem.
```
[ERROR] Tests run: 4, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 7.48 s <<< FAILURE! - in com.vaadin.flow.uitest.ui.InternalErrorIT
[ERROR] enableSessionExpiredNotification_sessionExpired_notificationShown[ANY_Chrome_](com.vaadin.flow.uitest.ui.InternalErrorIT)  Time elapsed: 7.479 s  <<< FAILURE!
java.lang.AssertionError: After enabling the 'Session Expired' notification, the page should not be refreshed after killing the session
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.assertTrue(Assert.java:42)
	at com.vaadin.flow.uitest.ui.InternalErrorIT.enableSessionExpiredNotification_sessionExpired_notificationShown(InternalErrorIT.java:92)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at com.vaadin.testbench.parallel.ParallelRunner$TBMethod.invokeExplosively(ParallelRunner.java:494)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at com.vaadin.testbench.parallel.ParallelRunner$1.evaluate(ParallelRunner.java:468)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
	at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:61)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.apache.maven.surefire.junitcore.pc.Scheduler$1.run(Scheduler.java:410)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)

[INFO] Running com.vaadin.flow.uitest.ui.ErrorPageIT
Starting ChromeDriver 86.0.4240.22 (398b0743353ff36fb1b82468f63a3a93b4e2e89e-refs/branch-heads/4240@{#378}) on port 14316
Only local connections are allowed.
Please see https://chromedriver.chromium.org/security-considerations for suggestions on keeping ChromeDriver safe.
ChromeDriver was started successfully.
Nov 17, 2020 2:29:37 AM org.openqa.selenium.remote.ProtocolHandshake createSession
INFO: Detected dialect: W3C
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.595 s - in com.vaadin.flow.uitest.ui.ErrorPageIT
[INFO] Running com.vaadin.flow.uitest.ui.dependencies.ContextInlineApiIT
[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0 s - in com.vaadin.flow.uitest.ui.dependencies.ContextInlineApiIT
[INFO] Running com.vaadin.flow.uitest.ui.template.collections.TwoWayListBindingIT
Starting ChromeDriver 86.0.4240.22 (398b0743353ff36fb1b82468f63a3a93b4e2e89e-refs/branch-heads/4240@{#378}) on port 12432
Only local connections are allowed.
Please see https://chromedriver.chromium.org/security-considerations for suggestions on keeping ChromeDriver safe.
ChromeDriver was started successfully.
Nov 17, 2020 2:29:20 AM org.openqa.selenium.remote.ProtocolHandshake createSession
INFO: Detected dialect: W3C
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.026 s - in com.vaadin.flow.uitest.ui.template.collections.TwoWayListBindingIT
[INFO] Running com.vaadin.flow.FaultyLocationIT
Starting ChromeDriver 86.0.4240.22 (398b0743353ff36fb1b82468f63a3a93b4e2e89e-refs/branch-heads/4240@{#378}) on port 14290
Only local connections are allowed.
Please see https://chromedriver.chromium.org/security-considerations for suggestions on keeping ChromeDriver safe.
ChromeDriver was started successfully.
Nov 17, 2020 2:29:39 AM org.openqa.selenium.remote.ProtocolHandshake createSession
INFO: Detected dialect: W3C
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.221 s - in com.vaadin.flow.FaultyLocationIT
[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   InternalErrorIT.enableSessionExpiredNotification_sessionExpired_notificationShown:92 After enabling the 'Session Expired' notification, the page should not be refreshed after killing the session
[INFO] 
[ERROR] Tests run: 310, Failures: 1, Errors: 0, Skipped: 10

```

After this fix this test works fine.
also discussed here:
https://github.com/vaadin/flow/pull/9361
and a problem here
https://github.com/vaadin/flow/pull/9321