### PR TITLE
feat: replace awesome-typescript-loader with ts-loader

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -294,7 +294,7 @@ public abstract class NodeUpdater implements FallibleCommand {
         defaults.put("html-webpack-plugin", "3.2.0");
         defaults.put("script-ext-html-webpack-plugin", "2.1.4");
         defaults.put("typescript", "4.0.3");
-        defaults.put("awesome-typescript-loader", "5.2.1");
+        defaults.put("ts-loader", "8.0.12");
 
         defaults.put("webpack", "4.42.0");
         defaults.put("webpack-cli", "3.3.11");

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -165,10 +165,7 @@ module.exports = {
       {
         test: /\.ts$/,
         use: [
-          {
-            loader: 'ts-loader',
-            options: { allowTsInNodeModules: true } 
-          }
+          'ts-loader'
         ]
       },
       {

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -165,7 +165,10 @@ module.exports = {
       {
         test: /\.ts$/,
         use: [
-          'ts-loader'
+          {
+            loader: 'ts-loader',
+            options: { allowTsInNodeModules: true } 
+          }
         ]
       },
       {

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -165,7 +165,7 @@ module.exports = {
       {
         test: /\.ts$/,
         use: [
-          'awesome-typescript-loader'
+          'ts-loader'
         ]
       },
       {

--- a/flow-tests/test-application-theme/test-theme-reusable/src/main/java/com/vaadin/flow/uitest/ui/theme/MyLitField.java
+++ b/flow-tests/test-application-theme/test-theme-reusable/src/main/java/com/vaadin/flow/uitest/ui/theme/MyLitField.java
@@ -23,7 +23,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 /**
  * LIT version of vaadin radio button for testing component theming.
  */
-@JsModule("@vaadin/vaadin-radio-button/vaadin-radio-button.ts")
+@JsModule("@vaadin/vaadin-radio-button/vaadin-radio-button.js")
 @Tag("vaadin-radio-button")
 @NpmPackage(value = "@vaadin/vaadin-radio-button", version = "2.0.0-alpha1")
 public class MyLitField extends Component {

--- a/flow-tests/test-embedding/test-embedding-application-theme/src/main/java/com/vaadin/flow/webcomponent/MyLitField.java
+++ b/flow-tests/test-embedding/test-embedding-application-theme/src/main/java/com/vaadin/flow/webcomponent/MyLitField.java
@@ -23,7 +23,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 /**
  * LIT version of vaadin radio button for testing component theming.
  */
-@JsModule("@vaadin/vaadin-radio-button/vaadin-radio-button.ts")
+@JsModule("@vaadin/vaadin-radio-button/vaadin-radio-button.js")
 @Tag("vaadin-radio-button")
 @NpmPackage(value = "@vaadin/vaadin-radio-button", version = "2.0.0-alpha1")
 public class MyLitField extends Component {

--- a/flow-tests/test-themes/src/main/java/com/vaadin/flow/uitest/ui/theme/MyLitField.java
+++ b/flow-tests/test-themes/src/main/java/com/vaadin/flow/uitest/ui/theme/MyLitField.java
@@ -23,7 +23,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 /**
  * LIT version of vaadin radio button for testing component theming.
  */
-@JsModule("@vaadin/vaadin-radio-button/vaadin-radio-button.ts")
+@JsModule("@vaadin/vaadin-radio-button/vaadin-radio-button.js")
 @Tag("vaadin-radio-button")
 @NpmPackage(value = "@vaadin/vaadin-radio-button", version = "2.0.0-alpha1")
 public class MyLitField extends Component {


### PR DESCRIPTION
`awesome-typescript-loader` has not been updated in the last 2 years and does not guarantee compatibility with TypeScript 4+. `ts-loader` on the other hand is well maintained and tested with TypeScript 4+, and is the most popular Webpack loader for TypeScript files.

Related to #9714.