### PR TITLE
Stop logging error when updating dev dependencies

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -229,7 +229,8 @@ public class TaskRunNpmInstall implements FallibleCommand {
 
         String genDevDependenciesPath = getDevDependenciesFilePath();
         if (genDevDependenciesPath == null) {
-            packageUpdater.log().error(
+            // #9345 - locking dev dependencies doesn't work for now
+            packageUpdater.log().debug(
                     "Couldn't find dev dependencies file path from proeprties file. "
                             + "Dev dependencies won't be locked");
             return versionsJson;
@@ -254,7 +255,8 @@ public class TaskRunNpmInstall implements FallibleCommand {
             throws IOException {
         URL resource = classFinder.getResource(path);
         if (resource == null) {
-            packageUpdater.log().warn("Couldn't find  dev dependencies file. "
+            // #9345 - locking dev dependencies doesn't work for now
+            packageUpdater.log().debug("Couldn't find  dev dependencies file. "
                     + "Dev dependencies won't be locked");
             return null;
         }


### PR DESCRIPTION
As there is a conflict with the dependencies and prevent adding
the flow-dev-dependencies package to the platform (#9345), this will hide
the unavoidable error that was logged for Vaadin apps.
 
Fixes #9251