### PR TITLE
chore: fix flaky tests that depends on mock count

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
@@ -53,6 +53,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.never;;
 
 @NotThreadSafe
 public class DevModeInitializerTest extends DevModeInitializerTestBase {
@@ -301,6 +302,8 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
     public void should_generateOpenApi_when_EndpointPresents()
             throws Exception {
         String originalJavaSourceFolder = null;
+        File generatedOpenApiJson = Paths
+                    .get(baseDir, DEFAULT_CONNECT_OPENAPI_JSON_FILE).toFile();
         try {
             originalJavaSourceFolder = System.getProperty("vaadin." 
                 + CONNECT_JAVA_SOURCE_FOLDER_TOKEN);
@@ -310,9 +313,6 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
             // to verify the mocked task is executed.
             System.setProperty("vaadin." + CONNECT_JAVA_SOURCE_FOLDER_TOKEN,
                 javaSourceFolder.getRoot().getAbsolutePath());
-
-            File generatedOpenApiJson = Paths
-                    .get(baseDir, DEFAULT_CONNECT_OPENAPI_JSON_FILE).toFile();
 
             Assert.assertFalse(generatedOpenApiJson.exists());
             DevModeInitializer devModeInitializer = new DevModeInitializer();
@@ -328,6 +328,7 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
                 System.clearProperty("vaadin." 
                     + CONNECT_JAVA_SOURCE_FOLDER_TOKEN);
             }
+            generatedOpenApiJson.delete();
         }
 
     }
