### PR TITLE
chore: framework#11859 Expired session: use 403 Forbidden instead of 410

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/communication/DefaultConnectionStateHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/DefaultConnectionStateHandler.java
@@ -141,7 +141,7 @@ public class DefaultConnectionStateHandler implements ConnectionStateHandler {
         int statusCode = xhr.getStatus();
         Console.warn("Heartbeat request returned " + statusCode);
 
-        if (statusCode == Response.SC_GONE) {
+        if (statusCode == Response.SC_FORBIDDEN) {
             // Session expired
             registry.getSystemErrorHandler().handleSessionExpiredError(null);
             stopApplication();

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -1715,8 +1715,15 @@ public abstract class VaadinService implements Serializable {
                  * endless loop. This can at least happen if refreshing a
                  * resource when the session has expired.
                  */
-                response.sendError(HttpServletResponse.SC_GONE,
-                        "Session expired");
+
+                // Ensure that the browser does not cache expired responses.
+                // iOS 6 Safari requires this (https://github.com/vaadin/framework/issues/3226)
+                response.setHeader("Cache-Control", "no-cache");
+                // If Content-Type is not set, browsers assume text/html and may
+                // complain about the empty response body (https://github.com/vaadin/framework/issues/4167)
+                response.setHeader("Content-Type", "text/plain");
+
+                response.sendError(HttpServletResponse.SC_FORBIDDEN, "Session expired");
             }
         } catch (IOException e) {
             throw new ServiceException(e);

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/HeartbeatHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/HeartbeatHandler.java
@@ -66,10 +66,10 @@ public class HeartbeatHandler extends SynchronizedRequestHandler
             ui.getInternals()
                     .setLastHeartbeatTimestamp(System.currentTimeMillis());
             // Ensure that the browser does not cache heartbeat responses.
-            // iOS 6 Safari requires this (#10370)
+            // iOS 6 Safari requires this (https://github.com/vaadin/framework/issues/3226)
             response.setHeader("Cache-Control", "no-cache");
             // If Content-Type is not set, browsers assume text/html and may
-            // complain about the empty response body (#12182)
+            // complain about the empty response body (https://github.com/vaadin/framework/issues/4167)
             response.setHeader("Content-Type", "text/plain");
         } else {
             response.sendError(HttpServletResponse.SC_NOT_FOUND,
@@ -93,7 +93,7 @@ public class HeartbeatHandler extends SynchronizedRequestHandler
             return false;
         }
 
-        response.sendError(HttpServletResponse.SC_GONE, "Session expired");
+        response.sendError(HttpServletResponse.SC_FORBIDDEN, "Session expired");
         return true;
     }
 }


### PR DESCRIPTION
relates to #9759 

forward port of https://github.com/vaadin/framework/pull/11859

Not sure about the `chore` label. 

Edit: I updated the issues to the full path for easier navigation.

