### PR TITLE
Fix: fix file system traversal of theme-loader to stop at root

### DIFF
--- a/flow-server/src/main/resources/plugins/theme-loader/package.json
+++ b/flow-server/src/main/resources/plugins/theme-loader/package.json
@@ -6,7 +6,7 @@
   ],
   "repository": "vaadin/flow",
   "name": "@vaadin/theme-loader",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "theme-loader.js",
   "author": "Vaadin Ltd",
   "license": "Apache-2.0",

--- a/flow-server/src/main/resources/plugins/theme-loader/theme-loader.js
+++ b/flow-server/src/main/resources/plugins/theme-loader/theme-loader.js
@@ -19,8 +19,8 @@ module.exports = function (source, map) {
   const logger = this.getLogger("theme-loader");
 
   let themeFolder = handledResourceFolder;
-  // Recurse up until we have no parent folder or we find the theme folder
-  while (fs.existsSync(path.resolve(themeFolder, ".."))
+  // Recurse up until we find the theme folder or don't have 'theme' on the path.
+  while (themeFolder.indexOf("theme") > 1
       && path.basename(path.resolve(themeFolder, "..")) !== "theme") {
     themeFolder = path.resolve(themeFolder, "..");
   }

--- a/flow-server/src/main/resources/plugins/theme-loader/theme-loader.js
+++ b/flow-server/src/main/resources/plugins/theme-loader/theme-loader.js
@@ -20,7 +20,7 @@ module.exports = function (source, map) {
 
   let themeFolder = handledResourceFolder;
   // Recurse up until we have no parent folder or we find the theme folder
-  while (fs.existsSync(path.basename(path.resolve(themeFolder, "..")))
+  while (fs.existsSync(path.resolve(themeFolder, ".."))
       && path.basename(path.resolve(themeFolder, "..")) !== "theme") {
     themeFolder = path.resolve(themeFolder, "..");
   }

--- a/flow-server/src/main/resources/plugins/theme-loader/theme-loader.js
+++ b/flow-server/src/main/resources/plugins/theme-loader/theme-loader.js
@@ -19,9 +19,17 @@ module.exports = function (source, map) {
   const logger = this.getLogger("theme-loader");
 
   let themeFolder = handledResourceFolder;
-  while (themeFolder && path.basename(path.resolve(themeFolder, "..")) !== "theme") {
+  // Recurse up until we have no parent folder or we find the theme folder
+  while (fs.existsSync(path.basename(path.resolve(themeFolder, "..")))
+      && path.basename(path.resolve(themeFolder, "..")) !== "theme") {
     themeFolder = path.resolve(themeFolder, "..");
   }
+  // If we have found no theme folder return without doing anything.
+  if(path.basename(path.resolve(themeFolder, "..")) !== "theme") {
+    this.callback(null, source, map);
+    return;
+  }
+
   logger.log("Using '", themeFolder, "' for the application theme base folder.");
 
   source = source.replace(urlMatcher, function (match, url, quoteMark, replace, fileUrl, endString) {


### PR DESCRIPTION
The theme-loader recursion for themeFolder should stop
at the root level. Also if no theme folder found we should
not spend time on replacement.