### PR TITLE
feat: support current pnpm versions

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -15,23 +15,18 @@
  */
 package com.vaadin.flow.server.frontend;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -42,9 +37,6 @@ import com.vaadin.flow.server.frontend.FrontendUtils.UnknownVersionException;
 import com.vaadin.flow.server.frontend.installer.InstallationException;
 import com.vaadin.flow.server.frontend.installer.NodeInstaller;
 import com.vaadin.flow.server.frontend.installer.ProxyConfig;
-
-import elemental.json.Json;
-import elemental.json.JsonObject;
 
 /**
  * Provides access to frontend tools (node.js and npm, pnpm) and optionally
@@ -96,11 +88,6 @@ public class FrontendTools {
                     new FrontendVersion("6.11.1"),
                     new FrontendVersion("6.11.2"));
 
-    static final String PNPM_INSTALLED_BY_NPM_FOLDER = "node_modules/pnpm/";
-
-    static final String PNPM_INSTALLED_BY_NPM = PNPM_INSTALLED_BY_NPM_FOLDER
-            + "bin/pnpm.js";
-
     private static final int SUPPORTED_NODE_MAJOR_VERSION = 10;
     private static final int SUPPORTED_NODE_MINOR_VERSION = 0;
     private static final int SUPPORTED_NPM_MAJOR_VERSION = 5;
@@ -109,9 +96,6 @@ public class FrontendTools {
     private static final int SHOULD_WORK_NODE_MINOR_VERSION = 9;
     private static final int SHOULD_WORK_NPM_MAJOR_VERSION = 5;
     private static final int SHOULD_WORK_NPM_MINOR_VERSION = 5;
-
-    public static final int SUPPORTED_PNPM_MAJOR_VERSION = 4;
-    public static final int SUPPORTED_PNPM_MINOR_VERSION = 4;
 
     private static final FrontendVersion SUPPORTED_NODE_VERSION = new FrontendVersion(
             SUPPORTED_NODE_MAJOR_VERSION, SUPPORTED_NODE_MINOR_VERSION);
@@ -132,6 +116,9 @@ public class FrontendTools {
     static final String SYSTEM_NOPROXY_PROPERTY_KEY = "NOPROXY";
     static final String SYSTEM_HTTPS_PROXY_PROPERTY_KEY = "HTTPS_PROXY";
     static final String SYSTEM_HTTP_PROXY_PROPERTY_KEY = "HTTP_PROXY";
+
+    public static final int SUPPORTED_PNPM_MAJOR_VERSION = 5;
+    public static final int SUPPORTED_PNPM_MINOR_VERSION = 0;
 
     private static final FrontendVersion SUPPORTED_PNPM_VERSION = new FrontendVersion(
             SUPPORTED_PNPM_MAJOR_VERSION, SUPPORTED_PNPM_MINOR_VERSION);
@@ -272,23 +259,14 @@ public class FrontendTools {
      *
      * @return the list of all commands in sequence that need to be executed to
      *         have pnpm running
-     * @see #getPnpmExecutable(String, boolean)
      */
     public List<String> getPnpmExecutable() {
-        Supplier<List<String>> result = doEnsurePnpm();
-        List<String> pnpmCommand = result.get();
+        List<String> pnpmCommand = getSuitablePnpm();
         if (!pnpmCommand.isEmpty()) {
+            pnpmCommand = new ArrayList<>(pnpmCommand);
             pnpmCommand.add("--shamefully-hoist=true");
         }
         return pnpmCommand;
-    }
-
-    /**
-     * Ensure that pnpm tool is available and install it if it's not.
-     *
-     */
-    public void ensurePnpm() {
-        doEnsurePnpm();
     }
 
     /**
@@ -324,47 +302,6 @@ public class FrontendTools {
             getLogger().warn("Error checking if npm is new enough", e);
         }
 
-    }
-
-    /**
-     * Locate <code>pnpm</code> executable if it's possible.
-     * <p>
-     * In case the tool is not found either {@link IllegalStateException} is
-     * thrown or an empty list is returned depending on {@code failOnAbsence}
-     * value.
-     *
-     * @param dir
-     *            the directory to search local pnpm script
-     *
-     * @param failOnAbsence
-     *            if {@code true} throws IllegalStateException if tool is not
-     *            found, if {@code false} return an empty list if tool is not
-     *            found
-     *
-     * @return the list of all commands in sequence that need to be executed to
-     *         have pnpm running
-     */
-    protected List<String> getPnpmExecutable(String dir,
-            boolean failOnAbsence) {
-        // First try local pnpm JS script if it exists
-        List<String> returnCommand = new ArrayList<>();
-        Optional<File> localPnpmScript = getLocalPnpmScript(dir);
-        if (localPnpmScript.isPresent()) {
-            returnCommand.add(getNodeExecutable());
-            returnCommand.add(localPnpmScript.get().getAbsolutePath());
-        } else {
-            // Otherwise look for regular `pnpm`
-            String command = FrontendUtils.isWindows() ? "pnpm.cmd" : "pnpm";
-            if (failOnAbsence) {
-                returnCommand.add(
-                        getExecutable(command, null, false).getAbsolutePath());
-            } else {
-                returnCommand.addAll(frontendToolsLocator.tryLocateTool(command)
-                        .map(File::getPath).map(Collections::singletonList)
-                        .orElse(Collections.emptyList()));
-            }
-        }
-        return returnCommand;
     }
 
     /**
@@ -425,64 +362,6 @@ public class FrontendTools {
                     npmVersion.getFullVersion(),
                     "by updating your global npm installation with `npm install -g npm@latest`");
             throw new IllegalStateException(badNpmVersion);
-        }
-    }
-
-    private List<String> ensurePnpm(String dir) {
-        List<String> pnpm = getSuitablePnpm(dir);
-        if (pnpm.isEmpty()) {
-            // copy the current content of package.json file to a temporary
-            // location
-            File packageJson = new File(dir, "package.json");
-            File tempFile = null;
-            boolean packageJsonExists = packageJson.canRead();
-            if (packageJsonExists) {
-                try {
-                    tempFile = File.createTempFile("package", "json");
-                    FileUtils.copyFile(packageJson, tempFile);
-                } catch (IOException exception) {
-                    throw new IllegalStateException(
-                            "Couldn't make a copy of package.json file",
-                            exception);
-                }
-                packageJson.delete();
-            }
-            try {
-                JsonObject pkgJson = Json.createObject();
-                pkgJson.put("name", "temp");
-                pkgJson.put("license", "UNLICENSED");
-                pkgJson.put("repository", "npm/npm");
-                pkgJson.put("description",
-                        "Temporary package for pnpm installation");
-                FileUtils.writeLines(packageJson,
-                        Collections.singletonList(pkgJson.toJson()));
-                JsonObject lockJson = Json.createObject();
-                lockJson.put("lockfileVersion", 1);
-                FileUtils.writeLines(new File(dir, "package-lock.json"),
-                        Collections.singletonList(lockJson.toJson()));
-            } catch (IOException e) {
-                getLogger().warn("Couldn't create temporary package.json");
-            }
-            // install pnpm locally using npm
-            installPnpm(dir, getNpmExecutable(false));
-
-            // remove package-lock.json which contains pnpm as a dependency.
-            new File(dir, "package-lock.json").delete();
-
-            if (packageJsonExists && tempFile != null) {
-                // return back the original package.json
-                try {
-                    FileUtils.copyFile(tempFile, packageJson);
-                } catch (IOException exception) {
-                    throw new IllegalStateException(
-                            "Couldn't restore package.json file back",
-                            exception);
-                }
-                tempFile.delete();
-            }
-            return Collections.emptyList();
-        } else {
-            return pnpm;
         }
     }
 
@@ -628,38 +507,9 @@ public class FrontendTools {
         return null;
     }
 
-    private Supplier<List<String>> doEnsurePnpm() {
-        List<String> path = getSuitablePnpm(baseDir);
-        if (!path.isEmpty()) {
-            getLogger().trace(
-                    "Found installed pnpm (globally or inside the '{}' project dir)",
-                    baseDir);
-            return () -> path;
-        }
-        String alternativeDir = getAlternativeDir();
-        List<String> pnpm = ensurePnpm(alternativeDir);
-        if (pnpm.isEmpty()) {
-            return () -> getPnpmExecutable(alternativeDir, true);
-        } else {
-            getLogger().info(
-                    "Using pnpm command installed in the '{}' directory",
-                    alternativeDir);
-            return () -> pnpm;
-        }
-    }
-
     private List<String> getNpmExecutable(boolean removePnpmLock) {
-        List<String> returnCommand = getNpmScriptCommand(baseDir);
-        if (returnCommand.isEmpty()) {
-            returnCommand = getNpmScriptCommand(getAlternativeDir());
-        }
-
-        if (returnCommand.isEmpty()) {
-            // Otherwise look for regular `npm`
-            String command = FrontendUtils.isWindows() ? "npm.cmd" : "npm";
-            returnCommand
-                    .add(getExecutable(command, null, true).getAbsolutePath());
-        }
+        List<String> returnCommand = new ArrayList<>(
+                getNpmCliToolExecutable("npm"));
         returnCommand.add("--no-update-notifier");
         returnCommand.add("--no-audit");
         returnCommand.add("--scripts-prepend-node-path=true");
@@ -675,11 +525,30 @@ public class FrontendTools {
         return returnCommand;
     }
 
-    private List<String> getNpmScriptCommand(String dir) {
+    private List<String> getNpmCliToolExecutable(String toolName) {
+        assert "npm".equals(toolName) || "npx".equals(toolName);
+        String scriptName = toolName + "-cli.js";
+
+        List<String> returnCommand = getNpmScriptCommand(baseDir, scriptName);
+        if (!returnCommand.isEmpty()) {
+            return returnCommand;
+        }
+        returnCommand = getNpmScriptCommand(getAlternativeDir(), scriptName);
+        if (!returnCommand.isEmpty()) {
+            return returnCommand;
+        }
+
+        // Otherwise look for regular `npm`/`npx`
+        String command = FrontendUtils.isWindows() ? toolName + ".cmd" : toolName;
+        return Collections.singletonList(
+                getExecutable(command, null, true).getAbsolutePath());
+    }
+
+    private List<String> getNpmScriptCommand(String dir, String scriptName) {
         // If `node` is not found in PATH, `node/node_modules/npm/bin/npm` will
         // not work because it's a shell or windows script that looks for node
         // and will fail. Thus we look for the `npm-cli` node script instead
-        File file = new File(dir, "node/node_modules/npm/bin/npm-cli.js");
+        File file = new File(dir, "node/node_modules/npm/bin/" + scriptName);
         List<String> returnCommand = new ArrayList<>();
         if (file.canRead()) {
             // We return a two element list with node binary and npm-cli script
@@ -689,104 +558,53 @@ public class FrontendTools {
         return returnCommand;
     }
 
-    List<String> getSuitablePnpm(String dir) {
-        List<String> pnpmCommand = getPnpmExecutable(dir, false);
-        String pnpmCommandString = String.join(" ", pnpmCommand);
+    List<String> getSuitablePnpm() {
+        // do NOT modify the order of flags, as it changes the behavior of npx
+        List<String> pnpmCommand = new ArrayList<>(
+                getNpmCliToolExecutable("npx"));
+        pnpmCommand.add("--yes");
+        pnpmCommand.add("--quiet");
+        pnpmCommand.add("pnpm");
 
-        if (!ignoreVersionChecks && !pnpmCommand.isEmpty()) {
-            // check whether globally or locally installed pnpm is new enough
-            try {
-                List<String> versionCmd = new ArrayList<>(pnpmCommand);
-                versionCmd.add("--version"); // NOSONAR
-                FrontendVersion pnpmVersion = FrontendUtils.getVersion("pnpm",
-                        versionCmd);
-                if (!FrontendUtils.isVersionAtLeast(pnpmVersion,
-                        SUPPORTED_PNPM_VERSION)) {
-                    getLogger().warn(
-                            "installed pnpm ('{}', version {}) is not supported (should be >={})",
-                            pnpmCommandString, pnpmVersion.getFullVersion(),
-                            SUPPORTED_PNPM_VERSION.getFullVersion());
-                    pnpmCommand = Collections.emptyList();
-                }
-            } catch (UnknownVersionException e) {
-                getLogger().warn("error checking pnpm version", e);
-            }
+        // check version of default pnpm
+        if (!ignoreVersionChecks && !checkPnpmVersion(pnpmCommand)) {
+            // pass version specifier to npx
+            pnpmCommand.set(pnpmCommand.size() - 1,
+                    "pnpm@" + DEFAULT_PNPM_VERSION);
         }
-        if (!pnpmCommand.isEmpty()) {
+        if (!ignoreVersionChecks && !checkPnpmVersion(pnpmCommand)) {
+            // This should not happen unless there is a too old pnpm installed
+            // locally into the project's node_modules folder overriding the
+            // package version specifier passed to npx.
+            throw new IllegalStateException(
+                    "unable to locate pnpm of supported version");
+        } else {
             getLogger().info("using '{}' for frontend package installation",
-                    pnpmCommandString);
+                    String.join(" ", pnpmCommand));
+            return pnpmCommand;
         }
-        return pnpmCommand;
     }
 
-    private void installPnpm(String dir, List<String> installCommand) {
-        getLogger().info("installing pnpm version {} locally",
-                DEFAULT_PNPM_VERSION);
-
-        List<String> command = new ArrayList<>();
-        command.addAll(installCommand);
-        command.add("install");
-        command.add("pnpm@" + DEFAULT_PNPM_VERSION);
-
-        if (getLogger().isDebugEnabled()) {
-            getLogger().debug(FrontendUtils.commandToString(dir, command));
-        }
-
-        ProcessBuilder builder = FrontendUtils.createProcessBuilder(command);
-        builder.environment().put("ADBLOCK", "1");
-        builder.directory(new File(dir));
-
-        builder.redirectInput(ProcessBuilder.Redirect.INHERIT);
-        builder.redirectError(ProcessBuilder.Redirect.INHERIT);
-
-        Process process = null;
+    private boolean checkPnpmVersion(List<String> pnpmCommand) {
         try {
-            process = builder.start();
-            getLogger().debug("Output of `{}`:",
-                    command.stream().collect(Collectors.joining(" ")));
-            try (BufferedReader reader = new BufferedReader(
-                    new InputStreamReader(process.getInputStream(),
-                            StandardCharsets.UTF_8))) {
-                String stdoutLine;
-                while ((stdoutLine = reader.readLine()) != null) {
-                    getLogger().debug(stdoutLine);
-                }
+            List<String> versionCmd = new ArrayList<>(pnpmCommand);
+            versionCmd.add("--version"); // NOSONAR
+            FrontendVersion pnpmVersion = FrontendUtils
+                    .getVersion("pnpm", versionCmd);
+            boolean versionNewEnough = FrontendUtils
+                    .isVersionAtLeast(pnpmVersion, SUPPORTED_PNPM_VERSION);
+            if (!versionNewEnough) {
+                getLogger()
+                        .warn("pnpm at '{}' is version {} which is not supported (expected >={})",
+                                String.join(" ", pnpmCommand),
+                                pnpmVersion.getFullVersion(),
+                                SUPPORTED_PNPM_VERSION.getFullVersion());
             }
-
-            int errorCode = process.waitFor();
-            if (errorCode != 0) {
-                getLogger().error("Couldn't install 'pnpm'");
-            } else {
-                getLogger().debug("Pnpm is successfully installed");
-            }
-        } catch (InterruptedException | IOException e) {
-            getLogger().error("Error when running `npm install`", e);
-        } finally {
-            if (process != null) {
-                process.destroyForcibly();
-            }
+            return versionNewEnough;
+        } catch (UnknownVersionException e) {
+            getLogger().warn("error checking pnpm version", e);
+            return false;
         }
-    }
-
-    private Optional<File> getLocalPnpmScript(String dir) {
-        File npmInstalled = new File(dir, PNPM_INSTALLED_BY_NPM);
-        if (npmInstalled.canRead()) {
-            return Optional.of(npmInstalled);
-        }
-
-        // For version 4.3.3 check ".ignored" folders
-        File movedPnpmScript = new File(dir,
-                "node_modules/.ignored_pnpm/bin/pnpm.js");
-        if (movedPnpmScript.canRead()) {
-            return Optional.of(movedPnpmScript);
-        }
-
-        movedPnpmScript = new File(dir,
-                "node_modules/.ignored/pnpm/bin/pnpm.js");
-        if (movedPnpmScript.canRead()) {
-            return Optional.of(movedPnpmScript);
-        }
-        return Optional.empty();
     }
 
     private String buildBadVersionString(String tool, String version,

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -59,7 +59,7 @@ public class FrontendTools {
 
     public static final String DEFAULT_NODE_VERSION = "v14.15.4";
 
-    public static final String DEFAULT_PNPM_VERSION = "4.5.0";
+    public static final String DEFAULT_PNPM_VERSION = "5.15.1";
 
     public static final String INSTALL_NODE_LOCALLY = "%n  $ mvn com.github.eirslett:frontend-maven-plugin:1.10.0:install-node-and-npm "
             + "-DnodeVersion=\"" + DEFAULT_NODE_VERSION + "\" ";
@@ -113,10 +113,6 @@ public class FrontendTools {
     public static final int SUPPORTED_PNPM_MAJOR_VERSION = 4;
     public static final int SUPPORTED_PNPM_MINOR_VERSION = 4;
 
-    // Due to a regression in pnpm, see #8434
-    private static final int BREAKING_PNPM_MAJOR_VERSION = 4;
-    private static final int BREAKING_PNPM_MINOR_VERSION = 6;
-
     private static final FrontendVersion SUPPORTED_NODE_VERSION = new FrontendVersion(
             SUPPORTED_NODE_MAJOR_VERSION, SUPPORTED_NODE_MINOR_VERSION);
     private static final FrontendVersion SHOULD_WORK_NODE_VERSION = new FrontendVersion(
@@ -139,10 +135,6 @@ public class FrontendTools {
 
     private static final FrontendVersion SUPPORTED_PNPM_VERSION = new FrontendVersion(
             SUPPORTED_PNPM_MAJOR_VERSION, SUPPORTED_PNPM_MINOR_VERSION);
-
-    // See #8434
-    private static final FrontendVersion BREAKING_PNPM_VERSION = new FrontendVersion(
-            BREAKING_PNPM_MAJOR_VERSION, BREAKING_PNPM_MINOR_VERSION);
 
     private final String baseDir;
     private final Supplier<String> alternativeDirGetter;
@@ -708,14 +700,12 @@ public class FrontendTools {
                 versionCmd.add("--version"); // NOSONAR
                 FrontendVersion pnpmVersion = FrontendUtils.getVersion("pnpm",
                         versionCmd);
-                if (!(FrontendUtils.isVersionAtLeast(pnpmVersion,
-                        SUPPORTED_PNPM_VERSION)
-                        && pnpmVersion.isOlderThan(BREAKING_PNPM_VERSION))) {
+                if (!FrontendUtils.isVersionAtLeast(pnpmVersion,
+                        SUPPORTED_PNPM_VERSION)) {
                     getLogger().warn(
-                            "installed pnpm ('{}', version {}) is not in the compatible versions range (>={}, <{})",
+                            "installed pnpm ('{}', version {}) is not supported (should be >={})",
                             pnpmCommandString, pnpmVersion.getFullVersion(),
-                            SUPPORTED_PNPM_VERSION.getFullVersion(),
-                            BREAKING_PNPM_VERSION.getFullVersion());
+                            SUPPORTED_PNPM_VERSION.getFullVersion());
                     pnpmCommand = Collections.emptyList();
                 }
             } catch (UnknownVersionException e) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -592,7 +592,7 @@ public class FrontendTools {
                         "--quiet", pnpm))
                 .filter(this::validatePnpmVersion)
                 .findFirst().orElseThrow(() -> new IllegalStateException(
-                        "Found too old `pnpm`. If installed into the project "
+                        "Found too old 'pnpm'. If installed into the project "
                                 + "'node_modules', upgrade 'pnpm' to at least "
                                 + SUPPORTED_PNPM_VERSION.getFullVersion()));
         getLogger().info("using '{}' for frontend package installation",

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -92,9 +92,21 @@ public class TaskUpdatePackages extends NodeUpdater {
             JsonObject packageJson = getPackageJson();
             modified = updatePackageJsonDependencies(packageJson, deps);
 
-
             if (modified) {
                 writePackageFile(packageJson);
+
+                if (enablePnpm) {
+                    // With pnpm dependency versions are pinned via pnpmfile.js
+                    // (instead of @vaadin/vaadin-shrinkwrap). When updating
+                    // a dependency in package.json, the old version may be
+                    // left in the pnpm-lock.yaml file, causing duplicate
+                    // dependencies. Work around this issue by deleting
+                    // pnpm-lock.yaml ("pnpm install" will re-generate).
+                    // For details, see:
+                    // https://github.com/pnpm/pnpm/issues/2587
+                    // https://github.com/vaadin/flow/issues/9719
+                    deletePnpmLockFile();
+                }
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -336,6 +348,13 @@ public class TaskUpdatePackages extends NodeUpdater {
             }
         }
         return null;
+    }
+
+    private void deletePnpmLockFile() throws IOException {
+        File lockFile = new File(npmFolder, "pnpm-lock.yaml");
+        if (lockFile.exists()) {
+            FileUtils.forceDelete(lockFile);
+        }
     }
 
     /**

--- a/flow-server/src/main/resources/pnpmfile.js
+++ b/flow-server/src/main/resources/pnpmfile.js
@@ -8,8 +8,6 @@
 
 const fs = require('fs');
 
-const packageJson = JSON.parse(fs.readFileSync('./package.json', 'utf-8'));
-
 const versionsFile = '[to-be-generated-by-flow]';
 
 if (!fs.existsSync(versionsFile)) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
@@ -85,7 +85,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         generatedDir = new File(baseDir, DEFAULT_GENERATED_DIR);
         resourcesDir = new File(baseDir, DEFAULT_FLOW_RESOURCES_FOLDER);
 
-        NodeUpdateTestUtil.createStubNode(true, true, false,
+        NodeUpdateTestUtil.createStubNode(true, true,
                 baseDir.getAbsolutePath());
 
         packageCreator = new TaskGeneratePackageJson(baseDir, generatedDir, resourcesDir);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
@@ -211,6 +211,18 @@ public abstract class AbstractNodeUpdatePackagesTest
     }
 
     @Test
+    public void pnpmIsInUse_packageJsonModified_removePnpmLock()
+            throws IOException {
+        packageUpdater = new TaskUpdatePackages(classFinder,
+                getScanner(classFinder), baseDir, generatedDir, null, false, true);
+        packageCreator.execute();
+        File pnpmLock = new File(baseDir, "pnpm-lock.yaml");
+        pnpmLock.createNewFile();
+        packageUpdater.execute();
+        Assert.assertFalse(pnpmLock.exists());
+    }
+
+    @Test
     public void npmIsInUse_packageJsonContainsFlowDeps_removeFlowDeps()
             throws IOException {
         // Generate package json in a proper format first

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -479,8 +479,9 @@ public class FrontendToolsTest {
     @Test
     public void getSuitablePnpm_tooOldVersionInstalledAndSkipVersionCheck_accepted()
             throws Exception {
-        tools = new FrontendTools(baseDir, () -> vaadinHomeDir, "v14.15.4",
-                new File(baseDir).toURI(), true);
+        tools = new FrontendTools(baseDir, () -> vaadinHomeDir,
+                FrontendTools.DEFAULT_NODE_VERSION, new File(baseDir).toURI(),
+                true);
         Assume.assumeFalse(tools.getNodeExecutable().isEmpty());
         createStubNode(false, true, baseDir);
         createFakePnpm("4.5.0");

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -504,27 +504,18 @@ public class FrontendToolsTest {
         Assert.assertNotEquals("expected pnpm version 4.5.0 accepted", 0,
                 pnpmCommand.size());
     }
-    @Test
-    public void getSuitablePnpm_tooNewVersionInstalled_rejected() throws Exception {
-        Assume.assumeFalse(
-                tools.getNodeExecutable().isEmpty());
-        createFakePnpm("5.5.0");
-        List<String> pnpmCommand = tools.getSuitablePnpm(baseDir);
-        Assert.assertEquals("expected pnpm version 5.5.0 rejected", 0,
-                pnpmCommand.size());
-    }
 
     @Test
-    public void getSuitablePnpm_tooNewVersionInstalledAndSkipVersionCheck_accepted()
+    public void getSuitablePnpm_tooOldVersionInstalledAndSkipVersionCheck_accepted()
             throws Exception {
         tools = new FrontendTools(baseDir, () -> vaadinHomeDir,
                 "v12.10.0", new File(baseDir).toURI(), true);
         Assume.assumeFalse(
                 tools.getNodeExecutable().isEmpty());
 
-        createFakePnpm("5.5.0");
+        createFakePnpm("4.3.0");
         List<String> pnpmCommand = tools.getSuitablePnpm(baseDir);
-        Assert.assertNotEquals("expected pnpm version 5.5.0 accepted", 0,
+        Assert.assertNotEquals("expected pnpm version 4.3.0 accepted", 0,
                 pnpmCommand.size());
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -20,7 +20,6 @@ import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -36,7 +35,6 @@ import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 import org.apache.commons.io.FileUtils;
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
@@ -225,31 +223,6 @@ public class FrontendToolsTest {
         assertFaultyNpmVersion(new FrontendVersion(6, 11, 2));
     }
 
-    /**
-     * This test doesn't do anything if pnpm is already installed (globally)
-     * which is true e.g. for or CI servers (TC/bender).
-     */
-    @Test
-    public void ensurePnpm_requestInstall_keepPackageJson_removePackageLock_ignoredPnpmExists_localPnpmIsRemoved()
-            throws IOException {
-        Assume.assumeTrue(
-                tools.getPnpmExecutable(vaadinHomeDir, false).isEmpty());
-        File packageJson = new File(vaadinHomeDir, "package.json");
-        FileUtils.writeStringToFile(packageJson, "{}", StandardCharsets.UTF_8);
-
-        File packageLockJson = new File(vaadinHomeDir, "package-lock.json");
-        FileUtils.writeStringToFile(packageLockJson, "{}",
-                StandardCharsets.UTF_8);
-
-        tools.ensurePnpm();
-        Assert.assertFalse(
-                tools.getPnpmExecutable(vaadinHomeDir, false).isEmpty());
-
-        Assert.assertEquals("{}", FileUtils.readFileToString(packageJson,
-                StandardCharsets.UTF_8));
-        Assert.assertFalse(packageLockJson.exists());
-    }
-
     @Test
     public void getPnpmExecutable_executableIsAvailable() {
         List<String> executable = tools.getPnpmExecutable();
@@ -257,16 +230,6 @@ public class FrontendToolsTest {
         Assert.assertTrue(executable.contains("--shamefully-hoist=true"));
         Assert.assertTrue(
                 executable.stream().anyMatch(cmd -> cmd.contains("pnpm")));
-    }
-
-    @Test
-    public void getPnpmExecutable_pnpmIsNotInstalledGlobally_pnpmIsInstalledInHome() {
-        List<String> executable = tools.getPnpmExecutable(baseDir, false);
-        Assume.assumeTrue(executable.isEmpty());
-
-        executable = tools.getPnpmExecutable();
-        Assert.assertThat(executable.get(1),
-                CoreMatchers.startsWith(vaadinHomeDir));
     }
 
     @Test
@@ -464,7 +427,7 @@ public class FrontendToolsTest {
         Assume.assumeFalse(
                 "Skipping test on windows until a fake node.exe that isn't caught by Window defender can be created.",
                 FrontendUtils.isWindows());
-        createStubNode(true, true, false, baseDir);
+        createStubNode(true, true, baseDir);
 
         assertNodeCommand(() -> baseDir);
     }
@@ -482,7 +445,7 @@ public class FrontendToolsTest {
         Assume.assumeFalse(
                 "Skipping test on windows until a fake node.exe that isn't caught by Window defender can be created.",
                 FrontendUtils.isWindows());
-        createStubNode(false, true, false, baseDir);
+        createStubNode(false, true, baseDir);
 
         assertNpmCommand(() -> baseDir);
     }
@@ -496,31 +459,38 @@ public class FrontendToolsTest {
     }
 
     @Test
-    public void getSuitablePnpm_compatibleVersionInstalled_accepted() throws Exception {
-        Assume.assumeFalse(
-                tools.getNodeExecutable().isEmpty());
+    public void getSuitablePnpm_incompatibleDefaultVersionInstalled_rejected() throws Exception {
+        createStubNode(false, true, baseDir);
         createFakePnpm("4.5.0");
-        List<String> pnpmCommand = tools.getSuitablePnpm(baseDir);
-        Assert.assertNotEquals("expected pnpm version 4.5.0 accepted", 0,
-                pnpmCommand.size());
+        List<String> pnpmCommand = tools.getSuitablePnpm();
+        Assert.assertEquals("expected pnpm version 4.5.0 rejected",
+                "pnpm@" + FrontendTools.DEFAULT_PNPM_VERSION,
+                pnpmCommand.get(pnpmCommand.size() - 1));
+    }
+    @Test
+    public void getSuitablePnpm_compatibleVersionInstalled_accepted() throws Exception {
+        createStubNode(false, true, baseDir);
+        createFakePnpm("5.15.1");
+        List<String> pnpmCommand = tools.getSuitablePnpm();
+        Assert.assertEquals("expected pnpm version 5.15.1 accepted", "pnpm",
+                pnpmCommand.get(pnpmCommand.size() - 1));
     }
 
     @Test
     public void getSuitablePnpm_tooOldVersionInstalledAndSkipVersionCheck_accepted()
             throws Exception {
-        tools = new FrontendTools(baseDir, () -> vaadinHomeDir,
-                "v12.10.0", new File(baseDir).toURI(), true);
-        Assume.assumeFalse(
-                tools.getNodeExecutable().isEmpty());
-
-        createFakePnpm("4.3.0");
-        List<String> pnpmCommand = tools.getSuitablePnpm(baseDir);
-        Assert.assertNotEquals("expected pnpm version 4.3.0 accepted", 0,
-                pnpmCommand.size());
+        tools = new FrontendTools(baseDir, () -> vaadinHomeDir, "v14.15.4",
+                new File(baseDir).toURI(), true);
+        Assume.assumeFalse(tools.getNodeExecutable().isEmpty());
+        createStubNode(false, true, baseDir);
+        createFakePnpm("4.5.0");
+        List<String> pnpmCommand = tools.getSuitablePnpm();
+        Assert.assertEquals("expected pnpm version 4.5.0 accepted", "pnpm",
+                pnpmCommand.get(pnpmCommand.size() - 1));
     }
 
     private void assertNpmCommand(Supplier<String> path) throws IOException {
-        createStubNode(false, true, false, vaadinHomeDir);
+        createStubNode(false, true, vaadinHomeDir);
 
         assertThat(tools.getNodeExecutable(), containsString("node"));
         assertThat(tools.getNodeExecutable(),
@@ -532,7 +502,7 @@ public class FrontendToolsTest {
     }
 
     private void assertNodeCommand(Supplier<String> path) throws IOException {
-        createStubNode(true, true, false, vaadinHomeDir);
+        createStubNode(true, true, vaadinHomeDir);
 
         assertThat(tools.getNodeExecutable(), containsString(DEFAULT_NODE));
         assertThat(tools.getNodeExecutable(), containsString(path.get()));
@@ -557,15 +527,18 @@ public class FrontendToolsTest {
         }
     }
 
-    private void createFakePnpm(String version) throws Exception {
-        File pnpmJs = new File(baseDir, FrontendTools.PNPM_INSTALLED_BY_NPM);
-        FileUtils.forceMkdir(pnpmJs.getParentFile());
+    private void createFakePnpm(String defaultPnpmVersion) throws Exception {
+        File npxJs = new File(baseDir, "node/node_modules/npm/bin/npx-cli.js");
+        FileUtils.forceMkdir(npxJs.getParentFile());
 
-        FileWriter fileWriter = new FileWriter(pnpmJs);
+        FileWriter fileWriter = new FileWriter(npxJs);
         try {
-            fileWriter.write(
-                    "if (process.argv.includes('--version') || process.argv.includes('-v')) {\n"
-                            + "    console.log('" + version + "');\n" + "}\n");
+            fileWriter
+                    .write("pnpmVersion = process.argv.filter(a=>a.startsWith('pnpm')).map(a=>a.substring(5))[0] || '"
+                            + defaultPnpmVersion + "'\n"
+                            + "if (process.argv.includes('--version') || process.argv.includes('-v')) {\n"
+                            + "    console.log(pnpmVersion);\n"
+                            + "}\n");
         } finally {
             fileWriter.close();
         }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateTestUtil.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateTestUtil.java
@@ -75,23 +75,16 @@ public class NodeUpdateTestUtil {
     // frontend-maven-plugin does
     // Also creates a stub version of webpack-devmode-server
     public static void createStubNode(boolean stubNode, boolean stubNpm,
-            boolean stubPnpm, String baseDir) throws IOException {
+            String baseDir) throws IOException {
 
         if (stubNpm) {
-            File npmCli = new File(baseDir,
-                    "node/node_modules/npm/bin/npm-cli.js");
-            FileUtils.forceMkdirParent(npmCli);
-            FileUtils.writeStringToFile(npmCli,
-                    "process.argv.includes('--version') && console.log('5.6.0');",
+            File binDir = new File(baseDir, "node/node_modules/npm/bin");
+            FileUtils.forceMkdir(binDir);
+            String stub = "process.argv.includes('--version') && console.log('6.14.10');";
+            FileUtils.writeStringToFile(new File(binDir, "npm-cli.js"), stub,
                     StandardCharsets.UTF_8);
-        }
-        if (stubPnpm) {
-            File ppmCli = new File(baseDir, "node_modules/pnpm/bin/pnpm.js");
-            FileUtils.forceMkdirParent(ppmCli);
-            FileUtils.writeStringToFile(ppmCli,
-                    "process.argv.includes('--version') && console.log('4.5.0');",
+            FileUtils.writeStringToFile(new File(binDir, "npx-cli.js"), stub,
                     StandardCharsets.UTF_8);
-            new File(baseDir, "node_modules/.modules.yaml").createNewFile();
         }
         if (stubNode) {
             File node = new File(baseDir,

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -45,10 +45,6 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
     public void setUp() throws IOException {
         super.setUp();
 
-        // ensure there is a valid pnpm installed in the system
-        new FrontendTools(getNodeUpdater().npmFolder.getAbsolutePath(),
-                () -> FrontendUtils.getVaadinHomeDirectory().getAbsolutePath())
-                        .ensurePnpm();
         // create an empty package.json so as pnpm can be run without error
         FileUtils.write(new File(getNodeUpdater().npmFolder, PACKAGE_JSON),
                 "{}", StandardCharsets.UTF_8);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -110,7 +110,7 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         // create some package.json file so pnpm does some installation into
         // node_modules folder
         FileUtils.write(packageJson,
-                "{\"dependencies\": {" + "\"pnpm\": \"4.5.0\"}}",
+                "{\"dependencies\": {" + "\"pnpm\": \"5.15.1\"}}",
                 StandardCharsets.UTF_8);
 
         getNodeUpdater().modified = true;

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateWebpackTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateWebpackTest.java
@@ -76,7 +76,7 @@ public class TaskUpdateWebpackTest extends NodeUpdateTestUtil {
         frontendGeneratedFolder = new File(baseDir,
                 DEFAULT_PROJECT_FRONTEND_GENERATED_DIR);
 
-        NodeUpdateTestUtil.createStubNode(true, true, false,
+        NodeUpdateTestUtil.createStubNode(true, true,
                 baseDir.getAbsolutePath());
 
         pwaConfiguration = new PwaConfiguration(

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTestBase.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTestBase.java
@@ -92,8 +92,11 @@ public class DevModeInitializerTestBase {
         appConfig = Mockito.mock(ApplicationConfiguration.class);
         mockApplicationConfiguration(appConfig, enablePnpm);
 
-        createStubNode(false, true, enablePnpm, baseDir);
+        createStubNode(false, true, baseDir);
         createStubWebpackServer("Compiled", 500, baseDir, true);
+
+        // Prevent TaskRunNpmInstall#cleanUp from deleting node_modules
+        new File(baseDir, "node_modules/.modules.yaml").createNewFile();
 
         servletContext = Mockito.mock(ServletContext.class);
         ServletRegistration vaadinServletRegistration = Mockito


### PR DESCRIPTION
Remove pnpm-lock.yaml when package.json dependencies 
are updated to work around pnpm/pnpm#2587. Invoke pnpm
via `npx` instead of installing into `~/.vaadin/node_modules`.

Part of #9719