### PR TITLE
chore: Bump Node.js default version to last LTS

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -128,7 +128,7 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo {
 
     /**
      * The node.js version to be used when node.js is installed automatically by
-     * Vaadin, for example `"v12.18.3"`. Defaults to null which uses the
+     * Vaadin, for example `"v14.15.4"`. Defaults to null which uses the
      * Vaadin-default node version - see {@link FrontendTools} for details.
      */
     @Parameter(property = "node.version", defaultValue = FrontendTools.DEFAULT_NODE_VERSION)

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -57,11 +57,11 @@ import elemental.json.JsonObject;
  */
 public class FrontendTools {
 
-    public static final String DEFAULT_NODE_VERSION = "v12.18.3";
+    public static final String DEFAULT_NODE_VERSION = "v14.15.4";
 
     public static final String DEFAULT_PNPM_VERSION = "4.5.0";
 
-    public static final String INSTALL_NODE_LOCALLY = "%n  $ mvn com.github.eirslett:frontend-maven-plugin:1.10.0:install-node-and-npm -DnodeVersion=\"v12.18.3\" ";
+    public static final String INSTALL_NODE_LOCALLY = "%n  $ mvn com.github.eirslett:frontend-maven-plugin:1.10.0:install-node-and-npm -DnodeVersion=\"v14.15.4\" ";
 
     private static final String MSG_PREFIX = "%n%n======================================================================================================";
     private static final String MSG_SUFFIX = "%n======================================================================================================%n";
@@ -192,7 +192,7 @@ public class FrontendTools {
      *            {@code null}
      * @param nodeVersion
      *            The node.js version to be used when node.js is installed
-     *            automatically by Vaadin, for example <code>"v12.18.3"</code>.
+     *            automatically by Vaadin, for example <code>"v14.15.4"</code>.
      *            Use {@value #DEFAULT_NODE_VERSION} by default.
      * @param nodeDownloadRoot
      *            Download node.js from this URL. Handy in heavily firewalled

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -61,7 +61,8 @@ public class FrontendTools {
 
     public static final String DEFAULT_PNPM_VERSION = "4.5.0";
 
-    public static final String INSTALL_NODE_LOCALLY = "%n  $ mvn com.github.eirslett:frontend-maven-plugin:1.10.0:install-node-and-npm -DnodeVersion=\"v14.15.4\" ";
+    public static final String INSTALL_NODE_LOCALLY = "%n  $ mvn com.github.eirslett:frontend-maven-plugin:1.10.0:install-node-and-npm "
+            + "-DnodeVersion=\"" + DEFAULT_NODE_VERSION + "\" ";
 
     private static final String MSG_PREFIX = "%n%n======================================================================================================";
     private static final String MSG_SUFFIX = "%n======================================================================================================%n";

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -117,7 +117,7 @@ public class NodeTasks implements FallibleCommand {
 
         /**
          * The node.js version to be used when node.js is installed
-         * automatically by Vaadin, for example <code>"v12.18.3"</code>.
+         * automatically by Vaadin, for example <code>"v14.15.4"</code>.
          * Defaults to {@value FrontendTools#DEFAULT_NODE_VERSION}.
          */
         private String nodeVersion = FrontendTools.DEFAULT_NODE_VERSION;
@@ -483,7 +483,7 @@ public class NodeTasks implements FallibleCommand {
 
         /**
          * Sets the node.js version to be used when node.js is installed
-         * automatically by Vaadin, for example <code>"v12.18.3"</code>.
+         * automatically by Vaadin, for example <code>"v14.15.4"</code>.
          * Defaults to {@value FrontendTools#DEFAULT_NODE_VERSION}.
          *
          * @param nodeVersion

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -91,7 +91,7 @@ public class TaskRunNpmInstall implements FallibleCommand {
      *            whether vaadin home node executable has to be used
      * @param nodeVersion
      *            The node.js version to be used when node.js is installed
-     *            automatically by Vaadin, for example <code>"v12.18.3"</code>.
+     *            automatically by Vaadin, for example <code>"v14.15.4"</code>.
      *            Use {@value FrontendTools#DEFAULT_NODE_VERSION} by default.
      * @param nodeDownloadRoot
      *            Download node.js from this URL. Handy in heavily firewalled

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
@@ -118,7 +118,7 @@ public class NodeInstaller {
     }
 
     /**
-     * Set the node version to install. (given as "v12.18.3")
+     * Set the node version to install. (given as "v14.15.4")
      *
      * @param nodeVersion
      *         version string
@@ -135,11 +135,11 @@ public class NodeInstaller {
      * This should be a url or directory under which we can find a directory
      * {@link #nodeVersion} and there should then exist the archived node
      * packages.
-     * For instance for v12.18.3 we should have under nodeDownloadRoot:
-     * ./v12.18.3/node-v12.18.3-linux-x64.tar.xz
-     * ./v12.18.3/node-v12.18.3-darwin-x64.tar.gz
-     * ./v12.18.3/node-v12.18.3-win-x64.zip
-     * ./v12.18.3/node-v12.18.3-win-x86.zip
+     * For instance for v14.15.4 we should have under nodeDownloadRoot:
+     * ./v14.15.4/node-v14.15.4-linux-x64.tar.xz
+     * ./v14.15.4/node-v14.15.4-darwin-x64.tar.gz
+     * ./v14.15.4/node-v14.15.4-win-x64.zip
+     * ./v14.15.4/node-v14.15.4-win-x86.zip
      *
      * @param nodeDownloadRoot
      *         custom download root

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -87,7 +87,8 @@ public class FrontendToolsTest {
     @Ignore("Ignored to lessen PRs hitting the server too often")
     public void installNode_NodeIsInstalledToTargetDirectory()
             throws FrontendUtils.UnknownVersionException {
-        String nodeExecutable = tools.installNode("v14.15.4", null);
+        String nodeExecutable = tools
+                .installNode(FrontendTools.DEFAULT_NODE_VERSION, null);
         Assert.assertNotNull(nodeExecutable);
 
         List<String> nodeVersionCommand = new ArrayList<>();
@@ -95,7 +96,8 @@ public class FrontendToolsTest {
         nodeVersionCommand.add("--version");
         FrontendVersion node = FrontendUtils.getVersion("node",
                 nodeVersionCommand);
-        Assert.assertEquals("14.15.4", node.getFullVersion());
+        Assert.assertEquals(FrontendTools.DEFAULT_NODE_VERSION,
+                node.getFullVersion());
 
         FrontendTools newTools = new FrontendTools(vaadinHomeDir, null);
         List<String> npmVersionCommand = new ArrayList<>(
@@ -158,9 +160,11 @@ public class FrontendToolsTest {
     @Test
     public void installNodeFromFileSystem_NodeIsInstalledToTargetDirectory()
             throws IOException {
-        prepareNodeDownloadableZipAt(baseDir, "v14.15.4");
+        prepareNodeDownloadableZipAt(baseDir,
+                FrontendTools.DEFAULT_NODE_VERSION);
 
-        String nodeExecutable = tools.installNode("v14.15.4",
+        String nodeExecutable = tools.installNode(
+                FrontendTools.DEFAULT_NODE_VERSION,
                 new File(baseDir).toPath().toUri());
         Assert.assertNotNull(nodeExecutable);
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -87,7 +87,7 @@ public class FrontendToolsTest {
     @Ignore("Ignored to lessen PRs hitting the server too often")
     public void installNode_NodeIsInstalledToTargetDirectory()
             throws FrontendUtils.UnknownVersionException {
-        String nodeExecutable = tools.installNode("v12.18.3", null);
+        String nodeExecutable = tools.installNode("v14.15.4", null);
         Assert.assertNotNull(nodeExecutable);
 
         List<String> nodeVersionCommand = new ArrayList<>();
@@ -95,7 +95,7 @@ public class FrontendToolsTest {
         nodeVersionCommand.add("--version");
         FrontendVersion node = FrontendUtils.getVersion("node",
                 nodeVersionCommand);
-        Assert.assertEquals("12.18.3", node.getFullVersion());
+        Assert.assertEquals("14.15.4", node.getFullVersion());
 
         FrontendTools newTools = new FrontendTools(vaadinHomeDir, null);
         List<String> npmVersionCommand = new ArrayList<>(
@@ -158,9 +158,9 @@ public class FrontendToolsTest {
     @Test
     public void installNodeFromFileSystem_NodeIsInstalledToTargetDirectory()
             throws IOException {
-        prepareNodeDownloadableZipAt(baseDir, "v12.18.3");
+        prepareNodeDownloadableZipAt(baseDir, "v14.15.4");
 
-        String nodeExecutable = tools.installNode("v12.18.3",
+        String nodeExecutable = tools.installNode("v14.15.4",
                 new File(baseDir).toPath().toUri());
         Assert.assertNotNull(nodeExecutable);
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/installer/DefaultFileDownloaderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/installer/DefaultFileDownloaderTest.java
@@ -31,7 +31,7 @@ public class DefaultFileDownloaderTest {
         Assert.assertFalse(
                 "Clean test should not contain a installation folder",
                 targetDir.exists());
-        File downloadDir = tmpDir.newFolder("v12.18.3");
+        File downloadDir = tmpDir.newFolder("v14.15.4");
         String downloadFileName = "MyDownload.zip";
 
         File archiveFile = new File(downloadDir, downloadFileName);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/installer/DefaultFileDownloaderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/installer/DefaultFileDownloaderTest.java
@@ -11,6 +11,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import com.vaadin.flow.server.frontend.FrontendTools;
+
 public class DefaultFileDownloaderTest {
 
     @Rule
@@ -31,7 +33,7 @@ public class DefaultFileDownloaderTest {
         Assert.assertFalse(
                 "Clean test should not contain a installation folder",
                 targetDir.exists());
-        File downloadDir = tmpDir.newFolder("v14.15.4");
+        File downloadDir = tmpDir.newFolder(FrontendTools.DEFAULT_NODE_VERSION);
         String downloadFileName = "MyDownload.zip";
 
         File archiveFile = new File(downloadDir, downloadFileName);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/installer/NodeInstallerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/installer/NodeInstallerTest.java
@@ -35,14 +35,14 @@ public class NodeInstallerTest {
             throws IOException {
         Platform platform = Platform.guess();
         String nodeExec = platform.isWindows() ? "node.exe" : "node";
-        String prefix = "node-v12.18.3-" + platform.getNodeClassifier();
+        String prefix = "node-v14.15.4-" + platform.getNodeClassifier();
 
         File targetDir = new File(baseDir + "/installation");
 
         Assert.assertFalse(
                 "Clean test should not contain a installation folder",
                 targetDir.exists());
-        File downloadDir = tmpDir.newFolder("v12.18.3");
+        File downloadDir = tmpDir.newFolder("v14.15.4");
         File archiveFile = new File(downloadDir,
                 prefix + "." + platform.getArchiveExtension());
         archiveFile.createNewFile();
@@ -86,7 +86,7 @@ public class NodeInstallerTest {
         }
 
         NodeInstaller nodeInstaller = new NodeInstaller(targetDir,
-                Collections.emptyList()).setNodeVersion("v12.18.3")
+                Collections.emptyList()).setNodeVersion("v14.15.4")
                 .setNodeDownloadRoot(new File(baseDir).toPath().toUri());
 
         try {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/installer/NodeInstallerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/installer/NodeInstallerTest.java
@@ -18,6 +18,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import com.vaadin.flow.server.frontend.FrontendTools;
+
 public class NodeInstallerTest {
 
     @Rule
@@ -35,14 +37,16 @@ public class NodeInstallerTest {
             throws IOException {
         Platform platform = Platform.guess();
         String nodeExec = platform.isWindows() ? "node.exe" : "node";
-        String prefix = "node-v14.15.4-" + platform.getNodeClassifier();
+        String prefix = String.format("node-%s-%s",
+                FrontendTools.DEFAULT_NODE_VERSION,
+                platform.getNodeClassifier());
 
         File targetDir = new File(baseDir + "/installation");
 
         Assert.assertFalse(
                 "Clean test should not contain a installation folder",
                 targetDir.exists());
-        File downloadDir = tmpDir.newFolder("v14.15.4");
+        File downloadDir = tmpDir.newFolder(FrontendTools.DEFAULT_NODE_VERSION);
         File archiveFile = new File(downloadDir,
                 prefix + "." + platform.getArchiveExtension());
         archiveFile.createNewFile();
@@ -86,7 +90,8 @@ public class NodeInstallerTest {
         }
 
         NodeInstaller nodeInstaller = new NodeInstaller(targetDir,
-                Collections.emptyList()).setNodeVersion("v14.15.4")
+                Collections.emptyList())
+                        .setNodeVersion(FrontendTools.DEFAULT_NODE_VERSION)
                 .setNodeDownloadRoot(new File(baseDir).toPath().toUri());
 
         try {


### PR DESCRIPTION
Bumps the default installed version of Node.js to `v14.15.4` (last LTS).