### PR TITLE
fix: Only create needed folders

### DIFF
--- a/flow-server/src/main/resources/plugins/application-theme-plugin/package.json
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/package.json
@@ -6,7 +6,7 @@
   ],
   "repository": "vaadin/flow",
   "name": "@vaadin/application-theme-plugin",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "application-theme-plugin.js",
   "author": "Vaadin Ltd",
   "license": "Apache-2.0",


### PR DESCRIPTION
When copying files for custom theme
only create directories that contain file
to be copied.

Generate directories with mkdirp instead
of fs.mkdir as it is more reliable.