### PR TITLE
fix: @ServiceRanking is not handled by the osgi bundle generation tool

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -48,6 +48,13 @@
             <version>${osgi.compendium.version}</version>
             <scope>provided</scope>
         </dependency>
+        
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.core</artifactId>
+            <version>${osgi.core.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
 
         <!-- API DEPENDENCIES -->

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DefaultApplicationConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DefaultApplicationConfigurationFactory.java
@@ -25,8 +25,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import org.osgi.framework.Constants;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.propertytypes.ServiceRanking;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,8 +51,8 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.TOKEN_FILE;
  * @since
  *
  */
-@Component(service = ApplicationConfigurationFactory.class)
-@ServiceRanking(Integer.MIN_VALUE)
+@Component(service = ApplicationConfigurationFactory.class, property = Constants.SERVICE_RANKING
+        + ":Integer=" + Integer.MIN_VALUE)
 public class DefaultApplicationConfigurationFactory
         extends AbstractConfigurationFactory
         implements ApplicationConfigurationFactory {

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/ItApplicationConfigurationFactory.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/ItApplicationConfigurationFactory.java
@@ -25,7 +25,8 @@ import com.vaadin.flow.server.frontend.FallbackChunk;
 import com.vaadin.flow.server.startup.ApplicationConfigurationFactory;
 import com.vaadin.flow.server.startup.DefaultApplicationConfigurationFactory;
 
-@Component(service = ApplicationConfigurationFactory.class)
+@Component(service = ApplicationConfigurationFactory.class, property = org.osgi.framework.Constants.SERVICE_RANKING
+        + ":Integer=" + Integer.MAX_VALUE)
 public class ItApplicationConfigurationFactory
         extends DefaultApplicationConfigurationFactory {
 


### PR DESCRIPTION
Use service.ranking property directly and avoid @ServiceRanking
annotation which for some reason is not handled by the bnd tools and no
rank is generated for the OSGI service descriptor.