### PR TITLE
fix: made path separator based on os

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateThemeImport.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateThemeImport.java
@@ -20,6 +20,7 @@ import static com.vaadin.flow.server.Constants.APPLICATION_THEME_ROOT;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -37,9 +38,14 @@ import com.vaadin.flow.theme.ThemeDefinition;
  * @since
  */
 public class TaskUpdateThemeImport implements FallibleCommand {
-    
-    public static final String APPLICATION_META_INF_RESOURCES = "src/main/resources/META-INF/resources";
-    public static final String APPLICATION_STATIC_RESOURCES = "src/main/resources/static";
+
+    private static final String SEPARATOR = FileSystems.getDefault()
+            .getSeparator();
+    public static final String APPLICATION_META_INF_RESOURCES = "src/main/resources/META-INF/resources"
+            .replace("/", SEPARATOR);
+    public static final String APPLICATION_STATIC_RESOURCES = "src/main/resources/static"
+            .replace("/", SEPARATOR);
+
 
     private final File themeImportFile;
     private final ThemeDefinition theme;
@@ -89,7 +95,9 @@ public class TaskUpdateThemeImport implements FallibleCommand {
             throws ExecutionFailedException {
 
         String themeName = theme.getName();
-        String themePath = String.join("/", APPLICATION_THEME_ROOT, themeName);
+        String delimiter = FileSystems.getDefault().getSeparator();
+        String themePath = String.join(delimiter, APPLICATION_THEME_ROOT,
+                themeName);
 
         List<String> appThemePossiblePaths = getAppThemePossiblePaths(
                 themePath);
@@ -140,19 +148,24 @@ public class TaskUpdateThemeImport implements FallibleCommand {
     }
 
     private List<String> getAppThemePossiblePaths(String themePath) {
-        String frontendTheme = String.join("/",
-                npmFolder.toPath()
-                .relativize(frontendDirectory.toPath()).toString(), themePath);
+        String separator = FileSystems.getDefault().getSeparator();
+        String frontendTheme = String.join(
+                separator, npmFolder.toPath()
+                            .relativize(frontendDirectory.toPath()).toString(),
+                themePath);
 
-        String themePathInMetaInfResources = String.join("/",
+        String themePathInMetaInfResources = String.join(separator,
                 APPLICATION_META_INF_RESOURCES, themePath);
 
-        String themePathInStaticResources = String.join("/",
+        String themePathInStaticResources = String.join(separator,
                 APPLICATION_STATIC_RESOURCES, themePath);
 
+        String nodeModulesPath = FrontendUtils.NODE_MODULES.replace("/",
+                separator);
+        String flowNpmPackageName = FrontendUtils.FLOW_NPM_PACKAGE_NAME
+                .replace("/", separator);
         String themePathInClassPathResources = String.join("",
-                FrontendUtils.NODE_MODULES, FrontendUtils.FLOW_NPM_PACKAGE_NAME,
-                themePath);
+                nodeModulesPath, flowNpmPackageName, themePath);
 
         return Arrays.asList(frontendTheme, themePathInMetaInfResources,
                 themePathInStaticResources, themePathInClassPathResources);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateThemeImportTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateThemeImportTest.java
@@ -26,6 +26,7 @@ import static com.vaadin.flow.server.frontend.TaskUpdateThemeImport.APPLICATION_
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileSystems;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -43,9 +44,11 @@ import net.jcip.annotations.NotThreadSafe;
 @NotThreadSafe
 public class TaskUpdateThemeImportTest {
 
+    private static final String SEPARATOR = FileSystems.getDefault()
+            .getSeparator();
     private static final String CUSTOM_THEME_NAME = "custom-theme";
     private static final String CUSTOM_VARIANT_NAME = "custom-variant";
-    private static final String CUSTOM_THEME_PATH = String.join("/",
+    private static final String CUSTOM_THEME_PATH = String.join(SEPARATOR,
             APPLICATION_THEME_ROOT, CUSTOM_THEME_NAME);
 
     @Rule
@@ -243,7 +246,7 @@ public class TaskUpdateThemeImportTest {
     @Test
     public void taskExecuted_customThemeFolderExistsInBothMetaInfResourcesAndInClasspath_throwsException() {
 
-        String metaInfResources = String.join("/",
+        String metaInfResources = String.join(SEPARATOR,
                 APPLICATION_META_INF_RESOURCES, CUSTOM_THEME_PATH);
         File themeDir = new File(projectRoot, metaInfResources);
         Assert.assertTrue(themeDir.mkdirs());
@@ -266,8 +269,8 @@ public class TaskUpdateThemeImportTest {
     @Test
     public void taskExecuted_customThemeFolderExistsInBothStaticResourcesAndInClasspath_throwsException() {
 
-        String staticResources = String.join("/", APPLICATION_STATIC_RESOURCES,
-                CUSTOM_THEME_PATH);
+        String staticResources = String.join(SEPARATOR,
+                APPLICATION_STATIC_RESOURCES, CUSTOM_THEME_PATH);
         File themeDir = new File(projectRoot, staticResources);
         Assert.assertTrue(themeDir.mkdirs());
 
@@ -289,12 +292,12 @@ public class TaskUpdateThemeImportTest {
     @Test
     public void taskExecuted_customThemeFolderExistsInBothStaticAndMetaInfResources_throwsException() {
 
-        String staticResources = String.join("/", APPLICATION_STATIC_RESOURCES,
-                CUSTOM_THEME_PATH);
+        String staticResources = String.join(SEPARATOR,
+                APPLICATION_STATIC_RESOURCES, CUSTOM_THEME_PATH);
         File themeDirInStatic = new File(projectRoot, staticResources);
         Assert.assertTrue(themeDirInStatic.mkdirs());
 
-        String metaInfResources = String.join("/",
+        String metaInfResources = String.join(SEPARATOR,
                 APPLICATION_META_INF_RESOURCES, CUSTOM_THEME_PATH);
         File themeDirInMetaInf = new File(projectRoot, metaInfResources);
         Assert.assertTrue(themeDirInMetaInf.mkdirs());
@@ -303,11 +306,11 @@ public class TaskUpdateThemeImportTest {
                 ExecutionFailedException.class, taskUpdateThemeImport::execute);
 
         Assert.assertTrue(e.getMessage().contains(String.format(
-                "Discovered Theme folder for theme '%s' "
-                        + "in more than one place in the project. Please "
-                        + "make sure there is only one theme folder with name '%s' "
-                        + "exists in the your project. ",
-                CUSTOM_THEME_NAME, CUSTOM_THEME_NAME)));
+            "Discovered Theme folder for theme '%s' "
+                    + "in more than one place in the project. Please "
+                    + "make sure there is only one theme folder with name '%s' "
+                    + "exists in the your project. ",
+            CUSTOM_THEME_NAME, CUSTOM_THEME_NAME)));
     }
 
     @Test
@@ -316,7 +319,7 @@ public class TaskUpdateThemeImportTest {
         File themeDir = new File(frontendDirectory, CUSTOM_THEME_PATH);
         Assert.assertTrue(themeDir.mkdirs());
 
-        String metaInfResources = String.join("/",
+        String metaInfResources = String.join(SEPARATOR,
                 APPLICATION_META_INF_RESOURCES, CUSTOM_THEME_PATH);
         File themeDirInMetaInf = new File(projectRoot, metaInfResources);
         Assert.assertTrue(themeDirInMetaInf.mkdirs());
@@ -338,8 +341,8 @@ public class TaskUpdateThemeImportTest {
         File themeDir = new File(frontendDirectory, CUSTOM_THEME_PATH);
         Assert.assertTrue(themeDir.mkdirs());
 
-        String staticResources = String.join("/", APPLICATION_STATIC_RESOURCES,
-                CUSTOM_THEME_PATH);
+        String staticResources = String.join(SEPARATOR,
+                APPLICATION_STATIC_RESOURCES, CUSTOM_THEME_PATH);
         File themeDirInStatic = new File(projectRoot, staticResources);
         Assert.assertTrue(themeDirInStatic.mkdirs());
 
@@ -360,12 +363,12 @@ public class TaskUpdateThemeImportTest {
         File themeDir = new File(frontendDirectory, CUSTOM_THEME_PATH);
         Assert.assertTrue(themeDir.mkdirs());
 
-        String staticResources = String.join("/", APPLICATION_STATIC_RESOURCES,
-                CUSTOM_THEME_PATH);
+        String staticResources = String.join(SEPARATOR,
+                APPLICATION_STATIC_RESOURCES, CUSTOM_THEME_PATH);
         File themeDirInStatic = new File(projectRoot, staticResources);
         Assert.assertTrue(themeDirInStatic.mkdirs());
 
-        String metaInfResources = String.join("/",
+        String metaInfResources = String.join(SEPARATOR,
                 APPLICATION_META_INF_RESOURCES, CUSTOM_THEME_PATH);
         File themeDirInMetaInf = new File(projectRoot, metaInfResources);
         Assert.assertTrue(themeDirInMetaInf.mkdirs());
@@ -389,12 +392,12 @@ public class TaskUpdateThemeImportTest {
         File classPathThemeDir = new File(projectRoot, classPathThemePath);
         Assert.assertTrue(classPathThemeDir.mkdirs());
 
-        String staticResources = String.join("/", APPLICATION_STATIC_RESOURCES,
-                CUSTOM_THEME_PATH);
+        String staticResources = String.join(SEPARATOR,
+                APPLICATION_STATIC_RESOURCES, CUSTOM_THEME_PATH);
         File themeDirInStatic = new File(projectRoot, staticResources);
         Assert.assertTrue(themeDirInStatic.mkdirs());
 
-        String metaInfResources = String.join("/",
+        String metaInfResources = String.join(SEPARATOR,
                 APPLICATION_META_INF_RESOURCES, CUSTOM_THEME_PATH);
         File themeDirInMetaInf = new File(projectRoot, metaInfResources);
         Assert.assertTrue(themeDirInMetaInf.mkdirs());


### PR DESCRIPTION
TaskUpdateThemeImportTest fails on windows agents. File Path separators are updated to use OS path separators.