### PR TITLE
chore: improve stability of two tests

### DIFF
--- a/flow-client/src/test/frontend/FlowTests.ts
+++ b/flow-client/src/test/frontend/FlowTests.ts
@@ -495,7 +495,7 @@ suite("Flow", () => {
       });
   });
 
-  test("onBeforeLeave should cancel `server->client` navigation", async () => {
+  test("onBeforeLeave should cancel `server->client` navigation", () => {
     // true to prevent navigation from server
     stubServerRemoteFunction('foobar-12345', true);
     mockInitResponse('foobar-12345');

--- a/flow-client/src/test/frontend/FlowTests.ts
+++ b/flow-client/src/test/frontend/FlowTests.ts
@@ -500,15 +500,11 @@ suite("Flow", () => {
     stubServerRemoteFunction('foobar-12345', true);
     mockInitResponse('foobar-12345');
 
-    await new Promise(resolve => setTimeout(resolve, 150));
-
     const flow = new Flow();
     const route = flow.serverSideRoutes[0];
 
     return route.action({pathname: 'Foo'})
       .then((elem: any) => {
-        //await new Promise(resolve => setTimeout(resolve, 500));
-
         assert.isDefined(elem.onBeforeLeave);
         assert.equal('Foo', flow.pathname);
 

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/LogoutIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/LogoutIT.java
@@ -31,7 +31,9 @@ public class LogoutIT extends ChromeBrowserTest {
         $(NativeButtonElement.class).first().click();
 
         // There can be "Session Expired" message because of heartbeat
-        checkLogsForErrors(msg -> msg.contains("Session Expired"));
+        // Strings defined in com.vaadin.flow.server.SystemMessages
+        checkLogsForErrors(msg -> msg.contains("Session Expired")
+                || msg.contains("Take note of any unsaved data, and <u>click here</u> or press ESC key to continue."));
 
         // There can't be any error dialog
         Assert.assertFalse(isElementPresent(By.className("v-system-error")));


### PR DESCRIPTION
Contains two stabilising fixes:
- A [rare fluke](https://bender.vaadin.com/viewLog.html?buildId=204930&buildTypeId=Flow_Flow60_Flow60Snapshot&tab=buildLog&_focus=15958) (also in master) occurs in `FlowTests` when the `setTimeout` calls intended to simulate asynchronous server response in `stubServerRemoteFunction` complete after the unit test, when `afterEach` has already deleted `window.Vaadin`. This causing `Flow.loadingFinished` ran by `Flow.serverConnected` to crash between the tests. The fix cancels all timers between in `afterEach`.
- With the right heartbeat timing, the browser console in`LogoutIT` can [contain a session expiration message](https://bender.vaadin.com/viewLog.html?buildId=205169&buildTypeId=Flow_Misc_FlakyItInvestigationTestByJohannes&tab=buildLog&branch_Flow_Misc=merge-offline-to-master&_focus=37588). The fix relaxes the acceptable console errors in the IT.
