### PR TITLE
feat: add getters for used Unit to HasSize

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/HasSize.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasSize.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.component;
 
+import java.util.Optional;
+
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementConstants;
 
@@ -165,6 +167,15 @@ public interface HasSize extends HasElement {
     }
 
     /**
+     * Gets the width unit defined for the component.
+     *
+     * @return the width unit which has been set for the component
+     */
+    default Optional<Unit> getWidthUnit() {
+        return Unit.getUnit(getWidth());
+    }
+
+    /**
      * Sets the height of the component.
      * <p>
      * The height should be in a format understood by the browser, e.g. "100px"
@@ -294,6 +305,15 @@ public interface HasSize extends HasElement {
      */
     default String getMaxHeight() {
         return getElement().getStyle().get(ElementConstants.STYLE_MAX_HEIGHT);
+    }
+
+    /**
+     * Gets the height unit defined for the component.
+     *
+     * @return the height unit which has been set for the component
+     */
+    default Optional<Unit> getHeightUnit() {
+        return Unit.getUnit(getHeight());
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/HasSize.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HasSize.java
@@ -167,9 +167,10 @@ public interface HasSize extends HasElement {
     }
 
     /**
-     * Gets the width unit defined for the component.
+     * Gets the width unit of the component, if defined.
      *
-     * @return the width unit which has been set for the component
+     * @return an optional width unit for the component, or an empty
+     *         optional if no width unit has been set
      */
     default Optional<Unit> getWidthUnit() {
         return Unit.getUnit(getWidth());
@@ -308,9 +309,10 @@ public interface HasSize extends HasElement {
     }
 
     /**
-     * Gets the height unit defined for the component.
+     * Gets the height unit of the component, if defined.
      *
-     * @return the height unit which has been set for the component
+     * @return an optional height unit for the component, or an empty
+     *         optional if no height unit has been set
      */
     default Optional<Unit> getHeightUnit() {
         return Unit.getUnit(getHeight());

--- a/flow-server/src/main/java/com/vaadin/flow/component/Unit.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Unit.java
@@ -23,17 +23,14 @@ import java.util.stream.Stream;
  */
 public enum Unit {
     /**
+     * Unit code representing in percentage of the containing element
+     * defined by terminal.
+     */
+    PERCENTAGE("%"),
+    /**
      * Unit code representing pixels.
      */
     PIXELS("px"),
-    /**
-     * Unit code representing points (1/72nd of an inch).
-     */
-    POINTS("pt"),
-    /**
-     * Unit code representing picas (12 points).
-     */
-    PICAS("pc"),
     /**
      * Unit code representing the font-size of the root font.
      */
@@ -42,6 +39,14 @@ public enum Unit {
      * Unit code representing the font-size of the relevant font.
      */
     EM("em"),
+    /**
+     * Unit code representing points (1/72nd of an inch).
+     */
+    POINTS("pt"),
+    /**
+     * Unit code representing picas (12 points).
+     */
+    PICAS("pc"),
     /**
      * Unit code representing the x-height of the relevant font.
      */
@@ -57,12 +62,7 @@ public enum Unit {
     /**
      * Unit code representing inches.
      */
-    INCH("in"),
-    /**
-     * Unit code representing in percentage of the containing element
-     * defined by terminal.
-     */
-    PERCENTAGE("%");
+    INCH("in");
 
     private final String symbol;
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/Unit.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Unit.java
@@ -72,6 +72,10 @@ public enum Unit {
      */
     MM("mm"),
     /**
+     * Unit code representing the width of the "0" (zero).
+     */
+    CH("ch"),
+    /**
      * Unit code representing centimeters.
      */
     CM("cm"),

--- a/flow-server/src/main/java/com/vaadin/flow/component/Unit.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Unit.java
@@ -40,6 +40,22 @@ public enum Unit {
      */
     EM("em"),
     /**
+     * Unit code representing the viewport's width.
+     */
+    VW("vw"),
+    /**
+     * Unit code representing the viewport's height.
+     */
+    VH("vh"),
+    /**
+     * Unit code representing the viewport's smaller dimension.
+     */
+    VMIN("vmin"),
+    /**
+     * Unit code representing the viewport's larger dimension.
+     */
+    VMAX("vmax"),
+    /**
      * Unit code representing points (1/72nd of an inch).
      */
     POINTS("pt"),

--- a/flow-server/src/main/java/com/vaadin/flow/component/Unit.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Unit.java
@@ -91,10 +91,16 @@ public enum Unit {
      * @return A Optional unit.
      */
     public static Optional<Unit> getUnit(String cssSize) {
-        if (cssSize == null) {
-             throw new IllegalArgumentException("The parameter can't be null");
+        if (cssSize == null || cssSize.isEmpty()) {
+            return Optional.empty();
         }
-        return getUnits().filter(unit -> cssSize.endsWith(unit.toString())).findFirst();
+
+        for (Unit unit : values()) {
+            if (cssSize.endsWith(unit.getSymbol())) {
+                return Optional.of(unit);
+            }
+        }
+        return Optional.empty();
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasSizeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasSizeTest.java
@@ -174,6 +174,7 @@ public class HasSizeTest {
         Assert.assertFalse(component.getWidthUnit().isPresent());
 
         component.setWidth("10px");
+        Assert.assertTrue(component.getWidthUnit().isPresent());
         Assert.assertEquals(Unit.PIXELS, component.getWidthUnit().get());
 
         component.setSizeUndefined();
@@ -186,6 +187,7 @@ public class HasSizeTest {
         Assert.assertFalse(component.getHeightUnit().isPresent());
 
         component.setHeight("10%");
+        Assert.assertTrue(component.getHeightUnit().isPresent());
         Assert.assertEquals(Unit.PERCENTAGE, component.getHeightUnit().get());
 
         component.setSizeUndefined();

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasSizeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasSizeTest.java
@@ -168,4 +168,27 @@ public class HasSizeTest {
         Assert.assertNull(component.getHeight());
     }
 
+    @Test
+    public void getWidthUnit() {
+        HasSizeComponent component = new HasSizeComponent();
+        Assert.assertFalse(component.getWidthUnit().isPresent());
+
+        component.setWidth("10px");
+        Assert.assertEquals(Unit.PIXELS, component.getWidthUnit().get());
+
+        component.setSizeUndefined();
+        Assert.assertFalse(component.getWidthUnit().isPresent());
+    }
+
+    @Test
+    public void getHeightUnit() {
+        HasSizeComponent component = new HasSizeComponent();
+        Assert.assertFalse(component.getHeightUnit().isPresent());
+
+        component.setHeight("10%");
+        Assert.assertEquals(Unit.PERCENTAGE, component.getWidthUnit().get());
+
+        component.setSizeUndefined();
+        Assert.assertFalse(component.getHeightUnit().isPresent());
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasSizeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasSizeTest.java
@@ -186,7 +186,7 @@ public class HasSizeTest {
         Assert.assertFalse(component.getHeightUnit().isPresent());
 
         component.setHeight("10%");
-        Assert.assertEquals(Unit.PERCENTAGE, component.getWidthUnit().get());
+        Assert.assertEquals(Unit.PERCENTAGE, component.getHeightUnit().get());
 
         component.setSizeUndefined();
         Assert.assertFalse(component.getHeightUnit().isPresent());

--- a/flow-server/src/test/java/com/vaadin/flow/component/HasSizeUnitTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HasSizeUnitTest.java
@@ -129,10 +129,4 @@ public class HasSizeUnitTest {
         float size = Unit.getSize(cssSize);        	
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void getUnitException() {
-        String cssSize = null;
-        Optional<Unit> size = Unit.getUnit(cssSize);        	
-    }
-
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/UnitTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/UnitTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.flow.component;
 
 import org.junit.Assert;

--- a/flow-server/src/test/java/com/vaadin/flow/component/UnitTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/UnitTest.java
@@ -20,13 +20,13 @@ import org.junit.Test;
 
 public class UnitTest {
 
-  @Test
-  public void getUnit() {
-    Assert.assertFalse(Unit.getUnit(null).isPresent());
-    Assert.assertFalse(Unit.getUnit("").isPresent());
-    Assert.assertFalse(Unit.getUnit("10unknown").isPresent());
+    @Test
+    public void getUnit() {
+        Assert.assertFalse(Unit.getUnit(null).isPresent());
+        Assert.assertFalse(Unit.getUnit("").isPresent());
+        Assert.assertFalse(Unit.getUnit("10unknown").isPresent());
 
-    Assert.assertEquals(Unit.PERCENTAGE, Unit.getUnit("100%").get());
-    Assert.assertEquals(Unit.PIXELS, Unit.getUnit("100px").get());
-  }
+        Assert.assertEquals(Unit.PERCENTAGE, Unit.getUnit("100%").get());
+        Assert.assertEquals(Unit.PIXELS, Unit.getUnit("100px").get());
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/UnitTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/UnitTest.java
@@ -1,0 +1,17 @@
+package com.vaadin.flow.component;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class UnitTest {
+
+  @Test
+  public void getUnit() {
+    Assert.assertFalse(Unit.getUnit(null).isPresent());
+    Assert.assertFalse(Unit.getUnit("").isPresent());
+    Assert.assertFalse(Unit.getUnit("10unknown").isPresent());
+
+    Assert.assertEquals(Unit.PERCENTAGE, Unit.getUnit("100%").get());
+    Assert.assertEquals(Unit.PIXELS, Unit.getUnit("100px").get());
+  }
+}


### PR DESCRIPTION
Improves the addition to `HasSize` for `Unit`. 

* adds `getWidthUnit` and `getHeightUnit` for better discoverability
  * Open Questions:
    * Optional<Unit> vs. null vs. Unit.PIXELS as default?
    *  Adding those APIs for Min/Max as well? This would increase the amount of methods quite a lot with less gain
* improve performance of `Unit`
  * change streaming to simple for-each 
  * change ordering of enum values, most used (% > px > others) 
  * Open Questions:
    * Should I replace the streaming API in `getSize` as well? 
* adds missing units `vw`, `vh`, `vmin` and `vmax`