### PR TITLE
feat: use superclass of VadinServlet/Request if possible

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -1706,9 +1706,10 @@ public abstract class VaadinService implements Serializable {
             SystemMessages systemMessages = getSystemMessages(
                     HandlerHelper.findLocale(null, request), request);
             String sessionExpiredURL = systemMessages.getSessionExpiredURL();
+
             if (sessionExpiredURL != null
-                    && (response instanceof VaadinServletResponse)) {
-                ((VaadinServletResponse) response)
+                    && (response instanceof HttpServletResponse)) {
+                ((HttpServletResponse) response)
                         .sendRedirect(sessionExpiredURL);
             } else {
                 /*

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -1707,7 +1707,12 @@ public abstract class VaadinService implements Serializable {
                     HandlerHelper.findLocale(null, request), request);
             String sessionExpiredURL = systemMessages.getSessionExpiredURL();
 
+            
             if (sessionExpiredURL != null
+                    && (response instanceof VaadinServletResponse)) {
+                ((VaadinServletResponse) response)
+                        .sendRedirect(sessionExpiredURL);
+            } else if (sessionExpiredURL != null
                     && (response instanceof HttpServletResponse)) {
                 ((HttpServletResponse) response)
                         .sendRedirect(sessionExpiredURL);

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletRequest.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletRequest.java
@@ -32,7 +32,7 @@ import javax.servlet.http.HttpSession;
 public class VaadinServletRequest extends HttpServletRequestWrapper
         implements VaadinRequest {
 
-    private final VaadinServletService vaadinService;
+    private final VaadinService vaadinService;
 
     /**
      * Wraps a http servlet request and associates with a vaadin service.
@@ -43,7 +43,7 @@ public class VaadinServletRequest extends HttpServletRequestWrapper
      *            the associated vaadin service
      */
     public VaadinServletRequest(HttpServletRequest request,
-            VaadinServletService vaadinService) {
+            VaadinService vaadinService) {
         super(request);
         this.vaadinService = vaadinService;
     }
@@ -73,7 +73,7 @@ public class VaadinServletRequest extends HttpServletRequestWrapper
     }
 
     @Override
-    public VaadinServletService getService() {
+    public VaadinService getService() {
         return vaadinService;
     }
 
@@ -91,8 +91,7 @@ public class VaadinServletRequest extends HttpServletRequestWrapper
         VaadinRequest currentRequest = VaadinRequest.getCurrent();
         if (currentRequest instanceof VaadinServletRequest) {
             return (VaadinServletRequest) currentRequest;
-        } else {
-            return null;
         }
+        return null;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletResponse.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletResponse.java
@@ -31,7 +31,7 @@ import javax.servlet.http.HttpServletResponseWrapper;
 public class VaadinServletResponse extends HttpServletResponseWrapper
         implements VaadinResponse {
 
-    private VaadinServletService vaadinService;
+    private VaadinService vaadinService;
 
     /**
      * Wraps a http servlet response and an associated vaadin service.
@@ -42,7 +42,7 @@ public class VaadinServletResponse extends HttpServletResponseWrapper
      *            the associated vaadin service
      */
     public VaadinServletResponse(HttpServletResponse response,
-            VaadinServletService vaadinService) {
+            VaadinService vaadinService) {
         super(response);
         this.vaadinService = vaadinService;
     }
@@ -78,7 +78,7 @@ public class VaadinServletResponse extends HttpServletResponseWrapper
     }
 
     @Override
-    public VaadinServletService getService() {
+    public VaadinService getService() {
         return vaadinService;
     }
 
@@ -95,8 +95,7 @@ public class VaadinServletResponse extends HttpServletResponseWrapper
         VaadinResponse currentResponse = VaadinResponse.getCurrent();
         if (currentResponse instanceof VaadinServletResponse) {
             return (VaadinServletResponse) currentResponse;
-        } else {
-            return null;
         }
+        return null;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
@@ -285,14 +285,14 @@ public class VaadinServletService extends VaadinService {
 
     @Override
     public String getContextRootRelativePath(VaadinRequest request) {
-        assert request instanceof VaadinServletRequest;
+        assert request instanceof HttpServletRequest;
         // Generate location from the request by finding how many "../" should
         // be added to the servlet path before we get to the context root
 
         // Should not take pathinfo into account because the base URI refers to
         // the servlet path
 
-        String servletPath = ((VaadinServletRequest) request).getServletPath();
+        String servletPath = ((HttpServletRequest) request).getServletPath();
         assert servletPath != null;
         if (!servletPath.endsWith("/")) {
             servletPath += "/";

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/FaviconHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/FaviconHandler.java
@@ -17,12 +17,12 @@ package com.vaadin.flow.server.communication;
 
 import java.io.IOException;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import com.vaadin.flow.server.RequestHandler;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
-import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.server.VaadinSession;
 
 /**
@@ -39,7 +39,9 @@ public class FaviconHandler implements RequestHandler {
     @Override
     public boolean handleRequest(VaadinSession session, VaadinRequest request,
             VaadinResponse response) throws IOException {
-        VaadinServletRequest httpRequest = (VaadinServletRequest) request;
+        //please be careful with changing HttpServletRequest. 
+        //may Implementations VaadinService just deliver HttpServletRequest.
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
         boolean isFavicon = httpRequest.getContextPath().isEmpty()
                 && httpRequest.getServletPath().isEmpty()
                 && "/favicon.ico".equals(httpRequest.getPathInfo());

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
@@ -16,11 +16,14 @@
 
 package com.vaadin.flow.server.communication;
 
+
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URLDecoder;
 import java.util.function.Function;
+
+import javax.servlet.http.HttpServletRequest;
 
 import com.vaadin.flow.component.PushConfiguration;
 import com.vaadin.flow.component.UI;
@@ -28,15 +31,14 @@ import com.vaadin.flow.component.internal.JavaScriptBootstrapUI;
 import com.vaadin.flow.internal.BootstrapHandlerHelper;
 import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.router.Location;
+import com.vaadin.flow.server.AppShellRegistry;
 import com.vaadin.flow.server.BootstrapHandler;
 import com.vaadin.flow.server.DevModeHandler;
 import com.vaadin.flow.server.HandlerHelper;
 import com.vaadin.flow.server.HandlerHelper.RequestType;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
-import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.server.VaadinSession;
-import com.vaadin.flow.server.AppShellRegistry;
 import com.vaadin.flow.shared.ApplicationConstants;
 
 import elemental.json.Json;
@@ -83,7 +85,7 @@ public class JavaScriptBootstrapHandler extends BootstrapHandler {
     }
 
     protected String getRequestUrl(VaadinRequest request) {
-        return ((VaadinServletRequest) request).getRequestURL().toString();
+        return ((HttpServletRequest) request).getRequestURL().toString();
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PushHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PushHandler.java
@@ -41,7 +41,6 @@ import com.vaadin.flow.server.SystemMessages;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServletRequest;
-import com.vaadin.flow.server.VaadinServletService;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.communication.ServerRpcHandler.InvalidUIDLSecurityKeyException;
 import com.vaadin.flow.shared.ApplicationConstants;
@@ -148,7 +147,7 @@ public class PushHandler {
         }
     };
 
-    private VaadinServletService service;
+    private VaadinService service;
 
     /**
      * Creates an instance connected to the given service.
@@ -156,7 +155,7 @@ public class PushHandler {
      * @param service
      *            the service this handler belongs to
      */
-    public PushHandler(VaadinServletService service) {
+    public PushHandler(VaadinService service) {
         this.service = service;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamResourceHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamResourceHandler.java
@@ -16,6 +16,8 @@
 package com.vaadin.flow.server.communication;
 
 import javax.servlet.ServletContext;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
@@ -26,7 +28,6 @@ import com.vaadin.flow.server.StreamResource;
 import com.vaadin.flow.server.StreamResourceWriter;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
-import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.server.VaadinSession;
 
 /**
@@ -60,7 +61,7 @@ public class StreamResourceHandler implements Serializable {
         StreamResourceWriter writer;
         session.lock();
         try {
-            ServletContext context = ((VaadinServletRequest) request)
+            ServletContext context = ((ServletRequest) request)
                     .getServletContext();
             response.setContentType(streamResource.getContentTypeResolver()
                     .apply(streamResource, context));

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
@@ -29,6 +29,8 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.jsoup.nodes.Attribute;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -44,7 +46,6 @@ import com.vaadin.flow.server.HandlerHelper;
 import com.vaadin.flow.server.PwaRegistry;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
-import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.webcomponent.WebComponentConfigurationRegistry;
 import com.vaadin.flow.shared.ApplicationConstants;
@@ -135,7 +136,7 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
      * @return Request's url.
      */
     protected String getRequestUrl(VaadinRequest request) {
-        return ((VaadinServletRequest) request).getRequestURL().toString();
+        return ((HttpServletRequest) request).getRequestURL().toString();
     }
 
     @Override

--- a/flow-server/src/test/java/com/vaadin/flow/server/CustomVaadinServiceImplementationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/CustomVaadinServiceImplementationTest.java
@@ -16,9 +16,13 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.server.communication.PushRequestHandler;
 
-public class OtherImplementationsTest {
+/**
+ * Makes sure that a custom vaadin service that is not vaadin servlet service can be used in when desired.
+ *
+ */
+public class CustomVaadinServiceImplementationTest {
     @Test
-    public void StaticFileServer_Constructor_uses_VadinService()
+    public void StaticFileServer_Constructor_uses_VaadinService()
             throws NoSuchMethodException, SecurityException {
 
         Assert.assertNotNull(
@@ -26,7 +30,7 @@ public class OtherImplementationsTest {
     }
 
     @Test
-    public void VaadinServlet_uses_VadinService()
+    public void VaadinServlet_uses_VaadinService_getService()
             throws NoSuchMethodException, SecurityException {
 
         Assert.assertNotNull(VaadinServlet.class.getDeclaredMethod(
@@ -45,7 +49,7 @@ public class OtherImplementationsTest {
     }
 
     @Test
-    public void VaadinServletRequest_uses_VadinService()
+    public void VaadinServletRequest_uses_VaadinService_getService()
             throws NoSuchMethodException, SecurityException {
 
         Assert.assertNotNull(VaadinServletRequest.class
@@ -59,7 +63,7 @@ public class OtherImplementationsTest {
     }
 
     @Test
-    public void VaadinServletResponse_uses_VadinService()
+    public void VaadinServletResponse_uses_VaadinService_getService()
             throws NoSuchMethodException, SecurityException {
 
         Assert.assertNotNull(VaadinServletResponse.class.getConstructor(
@@ -72,7 +76,7 @@ public class OtherImplementationsTest {
     }
 
     @Test
-    public void PushRequestHandler_uses_VadinService()
+    public void PushRequestHandler_uses_VaadinService_createPushHandler()
             throws NoSuchMethodException, SecurityException {
 
         Method mgetService = PushRequestHandler.class
@@ -81,12 +85,12 @@ public class OtherImplementationsTest {
     }
 
     @Test
-    public void VadinService_uses_VadinService() throws NoSuchMethodException,
+    public void VaadinResponse_sendError() throws NoSuchMethodException,
             SecurityException, ServiceException, IOException {
-        VaadinService vs = new MockVadinService();
+        VaadinService vs = new MockVaadinService();
 
-        VadinHttpServletResponseI response = Mockito
-                .mock(VadinHttpServletResponseI.class);
+        VaadinHttpServletResponseI response = Mockito
+                .mock(VaadinHttpServletResponseI.class);
 
         Mockito.doThrow(new RuntimeException(
                 "Please check that you really nead more than a HttpServletResponse"))
@@ -97,7 +101,7 @@ public class OtherImplementationsTest {
 
     }
 
-    abstract class AbstractMockVadinService extends VaadinService {
+    abstract class AbstractMockVaadinService extends VaadinService {
 
         private static final long serialVersionUID = 1L;
         public static final String TEST_SESSION_EXPIRED_URL = "TestSessionExpiredURL";
@@ -177,7 +181,7 @@ public class OtherImplementationsTest {
 
     }
 
-    class MockVadinService extends AbstractMockVadinService {
+    class MockVaadinService extends AbstractMockVaadinService {
 
         private static final long serialVersionUID = 1L;
 
@@ -198,7 +202,7 @@ public class OtherImplementationsTest {
         }
     }
 
-    interface VadinHttpServletResponseI
+    interface VaadinHttpServletResponseI
             extends VaadinResponse, HttpServletResponse {
 
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/OtherImplementationsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/OtherImplementationsTest.java
@@ -1,0 +1,205 @@
+package com.vaadin.flow.server;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Locale;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.server.communication.PushRequestHandler;
+
+public class OtherImplementationsTest {
+    @Test
+    public void StaticFileServer_Constructor_uses_VadinService()
+            throws NoSuchMethodException, SecurityException {
+
+        Assert.assertNotNull(
+                StaticFileServer.class.getConstructor(VaadinService.class));
+    }
+
+    @Test
+    public void VaadinServlet_uses_VadinService()
+            throws NoSuchMethodException, SecurityException {
+
+        Assert.assertNotNull(VaadinServlet.class.getDeclaredMethod(
+                "createStaticFileHandler", VaadinService.class));
+
+        Method mcreateVaadinResponse = VaadinServlet.class.getDeclaredMethod(
+                "createVaadinResponse", HttpServletResponse.class);
+        Assert.assertNotNull(mcreateVaadinResponse);
+        Assert.assertEquals(VaadinResponse.class,
+                mcreateVaadinResponse.getReturnType());
+
+        Method mgetService = VaadinServlet.class
+                .getDeclaredMethod("getService");
+        Assert.assertNotNull(mgetService);
+        Assert.assertEquals(VaadinService.class, mgetService.getReturnType());
+    }
+
+    @Test
+    public void VaadinServletRequest_uses_VadinService()
+            throws NoSuchMethodException, SecurityException {
+
+        Assert.assertNotNull(VaadinServletRequest.class
+                .getConstructor(HttpServletRequest.class, VaadinService.class));
+
+        Method mgetService = VaadinServletRequest.class
+                .getDeclaredMethod("getService");
+        Assert.assertNotNull(mgetService);
+        Assert.assertEquals(VaadinService.class, mgetService.getReturnType());
+
+    }
+
+    @Test
+    public void VaadinServletResponse_uses_VadinService()
+            throws NoSuchMethodException, SecurityException {
+
+        Assert.assertNotNull(VaadinServletResponse.class.getConstructor(
+                HttpServletResponse.class, VaadinService.class));
+
+        Method mgetService = VaadinServletResponse.class
+                .getDeclaredMethod("getService");
+        Assert.assertNotNull(mgetService);
+        Assert.assertEquals(VaadinService.class, mgetService.getReturnType());
+    }
+
+    @Test
+    public void PushRequestHandler_uses_VadinService()
+            throws NoSuchMethodException, SecurityException {
+
+        Method mgetService = PushRequestHandler.class
+                .getDeclaredMethod("createPushHandler", VaadinService.class);
+        Assert.assertNotNull(mgetService);
+    }
+
+    @Test
+    public void VadinService_uses_VadinService() throws NoSuchMethodException,
+            SecurityException, ServiceException, IOException {
+        VaadinService vs = new MockVadinService();
+
+        VadinHttpServletResponseI response = Mockito
+                .mock(VadinHttpServletResponseI.class);
+
+        Mockito.doThrow(new RuntimeException(
+                "Please check that you really nead more than a HttpServletResponse"))
+                .when(response)
+                .sendError(Mockito.anyInt(), Mockito.anyString());
+
+        vs.handleSessionExpired(Mockito.mock(VaadinRequest.class), response);
+
+    }
+
+    abstract class AbstractMockVadinService extends VaadinService {
+
+        private static final long serialVersionUID = 1L;
+        public static final String TEST_SESSION_EXPIRED_URL = "TestSessionExpiredURL";
+
+        @Override
+        protected RouteRegistry getRouteRegistry() {
+            // ignore
+            return null;
+        }
+
+        @Override
+        protected PwaRegistry getPwaRegistry() {
+            // ignore
+            return null;
+        }
+
+        @Override
+        public String getContextRootRelativePath(VaadinRequest request) {
+            // ignore
+            return null;
+        }
+
+        @Override
+        public String getMimeType(String resourceName) {
+            // ignore
+            return null;
+        }
+
+        @Override
+        protected boolean requestCanCreateSession(VaadinRequest request) {
+            // ignore
+            return false;
+        }
+
+        @Override
+        public String getServiceName() {
+            // ignore
+            return null;
+        }
+
+        @Override
+        public String getMainDivId(VaadinSession session,
+                VaadinRequest request) {
+            // ignore
+            return null;
+        }
+
+        @Override
+        public URL getStaticResource(String url) {
+            // ignore
+            return null;
+        }
+
+        @Override
+        public URL getResource(String url) {
+            // ignore
+            return null;
+        }
+
+        @Override
+        public InputStream getResourceAsStream(String url) {
+            // ignore
+            return null;
+        }
+
+        @Override
+        public String resolveResource(String url) {
+            // ignore
+            return null;
+        }
+
+        @Override
+        protected VaadinContext constructVaadinContext() {
+            // ignore
+            return null;
+        }
+
+    }
+
+    class MockVadinService extends AbstractMockVadinService {
+
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public Iterable<RequestHandler> getRequestHandlers() {
+
+            return new ArrayList<>();
+        }
+
+        @Override
+        public SystemMessages getSystemMessages(Locale locale,
+                VaadinRequest request) {
+
+            SystemMessages systemMessages = Mockito.mock(SystemMessages.class);
+            Mockito.when(systemMessages.getSessionExpiredURL())
+                    .thenReturn(TEST_SESSION_EXPIRED_URL);
+            return systemMessages;
+        }
+    }
+
+    interface VadinHttpServletResponseI
+            extends VaadinResponse, HttpServletResponse {
+
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServletTest.java
@@ -140,7 +140,7 @@ public class VaadinServletTest {
 
             @Override
             protected StaticFileHandler createStaticFileHandler(
-                    VaadinServletService servletService) {
+                    VaadinService servletService) {
                 return Mockito.mock(StaticFileHandler.class);
             }
 
@@ -179,7 +179,7 @@ public class VaadinServletTest {
 
                 @Override
                 protected StaticFileHandler createStaticFileHandler(
-                        VaadinServletService servletService) {
+                        VaadinService servletService) {
                     return Mockito.mock(StaticFileHandler.class);
                 }
 


### PR DESCRIPTION
I cases you are not using the `VaadinServletService` because you ship your own own (Servlet-based) `VaadinService`.

Then you are, at the moment, not able to use fundamental classes like `VaadinServlet`. This is because they use your VaadinServletService. But you are not using any methods of VaadinServletService because VaadinService is enough. So I suggest to use superclasses if possible.

`VaadinServletRequest`needs a `VaadinServletService`

```
    @Override
    public VaadinServletService getService() {
        return vaadinService;
    }
```
If you have your own VaadinService implementation you can't rely on VaadinServletRequest
ant an the moment you cant use a lot of classes like `VaadinServlet`, `PushRequestHandler`, `StreamResourceHandler`, `WebComponentBootstrapHandler`