### PR TITLE
fix: Add polyfill for constructable stylesheets

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -310,6 +310,9 @@ public abstract class NodeUpdater implements FallibleCommand {
         defaults.put("lit-html", "1.2.1");
         defaults.put("@types/validator", "13.1.0");
         defaults.put("validator", "13.1.17");
+        // Constructable style sheets is only implemented for chrome,
+        // polyfill needed for FireFox et.al. at the moment
+        defaults.put("construct-style-sheets-polyfill", "2.4.2");
 
         // Forcing chokidar version for now until new babel version is available
         // check out https://github.com/babel/babel/issues/11488

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/package.json
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/package.json
@@ -6,7 +6,7 @@
   ],
   "repository": "vaadin/flow",
   "name": "@vaadin/application-theme-plugin",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "application-theme-plugin.js",
   "author": "Vaadin Ltd",
   "license": "Apache-2.0",

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
@@ -27,7 +27,8 @@ const themeComponentsFolder = 'components';
 // the document. E.g. @font-face must be in this
 const themeFileAlwaysAddToDocument = 'document.css';
 
-const headerImport = ``;
+const headerImport = `import 'construct-style-sheets-polyfill';
+`;
 
 const injectGlobalCssMethod = `
 // target: Document | ShadowRoot


### PR DESCRIPTION
Add the constructable stylesheets polyfill so
app theme also works with non chrome based browsers.

Fixes #9488