@@ -336,18 +337,19 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
     public void should_notGenerateOpenApi_when_EndpointIsNotUsed()
             throws Exception {
         String originalJavaSourceFolder = null;
+        File generatedOpenApiJson = Paths
+                    .get(baseDir, DEFAULT_CONNECT_OPENAPI_JSON_FILE).toFile();
         try {
             originalJavaSourceFolder = System.getProperty("vaadin." 
                 + CONNECT_JAVA_SOURCE_FOLDER_TOKEN);
             System.clearProperty("vaadin." 
                 + CONNECT_JAVA_SOURCE_FOLDER_TOKEN);
 
-            File generatedOpenApiJson = Paths
-                    .get(baseDir, DEFAULT_CONNECT_OPENAPI_JSON_FILE).toFile();
+            
             Assert.assertFalse(generatedOpenApiJson.exists());
             devModeInitializer.onStartup(classes, servletContext);
 
-            Mockito.verify(taskGenerateConnect, times(0)).execute();
+            Mockito.verify(taskGenerateConnect, never()).execute();
         } finally {
             if (originalJavaSourceFolder != null) {
                 System.setProperty("vaadin." 
@@ -356,6 +358,7 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
                 System.clearProperty("vaadin." 
                     + CONNECT_JAVA_SOURCE_FOLDER_TOKEN);
             }
+            generatedOpenApiJson.delete();
         }
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
@@ -300,54 +300,93 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
     @Test
     public void should_generateOpenApi_when_EndpointPresents()
             throws Exception {
+        String originalJavaSourceFolder = null;
+        try {
+            originalJavaSourceFolder = System.getProperty("vaadin." 
+                + CONNECT_JAVA_SOURCE_FOLDER_TOKEN);
 
-        // Configure a folder to check the endpoints, doesn't matter
-        // which folder, since the actual task won't be run, just
-        // to verify the mocked task is executed.
-        File src = new File(
-                getClass().getClassLoader().getResource("com").getFile());
-        System.setProperty("vaadin." + CONNECT_JAVA_SOURCE_FOLDER_TOKEN,
-                src.getAbsolutePath());
+            // Configure a folder to check the endpoints, doesn't matter
+            // which folder, since the actual task won't be run, just
+            // to verify the mocked task is executed.
+            System.setProperty("vaadin." + CONNECT_JAVA_SOURCE_FOLDER_TOKEN,
+                javaSourceFolder.getRoot().getAbsolutePath());
 
-        File generatedOpenApiJson = Paths
-                .get(baseDir, DEFAULT_CONNECT_OPENAPI_JSON_FILE).toFile();
+            File generatedOpenApiJson = Paths
+                    .get(baseDir, DEFAULT_CONNECT_OPENAPI_JSON_FILE).toFile();
 
-        Assert.assertFalse(generatedOpenApiJson.exists());
-        DevModeInitializer devModeInitializer = new DevModeInitializer();
-        devModeInitializer.onStartup(classes, servletContext);
-        waitForDevModeServer();
-        
-        Mockito.verify(taskGenerateConnect, times(1)).execute();
+            Assert.assertFalse(generatedOpenApiJson.exists());
+            DevModeInitializer devModeInitializer = new DevModeInitializer();
+            devModeInitializer.onStartup(classes, servletContext);
+            waitForDevModeServer();
+
+            Mockito.verify(taskGenerateConnect, times(1)).execute();
+        } finally {
+            if (originalJavaSourceFolder != null) {
+                System.setProperty("vaadin." 
+                    + CONNECT_JAVA_SOURCE_FOLDER_TOKEN, originalJavaSourceFolder);
+            } else {
+                System.clearProperty("vaadin." 
+                    + CONNECT_JAVA_SOURCE_FOLDER_TOKEN);
+            }
+        }
+
     }
 
     @Test
     public void should_notGenerateOpenApi_when_EndpointIsNotUsed()
             throws Exception {
-        File generatedOpenApiJson = Paths
-                .get(baseDir, DEFAULT_CONNECT_OPENAPI_JSON_FILE).toFile();
-        Assert.assertFalse(generatedOpenApiJson.exists());
-        devModeInitializer.onStartup(classes, servletContext);
-        
-        Mockito.verify(taskGenerateConnect, times(0)).execute();
+        String originalJavaSourceFolder = null;
+        try {
+            originalJavaSourceFolder = System.getProperty("vaadin." 
+                + CONNECT_JAVA_SOURCE_FOLDER_TOKEN);
+            System.clearProperty("vaadin." 
+                + CONNECT_JAVA_SOURCE_FOLDER_TOKEN);
+
+            File generatedOpenApiJson = Paths
+                    .get(baseDir, DEFAULT_CONNECT_OPENAPI_JSON_FILE).toFile();
+            Assert.assertFalse(generatedOpenApiJson.exists());
+            devModeInitializer.onStartup(classes, servletContext);
+
+            Mockito.verify(taskGenerateConnect, times(0)).execute();
+        } finally {
+            if (originalJavaSourceFolder != null) {
+                System.setProperty("vaadin." 
+                    + CONNECT_JAVA_SOURCE_FOLDER_TOKEN, originalJavaSourceFolder);
+            } else {
+                System.clearProperty("vaadin." 
+                    + CONNECT_JAVA_SOURCE_FOLDER_TOKEN);
+            }
+        }
     }
 
     @Test
     public void should_generateTs_files() throws Exception {
+        String originalJavaSourceFolder = null;
+        try {
+            originalJavaSourceFolder = System.getProperty("vaadin." 
+                + CONNECT_JAVA_SOURCE_FOLDER_TOKEN);
 
-        // Configure a folder to check the endpoints, doesn't matter
-        // which folder, since the actual task won't be run, just
-        // to verify the mocked task is executed.
-        File src = new File(
-                getClass().getClassLoader().getResource("com").getFile());
-        System.setProperty("vaadin." + CONNECT_JAVA_SOURCE_FOLDER_TOKEN,
-                src.getAbsolutePath());
+            // Configure a folder to check the endpoints, doesn't matter
+            // which folder, since the actual task won't be run, just
+            // to verify the mocked task is executed.
+            System.setProperty("vaadin." + CONNECT_JAVA_SOURCE_FOLDER_TOKEN,
+                javaSourceFolder.getRoot().getAbsolutePath());
 
-        DevModeInitializer devModeInitializer = new DevModeInitializer();
+            DevModeInitializer devModeInitializer = new DevModeInitializer();
 
-        devModeInitializer.onStartup(classes, servletContext);
-        waitForDevModeServer();
+            devModeInitializer.onStartup(classes, servletContext);
+            waitForDevModeServer();
 
-        Mockito.verify(taskGenerateConnect, times(1)).execute();
+            Mockito.verify(taskGenerateConnect, times(1)).execute();
+        } finally {
+            if (originalJavaSourceFolder != null) {
+                System.setProperty("vaadin." 
+                    + CONNECT_JAVA_SOURCE_FOLDER_TOKEN, originalJavaSourceFolder);
+            } else {
+                System.clearProperty("vaadin." 
+                    + CONNECT_JAVA_SOURCE_FOLDER_TOKEN);
+            }
+        }
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTestBase.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTestBase.java
@@ -66,9 +66,9 @@ public class DevModeInitializerTestBase {
     File webpackFile;
     String baseDir;
     Lookup lookup = Mockito.mock(Lookup.class);;
-    EndpointGeneratorTaskFactory endpointGeneratorTaskFactory = Mockito.mock(EndpointGeneratorTaskFactory.class);
-    TaskGenerateConnect taskGenerateConnect = Mockito.mock(TaskGenerateConnect.class);
-    TaskGenerateOpenApi taskGenerateOpenApi = Mockito.mock(TaskGenerateOpenApi.class);
+    EndpointGeneratorTaskFactory endpointGeneratorTaskFactory;
+    TaskGenerateConnect taskGenerateConnect;
+    TaskGenerateOpenApi taskGenerateOpenApi;
 
     public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -94,6 +94,9 @@ public class DevModeInitializerTestBase {
 
         Mockito.when(servletContext.getAttribute(Lookup.class.getName()))
                 .thenReturn(lookup);
+        endpointGeneratorTaskFactory = Mockito.mock(EndpointGeneratorTaskFactory.class);
+        taskGenerateConnect = Mockito.mock(TaskGenerateConnect.class);
+        taskGenerateOpenApi = Mockito.mock(TaskGenerateOpenApi.class);
         Mockito.doReturn(endpointGeneratorTaskFactory).when(lookup)
                 .lookup(EndpointGeneratorTaskFactory.class);
         Mockito.doReturn(taskGenerateConnect).when(endpointGeneratorTaskFactory)

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTestBase.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTestBase.java
@@ -21,6 +21,7 @@ import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 
@@ -65,12 +66,15 @@ public class DevModeInitializerTestBase {
     File mainPackageFile;
     File webpackFile;
     String baseDir;
-    Lookup lookup = Mockito.mock(Lookup.class);;
+    Lookup lookup;
     EndpointGeneratorTaskFactory endpointGeneratorTaskFactory;
     TaskGenerateConnect taskGenerateConnect;
     TaskGenerateOpenApi taskGenerateOpenApi;
 
     public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Rule
+    public final TemporaryFolder javaSourceFolder = new TemporaryFolder();
 
     public static class VaadinServletSubClass extends VaadinServlet {
 
@@ -92,6 +96,7 @@ public class DevModeInitializerTestBase {
         ServletRegistration vaadinServletRegistration = Mockito
                 .mock(ServletRegistration.class);
 
+        lookup = Mockito.mock(Lookup.class);;
         Mockito.when(servletContext.getAttribute(Lookup.class.getName()))
                 .thenReturn(lookup);
         endpointGeneratorTaskFactory = Mockito.mock(EndpointGeneratorTaskFactory.class);
@@ -187,6 +192,7 @@ public class DevModeInitializerTestBase {
         webpackFile.delete();
         mainPackageFile.delete();
         temporaryFolder.delete();
+        javaSourceFolder.delete();
         if (getDevModeHandler() != null) {
             getDevModeHandler().stop();
         }

--- a/fusion-endpoint/src/test/java/com/vaadin/flow/server/startup/fusion/DevModeInitializerEndpointTest.java
+++ b/fusion-endpoint/src/test/java/com/vaadin/flow/server/startup/fusion/DevModeInitializerEndpointTest.java
@@ -128,63 +128,105 @@ public class DevModeInitializerEndpointTest {
     @Test
     public void should_generateOpenApi_when_EndpointPresents()
             throws Exception {
-
-        // Configure a folder that has .java classes with valid endpoints
-        // Not using `src/test/java` because there are invalid endpoint names
-        // in some tests
-        File src = new File(
-                getClass().getClassLoader().getResource("java").getFile());
-        System.setProperty("vaadin." + CONNECT_JAVA_SOURCE_FOLDER_TOKEN,
-                src.getAbsolutePath());
-
+        String originalJavaSourceFolder = null;
         File generatedOpenApiJson = Paths
-                .get(baseDir, DEFAULT_CONNECT_OPENAPI_JSON_FILE).toFile();
+                    .get(baseDir, DEFAULT_CONNECT_OPENAPI_JSON_FILE).toFile();
+        try {
+            originalJavaSourceFolder = System.getProperty("vaadin." 
+                + CONNECT_JAVA_SOURCE_FOLDER_TOKEN);
+            // Configure a folder that has .java classes with valid endpoints
+            // Not using `src/test/java` because there are invalid endpoint names
+            // in some tests
+            File src = new File(
+                    getClass().getClassLoader().getResource("java").getFile());
+            System.setProperty("vaadin." + CONNECT_JAVA_SOURCE_FOLDER_TOKEN,
+                    src.getAbsolutePath());
 
-        Assert.assertFalse(generatedOpenApiJson.exists());
-        DevModeInitializer devModeInitializer = new DevModeInitializer();
-        devModeInitializer.onStartup(classes, servletContext);
-        waitForDevModeServer();
-        Thread.sleep(200);
-        Assert.assertTrue("Should generate OpenAPI spec if Endpoint is used.",
-                generatedOpenApiJson.exists());
+            Assert.assertFalse(generatedOpenApiJson.exists());
+            DevModeInitializer devModeInitializer = new DevModeInitializer();
+            devModeInitializer.onStartup(classes, servletContext);
+            waitForDevModeServer();
+            Thread.sleep(200);
+            Assert.assertTrue("Should generate OpenAPI spec if Endpoint is used.",
+                    generatedOpenApiJson.exists());
+        } finally {
+            if (originalJavaSourceFolder != null) {
+                System.setProperty("vaadin." 
+                    + CONNECT_JAVA_SOURCE_FOLDER_TOKEN, originalJavaSourceFolder);
+            } else {
+                System.clearProperty("vaadin." 
+                    + CONNECT_JAVA_SOURCE_FOLDER_TOKEN);
+            }
+            generatedOpenApiJson.delete();
+        }
     }
 
     @Test
     public void should_notGenerateOpenApi_when_EndpointIsNotUsed()
             throws Exception {
+        String originalJavaSourceFolder = null;
         File generatedOpenApiJson = Paths
                 .get(baseDir, DEFAULT_CONNECT_OPENAPI_JSON_FILE).toFile();
-        Assert.assertFalse(generatedOpenApiJson.exists());
-        devModeInitializer.onStartup(classes, servletContext);
-        Assert.assertFalse(
+        try {
+            originalJavaSourceFolder = System.getProperty("vaadin." 
+                + CONNECT_JAVA_SOURCE_FOLDER_TOKEN);
+        
+            System.clearProperty("vaadin." 
+                + CONNECT_JAVA_SOURCE_FOLDER_TOKEN);
+
+            Assert.assertFalse(generatedOpenApiJson.exists());
+            devModeInitializer.onStartup(classes, servletContext);
+            Assert.assertFalse(
                 "Should not generate OpenAPI spec if Endpoint is not used.",
                 generatedOpenApiJson.exists());
+        } finally {
+            if (originalJavaSourceFolder != null) {
+                System.setProperty("vaadin." 
+                    + CONNECT_JAVA_SOURCE_FOLDER_TOKEN, originalJavaSourceFolder);
+            } else {
+                System.clearProperty("vaadin." 
+                    + CONNECT_JAVA_SOURCE_FOLDER_TOKEN);
+            }
+            generatedOpenApiJson.delete();
+        }
     }
 
     @Test
     public void should_generateTs_files() throws Exception {
+        String originalJavaSourceFolder = null;
+        try {
+            originalJavaSourceFolder = System.getProperty("vaadin." 
+                + CONNECT_JAVA_SOURCE_FOLDER_TOKEN);
+            // Configure a folder that has .java classes with valid endpoints
+            // Not using `src/test/java` because there are invalid endpoint names
+            // in some tests
+            File src = new File(
+                    getClass().getClassLoader().getResource("java").getFile());
+            System.setProperty("vaadin." + CONNECT_JAVA_SOURCE_FOLDER_TOKEN,
+                    src.getAbsolutePath());
 
-        // Configure a folder that has .java classes with valid endpoints
-        // Not using `src/test/java` because there are invalid endpoint names
-        // in some tests
-        File src = new File(
-                getClass().getClassLoader().getResource("java").getFile());
-        System.setProperty("vaadin." + CONNECT_JAVA_SOURCE_FOLDER_TOKEN,
-                src.getAbsolutePath());
+            DevModeInitializer devModeInitializer = new DevModeInitializer();
 
-        DevModeInitializer devModeInitializer = new DevModeInitializer();
+            File ts1 = new File(baseDir,
+                    DEFAULT_CONNECT_GENERATED_TS_DIR + "MyEndpoint.ts");
+            File ts2 = new File(baseDir, DEFAULT_CONNECT_GENERATED_TS_DIR
+                    + "connect-client.default.ts");
 
-        File ts1 = new File(baseDir,
-                DEFAULT_CONNECT_GENERATED_TS_DIR + "MyEndpoint.ts");
-        File ts2 = new File(baseDir, DEFAULT_CONNECT_GENERATED_TS_DIR
-                + "connect-client.default.ts");
-
-        assertFalse(ts1.exists());
-        assertFalse(ts2.exists());
-        devModeInitializer.onStartup(classes, servletContext);
-        waitForDevModeServer();
-        assertTrue(ts1.exists());
-        assertTrue(ts2.exists());
+            assertFalse(ts1.exists());
+            assertFalse(ts2.exists());
+            devModeInitializer.onStartup(classes, servletContext);
+            waitForDevModeServer();
+            assertTrue(ts1.exists());
+            assertTrue(ts2.exists());
+        } finally {
+            if (originalJavaSourceFolder != null) {
+                System.setProperty("vaadin." 
+                    + CONNECT_JAVA_SOURCE_FOLDER_TOKEN, originalJavaSourceFolder);
+            } else {
+                System.clearProperty("vaadin." 
+                    + CONNECT_JAVA_SOURCE_FOLDER_TOKEN);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Move mock initialization to the setup method so that the tests depend on verify count won't affect each other.