### PR TITLE
Cherry pick to 5.0

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataView.java
@@ -132,6 +132,11 @@ public abstract class AbstractDataView<T> implements DataView<T> {
     }
 
     @Override
+    public void refreshAll() {
+        dataProviderSupplier.get().refreshAll();
+    }
+
+    @Override
     public void setIdentifierProvider(
             IdentifierProvider<T> identifierProvider) {
         Objects.requireNonNull(identifierProvider,

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataView.java
@@ -74,6 +74,11 @@ public interface DataView<T> extends Serializable {
     void refreshItem(T item);
 
     /**
+     * Notifies the component that all the items should be refreshed.
+     */
+    void refreshAll();
+
+    /**
      * Add an item count change listener that is fired when the item count
      * changes. This can happen for instance when filtering the items.
      * <p>

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractDataViewTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractDataViewTest.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.component.Component;
@@ -86,6 +87,19 @@ public class AbstractDataViewTest {
                 .fireEvent(component, new ItemCountChangeEvent<>(component, 10, false));
 
         Assert.assertEquals(10, fired.get());
+    }
+
+    @Test
+    public void refreshAll_listenersNotified() {
+        AtomicReference<DataChangeEvent<Item>> refreshAllEvent =
+                new AtomicReference<>();
+        dataProvider.addDataProviderListener(event -> {
+            Assert.assertNull(refreshAllEvent.get());
+            refreshAllEvent.set(event);
+        });
+        dataView.refreshAll();
+        Assert.assertNotNull(refreshAllEvent.get());
+        Assert.assertEquals(dataProvider, refreshAllEvent.get().getSource());
     }
 
     /**

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HasHierarchicalDataProviderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HasHierarchicalDataProviderTest.java
@@ -121,6 +121,11 @@ public class HasHierarchicalDataProviderTest {
         }
 
         @Override
+        public void refreshAll() {
+
+        }
+
+        @Override
         public TestListDataView addItems(Collection<String> items) {
             return null;
         }


### PR DESCRIPTION
Adds the missed refresh all method to data view API.

Fixes: #9574
(cherry picked from commit c60b51bd775a036982af580998e89097e165751c)