### PR TITLE
fix(tests): extend timeouts for stub webpack server connection attempts

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
@@ -377,7 +377,7 @@ public class DevModeHandlerTest {
     @Test(expected = ConnectException.class)
     public void should_ThrowAnException_When_WebpackNotListening()
             throws IOException {
-        createStubWebpackServer("Compiled", 100, baseDir, false);
+        createStubWebpackServer("Compiled", 3000, baseDir, false);
         HttpServletRequest request = prepareRequest("/VAADIN//foo.js");
         DevModeHandler handler = DevModeHandler.start(0, createDevModeLookup(),
                 npmFolder, CompletableFuture.completedFuture(null));

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
@@ -455,7 +455,7 @@ public class IndexHtmlRequestHandlerTest {
         File npmFolder = temporaryFolder.getRoot();
         String baseDir = npmFolder.getAbsolutePath();
         new File(baseDir, FrontendUtils.WEBPACK_CONFIG).createNewFile();
-        createStubWebpackServer("Failed to compile", 300, baseDir);
+        createStubWebpackServer("Failed to compile", 3000, baseDir);
 
         // Create a DevModeHandler
         deploymentConfiguration.setEnableDevServer(true);
@@ -492,6 +492,8 @@ public class IndexHtmlRequestHandlerTest {
                         "<div class=\"v-system-error\" onclick=\"this.parentElement.removeChild(this)\">"));
         Assert.assertTrue("Should show webpack failure error",
                 indexHtml.contains("Failed to compile"));
+
+        handler.stop();
     }
 
     @Test


### PR DESCRIPTION
Connected to #9774

When port listening is not enabled in stub webpack server, there is a failed
connection in DevModeHandler. On Windows it needs at least
1.5s to fail (for 3 attempts with 500ms intervals).

This change makes the stub server to run long enough for failing connection
attempts on Windows, so that DevModeHandler startup could ensure it is
still running after that connection error.