### PR TITLE
fix: reconnect dialog settings to vaadin-connection-indicator

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
@@ -118,8 +118,7 @@ public class ApplicationConnection {
             }
         }
 
-        registry.getConnectionState()
-                .setState(ConnectionState.LOADING);
+        ConnectionIndicator.setState(ConnectionIndicator.LOADING);
     }
 
     /**

--- a/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/ApplicationConnection.java
@@ -22,7 +22,7 @@ import com.google.gwt.core.client.Scheduler;
 
 import com.vaadin.client.communication.LoadingIndicatorConfigurator;
 import com.vaadin.client.communication.PollConfigurator;
-import com.vaadin.client.communication.ReconnectDialogConfiguration;
+import com.vaadin.client.communication.ReconnectConfiguration;
 import com.vaadin.client.flow.RouterLinkHandler;
 import com.vaadin.client.flow.StateNode;
 import com.vaadin.client.flow.binding.Binder;
@@ -61,7 +61,7 @@ public class ApplicationConnection {
 
         // Bind UI configuration objects
         PollConfigurator.observe(rootNode, registry.getPoller());
-        ReconnectDialogConfiguration.bind(registry.getConnectionStateHandler());
+        ReconnectConfiguration.bind(registry.getConnectionStateHandler());
         LoadingIndicatorConfigurator.observe(rootNode);
 
         Element body = Browser.getDocument().getBody();

--- a/flow-client/src/main/java/com/vaadin/client/ConnectionIndicator.java
+++ b/flow-client/src/main/java/com/vaadin/client/ConnectionIndicator.java
@@ -17,12 +17,12 @@
 package com.vaadin.client;
 
 /**
- * GWT interface to window.Vaadin.connectionState.
+ * GWT interface to ConnectionIndicator.ts
  *
  * @author Vaadin Ltd
  * @since 1.0
  */
