### PR TITLE
feat: transition to RECONNECTING when receiving browser online event

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
@@ -119,7 +119,7 @@ public class ApplicationConnection {
         }
 
         registry.getConnectionState()
-                .setState(ConnectionState.State.LOADING);
+                .setState(ConnectionState.LOADING);
     }
 
     /**

--- a/flow-client/src/main/java/com/vaadin/client/ConnectionState.java
+++ b/flow-client/src/main/java/com/vaadin/client/ConnectionState.java
@@ -42,15 +42,17 @@ public class ConnectionState {
 
     /**
      * Application has been temporarily disconnected from the server because the
-     * last transaction over the write (XHR / heartbeat / endpoint call) resulted
-     * in a network error. Flow is attempting to reconnect.
+     * last transaction over the wire (XHR / heartbeat / endpoint call) resulted
+     * in a network error, or the browser has received the 'online' event and needs
+     * to verify reconnection with the server. Flow is attempting to reconnect
+     * a configurable number of times before giving up.
      */
     public static final String RECONNECTING = "reconnecting";
 
     /**
-     * Application has been permanently disconnected due to browser going offline,
-     * or the server not being reached after a number of reconnect attempts
-     * (see ReconnectDialogConfiguration.java: RECONNECT_ATTEMPTS_KEY).
+     * Application has been permanently disconnected due to browser receiving the
+     * 'offline' event, or the server not being reached after a number of reconnect
+     * attempts.
      */
     public static final String CONNECTION_LOST = "connection-lost";
 

--- a/flow-client/src/main/java/com/vaadin/client/ConnectionState.java
+++ b/flow-client/src/main/java/com/vaadin/client/ConnectionState.java
@@ -24,63 +24,59 @@ package com.vaadin.client;
  */
 public class ConnectionState {
 
-    /**
-     * Shared with ConnectionState.ts: ConnectionState
+    /*
+     * Constants shared with ConnectionState.ts
      */
-    public enum State {
-        /**
-         * Application is connected to server: last transaction over the wire (XHR /
-         * heartbeat / endpoint call) was successful.
-         */
-        CONNECTED("connected"),
 
-        /**
-         * Application is connected and Flow is loading application state from the
-         * server, or Fusion is waiting for an endpoint call to return.
-         */
-        LOADING("loading"),
+    /**
+     * Application is connected to server: last transaction over the wire (XHR /
+     * heartbeat / endpoint call) was successful.
+     */
+    public static final String CONNECTED = "connected";
 
-        /**
-         * Application has been temporarily disconnected from the server because the
-         * last transaction over the write (XHR / heartbeat / endpoint call) resulted
-         * in a network error. Flow is attempting to reconnect.
-         */
-        RECONNECTING("reconnecting"),
+    /**
+     * Application is connected and Flow is loading application state from the
+     * server, or Fusion is waiting for an endpoint call to return.
+     */
+    public static final String LOADING = "loading";
 
-        /**
-         * Application has been permanently disconnected due to browser going offline,
-         * or the server not being reached after a number of reconnect attempts
-         * (see ReconnectDialogConfiguration.java: RECONNECT_ATTEMPTS_KEY).
-         */
-        CONNECTION_LOST("connection-lost");
+    /**
+     * Application has been temporarily disconnected from the server because the
+     * last transaction over the write (XHR / heartbeat / endpoint call) resulted
+     * in a network error. Flow is attempting to reconnect.
+     */
+    public static final String RECONNECTING = "reconnecting";
 
-
-        private final String value;
-
-        State(String value) {
-            this.value = value;
-        }
-
-        @Override
-        public String toString() {
-            return this.value;
-        }
-
-    }
+    /**
+     * Application has been permanently disconnected due to browser going offline,
+     * or the server not being reached after a number of reconnect attempts
+     * (see ReconnectDialogConfiguration.java: RECONNECT_ATTEMPTS_KEY).
+     */
+    public static final String CONNECTION_LOST = "connection-lost";
 
     /**
      * Set the connection state to be displayed by the loading indicator.
-     * @param state
-     *      the connection state
+     *
+     * @param state the connection state
      */
-    public void setState(State state) {
-        setState(state.toString());
-    }
-
-    private native void setState(String state)
+    public native void setState(String state)
     /*-{
         if ($wnd.Vaadin.connectionState) {
             $wnd.Vaadin.connectionState.state = state;
+        }
+    }-*/;
+
+    /**
+     * Get the connection state.
+     *
+     * @return the connection state
+     */
+    public native String getState()
+    /*-{
+        if ($wnd.Vaadin.connectionState) {
+            return $wnd.Vaadin.connectionState.state;
+        } else {
+            return null;
         }
     }-*/;
 }

