### PR TITLE
fix(offline): do not depend on global connection state for isActive

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/Connect.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Connect.ts
@@ -421,13 +421,14 @@ export class ConnectClient {
     // this way makes the folding down below more concise.
     const fetchNext: MiddlewareNext =
       async (context: MiddlewareContext): Promise<Response> => {
-        $wnd.Vaadin.connectionState.loadingStarted();
+        $wnd.Vaadin.Flow?.clients?.TypeScript?.loadingStarted();
         return fetch(context.request)
           .then(response => {
-            $wnd.Vaadin.connectionState.loadingSucceeded();
+            $wnd.Vaadin.Flow?.clients?.TypeScript?.loadingFinished();
             return response;
           })
           .catch(error => {
+            $wnd.Vaadin.Flow?.clients?.TypeScript?.loadingFinished();
             $wnd.Vaadin.connectionState.state = ConnectionState.CONNECTION_LOST;
             return Promise.reject(error);
           });

--- a/flow-client/src/main/resources/META-INF/resources/frontend/ConnectionState.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/ConnectionState.ts
@@ -55,7 +55,7 @@ export class ConnectionStateStore {
     this.loadingCount += 1;
   }
 
-  loadingSucceeded(): void {
+  loadingFinished(): void {
     if (this.loadingCount > 0) {
       this.loadingCount -= 1;
       if (this.loadingCount === 0) {

--- a/flow-client/src/test/frontend/ConnectionStateTests.ts
+++ b/flow-client/src/test/frontend/ConnectionStateTests.ts
@@ -72,8 +72,8 @@ describe('ConnectionStateStore', () => {
 
     store.loadingStarted();
     store.loadingStarted();
-    store.loadingSucceeded();
-    store.loadingSucceeded();
+    store.loadingFinished();
+    store.loadingFinished();
     assert.deepEqual(states,
       [[ConnectionState.CONNECTED, ConnectionState.LOADING],
         [ConnectionState.LOADING, ConnectionState.CONNECTED]]);
@@ -90,7 +90,7 @@ describe('ConnectionStateStore', () => {
     store.loadingStarted();
     store.state = ConnectionState.CONNECTION_LOST;
     store.loadingStarted();
-    store.loadingSucceeded();
+    store.loadingFinished();
 
     assert.deepEqual(states,
       [[ConnectionState.CONNECTED, ConnectionState.LOADING],


### PR DESCRIPTION
This reverts part of 0d1a6a22ead081416846dc83fd323d1da14d861f, which made
Flow.isActive dependent on the global connection state. This caused flaky tests
and was incorrect use of global state which may be modified by other clients.
Rather each client must independently compute isActive.

Also renamed ConnectionState.loadingSucceeded to the more descriptive
loadingFinished.