### PR TITLE
feat: implement NativeDetails as html component

### DIFF
--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/NativeDetailsElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/NativeDetailsElement.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.testbench.TestBenchElement;
+import com.vaadin.testbench.elementsbase.Element;
+
+/**
+ * A TestBench element representing a <code>&lt;details&gt;</code> element.
+ *
+ * @since
+ */
+@Element("details")
+public class NativeDetailsElement extends TestBenchElement {
+
+}

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/NativeDetailsElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/NativeDetailsElement.java
@@ -29,8 +29,8 @@ import com.vaadin.testbench.elementsbase.Element;
 public class NativeDetailsElement extends TestBenchElement {
 
     /**
-     * Dispatches a {@code toggle} event by clicking the summary
-     * of the details. Toggles the details element open state.
+     * Dispatches a {@code toggle} event by clicking the summary of the details.
+     * Toggles the details element open state.
      */
     public void toggle() {
         findElement(By.tagName("summary")).click();

--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/NativeDetailsElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/NativeDetailsElement.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component.html.testbench;
 
+import org.openqa.selenium.By;
+
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.testbench.elementsbase.Element;
 
@@ -26,4 +28,11 @@ import com.vaadin.testbench.elementsbase.Element;
 @Element("details")
 public class NativeDetailsElement extends TestBenchElement {
 
+    /**
+     * Dispatches a {@code toggle} event by clicking the summary
+     * of the details. Toggles the details element open state.
+     */
+    public void toggle() {
+        findElement(By.tagName("summary")).click();
+    }
 }

--- a/flow-html-components-testbench/src/test/java/com/vaadin/flow/component/html/testbench/NativeDetailsElementIT.java
+++ b/flow-html-components-testbench/src/test/java/com/vaadin/flow/component/html/testbench/NativeDetailsElementIT.java
@@ -1,0 +1,42 @@
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class NativeDetailsElementIT extends ChromeBrowserTest {
+
+    private NativeDetailsElement details;
+    private DivElement log;
+
+    @Before
+    public void open() {
+        getDriver().get("http://localhost:8888/Details");
+        details = $(NativeDetailsElement.class).id("details");
+        log = $(DivElement.class).id("log");
+    }
+
+    @Test
+    public void openDetails() {
+        details.setProperty("open", true);
+        Assert.assertEquals("Toggle event is 'true'", log.getText());
+    }
+
+    @Test
+    public void openAndCloseDetails() {
+        details.setProperty("open", true);
+        Assert.assertEquals("Toggle event is 'true'", log.getText());
+
+        details.setProperty("open", false);
+        Assert.assertEquals("Toggle event is 'false'", log.getText());
+    }
+
+    @Test
+    public void closingAlreadyClosedDetails() {
+        details.setProperty("open", false);
+        // Event should not be triggered, because details open property
+        // defaults to false
+        Assert.assertEquals("", log.getText());
+    }
+}

--- a/flow-html-components-testbench/src/test/java/com/vaadin/flow/component/html/testbench/NativeDetailsElementIT.java
+++ b/flow-html-components-testbench/src/test/java/com/vaadin/flow/component/html/testbench/NativeDetailsElementIT.java
@@ -1,42 +1,84 @@
 package com.vaadin.flow.component.html.testbench;
 
-import com.vaadin.flow.testutil.ChromeBrowserTest;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
 
 public class NativeDetailsElementIT extends ChromeBrowserTest {
 
     private NativeDetailsElement details;
     private DivElement log;
-
-    @Before
-    public void open() {
-        getDriver().get("http://localhost:8888/Details");
-        details = $(NativeDetailsElement.class).id("details");
-        log = $(DivElement.class).id("log");
-    }
+    private NativeButtonElement button;
 
     @Test
     public void openDetails() {
+        prepareTest(false);
+
         details.setProperty("open", true);
-        Assert.assertEquals("Toggle event is 'true'", log.getText());
+        Assert.assertEquals("Toggle event number '1' is 'true'", log.getText());
     }
 
     @Test
     public void openAndCloseDetails() {
+        prepareTest(false);
+
         details.setProperty("open", true);
-        Assert.assertEquals("Toggle event is 'true'", log.getText());
+        Assert.assertEquals("Toggle event number '1' is 'true'", log.getText());
 
         details.setProperty("open", false);
-        Assert.assertEquals("Toggle event is 'false'", log.getText());
+        Assert.assertEquals("Toggle event number '2' is 'false'", log.getText());
     }
 
     @Test
     public void closingAlreadyClosedDetails() {
+        prepareTest(false);
+
         details.setProperty("open", false);
         // Event should not be triggered, because details open property
         // defaults to false
         Assert.assertEquals("", log.getText());
+    }
+
+    @Test
+    public void openAndCloseDetailsFromOtherServerSideComponent() {
+        prepareTest(false);
+
+        button.click();
+        Assert.assertEquals("Toggle event number '1' is 'true'", log.getText());
+
+        button.click();
+        Assert.assertEquals("Toggle event number '2' is 'false'", log.getText());
+    }
+
+    @Test
+    public void toggleNativeDetailsWithTestBenchElement() {
+        prepareTest(false);
+
+        details.toggle();
+        Assert.assertEquals("Toggle event number '1' is 'true'", log.getText());
+
+        details.toggle();
+        Assert.assertEquals("Toggle event number '2' is 'false'", log.getText());
+    }
+
+    @Test
+    public void openDetailsFromServerSideOnInitialRendering() {
+        prepareTest(true);
+
+        // Event should be triggered once, because details was already opened on server side
+        // triggering the toggle event.
+        Assert.assertEquals("Toggle event number '1' is 'true'", log.getText());
+
+        details.setProperty("open", true);
+        // Event should not be triggered again, because details was already opened.
+        Assert.assertEquals("Toggle event number '1' is 'true'", log.getText());
+    }
+
+    private void prepareTest(boolean detailsOpen) {
+        getDriver().get("http://localhost:8888/Details" + (detailsOpen ? "/open" : ""));
+        details = $(NativeDetailsElement.class).id("details");
+        log = $(DivElement.class).id("log");
+        button = $(NativeButtonElement.class).id("btn");
     }
 }

--- a/flow-html-components-testbench/src/test/java/com/vaadin/flow/component/html/testbench/NativeDetailsElementIT.java
+++ b/flow-html-components-testbench/src/test/java/com/vaadin/flow/component/html/testbench/NativeDetailsElementIT.java
@@ -27,7 +27,8 @@ public class NativeDetailsElementIT extends ChromeBrowserTest {
         Assert.assertEquals("Toggle event number '1' is 'true'", log.getText());
 
         details.setProperty("open", false);
-        Assert.assertEquals("Toggle event number '2' is 'false'", log.getText());
+        Assert.assertEquals("Toggle event number '2' is 'false'",
+                log.getText());
     }
 
     @Test
@@ -48,7 +49,8 @@ public class NativeDetailsElementIT extends ChromeBrowserTest {
         Assert.assertEquals("Toggle event number '1' is 'true'", log.getText());
 
         button.click();
-        Assert.assertEquals("Toggle event number '2' is 'false'", log.getText());
+        Assert.assertEquals("Toggle event number '2' is 'false'",
+                log.getText());
     }
 
     @Test
@@ -59,24 +61,28 @@ public class NativeDetailsElementIT extends ChromeBrowserTest {
         Assert.assertEquals("Toggle event number '1' is 'true'", log.getText());
 
         details.toggle();
-        Assert.assertEquals("Toggle event number '2' is 'false'", log.getText());
+        Assert.assertEquals("Toggle event number '2' is 'false'",
+                log.getText());
     }
 
     @Test
     public void openDetailsFromServerSideOnInitialRendering() {
         prepareTest(true);
 
-        // Event should be triggered once, because details was already opened on server side
+        // Event should be triggered once, because details was already opened on
+        // server side
         // triggering the toggle event.
         Assert.assertEquals("Toggle event number '1' is 'true'", log.getText());
 
         details.setProperty("open", true);
-        // Event should not be triggered again, because details was already opened.
+        // Event should not be triggered again, because details was already
+        // opened.
         Assert.assertEquals("Toggle event number '1' is 'true'", log.getText());
     }
 
     private void prepareTest(boolean detailsOpen) {
-        getDriver().get("http://localhost:8888/Details" + (detailsOpen ? "/open" : ""));
+        getDriver().get(
+                "http://localhost:8888/Details" + (detailsOpen ? "/open" : ""));
         details = $(NativeDetailsElement.class).id("details");
         log = $(DivElement.class).id("log");
         button = $(NativeButtonElement.class).id("btn");

--- a/flow-html-components-testbench/src/test/java/com/vaadin/flow/component/html/testbench/NativeDetailsView.java
+++ b/flow-html-components-testbench/src/test/java/com/vaadin/flow/component/html/testbench/NativeDetailsView.java
@@ -1,22 +1,43 @@
 package com.vaadin.flow.component.html.testbench;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeDetails;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.AfterNavigationEvent;
+import com.vaadin.flow.router.AfterNavigationObserver;
 
 @Route("Details")
-public class NativeDetailsView extends Div {
+public class NativeDetailsView extends Div implements AfterNavigationObserver {
+
+    private final NativeDetails details;
 
     public NativeDetailsView() {
+        AtomicInteger eventCounter = new AtomicInteger(0);
+
         Div log = new Div();
         log.setId("log");
 
-        NativeDetails details = new NativeDetails("summary", new Paragraph("content"));
+        details = new NativeDetails("summary", new Paragraph("content"));
         details.setId("details");
-        details.addOpenChangedListener(e -> {
-            log.setText("Toggle event is '" + e.isOpened() + "'");
+        details.addToggleListener(e -> {
+            log.setText("Toggle event number '" + eventCounter.incrementAndGet() + "' is '" + e.isOpened() + "'");
         });
-        add(log, details);
+
+        NativeButton button = new NativeButton("open or close summary");
+        button.setId("btn");
+        button.addClickListener(e -> {
+            // reverts the current details' open state
+            details.setOpen(!details.isOpen());
+        });
+        add(log, button, details);
+    }
+
+    @Override
+    public void afterNavigation(AfterNavigationEvent event) {
+        details.setOpen(event.getLocation().getPath().endsWith("open"));
     }
 }

--- a/flow-html-components-testbench/src/test/java/com/vaadin/flow/component/html/testbench/NativeDetailsView.java
+++ b/flow-html-components-testbench/src/test/java/com/vaadin/flow/component/html/testbench/NativeDetailsView.java
@@ -1,0 +1,22 @@
+package com.vaadin.flow.component.html.testbench;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeDetails;
+import com.vaadin.flow.component.html.Paragraph;
+import com.vaadin.flow.router.Route;
+
+@Route("Details")
+public class NativeDetailsView extends Div {
+
+    public NativeDetailsView() {
+        Div log = new Div();
+        log.setId("log");
+
+        NativeDetails details = new NativeDetails("summary", new Paragraph("content"));
+        details.setId("details");
+        details.addOpenChangedListener(e -> {
+            log.setText("Toggle event is '" + e.isOpened() + "'");
+        });
+        add(log, details);
+    }
+}

--- a/flow-html-components-testbench/src/test/java/com/vaadin/flow/component/html/testbench/NativeDetailsView.java
+++ b/flow-html-components-testbench/src/test/java/com/vaadin/flow/component/html/testbench/NativeDetailsView.java
@@ -24,7 +24,8 @@ public class NativeDetailsView extends Div implements AfterNavigationObserver {
         details = new NativeDetails("summary", new Paragraph("content"));
         details.setId("details");
         details.addToggleListener(e -> {
-            log.setText("Toggle event number '" + eventCounter.incrementAndGet() + "' is '" + e.isOpened() + "'");
+            log.setText("Toggle event number '" + eventCounter.incrementAndGet()
+                    + "' is '" + e.isOpened() + "'");
         });
 
         NativeButton button = new NativeButton("open or close summary");

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeDetails.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeDetails.java
@@ -27,6 +27,7 @@ import com.vaadin.flow.component.HtmlContainer;
 import com.vaadin.flow.component.PropertyDescriptor;
 import com.vaadin.flow.component.PropertyDescriptors;
 import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.shared.Registration;
 import java.util.Objects;
 
@@ -127,7 +128,17 @@ public class NativeDetails extends HtmlComponent implements ClickNotifier<Native
      * @return the summary component
      */
     public Summary getSummary() {
-      return summary;
+        return summary;
+    }
+
+    /**
+     * Returns the textual summary of this details.
+     *
+     * @return the text content of the summary, not <code>null</code>
+     * @see Element#getText()
+     */
+    public String getSummaryText() {
+        return summary.getText();
     }
 
     /**
@@ -138,7 +149,7 @@ public class NativeDetails extends HtmlComponent implements ClickNotifier<Native
      * @param summary
      *            the summary text to set.
      */
-    public void setSummary(String summary) {
+    public void setSummaryText(String summary) {
         this.summary.setText(summary);
     }
 
@@ -189,7 +200,7 @@ public class NativeDetails extends HtmlComponent implements ClickNotifier<Native
      * @return whether details are expanded or collapsed
      */
     public boolean isOpen() {
-        return openDescriptor.get(this);
+        return get(openDescriptor);
     }
 
     /**
@@ -200,7 +211,7 @@ public class NativeDetails extends HtmlComponent implements ClickNotifier<Native
      * @param open the boolean value to set
      */
     public void setOpen(boolean open) {
-        openDescriptor.set(this, open);
+        set(openDescriptor, open);
     }
 
     /**

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeDetails.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeDetails.java
@@ -37,7 +37,8 @@ import com.vaadin.flow.shared.Registration;
  * @since
  */
 @Tag(Tag.DETAILS)
-public class NativeDetails extends HtmlComponent implements ClickNotifier<NativeDetails> {
+public class NativeDetails extends HtmlComponent
+        implements ClickNotifier<NativeDetails> {
 
     /**
      * Component representing a <code>&lt;summary&gt;</code> element.
@@ -45,7 +46,8 @@ public class NativeDetails extends HtmlComponent implements ClickNotifier<Native
      * @author Vaadin Ltd
      */
     @Tag(Tag.SUMMARY)
-    public static class Summary extends HtmlContainer implements ClickNotifier<Summary> {
+    public static class Summary extends HtmlContainer
+            implements ClickNotifier<Summary> {
 
         /**
          * Creates a new empty summary.
@@ -104,8 +106,7 @@ public class NativeDetails extends HtmlComponent implements ClickNotifier<Native
     }
 
     /**
-     * Creates a new details using the provided summary content
-     * and content.
+     * Creates a new details using the provided summary content and content.
      *
      * @param summaryContent
      *            the summary content to set.
@@ -118,8 +119,7 @@ public class NativeDetails extends HtmlComponent implements ClickNotifier<Native
     }
 
     /**
-     * Returns {@link Summary} component associated
-     * with this details.
+     * Returns {@link Summary} component associated with this details.
      *
      * @return the summary component
      */
@@ -138,8 +138,8 @@ public class NativeDetails extends HtmlComponent implements ClickNotifier<Native
     }
 
     /**
-     * Sets the text of the summary.
-     * Removes previously set components of the summary.
+     * Sets the text of the summary. Removes previously set components of the
+     * summary.
      *
      * @see #getSummary()
      * @param summary
@@ -150,16 +150,16 @@ public class NativeDetails extends HtmlComponent implements ClickNotifier<Native
     }
 
     /**
-     * Sets the components of the summary.
-     * Removes previously set text or components of the summary.
+     * Sets the components of the summary. Removes previously set text or
+     * components of the summary.
      *
      * @see #getSummary()
      * @param summaryContent
      *            the summary content to set.
      */
     public void setSummary(Component... summaryContent) {
-       this.summary.removeAll();
-       this.summary.add(summaryContent);
+        this.summary.removeAll();
+        this.summary.add(summaryContent);
     }
 
     /**
@@ -173,8 +173,7 @@ public class NativeDetails extends HtmlComponent implements ClickNotifier<Native
     }
 
     /**
-     * Sets the details content and removes the
-     * previously set content.
+     * Sets the details content and removes the previously set content.
      *
      * @see #getContent()
      * @param content
@@ -190,8 +189,7 @@ public class NativeDetails extends HtmlComponent implements ClickNotifier<Native
     }
 
     /**
-     * Return whether or not the details is opened and the content
-     * is displayed.
+     * Return whether or not the details is opened and the content is displayed.
      *
      * @return whether details are expanded or collapsed
      */
@@ -201,11 +199,12 @@ public class NativeDetails extends HtmlComponent implements ClickNotifier<Native
     }
 
     /**
-     * Sets whether or not the details should be opened.
-     * {@code true} if the details should be opened and the
-     * content should be displayed, {@code false} to collapse it.
+     * Sets whether or not the details should be opened. {@code true} if the
+     * details should be opened and the content should be displayed,
+     * {@code false} to collapse it.
      *
-     * @param open the boolean value to set
+     * @param open
+     *            the boolean value to set
      */
     public void setOpen(boolean open) {
         getElement().setProperty("open", open);
@@ -214,13 +213,13 @@ public class NativeDetails extends HtmlComponent implements ClickNotifier<Native
     /**
      * Represents the DOM event "toggle".
      *
-     * In addition to the usual events supported by HTML elements,
-     * the details element supports the toggle event, which is dispatched
-     * to the details element whenever its state changes between open and closed.
+     * In addition to the usual events supported by HTML elements, the details
+     * element supports the toggle event, which is dispatched to the details
+     * element whenever its state changes between open and closed.
      *
-     * It is sent after the state is changed, although if the state
-     * changes multiple times before the browser can dispatch the event,
-     * the events are coalesced so that only one is sent.
+     * It is sent after the state is changed, although if the state changes
+     * multiple times before the browser can dispatch the event, the events are
+     * coalesced so that only one is sent.
      *
      * @see <a href=
      *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details">https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details</a>
@@ -252,15 +251,16 @@ public class NativeDetails extends HtmlComponent implements ClickNotifier<Native
     }
 
     /**
-     * Adds a listener for {@code toggle} events fired by the
-     * details, which are dispatched to the details element
-     * whenever its state changes between open and closed.
+     * Adds a listener for {@code toggle} events fired by the details, which are
+     * dispatched to the details element whenever its state changes between open
+     * and closed.
      *
      * @param listener
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    public Registration addToggleListener(ComponentEventListener<ToggleEvent> listener) {
+    public Registration addToggleListener(
+            ComponentEventListener<ToggleEvent> listener) {
         return ComponentUtil.addListener(this, ToggleEvent.class, listener);
     }
 }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeDetails.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeDetails.java
@@ -15,21 +15,20 @@
  */
 package com.vaadin.flow.component.html;
 
+import java.util.Objects;
+
 import com.vaadin.flow.component.ClickNotifier;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.DomEvent;
-import com.vaadin.flow.component.EventData;
 import com.vaadin.flow.component.HtmlComponent;
 import com.vaadin.flow.component.HtmlContainer;
-import com.vaadin.flow.component.PropertyDescriptor;
-import com.vaadin.flow.component.PropertyDescriptors;
+import com.vaadin.flow.component.Synchronize;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.shared.Registration;
-import java.util.Objects;
 
 /**
  * Component representing a <code>&lt;details&gt;</code> element.
@@ -39,9 +38,6 @@ import java.util.Objects;
  */
 @Tag(Tag.DETAILS)
 public class NativeDetails extends HtmlComponent implements ClickNotifier<NativeDetails> {
-
-    private static final PropertyDescriptor<Boolean, Boolean> openDescriptor = PropertyDescriptors
-      .propertyWithDefault("open", false);
 
     /**
      * Component representing a <code>&lt;summary&gt;</code> element.
@@ -199,8 +195,9 @@ public class NativeDetails extends HtmlComponent implements ClickNotifier<Native
      *
      * @return whether details are expanded or collapsed
      */
+    @Synchronize(property = "open", value = "toggle")
     public boolean isOpen() {
-        return get(openDescriptor);
+        return getElement().getProperty("open", false);
     }
 
     /**
@@ -211,7 +208,7 @@ public class NativeDetails extends HtmlComponent implements ClickNotifier<Native
      * @param open the boolean value to set
      */
     public void setOpen(boolean open) {
-        set(openDescriptor, open);
+        getElement().setProperty("open", open);
     }
 
     /**
@@ -231,8 +228,6 @@ public class NativeDetails extends HtmlComponent implements ClickNotifier<Native
     @DomEvent("toggle")
     public static class ToggleEvent extends ComponentEvent<NativeDetails> {
 
-        private final boolean opened;
-
         /**
          * ToggleEvent base constructor.
          *
@@ -241,14 +236,9 @@ public class NativeDetails extends HtmlComponent implements ClickNotifier<Native
          * @param fromClient
          *            <code>true</code> if the event originated from the client
          *            side, <code>false</code> otherwise
-         * @param opened
-         *            <code>true</code> if the details was opened,
-         *            <code>false</code> otherwise
          */
-        public ToggleEvent(NativeDetails source, boolean fromClient,
-                           @EventData("event.target.open") boolean opened) {
+        public ToggleEvent(NativeDetails source, boolean fromClient) {
             super(source, fromClient);
-            this.opened = opened;
         }
 
         /**
@@ -257,21 +247,20 @@ public class NativeDetails extends HtmlComponent implements ClickNotifier<Native
          * @return whether details are expanded or collapsed
          */
         public boolean isOpened() {
-            return opened;
+            return getSource().isOpen();
         }
     }
 
     /**
      * Adds a listener for {@code toggle} events fired by the
-     * details.
+     * details, which are dispatched to the details element
+     * whenever its state changes between open and closed.
      *
      * @param listener
      *            the listener
      * @return a {@link Registration} for removing the event listener
      */
-    public Registration addOpenChangedListener(
-      ComponentEventListener<ToggleEvent> listener) {
-        return ComponentUtil.addListener(this, ToggleEvent.class,
-          listener);
+    public Registration addToggleListener(ComponentEventListener<ToggleEvent> listener) {
+        return ComponentUtil.addListener(this, ToggleEvent.class, listener);
     }
 }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeDetails.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeDetails.java
@@ -227,8 +227,13 @@ public class NativeDetails extends HtmlComponent
     @DomEvent("toggle")
     public static class ToggleEvent extends ComponentEvent<NativeDetails> {
 
+        private final boolean open;
+
         /**
          * ToggleEvent base constructor.
+         * <p>
+         * Note: This event is always triggered on client side.
+         * Resulting in {@code fromClient} to be always {@code true}.
          *
          * @param source
          *            the source component
@@ -238,15 +243,18 @@ public class NativeDetails extends HtmlComponent
          */
         public ToggleEvent(NativeDetails source, boolean fromClient) {
             super(source, fromClient);
+            this.open = source.isOpen();
         }
 
         /**
          * Return whether or not the details was opened or closed in this event.
+         * <p>
+         * Delegating to the source component after the toggle event occurred.
          *
          * @return whether details are expanded or collapsed
          */
         public boolean isOpened() {
-            return getSource().isOpen();
+            return open;
         }
     }
 
@@ -254,6 +262,9 @@ public class NativeDetails extends HtmlComponent
      * Adds a listener for {@code toggle} events fired by the details, which are
      * dispatched to the details element whenever its state changes between open
      * and closed.
+     * <p>
+     * Note: This event is always triggered on client side. Resulting in
+     * {@code isFromClient()} to always return {@code true}.
      *
      * @param listener
      *            the listener

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeDetails.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeDetails.java
@@ -64,7 +64,7 @@ public class NativeDetails extends HtmlComponent implements ClickNotifier<Native
     private Component content;
 
     /**
-     * Creates a new details with an empty summary..
+     * Creates a new details with an empty summary.
      */
     public NativeDetails() {
         super();
@@ -233,6 +233,18 @@ public class NativeDetails extends HtmlComponent implements ClickNotifier<Native
 
         private final boolean opened;
 
+        /**
+         * ToggleEvent base constructor.
+         *
+         * @param source
+         *            the source component
+         * @param fromClient
+         *            <code>true</code> if the event originated from the client
+         *            side, <code>false</code> otherwise
+         * @param opened
+         *            <code>true</code> if the details was opened,
+         *            <code>false</code> otherwise
+         */
         public ToggleEvent(NativeDetails source, boolean fromClient,
                            @EventData("event.target.open") boolean opened) {
             super(source, fromClient);
@@ -240,6 +252,8 @@ public class NativeDetails extends HtmlComponent implements ClickNotifier<Native
         }
 
         /**
+         * Return whether or not the details was opened or closed in this event.
+         *
          * @return whether details are expanded or collapsed
          */
         public boolean isOpened() {

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeDetails.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/NativeDetails.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import com.vaadin.flow.component.ClickNotifier;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.component.DomEvent;
+import com.vaadin.flow.component.EventData;
+import com.vaadin.flow.component.HtmlComponent;
+import com.vaadin.flow.component.HtmlContainer;
+import com.vaadin.flow.component.PropertyDescriptor;
+import com.vaadin.flow.component.PropertyDescriptors;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.shared.Registration;
+import java.util.Objects;
+
+/**
+ * Component representing a <code>&lt;details&gt;</code> element.
+ *
+ * @author Vaadin Ltd
+ * @since
+ */
+@Tag(Tag.DETAILS)
+public class NativeDetails extends HtmlComponent implements ClickNotifier<NativeDetails> {
+
+    private static final PropertyDescriptor<Boolean, Boolean> openDescriptor = PropertyDescriptors
+      .propertyWithDefault("open", false);
+
+    /**
+     * Component representing a <code>&lt;summary&gt;</code> element.
+     *
+     * @author Vaadin Ltd
+     */
+    @Tag(Tag.SUMMARY)
+    public static class Summary extends HtmlContainer implements ClickNotifier<Summary> {
+
+        /**
+         * Creates a new empty summary.
+         */
+        public Summary() {
+            super();
+        }
+
+    }
+
+    private final Summary summary;
+    private Component content;
+
+    /**
+     * Creates a new details with an empty summary..
+     */
+    public NativeDetails() {
+        super();
+        summary = new Summary();
+        getElement().appendChild(summary.getElement());
+    }
+
+    /**
+     * Creates a new details with the given summary.
+     *
+     * @param summary
+     *            the summary to set.
+     */
+    public NativeDetails(String summary) {
+        this();
+        this.summary.setText(summary);
+    }
+
+    /**
+     * Creates a new details with the given content of the summary.
+     *
+     * @param summaryContent
+     *            the summary content to set.
+     */
+    public NativeDetails(Component summaryContent) {
+        this();
+        summary.add(summaryContent);
+    }
+
+    /**
+     * Creates a new details using the provided summary and content.
+     *
+     * @param summary
+     *            the summary text to set.
+     * @param content
+     *            the content component to set.
+     */
+    public NativeDetails(String summary, Component content) {
+        this(summary);
+        setContent(content);
+    }
+
+    /**
+     * Creates a new details using the provided summary content
+     * and content.
+     *
+     * @param summaryContent
+     *            the summary content to set.
+     * @param content
+     *            the content component to set.
+     */
+    public NativeDetails(Component summaryContent, Component content) {
+        this(summaryContent);
+        setContent(content);
+    }
+
+    /**
+     * Returns {@link Summary} component associated
+     * with this details.
+     *
+     * @return the summary component
+     */
+    public Summary getSummary() {
+      return summary;
+    }
+
+    /**
+     * Sets the text of the summary.
+     * Removes previously set components of the summary.
+     *
+     * @see #getSummary()
+     * @param summary
+     *            the summary text to set.
+     */
+    public void setSummary(String summary) {
+        this.summary.setText(summary);
+    }
+
+    /**
+     * Sets the components of the summary.
+     * Removes previously set text or components of the summary.
+     *
+     * @see #getSummary()
+     * @param summaryContent
+     *            the summary content to set.
+     */
+    public void setSummary(Component... summaryContent) {
+       this.summary.removeAll();
+       this.summary.add(summaryContent);
+    }
+
+    /**
+     * Returns the details content which was set via
+     * {@link #setContent(Component)}.
+     *
+     * @return the content of the details, can be <code>null</code>.
+     */
+    public Component getContent() {
+        return content;
+    }
+
+    /**
+     * Sets the details content and removes the
+     * previously set content.
+     *
+     * @see #getContent()
+     * @param content
+     *            the content of the details to set
+     */
+    public void setContent(Component content) {
+        Objects.requireNonNull(content, "Content to set cannot be null");
+        if (this.content != null) {
+            this.content.getElement().removeFromParent();
+        }
+        this.content = content;
+        getElement().appendChild(content.getElement());
+    }
+
+    /**
+     * Return whether or not the details is opened and the content
+     * is displayed.
+     *
+     * @return whether details are expanded or collapsed
+     */
+    public boolean isOpen() {
+        return openDescriptor.get(this);
+    }
+
+    /**
+     * Sets whether or not the details should be opened.
+     * {@code true} if the details should be opened and the
+     * content should be displayed, {@code false} to collapse it.
+     *
+     * @param open the boolean value to set
+     */
+    public void setOpen(boolean open) {
+        openDescriptor.set(this, open);
+    }
+
+    /**
+     * Represents the DOM event "toggle".
+     *
+     * In addition to the usual events supported by HTML elements,
+     * the details element supports the toggle event, which is dispatched
+     * to the details element whenever its state changes between open and closed.
+     *
+     * It is sent after the state is changed, although if the state
+     * changes multiple times before the browser can dispatch the event,
+     * the events are coalesced so that only one is sent.
+     *
+     * @see <a href=
+     *      "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details">https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details</a>
+     */
+    @DomEvent("toggle")
+    public static class ToggleEvent extends ComponentEvent<NativeDetails> {
+
+        private final boolean opened;
+
+        public ToggleEvent(NativeDetails source, boolean fromClient,
+                           @EventData("event.target.open") boolean opened) {
+            super(source, fromClient);
+            this.opened = opened;
+        }
+
+        /**
+         * @return whether details are expanded or collapsed
+         */
+        public boolean isOpened() {
+            return opened;
+        }
+    }
+
+    /**
+     * Adds a listener for {@code toggle} events fired by the
+     * details.
+     *
+     * @param listener
+     *            the listener
+     * @return a {@link Registration} for removing the event listener
+     */
+    public Registration addOpenChangedListener(
+      ComponentEventListener<ToggleEvent> listener) {
+        return ComponentUtil.addListener(this, ToggleEvent.class,
+          listener);
+    }
+}

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/HtmlComponentSmokeTest.java
@@ -61,13 +61,26 @@ public class HtmlComponentSmokeTest {
         testValues.put(int.class, 42);
         testValues.put(IFrame.ImportanceType.class, IFrame.ImportanceType.HIGH);
         testValues.put(IFrame.SandboxType[].class, new IFrame.SandboxType[] { IFrame.SandboxType.ALLOW_POPUPS, IFrame.SandboxType.ALLOW_MODALS });
+        testValues.put(Component.class, new Paragraph("Component"));
+    }
+
+    private static final Map<Class<?>, Map<Class<?>, Object>> specialTestValues = new HashMap<>();
+    static {
+        specialTestValues.put(NativeDetails.class, new HashMap<>());
+        specialTestValues.computeIfPresent(NativeDetails.class, (key, nestedTestValueMap) -> {
+            nestedTestValueMap.put(boolean.class, true); // special case because setOpen defaults to false
+            return nestedTestValueMap;
+        });
     }
 
     // For classes registered here testStringConstructor will be ignored. This test checks whether the content of the
     // element is the constructor argument. However, for some HTMLComponents this test is not valid.
+    //
+    // -  NativeDetails delegates it's string constructor to the nested <summary>
     private static final Set<Class<?>> ignoredStringConstructors = new HashSet<>();
     static {
         ignoredStringConstructors.add(IFrame.class);
+        ignoredStringConstructors.add(NativeDetails.class);
     }
 
     @Test
@@ -169,7 +182,7 @@ public class HtmlComponentSmokeTest {
     }
 
     private static boolean isSpecialSetter(Method method) {
-        // Shorthand for Lablel.setFor(String)
+        // Shorthand for Label.setFor(String)
         if (method.getDeclaringClass() == Label.class
                 && method.getName().equals("setFor")
                 && method.getParameterTypes()[0] == Component.class) {
@@ -178,6 +191,15 @@ public class HtmlComponentSmokeTest {
         // setFoo(AbstractStreamResource) for resource URLs
         if (method.getParameterCount() == 1 && AbstractStreamResource.class
                 .isAssignableFrom(method.getParameters()[0].getType())) {
+            return true;
+        }
+
+        // -  NativeDetails delegates it's setSummaryText to the nested <summary>
+        // NativeDetails::setSummaryText(String summary)
+        // -  NativeDetails allows to setSummary(Component..) but it returns Summary getSummary instead of Component[]
+        // NativeDetails::setSummary(Component... components)
+        if (method.getDeclaringClass() == NativeDetails.class
+                && method.getName().startsWith("setSummary")) {
             return true;
         }
 
@@ -199,7 +221,13 @@ public class HtmlComponentSmokeTest {
         Assert.assertEquals(setter + " should have the same type as its getter",
                 propertyType, getterType);
 
-        Object testValue = testValues.get(propertyType);
+        Map<Class<?>, Object> specialValueMap = specialTestValues.get(instance.getClass());
+        Object testValue;
+        if (specialValueMap != null && specialValueMap.containsKey(propertyType)) {
+            testValue = specialValueMap.get(propertyType);
+        } else {
+            testValue = testValues.get(propertyType);
+        }
 
         if (testValue == null) {
             throw new UnsupportedOperationException(

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeDetailsTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeDetailsTest.java
@@ -23,11 +23,12 @@ public class NativeDetailsTest extends ComponentTest {
 
     @Override
     protected void addProperties() {
+        // Properties are whitelisted because ComponentTest
+        // expects to have PropertyDescriptor for each property.
         whitelistProperty("content");
         whitelistProperty("summary");
         whitelistProperty("summaryText");
-        addProperty("open", boolean.class, false,
-          true, false,true);
+        whitelistProperty("open");
     }
 
     @Test

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeDetailsTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeDetailsTest.java
@@ -40,7 +40,7 @@ public class NativeDetailsTest extends ComponentTest {
         details = new NativeDetails(new Paragraph("text-summary"));
         Assert.assertEquals("", details.getSummaryText());
         Assert.assertEquals("text-summary",
-          details.getSummary().getElement().getTextRecursively());
+                details.getSummary().getElement().getTextRecursively());
         Assert.assertNull(details.getContent());
 
         Paragraph content = new Paragraph("content");
@@ -49,20 +49,21 @@ public class NativeDetailsTest extends ComponentTest {
         Assert.assertEquals(content, details.getContent());
     }
 
-
     @Test
     public void testSetSummaryReplacesSummary() {
         Paragraph summmary2 = new Paragraph("summary2");
-        NativeDetails details = new NativeDetails("summary1", new Paragraph("content"));
+        NativeDetails details = new NativeDetails("summary1",
+                new Paragraph("content"));
         Assert.assertEquals("summary1", details.getSummaryText());
 
         details.setSummary(summmary2);
         Assert.assertEquals("summary2",
-          details.getSummary().getElement().getTextRecursively());
+                details.getSummary().getElement().getTextRecursively());
 
         details.setSummaryText("summary3");
         Assert.assertEquals("summary3", details.getSummaryText());
     }
+
     @Test
     public void testSetContentReplacesContent() {
         Paragraph content1 = new Paragraph("content1");

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeDetailsTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeDetailsTest.java
@@ -25,6 +25,7 @@ public class NativeDetailsTest extends ComponentTest {
     protected void addProperties() {
         whitelistProperty("content");
         whitelistProperty("summary");
+        whitelistProperty("summaryText");
         addProperty("open", boolean.class, false,
           true, false,true);
     }
@@ -32,18 +33,18 @@ public class NativeDetailsTest extends ComponentTest {
     @Test
     public void testConstructorParams() {
         NativeDetails details = new NativeDetails("text-summary");
-        Assert.assertEquals("text-summary", details.getSummary().getText());
+        Assert.assertEquals("text-summary", details.getSummaryText());
         Assert.assertNull(details.getContent());
 
         details = new NativeDetails(new Paragraph("text-summary"));
-        Assert.assertEquals("", details.getSummary().getText());
+        Assert.assertEquals("", details.getSummaryText());
         Assert.assertEquals("text-summary",
           details.getSummary().getElement().getTextRecursively());
         Assert.assertNull(details.getContent());
 
         Paragraph content = new Paragraph("content");
         details = new NativeDetails("text-summary", content);
-        Assert.assertEquals("text-summary", details.getSummary().getText());
+        Assert.assertEquals("text-summary", details.getSummaryText());
         Assert.assertEquals(content, details.getContent());
     }
 
@@ -52,14 +53,14 @@ public class NativeDetailsTest extends ComponentTest {
     public void testSetSummaryReplacesSummary() {
         Paragraph summmary2 = new Paragraph("summary2");
         NativeDetails details = new NativeDetails("summary1", new Paragraph("content"));
-        Assert.assertEquals("summary1", details.getSummary().getText());
+        Assert.assertEquals("summary1", details.getSummaryText());
 
         details.setSummary(summmary2);
         Assert.assertEquals("summary2",
           details.getSummary().getElement().getTextRecursively());
 
-        details.setSummary("summary3");
-        Assert.assertEquals("summary3", details.getSummary().getText());
+        details.setSummaryText("summary3");
+        Assert.assertEquals("summary3", details.getSummaryText());
     }
     @Test
     public void testSetContentReplacesContent() {

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeDetailsTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/NativeDetailsTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.html;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class NativeDetailsTest extends ComponentTest {
+    // Actual test methods in super class
+
+    @Override
+    protected void addProperties() {
+        whitelistProperty("content");
+        whitelistProperty("summary");
+        addProperty("open", boolean.class, false,
+          true, false,true);
+    }
+
+    @Test
+    public void testConstructorParams() {
+        NativeDetails details = new NativeDetails("text-summary");
+        Assert.assertEquals("text-summary", details.getSummary().getText());
+        Assert.assertNull(details.getContent());
+
+        details = new NativeDetails(new Paragraph("text-summary"));
+        Assert.assertEquals("", details.getSummary().getText());
+        Assert.assertEquals("text-summary",
+          details.getSummary().getElement().getTextRecursively());
+        Assert.assertNull(details.getContent());
+
+        Paragraph content = new Paragraph("content");
+        details = new NativeDetails("text-summary", content);
+        Assert.assertEquals("text-summary", details.getSummary().getText());
+        Assert.assertEquals(content, details.getContent());
+    }
+
+
+    @Test
+    public void testSetSummaryReplacesSummary() {
+        Paragraph summmary2 = new Paragraph("summary2");
+        NativeDetails details = new NativeDetails("summary1", new Paragraph("content"));
+        Assert.assertEquals("summary1", details.getSummary().getText());
+
+        details.setSummary(summmary2);
+        Assert.assertEquals("summary2",
+          details.getSummary().getElement().getTextRecursively());
+
+        details.setSummary("summary3");
+        Assert.assertEquals("summary3", details.getSummary().getText());
+    }
+    @Test
+    public void testSetContentReplacesContent() {
+        Paragraph content1 = new Paragraph("content1");
+        Paragraph content2 = new Paragraph("content2");
+        NativeDetails details = new NativeDetails("text-summary", content1);
+        Assert.assertEquals(content1, details.getContent());
+        Assert.assertTrue(content1.getParent().isPresent());
+        Assert.assertFalse(content2.getParent().isPresent());
+
+        details.setContent(content2);
+        Assert.assertEquals(content2, details.getContent());
+        Assert.assertTrue(content2.getParent().isPresent());
+        Assert.assertFalse(content1.getParent().isPresent());
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/component/Tag.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Tag.java
@@ -59,6 +59,10 @@ public @interface Tag {
      */
     String DD = "dd";
     /**
+     * Tag for an <code>&lt;details&gt;</code>.
+     */
+    String DETAILS = "details";
+    /**
      * Tag for an <code>&lt;div&gt;</code>.
      */
     String DIV = "div";
@@ -170,6 +174,10 @@ public @interface Tag {
      * Tag for an <code>&lt;strong&gt;</code>.
      */
     String STRONG = "strong";
+    /**
+     * Tag for an <code>&lt;summary&gt;</code>.
+     */
+    String SUMMARY = "summary";
     /**
      * Tag for an <code>&lt;textarea&gt;</code>.
      */


### PR DESCRIPTION
Reasoning: Currently `<details>` is missing from the list of html components. This PR fixes this. 

`NativeDetails`  is based on `vaadin-details` except that the html property is called `open` instead of `opened` and the event is called `Toggle` like the html dom event. 

To reduce the API noise `NativeDetails` extends `HtmlComponent` instead of `HtmlContainer`. `HasText` and `HasComponents` would interfere with the already set `<summary>` inside the `<details>`.