### PR TITLE
fix: Vaadin.Flow.clients.TypeScript.isActive for endpoint requests

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/Connect.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Connect.ts
@@ -420,23 +420,17 @@ export class ConnectClient {
     // chain item for our convenience. Always having an ending of the chain
     // this way makes the folding down below more concise.
     const fetchNext: MiddlewareNext =
-      async(context: MiddlewareContext): Promise<Response> => {
-        if ($wnd.Vaadin.connectionState) {
-          $wnd.Vaadin.connectionState.loadingStarted();
-        }
-       return fetch(context.request)
-            .then(response => {
-              if ($wnd.Vaadin.connectionState) {
-                $wnd.Vaadin.connectionState.loadingSucceeded();
-              }
-              return response;
-            })
-            .catch(error => {
-              if ($wnd.Vaadin.connectionState) {
-                $wnd.Vaadin.connectionState.state = ConnectionState.CONNECTION_LOST;
-              }
-              return Promise.reject(error);
-            });
+      async (context: MiddlewareContext): Promise<Response> => {
+        $wnd.Vaadin.connectionState.loadingStarted();
+        return fetch(context.request)
+          .then(response => {
+            $wnd.Vaadin.connectionState.loadingSucceeded();
+            return response;
+          })
+          .catch(error => {
+            $wnd.Vaadin.connectionState.state = ConnectionState.CONNECTION_LOST;
+            return Promise.reject(error);
+          });
       };
 
     // Assemble the final middlewares array from internal

--- a/flow-client/src/test/frontend/ConnectTests.ts
+++ b/flow-client/src/test/frontend/ConnectTests.ts
@@ -28,7 +28,8 @@ describe('ConnectClient', () => {
   beforeEach(() => {
     const connectionStateStore = new ConnectionStateStore(ConnectionState.CONNECTED);
     (window as any).Vaadin.connectionState = connectionStateStore;
-    localStorage.clear();});
+    localStorage.clear();
+  });
 
   after(() => {
     const $wnd = window as any;
@@ -224,7 +225,10 @@ describe('ConnectClient', () => {
       // @ts-ignore
       const OriginalVaadin = window.Vaadin;
       // @ts-ignore
-      window.Vaadin = {TypeScript: {csrfToken: 'foo'}};
+      window.Vaadin = {
+        TypeScript: {csrfToken: 'foo'},
+        connectionState: (window as any).Vaadin.connectionState
+      };
 
       await client.call('FooEndpoint', 'fooMethod');
 


### PR DESCRIPTION
Allows TestBench tests to assume that all initial endpoint requests have
completed before the test case is executed.