### PR TITLE
fix: reorder manifest and compression plugins

### DIFF
--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -256,10 +256,14 @@ module.exports = {
     maxAssetSize: 2097152 // 2MB
   },
   plugins: [
-    // Generate compressed bundles when not devMode
-    !devMode && new CompressionPlugin(),
+    // Service worker for offline
+    pwaEnabled && serviceWorkerPlugin,
+
     // Generate manifest.json file
     new ManifestPlugin(),
+
+    // Generate compressed bundles when not devMode
+    !devMode && new CompressionPlugin(),
 
     new ApplicationThemePlugin({
       themeResourceFolder: path.resolve(flowFrontendFolder, 'theme'),
@@ -285,7 +289,5 @@ module.exports = {
     useClientSideIndexFileForBootstrapping && new ScriptExtHtmlWebpackPlugin({
       defaultAttribute: 'defer'
     }),
-    // Service worker for offline
-    pwaEnabled && serviceWorkerPlugin,
   ].filter(Boolean)
 };

--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -325,6 +325,7 @@
                 <module>test-mixed/pom-npm.xml</module>
                 <module>test-dev-mode</module>
                 <module>test-pwa</module>
+                <module>test-pwa/pom-production.xml</module>
                 <module>test-root-ui-context</module>
                 <module>test-router-custom-context</module>
                 <module>test-live-reload</module>
@@ -351,6 +352,7 @@
                 <module>test-ccdm</module>
                 <module>test-ccdm/pom-production.xml</module>
                 <module>test-ccdm-flow-navigation</module>
+                <module>test-ccdm-flow-navigation/pom-production.xml</module>
 
                 <module>test-root-context</module>
 

--- a/flow-tests/test-ccdm-flow-navigation/pom-production.xml
+++ b/flow-tests/test-ccdm-flow-navigation/pom-production.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.vaadin</groupId>
+        <artifactId>flow-tests</artifactId>
+        <version>6.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>test-ccdm-flow-navigation-prod</artifactId>
+    <name>Test navigation between ts and java views (production mode)</name>
+    <version>6.0-SNAPSHOT</version>
+    <packaging>war</packaging>
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-html-components-testbench</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- This module is mapped to default web context -->
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <configuration>
+                    <systemProperties>
+                        <systemProperty>
+                            <!-- make sure we do not leave webpack-dev-server running after IT -->
+                            <name>vaadin.reuseDevServer</name>
+                            <value>false</value>
+                        </systemProperty>
+                    </systemProperties>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>flow-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-frontend</goal>
+                            <goal>build-frontend</goal>
+                        </goals>
+                        <phase>compile</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <productionMode>true</productionMode>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <profiles>
+        <profile>
+            <id>local-run</id>
+            <activation>
+                <property>
+                    <name>!test.use.hub</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.lazerycode.selenium</groupId>
+                        <artifactId>driver-binary-downloader-maven-plugin
+                        </artifactId>
+                        <version>
+                            ${driver.binary.downloader.maven.plugin.version}
+                        </version>
+                        <configuration>
+                            <onlyGetDriversForHostOperatingSystem>true
+                            </onlyGetDriversForHostOperatingSystem>
+                            <rootStandaloneServerDirectory>
+                                ${project.rootdir}/driver
+                            </rootStandaloneServerDirectory>
+                            <downloadedZipFileDirectory>
+                                ${project.rootdir}/driver_zips
+                            </downloadedZipFileDirectory>
+                            <customRepositoryMap>
+                                ${project.rootdir}/drivers.xml
+                            </customRepositoryMap>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>selenium</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/flow-tests/test-pwa/pom-production.xml
+++ b/flow-tests/test-pwa/pom-production.xml
@@ -22,13 +22,6 @@
             <artifactId>flow-test-resources</artifactId>
             <version>${project.version}</version>
         </dependency>
-
-        <dependency>
-            <groupId>com.google.gwt</groupId>
-            <artifactId>gwt-dev</artifactId>
-            <version>2.8.2</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/flow-tests/test-pwa/pom-production.xml
+++ b/flow-tests/test-pwa/pom-production.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>flow-tests</artifactId>
+        <groupId>com.vaadin</groupId>
+        <version>6.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>flow-test-pwa-prod</artifactId>
+    <name>Flow tests for PWA annotation (production mode)</name>
+
+    <packaging>war</packaging>
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-test-resources</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.gwt</groupId>
+            <artifactId>gwt-dev</artifactId>
+            <version>2.8.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>flow-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-frontend</goal>
+                            <goal>build-frontend</goal>
+                        </goals>
+                        <phase>compile</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <productionMode>true</productionMode>
+                </configuration>
+            </plugin>
+            <!-- This module is mapped to default web context -->
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>${jetty.version}</version>
+                <configuration>
+                    <webApp>
+                        <baseResource implementation="org.eclipse.jetty.util.resource.ResourceCollection">
+                            <resourcesAsCSV>${project.basedir}/public,${project.basedir}/src/main/webapp</resourcesAsCSV>
+                        </baseResource>
+                    </webApp>
+                </configuration>
+
+                <executions>
+                    <!-- start and stop jetty (running our app) when running
+                        integration tests -->
+                    <execution>
+                        <id>start-jetty</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>stop-jetty</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>local-run</id>
+            <activation>
+                <property>
+                    <name>!test.use.hub</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.lazerycode.selenium</groupId>
+                        <artifactId>driver-binary-downloader-maven-plugin</artifactId>
+                        <version>${driver.binary.downloader.maven.plugin.version}</version>
+                        <configuration>
+                            <onlyGetDriversForHostOperatingSystem>true</onlyGetDriversForHostOperatingSystem>
+                            <rootStandaloneServerDirectory>${project.rootdir}/driver</rootStandaloneServerDirectory>
+                            <downloadedZipFileDirectory>${project.rootdir}/driver_zips</downloadedZipFileDirectory>
+                            <customRepositoryMap>${project.rootdir}/drivers.xml</customRepositoryMap>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>selenium</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/flow-tests/test-pwa/pom.xml
+++ b/flow-tests/test-pwa/pom.xml
@@ -22,13 +22,6 @@
             <artifactId>flow-test-resources</artifactId>
             <version>${project.version}</version>
         </dependency>
-
-        <dependency>
-            <groupId>com.google.gwt</groupId>
-            <artifactId>gwt-dev</artifactId>
-            <version>2.8.2</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/flow-tests/test-pwa/src/test/java/com/vaadin/flow/pwatest/ui/PwaTestIT.java
+++ b/flow-tests/test-pwa/src/test/java/com/vaadin/flow/pwatest/ui/PwaTestIT.java
@@ -196,8 +196,6 @@ public class PwaTestIT extends ChromeDeviceTest {
 
     @Test
     public void compareUncompressedAndCompressedServiceWorkerJS() throws IOException {
-        open();
-
         // test only in production mode
         Assume.assumeTrue(isProductionMode());
 

--- a/flow-tests/test-pwa/src/test/java/com/vaadin/flow/pwatest/ui/PwaTestIT.java
+++ b/flow-tests/test-pwa/src/test/java/com/vaadin/flow/pwatest/ui/PwaTestIT.java
@@ -199,9 +199,7 @@ public class PwaTestIT extends ChromeDeviceTest {
         open();
 
         // test only in production mode
-        boolean devMode = (boolean) getCommandExecutor().executeScript(
-                "return window.Vaadin && !!window.Vaadin.developmentMode;");
-        Assume.assumeFalse(devMode);
+        Assume.assumeTrue(isProductionMode());
 
         byte[] uncompressed = readBytesFromUrl(getRootURL() + "/sw.js");
         byte[] compressed = readBytesFromUrl(getRootURL() + "/sw.js.gz");
@@ -271,5 +269,10 @@ public class PwaTestIT extends ChromeDeviceTest {
         }
         buffer.flush();
         return buffer.toByteArray();
+    }
+
+    private boolean isProductionMode() throws IOException {
+        JsonObject stats = readJsonFromUrl(getRootURL() + "/VAADIN/stats.json?v-r=init");
+        return stats.getObject("appConfig").getBoolean("productionMode");
     }
 }

--- a/flow-tests/test-pwa/src/test/java/com/vaadin/flow/pwatest/ui/PwaTestIT.java
+++ b/flow-tests/test-pwa/src/test/java/com/vaadin/flow/pwatest/ui/PwaTestIT.java
@@ -28,6 +28,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import elemental.json.Json;
+import elemental.json.JsonObject;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
@@ -35,14 +37,12 @@ import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.mobile.NetworkConnection;
 
-import com.google.gwt.thirdparty.json.JSONException;
-import com.google.gwt.thirdparty.json.JSONObject;
 import com.vaadin.flow.testutil.ChromeDeviceTest;
 
 public class PwaTestIT extends ChromeDeviceTest {
 
     @Test
-    public void testPwaResources() throws IOException, JSONException {
+    public void testPwaResources() throws IOException {
         open();
         WebElement head = findElement(By.tagName("head"));
 
@@ -83,7 +83,7 @@ public class PwaTestIT extends ChromeDeviceTest {
         String href = elements.get(0).getAttribute("href");
         Assert.assertTrue(href + " didn't respond with resource", exists(href));
         // Verify user values in manifest.webmanifest
-        JSONObject manifest = readJsonFromUrl(href);
+        JsonObject manifest = readJsonFromUrl(href);
         Assert.assertEquals(ParentLayout.PWA_NAME, manifest.getString("name"));
         Assert.assertEquals(ParentLayout.PWA_SHORT_NAME,
                 manifest.getString("short_name"));
@@ -245,8 +245,8 @@ public class PwaTestIT extends ChromeDeviceTest {
         }
     }
 
-    private static JSONObject readJsonFromUrl(String url)
-            throws IOException, JSONException {
-        return new JSONObject(readStringFromUrl(url));
+    private static JsonObject readJsonFromUrl(String url)
+            throws IOException {
+        return Json.parse(readStringFromUrl(url));
     }
 }

--- a/flow-tests/test-pwa/src/test/java/com/vaadin/flow/pwatest/ui/PwaTestIT.java
+++ b/flow-tests/test-pwa/src/test/java/com/vaadin/flow/pwatest/ui/PwaTestIT.java
@@ -18,7 +18,7 @@ package com.vaadin.flow.pwatest.ui;
 import java.io.*;
 import java.net.URL;
 import java.net.URLConnection;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -37,7 +37,6 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.mobile.NetworkConnection;
 
 import com.vaadin.flow.testutil.ChromeDeviceTest;
-import sun.misc.IOUtils;
 
 public class PwaTestIT extends ChromeDeviceTest {
 
@@ -206,7 +205,7 @@ public class PwaTestIT extends ChromeDeviceTest {
 
         byte[] uncompressed = readBytesFromUrl(getRootURL() + "/sw.js");
         byte[] compressed = readBytesFromUrl(getRootURL() + "/sw.js.gz");
-        byte[] decompressed = IOUtils.readAllBytes(
+        byte[] decompressed = readAllBytes(
                 new GZIPInputStream(new ByteArrayInputStream(compressed)));
         Assert.assertArrayEquals(uncompressed, decompressed);
     }
@@ -249,16 +248,7 @@ public class PwaTestIT extends ChromeDeviceTest {
     }
 
     private static String readStringFromUrl(String url) throws IOException {
-        try (InputStream is = new URL(url).openStream()) {
-            BufferedReader rd = new BufferedReader(
-                    new InputStreamReader(is, Charset.forName("UTF-8")));
-            StringBuilder sb = new StringBuilder();
-            int cp;
-            while ((cp = rd.read()) != -1) {
-                sb.append((char) cp);
-            }
-            return sb.toString();
-        }
+        return new String(readAllBytes(new URL(url).openStream()), StandardCharsets.UTF_8);
     }
 
     private static JsonObject readJsonFromUrl(String url)
@@ -268,7 +258,18 @@ public class PwaTestIT extends ChromeDeviceTest {
 
     private static byte[] readBytesFromUrl(String url) throws IOException {
         try (InputStream is = new URL(url).openStream()) {
-            return IOUtils.readAllBytes(is);
+            return readAllBytes(is);
         }
+    }
+
+    private static byte[] readAllBytes(InputStream inputStream) throws IOException {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        int count;
+        byte[] data = new byte[1024];
+        while ((count = inputStream.read(data, 0, data.length)) != -1) {
+            buffer.write(data, 0, count);
+        }
+        buffer.flush();
+        return buffer.toByteArray();
     }
 }

--- a/flow-tests/test-pwa/src/test/java/com/vaadin/flow/pwatest/ui/PwaTestIT.java
+++ b/flow-tests/test-pwa/src/test/java/com/vaadin/flow/pwatest/ui/PwaTestIT.java
@@ -208,7 +208,7 @@ public class PwaTestIT extends ChromeDeviceTest {
         byte[] compressed = readBytesFromUrl(getRootURL() + "/sw.js.gz");
         byte[] decompressed = IOUtils.readAllBytes(
                 new GZIPInputStream(new ByteArrayInputStream(compressed)));
-        Assert.assertArrayEquals(decompressed, uncompressed);
+        Assert.assertArrayEquals(uncompressed, decompressed);
     }
 
     @Override


### PR DESCRIPTION
Also run offline test modules (`test-pwa` and `test-ccdm-flow-navigation`) in production mode.

Fixes #9457.