-public class ConnectionState {
+public class ConnectionIndicator {
 
     /*
      * Constants shared with ConnectionState.ts
@@ -43,25 +43,29 @@ public class ConnectionState {
     /**
      * Application has been temporarily disconnected from the server because the
      * last transaction over the wire (XHR / heartbeat / endpoint call) resulted
-     * in a network error, or the browser has received the 'online' event and needs
-     * to verify reconnection with the server. Flow is attempting to reconnect
-     * a configurable number of times before giving up.
+     * in a network error, or the browser has received the 'online' event and
+     * needs to verify reconnection with the server. Flow is attempting to
+     * reconnect a configurable number of times before giving up.
      */
     public static final String RECONNECTING = "reconnecting";
 
     /**
-     * Application has been permanently disconnected due to browser receiving the
-     * 'offline' event, or the server not being reached after a number of reconnect
-     * attempts.
+     * Application has been permanently disconnected due to browser receiving
+     * the 'offline' event, or the server not being reached after a number of
+     * reconnect attempts.
      */
     public static final String CONNECTION_LOST = "connection-lost";
+
+    private ConnectionIndicator() {
+        // No instance should ever be created
+    }
 
     /**
      * Set the connection state to be displayed by the loading indicator.
      *
      * @param state the connection state
      */
-    public native void setState(String state)
+    public static native void setState(String state)
     /*-{
         if ($wnd.Vaadin.connectionState) {
             $wnd.Vaadin.connectionState.state = state;
@@ -73,12 +77,25 @@ public class ConnectionState {
      *
      * @return the connection state
      */
-    public native String getState()
+    public static native String getState()
     /*-{
         if ($wnd.Vaadin.connectionState) {
             return $wnd.Vaadin.connectionState.state;
         } else {
             return null;
+        }
+    }-*/;
+
+    /**
+     * Set a property of the connection indicator component.
+     *
+     * @param property the property to set
+     * @param value    the value to set
+     */
+    public static native void setProperty(String property, Object value)
+    /*-{
+        if ($wnd.Vaadin.connectionIndicator) {
+            $wnd.Vaadin.connectionIndicator[property] = value;
         }
     }-*/;
 }

--- a/flow-client/src/main/java/com/vaadin/client/DefaultRegistry.java
+++ b/flow-client/src/main/java/com/vaadin/client/DefaultRegistry.java
@@ -22,7 +22,7 @@ import com.vaadin.client.communication.MessageHandler;
 import com.vaadin.client.communication.MessageSender;
 import com.vaadin.client.communication.Poller;
 import com.vaadin.client.communication.PushConfiguration;
-import com.vaadin.client.communication.ReconnectDialogConfiguration;
+import com.vaadin.client.communication.ReconnectConfiguration;
 import com.vaadin.client.communication.RequestResponseTracker;
 import com.vaadin.client.communication.ServerConnector;
 import com.vaadin.client.communication.ServerRpcQueue;
@@ -113,8 +113,8 @@ public class DefaultRegistry extends Registry {
                 new DefaultConnectionStateHandler(this));
         set(XhrConnection.class, new XhrConnection(this));
         set(PushConfiguration.class, new PushConfiguration(this));
-        set(ReconnectDialogConfiguration.class,
-                new ReconnectDialogConfiguration(this));
+        set(ReconnectConfiguration.class,
+                new ReconnectConfiguration(this));
         if (!applicationConfiguration.isClientRouting()) {
             if (applicationConfiguration.isWebComponentMode()) {
                 set(ScrollPositionHandler.class, new WebComponentScrollHandler());

--- a/flow-client/src/main/java/com/vaadin/client/DefaultRegistry.java
+++ b/flow-client/src/main/java/com/vaadin/client/DefaultRegistry.java
@@ -96,7 +96,6 @@ public class DefaultRegistry extends Registry {
         set(SystemErrorHandler.class, new SystemErrorHandler(this));
         set(UILifecycle.class, new UILifecycle());
         set(StateTree.class, new StateTree(this));
-        set(ConnectionState.class, new ConnectionState());
         set(RequestResponseTracker.class, new RequestResponseTracker(this));
         set(MessageHandler.class, new MessageHandler(this));
         set(MessageSender.class, new MessageSender(this));

--- a/flow-client/src/main/java/com/vaadin/client/Registry.java
+++ b/flow-client/src/main/java/com/vaadin/client/Registry.java
@@ -106,15 +106,6 @@ public class Registry {
     }
 
     /**
-     * Gets the {@link ConnectionState} singleton.
-     *
-     * @return the {@link ConnectionState} singleton
-     */
-    public ConnectionState getConnectionState() {
-        return get(ConnectionState.class);
-    }
-
-    /**
      * Gets the {@link ApplicationConnection} singleton.
      *
      * @return the {@link ApplicationConnection} singleton

--- a/flow-client/src/main/java/com/vaadin/client/Registry.java
+++ b/flow-client/src/main/java/com/vaadin/client/Registry.java
@@ -21,7 +21,7 @@ import com.vaadin.client.communication.MessageHandler;
 import com.vaadin.client.communication.MessageSender;
 import com.vaadin.client.communication.Poller;
 import com.vaadin.client.communication.PushConfiguration;
-import com.vaadin.client.communication.ReconnectDialogConfiguration;
+import com.vaadin.client.communication.ReconnectConfiguration;
 import com.vaadin.client.communication.RequestResponseTracker;
 import com.vaadin.client.communication.ServerConnector;
 import com.vaadin.client.communication.ServerRpcQueue;
@@ -223,12 +223,12 @@ public class Registry {
     }
 
     /**
-     * Gets the {@link ReconnectDialogConfiguration} singleton.
+     * Gets the {@link ReconnectConfiguration} singleton.
      *
-     * @return the {@link ReconnectDialogConfiguration} singleton
+     * @return the {@link ReconnectConfiguration} singleton
      */
-    public ReconnectDialogConfiguration getReconnectDialogConfiguration() {
-        return get(ReconnectDialogConfiguration.class);
+    public ReconnectConfiguration getReconnectConfiguration() {
+        return get(ReconnectConfiguration.class);
     }
 
     /**

--- a/flow-client/src/main/java/com/vaadin/client/communication/DefaultConnectionStateHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/DefaultConnectionStateHandler.java
@@ -312,14 +312,18 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
     @Override
     public void configurationUpdated() {
         // All other properties are fetched directly from the state when needed
-        ConnectionIndicator.setProperty("reconnectModal",
-                getConfiguration().isDialogModal());
-        ConnectionIndicator.setProperty("reconnectingText",
-                getConfiguration().getDialogText());
+        if (getConfiguration().getDialogText() != null) {
+            ConnectionIndicator.setProperty("reconnectingText",
+                    getConfiguration().getDialogText());
+        }
+        if (getConfiguration().getDialogTextGaveUp() != null) {
+        ConnectionIndicator.setProperty("offlineText",
+                getConfiguration().getDialogTextGaveUp());
+        }
     }
 
-    private ReconnectDialogConfiguration getConfiguration() {
-        return registry.getReconnectDialogConfiguration();
+    private ReconnectConfiguration getConfiguration() {
+        return registry.getReconnectConfiguration();
     }
 
     @Override

--- a/flow-client/src/main/java/com/vaadin/client/communication/DefaultConnectionStateHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/DefaultConnectionStateHandler.java
@@ -23,7 +23,7 @@ import com.google.gwt.user.client.Timer;
 import com.google.gwt.xhr.client.XMLHttpRequest;
 
 import com.vaadin.client.Console;
-import com.vaadin.client.ConnectionState;
+import com.vaadin.client.ConnectionIndicator;
 import com.vaadin.client.Registry;
 import com.vaadin.client.UILifecycle;
 import com.vaadin.client.UILifecycle.UIState;
@@ -178,8 +178,8 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
             return;
         }
 
-        registry.getConnectionState().setState(
-                ConnectionState.RECONNECTING);
+        ConnectionIndicator.setState(
+                ConnectionIndicator.RECONNECTING);
 
         if (!isReconnecting()) {
             // First problem encounter
@@ -280,7 +280,7 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
             endRequest();
         }
 
-        registry.getConnectionState().setState(ConnectionState.CONNECTION_LOST);
+        ConnectionIndicator.setState(ConnectionIndicator.CONNECTION_LOST);
         pauseHeartbeats();
     }
 
@@ -312,6 +312,10 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
     @Override
     public void configurationUpdated() {
         // All other properties are fetched directly from the state when needed
+        ConnectionIndicator.setProperty("reconnectModal",
+                getConfiguration().isDialogModal());
+        ConnectionIndicator.setProperty("reconnectingText",
+                getConfiguration().getDialogText());
     }
 
     private ReconnectDialogConfiguration getConfiguration() {
@@ -452,9 +456,7 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
 
         reconnectionCause = null;
         reconnectAttempt = 0;
-
-        registry.getConnectionState()
-                .setState(ConnectionState.CONNECTED);
+        ConnectionIndicator.setState(ConnectionIndicator.CONNECTED);
 
         Console.log("Re-established connection to server");
     }

--- a/flow-client/src/main/java/com/vaadin/client/communication/LoadingIndicatorConfigurator.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/LoadingIndicatorConfigurator.java
@@ -17,6 +17,7 @@ package com.vaadin.client.communication;
 
 import java.util.function.Consumer;
 
+import com.vaadin.client.ConnectionIndicator;
 import com.vaadin.client.flow.StateNode;
 import com.vaadin.client.flow.nodefeature.MapProperty;
 import com.vaadin.client.flow.nodefeature.NodeMap;
@@ -84,23 +85,19 @@ public class LoadingIndicatorConfigurator {
                 .accept(e.getSource().getValueOrDefault(defaultValue)));
     }
 
-    private static native void setFirstDelay(int delay)
-    /*-{
-        $wnd.Vaadin.connectionIndicator.firstDelay = delay;
-    }-*/;
+    private static void setFirstDelay(int delay) {
+        ConnectionIndicator.setProperty("firstDelay", delay);
+    }
 
-    private static native void setSecondDelay(int delay)
-    /*-{
-        $wnd.Vaadin.connectionIndicator.secondDelay = delay;
-    }-*/;
+    private static void setSecondDelay(int delay) {
+        ConnectionIndicator.setProperty("secondDelay", delay);
+    }
 
-    private static native void setThirdDelay(int delay)
-    /*-{
-        $wnd.Vaadin.connectionIndicator.thirdDelay = delay;
-    }-*/;
+    private static void setThirdDelay(int delay) {
+        ConnectionIndicator.setProperty("thirdDelay", delay);
+    }
 
-    private static native void setApplyDefaultTheme(boolean apply)
-    /*-{
-        $wnd.Vaadin.connectionIndicator.applyDefaultTheme = apply;
-    }-*/;
+    private static void setApplyDefaultTheme(boolean apply) {
+        ConnectionIndicator.setProperty("applyDefaultTheme", apply);
+    }
 }

--- a/flow-client/src/main/java/com/vaadin/client/communication/MessageSender.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/MessageSender.java
@@ -17,7 +17,7 @@ package com.vaadin.client.communication;
 
 import com.google.gwt.core.client.GWT;
 import com.vaadin.client.Console;
-import com.vaadin.client.ConnectionState;
+import com.vaadin.client.ConnectionIndicator;
 import com.vaadin.client.Registry;
 import com.vaadin.flow.shared.ApplicationConstants;
 
@@ -106,8 +106,7 @@ public class MessageSender {
 
         JsonObject extraJson = Json.createObject();
         if (showLoadingIndicator) {
-            registry.getConnectionState().setState(
-                    ConnectionState.LOADING);
+            ConnectionIndicator.setState(ConnectionIndicator.LOADING);
         }
         send(reqJson, extraJson);
     }

--- a/flow-client/src/main/java/com/vaadin/client/communication/ReconnectConfiguration.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/ReconnectConfiguration.java
@@ -23,8 +23,8 @@ import com.vaadin.flow.internal.nodefeature.NodeFeatures;
 import com.vaadin.flow.internal.nodefeature.ReconnectDialogConfigurationMap;
 
 /**
- * Tracks the reconnect dialog configuration stored in the root node and
- * provides it with an easier to use API.
+ * Tracks the reconnect configuration stored in the root node and provides it
+ * with an easier to use API.
  * <p>
  * Also triggers {@link ConnectionStateHandler#configurationUpdated()} whenever
  * part of the configuration changes.
@@ -32,7 +32,7 @@ import com.vaadin.flow.internal.nodefeature.ReconnectDialogConfigurationMap;
  * @author Vaadin Ltd
  * @since 1.0
  */
-public class ReconnectDialogConfiguration {
+public class ReconnectConfiguration {
 
     private final Registry registry;
 
@@ -42,7 +42,7 @@ public class ReconnectDialogConfiguration {
      * @param registry
      *            the registry
      */
-    public ReconnectDialogConfiguration(Registry registry) {
+    public ReconnectConfiguration(Registry registry) {
         this.registry = registry;
     }
 
@@ -50,7 +50,7 @@ public class ReconnectDialogConfiguration {
      * Binds this ReconnectDialogConfiguration to the given
      * {@link ConnectionStateHandler} so that
      * {@link ConnectionStateHandler#configurationUpdated()} is run whenever a
-     * relevant part of {@link ReconnectDialogConfiguration} changes.
+     * relevant part of {@link ReconnectConfiguration} changes.
      *
      * @param connectionStateHandler
      *            the connection state handler to bind to
@@ -67,26 +67,16 @@ public class ReconnectDialogConfiguration {
     }
 
     /**
-     * Checks whether the reconnect dialog should be modal, i.e. prevent
-     * application usage while being shown.
-     *
-     * @return true if the dialog is modal, false otherwise
-     */
-    public boolean isDialogModal() {
-        return getProperty(ReconnectDialogConfigurationMap.DIALOG_MODAL_KEY)
-                .getValueOrDefault(
-                        ReconnectDialogConfigurationMap.DIALOG_MODAL_DEFAULT);
-    }
-
-    /**
      * Gets the text to show in the reconnect dialog.
      *
      * @return the text to show in the reconnect dialog.
+     *
+     * @deprecated The API for configuring the connection indicator has changed.
      */
+    @Deprecated
     public String getDialogText() {
         return getProperty(ReconnectDialogConfigurationMap.DIALOG_TEXT_KEY)
-                .getValueOrDefault(
-                        ReconnectDialogConfigurationMap.DIALOG_TEXT_DEFAULT);
+                .getValueOrDefault(null);
     }
 
     /**
@@ -95,12 +85,14 @@ public class ReconnectDialogConfiguration {
      *
      * @return the text to show in the reconnect dialog when no longer trying to
      *         reconnect
+     *
+     * @deprecated The API for configuring the connection indicator has changed.
      */
+    @Deprecated
     public String getDialogTextGaveUp() {
         return getProperty(
                 ReconnectDialogConfigurationMap.DIALOG_TEXT_GAVE_UP_KEY)
-                        .getValueOrDefault(
-                                ReconnectDialogConfigurationMap.DIALOG_TEXT_GAVE_UP_DEFAULT);
+                .getValueOrDefault(null);
     }
 
     /**
@@ -127,18 +119,4 @@ public class ReconnectDialogConfiguration {
                         .getValueOrDefault(
                                 ReconnectDialogConfigurationMap.RECONNECT_INTERVAL_DEFAULT);
     }
-
-    /**
-     * Gets the time in milliseconds to wait after noticing a loss of connection
-     * but before showing the reconnect dialog.
-     *
-     * @return the time in milliseconds to wait before showing the dialog
-     */
-    public int getDialogGracePeriod() {
-        return getProperty(
-                ReconnectDialogConfigurationMap.DIALOG_GRACE_PERIOD_KEY)
-                        .getValueOrDefault(
-                                ReconnectDialogConfigurationMap.DIALOG_GRACE_PERIOD_DEFAULT);
-    }
-
 }

--- a/flow-client/src/main/java/com/vaadin/client/communication/RequestResponseTracker.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/RequestResponseTracker.java
@@ -20,7 +20,7 @@ import com.google.web.bindery.event.shared.Event;
 import com.google.web.bindery.event.shared.EventBus;
 import com.google.web.bindery.event.shared.HandlerRegistration;
 
-import com.vaadin.client.ConnectionState;
+import com.vaadin.client.ConnectionIndicator;
 import com.vaadin.client.Registry;
 import com.vaadin.client.gwt.com.google.web.bindery.event.shared.SimpleEventBus;
 
@@ -125,8 +125,7 @@ public class RequestResponseTracker {
                     || registry.getServerRpcQueue().isFlushPending();
 
             if (terminated || !requestNowOrSoon) {
-                registry.getConnectionState().setState(
-                        ConnectionState.CONNECTED);
+                ConnectionIndicator.setState(ConnectionIndicator.CONNECTED);
             }
         });
 

--- a/flow-client/src/main/resources/META-INF/resources/frontend/ConnectionIndicator.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/ConnectionIndicator.ts
@@ -51,12 +51,6 @@ export class ConnectionIndicator extends LitElement {
   expandedDuration: number = 2000;
 
   /**
-   * Whether the connection state message should be modal.
-   */
-  @property({type: Boolean})
-  reconnectModal: boolean = false;
-
-  /**
    * The message shown when the connection goes to connected state.
    */
   @property({type: String})
@@ -124,8 +118,7 @@ export class ConnectionIndicator extends LitElement {
        style="${this.getLoadingBarStyle()}"></div>
 
       <div class="v-status-message ${classMap({
-        active: this.reconnecting,
-        modal: this.reconnectModal
+        active: this.reconnecting
       })}">
         <span class="text">
           ${this.renderMessage()}

--- a/flow-client/src/test-gwt/java/com/vaadin/client/communication/GwtDefaultConnectionStateHandlerTest.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/communication/GwtDefaultConnectionStateHandlerTest.java
@@ -34,7 +34,7 @@ public class GwtDefaultConnectionStateHandlerTest extends ClientEngineTestBase {
                     getRootNode().getMap(NodeFeatures.RECONNECT_DIALOG_CONFIGURATION)
                             .getProperty(ReconnectDialogConfigurationMap.RECONNECT_INTERVAL_KEY).setValue((double)10000000);
                 }});
-                set(ReconnectDialogConfiguration.class, new ReconnectDialogConfiguration(this));
+                set(ReconnectConfiguration.class, new ReconnectConfiguration(this));
                 set(Heartbeat.class, new Heartbeat(this));
                 set(RequestResponseTracker.class,
                         new RequestResponseTracker(this));

--- a/flow-client/src/test-gwt/java/com/vaadin/client/communication/GwtDefaultConnectionStateHandlerTest.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/communication/GwtDefaultConnectionStateHandlerTest.java
@@ -38,7 +38,6 @@ public class GwtDefaultConnectionStateHandlerTest extends ClientEngineTestBase {
                 set(Heartbeat.class, new Heartbeat(this));
                 set(RequestResponseTracker.class,
                         new RequestResponseTracker(this));
-                set(ConnectionState.class, new ConnectionState());
                 set(ConnectionStateHandler.class,
                         handler = new DefaultConnectionStateHandler(this));
             }
@@ -56,51 +55,51 @@ public class GwtDefaultConnectionStateHandlerTest extends ClientEngineTestBase {
 
     public void test_onlineEventFollowedByOffline_connectionLost() {
         Browser.getWindow().dispatchEvent(createEvent("offline"));
-        assertEquals(ConnectionState.CONNECTION_LOST,
-                registry.getConnectionState().getState());
+        assertEquals(ConnectionIndicator.CONNECTION_LOST,
+                ConnectionIndicator.getState());
 
         Browser.getWindow().dispatchEvent(createEvent("online"));
-        assertEquals(ConnectionState.RECONNECTING,
-                registry.getConnectionState().getState());
+        assertEquals(ConnectionIndicator.RECONNECTING,
+                ConnectionIndicator.getState());
 
         Browser.getWindow().dispatchEvent(createEvent("offline"));
-        assertEquals(ConnectionState.CONNECTION_LOST,
-                registry.getConnectionState().getState());
+        assertEquals(ConnectionIndicator.CONNECTION_LOST,
+                ConnectionIndicator.getState());
     }
 
     public void test_onlineEventHeartbeatSucceeds_connected() {
         Browser.getWindow().dispatchEvent(createEvent("offline"));
-        assertEquals(ConnectionState.CONNECTION_LOST,
-                registry.getConnectionState().getState());
+        assertEquals(ConnectionIndicator.CONNECTION_LOST,
+                ConnectionIndicator.getState());
 
         Browser.getWindow().dispatchEvent(createEvent("online"));
-        assertEquals(ConnectionState.RECONNECTING,
-                registry.getConnectionState().getState());
+        assertEquals(ConnectionIndicator.RECONNECTING,
+                ConnectionIndicator.getState());
 
         handler.heartbeatOk();
-        assertEquals(ConnectionState.CONNECTED,
-                registry.getConnectionState().getState());
+        assertEquals(ConnectionIndicator.CONNECTED,
+                ConnectionIndicator.getState());
     }
 
     public void test_onlineEventButHeartbeatFails_continuesReconnectingAndFinallyGivesUp() {
         Browser.getWindow().dispatchEvent(createEvent("offline"));
-        assertEquals(ConnectionState.CONNECTION_LOST,
-                registry.getConnectionState().getState());
+        assertEquals(ConnectionIndicator.CONNECTION_LOST,
+                ConnectionIndicator.getState());
 
         Browser.getWindow().dispatchEvent(createEvent("online"));
-        assertEquals(ConnectionState.RECONNECTING,
-                registry.getConnectionState().getState());
+        assertEquals(ConnectionIndicator.RECONNECTING,
+                ConnectionIndicator.getState());
 
         // second attempt (first attempt immediately after transitioning to
         // ConnectionState.RECONNECTING): should keep reconnecting
         handler.heartbeatException(XMLHttpRequest.create(), new Exception("some exception"));
-        assertEquals(ConnectionState.RECONNECTING,
-                registry.getConnectionState().getState());
+        assertEquals(ConnectionIndicator.RECONNECTING,
+                ConnectionIndicator.getState());
 
         // third attempt: should transition to CONNECTION_LOST
         handler.heartbeatException(XMLHttpRequest.create(), new Exception("some exception"));
-        assertEquals(ConnectionState.CONNECTION_LOST,
-                registry.getConnectionState().getState());
+        assertEquals(ConnectionIndicator.CONNECTION_LOST,
+                ConnectionIndicator.getState());
     }
 
     private static native Event createEvent(String type)

--- a/flow-client/src/test/frontend/ConnectionIndicatorTests.ts
+++ b/flow-client/src/test/frontend/ConnectionIndicatorTests.ts
@@ -47,7 +47,6 @@ suite('ConnectionIndicator', () => {
       assert.equal(connectionIndicator.secondDelay, 1500);
       assert.equal(connectionIndicator.thirdDelay, 5000);
       assert.equal(connectionIndicator.expandedDuration, 2000);
-      assert.isFalse(connectionIndicator.reconnectModal);
 
       // Strings
       assert.match(connectionIndicator.onlineText, /online/i);

--- a/flow-client/src/test/java/com/vaadin/client/DomApiAbstractionUsageTest.java
+++ b/flow-client/src/test/java/com/vaadin/client/DomApiAbstractionUsageTest.java
@@ -37,8 +37,8 @@ public class DomApiAbstractionUsageTest {
     private static final Set<String> ignoredClasses = Stream
             .of(DomElement.class, DomNode.class, ResourceLoader.class,
                     BrowserInfo.class, SystemErrorHandler.class,
-                    ConnectionState.class, RouterLinkHandler.class,
-                    Profiler.class, ScrollPositionHandler.class)
+                    RouterLinkHandler.class, Profiler.class,
+                    ScrollPositionHandler.class)
             .map(Class::getName).collect(Collectors.toSet());
 
     private static final Set<Class<?>> ignoredElementalClasses = Stream

--- a/flow-client/src/test/java/com/vaadin/client/communication/ReconnectConfigurationTest.java
+++ b/flow-client/src/test/java/com/vaadin/client/communication/ReconnectConfigurationTest.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.client.communication;
 
-import static com.vaadin.flow.internal.nodefeature.ReconnectDialogConfigurationMap.DIALOG_TEXT_DEFAULT;
-import static com.vaadin.flow.internal.nodefeature.ReconnectDialogConfigurationMap.DIALOG_TEXT_GAVE_UP_DEFAULT;
 import static com.vaadin.flow.internal.nodefeature.ReconnectDialogConfigurationMap.DIALOG_TEXT_GAVE_UP_KEY;
 import static com.vaadin.flow.internal.nodefeature.ReconnectDialogConfigurationMap.DIALOG_TEXT_KEY;
 import static com.vaadin.flow.internal.nodefeature.ReconnectDialogConfigurationMap.RECONNECT_ATTEMPTS_DEFAULT;
@@ -76,8 +74,9 @@ public class ReconnectConfigurationTest
 
     @Test
     public void defaults() {
-        Assert.assertEquals(DIALOG_TEXT_DEFAULT, configuration.getDialogText());
-        Assert.assertEquals(DIALOG_TEXT_GAVE_UP_DEFAULT,
+        // Defaults for dialog properties moved to ConnectionIndicator.ts
+        Assert.assertEquals(null, configuration.getDialogText());
+        Assert.assertEquals(null,
                 configuration.getDialogTextGaveUp());
         Assert.assertEquals(RECONNECT_ATTEMPTS_DEFAULT,
                 configuration.getReconnectAttempts());

--- a/flow-client/src/test/java/com/vaadin/client/communication/ReconnectConfigurationTest.java
+++ b/flow-client/src/test/java/com/vaadin/client/communication/ReconnectConfigurationTest.java
@@ -15,10 +15,6 @@
  */
 package com.vaadin.client.communication;
 
-import static com.vaadin.flow.internal.nodefeature.ReconnectDialogConfigurationMap.DIALOG_GRACE_PERIOD_DEFAULT;
-import static com.vaadin.flow.internal.nodefeature.ReconnectDialogConfigurationMap.DIALOG_GRACE_PERIOD_KEY;
-import static com.vaadin.flow.internal.nodefeature.ReconnectDialogConfigurationMap.DIALOG_MODAL_DEFAULT;
-import static com.vaadin.flow.internal.nodefeature.ReconnectDialogConfigurationMap.DIALOG_MODAL_KEY;
 import static com.vaadin.flow.internal.nodefeature.ReconnectDialogConfigurationMap.DIALOG_TEXT_DEFAULT;
 import static com.vaadin.flow.internal.nodefeature.ReconnectDialogConfigurationMap.DIALOG_TEXT_GAVE_UP_DEFAULT;
 import static com.vaadin.flow.internal.nodefeature.ReconnectDialogConfigurationMap.DIALOG_TEXT_GAVE_UP_KEY;
@@ -43,11 +39,11 @@ import com.vaadin.client.flow.nodefeature.MapProperty;
 import com.vaadin.client.flow.reactive.Reactive;
 import com.vaadin.flow.internal.nodefeature.NodeFeatures;
 
-public class ReconnectDialogConfigurationTest
+public class ReconnectConfigurationTest
         extends AbstractConfigurationTest {
 
     private StateTree stateTree;
-    private ReconnectDialogConfiguration configuration;
+    private ReconnectConfiguration configuration;
     private AtomicInteger configurationUpdatedCalled = new AtomicInteger(0);
 
     {
@@ -57,7 +53,7 @@ public class ReconnectDialogConfigurationTest
                 stateTree = new StateTree(this);
                 set(StateTree.class, stateTree);
                 // Binds to the root node
-                configuration = new ReconnectDialogConfiguration(this);
+                configuration = new ReconnectConfiguration(this);
                 ConnectionStateHandler connectionStateHandler = Mockito
                         .mock(ConnectionStateHandler.class);
                 Mockito.doAnswer(new Answer<Void>() {
@@ -66,14 +62,13 @@ public class ReconnectDialogConfigurationTest
                             throws Throwable {
                         // Read some values to be able to test that the
                         // reactive computation works properly
-                        configuration.isDialogModal();
                         configuration.getDialogText();
                         configurationUpdatedCalled.incrementAndGet();
                         return null;
                     }
                 }).when(connectionStateHandler).configurationUpdated();
 
-                ReconnectDialogConfiguration.bind(connectionStateHandler);
+                ReconnectConfiguration.bind(connectionStateHandler);
                 set(ConnectionStateHandler.class, connectionStateHandler);
             }
         };
@@ -88,10 +83,6 @@ public class ReconnectDialogConfigurationTest
                 configuration.getReconnectAttempts());
         Assert.assertEquals(RECONNECT_INTERVAL_DEFAULT,
                 configuration.getReconnectInterval());
-        Assert.assertEquals(DIALOG_GRACE_PERIOD_DEFAULT,
-                configuration.getDialogGracePeriod());
-        Assert.assertEquals(DIALOG_MODAL_DEFAULT,
-                configuration.isDialogModal());
     }
 
     @Override
@@ -112,11 +103,6 @@ public class ReconnectDialogConfigurationTest
     }
 
     @Test
-    public void setGetDialogGracePeriod() {
-        testInt(DIALOG_GRACE_PERIOD_KEY, configuration::getDialogGracePeriod);
-    }
-
-    @Test
     public void setGetReconnectAttempts() {
         testInt(RECONNECT_ATTEMPTS_KEY, configuration::getReconnectAttempts);
     }
@@ -127,14 +113,9 @@ public class ReconnectDialogConfigurationTest
     }
 
     @Test
-    public void setGetDialogModal() {
-        testBoolean(DIALOG_MODAL_KEY, configuration::isDialogModal);
-    }
-
-    @Test
     public void reactsToChanges() {
         configurationUpdatedCalled.set(0);
-        getProperty(DIALOG_MODAL_KEY).setValue(true);
+        getProperty(DIALOG_TEXT_GAVE_UP_KEY).setValue("bar");
         Reactive.flush();
         Assert.assertEquals(1, configurationUpdatedCalled.get());
         getProperty(DIALOG_TEXT_KEY).setValue("foo");
@@ -147,8 +128,6 @@ public class ReconnectDialogConfigurationTest
         configurationUpdatedCalled.set(0);
         getProperty(RECONNECT_INTERVAL_KEY).setValue(13);
         getProperty(RECONNECT_ATTEMPTS_KEY).setValue(13);
-        getProperty(DIALOG_GRACE_PERIOD_KEY).setValue(13);
-        getProperty(DIALOG_MODAL_KEY).setValue(true);
         getProperty(DIALOG_TEXT_KEY).setValue("abc");
         getProperty(DIALOG_TEXT_GAVE_UP_KEY).setValue("def");
         Assert.assertEquals(0, configurationUpdatedCalled.get());

--- a/flow-server/src/main/java/com/vaadin/flow/component/ReconnectDialogConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ReconnectDialogConfiguration.java
@@ -109,11 +109,13 @@ public interface ReconnectDialogConfiguration extends Serializable {
      * Gets the timeout (in milliseconds) between noticing a loss of connection
      * and showing the dialog.
      * <p>
-     * The default is
-     * {@value ReconnectDialogConfigurationMap#DIALOG_GRACE_PERIOD_DEFAULT}
      *
      * @return the time to wait before showing a dialog
+     *
+     * @deprecated this method is a no-op. The connection indicator has
+     * changed, and there is no longer a grace period.
      */
+    @Deprecated
     int getDialogGracePeriod();
 
     /**
@@ -122,7 +124,11 @@ public interface ReconnectDialogConfiguration extends Serializable {
      *
      * @param dialogGracePeriod
      *            the time to wait before showing a dialog
+     *
+     * @deprecated this method is a no-op. The connection indicator no longer
+     *             has a grace period.
      */
+    @Deprecated
     void setDialogGracePeriod(int dialogGracePeriod);
 
     /**
@@ -135,17 +141,23 @@ public interface ReconnectDialogConfiguration extends Serializable {
      *
      * @param dialogModal
      *            true to make the dialog modal, false otherwise
+     *
+     * @deprecated this method is a no-op. The connection indicator is now never
+     *             modal. This method will be removed in Vaadin 20.
      */
+    @Deprecated
     void setDialogModal(boolean dialogModal);
 
     /**
      * Checks the modality of the dialog.
      * <p>
-     * The default is
-     * {@value ReconnectDialogConfigurationMap#DIALOG_MODAL_DEFAULT}
      *
      * @see #setDialogModal(boolean)
      * @return true if the dialog is modal, false otherwise
+     *
+     * @deprecated this method is a no-op. The connection indicator is now never
+     *             modal.
      */
+    @Deprecated
     boolean isDialogModal();
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ReconnectDialogConfigurationMap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ReconnectDialogConfigurationMap.java
@@ -17,6 +17,8 @@ package com.vaadin.flow.internal.nodefeature;
 
 import com.vaadin.flow.component.ReconnectDialogConfiguration;
 import com.vaadin.flow.internal.StateNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Map for storing the reconnect dialog configuration for a UI.
@@ -35,10 +37,6 @@ public class ReconnectDialogConfigurationMap extends NodeMap
     public static final int RECONNECT_ATTEMPTS_DEFAULT = 10000;
     public static final String RECONNECT_INTERVAL_KEY = "reconnectInterval";
     public static final int RECONNECT_INTERVAL_DEFAULT = 5000;
-    public static final String DIALOG_GRACE_PERIOD_KEY = "dialogGracePeriod";
-    public static final int DIALOG_GRACE_PERIOD_DEFAULT = 400;
-    public static final String DIALOG_MODAL_KEY = "dialogModal";
-    public static final boolean DIALOG_MODAL_DEFAULT = false;
 
     /**
      * Creates a new map for the given node.
@@ -94,23 +92,35 @@ public class ReconnectDialogConfigurationMap extends NodeMap
 
     @Override
     public int getDialogGracePeriod() {
-        return getOrDefault(DIALOG_GRACE_PERIOD_KEY,
-                DIALOG_GRACE_PERIOD_DEFAULT);
+        getLogger()
+                .warn("dialogGracePeriod: this property has been deprecated, "
+                        + "and will be permanently removed in Vaadin 20");
+        return 0;
     }
 
     @Override
     public void setDialogGracePeriod(int dialogGracePeriod) {
-        put(DIALOG_GRACE_PERIOD_KEY, dialogGracePeriod);
+        getLogger()
+                .warn("dialogGracePeriod: this property has been deprecated, "
+                        + "and will be permanently removed in Vaadin 20");
     }
 
     @Override
     public boolean isDialogModal() {
-        return getOrDefault(DIALOG_MODAL_KEY, DIALOG_MODAL_DEFAULT);
+        getLogger()
+                .warn("dialogModal: this property has been deprecated, and will"
+                        + "be permanently removed in Vaadin 20");
+        return false;
     }
 
     @Override
     public void setDialogModal(boolean dialogModal) {
-        put(DIALOG_MODAL_KEY, dialogModal);
+        getLogger()
+                .warn("dialogModal: this property has been deprecated, and will"
+                        + "be permanently removed in Vaadin 20");
     }
 
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(ElementPropertyMap.class);
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/ReconnectDialogConfigurationMapTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/ReconnectDialogConfigurationMapTest.java
@@ -42,12 +42,6 @@ public class ReconnectDialogConfigurationMapTest
         Assert.assertEquals(
                 ReconnectDialogConfigurationMap.RECONNECT_INTERVAL_DEFAULT,
                 map.getReconnectInterval());
-        Assert.assertEquals(
-                ReconnectDialogConfigurationMap.DIALOG_GRACE_PERIOD_DEFAULT,
-                map.getDialogGracePeriod());
-        Assert.assertEquals(
-                ReconnectDialogConfigurationMap.DIALOG_MODAL_DEFAULT,
-                map.isDialogModal());
     }
 
     @Test
@@ -73,19 +67,4 @@ public class ReconnectDialogConfigurationMapTest
         testInt(map, ReconnectDialogConfigurationMap.RECONNECT_INTERVAL_KEY,
                 map::setReconnectInterval, map::getReconnectInterval);
     }
-
-    @Test
-    public void setGetDialogGracePeriod() {
-        testInt(map, ReconnectDialogConfigurationMap.DIALOG_GRACE_PERIOD_KEY,
-                map::setDialogGracePeriod, map::getDialogGracePeriod);
-
-    }
-
-    @Test
-    public void setGetDialogModal() {
-        testBoolean(map, ReconnectDialogConfigurationMap.DIALOG_MODAL_KEY,
-                map::setDialogModal, map::isDialogModal);
-
-    }
-
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
@@ -1540,9 +1540,6 @@ public class BootstrapHandlerTest {
 
         Assert.assertEquals(PushMode.MANUAL,
                 testUI.getPushConfiguration().getPushMode());
-
-        Assert.assertTrue(
-                testUI.getReconnectDialogConfiguration().isDialogModal());
     }
 
 }

--- a/flow-tests/test-ccdm-flow-navigation/src/main/java/com/vaadin/flow/navigate/ConnectionIndicatorView.java
+++ b/flow-tests/test-ccdm-flow-navigation/src/main/java/com/vaadin/flow/navigate/ConnectionIndicatorView.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.navigate;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.PageTitle;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "connection-indicator")
+@PageTitle("Connection Indicator Tests")
+public class ConnectionIndicatorView extends Div {
+
+    public static final String CONNECT_SERVER = "connect-server";
+    public static final String SET_CUSTOM_MESSAGES = "set-custom-message";
+    public static final String CUSTOM_RECONNECTING_MESSAGE = "custom reconnecting from Java";
+    public static final String CUSTOM_OFFLINE_MESSAGE = "custom offline from Java";
+
+    public ConnectionIndicatorView() {
+        NativeButton ping = new NativeButton("Ping server",
+            e -> add(new Span("Server reached")));
+        ping.setId(CONNECT_SERVER);
+        add(ping);
+
+        NativeButton setCustomReconnecting = new NativeButton(
+            "Set custom reconnecting message",
+            e -> {
+                UI ui = getUI().get();
+                ui.getReconnectDialogConfiguration().setDialogText(
+                    CUSTOM_RECONNECTING_MESSAGE);
+                ui.getReconnectDialogConfiguration().setDialogTextGaveUp(
+                    CUSTOM_OFFLINE_MESSAGE);
+            });
+        setCustomReconnecting.setId(SET_CUSTOM_MESSAGES);
+        add(setCustomReconnecting);
+    }
+
+}

--- a/flow-tests/test-ccdm-flow-navigation/src/test/java/com/vaadin/flow/navigate/ConnectionIndicatorIT.java
+++ b/flow-tests/test-ccdm-flow-navigation/src/test/java/com/vaadin/flow/navigate/ConnectionIndicatorIT.java
@@ -23,13 +23,11 @@ import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.mobile.NetworkConnection;
 
-import static com.vaadin.flow.navigate.HelloWorldView.NAVIGATE_ABOUT;
-
 public class ConnectionIndicatorIT extends ChromeDeviceTest {
 
     @Test
     public void online_goingOffline_customisedMessageShown() throws Exception {
-        getDriver().get(getRootURL() + "/");
+        getDriver().get(getRootURL() + "/connection-indicator");
         waitForServiceWorkerReady();
         setConnectionType(NetworkConnection.ConnectionType.AIRPLANE_MODE);
         try {
@@ -42,7 +40,7 @@ public class ConnectionIndicatorIT extends ChromeDeviceTest {
 
     @Test
     public void offline_goingOnline_customisedMessageShown() throws Exception {
-        getDriver().get(getRootURL() + "/");
+        getDriver().get(getRootURL() + "/connection-indicator");
         waitForServiceWorkerReady();
         setConnectionType(NetworkConnection.ConnectionType.AIRPLANE_MODE);
         try {
@@ -57,15 +55,35 @@ public class ConnectionIndicatorIT extends ChromeDeviceTest {
 
     @Test
     public void offline_serverConnectionAttempted_customisedMessageShown() throws Exception {
-        getDriver().get(getRootURL() + "/hello");
+        getDriver().get(getRootURL() + "/connection-indicator");
         waitForServiceWorkerReady();
         setConnectionType(NetworkConnection.ConnectionType.AIRPLANE_MODE);
         try {
             expectConnectionState("connection-lost");
-            findElement(By.id(NAVIGATE_ABOUT)).click();
+            findElement(By.id(ConnectionIndicatorView.CONNECT_SERVER)).click();
             testBench().disableWaitForVaadin(); // offline - do run the WAIT_FOR_VAADIN script
             expectConnectionState("reconnecting");
             Assert.assertEquals("Custom reconnecting", getConnectionIndicatorStatusText());
+        } finally {
+            setConnectionType(NetworkConnection.ConnectionType.ALL);
+        }
+    }
+
+    @Test
+    public void offline_serverConnectionAttempted_javaCustomisedMessagesShown() throws Exception {
+        getDriver().get(getRootURL() + "/connection-indicator");
+        waitForServiceWorkerReady();
+        findElement(By.id(ConnectionIndicatorView.SET_CUSTOM_MESSAGES)).click();
+        setConnectionType(NetworkConnection.ConnectionType.AIRPLANE_MODE);
+        try {
+            expectConnectionState("connection-lost");
+            Assert.assertEquals(ConnectionIndicatorView.CUSTOM_OFFLINE_MESSAGE,
+                getConnectionIndicatorStatusText());
+            findElement(By.id(ConnectionIndicatorView.CONNECT_SERVER)).click();
+            testBench().disableWaitForVaadin(); // offline - do run the WAIT_FOR_VAADIN script
+            expectConnectionState("reconnecting");
+            Assert.assertEquals(ConnectionIndicatorView.CUSTOM_RECONNECTING_MESSAGE,
+                getConnectionIndicatorStatusText());
         } finally {
             setConnectionType(NetworkConnection.ConnectionType.ALL);
         }


### PR DESCRIPTION
The Java API for configuring the messages shown in the reconnect dialog (`ReconnectDialogConfiguration.setDialogText` and `ReconnectDialogConfiguration.getDialogTextGaveUp`) now carry over to the corresponding properties of the new `<vaadin-connection-indicator>` component (`reconnectingText` and `offlineText`, respectively). The `flow-client` class `ReconnectDialogConfiguration` has been renamed to `ReconnectConfiguration` to better capture that it manages the reconnect logic (connection attempts and interval), not the dialog visuals.

Two properties, which have no corrspondence in the new connection indicator (`ReconnectDialogConfiguration.setDialogGracePeriod` and `ReconnectDialogConfiguration.setDialogModal` are now no-ops and have been deprecated).

Fixes #9401.