### PR TITLE
fix: file-loader name for windows execution

### DIFF
--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -210,7 +210,7 @@ module.exports = {
             name(resourcePath, resourceQuery) {
               const urlResource = resourcePath.substring(frontendFolder.length);
               if(urlResource.match(themePartRegex)){
-                return /^(\\|\/)theme\1[\s\S]*?\1(.*)/.exec(urlResource)[2];
+                return /^(\\|\/)theme\1[\s\S]*?\1(.*)/.exec(urlResource)[2].replace(/\\/, "/");
               }
               return '[path][name].[ext]';
             }


### PR DESCRIPTION
Windows file path separator \ should not
be used as it will result in %0B when it should
be /