--- a/flow-client/src/main/java/com/vaadin/client/communication/DefaultConnectionStateHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/DefaultConnectionStateHandler.java
@@ -611,10 +611,9 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
     }
 
     private void registerConnectionStateEventHandlers() {
-        Browser.getWindow().addEventListener("offline", event -> {
-            // Browser goes offline: CONNECTION_LOST and stop heartbeats
-            giveUp();
-        });
+        Browser.getWindow().addEventListener("offline", event ->
+                // Browser goes offline: CONNECTION_LOST and stop heartbeats
+                giveUp());
 
         Browser.getWindow().addEventListener("online", event -> {
             // Browser goes back online: RECONNECTING while verifying

--- a/flow-client/src/main/java/com/vaadin/client/communication/DefaultConnectionStateHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/DefaultConnectionStateHandler.java
@@ -30,6 +30,7 @@ import com.vaadin.client.UILifecycle.UIState;
 import com.vaadin.client.WidgetUtil;
 import com.vaadin.client.communication.AtmospherePushConnection.AtmosphereResponse;
 
+import elemental.client.Browser;
 import elemental.json.JsonObject;
 
 /**
@@ -101,6 +102,7 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
             if (e.getUiLifecycle().isTerminated()) {
                 if (isReconnecting()) {
                     giveUp();
+                    stopApplication();
                 }
                 if (scheduledReconnect != null
                         && scheduledReconnect.isRunning()) {
@@ -112,7 +114,10 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
         // Allow dialog to cache needed resources to make them available when we
         // are offline
         reconnectDialog.preload();
-    };
+
+        // Register online / offline handlers
+        registerConnectionStateEventHandlers();
+    }
 
     /**
      * Checks if we are currently trying to reconnect.
@@ -186,6 +191,9 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
             return;
         }
 
+        registry.getConnectionState().setState(
+                ConnectionState.RECONNECTING);
+
         if (!isReconnecting()) {
             // First problem encounter
             reconnectionCause = type;
@@ -220,7 +228,7 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
         Console.log("Reconnect attempt " + reconnectAttempt + " for " + type);
 
         if (reconnectAttempt >= getConfiguration().getReconnectAttempts()) {
-            // Max attempts reached, stop trying
+            // Max attempts reached, stop trying and go back to CONNECTION_LOST
             giveUp();
         } else {
             updateDialog();
@@ -294,8 +302,8 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
     }
 
     /**
-     * Called when we should give up trying to reconnect and let the user decide
-     * how to continue.
+     * Called when we should give up trying to reconnect and inform the user
+     * that the application is in CONNECTION_LOST state.
      */
     protected final void giveUp() {
         reconnectionCause = null;
@@ -305,20 +313,13 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
         }
 
         stopDialogTimer();
-        if (!isDialogVisible()) {
-            // It SHOULD always be visible at this point, unless you have a
-            // really strange configuration (grace time longer than total
-            // reconnect time)
-            showDialog();
-        }
+        hideDialog();
+
         reconnectDialog.setText(getDialogTextGaveUp(reconnectAttempt));
         reconnectDialog.setReconnecting(false);
 
-        registry.getConnectionState().setState(
-                ConnectionState.State.CONNECTION_LOST);
-
-        // Stopping the application stops heartbeats and push
-        stopApplication();
+        registry.getConnectionState().setState(ConnectionState.CONNECTION_LOST);
+        pauseHeartbeats();
     }
 
     /**
@@ -347,8 +348,6 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
     protected void showDialog() {
         reconnectDialog.setReconnecting(true);
         reconnectDialog.show();
-        registry.getConnectionState().setState(
-                ConnectionState.State.RECONNECTING);
     }
 
     /**
@@ -533,7 +532,7 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
         stopDialogTimer();
         hideDialog();
         registry.getConnectionState()
-                .setState(ConnectionState.State.CONNECTED);
+                .setState(ConnectionState.CONNECTED);
 
         Console.log("Re-established connection to server");
     }
@@ -600,5 +599,28 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
             JavaScriptObject response) {
         debug("pushClosed()");
         Console.log("Push connection closed");
+    }
+
+    private void pauseHeartbeats() {
+        registry.getHeartbeat().setInterval(0);
+    }
+
+    private void resumeHeartbeats() {
+        registry.getHeartbeat().setInterval(
+                registry.getApplicationConfiguration().getHeartbeatInterval());
+    }
+
+    private void registerConnectionStateEventHandlers() {
+        Browser.getWindow().addEventListener("offline", event -> {
+            // Browser goes offline: CONNECTION_LOST and stop heartbeats
+            giveUp();
+        });
+
+        Browser.getWindow().addEventListener("online", event -> {
+            // Browser goes back online: RECONNECTING while verifying
+            // server connection using heartbeat
+            resumeHeartbeats();
+            handleRecoverableError(Type.HEARTBEAT, null);
+        });
     }
 }

--- a/flow-client/src/main/java/com/vaadin/client/communication/MessageSender.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/MessageSender.java
@@ -107,7 +107,7 @@ public class MessageSender {
         JsonObject extraJson = Json.createObject();
         if (showLoadingIndicator) {
             registry.getConnectionState().setState(
-                    ConnectionState.State.LOADING);
+                    ConnectionState.LOADING);
         }
         send(reqJson, extraJson);
     }

--- a/flow-client/src/main/java/com/vaadin/client/communication/RequestResponseTracker.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/RequestResponseTracker.java
@@ -126,7 +126,7 @@ public class RequestResponseTracker {
 
             if (terminated || !requestNowOrSoon) {
                 registry.getConnectionState().setState(
-                        ConnectionState.State.CONNECTED);
+                        ConnectionState.CONNECTED);
             }
         });
 

--- a/flow-client/src/main/resources/META-INF/resources/frontend/ConnectionState.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/ConnectionState.ts
@@ -92,10 +92,4 @@ if (!$wnd.Vaadin?.connectionState) {
   $wnd.Vaadin = $wnd.Vaadin || {};
   $wnd.Vaadin.connectionState = new ConnectionStateStore(
     navigator.onLine ? ConnectionState.CONNECTED : ConnectionState.CONNECTION_LOST);
-  $wnd.addEventListener('online', () => {
-    $wnd.Vaadin.connectionState.state = ConnectionState.CONNECTED;
-  });
-  $wnd.addEventListener('offline', () => {
-    $wnd.Vaadin.connectionState.state = ConnectionState.CONNECTION_LOST;
-  });
 }

--- a/flow-client/src/main/resources/META-INF/resources/frontend/ConnectionState.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/ConnectionState.ts
@@ -13,15 +13,17 @@ export enum ConnectionState {
 
   /**
    * Application has been temporarily disconnected from the server because the
-   * last transaction over the write (XHR / heartbeat / endpoint call) resulted
-   * in a network error. Flow is attempting to reconnect.
+   * last transaction over the wire (XHR / heartbeat / endpoint call) resulted
+   * in a network error, or the browser has received the 'online' event and needs
+   * to verify reconnection with the server. Flow is attempting to reconnect
+   * a configurable number of times before giving up.
    */
   RECONNECTING = 'reconnecting',
 
   /**
-   * Application has been permanently disconnected due to browser going offline,
-   * or the server not being reached after a number of reconnect attempts
-   * (see ReconnectDialogConfiguration.java: RECONNECT_ATTEMPTS_KEY).
+   * Application has been permanently disconnected due to browser receiving the
+   * 'offline' event, or the server not being reached after a number of reconnect
+   * attempts.
    */
   CONNECTION_LOST = 'connection-lost'
 }

--- a/flow-client/src/test-gwt/java/com/vaadin/client/GwtSuite.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/GwtSuite.java
@@ -1,5 +1,6 @@
 package com.vaadin.client;
 
+import com.vaadin.client.communication.GwtDefaultConnectionStateHandlerTest;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 
@@ -53,6 +54,7 @@ public class GwtSuite extends GWTTestSuite {
         suite.addTestSuite(GwtDependencyLoaderTest.class);
         suite.addTestSuite(GwtMessageHandlerTest.class);
         suite.addTestSuite(GwtMultipleBindingTest.class);
+        suite.addTestSuite(GwtDefaultConnectionStateHandlerTest.class);
         return suite;
     }
 }

