### PR TITLE
test: ignore ThemeLiveReloadIT

### DIFF
--- a/flow-tests/test-application-theme/test-theme-live-reload/src/test/java/com/vaadin/flow/uitest/ui/ThemeLiveReloadIT.java
+++ b/flow-tests/test-application-theme/test-theme-live-reload/src/test/java/com/vaadin/flow/uitest/ui/ThemeLiveReloadIT.java
@@ -26,12 +26,14 @@ import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
+@Ignore("https://github.com/vaadin/flow/issues/9746")
 @NotThreadSafe
 public class ThemeLiveReloadIT extends ChromeBrowserTest {
 


### PR DESCRIPTION
Ignores ThemeLiveReloadIT temporary until https://github.com/vaadin/flow/issues/9746 is fixed.