### PR TITLE
chore: fix exception message

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
@@ -229,10 +229,12 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
         String frontendDir = FrontendUtils.getProjectFrontendDir(
                 service.getDeploymentConfiguration());
         String indexHtmlFilePath;
-        if(frontendDir.endsWith(File.separator)) {
+        if(frontendDir.endsWith("/") || frontendDir.endsWith(File.separator)) {
             indexHtmlFilePath = frontendDir + "index.html";
-        } else {
+        } else if(frontendDir.contains(File.separator)){
             indexHtmlFilePath = frontendDir + File.separatorChar + "index.html";
+        } else {
+            indexHtmlFilePath = frontendDir + "/index.html";
         }
         String message = String
                 .format("Failed to load content of '%1$s'. "

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
@@ -129,12 +129,8 @@ public class IndexHtmlRequestHandlerTest {
                 .mock(VaadinServletRequest.class);
         Mockito.when(vaadinRequest.getService()).thenReturn(vaadinService);
 
-        String path;
-        if (DEFAULT_FRONTEND_DIR.endsWith(File.separator)) {
-            path = DEFAULT_FRONTEND_DIR + "index.html";
-        } else {
-            path = DEFAULT_FRONTEND_DIR + File.separatorChar + "/index.html";
-        }
+        String path = DEFAULT_FRONTEND_DIR + "index.html";
+
         String expectedError = String
                 .format("Failed to load content of '%1$s'. "
                         + "It is required to have '%1$s' file when "


### PR DESCRIPTION
Fix the exception message and its test
to handle the file separator correctly.
If the base only contains / and the system
separator is \ we should add a / and not the
system separator.

Fixes 6.0 windows build failure.