### PR TITLE
Fixed flaky tests caused by gc:ed variable ui in ValidatorTestBase.java

### DIFF
--- a/flow-data/src/test/java/com/vaadin/flow/data/validator/ValidatorTestBase.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/validator/ValidatorTestBase.java
@@ -30,10 +30,11 @@ public class ValidatorTestBase {
 
     private TestLabel localeContext;
     private Locale locale = Locale.US;
+    private UI ui;
 
     @Before
     public void setUp() {
-        UI ui = new UI() {
+        ui = new UI() {
             @Override
             public Locale getLocale() {
                 return locale;


### PR DESCRIPTION
Fixed flaky test that caused by `com.vaadin.flow.component.UI` in class `ValidatorTestBase`. 

- **[Issue]** 
If only run `mvn -pl flow-data test -Dtest=BeanValidatorTest#testInvalidDecimalsFailsInFrench` command, the [`testInvalidDecimalsFailsInFrench`](https://github.com/vaadin/flow/blob/be4ddc785a22728b999e37551bb0d85bb3e4def6/flow-data/src/test/java/com/vaadin/flow/data/validator/BeanValidatorTest.java#L63) will failed because of the incorrect language setup 
    - **error msg**: 
    ```
        [ERROR] Failures: 
        [ERROR] BeanValidatorTest.testInvalidDecimalsFailsInFrench:66->ValidatorTestBase.assertFails:59 expected:<[valeur numérique hors limite (<3 chiffres>.<2 chiffres> attendu])> but was:<[numeric value out of bounds (<3 digits>.<2 digits> expected])>
    ```
    - **solution**: 
Added a `ui` variable in the `ValidatorTestBase` class to attach strong reference, in order to **avoid garbage collecting** it during the test run. 

The flaky test is found by running [iDFlakies](https://github.com/idflakies/iDFlakies), after fixing the issue, there's no flaky tests in `BeanValidatorTest.java`