### PR TITLE
Inject Lumo CSS into shadow roots

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -59,7 +59,7 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.IMPORTS_NAME;
  */
 public class TaskUpdateImports extends NodeUpdater {
 
-    private static final String THEME_LINE_TPL = "addCssBlock('%s', true);";
+    private static final String THEME_LINE_TPL = "%saddCssBlock('%s', true);";
     private static final String THEME_VARIANT_TPL = "document.documentElement.setAttribute('%s', '%s');";
     // Trim and remove new lines.
     private static final Pattern NEW_LINE_TRIM = Pattern
@@ -133,12 +133,17 @@ public class TaskUpdateImports extends NodeUpdater {
             ThemeDefinition themeDef = getThemeDefinition();
 
             if (theme != null) {
+                boolean hasApplicationTheme = themeDef != null && !"".equals(themeDef.getName());
+                // There is no application theme in use, write theme includes here. Otherwise they are written by the theme
                 if (!theme.getHeaderInlineContents().isEmpty()) {
                     lines.add("");
+                    if (hasApplicationTheme) {
+                        lines.add("// Handled in the application theme");
+                    }
                     theme.getHeaderInlineContents()
-                            .forEach(html -> addLines(lines,
-                                    String.format(THEME_LINE_TPL, NEW_LINE_TRIM
-                                            .matcher(html).replaceAll(""))));
+                    .forEach(html -> addLines(lines,
+                    String.format(THEME_LINE_TPL, hasApplicationTheme ? "// ":"" ,NEW_LINE_TRIM
+                    .matcher(html).replaceAll(""))));
                 }
                 if (themeDef != null) {
                     theme.getHtmlAttributes(themeDef.getVariant()).forEach(

--- a/flow-tests/test-application-theme/reusable-theme/src/main/resources/META-INF/resources/themes/reusable-theme/theme.json
+++ b/flow-tests/test-application-theme/reusable-theme/src/main/resources/META-INF/resources/themes/reusable-theme/theme.json
@@ -4,5 +4,6 @@
     "@fortawesome/fontawesome-free": {
       "svgs/regular/**": "fortawesome/icons"
     }
-  }
+  },
+  "lumoImports": ["color","typography","badge"]
 }

--- a/flow-tests/test-application-theme/test-theme-reusable/frontend/ts-component.ts
+++ b/flow-tests/test-application-theme/test-theme-reusable/frontend/ts-component.ts
@@ -1,0 +1,16 @@
+import { css, customElement, html, LitElement } from "lit-element";
+import { applyTheme } from "./generated/theme";
+
+@customElement("ts-component")
+export class TsComponent extends LitElement {
+  connectedCallback() {
+    super.connectedCallback();
+    applyTheme(this.renderRoot);
+  }
+  static get styles() {
+    return css``;
+  }
+  render() {
+    return html` <div theme="badge">This is a badge</div> `;
+  }
+}

--- a/flow-tests/test-application-theme/test-theme-reusable/src/main/java/com/vaadin/flow/uitest/ui/theme/TSView.java
+++ b/flow-tests/test-application-theme/test-theme-reusable/src/main/java/com/vaadin/flow/uitest/ui/theme/TSView.java
@@ -1,0 +1,13 @@
+package com.vaadin.flow.uitest.ui.theme;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.router.Route;
+
+@Route("com.vaadin.flow.uitest.ui.theme.TSView")
+@Tag("ts-component")
+@JsModule("./ts-component.ts")
+public class TSView extends Component {
+
+}

--- a/flow-tests/test-application-theme/test-theme-reusable/src/test/java/com/vaadin/flow/uitest/ui/theme/TSIT.java
+++ b/flow-tests/test-application-theme/test-theme-reusable/src/test/java/com/vaadin/flow/uitest/ui/theme/TSIT.java
@@ -1,0 +1,44 @@
+
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.theme;
+
+import com.vaadin.flow.component.html.testbench.DivElement;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TSIT extends ChromeBrowserTest {
+
+    @Test
+    public void lumoBadgeIsRenderedCorrectly() {
+        open();
+        checkLogsForErrors();
+
+        DivElement badge = $("ts-component").first().$(DivElement.class).attribute("theme", "badge").first();
+        String badgeBackgroundColor = badge.getCssValue("backgroundColor");
+        Assert.assertEquals("rgba(22, 118, 243, 0.1)", badgeBackgroundColor);
+    }
+
+    @Override
+    protected String getTestPath() {
+        String path = super.getTestPath();
+        String view = "view/";
+        return path.replace(view, "path/");
+    }
+
+}


### PR DESCRIPTION
Adds support for
"lumoImports": ["color", "typography", "badge", ... ]
to theme.json to override the default ["color", "typography"]

package.json is added to the test to be able to get only one version of @polymer/polymer

If you do not have an application theme specified, Lumo imports are injected by generated-flow-imports.js like before.
If you have an application theme, Lumo imports are injected as part of applying the theme.

In both cases, Lumo imports are added to the beginning of <head> so they are considered before any other styles, such as @CssImport:ed stylesheets. This allows overriding Lumo CSS rules no matter how you add the CSS.

Fixes #9765