--- a/flow-client/src/test-gwt/java/com/vaadin/client/communication/GwtDefaultConnectionStateHandlerTest.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/communication/GwtDefaultConnectionStateHandlerTest.java
@@ -1,0 +1,120 @@
+package com.vaadin.client.communication;
+
+import com.google.gwt.xhr.client.XMLHttpRequest;
+import com.vaadin.client.*;
+import com.vaadin.client.flow.StateTree;
+import com.vaadin.flow.internal.nodefeature.NodeFeatures;
+import com.vaadin.flow.internal.nodefeature.ReconnectDialogConfigurationMap;
+import elemental.client.Browser;
+import elemental.events.Event;
+
+public class GwtDefaultConnectionStateHandlerTest extends ClientEngineTestBase {
+
+    private DefaultConnectionStateHandler handler;
+    private Registry registry;
+
+    @Override
+    protected void gwtSetUp() throws Exception {
+        super.gwtSetUp();
+        createDummyConnectionState();
+
+        registry = new Registry() {
+            {
+                UILifecycle uiLifecycle = new UILifecycle();
+                uiLifecycle.setState(UILifecycle.UIState.RUNNING);
+                set(UILifecycle.class, uiLifecycle);
+                set(ApplicationConfiguration.class, new ApplicationConfiguration() {{
+                    setHeartbeatInterval(10);
+                    setServiceUrl("");
+                }});
+                set(StateTree.class, new StateTree(this) {{
+                    getRootNode().getMap(NodeFeatures.RECONNECT_DIALOG_CONFIGURATION)
+                            .getProperty(ReconnectDialogConfigurationMap.RECONNECT_ATTEMPTS_KEY).setValue((double)3);
+                    // keep the timer from interfering with the test:
+                    getRootNode().getMap(NodeFeatures.RECONNECT_DIALOG_CONFIGURATION)
+                            .getProperty(ReconnectDialogConfigurationMap.RECONNECT_INTERVAL_KEY).setValue((double)10000000);
+                }});
+                set(ReconnectDialogConfiguration.class, new ReconnectDialogConfiguration(this));
+                set(Heartbeat.class, new Heartbeat(this));
+                set(RequestResponseTracker.class,
+                        new RequestResponseTracker(this));
+                set(ConnectionState.class, new ConnectionState());
+                set(ConnectionStateHandler.class,
+                        handler = new DefaultConnectionStateHandler(this));
+            }
+        };
+    }
+
+    public void test_browserEvents_stopsHeartbeats() {
+        registry.getHeartbeat().setInterval(10);
+        Browser.getWindow().dispatchEvent(createEvent("offline"));
+        assertEquals(0, registry.getHeartbeat().getInterval());
+
+        Browser.getWindow().dispatchEvent(createEvent("online"));
+        assertEquals(10, registry.getHeartbeat().getInterval());
+    }
+
+    public void test_onlineEventFollowedByOffline_connectionLost() {
+        Browser.getWindow().dispatchEvent(createEvent("offline"));
+        assertEquals(ConnectionState.CONNECTION_LOST,
+                registry.getConnectionState().getState());
+
+        Browser.getWindow().dispatchEvent(createEvent("online"));
+        assertEquals(ConnectionState.RECONNECTING,
+                registry.getConnectionState().getState());
+
+        Browser.getWindow().dispatchEvent(createEvent("offline"));
+        assertEquals(ConnectionState.CONNECTION_LOST,
+                registry.getConnectionState().getState());
+    }
+
+    public void test_onlineEventHeartbeatSucceeds_connected() {
+        Browser.getWindow().dispatchEvent(createEvent("offline"));
+        assertEquals(ConnectionState.CONNECTION_LOST,
+                registry.getConnectionState().getState());
+
+        Browser.getWindow().dispatchEvent(createEvent("online"));
+        assertEquals(ConnectionState.RECONNECTING,
+                registry.getConnectionState().getState());
+
+        handler.heartbeatOk();
+        assertEquals(ConnectionState.CONNECTED,
+                registry.getConnectionState().getState());
+    }
+
+    public void test_onlineEventButHeartbeatFails_continuesReconnectingAndFinallyGivesUp() {
+        Browser.getWindow().dispatchEvent(createEvent("offline"));
+        assertEquals(ConnectionState.CONNECTION_LOST,
+                registry.getConnectionState().getState());
+
+        Browser.getWindow().dispatchEvent(createEvent("online"));
+        assertEquals(ConnectionState.RECONNECTING,
+                registry.getConnectionState().getState());
+
+        // second attempt (first attempt immediately after transitioning to
+        // ConnectionState.RECONNECTING): should keep reconnecting
+        handler.heartbeatException(XMLHttpRequest.create(), new Exception("some exception"));
+        assertEquals(ConnectionState.RECONNECTING,
+                registry.getConnectionState().getState());
+
+        // third attempt: should transition to CONNECTION_LOST
+        handler.heartbeatException(XMLHttpRequest.create(), new Exception("some exception"));
+        assertEquals(ConnectionState.CONNECTION_LOST,
+                registry.getConnectionState().getState());
+    }
+
+    private static native Event createEvent(String type)
+    /*-{
+        return new Event(type);
+    }-*/;
+
+    private static native void createDummyConnectionState()
+    /*-{
+      if (!$wnd.Vaadin) {
+        $wnd.Vaadin = {};
+      }
+      if (!$wnd.Vaadin.connectionState) {
+        $wnd.Vaadin.connectionState = { state: 'connected' };
+      }
+    }-*/;
+}


### PR DESCRIPTION
Also pause heartbeats during `CONNECTION_LOST`.

Fixes #9424.
