### PR TITLE
fix: revert changes which broke route registration

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/osgi/ServletContainerInitializerExtender.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/osgi/ServletContainerInitializerExtender.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.osgi;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.util.tracker.BundleTracker;
+
+/**
+ * Service to start bundle tracker.
+ * 
+ * @author Vaadin Ltd
+ * @since 1.2
+ */
+@Component(immediate = true)
+public class ServletContainerInitializerExtender {
+
+    private BundleTracker<Bundle> tracker;
+
+    @Activate
+    public void activate(BundleContext context) {
+        tracker = new VaadinBundleTracker(context);
+        tracker.open();
+    }
+
+    @Deactivate
+    public void deactivate() {
+        if (tracker != null) {
+            tracker.close();
+            tracker = null;
+        }
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/osgi/ServletContainerInitializerExtender.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/osgi/ServletContainerInitializerExtender.java
@@ -33,12 +33,21 @@ public class ServletContainerInitializerExtender {
 
     private BundleTracker<Bundle> tracker;
 
+    /**
+     * Activates the component.
+     * 
+     * @param context
+     *            the provided bundle context
+     */
     @Activate
     public void activate(BundleContext context) {
         tracker = new VaadinBundleTracker(context);
         tracker.open();
     }
 
+    /**
+     * Deactivate the component.
+     */
     @Deactivate
     public void deactivate() {
         if (tracker != null) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/osgi/VaadinBundleTracker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/osgi/VaadinBundleTracker.java
@@ -15,6 +15,13 @@
  */
 package com.vaadin.flow.server.osgi;
 
+import javax.servlet.Servlet;
+import javax.servlet.ServletContainerInitializer;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
@@ -32,13 +39,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import javax.servlet.Servlet;
-import javax.servlet.ServletContainerInitializer;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.commons.io.IOUtils;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -46,8 +46,6 @@ import org.osgi.framework.BundleEvent;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.framework.wiring.BundleWiring;
 import org.osgi.service.component.annotations.Activate;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
 import org.osgi.util.tracker.BundleTracker;
 import org.slf4j.LoggerFactory;
@@ -65,7 +63,6 @@ import org.slf4j.LoggerFactory;
  * @author Vaadin Ltd
  * @since 1.2
  */
-@Component(immediate = true)
 public class VaadinBundleTracker extends BundleTracker<Bundle> {
 
     private final Bundle flowServerBundle;
@@ -118,16 +115,6 @@ public class VaadinBundleTracker extends BundleTracker<Bundle> {
     public VaadinBundleTracker(BundleContext context) {
         super(context, Bundle.ACTIVE | Bundle.RESOLVED, null);
         flowServerBundle = context.getBundle();
-        open();
-    }
-
-    /**
-     * OSGi ServiceComponentRuntime calls this method while unregister the
-     * Service(e.g when stop/uninstall the bundle)
-     */
-    @Deactivate
-    public void deactivate() {
-        close();
     }
 
     @Override


### PR DESCRIPTION
Need to active the tracker from an servlet context initializer because @Activate doesn't work on CTOR with parameter