### PR TITLE
fix(tests): add JSON HTTP server to stub webpackDevServer

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
@@ -115,7 +115,7 @@ public class DevModeHandlerTest {
         mockApplicationConfiguration(configuration);
 
         new File(baseDir, FrontendUtils.WEBPACK_CONFIG).createNewFile();
-        createStubWebpackServer("Compiled", 100, baseDir);
+        createStubWebpackServer("Compiled", 100, baseDir, true);
     }
 
     @After
@@ -225,7 +225,7 @@ public class DevModeHandlerTest {
         Mockito.when(configuration.getStringProperty(
                 SERVLET_PARAMETER_DEVMODE_WEBPACK_TIMEOUT, null))
                 .thenReturn("100");
-        createStubWebpackServer("Failed to compile", 300, baseDir);
+        createStubWebpackServer("Failed to compile", 300, baseDir, true);
         DevModeHandler handler = DevModeHandler.start(createDevModeLookup(),
                 npmFolder, CompletableFuture.completedFuture(null));
         assertNotNull(handler);
@@ -377,6 +377,7 @@ public class DevModeHandlerTest {
     @Test(expected = ConnectException.class)
     public void should_ThrowAnException_When_WebpackNotListening()
             throws IOException {
+        createStubWebpackServer("Compiled", 100, baseDir, false);
         HttpServletRequest request = prepareRequest("/VAADIN//foo.js");
         DevModeHandler handler = DevModeHandler.start(0, createDevModeLookup(),
                 npmFolder, CompletableFuture.completedFuture(null));

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateTestUtil.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateTestUtil.java
@@ -122,14 +122,28 @@ public class NodeUpdateTestUtil {
 
         serverFile.createNewFile();
         serverFile.setExecutable(true);
-        FileUtils.write(serverFile,
-                ("#!/usr/bin/env node\n" + "const fs = require('fs');\n"
-                        + "const args = String(process.argv);\n"
-                        + "fs.writeFileSync('" + WEBPACK_TEST_OUT_FILE
-                        + "', args);\n" + "console.log(args + '\\n[wps]: "
-                        + readyString + ".');\n" + "setTimeout(() => {}, "
-                        + milliSecondsToRun + ");\n"),
-                "UTF-8");
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("#!/user/bin/env node\n");
+        sb.append("const args = String(process.argv);\n");
+        sb.append("const fs = require('fs');\n");
+        sb.append("const http = require('http');\n");
+        sb.append("fs.writeFileSync('").append(WEBPACK_TEST_OUT_FILE)
+                .append("', args);\n");
+        sb.append("const port = Number.parseInt(process.argv[")
+                .append("process.argv.indexOf('--port') + 1").append("]);\n");
+        sb.append("const server = new http.Server((req, res) => {\n");
+        sb.append("  res.writeHead(200, {")
+                .append("'Content-Type': 'application/json',").append("});\n");
+        sb.append("  res.write('{}');\n");
+        sb.append("  res.end();\n");
+        sb.append("});\n");
+        sb.append("server.listen(port);\n");
+        sb.append("console.log(args);\n");
+        sb.append("console.log('[wps]: ").append(readyString).append(".');\n");
+        sb.append("setTimeout(() => server.close(), ").append(milliSecondsToRun)
+                .append(");\n");
+        FileUtils.write(serverFile, sb.toString(), "UTF-8");
     }
 
     static URL getTestResource(String resourceName) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateTestUtil.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateTestUtil.java
@@ -116,7 +116,7 @@ public class NodeUpdateTestUtil {
     // for a while and output arguments passed to a file, so as tests can check
     // it
     public static void createStubWebpackServer(String readyString,
-            int milliSecondsToRun, String baseDir) throws IOException {
+            int milliSecondsToRun, String baseDir, boolean enableListening) throws IOException {
         File serverFile = new File(baseDir, WEBPACK_SERVER);
         FileUtils.forceMkdirParent(serverFile);
 
@@ -130,20 +130,28 @@ public class NodeUpdateTestUtil {
         sb.append("const http = require('http');\n");
         sb.append("fs.writeFileSync('").append(WEBPACK_TEST_OUT_FILE)
                 .append("', args);\n");
-        sb.append("const port = Number.parseInt(process.argv[")
-                .append("process.argv.indexOf('--port') + 1").append("]);\n");
-        sb.append("const server = new http.Server((req, res) => {\n");
-        sb.append("  res.writeHead(200, {")
-                .append("'Content-Type': 'application/json',").append("});\n");
-        sb.append("  res.write('{}');\n");
-        sb.append("  res.end();\n");
-        sb.append("});\n");
-        sb.append("server.listen(port);\n");
+        if (enableListening) {
+            sb.append("const port = Number.parseInt(process.argv[")
+                    .append("process.argv.indexOf('--port') + 1").append("]);\n");
+            sb.append("const server = new http.Server((req, res) => {\n");
+            sb.append("  res.writeHead(200, {")
+                    .append("'Content-Type': 'application/json',").append("});\n");
+            sb.append("  res.write('{}');\n");
+            sb.append("  res.end();\n");
+            sb.append("});\n");
+            sb.append("server.listen(port);\n");
+            sb.append("setTimeout(() => server.close(), ").append(milliSecondsToRun).append(");\n");
+        } else {
+            sb.append("setTimeout(() => {}, ").append(milliSecondsToRun).append(");\n");
+        }
         sb.append("console.log(args);\n");
         sb.append("console.log('[wps]: ").append(readyString).append(".');\n");
-        sb.append("setTimeout(() => server.close(), ").append(milliSecondsToRun)
-                .append(");\n");
         FileUtils.write(serverFile, sb.toString(), "UTF-8");
+    }
+
+    public static void createStubWebpackServer(String readyString,
+            int milliSecondsToRun, String baseDir) throws IOException {
+        createStubWebpackServer(readyString, milliSecondsToRun, baseDir, false);
     }
 
     static URL getTestResource(String resourceName) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTestBase.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTestBase.java
@@ -93,7 +93,7 @@ public class DevModeInitializerTestBase {
         mockApplicationConfiguration(appConfig, enablePnpm);
 
         createStubNode(false, true, enablePnpm, baseDir);
-        createStubWebpackServer("Compiled", 500, baseDir);
+        createStubWebpackServer("Compiled", 500, baseDir, true);
 
         servletContext = Mockito.mock(ServletContext.class);
         ServletRegistration vaadinServletRegistration = Mockito


### PR DESCRIPTION
Fixes #9774

The change makes the stub `webpack-dev-server.js` used in testing listen to
the specified port, so that `DevModeHandler` could connect to it. This resolves
connection errors that used to occur when running
`DevModeInitializerTest` tests, as well as fixes the test errors on
Windows caused by the OS timeout and retries for failed connection
attempts.