### PR TITLE
refactor!: Move theme-generated.js to frontend/generated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,4 @@ yarn.lock
 flow-client/src/main/resources/META-INF/resources/frontend/FlowClient.js
 flow-tests/**/types.d.ts
 /flow-tests/**/*.generated.js
-/flow-tests/**/generated/vaadin.ts
+/flow-tests/**/generated/**

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -187,8 +187,8 @@ public class FrontendUtils {
      */
     public static final String IMPORTS_D_TS_NAME = "generated-flow-imports.d.ts";
 
-    public static final String THEME_IMPORTS_D_TS_NAME = "theme-generated.d.ts";
-    public static final String THEME_IMPORTS_NAME = "theme-generated.js";
+    public static final String THEME_IMPORTS_D_TS_NAME = "theme.d.ts";
+    public static final String THEME_IMPORTS_NAME = "theme.js";
 
     /**
      * File name of the bootstrap file that is generated in frontend

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -591,7 +591,8 @@ public class NodeTasks implements FallibleCommand {
                     builder.webpackGeneratedTemplate,
                     new File(builder.generatedFolder, IMPORTS_NAME),
                     builder.useDeprecatedV14Bootstrapping,
-                    builder.flowResourcesFolder, pwaConfiguration));
+                    builder.flowResourcesFolder, pwaConfiguration,
+                    builder.connectClientTsApiFolder));
         }
 
         if (builder.enableImportsUpdate) {
@@ -604,7 +605,8 @@ public class NodeTasks implements FallibleCommand {
 
             commands.add(new TaskUpdateThemeImport(builder.npmFolder,
                 frontendDependencies.getThemeDefinition(),
-                    builder.frontendDirectory));
+                    builder.frontendDirectory,
+                    builder.connectClientTsApiFolder));
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -604,7 +604,7 @@ public class NodeTasks implements FallibleCommand {
                             builder.tokenFileData, builder.enablePnpm));
 
             commands.add(new TaskUpdateThemeImport(builder.npmFolder,
-                frontendDependencies.getThemeDefinition(),
+                frontendDependencies.getThemeDefinition(), // NOSONAR
                     builder.frontendDirectory,
                     builder.connectClientTsApiFolder));
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrap.java
@@ -91,8 +91,7 @@ public class TaskGenerateBootstrap extends AbstractTaskClientGenerator {
     private Collection<String> getThemeLines() {
         Collection<String> lines = new ArrayList<>();
         if (shouldApplyAppTheme()) {
-            lines.add(
-                    "import { applyTheme } from '@vaadin/flow-frontend/themes/theme-generated';");
+            lines.add("import { applyTheme } from './theme';");
             lines.add("applyTheme(document);");
             lines.add("");
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateThemeImport.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateThemeImport.java
@@ -51,15 +51,12 @@ public class TaskUpdateThemeImport implements FallibleCommand {
     private final File npmFolder;
 
     TaskUpdateThemeImport(File npmFolder, ThemeDefinition theme,
-            File frontendDirectory) {
+            File frontendDirectory, File frontendGeneratedFolder) {
         this.theme = theme;
         this.frontendDirectory = frontendDirectory;
         this.npmFolder = npmFolder;
-        themeImportFile = new File(
-                new File(frontendDirectory, FrontendUtils.GENERATED),
-                THEME_IMPORTS_NAME);
-        themeImportFileDefinition = new File(
-                new File(frontendDirectory, FrontendUtils.GENERATED),
+        themeImportFile = new File(frontendGeneratedFolder, THEME_IMPORTS_NAME);
+        themeImportFileDefinition = new File(frontendGeneratedFolder,
                 THEME_IMPORTS_D_TS_NAME);
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateThemeImport.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateThemeImport.java
@@ -33,8 +33,8 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.THEME_IMPORTS_D_TS_N
 import static com.vaadin.flow.server.frontend.FrontendUtils.THEME_IMPORTS_NAME;
 
 /**
- * Task for generating the theme-generated.js file for importing application
- * theme.
+ * Task for generating the 'frontend/generated/theme.js file for importing
+ * application theme.
  *
  * @since
  */
