### PR TITLE
Fix: theme files can now be referenced as theme/theme-name

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.server;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -59,6 +58,7 @@ import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_WE
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_WEBPACK_OPTIONS;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_WEBPACK_SUCCESS_PATTERN;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_WEBPACK_TIMEOUT;
+import static com.vaadin.flow.server.StaticFileServer.themeFolder;
 import static com.vaadin.flow.server.frontend.FrontendUtils.GREEN;
 import static com.vaadin.flow.server.frontend.FrontendUtils.RED;
 import static com.vaadin.flow.server.frontend.FrontendUtils.commandToString;
@@ -285,9 +285,9 @@ public final class DevModeHandler implements RequestHandler {
      */
     public boolean isDevModeRequest(HttpServletRequest request) {
         String pathInfo = request.getPathInfo();
-        return pathInfo != null && pathInfo.startsWith("/" + VAADIN_MAPPING)
-                && !pathInfo
-                        .startsWith("/" + StreamRequestHandler.DYN_RES_PREFIX);
+        return pathInfo != null && (pathInfo.startsWith("/" + VAADIN_MAPPING)
+            || themeFolder.matcher(pathInfo).find()) && !pathInfo
+            .startsWith("/" + StreamRequestHandler.DYN_RES_PREFIX);
     }
 
     /**
@@ -323,6 +323,11 @@ public final class DevModeHandler implements RequestHandler {
                     requestFilename);
             response.setStatus(HttpServletResponse.SC_FORBIDDEN);
             return true;
+        }
+
+        // Redirect theme source request
+        if(themeFolder.matcher(requestFilename).find()) {
+            requestFilename = "/VAADIN/static" + requestFilename;
         }
 
         HttpURLConnection connection = prepareConnection(requestFilename,

--- a/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
@@ -58,7 +58,7 @@ import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_WE
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_WEBPACK_OPTIONS;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_WEBPACK_SUCCESS_PATTERN;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_WEBPACK_TIMEOUT;
-import static com.vaadin.flow.server.StaticFileServer.themeFolder;
+import static com.vaadin.flow.server.StaticFileServer.APP_THEME_PATTERN;
 import static com.vaadin.flow.server.frontend.FrontendUtils.GREEN;
 import static com.vaadin.flow.server.frontend.FrontendUtils.RED;
 import static com.vaadin.flow.server.frontend.FrontendUtils.commandToString;
@@ -286,7 +286,7 @@ public final class DevModeHandler implements RequestHandler {
     public boolean isDevModeRequest(HttpServletRequest request) {
         String pathInfo = request.getPathInfo();
         return pathInfo != null && (pathInfo.startsWith("/" + VAADIN_MAPPING)
-            || themeFolder.matcher(pathInfo).find()) && !pathInfo
+            || APP_THEME_PATTERN.matcher(pathInfo).find()) && !pathInfo
             .startsWith("/" + StreamRequestHandler.DYN_RES_PREFIX);
     }
 
@@ -326,7 +326,7 @@ public final class DevModeHandler implements RequestHandler {
         }
 
         // Redirect theme source request
-        if(themeFolder.matcher(requestFilename).find()) {
+        if(APP_THEME_PATTERN.matcher(requestFilename).find()) {
             requestFilename = "/VAADIN/static" + requestFilename;
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
@@ -57,7 +57,8 @@ public class StaticFileServer implements StaticFileHandler {
     private DeploymentConfiguration deploymentConfiguration;
 
     // Matcher to match string starting with '/theme/[theme-name]/'
-    protected static final Pattern themeFolder = Pattern.compile("^\\/theme\\/[\\s\\S]*?\\/");
+    protected static final Pattern APP_THEME_PATTERN = Pattern
+        .compile("^\\/theme\\/[\\s\\S]+?\\/");
 
     /**
      * Constructs a file server.
@@ -83,8 +84,9 @@ public class StaticFileServer implements StaticFileHandler {
             return false;
         }
 
-        if (themeFolder.matcher(requestFilename).find() || requestFilename.startsWith("/" + VAADIN_STATIC_FILES_PATH)
-                || requestFilename.startsWith("/" + VAADIN_BUILD_FILES_PATH)) {
+        if (APP_THEME_PATTERN.matcher(requestFilename).find() || requestFilename
+            .startsWith("/" + VAADIN_STATIC_FILES_PATH) || requestFilename
+            .startsWith("/" + VAADIN_BUILD_FILES_PATH)) {
             // The path is reserved for internal resources only
             // We rather serve 404 than let it fall through
             return true;
@@ -114,7 +116,7 @@ public class StaticFileServer implements StaticFileHandler {
 
         URL resourceUrl = null;
         if (isAllowedVAADINBuildOrStaticUrl(filenameWithPath)) {
-            if(themeFolder.matcher(filenameWithPath).find()) {
+            if(APP_THEME_PATTERN.matcher(filenameWithPath).find()) {
                 resourceUrl = servletService.getClassLoader()
                     .getResource("META-INF/VAADIN/static" + filenameWithPath);
             } else {
@@ -203,9 +205,10 @@ public class StaticFileServer implements StaticFileHandler {
      * @return true if we are ok to try serving the file
      */
     private boolean isAllowedVAADINBuildOrStaticUrl(String filenameWithPath) {
-        // Check that we target VAADIN/build
-        return filenameWithPath.startsWith("/" + VAADIN_BUILD_FILES_PATH) || filenameWithPath.startsWith("/" + VAADIN_STATIC_FILES_PATH)
-            || themeFolder.matcher(filenameWithPath).find();
+        // Check that we target VAADIN/build | VAADIN/static | theme/theme-name
+        return filenameWithPath.startsWith("/" + VAADIN_BUILD_FILES_PATH)
+            || filenameWithPath.startsWith("/" + VAADIN_STATIC_FILES_PATH)
+            || APP_THEME_PATTERN.matcher(filenameWithPath).find();
     }
 
     /**
@@ -297,7 +300,7 @@ public class StaticFileServer implements StaticFileHandler {
         if (request.getPathInfo() == null) {
             return request.getServletPath();
         } else if (request.getPathInfo().startsWith("/" + VAADIN_MAPPING)
-            || themeFolder.matcher(request.getPathInfo()).find()) {
+            || APP_THEME_PATTERN.matcher(request.getPathInfo()).find()) {
             return request.getPathInfo();
         }
         return request.getServletPath() + request.getPathInfo();

--- a/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
@@ -57,7 +57,7 @@ public class StaticFileServer implements StaticFileHandler {
     private DeploymentConfiguration deploymentConfiguration;
 
     // Matcher to match string starting with '/theme/[theme-name]/'
-    private static final Pattern themeFolder = Pattern.compile("^\\/theme\\/[\\s\\S]*?\\/");
+    protected static final Pattern themeFolder = Pattern.compile("^\\/theme\\/[\\s\\S]*?\\/");
 
     /**
      * Constructs a file server.

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/application-theme-plugin.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/application-theme-plugin.js
@@ -112,7 +112,7 @@ function handleThemes(themeName, themesFolder, projectStaticAssetsOutputFolder) 
 
     const themeProperties = getThemeProperties(themeFolder);
 
-    copyStaticAssets(themeProperties, projectStaticAssetsOutputFolder, logger);
+    copyStaticAssets(themeName, themeProperties, projectStaticAssetsOutputFolder, logger);
 
     const themeFile = generateThemeFile(themeFolder, themeName, themeProperties);
 

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/package.json
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/package.json
@@ -6,7 +6,7 @@
   ],
   "repository": "vaadin/flow",
   "name": "@vaadin/application-theme-plugin",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "main": "application-theme-plugin.js",
   "author": "Vaadin Ltd",
   "license": "Apache-2.0",

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-copy.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-copy.js
@@ -45,11 +45,12 @@ const glob = require('glob');
  *
  * Note! there can be multiple copy-rules with target folders for one npm package asset.
  *
- * @param {json} themeProperties
- * @param {string} projectStaticAssetsOutputFolder
+ * @param {string} themeName name of the theme we are copying assets for
+ * @param {json} themeProperties theme properties json with data on assets
+ * @param {string} projectStaticAssetsOutputFolder project output folder where we copy assets to under theme/[themeName]
  * @param {logger} theme plugin logger
  */
-function copyStaticAssets(themeProperties, projectStaticAssetsOutputFolder, logger) {
+function copyStaticAssets(themeName, themeProperties, projectStaticAssetsOutputFolder, logger) {
 
   const assets = themeProperties['assets'];
   if (!assets) {
@@ -66,7 +67,7 @@ function copyStaticAssets(themeProperties, projectStaticAssetsOutputFolder, logg
     Object.keys(copyRules).forEach((copyRule) => {
       const nodeSources = path.resolve('node_modules/', module, copyRule);
       const files = glob.sync(nodeSources, { nodir: true });
-      const targetFolder = path.resolve(projectStaticAssetsOutputFolder, copyRules[copyRule]);
+      const targetFolder = path.resolve(projectStaticAssetsOutputFolder, "theme", themeName, copyRules[copyRule]);
 
       fs.mkdirSync(targetFolder, {
         recursive: true

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-copy.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-copy.js
@@ -66,15 +66,19 @@ function copyStaticAssets(themeName, themeProperties, projectStaticAssetsOutputF
     const copyRules = assets[module];
     Object.keys(copyRules).forEach((copyRule) => {
       const nodeSources = path.resolve('node_modules/', module, copyRule);
-      const files = glob.sync(nodeSources, { nodir: true });
+      const files = glob.sync(nodeSources, {nodir: true});
       const targetFolder = path.resolve(projectStaticAssetsOutputFolder, "theme", themeName, copyRules[copyRule]);
 
       fs.mkdirSync(targetFolder, {
         recursive: true
       });
       files.forEach((file) => {
-        logger.trace("Copying: ", file, '=>', targetFolder);
-        fs.copyFileSync(file, path.resolve(targetFolder, path.basename(file)));
+        const copyTarget = path.resolve(targetFolder, path.basename(file));
+        // Only copy if target file doesn't exist or if file to copy is newer
+        if (!fs.existsSync(copyTarget) || fs.statSync(copyTarget).mtime < fs.statSync(file).mtime) {
+          logger.trace("Copying: ", file, '=>', targetFolder);
+          fs.copyFileSync(file, copyTarget);
+        }
       });
     });
   });

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -209,7 +209,7 @@ module.exports = {
             outputPath: 'static/',
             name(resourcePath, resourceQuery) {
               if (resourcePath.match(/(\\|\/)node_modules\1/)) {
-                return /(\\|\/)node_modules\1(?!.*node_modules)([\S]*)/.exec(resourcePath)[2].replace(/\\/g, "/");
+                return /(\\|\/)node_modules\1(?!.*node_modules)([\S]+)/.exec(resourcePath)[2].replace(/\\/g, "/");
               }
               return '[path][name].[ext]';
             }

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -208,15 +208,11 @@ module.exports = {
           options: {
             outputPath: 'static/',
             name(resourcePath, resourceQuery) {
-              const urlResource = resourcePath.substring(frontendFolder.length);
-              if(urlResource.match(themePartRegex)){
-                return /^(\\|\/)theme\1[\s\S]*?\1(.*)/.exec(urlResource)[2].replace(/\\/, "/");
-              }
-              if(urlResource.match(/(\\|\/)node_modules\1/)) {
-                return /(\\|\/)node_modules\1(?!.*node_modules)([\S]*)/.exec(urlResource)[2].replace(/\\/g, "/");
+              
+              if(resourcePath.match(/(\\|\/)node_modules\1/)) {
+                return /(\\|\/)node_modules\1(?!.*node_modules)([\S]*)/.exec(resourcePath)[2].replace(/\\/g, "/");
               }
               return '[path][name].[ext]';
-            }
           }
         }],
       },

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -208,11 +208,11 @@ module.exports = {
           options: {
             outputPath: 'static/',
             name(resourcePath, resourceQuery) {
-              
-              if(resourcePath.match(/(\\|\/)node_modules\1/)) {
+              if (resourcePath.match(/(\\|\/)node_modules\1/)) {
                 return /(\\|\/)node_modules\1(?!.*node_modules)([\S]*)/.exec(resourcePath)[2].replace(/\\/g, "/");
               }
               return '[path][name].[ext]';
+            }
           }
         }],
       },

--- a/flow-tests/test-embedding/test-embedding-application-theme/src/test/java/com/vaadin/flow/webcomponent/ApplicationThemeComponentIT.java
+++ b/flow-tests/test-embedding/test-embedding-application-theme/src/test/java/com/vaadin/flow/webcomponent/ApplicationThemeComponentIT.java
@@ -45,7 +45,7 @@ public class ApplicationThemeComponentIT extends ChromeBrowserTest {
         final TestBenchElement themedComponent = $("themed-component").first();
 
         Assert.assertEquals(
-            "url(\"" + getRootURL() + "/VAADIN/static/img/bg.jpg\")",
+            "url(\"" + getRootURL() + "/VAADIN/static/theme/embedded-theme/img/bg.jpg\")",
             themedComponent.getCssValue("background-image"));
 
         Assert.assertEquals("Ostrich",
@@ -53,12 +53,12 @@ public class ApplicationThemeComponentIT extends ChromeBrowserTest {
 
         final WebElement body = findElement(By.tagName("body"));
         Assert.assertNotEquals(
-            "url(\"" + getRootURL() + "/path/VAADIN/static/img/bg.jpg\")",
+            "url(\"" + getRootURL() + "/path/VAADIN/static/theme/embedded-theme/img/bg.jpg\")",
             body.getCssValue("background-image"));
 
         Assert.assertNotEquals("Ostrich", body.getCssValue("font-family"));
 
-        getDriver().get(getRootURL() + "/VAADIN/static/img/bg.jpg");
+        getDriver().get(getRootURL() + "/VAADIN/static/theme/embedded-theme/img/bg.jpg");
         Assert.assertFalse("app-theme background file should be served",
             driver.getPageSource().contains("Could not navigate"));
     }

--- a/flow-tests/test-themes/src/main/java/com/vaadin/flow/uitest/ui/theme/ThemeView.java
+++ b/flow-tests/test-themes/src/main/java/com/vaadin/flow/uitest/ui/theme/ThemeView.java
@@ -51,7 +51,7 @@ public class ThemeView extends Div {
         faText.setId(FONTAWESOME_ID);
 
         Image snowFlake = new Image(
-            "VAADIN/static/fortawesome/icons/snowflake.svg", "snowflake");
+            "theme/app-theme/fortawesome/icons/snowflake.svg", "snowflake");
         snowFlake.setHeight("1em");
         snowFlake.setId(SNOWFLAKE_ID);
 

--- a/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
+++ b/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
@@ -54,11 +54,11 @@ public class ThemeIT extends ChromeBrowserTest {
 
     @Test
     public void secondTheme_staticFilesNotCopied() {
-        getDriver().get(getRootURL() + "/path/VAADIN/static/img/bg.jpg");
+        getDriver().get(getRootURL() + "/path/theme/app-theme/img/bg.jpg");
         Assert.assertFalse("app-theme static files should be copied",
             driver.getPageSource().contains("HTTP ERROR 404 Not Found"));
 
-        getDriver().get(getRootURL() + "/path/VAADIN/static/no-copy.txt");
+        getDriver().get(getRootURL() + "/path/theme/app-theme/no-copy.txt");
         Assert.assertTrue("no-copy theme should not be handled",
             driver.getPageSource().contains("HTTP ERROR 404 Not Found"));
     }
@@ -70,13 +70,15 @@ public class ThemeIT extends ChromeBrowserTest {
         checkLogsForErrors();
 
         final WebElement body = findElement(By.tagName("body"));
+        // Note theme/app-theme gets VAADIN/static from the file-loader
         Assert.assertEquals(
-            "url(\"" + getRootURL() + "/path/VAADIN/static/img/bg.jpg\")",
+            "url(\"" + getRootURL() + "/path/VAADIN/static/theme/app-theme/img/bg.jpg\")",
             body.getCssValue("background-image"));
 
         Assert.assertEquals("Ostrich", body.getCssValue("font-family"));
 
-        getDriver().get(getRootURL() + "/path/VAADIN/static/img/bg.jpg");
+        // Note theme/app-theme gets VAADIN/static from the file-loader
+        getDriver().get(getRootURL() + "/path/VAADIN/static/theme/app-theme/img/bg.jpg");
         Assert.assertFalse("app-theme background file should be served",
             driver.getPageSource().contains("Could not navigate"));
     }
@@ -128,22 +130,23 @@ public class ThemeIT extends ChromeBrowserTest {
         open();
         checkLogsForErrors();
 
+        // Note theme/app-theme gets VAADIN/static from the file-loader
         Assert.assertEquals("Imported css file URLs should have been handled.",
             "url(\"" + getRootURL()
-                + "/path/VAADIN/static/icons/archive.png\")",
+                + "/path/VAADIN/static/theme/app-theme/icons/archive.png\")",
             $(SpanElement.class).id(SUB_COMPONENT_ID)
                 .getCssValue("background-image"));
     }
 
     @Test
-    public void staticModuleAsset_servedFromStatic() {
+    public void staticModuleAsset_servedFromAppTheme() {
         open();
         checkLogsForErrors();
 
         Assert.assertEquals(
-            "Node assets should have been copied to 'VAADIN/static'",
+            "Node assets should have been copied to 'theme/app-theme'",
             getRootURL()
-                + "/path/VAADIN/static/fortawesome/icons/snowflake.svg",
+                + "/path/theme/app-theme/fortawesome/icons/snowflake.svg",
             $(ImageElement.class).id(SNOWFLAKE_ID).getAttribute("src"));
 
         open(getRootURL() + "/path/" + $(ImageElement.class).id(SNOWFLAKE_ID)


### PR DESCRIPTION
Theme files are now copied undet theme/[theme-name]
and can be refernced by theme/them-name/path/file.ff
even though they are located at VAADIN/static

Fixes #9405 
Fixes #9535