### PR TITLE
Revert "feat: replace awesome-typescript-loader with ts-loader (#9721)"

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -294,7 +294,7 @@ public abstract class NodeUpdater implements FallibleCommand {
         defaults.put("html-webpack-plugin", "3.2.0");
         defaults.put("script-ext-html-webpack-plugin", "2.1.4");
         defaults.put("typescript", "4.0.3");
-        defaults.put("ts-loader", "8.0.12");
+        defaults.put("awesome-typescript-loader", "5.2.1");
 
         defaults.put("webpack", "4.42.0");
         defaults.put("webpack-cli", "3.3.11");

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -233,7 +233,7 @@ module.exports = {
       {
         test: /\.ts$/,
         use: [
-          'ts-loader'
+          'awesome-typescript-loader'
         ]
       },
       {

--- a/flow-tests/test-application-theme/test-theme-reusable/src/main/java/com/vaadin/flow/uitest/ui/theme/MyLitField.java
+++ b/flow-tests/test-application-theme/test-theme-reusable/src/main/java/com/vaadin/flow/uitest/ui/theme/MyLitField.java
@@ -23,7 +23,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 /**
  * LIT version of vaadin radio button for testing component theming.
  */
-@JsModule("@vaadin/vaadin-radio-button/vaadin-radio-button.js")
+@JsModule("@vaadin/vaadin-radio-button/vaadin-radio-button.ts")
 @Tag("vaadin-radio-button")
 @NpmPackage(value = "@vaadin/vaadin-radio-button", version = "2.0.0-alpha1")
 public class MyLitField extends Component {

--- a/flow-tests/test-embedding/test-embedding-application-theme/src/main/java/com/vaadin/flow/webcomponent/MyLitField.java
+++ b/flow-tests/test-embedding/test-embedding-application-theme/src/main/java/com/vaadin/flow/webcomponent/MyLitField.java
@@ -23,7 +23,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 /**
  * LIT version of vaadin radio button for testing component theming.
  */
-@JsModule("@vaadin/vaadin-radio-button/vaadin-radio-button.js")
+@JsModule("@vaadin/vaadin-radio-button/vaadin-radio-button.ts")
 @Tag("vaadin-radio-button")
 @NpmPackage(value = "@vaadin/vaadin-radio-button", version = "2.0.0-alpha1")
 public class MyLitField extends Component {

--- a/flow-tests/test-themes/src/main/java/com/vaadin/flow/uitest/ui/theme/MyLitField.java
+++ b/flow-tests/test-themes/src/main/java/com/vaadin/flow/uitest/ui/theme/MyLitField.java
@@ -23,7 +23,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 /**
  * LIT version of vaadin radio button for testing component theming.
  */
-@JsModule("@vaadin/vaadin-radio-button/vaadin-radio-button.js")
+@JsModule("@vaadin/vaadin-radio-button/vaadin-radio-button.ts")
 @Tag("vaadin-radio-button")
 @NpmPackage(value = "@vaadin/vaadin-radio-button", version = "2.0.0-alpha1")
 public class MyLitField extends Component {


### PR DESCRIPTION
This reverts commit be4d8728f82d47ec6cdf2a07d8d8ef8d5d9980a6.
be4d8728f82d47ec6cdf2a07d8d8ef8d5d9980a6 broke the CI, revert it first to make the CI green.