### PR TITLE
feat: implement HasOrderedComponents in HTML layout elements

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Article.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Article.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.html;
 
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasOrderedComponents;
 import com.vaadin.flow.component.HtmlContainer;
 import com.vaadin.flow.component.Tag;
 
@@ -27,7 +28,7 @@ import com.vaadin.flow.component.Tag;
  * @since 1.0
  */
 @Tag(Tag.ARTICLE)
-public class Article extends HtmlContainer implements ClickNotifier<Article> {
+public class Article extends HtmlContainer implements ClickNotifier<Article>, HasOrderedComponents {
 
     /**
      * Creates a new empty article.

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Aside.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Aside.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.html;
 
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasOrderedComponents;
 import com.vaadin.flow.component.HtmlContainer;
 import com.vaadin.flow.component.Tag;
 
@@ -27,7 +28,7 @@ import com.vaadin.flow.component.Tag;
  * @since 1.0
  */
 @Tag(Tag.ASIDE)
-public class Aside extends HtmlContainer implements ClickNotifier<Aside> {
+public class Aside extends HtmlContainer implements ClickNotifier<Aside>, HasOrderedComponents {
 
     /**
      * Creates a new empty aside.

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Div.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Div.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.html;
 
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasOrderedComponents;
 import com.vaadin.flow.component.HtmlContainer;
 import com.vaadin.flow.component.Tag;
 
@@ -27,7 +28,7 @@ import com.vaadin.flow.component.Tag;
  * @since 1.0
  */
 @Tag(Tag.DIV)
-public class Div extends HtmlContainer implements ClickNotifier<Div> {
+public class Div extends HtmlContainer implements ClickNotifier<Div>, HasOrderedComponents {
 
     /**
      * Creates a new empty div.

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Footer.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Footer.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.html;
 
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasOrderedComponents;
 import com.vaadin.flow.component.HtmlContainer;
 import com.vaadin.flow.component.Tag;
 
@@ -27,7 +28,7 @@ import com.vaadin.flow.component.Tag;
  * @since 1.0
  */
 @Tag(Tag.FOOTER)
-public class Footer extends HtmlContainer implements ClickNotifier<Footer> {
+public class Footer extends HtmlContainer implements ClickNotifier<Footer>, HasOrderedComponents {
 
     /**
      * Creates a new empty footer.

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Header.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Header.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.html;
 
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasOrderedComponents;
 import com.vaadin.flow.component.HtmlContainer;
 import com.vaadin.flow.component.Tag;
 
@@ -27,7 +28,7 @@ import com.vaadin.flow.component.Tag;
  * @since 1.0
  */
 @Tag(Tag.HEADER)
-public class Header extends HtmlContainer implements ClickNotifier<Header> {
+public class Header extends HtmlContainer implements ClickNotifier<Header>, HasOrderedComponents {
 
     /**
      * Creates a new empty header.

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Main.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Main.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.html;
 
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasOrderedComponents;
 import com.vaadin.flow.component.HtmlContainer;
 import com.vaadin.flow.component.Tag;
 
@@ -27,7 +28,7 @@ import com.vaadin.flow.component.Tag;
  * @since 1.0
  */
 @Tag(Tag.MAIN)
-public class Main extends HtmlContainer implements ClickNotifier<Main> {
+public class Main extends HtmlContainer implements ClickNotifier<Main>, HasOrderedComponents {
 
     /**
      * Creates a new empty main.

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Nav.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Nav.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.html;
 
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasOrderedComponents;
 import com.vaadin.flow.component.HtmlContainer;
 import com.vaadin.flow.component.Tag;
 
@@ -27,7 +28,7 @@ import com.vaadin.flow.component.Tag;
  * @since 1.0
  */
 @Tag(Tag.NAV)
-public class Nav extends HtmlContainer implements ClickNotifier<Nav> {
+public class Nav extends HtmlContainer implements ClickNotifier<Nav>, HasOrderedComponents {
 
     /**
      * Creates a new empty nav.

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Section.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Section.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.component.html;
 
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasOrderedComponents;
 import com.vaadin.flow.component.HtmlContainer;
 import com.vaadin.flow.component.Tag;
 
@@ -27,7 +28,7 @@ import com.vaadin.flow.component.Tag;
  * @since 1.0
  */
 @Tag(Tag.SECTION)
-public class Section extends HtmlContainer implements ClickNotifier<Section> {
+public class Section extends HtmlContainer implements ClickNotifier<Section>, HasOrderedComponents {
 
     /**
      * Creates a new empty section.

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/ArticleTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/ArticleTest.java
@@ -15,12 +15,20 @@
  */
 package com.vaadin.flow.component.html;
 
+import org.junit.Test;
+
 public class ArticleTest extends ComponentTest {
     // Actual test methods in super class
 
     @Override
     protected void addProperties() {
         // Component defines no new properties
+    }
+
+    @Test
+    @Override
+    public void testHasOrderedComponents() {
+        super.testHasOrderedComponents();
     }
 
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/AsideTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/AsideTest.java
@@ -15,12 +15,20 @@
  */
 package com.vaadin.flow.component.html;
 
+import org.junit.Test;
+
 public class AsideTest extends ComponentTest {
     // Actual test methods in super class
 
     @Override
     protected void addProperties() {
         // Component defines no new properties
+    }
+
+    @Test
+    @Override
+    public void testHasOrderedComponents() {
+        super.testHasOrderedComponents();
     }
 
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/ComponentTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/ComponentTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.html;
 
+import com.vaadin.flow.component.HasOrderedComponents;
 import java.beans.BeanInfo;
 import java.beans.IntrospectionException;
 import java.beans.Introspector;
@@ -115,6 +116,25 @@ public abstract class ComponentTest {
 
     protected Component getComponent() {
         return component;
+    }
+
+    protected void testHasOrderedComponents() {
+        if (!(component instanceof HasOrderedComponents)) {
+            Assert.fail("Component " + component.getClass() + " did not implement HasOrderedComponents anymore.");
+        }
+
+        HasOrderedComponents component = (HasOrderedComponents) this.component;
+        Assert.assertEquals(0, component.getComponentCount());
+
+        Paragraph firstChildren = new Paragraph("first children");
+        component.add(firstChildren);
+        Assert.assertEquals(firstChildren, component.getComponentAt(0));
+
+        Paragraph newFirstChildren = new Paragraph("new first children");
+        component.addComponentAtIndex(0, newFirstChildren);
+        Assert.assertEquals(newFirstChildren, component.getComponentAt(0));
+
+        Assert.assertEquals(1, component.indexOf(firstChildren));
     }
 
     @Test

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/DivTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/DivTest.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.html;
 
+import org.junit.Test;
+
 public class DivTest extends ComponentTest {
 
     // Actual test methods in super class
@@ -22,6 +24,12 @@ public class DivTest extends ComponentTest {
     @Override
     protected void addProperties() {
         // Component defines no new properties
+    }
+
+    @Test
+    @Override
+    public void testHasOrderedComponents() {
+        super.testHasOrderedComponents();
     }
 
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/FooterTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/FooterTest.java
@@ -15,12 +15,20 @@
  */
 package com.vaadin.flow.component.html;
 
+import org.junit.Test;
+
 public class FooterTest extends ComponentTest {
     // Actual test methods in super class
 
     @Override
     protected void addProperties() {
         // Component defines no new properties
+    }
+
+    @Test
+    @Override
+    public void testHasOrderedComponents() {
+        super.testHasOrderedComponents();
     }
 
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/HeaderTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/HeaderTest.java
@@ -15,12 +15,20 @@
  */
 package com.vaadin.flow.component.html;
 
+import org.junit.Test;
+
 public class HeaderTest extends ComponentTest {
     // Actual test methods in super class
 
     @Override
     protected void addProperties() {
         // Component defines no new properties
+    }
+
+    @Test
+    @Override
+    public void testHasOrderedComponents() {
+        super.testHasOrderedComponents();
     }
 
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/MainTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/MainTest.java
@@ -15,12 +15,20 @@
  */
 package com.vaadin.flow.component.html;
 
+import org.junit.Test;
+
 public class MainTest extends ComponentTest {
     // Actual test methods in super class
 
     @Override
     protected void addProperties() {
         // Component defines no new properties
+    }
+
+    @Test
+    @Override
+    public void testHasOrderedComponents() {
+        super.testHasOrderedComponents();
     }
 
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NavTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NavTest.java
@@ -15,12 +15,20 @@
  */
 package com.vaadin.flow.component.html;
 
+import org.junit.Test;
+
 public class NavTest extends ComponentTest {
     // Actual test methods in super class
 
     @Override
     protected void addProperties() {
         // Component defines no new properties
+    }
+
+    @Test
+    @Override
+    public void testHasOrderedComponents() {
+        super.testHasOrderedComponents();
     }
 
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/SectionTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/SectionTest.java
@@ -15,12 +15,20 @@
  */
 package com.vaadin.flow.component.html;
 
+import org.junit.Test;
+
 public class SectionTest extends ComponentTest {
     // Actual test methods in super class
 
     @Override
     protected void addProperties() {
         // Component defines no new properties
+    }
+
+    @Test
+    @Override
+    public void testHasOrderedComponents() {
+        super.testHasOrderedComponents();
     }
 
 }


### PR DESCRIPTION
closes #8188

This PR implements HasOrderedComponents for all common HTML layout elements: 

* Aside
* Article
* Div
* Footer
* Header
* Main
* Nav 
* Section

The test is created in the base test class to simplify the unit testing of all components. To make sure that the interface isn't removed by accident, every class implements the test explicitly and fails if the interface is removed.