@@ -52,18 +52,15 @@ public class TaskUpdateThemeImport implements FallibleCommand {
 
     TaskUpdateThemeImport(File npmFolder, ThemeDefinition theme,
             File frontendDirectory) {
-        File nodeModules = new File(npmFolder, FrontendUtils.NODE_MODULES);
-        File flowFrontend = new File(nodeModules,
-                FrontendUtils.FLOW_NPM_PACKAGE_NAME);
-        this.themeImportFile = new File(
-                new File(flowFrontend, APPLICATION_THEME_ROOT),
-                THEME_IMPORTS_NAME);
-        themeImportFileDefinition = new File(
-            new File(flowFrontend, APPLICATION_THEME_ROOT),
-            THEME_IMPORTS_D_TS_NAME);
         this.theme = theme;
         this.frontendDirectory = frontendDirectory;
         this.npmFolder = npmFolder;
+        themeImportFile = new File(
+                new File(frontendDirectory, FrontendUtils.GENERATED),
+                THEME_IMPORTS_NAME);
+        themeImportFileDefinition = new File(
+                new File(frontendDirectory, FrontendUtils.GENERATED),
+                THEME_IMPORTS_D_TS_NAME);
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateThemeImport.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateThemeImport.java
@@ -33,8 +33,10 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.THEME_IMPORTS_D_TS_N
 import static com.vaadin.flow.server.frontend.FrontendUtils.THEME_IMPORTS_NAME;
 
 /**
- * Task for generating the 'frontend/generated/theme.js file for importing
- * application theme.
+ * Task generating the theme definition file 'theme.js' for importing
+ * application theme into the generated frontend directory.
+ * 
+ * Default directory is ' ./frontend/generated' 
  *
  * @since
  */

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateWebpack.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateWebpack.java
@@ -64,6 +64,7 @@ public class TaskUpdateWebpack implements FallibleCommand {
     private final Path flowResourcesFolder;
     private final PwaConfiguration pwaConfiguration;
     private final Path resourceFolder;
+    private final Path frontendGeneratedFolder;
 
     /**
      * Create an instance of the updater given all configurable parameters.
@@ -88,13 +89,16 @@ public class TaskUpdateWebpack implements FallibleCommand {
      *            whether the application running with deprecated V14 bootstrapping
      * @param flowResourcesFolder
      *            relative path to `flow-frontend` package
+     * @param frontendGeneratedFolder
+     *            the folder with frontend auto-generated files
      */
     @SuppressWarnings("squid:S00107")
     TaskUpdateWebpack(File frontendDirectory, File webpackConfigFolder,
             File webpackOutputDirectory, File resourceOutputDirectory,
             String webpackTemplate, String webpackGeneratedTemplate,
             File generatedFlowImports, boolean useV14Bootstrapping,
-            File flowResourcesFolder, PwaConfiguration pwaConfiguration) {
+            File flowResourcesFolder, PwaConfiguration pwaConfiguration,
+            File frontendGeneratedFolder) {
         this.frontendDirectory = frontendDirectory.toPath();
         this.webpackTemplate = webpackTemplate;
         this.webpackGeneratedTemplate = webpackGeneratedTemplate;
@@ -107,6 +111,7 @@ public class TaskUpdateWebpack implements FallibleCommand {
         this.pwaConfiguration = pwaConfiguration;
         this.resourceFolder = new File(webpackOutputDirectory,
                 VAADIN_STATIC_FILES_PATH).toPath();
+        this.frontendGeneratedFolder = frontendGeneratedFolder.toPath();
     }
 
     @Override
@@ -178,6 +183,9 @@ public class TaskUpdateWebpack implements FallibleCommand {
                 new Pair<>("const frontendFolder",
                         formatPathResolve(getEscapedRelativeWebpackPath(
                                 frontendDirectory))),
+                new Pair<>("const frontendGeneratedFolder",
+                        formatPathResolve(getEscapedRelativeWebpackPath(
+                            frontendGeneratedFolder))),
                 new Pair<>("const mavenOutputFolderForFlowBundledFiles",
                         formatPathResolve(getEscapedRelativeWebpackPath(
                                 webpackOutputPath))),

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -338,18 +338,12 @@ public class DevModeInitializer
                     Paths.get(baseDir, DEFAULT_CONNECT_OPENAPI_JSON_FILE)
                             .toString());
 
-            String connectTsFolder = config.getStringProperty(
-                    CONNECT_GENERATED_TS_DIR_TOKEN,
-                    Paths.get(baseDir, DEFAULT_CONNECT_GENERATED_TS_DIR)
-                            .toString());
-
             builder.withConnectJavaSourceFolder(
                     new File(connectJavaSourceFolder))
                     .withConnectApplicationProperties(
                             new File(connectApplicationProperties))
                     .withConnectGeneratedOpenApiJson(
-                            new File(connectOpenApiJsonFile))
-                    .withConnectClientTsApiFolder(new File(connectTsFolder));
+                            new File(connectOpenApiJsonFile));
         }
 
         // If we are missing either the base or generated package json files
@@ -373,10 +367,16 @@ public class DevModeInitializer
         boolean useHomeNodeExec = config.getBooleanProperty(
                 InitParameters.REQUIRE_HOME_NODE_EXECUTABLE, false);
 
+        String connectTsFolder = config.getStringProperty(
+                CONNECT_GENERATED_TS_DIR_TOKEN,
+                Paths.get(baseDir, DEFAULT_CONNECT_GENERATED_TS_DIR)
+                        .toString());
+
         JsonObject tokenFileData = Json.createObject();
         NodeTasks tasks = builder.enablePackagesUpdate(true)
                 .useByteCodeScanner(useByteCodeScanner)
                 .withFlowResourcesFolder(flowResourcesFolder)
+                .withConnectClientTsApiFolder(new File(connectTsFolder))
                 .copyResources(frontendLocations)
                 .copyLocalResources(new File(baseDir,
                         Constants.LOCAL_FRONTEND_RESOURCES_PATH))

--- a/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentGenerator.java
@@ -160,7 +160,7 @@ public class WebComponentGenerator {
 
         if (themeName != null && !themeName.isEmpty()) {
             replacements.put("ThemeImport",
-                "import {applyTheme} from '@vaadin/flow-frontend/themes/theme-generated';\n\n");
+                "import {applyTheme} from 'generated/theme';\n\n");
             replacements.put("ApplyTheme", "applyTheme(shadow);\n    ");
         } else {
             replacements.put("ThemeImport", "");

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/application-theme-plugin.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/application-theme-plugin.js
@@ -24,9 +24,7 @@ const { processThemeResources, extractThemeName } = require('./theme-handle');
  *  themeResourceFolder             - theme folder where flow copies local and jar resource frontend files
  *  themeProjectFolders             - array of possible locations for theme folders inside the project
  *  projectStaticAssetsOutputFolder - path to where static assets should be put
- *  projectFrontendFolder           - folder in project where frontend (flow
- *  templates, fusion views, styles etc.) files and theme auto-generated
- *  files are placed
+ *  frontendGeneratedFolder         - the path to where frontend auto-generated files are put
  *
  *  @throws Error in constructor if required option is not received
  */
@@ -43,8 +41,8 @@ class ApplicationThemePlugin {
     if (!this.options.themeProjectFolders) {
       throw new Error("Missing themeProjectFolders path array");
     }
-    if (!this.options.projectFrontendFolder) {
-      throw new Error("Missing projectFrontendFolder path");
+    if (!this.options.frontendGeneratedFolder) {
+      throw new Error("Missing frontendGeneratedFolder path");
     }
   }
 

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/application-theme-plugin.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/application-theme-plugin.js
@@ -24,6 +24,9 @@ const { processThemeResources, extractThemeName } = require('./theme-handle');
  *  themeResourceFolder             - theme folder where flow copies local and jar resource frontend files
  *  themeProjectFolders             - array of possible locations for theme folders inside the project
  *  projectStaticAssetsOutputFolder - path to where static assets should be put
+ *  projectFrontendFolder           - folder in project where frontend (flow
+ *  templates, fusion views, styles etc.) files and theme auto-generated
+ *  files are placed
  *
  *  @throws Error in constructor if required option is not received
  */
@@ -39,6 +42,9 @@ class ApplicationThemePlugin {
     }
     if (!this.options.themeProjectFolders) {
       throw new Error("Missing themeProjectFolders path array");
+    }
+    if (!this.options.projectFrontendFolder) {
+      throw new Error("Missing projectFrontendFolder path");
     }
   }
 

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/package.json
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/package.json
@@ -6,7 +6,7 @@
   ],
   "repository": "vaadin/flow",
   "name": "@vaadin/application-theme-plugin",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "main": "application-theme-plugin.js",
   "author": "Vaadin Ltd",
   "license": "Apache-2.0",

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-handle.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-handle.js
@@ -37,7 +37,7 @@ const nameRegex = /themes\/(.*)\/\1.generated.js/;
  * @param logger application theme plugin logger
  */
 function processThemeResources(options, logger) {
-  const themeName = extractThemeName(options.themeResourceFolder);
+  const themeName = extractThemeName(options.projectFrontendFolder);
   if (themeName) {
     findThemeFolderAndHandleTheme(themeName, options, logger);
   } else {
@@ -140,22 +140,24 @@ function getThemeProperties(themeFolder) {
 }
 
 /**
- * Extracts current theme name from 'theme-generated.js' file located on a
+ * Extracts current theme name from 'generated/theme.js' file located on a
  * given folder.
- * @param themeFolder theme folder where flow generates 'theme-generated.js'
+ * @param frontendFolder folder in project containing frontend resources and
+ * theme auto-generated files
  * file and copies local and jar resource frontend files
  * @returns {string} current theme name
  */
-function extractThemeName(themeFolder) {
-  if (!themeFolder) {
-    throw new Error("Couldn't extract theme name from 'theme-generated.js'," +
+function extractThemeName(frontendFolder) {
+  if (!frontendFolder) {
+    throw new Error("Couldn't extract theme name from 'generated/theme.js'," +
       " because the path to folder containing this file is empty. Please set" +
       " the a correct folder path in ApplicationThemePlugin constructor" +
       " parameters.");
   }
-  const generatedThemeFile = path.resolve(themeFolder, "theme-generated.js");
+  const generatedThemeFile = path.resolve(frontendFolder, "generated", "theme.js");
   if (fs.existsSync(generatedThemeFile)) {
-    // read theme name from the theme-generated.js as there we always mark the used theme for webpack to handle.
+    // read theme name from the 'generated/theme.js' as there we always
+    // mark the used theme for webpack to handle.
     const themeName = nameRegex.exec(fs.readFileSync(generatedThemeFile, {encoding: 'utf8'}))[1];
     if (!themeName) {
       throw new Error("Couldn't parse theme name from '" + generatedThemeFile + "'.");

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-handle.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-handle.js
@@ -37,7 +37,7 @@ const nameRegex = /themes\/(.*)\/\1.generated.js/;
  * @param logger application theme plugin logger
  */
 function processThemeResources(options, logger) {
-  const themeName = extractThemeName(options.projectFrontendFolder);
+  const themeName = extractThemeName(options.frontendGeneratedFolder);
   if (themeName) {
     findThemeFolderAndHandleTheme(themeName, options, logger);
   } else {
@@ -140,21 +140,19 @@ function getThemeProperties(themeFolder) {
 }
 
 /**
- * Extracts current theme name from 'generated/theme.js' file located on a
+ * Extracts current theme name from auto-generated 'theme.js' file located on a
  * given folder.
- * @param frontendFolder folder in project containing frontend resources and
- * theme auto-generated files
- * file and copies local and jar resource frontend files
+ * @param frontendGeneratedFolder folder in project containing 'theme.js' file
  * @returns {string} current theme name
  */
-function extractThemeName(frontendFolder) {
-  if (!frontendFolder) {
-    throw new Error("Couldn't extract theme name from 'generated/theme.js'," +
+function extractThemeName(frontendGeneratedFolder) {
+  if (!frontendGeneratedFolder) {
+    throw new Error("Couldn't extract theme name from 'theme.js'," +
       " because the path to folder containing this file is empty. Please set" +
       " the a correct folder path in ApplicationThemePlugin constructor" +
       " parameters.");
   }
-  const generatedThemeFile = path.resolve(frontendFolder, "generated", "theme.js");
+  const generatedThemeFile = path.resolve(frontendGeneratedFolder, "theme.js");
   if (fs.existsSync(generatedThemeFile)) {
     // read theme name from the 'generated/theme.js' as there we always
     // mark the used theme for webpack to handle.

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -169,12 +169,12 @@ const flowFrontendThemesFolder = path.resolve(flowFrontendFolder, 'themes');
 const themeName = extractThemeName(flowFrontendThemesFolder);
 const themeOptions = {
   devMode: devMode,
-  // The following matches target/flow-frontend/themes/theme-generated.js
-  // and for theme in JAR that is copied to target/flow-frontend/themes/
-  // and not frontend/themes
+  // The following matches folder 'target/flow-frontend/themes/'
+  // (not 'frontend/themes') for theme in JAR that is copied there
   themeResourceFolder: flowFrontendThemesFolder,
   themeProjectFolders: themeProjectFolders,
   projectStaticAssetsOutputFolder: projectStaticAssetsOutputFolder,
+  projectFrontendFolder: frontendFolder
 };
 const processThemeResourcesCallback = (logger) => processThemeResources(themeOptions, logger);
 

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -27,6 +27,7 @@ const themePartRegex = /(\\|\/)themes\1[\s\S]*?\1/;
 //  - flow templates for classic Flow
 //  - client code with index.html and index.[ts/js] for CCDM
 const frontendFolder = '[to-be-generated-by-flow]';
+const frontendGeneratedFolder = '[to-be-generated-by-flow]';
 const fileNameOfTheFlowGeneratedMainEntryPoint = '[to-be-generated-by-flow]';
 const mavenOutputFolderForFlowBundledFiles = '[to-be-generated-by-flow]';
 const mavenOutputFolderForResourceFiles = '[to-be-generated-by-flow]';
@@ -174,7 +175,7 @@ const themeOptions = {
   themeResourceFolder: flowFrontendThemesFolder,
   themeProjectFolders: themeProjectFolders,
   projectStaticAssetsOutputFolder: projectStaticAssetsOutputFolder,
-  projectFrontendFolder: frontendFolder
+  frontendGeneratedFolder: frontendGeneratedFolder
 };
 const processThemeResourcesCallback = (logger) => processThemeResources(themeOptions, logger);
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksTest.java
@@ -34,6 +34,7 @@ import com.vaadin.flow.server.frontend.NodeTasks.Builder;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder.DefaultClassFinder;
 
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_CONNECT_GENERATED_TS_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.IMPORTS_NAME;
@@ -151,7 +152,9 @@ public class NodeTasksTest {
                         .enableImportsUpdate(true).runNpmInstall(false)
                         .withEmbeddableWebComponents(false)
                         .useV14Bootstrap(false).withFlowResourcesFolder(
-                                new File(userDir, TARGET + "flow-frontend"));
+                                new File(userDir, TARGET + "flow-frontend"))
+                        .withConnectClientTsApiFolder(new File(userDir,
+                                DEFAULT_CONNECT_GENERATED_TS_DIR));
         builder.build().execute();
         String webpackGeneratedContent = Files
                 .lines(new File(userDir, WEBPACK_GENERATED).toPath())

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrapTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrapTest.java
@@ -87,7 +87,7 @@ public class TaskGenerateBootstrapTest {
 
         final List<String> expectedContent = Arrays.asList(
                 "import '../../target/index';",
-                "import { applyTheme } from '@vaadin/flow-frontend/themes/theme-generated';",
+                "import { applyTheme } from './theme';",
                 "applyTheme(document);");
 
         expectedContent.forEach(expectedLine -> Assert.assertTrue(

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateThemeImportTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateThemeImportTest.java
@@ -67,13 +67,12 @@ public class TaskUpdateThemeImportTest {
         npmFolder = temporaryFolder.getRoot();
         frontendDirectory = new File(projectRoot, DEFAULT_FRONTEND_DIR);
 
-        File nodeModules = new File(npmFolder, NODE_MODULES);
-        File flowFrontend = new File(nodeModules, FLOW_NPM_PACKAGE_NAME);
+        File frontendFolder = new File(npmFolder, FrontendUtils.DEFAULT_FRONTEND_DIR);
         themeImportFile = new File(
-                new File(flowFrontend, APPLICATION_THEME_ROOT),
+                new File(frontendFolder, FrontendUtils.GENERATED),
             THEME_IMPORTS_NAME);
         themeImportTsFile = new File(
-            new File(flowFrontend, APPLICATION_THEME_ROOT),
+            new File(frontendFolder, FrontendUtils.GENERATED),
             THEME_IMPORTS_D_TS_NAME);
         dummyThemeClass = Mockito.mock(AbstractTheme.class).getClass();
         customTheme = new ThemeDefinition(dummyThemeClass, CUSTOM_VARIANT_NAME,
@@ -193,23 +192,23 @@ public class TaskUpdateThemeImportTest {
 
     private void assertThemeGeneratedDefinitionFilesNotExisted() {
         Assert.assertFalse(
-            "\"theme-generated.js\" should not exist before"
+            "\"theme.js\" should not exist before"
                 + " executing TaskUpdateThemeImport.",
             themeImportFile.exists());
 
         Assert.assertFalse(
-            "\"theme-generated.d.ts\" should not exist before"
+            "\"theme.d.ts\" should not exist before"
                 + " executing TaskUpdateThemeImport.",
             themeImportTsFile.exists());
     }
     private void assertThemeGeneratedDefinitionFilesExists() {
         Assert.assertTrue(
-            "\"theme-generated.js\" should be created as the "
+            "\"theme.js\" should be created as the "
                 + "result of executing TaskUpdateThemeImport.",
             themeImportFile.exists());
 
         Assert.assertTrue(
-            "\"theme-generated.d.ts\" should be created as the "
+            "\"theme.d.ts\" should be created as the "
                 + "result of executing TaskUpdateThemeImport.",
             themeImportTsFile.exists());
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateThemeImportTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateThemeImportTest.java
@@ -33,6 +33,7 @@ import com.vaadin.flow.theme.AbstractTheme;
 import com.vaadin.flow.theme.ThemeDefinition;
 
 import static com.vaadin.flow.server.Constants.APPLICATION_THEME_ROOT;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_CONNECT_GENERATED_TS_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
 import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
@@ -55,6 +56,7 @@ public class TaskUpdateThemeImportTest {
     private File projectRoot;
     private File npmFolder;
     private File frontendDirectory;
+    private File frontendGeneratedDirectory;
     private File themeImportFile;
     private File themeImportTsFile;
     private Class<? extends AbstractTheme> dummyThemeClass;
@@ -66,6 +68,8 @@ public class TaskUpdateThemeImportTest {
         projectRoot = temporaryFolder.getRoot();
         npmFolder = temporaryFolder.getRoot();
         frontendDirectory = new File(projectRoot, DEFAULT_FRONTEND_DIR);
+        frontendGeneratedDirectory = new File(projectRoot,
+            DEFAULT_CONNECT_GENERATED_TS_DIR);
 
         File frontendFolder = new File(npmFolder, FrontendUtils.DEFAULT_FRONTEND_DIR);
         themeImportFile = new File(
@@ -78,7 +82,7 @@ public class TaskUpdateThemeImportTest {
         customTheme = new ThemeDefinition(dummyThemeClass, CUSTOM_VARIANT_NAME,
                 CUSTOM_THEME_NAME);
         taskUpdateThemeImport = new TaskUpdateThemeImport(npmFolder,
-                customTheme, frontendDirectory);
+                customTheme, frontendDirectory, frontendGeneratedDirectory);
     }
 
     @Test
@@ -89,7 +93,7 @@ public class TaskUpdateThemeImportTest {
 
         TaskUpdateThemeImport taskUpdateThemeImportWithNonExistentThemeFolder =
                 new TaskUpdateThemeImport(npmFolder, customTheme,
-                        faultyFrontendDirectory);
+                        faultyFrontendDirectory, frontendGeneratedDirectory);
 
         ExecutionFailedException e = Assert.assertThrows(
                 ExecutionFailedException.class,

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateWebpackTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateWebpackTest.java
@@ -36,6 +36,7 @@ import org.junit.rules.TemporaryFolder;
 import com.vaadin.flow.server.PWA;
 import com.vaadin.flow.server.PwaConfiguration;
 
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_CONNECT_GENERATED_TS_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FLOW_RESOURCES_FOLDER;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.IMPORTS_NAME;
@@ -64,6 +65,7 @@ public class TaskUpdateWebpackTest extends NodeUpdateTestUtil {
     private File webpackGenerated;
     private File baseDir;
     private File frontendFolder;
+    private File frontendGeneratedFolder;
     private PwaConfiguration pwaConfiguration;
     private boolean useV14Bootstrapping = false;
 
@@ -71,6 +73,8 @@ public class TaskUpdateWebpackTest extends NodeUpdateTestUtil {
     public void setup() throws Exception {
         baseDir = temporaryFolder.getRoot();
         frontendFolder = new File(baseDir, "frontend");
+        frontendGeneratedFolder = new File(baseDir,
+                DEFAULT_CONNECT_GENERATED_TS_DIR);
 
         NodeUpdateTestUtil.createStubNode(true, true, false,
                 baseDir.getAbsolutePath());
@@ -164,7 +168,7 @@ public class TaskUpdateWebpackTest extends NodeUpdateTestUtil {
                 baseDir, new File(baseDir, "baz"), new File(baseDir, "foo"),
                 WEBPACK_CONFIG, WEBPACK_GENERATED, new File(baseDir, "bar"),
                 false, new File(baseDir, DEFAULT_FLOW_RESOURCES_FOLDER),
-                pwaConfiguration);
+                pwaConfiguration, frontendGeneratedFolder);
 
         newUpdater.execute();
 
@@ -317,7 +321,7 @@ public class TaskUpdateWebpackTest extends NodeUpdateTestUtil {
                 new File(baseDir, DEFAULT_GENERATED_DIR + IMPORTS_NAME),
                 useV14Bootstrapping,
                 new File(baseDir, DEFAULT_FLOW_RESOURCES_FOLDER),
-                pwaConfiguration);
+                pwaConfiguration, frontendGeneratedFolder);
     }
 
     private void assertWebpackGeneratedConfigContent(String entryPoint,

--- a/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/WebComponentGeneratorTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/WebComponentGeneratorTest.java
@@ -175,13 +175,15 @@ public class WebComponentGeneratorTest {
     @Test
     public void providedJSModuleContainsCorrectThemeReplacements() {
         String module = WebComponentGenerator.generateModule(
-                new DefaultWebComponentExporterFactory<MyComponent>(
+                new DefaultWebComponentExporterFactory<>(
                         MyComponentExporter.class),
                 "", false, "my-theme");
         // make sure that the test works on windows machines:
         module = module.replace("\r", "");
         MatcherAssert.assertThat(module,
-                startsWith("import {applyTheme} from '@vaadin/flow-frontend/themes/theme-generated';\n\nclass Tag extends HTMLElement {"));
+                startsWith("import {applyTheme} from '"
+                        + "generated/theme';\n\nclass Tag extends "
+                        + "HTMLElement {"));
         MatcherAssert
             .assertThat(module, containsString("style.innerHTML = `\n" //
                 + "      :host {\n" //


### PR DESCRIPTION
Renames `theme-generated.js` to `theme.js` and moves it to `frontend/generated` folder.

Fixes: https://github.com/vaadin/flow/issues/9687