### PR TITLE
fix(tests): enable JSON HTTP server in rest of failed tests

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
@@ -377,7 +377,7 @@ public class DevModeHandlerTest {
     @Test(expected = ConnectException.class)
     public void should_ThrowAnException_When_WebpackNotListening()
             throws IOException {
-        createStubWebpackServer("Compiled", 100, baseDir, false);
+        createStubWebpackServer("Compiled", 100, baseDir, true);
         HttpServletRequest request = prepareRequest("/VAADIN//foo.js");
         DevModeHandler handler = DevModeHandler.start(0, createDevModeLookup(),
                 npmFolder, CompletableFuture.completedFuture(null));

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
@@ -455,7 +455,7 @@ public class IndexHtmlRequestHandlerTest {
         File npmFolder = temporaryFolder.getRoot();
         String baseDir = npmFolder.getAbsolutePath();
         new File(baseDir, FrontendUtils.WEBPACK_CONFIG).createNewFile();
-        createStubWebpackServer("Failed to compile", 300, baseDir);
+        createStubWebpackServer("Failed to compile", 300, baseDir, true);
 
         // Create a DevModeHandler
         deploymentConfiguration.setEnableDevServer(true);


### PR DESCRIPTION
Fixes the rest of failed tests.

Related-to: #9774