### PR TITLE
chore: Update tests to not accept faulty annotations

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/AppShellRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AppShellRegistry.java
@@ -184,7 +184,9 @@ public class AppShellRegistry implements Serializable {
         validOnlyForAppShell.remove(PageTitle.class);
         if(WebComponentExporter.class.isAssignableFrom(clz)) {
             // Webcomponent exporter should have the theme annotation
+            // and Push annotation as it is not appShell configured.
             validOnlyForAppShell.remove(Theme.class);
+            validOnlyForAppShell.remove(Push.class);
         }
 
         String offending = getClassAnnotations(clz, validOnlyForAppShell);

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/VaadinAppShellInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/VaadinAppShellInitializerTest.java
@@ -105,6 +105,7 @@ public class VaadinAppShellInitializerTest {
     }
 
     @Theme(themeClass = AbstractTheme.class)
+    @Push(PushMode.AUTOMATIC)
     public static class NonOffendingExporter
         extends WebComponentExporter<WebHolder> {
         public NonOffendingExporter() {

--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -276,11 +276,6 @@
                                 <value>${vaadin.useDeprecatedV14Bootstrapping}
                                 </value>
                             </systemProperty>
-                            <systemProperty>
-                                <name>vaadin.allow.appshell.annotations
-                                </name>
-                                <value>true</value>
-                            </systemProperty>
                         </systemProperties>
                     </configuration>
                 </plugin>

--- a/flow-tests/test-application-theme/test-reusable-as-parent/pom.xml
+++ b/flow-tests/test-application-theme/test-reusable-as-parent/pom.xml
@@ -59,17 +59,6 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <!-- do not allow faulty app shell annotations for module -->
-                <!-- This should be removed when flow-tests do not break app shell annotation-->
-                <!-- flow-tests should not allow faulty annotations -->
-                <configuration>
-                    <systemProperties>
-                        <systemProperty>
-                            <name>vaadin.allow.appshell.annotations</name>
-                            <value>false</value>
-                        </systemProperty>
-                    </systemProperties>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/flow-tests/test-application-theme/test-theme-live-reload/pom.xml
+++ b/flow-tests/test-application-theme/test-theme-live-reload/pom.xml
@@ -49,17 +49,6 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <!-- do not allow faulty app shell annotations for module -->
-                <!-- This should be removed when flow-tests do not break app shell annotation-->
-                <!-- flow-tests should not allow faulty annotations -->
-                <configuration>
-                    <systemProperties>
-                        <systemProperty>
-                            <name>vaadin.allow.appshell.annotations</name>
-                            <value>false</value>
-                        </systemProperty>
-                    </systemProperties>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/flow-tests/test-application-theme/test-theme-reusable/pom.xml
+++ b/flow-tests/test-application-theme/test-theme-reusable/pom.xml
@@ -59,17 +59,6 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <!-- do not allow faulty app shell annotations for module -->
-                <!-- This should be removed when flow-tests do not break app shell annotation-->
-                <!-- flow-tests should not allow faulty annotations -->
-                <configuration>
-                    <systemProperties>
-                        <systemProperty>
-                            <name>vaadin.allow.appshell.annotations</name>
-                            <value>false</value>
-                        </systemProperty>
-                    </systemProperties>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/flow-tests/test-embedding/test-embedding-application-theme/pom.xml
+++ b/flow-tests/test-embedding/test-embedding-application-theme/pom.xml
@@ -53,17 +53,6 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <version>${jetty.version}</version>
-                <!-- do not allow faulty app shell annotations for module -->
-                <!-- This should be removed when flow-tests do not break app shell annotation-->
-                <!-- flow-tests should not allow faulty annotations -->
-                <configuration>
-                    <systemProperties>
-                        <systemProperty>
-                            <name>vaadin.allow.appshell.annotations</name>
-                            <value>false</value>
-                        </systemProperty>
-                    </systemProperties>
-                </configuration>
             </plugin>
 
             <plugin>

--- a/flow-tests/test-misc/pom.xml
+++ b/flow-tests/test-misc/pom.xml
@@ -56,17 +56,6 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <!-- do not allow faulty app shell annotations for module -->
-                <!-- This should be removed when flow-tests do not break app shell annotation-->
-                <!-- flow-tests should not allow faulty annotations -->
-                <configuration>
-                    <systemProperties>
-                        <systemProperty>
-                            <name>vaadin.allow.appshell.annotations</name>
-                            <value>false</value>
-                        </systemProperty>
-                    </systemProperties>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/flow-tests/test-root-ui-context/pom.xml
+++ b/flow-tests/test-root-ui-context/pom.xml
@@ -61,6 +61,15 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <systemProperties>
+                        <systemProperty>
+                            <!-- Allow annotations due to push tests -->
+                            <name>vaadin.allow.appshell.annotations</name>
+                            <value>true</value>
+                        </systemProperty>
+                    </systemProperties>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/flow-tests/test-router-custom-context/src/main/java/com/vaadin/flow/contexttest/ui/AppShell.java
+++ b/flow-tests/test-router-custom-context/src/main/java/com/vaadin/flow/contexttest/ui/AppShell.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.contexttest.ui;
+
+import com.vaadin.flow.component.page.AppShellConfigurator;
+import com.vaadin.flow.theme.NoTheme;
+
+@NoTheme
+public class AppShell implements AppShellConfigurator {
+}

--- a/flow-tests/test-router-custom-context/src/main/java/com/vaadin/flow/contexttest/ui/DependencyLayout.java
+++ b/flow-tests/test-router-custom-context/src/main/java/com/vaadin/flow/contexttest/ui/DependencyLayout.java
@@ -43,7 +43,6 @@ import java.nio.charset.StandardCharsets;
  * @since 1.2
  */
 @StyleSheet("context://test-files/css/allred.css")
-@NoTheme
 public abstract class DependencyLayout extends Div {
 
     public static final String RUN_PUSH_ID = "runPush";

--- a/flow-tests/test-themes/pom.xml
+++ b/flow-tests/test-themes/pom.xml
@@ -52,17 +52,6 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <!-- do not allow faulty app shell annotations for module -->
-                <!-- This should be removed when flow-tests do not break app shell annotation-->
-                <!-- flow-tests should not allow faulty annotations -->
-                <configuration>
-                    <systemProperties>
-                        <systemProperty>
-                            <name>vaadin.allow.appshell.annotations</name>
-                            <value>false</value>
-                        </systemProperty>
-                    </systemProperties>
-                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Flow tests should not use app shell annotations
on wrong classes. Only exception is the push
test module.
Embedded exporters are allowed to have both
push and theme annotations as they are stand
alone applications.

Closes #9379