### PR TITLE
fix: flaky unit test due to race for port numbers

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
@@ -314,6 +314,7 @@ public class DevModeHandlerTest {
         HttpServletRequest request = prepareRequest("/foo/VAADIN//foo.bar");
         DevModeHandler handler = DevModeHandler.start(createDevModeLookup(),
                 npmFolder, CompletableFuture.completedFuture(null));
+        handler.join();
         assertFalse(handler.isDevModeRequest(request));
     }
 
@@ -323,6 +324,7 @@ public class DevModeHandlerTest {
                 "/" + StreamRequestHandler.DYN_RES_PREFIX + "foo");
         DevModeHandler handler = DevModeHandler.start(createDevModeLookup(),
                 npmFolder, CompletableFuture.completedFuture(null));
+        handler.join();
         assertFalse(handler.isDevModeRequest(request));
     }
 
@@ -331,6 +333,7 @@ public class DevModeHandlerTest {
         HttpServletRequest request = prepareRequest("/VAADIN/foo.bar");
         DevModeHandler handler = DevModeHandler.start(createDevModeLookup(),
                 npmFolder, CompletableFuture.completedFuture(null));
+        handler.join();
         assertTrue(handler.isDevModeRequest(request));
     }
 


### PR DESCRIPTION
Many `DevModeHandlerTest` unit tests start a separate thread that looks for a free port via `DevModeHandler::getFreePort`. This method is also used in the tests themselves, primarily via the private method `DevModeHandlerTest::prepareHttpServer`. Even though unit tests are run in sequence, a race conditions over ports between a thread started by a previous test and the setup code of the next test can occur fairly easily. For instance, in the recent builds of master there are two failures related to this:
- https://bender.vaadin.com/viewLog.html?buildId=205729&buildTypeId=Flow_Flow60_Flow60Snapshot
- https://bender.vaadin.com/viewLog.html?buildId=204456&buildTypeId=Flow_Flow60_Flow60Snapshot

This PR adds a `handler.join()` to a few unit tests that were missing it, to ensure that both port binding and release has completed before the continuing to the next unit test.