### PR TITLE
chore: Update contributing guide with setup info

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,149 @@
 # Contributing to Vaadin Flow
 
-*There are many ways to participate to the Vaadin Flow project. You can ask questions and participate to discussion in [gitter](https://gitter.im/vaadin-flow/Lobby), [forum](https://vaadin.com/forum), [fill bug reports](https://github.com/vaadin/flow/issues) and enhancement suggestions and contribute code. These instructions are for contributing code to Flow.*
+*There are many ways to participate to the Vaadin Flow project. You can ask questions and participate to discussion in [Discord](https://discord.com/channels/732335336448852018/774366844684468284), [forum](https://vaadin.com/forum), [fill bug reports](https://github.com/vaadin/flow/issues) and enhancement suggestions and contribute code. These instructions are for contributing code to Flow project itself.*
 
-# Summary
+## TL;DR:
+- [Always setup your project to follow the coding conventions](#project-setup)
+- Always contribute on top of the `master` branch
+- Always write a unit test for the code changes or explain why it is impossible. For browser features, write an integration (TestBench) test (too).
+- [Write a good commit message](#describe-your-changes)
+- Remember: small changes get in faster & solve only one problem per patch
+- Never contribute enhancements / features without discussing it in a github issue first.
+- You can ask for help or feedback in the github issue, draft PR or in [Discord](https://discord.com/channels/732335336448852018/774366844684468284)
+- Threat people with the same respect you would wish them to give to you - it never hurt anyone to be polite.
 
-All fixes should always target the `master` branch. We will pick the bugfixes 
-to correct branches from the `master`.
+
+# Project Setup
+
+Specific details worth mentioning are:
+- Line length is 80 characters
+- Use spaces instead of tabs for indentation
+- Use UTF-8 encoding
+- Use unix-style line endings (\n)
+
+Please follow the instructions below to set up your development environment to follow our coding conventions.
+
+## IntelliJ IDEA
+
+Import the project with `File`->`New`->`Project from existing sources...`.
+
+Then setup the workspace settings:
+
+1. Install the Eclipse Code Formatter plugin, then restart IDEA
+1. Open Settings (Ctrl + Alt + S or CMD + ,)
+1. On the Other Settings / Eclipse Code Formatter page
+  1. Check Use the Eclipse code formatter
+  1. In the  Supported file types section, check Enable Java
+  1. In Eclipse Java Formatter config file, browse to your local copy of [VaadinJavaConventions.xml](https://github.com/vaadin/flow/blob/master/eclipse/VaadinJavaConventions.xml)
+  1. Uncheck Optimize Imports
+1. Go to Editor / Code Style, and set Right margin (columns) to 80
+1. Go to Editor / Code Style / Java and on the Imports tab
+  1. Make sure that Use single class import is checked
+  1. Set both Class count to use import with ‘*’ and Names count to use static import with ‘*’ to 99
+  1. On the Import Layout pane, make sure that Layout static imports separately is checked
+  1. Remove all the packages in the list Packages to Use Import with '*'
+  1. Organize Java imports to comply to the convention defined below.
+1. Go to Editor / Copyright / Copyright Profiles and create a new profile named Vaadin, with the copyright text as defined below
+1. Go one level higher, to Editor / Copyright, and set Default project copyright to the Vaadin profile you just created
+
+[Note]  Although IDEA (since release 13) can import Eclipse formatter settings directly, it seems that for the current VaadinJavaConventions.xml, this doesn’t quite work seamlessly. Until this issues with this have been solved, it is not recommended to go down that path.
+
+#### Import order
+Java imports should be organized in the following order:
+```java
+import javax.*
+import java.*
+<blank line>
+import all other imports
+<blank line>
+import com.google.gwt.*
+import com.vaadin.*
+<blank line>
+import elemental.*
+import static all other imports
+```
+
+#### Copyright notice
+The following copyright should be applied to all source files:
+```
+Copyright 2000-$today.year Vaadin Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy of
+the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+```
+To make IDEA apply it automatically, go to
+`Settings`->`Editor`->`Copyright`->`Copyright Profiles` and add a profile for Vaadin.
+
+## Eclipse
+
+### Import the Project into the Workspace
+
+1. Do *File* -> *Import* -> *General* -> *Existing Maven Project*
+1. Select the *flow* folder (where you cloned the project)
+1. Ensure all projects are checked
+1. Click “finish” to complete the import
+1. Disable HTML and XML validation in the workspace to avoid validating Bower dependencies
+ 1. Eclipse preferences -> *Validation*
+ 1. Uncheck *Build* for *HTML Syntax Validator*
+ 1. Uncheck *Build* for *XML Validator*
+
+Note that the first compilation takes a while to finish as Maven downloads dependencies used in the projects.
+
+### Set up workspace to follow coding conventions
+The following preferences need to be set to keep the project consistent. You need to do this especially to be able to contribute changes to the project.
+
+1. Open *Window* -> *Preferences* (Windows) or *Eclipse* -> *Preferences* (Mac)
+1. On the Java / Code Style / Formatter page, import <flow-root>/eclipse/VaadinJavaConventions.xml
+1. On the Java / Code Style / Organize Imports page, import <flow-root>/eclipse/flow.importorder
+1. On the Java / Code Style / Code Templates page, edit the Comments / Files template to add [the copyright text below](#copyright-text-for-eclipse)
+1. On the Editor / Save Actions tab, make sure that in case Format source code is active, the Format edited lines option is selected. Never use the Format all lines option, as that may introduce loads of unnecessary code changes, making code reviews a nightmare!
+1. Go to *General* ->  *Workspace*
+ 1. Set *Text file encoding* to *UTF-8*
+ 1. Set *New text file line delimiter* to *Unix*
+1. Go to XML -> XML Files -> Editor
+ 1. Ensure the settings are follows:
+<pre><code>Line width: 72
+Format comments: true
+Join lines: true
+Insert whitespace before closing empty end-tags: true
+Indent-using spaces: true
+Indentation size: 4
+</code></pre>
+
+#### Copyright text for Eclipse
+```
+Copyright 2000-${currentDate:date('yyyy')} Vaadin Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy of
+the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+```
+
+## VSCode
+
+Introductions for making contributions with VSCode are not done - to be contributed by someone who knows how to set it up to follow the same conventions as with IDEA / Eclipse above.
+
+# Contributing a patch
+
+All contributions should target the `master` branch. We will pick the changes 
+to correct version branches from the `master`. **For enhancements and new features, you should always first discuss it in an github issue, to make sure it acceptable. The enhancement should have an Acceptance Criteria written to it that states what is needed to be done.**
 
 We like quality patches that solve problems. A quality patch follows good coding practices - it’s easy to read and understand. For more complicated fixes or features, the change should be broken down into several smaller easy to understand patches. Most of this is really just what we consider to be common sense and best development practices.
 
@@ -21,39 +159,31 @@ In other words:
  * Don't get discouraged - or impatient: reviewers are people too and will sometimes forget. Give them a friendly poke if you feel the PR has been forgotten about. 
  * Most PRs take a few iterations of review before they are merged. 
 
-# We encourage you to get in touch
+### We encourage you to get in touch
 
-Getting in touch with us on the [gitter](https://gitter.im/vaadin-flow/Lobby) is the best place to start. We’re more than happy to help you get started, and we’re happy to engage in conversation about feature suggestions and bug fixes. We welcome contributors and contributions and we’re here to help.
+Commenting on the issue you want to work on or getting in touch with us on [Discord](https://discord.com/channels/732335336448852018/774366844684468284) before starting. We’re more than happy to help you get started, and we’re happy to engage in conversation about feature suggestions and bug fixes. We welcome contributors and contributions and we’re here to help. But please don't expect us to answer immediately, as we have other work to do too.
 
-Getting in touch with us early will also help us co-ordinate efforts so that not everyone ends up working on the same bug or feature at the same time.
+Getting in touch with us early will help in getting the fix or implementation right and reduces time in review.
 
-# Obtain a current source tree
+### Describe your changes
 
-The Flow repository can be cloned using `git clone git@github.com:vaadin/flow.git` or using your favorite Git tool.
+Properly formed Git commit subject line should always be able to complete the following sentence:
 
-Remember to do `git checkout master` and `git pull` to make sure you are creating your commits on top of a recent enough version. 
+```If applied, this commit will <your subject line here>```
 
-https://robots.thoughtbot.com/keeping-a-github-fork-updated has instructions on how to keep your local fork up to date.
-
-## Set up your development environment
-
-To set up the project to your IDE, follow the instructions in the [README.md](https://github.com/vaadin/flow/blob/master/README.md).
-
-# Describe your changes
-
-## Describe your problem
+#### Describe your problem
 
 Whether your patch is a one-line bug fix or 5000 lines of a new feature, there must be an underlying problem that motivated you to do this work. Convince the reviewer that there is a problem worth fixing and that it makes sense for them to read past the first paragraph. This is often already described in bug/enhancement issue, but also summarise it in your commit message.
 
-## Describe user-visible impact
+#### Describe user-visible impact
 
-Straight up crashes and lockups are pretty convincing, but not all bugs are that blatant.  Even if the problem was spotted during code review, describe the impact you think it can have on users. 
+Straight up crashes and lockups are pretty convincing, but not all bugs are that blatant. Even if the problem was spotted during code review, describe the impact you think it can have on users. 
 
-## Describe the solution
+#### Describe the solution
 
 Once the problem is established, describe what you are actually doing about it in technical detail.  It's important to describe the change in plain English for the reviewer to verify that the code is behaving as you intend it to.
 
-## Solve only one problem per patch
+#### Solve only one problem per patch
 
 If your description starts to get long, that's a sign that you probably need to split up your patch. See “Only one logical change per patch”.
 
@@ -61,7 +191,7 @@ Describe your changes in imperative mood, e.g. "make xyzzy do frotz". If the pat
 
 However, try to make your explanation understandable without external resources.  In addition to giving a URL to a ticket or bug description, summarise the relevant points of the discussion that led to the patch as submitted.
 
-# Separate your changes
+### Separate your changes
 
 Separate all enhancements, fixes and new features into different pull requests.
 
@@ -75,35 +205,42 @@ If one patch depends on another patch in order for a change to be complete, that
 
 When dividing your change into a series of patches, take special care to ensure that the project builds and runs properly after each patch in the series.  Developers using "git bisect" to track down a problem can end up splitting your patch series at any point; they will not thank you if you introduce bugs in the middle. Compilation failures are especially annoying to deal with. 
 
-# Style-check your changes
+### Style-check your changes
 
-Check your patch for basic style violations. If you use Eclipse, use the formatting rules preconfigured in the project to make life easier for all involved, and configure save actions as described in [README.md](https://github.com/vaadin/flow/blob/master/README.md). 
-
+Check your patch for basic style violations. There should be none [if you have setup your project correctly following the instructions](#project-setup).
 Patches causing unnecessary style/whitespace changes are messy and will likely be bounced back. 
 
-If you are touching old files and want to update them to current style conventions, please do so in a separate commit. It is usually best to have this commit be the first in the series.
+**If you are touching old files and want to update them to current style conventions, please do so in a separate commit/PR. It is usually best to have this commit be the first in the series.**
 
-# Example of a good commit message
+### Writing a good commit message
 
-    Create a Valo icon font for icons used in Valo (#18472)
+Here is an example:
+
+    feat: Create a Valo icon font for icons in Valo
     
     Valo uses only a handful of icons from Font Awesome. This change introduces a separate icon font for valo (9KB instead of 80KB) and decouples Valo from Font Awesome to enable updating Font Awesome without taking Valo into account.
     
     This change also makes it easy to not load Font Awesome when using Valo by setting $v-font-awesome:false
     
-    For backwards compatibility, Font Awesome is loaded by default
+    For backwards compatibility, Font Awesome is loaded by default.
+    
+    Fixes #18472
 
-## Example breakdown
+#### Example breakdown - subject line
 
-Start with a good Commit message in imperative form. Reference a ticket number if applicable: 
+    feat: Create a Valo icon font for icons in Valo
 
-    Create a Valo icon font for icons used in Valo (#18472)
+Start with a good subject message in imperative form with 50 chars or less. A properly formed Git commit subject line should always be able to complete the following sentence:
 
-### Describe the problem:
+If applied, this commit will <your subject line here>
+    
+Pending if type of changes you are doing, the subject line should start with either `feat/fix/chore/refactor`. In case there are breaking changes, use ! after the prefix, like `refactor!:`. In case you don't know what to write there, let the reviewer do it when merging the PR.
+
+#### Describe the problem:
 
     Valo uses only a handful of icons from Font Awesome.
 
-### Describe the user impact & describe what was done to solve the problem:
+#### Describe the user impact & describe what was done to solve the problem:
 
     This change introduces a separate icon font for valo (9KB instead of 80KB) and decouples Valo from Font Awesome to enable updating Font Awesome without taking Valo into account.
     
@@ -111,9 +248,18 @@ Start with a good Commit message in imperative form. Reference a ticket number i
     
     For backwards compatibility, Font Awesome is loaded by default
 
-# Include a test
+#### Reference the issue
 
-Ideally, we would like all patches to include automated tests. Unit tests are preferred. If there’s a change to UI Code, we would prefer an integration test. 
+Reference an issue number using [the magic words](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) to close the issue:
+```
+Fixes #18472
+```
+If the issue is not closed by this PR, you can still refer to it with e.g. `Part of #1234`.
+In case the issue is in another repository, you can link to it with the syntax: `Part of vaadin/spring#1234` where the first part is for the organization, the second for the repository followed by the issue (or PR) number there.
+
+### Include a test
+
+Ideally, we would like all patches to include automated tests. Unit tests are preferred. If there’s a change to UI Code, we would additionally prefer an integration test.
 
 Our integration tests use TestBench that requires a license. If you don't have any, it's ok: we can make do with a Test UI class that contains a test case as well a clear instructions for how to perform the test.
 This also goes for features that are hard to test automatically.
@@ -126,7 +272,7 @@ If the patch is a performance improvement, please include some benchmark data th
 
 If you can clearly prove that the patch works, it dramatically increases the odds of it being included in a quick and timely fashion.
 
-# Respond to review comments
+### Respond to review comments
 
 Your pull request will almost certainly get comments from reviewers on ways in which the patch can be improved.  You must respond to those comments; ignoring reviewers is a good way to get ignored in return.  Review comments or questions that do not lead to a code change should almost certainly bring about a comment or changelog entry so that the next reviewer better understands what is going on.
 
@@ -134,15 +280,23 @@ Be sure to tell the reviewers what changes you are making. Respond politely to c
 
 If there is feedback that is blocking merging of the pull request, and there is no response from the author in a reasonable time, we may reject it. You are then of course free to resubmit the pull request. The rejection is done not out of spite, but to keep the queue of incoming pull requests manageable and to prevent the queue from spiraling out of control. 
 
-# Don't get discouraged - or impatient.
+### Don't get discouraged - or impatient.
 
 After you have submitted your change, be patient and wait.  Reviewers are busy people and may not get to your patch right away. Ideally, we try to get a response within one business day.
 
 You should receive comments within a week or so; if that does not happen, make sure that you have sent your patches to the right place.  Wait for a minimum of one week before resubmitting or pinging reviewers - possibly longer during busy times like merge windows for minor or major release versions. 
 
-# Submitting the patches
+## Submitting the patches
 
-## Creating a pull request in GitHub
+### Obtain a current source tree
+
+The Flow repository can be cloned using `git clone git@github.com:vaadin/flow.git` or using your favorite Git tool.
+
+Remember to do `git checkout master` and `git pull` to make sure you are creating your commits on top of a recent enough version. 
+
+https://robots.thoughtbot.com/keeping-a-github-fork-updated has instructions on how to keep your local fork up to date.
+
+### Creating a pull request in GitHub
 
 All our projects accept contributions as GitHub pull requests. The first time you create a pull request, you will be asked to electronically sign a contribution agreement.
 
@@ -151,3 +305,49 @@ https://yangsu.github.io/pull-request-tutorial/ has instructions on how to creat
 Please note that PR should target the `master` branch. 
 
 **Remember to check the "Allow edits from maintainers" so we can rebase the PR or make small changes if necessary**.
+
+# Tips for contributing code
+
+## Running tests
+The unit tests for the projects can be run using
+<pre><code>mvn test</code></pre> or by selecting the test class in IDE and running it there.
+
+IT tests can be run with
+<pre><code>mvn verify</code></pre> or by starting the Jetty for the IT module with `jetty:run` and then runnign the test class in IDE.
+
+To run IT tests locally, you'll need a [Testbench](https://vaadin.com/testbench) license and a Chrome browser installed (currently this is the only browser that IT tests are run in).
+If you don't have the license, it's ok, our CI system will run those tests for you after you create a pull request. 
+Refer to the [contribution guide](/CONTRIBUTING.md) for details. 
+
+When running IT tests locally, by default, local Chrome is used to run tests, make sure it's installed.
+
+## Building a package
+The distribution package is built and installed into the local Maven repository by doing
+
+1. mvn install
+
+## Running SuperDevMode
+Some flow internals use GWT in the client code. superDevMode allows to reload GWT changes on the fly, but it requires some setup first.
+
+To start superDevMode do the following:
+
+1. Get flow source code
+1. If you are planning to launch the mode for the external application based on flow, first make sure that flow source code is of the same version as the application uses.
+If it's not true, either update the application dependencies or check out the corresponding flow tag and rebuild both flow and the application.
+1. Navigate to flow-client package in flow project
+1. Run `mvn -Psdm clean install gwt:compile gwt:run-codeserver -DskipTests`
+1. Start the application server
+1. Open the application page and use the bookmarks to control dev mode
+If you have no bookmarks, navigate to http://localhost:9876 to setup them.
+
+Alternatively, in Eclipse run .launch files from flow-client/eclipse in the order:
+
+1. Compile ClientEngine.launch
+2. Super Dev Mode.launch
+
+> NOTE! SuperDevMode should be compiled before the application server is launched,
+> also, Flow version should match with the application one
+> as else the application won't be able to run SDM and you will receive the
+> exception `Can't find any GWT Modules on this page.`
+
+More info about SuperDevMode: http://www.gwtproject.org/articles/superdevmode.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -327,6 +327,9 @@ The distribution package is built and installed into the local Maven repository 
 1. mvn install
 
 ## Running SuperDevMode
+
+**NOTE The following instructions are outdated and need further tweaking to get SDM running.**
+
 Some flow internals use GWT in the client code. superDevMode allows to reload GWT changes on the fly, but it requires some setup first.
 
 To start superDevMode do the following:

--- a/README.md
+++ b/README.md
@@ -6,11 +6,9 @@ Vaadin Flow
 
 **For instructions about developing web applications with Vaadin Flow**, please refer to [the starter packs for Vaadin 14 with Flow](https://vaadin.com/start) or [the documentation](https://vaadin.com/docs/flow/Overview.html).
 
-To contribute, first refer to [Contribution Guide](/CONTRIBUTING.md) for general instructions and requirements for contributing code to Flow.
+**To contribute, first refer to [Contribution Guide](/CONTRIBUTING.md) for general instructions and requirements for contributing code to Flow.**
 
 Join Vaadin Flow community chat in https://discord.gg/MYFq5RTbBn
-
-Instructions on how to set up a working environment for developing the Flow project follow below.
 
 The `master` branch is the latest version (6.0) that will at some point be released in the [Vaadin platform 19.0](https://github.com/vaadin/platform). See other branches for other framework versions:
 
@@ -28,90 +26,4 @@ The `master` branch is the latest version (6.0) that will at some point be relea
 |  3.1   |  16.0.x                                                         |  3.1.x                                                  |
 |  4.0   |  17.0.x                                                         |  4.x                                                    |
 |  5.0   |  18.0.x                                                         |  5.x                                                    |
-
-Setting up Eclipse to Develop Flow
-=========
-
-Import the Project into the Workspace
-------------
-1. Do *File* -> *Import* -> *General* -> *Existing Maven Project*
-1. Select the *flow* folder (where you cloned the project)
-1. Ensure all projects are checked
-1. Click “finish” to complete the import
-1. Disable HTML and XML validation in the workspace to avoid validating Bower dependencies
- 1. Eclipse preferences -> *Validation*
- 1. Uncheck *Build* for *HTML Syntax Validator*
- 1. Uncheck *Build* for *XML Validator*
-
-
-Note that the first compilation takes a while to finish as Maven downloads dependencies used in the projects.
-
-Compiling the Client Engine
---------
-Compile the client engine by executing the Eclipse build configuration *Compile ClientEngine* in *flow-client/eclipse*
-
-Set up extra workspace preferences
---------
-The following preferences need to be set to keep the project consistent. You need to do this especially to be able to contribute changes to the project.
-
-1. Open *Window* -> *Preferences* (Windows) or *Eclipse* -> *Preferences* (Mac)
-1. Go to *General* ->  *Workspace*
- 1. Set *Text file encoding* to *UTF-8*
- 1. Set *New text file line delimiter* to *Unix*
-1. Go to XML -> XML Files -> Editor
- 1. Ensure the settings are follows:
-<pre><code>Line width: 72
-Format comments: true
-Join lines: true
-Insert whitespace before closing empty end-tags: true
-Indent-using spaces: true
-Indentation size: 4
-</code></pre>
-
-Running tests
-=====
-The unit tests for the projects can be run using
-<pre><code>mvn test</code></pre>
-
-IT tests can be run with
-<pre><code>mvn verify</code></pre>
-
-To run IT tests locally, you'll need a [Testbench](https://vaadin.com/testbench) license and a Chrome browser installed (currently this is the only browser that IT tests are run in).
-If you don't have the license, it's ok, our CI system will run those tests for you after you create a pull request. 
-Refer to the [contribution guide](/CONTRIBUTING.md) for details. 
-
-When running IT tests locally, by default, local Chrome is used to run tests, make sure it's installed.
-
-Building a package
-=====
-The distribution package is built and installed into the local Maven repository by doing
-
-1. mvn install
-
-Running SuperDevMode
-=====
-Some flow internals use GWT in the client code. superDevMode allows to reload GWT changes on the fly, but it requires some setup first.
-
-To start superDevMode do the following:
-
-1. Get flow source code
-1. If you are planning to launch the mode for the external application based on flow, first make sure that flow source code is of the same version as the application uses.
-If it's not true, either update the application dependencies or check out the corresponding flow tag and rebuild both flow and the application.
-1. Navigate to flow-client package in flow project
-1. Run `mvn -Psdm clean install gwt:compile gwt:run-codeserver -DskipTests`
-1. Start the application server
-1. Open the application page and use the bookmarks to control dev mode
-If you have no bookmarks, navigate to http://localhost:9876 to setup them.
-
-In eclipse run .launch files from flow-client/eclipse in the order:
-
-1. Compile ClientEngine.launch
-2. Super Dev Mode.launch
-
-> NOTE! SuperDevMode should be compiled before the application server is launched,
-> also, flow version should match with the application one
-> as else the application won't be able to run SDM and you will receive the
-> exception `Can't find any GWT Modules on this page.`
-
-More info about SuperDevMode: http://www.gwtproject.org/articles/superdevmode.html
 


### PR DESCRIPTION
The contribution guide was missing the project setup information.

There were outdated instructions in the readme, which was on the other hand not up to date and only had instructions for Eclipse.
