### PR TITLE
Use existing getRequestUrl method

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
@@ -434,7 +434,7 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
         String url = request.getParameter(REQ_PARAM_URL);
         // if 'url' parameter was not available, use request url
         if (url == null) {
-            url = ((VaadinServletRequest) request).getRequestURL().toString();
+            url = getRequestUrl(request);
         }
         return url
                 // +1 is to keep the trailing slash


### PR DESCRIPTION
`((VaadinServletRequest) request).getRequestURL().toString()` is currently used in the `getServiceUrl` method. However, this code already exists as method `getRequestUrl`. Thus, we should use `getRequestUrl`.