### PR TITLE
test: mark ThemeLiveReloadIT as not thread safe

### DIFF
--- a/flow-tests/test-application-theme/test-theme-live-reload/pom.xml
+++ b/flow-tests/test-application-theme/test-theme-live-reload/pom.xml
@@ -23,6 +23,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>annotations</artifactId>
+            <version>3.0.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-lumo-theme</artifactId>
             <version>${project.version}</version>

--- a/flow-tests/test-application-theme/test-theme-live-reload/src/test/java/com/vaadin/flow/uitest/ui/ThemeLiveReloadIT.java
+++ b/flow-tests/test-application-theme/test-theme-live-reload/src/test/java/com/vaadin/flow/uitest/ui/ThemeLiveReloadIT.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
+import net.jcip.annotations.NotThreadSafe;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Assert;
@@ -31,6 +32,7 @@ import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
+@NotThreadSafe
 public class ThemeLiveReloadIT extends ChromeBrowserTest {
 
     private static final String RED_COLOR = "rgba(255, 0, 0, 1)";


### PR DESCRIPTION
Marks ThemeLiveReloadIT as not thread safe, since it's tests modify server's state and are run in parallel by default on the CI.