### PR TITLE
fix: verify server live by HEAD to /sw.js instead of /

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
@@ -360,11 +360,16 @@ export class Flow {
     // Note: if flow-client is loaded, it instead handles the state transitions.
     $wnd.addEventListener('online', () => {
       if (!this.isFlowClientLoaded()) {
-        // else, send an HTTP HEAD request to verify the server being online
-        // we don't care about HTTP errors, only network failure
+        // Send an HTTP HEAD request for sw.js to verify server reachability.
+        // We do not expect sw.js to be cached, so the request goes to the
+        // server rather than being served from local cache.
+        // Require network-level failure to revert the state to CONNECTION_LOST
+        // (HTTP error code is ok since it still verifies server's presence).
         $wnd.Vaadin.connectionState.state = ConnectionState.RECONNECTING;
         const http = new XMLHttpRequest();
-        http.open('HEAD', location.pathname || '/');
+        const serverRoot = location.pathname || '/';
+        http.open('HEAD', serverRoot +
+          (serverRoot.endsWith('/') ? '' : ' /') + 'sw.js');
         http.onload = () => {
           $wnd.Vaadin.connectionState.state = ConnectionState.CONNECTED;
         };

--- a/flow-client/src/test/frontend/FlowTests.ts
+++ b/flow-client/src/test/frontend/FlowTests.ts
@@ -712,7 +712,7 @@ suite("Flow", () => {
   });
 
   test("when no Flow client loaded, should transition to CONNECTED when receiving 'offline' and then 'online' events and connection is reestablished", async () => {
-    mock.use('HEAD', /^.*/, (req, res) => {
+    mock.use('HEAD', /^.*sw.js/, (req, res) => {
       return res.status(200);
     });
     new Flow();


### PR DESCRIPTION
To avoid false positive due to service worker serving precached index.html.

Fixes #9688.