### PR TITLE
Refactor startup initializers to use VaadinContext

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/AnnotationValidator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/AnnotationValidator.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.server.startup;
 
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
 import javax.servlet.annotation.HandlesTypes;
 
 import java.util.Arrays;
@@ -26,6 +24,7 @@ import java.util.Set;
 import com.vaadin.flow.component.page.BodySize;
 import com.vaadin.flow.component.page.Inline;
 import com.vaadin.flow.component.page.Viewport;
+import com.vaadin.flow.server.VaadinContext;
 
 /**
  * Validation class that is run during servlet container initialization which
@@ -35,11 +34,10 @@ import com.vaadin.flow.component.page.Viewport;
  */
 @HandlesTypes({ Viewport.class, BodySize.class, Inline.class })
 public class AnnotationValidator extends AbstractAnnotationValidator
-        implements ClassLoaderAwareServletContainerInitializer {
+        implements VaadinServletContextStartupInitializer {
 
     @Override
-    public void process(Set<Class<?>> classSet, ServletContext servletContext)
-            throws ServletException {
+    public void initialize(Set<Class<?>> classSet, VaadinContext context) {
         validateClasses(classSet);
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ApplicationRouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ApplicationRouteRegistry.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.server.startup;
 
-import javax.servlet.ServletContext;
-
 import java.io.Serializable;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
@@ -46,7 +44,6 @@ import com.vaadin.flow.router.internal.PathUtil;
 import com.vaadin.flow.router.internal.RouteTarget;
 import com.vaadin.flow.server.PWA;
 import com.vaadin.flow.server.VaadinContext;
-import com.vaadin.flow.server.VaadinServletContext;
 
 /**
  * Registry for holding navigation target components found on servlet
@@ -107,7 +104,7 @@ public class ApplicationRouteRegistry extends AbstractRouteRegistry {
      * @param context
      *            the vaadin context for which to get a route registry, not
      *            <code>null</code>
-     * @return a registry instance for the given servlet context, not
+     * @return a registry instance for the given context, not
      *         <code>null</code>
      */
     public static ApplicationRouteRegistry getInstance(VaadinContext context) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ClassLoaderAwareServletContainerInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ClassLoaderAwareServletContainerInitializer.java
@@ -92,7 +92,7 @@ public interface ClassLoaderAwareServletContainerInitializer
                         .filter(method -> !method.isDefault()
                                 && !method.isSynthetic())
                         .findFirst().get().getName();
-                Method operation = Stream.of(initializer.getDeclaredMethods())
+                Method operation = Stream.of(initializer.getMethods())
                         .filter(method -> method.getName()
                                 .equals(processMethodName))
                         .findFirst().get();
@@ -136,7 +136,7 @@ public interface ClassLoaderAwareServletContainerInitializer
      * Implement this method instead of {@link #onStartup(Set, ServletContext)}
      * to handle classes accessible by different classloaders.
      *
-     * @param set
+     * @param classSet
      *            the Set of application classes that extend, implement, or have
      *            been annotated with the class types specified by the
      *            {@link javax.servlet.annotation.HandlesTypes HandlesTypes}
@@ -144,9 +144,9 @@ public interface ClassLoaderAwareServletContainerInitializer
      *            <tt>ServletContainerInitializer</tt> has not been annotated
      *            with <tt>HandlesTypes</tt>
      *
-     * @param ctx
+     * @param context
      *            the <tt>ServletContext</tt> of the web application that is
-     *            being started and in which the classes contained in <tt>c</tt>
+     *            being started and in which the classes contained in <tt>classSet</tt>
      *            were found
      *
      * @throws ServletException
@@ -154,5 +154,5 @@ public interface ClassLoaderAwareServletContainerInitializer
      *
      * @see #onStartup(Set, ServletContext)
      */
-    void process(Set<Class<?>> set, ServletContext ctx) throws ServletException;
+    void process(Set<Class<?>> classSet, ServletContext context) throws ServletException;
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DeferredServletContextInitializers.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DeferredServletContextInitializers.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.di.LookupInitializer;
 import com.vaadin.flow.server.VaadinContext;
 
 /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ErrorNavigationTargetInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ErrorNavigationTargetInitializer.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.server.startup;
 
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
 import javax.servlet.annotation.HandlesTypes;
 
 import java.util.HashSet;
@@ -25,7 +23,7 @@ import java.util.stream.Collectors;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.router.HasErrorParameter;
-import com.vaadin.flow.server.VaadinServletContext;
+import com.vaadin.flow.server.VaadinContext;
 
 /**
  * Servlet initializer for collecting all available error handler navigation
@@ -35,12 +33,11 @@ import com.vaadin.flow.server.VaadinServletContext;
  */
 @HandlesTypes(HasErrorParameter.class)
 public class ErrorNavigationTargetInitializer
-        implements ClassLoaderAwareServletContainerInitializer {
+        implements VaadinServletContextStartupInitializer {
 
     @SuppressWarnings("unchecked")
     @Override
-    public void process(Set<Class<?>> classSet, ServletContext servletContext)
-            throws ServletException {
+    public void initialize(Set<Class<?>> classSet, VaadinContext context) {
         if (classSet == null) {
             classSet = new HashSet<>();
         }
@@ -51,7 +48,7 @@ public class ErrorNavigationTargetInitializer
                 .collect(Collectors.toSet());
 
         ApplicationRouteRegistry
-                .getInstance(new VaadinServletContext(servletContext))
+                .getInstance(context)
                 .setErrorNavigationTargets(routes);
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/RouteRegistryInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/RouteRegistryInitializer.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.server.startup;
 
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
 import javax.servlet.annotation.HandlesTypes;
 
 import java.util.Set;
@@ -29,7 +27,7 @@ import com.vaadin.flow.router.RouteAlias;
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.flow.server.AmbiguousRouteConfigurationException;
 import com.vaadin.flow.server.InvalidRouteConfigurationException;
-import com.vaadin.flow.server.VaadinServletContext;
+import com.vaadin.flow.server.VaadinContext;
 
 /**
  * Servlet initializer for collecting all available {@link Route}s on startup.
@@ -38,12 +36,11 @@ import com.vaadin.flow.server.VaadinServletContext;
  */
 @HandlesTypes({ Route.class, RouteAlias.class })
 public class RouteRegistryInitializer extends AbstractRouteRegistryInitializer
-        implements ClassLoaderAwareServletContainerInitializer {
+        implements VaadinServletContextStartupInitializer {
 
     @Override
-    public void process(Set<Class<?>> classSet, ServletContext servletContext)
-            throws ServletException {
-        VaadinServletContext context = new VaadinServletContext(servletContext);
+    public void initialize(Set<Class<?>> classSet, VaadinContext context)
+            throws VaadinInitializerException {
         try {
             if (classSet == null) {
                 ApplicationRouteRegistry routeRegistry = ApplicationRouteRegistry
@@ -65,7 +62,7 @@ public class RouteRegistryInitializer extends AbstractRouteRegistryInitializer
             routeRegistry.setPwaConfigurationClass(validatePwaClass(
                     routes.stream().map(clazz -> (Class<?>) clazz)));
         } catch (InvalidRouteConfigurationException irce) {
-            throw new ServletException(
+            throw new VaadinInitializerException(
                     "Exception while registering Routes on servlet startup",
                     irce);
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletVerifier.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletVerifier.java
@@ -15,7 +15,8 @@
  */
 package com.vaadin.flow.server.startup;
 
-import javax.servlet.ServletContext;
+import com.vaadin.flow.server.VaadinContext;
+
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 
@@ -29,11 +30,16 @@ import java.util.Set;
  *
  * @since 1.0
  */
-public class ServletVerifier implements ClassLoaderAwareServletContainerInitializer {
+public class ServletVerifier implements VaadinServletContextStartupInitializer {
+
     @Override
-    public void process(Set<Class<?>> c, ServletContext ctx)
-            throws ServletException {
-        verifyServletVersion();
+    public void initialize(Set<Class<?>> classSet, VaadinContext context)
+            throws VaadinInitializerException {
+        try {
+            verifyServletVersion();
+        } catch (ServletException e) {
+            throw new VaadinInitializerException(e.getMessage(), e);
+        }
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinAppShellInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinAppShellInitializer.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.server.startup;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
-import javax.servlet.ServletException;
 import javax.servlet.annotation.HandlesTypes;
 import javax.servlet.annotation.WebListener;
 
@@ -30,6 +29,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.vaadin.flow.server.VaadinContext;
+import com.vaadin.flow.server.VaadinServletContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,7 +46,6 @@ import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.InvalidApplicationConfigurationException;
 import com.vaadin.flow.server.PWA;
 import com.vaadin.flow.server.PageConfigurator;
-import com.vaadin.flow.server.VaadinServletContext;
 import com.vaadin.flow.theme.NoTheme;
 import com.vaadin.flow.theme.Theme;
 
@@ -67,15 +67,31 @@ import static com.vaadin.flow.server.AppShellRegistry.ERROR_HEADER_OFFENDING_PWA
 // it
 @WebListener
 public class VaadinAppShellInitializer
-        implements ClassLoaderAwareServletContainerInitializer,
+        implements VaadinServletContextStartupInitializer,
         // implementing ServletContextListener is needed for the @WebListener
         // annotation.
         ServletContextListener, Serializable {
 
     @Override
-    public void process(Set<Class<?>> classes, ServletContext context)
-            throws ServletException {
+    public void initialize(Set<Class<?>> classes, VaadinContext context) {
         init(classes, context);
+    }
+
+    /**
+     * Initializes the {@link AppShellRegistry} for the application.
+     *
+     * @deprecated Use {@link #init(Set, VaadinContext)} instead
+     *            by wrapping {@link ServletContext} with {@link VaadinServletContext}.
+     *
+     * @param classes
+     *            a set of classes that matches the {@link HandlesTypes} set in
+     *            this class.
+     * @param context
+     *            the servlet context.
+     */
+    @Deprecated
+    public static void init(Set<Class<?>> classes, ServletContext context) {
+        init(classes, new VaadinServletContext(context));
     }
 
     /**
@@ -85,12 +101,12 @@ public class VaadinAppShellInitializer
      *            a set of classes that matches the {@link HandlesTypes} set in
      *            this class.
      * @param context
-     *            the servlet context.
+     *            the {@link VaadinContext}.
      */
     @SuppressWarnings("unchecked")
-    public static void init(Set<Class<?>> classes, ServletContext context) {
+    public static void init(Set<Class<?>> classes, VaadinContext context) {
         ApplicationConfiguration config = ApplicationConfiguration
-                .get(new VaadinServletContext(context));
+                .get(context);
 
         if (config.useV14Bootstrap()) {
             return;
@@ -100,7 +116,7 @@ public class VaadinAppShellInitializer
                 Constants.ALLOW_APPSHELL_ANNOTATIONS, false);
 
         AppShellRegistry registry = AppShellRegistry
-                .getInstance(new VaadinServletContext(context));
+                .getInstance(context);
         registry.reset();
 
         if (classes == null || classes.isEmpty()) {
@@ -170,7 +186,7 @@ public class VaadinAppShellInitializer
      * scanning.
      *
      * @return list of annotations handled by
-     *         {@link VaadinAppShellInitializer#init(Set, ServletContext)}
+     *         {@link VaadinAppShellInitializer#init(Set, VaadinContext)}
      */
     @SuppressWarnings("unchecked")
     public static List<Class<? extends Annotation>> getValidAnnotations() {
@@ -186,7 +202,7 @@ public class VaadinAppShellInitializer
      * scanning.
      *
      * @return list of super classes handled by
-     *         {@link VaadinAppShellInitializer#init(Set, ServletContext)}
+     *         {@link VaadinAppShellInitializer#init(Set, VaadinContext)}
      */
     public static List<Class<?>> getValidSupers() {
         return Arrays.stream(getHandledTypes())

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinContextStartupInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinContextStartupInitializer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.startup;
+
+import com.vaadin.flow.server.VaadinContext;
+
+import javax.servlet.ServletContext;
+import java.util.Set;
+
+/**
+ * Applies this initializer to the given {@link VaadinContext}.
+ *
+ * It is intended to be called either:
+ * <ul>
+ * <li>directly by non-servlet implementing HTTP frameworks or</li>
+ * <li>indirectly on servlet container initialization (via
+ * {@link ClassLoaderAwareServletContainerInitializer#onStartup(Set, ServletContext)})</li>
+ * </ul>
+ *
+ * @since
+ *
+ * @see ClassLoaderAwareServletContainerInitializer
+ * @see VaadinServletContextStartupInitializer
+ */
+@FunctionalInterface
+public interface VaadinContextStartupInitializer {
+
+    /**
+     * Applies this initializer to the given context
+     *
+     * @param classSet
+     *            the Set of application classes which this initializer
+     *            needs to do its job
+     *
+     * @param context
+     *            the {@link VaadinContext} to use with this initializer
+     *
+     * @throws VaadinInitializerException
+     *            if an error has occurred
+     */
+    void initialize(Set<Class<?>> classSet, VaadinContext context) throws VaadinInitializerException;
+
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinInitializerException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinInitializerException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.startup;
+
+/**
+ * Indicates an issue during Vaadin initialization.
+ *
+ * @since
+ */
+public class VaadinInitializerException extends Exception {
+
+    /**
+     * Constructs a new exception with the specified detail message.
+     *
+     * @param message
+     *            the detail message. The detail message is saved for later
+     *            retrieval by the {@link #getMessage()} method.
+     */
+    public VaadinInitializerException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and
+     * cause.
+     *
+     * @param  message the detail message (which is saved for later retrieval
+     *         by the {@link #getMessage()} method).
+     * @param  cause the cause (which is saved for later retrieval by the
+     *         {@link #getCause()} method).  (A <tt>null</tt> value is
+     *         permitted, and indicates that the cause is nonexistent or
+     *         unknown.)
+     */
+    public VaadinInitializerException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinServletContextStartupInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinServletContextStartupInitializer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.startup;
+
+import com.vaadin.flow.server.VaadinServletContext;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import java.util.Set;
+
+/**
+ * Allows a library/runtime to be notified of a web
+ * application's startup phase and perform any required programmatic
+ * registration of servlets, filters, and listeners in response to it.
+ *
+ * @since
+ *
+ * @see ClassLoaderAwareServletContainerInitializer
+ */
+@FunctionalInterface
+public interface VaadinServletContextStartupInitializer extends
+        ClassLoaderAwareServletContainerInitializer,
+        VaadinContextStartupInitializer {
+
+    @Override
+    default void process(Set<Class<?>> classSet, ServletContext context) throws ServletException {
+        try {
+            initialize(classSet, new VaadinServletContext(context));
+        } catch (VaadinInitializerException e) {
+            throw new ServletException(e);
+        }
+    }
+
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/WebComponentConfigurationRegistryInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/WebComponentConfigurationRegistryInitializer.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.server.startup;
 
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
 import javax.servlet.annotation.HandlesTypes;
 
 import java.util.Collections;
@@ -33,7 +31,7 @@ import com.vaadin.flow.component.WebComponentExporterFactory;
 import com.vaadin.flow.component.webcomponent.WebComponentConfiguration;
 import com.vaadin.flow.internal.CustomElementNameValidator;
 import com.vaadin.flow.server.InvalidCustomElementNameException;
-import com.vaadin.flow.server.VaadinServletContext;
+import com.vaadin.flow.server.VaadinContext;
 import com.vaadin.flow.server.webcomponent.WebComponentConfigurationRegistry;
 import com.vaadin.flow.server.webcomponent.WebComponentExporterUtils;
 
@@ -48,23 +46,23 @@ import com.vaadin.flow.server.webcomponent.WebComponentExporterUtils;
  */
 @HandlesTypes({ WebComponentExporter.class, WebComponentExporterFactory.class })
 public class WebComponentConfigurationRegistryInitializer
-        implements ClassLoaderAwareServletContainerInitializer {
+        implements VaadinServletContextStartupInitializer {
 
     @Override
     @SuppressWarnings("rawtypes")
-    public void process(Set<Class<?>> set, ServletContext servletContext)
-            throws ServletException {
+    public void initialize(Set<Class<?>> classSet, VaadinContext context)
+            throws VaadinInitializerException {
         WebComponentConfigurationRegistry instance = WebComponentConfigurationRegistry
-                .getInstance(new VaadinServletContext(servletContext));
+                .getInstance(context);
 
-        if (set == null || set.isEmpty()) {
+        if (classSet == null || classSet.isEmpty()) {
             instance.setConfigurations(Collections.emptySet());
             return;
         }
 
         try {
             Set<WebComponentExporterFactory> factories = WebComponentExporterUtils
-                    .getFactories(set);
+                    .getFactories(classSet);
             Set<WebComponentConfiguration<? extends Component>> configurations = constructConfigurations(
                     factories);
 
@@ -73,7 +71,7 @@ public class WebComponentConfigurationRegistryInitializer
 
             instance.setConfigurations(configurations);
         } catch (Exception e) {
-            throw new ServletException(
+            throw new VaadinInitializerException(
                     String.format("%s failed to collect %s implementations!",
                             WebComponentConfigurationRegistryInitializer.class
                                     .getSimpleName(),

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/WebComponentExporterAwareValidator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/WebComponentExporterAwareValidator.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.server.startup;
 
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
 import javax.servlet.annotation.HandlesTypes;
 
 import java.util.Arrays;
@@ -28,6 +26,7 @@ import com.googlecode.gentyref.GenericTypeReflector;
 
 import com.vaadin.flow.component.WebComponentExporter;
 import com.vaadin.flow.component.page.Push;
+import com.vaadin.flow.server.VaadinContext;
 
 /**
  * Checks that specific annotations are not configured wrong.
@@ -40,11 +39,10 @@ import com.vaadin.flow.component.page.Push;
 @HandlesTypes(Push.class)
 public class WebComponentExporterAwareValidator
         extends AbstractAnnotationValidator
-        implements ClassLoaderAwareServletContainerInitializer {
+        implements VaadinServletContextStartupInitializer {
 
     @Override
-    public void process(Set<Class<?>> classSet, ServletContext servletContext)
-            throws ServletException {
+    public void initialize(Set<Class<?>> classSet, VaadinContext context) {
         validateClasses(classSet);
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
@@ -1,7 +1,5 @@
 package com.vaadin.flow.server.startup;
 
-import javax.servlet.ServletException;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -23,6 +21,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
+import com.vaadin.flow.server.VaadinServletContext;
 import net.jcip.annotations.NotThreadSafe;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -122,32 +121,32 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
 
     @Test
     public void loadingJars_useModernResourcesFolder_allFilesExist()
-            throws IOException, ServletException {
+            throws IOException, VaadinInitializerException {
         loadingJars_allFilesExist(RESOURCES_FRONTEND_DEFAULT);
     }
 
     @Test
     public void loadingZipProtocolJars_useModernResourcesFolder_allFilesExist()
-            throws IOException, ServletException {
+            throws IOException, VaadinInitializerException {
         loadingZipProtocolJars_allFilesExist(RESOURCES_FRONTEND_DEFAULT);
     }
 
     @Test
     public void loadingJars_useObsoleteResourcesFolder_allFilesExist()
-            throws IOException, ServletException {
+            throws IOException, VaadinInitializerException {
         loadingJars_allFilesExist(COMPATIBILITY_RESOURCES_FRONTEND_DEFAULT);
     }
 
     @Test
     public void loadingFsResources_useModernResourcesFolder_allFilesExist()
-            throws IOException, ServletException {
+            throws IOException, VaadinInitializerException {
         loadingFsResources_allFilesExist("/dir-with-modern-frontend/",
                 RESOURCES_FRONTEND_DEFAULT);
     }
 
     @Test
     public void loadingFsResources_useObsoleteResourcesFolder_allFilesExist()
-            throws IOException, ServletException {
+            throws IOException, VaadinInitializerException {
         loadingFsResources_allFilesExist("/dir-with-frontend-resources/",
                 COMPATIBILITY_RESOURCES_FRONTEND_DEFAULT);
     }
@@ -426,7 +425,7 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
         servletContextAttributes.put(Lookup.class.getName(), lookup);
 
         process();
-        assertTrue(DevModeInitializer.isDevModeAlreadyStarted(servletContext));
+        assertTrue(DevModeInitializer.isDevModeAlreadyStarted(new VaadinServletContext(servletContext)));
     }
 
     @Test(expected = IllegalStateException.class)
@@ -495,7 +494,7 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
     }
 
     private void loadingJars_allFilesExist(String resourcesFolder)
-            throws IOException, ServletException {
+            throws IOException, VaadinInitializerException {
         loadingJarsWithProtocol_allFilesExist(resourcesFolder, s -> {
             try {
                 return new URL("jar:" + s);
@@ -506,7 +505,7 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
     }
 
     private void loadingZipProtocolJars_allFilesExist(String resourcesFolder)
-            throws IOException, ServletException {
+            throws IOException, VaadinInitializerException {
         final URLStreamHandler dummyZipHandler = new URLStreamHandler() {
 
             @Override
@@ -527,7 +526,7 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
 
     private void loadingJarsWithProtocol_allFilesExist(String resourcesFolder,
             Function<String, URL> urlBuilder)
-            throws IOException, ServletException {
+            throws IOException, VaadinInitializerException {
         // Create jar urls with the given urlBuilder for test
         String urlPath = this.getClass().getResource("/").toString()
                 .replace("target/test-classes/", "")
@@ -555,14 +554,14 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
     }
 
     private void loadingFsResources_allFilesExist(String resourcesRoot,
-            String resourcesFolder) throws IOException, ServletException {
+            String resourcesFolder) throws IOException, VaadinInitializerException {
         List<URL> urls = Collections.singletonList(
                 getClass().getResource(resourcesRoot + resourcesFolder));
         loadingFsResources_allFilesExist(urls, resourcesFolder);
     }
 
     private void loadingFsResources_allFilesExist(Collection<URL> urls,
-            String resourcesFolder) throws IOException, ServletException {
+            String resourcesFolder) throws IOException, VaadinInitializerException {
         // Create mock loader with the single jar to be found
         ClassLoader classLoader = Mockito.mock(ClassLoader.class);
         Mockito.when(classLoader.getResources(resourcesFolder))

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/WebComponentConfigurationRegistryInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/WebComponentConfigurationRegistryInitializerTest.java
@@ -339,7 +339,7 @@ public class WebComponentConfigurationRegistryInitializerTest {
 
         @Override
         public boolean matches(Object o) {
-            Throwable throwable = (Throwable) o;
+            Throwable throwable = ((Throwable) o).getCause();
 
             if (!throwableType.equals(throwable.getClass())) {
                 return false;

--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
@@ -112,6 +112,8 @@ public abstract class ClassesSerializableTest extends ClassFinder {
                 "com\\.vaadin\\.flow\\.server\\.startup\\.ApplicationRouteRegistry\\$OSGiRouteRegistry",
                 "com\\.vaadin\\.flow\\.server\\.startup\\.ApplicationRouteRegistry\\$OSGiDataCollector",
                 "com\\.vaadin\\.flow\\.server\\.startup\\.ClassLoaderAwareServletContainerInitializer",
+                "com\\.vaadin\\.flow\\.server\\.startup\\.VaadinServletContextStartupInitializer",
+                "com\\.vaadin\\.flow\\.server\\.startup\\.VaadinContextStartupInitializer",
                 "com\\.vaadin\\.flow\\.server\\.startup\\.ServletDeployer",
                 "com\\.vaadin\\.flow\\.server\\.startup\\.ServletDeployer\\$StubServletConfig",
                 "com\\.vaadin\\.flow\\.server\\.startup\\.ServletContextListeners",


### PR DESCRIPTION
This is the successor to [this pull request](https://github.com/vaadin/flow/pull/8469) (which ran long and had too many updates).

Most Vaadin startup initializers don't actually need `ServletContext`. Thus, their methods should use VaaddinContext instead. This pull request attempts to fix. This allows non-servlet implementing HTTP frameworks (such as [VertxVaadin](https://github.com/mcollovati/vertx-vaadin)) to directly call the main initialization logic via `VaadinContextStartupInitializer#initialize(Set, VaadinConntext)}` instead of needing to create fake `ServletContext`s.

I also standardized parameter names of overriden methods and also deprecated (where it made sense) public methods that used `ServletContext` in favor of a new method which uses `VaadinContext`.

I believe this fixes #5735 and also fixes #2775. In addition, this provides a good step towards allowing external libraries to reduce the dependency on servlet-api (#4613).