### PR TITLE
chore: Make NodeTasks less failure prone

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -136,13 +136,6 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo {
     @Parameter(defaultValue = FrontendUtils.WEBPACK_GENERATED)
     private String webpackGeneratedTemplate;
 
-    /**
-     * Copy the `sw.ts` from the specified URL. Default is the template provided
-     * by this plugin. Set it to empty string to disable the feature.
-     */
-    @Parameter(defaultValue = FrontendUtils.SERVICE_WORKER_SRC)
-    private String serviceWorkerTemplate;
-
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         updateBuildFile();
@@ -191,7 +184,7 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo {
                         .runNpmInstall(runNpmInstall)
                         .withWebpack(webpackOutputDirectory,
                                 resourceOutputDirectory, webpackTemplate,
-                                webpackGeneratedTemplate, serviceWorkerTemplate)
+                                webpackGeneratedTemplate)
                         .useV14Bootstrap(useDeprecatedV14Bootstrapping())
                         .enablePackagesUpdate(true)
                         .useByteCodeScanner(optimizeBundle)

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
@@ -157,8 +157,6 @@ public class BuildFrontendMojoTest {
                 WEBPACK_CONFIG);
         ReflectionUtils.setVariableValueInObject(mojo,
                 "webpackGeneratedTemplate", WEBPACK_GENERATED);
-        ReflectionUtils.setVariableValueInObject(mojo,
-                "serviceWorkerTemplate", SERVICE_WORKER_SRC);
         ReflectionUtils.setVariableValueInObject(mojo, "webpackOutputDirectory",
                 webpackOutputDirectory);
         ReflectionUtils.setVariableValueInObject(mojo,

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -581,7 +581,7 @@ public class NodeTasks implements FallibleCommand {
         }
 
         if (enableWebpackConfigUpdate) {
-            PwaConfiguration pwaConfiguration = frontendDependencies // NOSONAR
+            PwaConfiguration pwaConfiguration = frontendDependencies
                     .getPwaConfiguration();
             commands.add(new TaskUpdateWebpack(builder.frontendDirectory,
                     builder.npmFolder, builder.webpackOutputDirectory,
@@ -602,9 +602,8 @@ public class NodeTasks implements FallibleCommand {
                             builder.tokenFileData, builder.enablePnpm));
 
             commands.add(new TaskUpdateThemeImport(builder.npmFolder,
-                frontendDependencies == null ? null : frontendDependencies.getThemeDefinition(),
-                    builder.frontendDirectory,
-                    builder.connectClientTsApiFolder));
+                frontendDependencies.getThemeDefinition(),
+                builder.frontendDirectory, builder.connectClientTsApiFolder));
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -210,14 +210,11 @@ public class NodeTasks implements FallibleCommand {
          * @param webpackGeneratedTemplate
          *            name of the webpack resource to be used as template when
          *            creating the <code>webpack.generated.js</code> file.
-         * @param serviceWorkerTemplate
-         *            name of the service worker resource to be used as template
-         *            when creating the <code>sw.ts</code> file.
          * @return this builder
          */
         public Builder withWebpack(File webpackOutputDirectory,
                 File resourceOutputDirectory, String webpackTemplate,
-                String webpackGeneratedTemplate, String serviceWorkerTemplate) {
+                String webpackGeneratedTemplate) {
             this.webpackOutputDirectory = webpackOutputDirectory;
             this.resourceOutputDirectory = resourceOutputDirectory;
             this.webpackTemplate = webpackTemplate;
@@ -521,6 +518,13 @@ public class NodeTasks implements FallibleCommand {
         boolean enableWebpackConfigUpdate = builder.webpackTemplate != null
                 && !builder.webpackTemplate.isEmpty();
 
+        if (builder.createMissingPackageJson) {
+            TaskGeneratePackageJson packageCreator = new TaskGeneratePackageJson(
+                builder.npmFolder, builder.generatedFolder,
+                builder.flowResourcesFolder);
+            commands.add(packageCreator);
+        }
+
         if (builder.enablePackagesUpdate || builder.enableImportsUpdate
                 || enableWebpackConfigUpdate) {
             frontendDependencies = new FrontendDependenciesScanner.FrontendDependenciesScannerFactory()
@@ -532,13 +536,25 @@ public class NodeTasks implements FallibleCommand {
                         classFinder);
                 generator.generateWebComponents(builder.generatedFolder, frontendDependencies.getThemeDefinition());
             }
-        }
 
-        if (builder.createMissingPackageJson) {
-            TaskGeneratePackageJson packageCreator = new TaskGeneratePackageJson(
-                    builder.npmFolder, builder.generatedFolder,
-                    builder.flowResourcesFolder);
-            commands.add(packageCreator);
+            TaskUpdatePackages packageUpdater = null;
+            if (builder.enablePackagesUpdate && builder.flowResourcesFolder != null) {
+                packageUpdater = new TaskUpdatePackages(classFinder,
+                    frontendDependencies, builder.npmFolder,
+                    builder.generatedFolder, builder.flowResourcesFolder,
+                    builder.cleanNpmFiles, builder.enablePnpm);
+                commands.add(packageUpdater);
+
+            }
+            if (packageUpdater != null && builder.runNpmInstall) {
+                commands.add(new TaskRunNpmInstall(classFinder, packageUpdater,
+                    builder.enablePnpm, builder.requireHomeNodeExec,
+                    builder.nodeVersion, builder.nodeDownloadRoot));
+
+                commands.add(new TaskInstallWebpackPlugins(
+                    new File(builder.npmFolder, NODE_MODULES)));
+            }
+
         }
 
         if (!builder.useDeprecatedV14Bootstrapping) {
@@ -553,33 +569,15 @@ public class NodeTasks implements FallibleCommand {
             commands.add(new TaskGenerateBootstrap(frontendDependencies, builder.frontendDirectory));
         }
 
-        if (builder.enablePackagesUpdate) {
-            TaskUpdatePackages packageUpdater = new TaskUpdatePackages(
-                    classFinder, frontendDependencies, builder.npmFolder,
-                    builder.generatedFolder, builder.flowResourcesFolder,
-                    builder.cleanNpmFiles, builder.enablePnpm);
-            commands.add(packageUpdater);
-
-            if (builder.runNpmInstall) {
-                commands.add(new TaskRunNpmInstall(
-                        classFinder, packageUpdater,
-                        builder.enablePnpm, builder.requireHomeNodeExec,
-                        builder.nodeVersion, builder.nodeDownloadRoot));
-
-                commands.add(new TaskInstallWebpackPlugins(
-                    new File(builder.npmFolder, NODE_MODULES)));
-            }
-        }
-
-        if (builder.jarFiles != null) {
+        if (builder.jarFiles != null && builder.flowResourcesFolder != null) {
             commands.add(new TaskCopyFrontendFiles(builder.flowResourcesFolder,
                     builder.jarFiles));
+        }
 
-            if (builder.localResourcesFolder != null) {
-                commands.add(new TaskCopyLocalFrontendFiles(
-                        builder.flowResourcesFolder,
-                        builder.localResourcesFolder));
-            }
+        if (builder.localResourcesFolder != null && builder.flowResourcesFolder != null) {
+            commands.add(
+                new TaskCopyLocalFrontendFiles(builder.flowResourcesFolder,
+                    builder.localResourcesFolder));
         }
 
         if (enableWebpackConfigUpdate) {
@@ -604,7 +602,7 @@ public class NodeTasks implements FallibleCommand {
                             builder.tokenFileData, builder.enablePnpm));
 
             commands.add(new TaskUpdateThemeImport(builder.npmFolder,
-                frontendDependencies.getThemeDefinition(), // NOSONAR
+                frontendDependencies == null ? null : frontendDependencies.getThemeDefinition(),
                     builder.frontendDirectory,
                     builder.connectClientTsApiFolder));
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCopyLocalFrontendFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCopyLocalFrontendFiles.java
@@ -39,8 +39,10 @@ public class TaskCopyLocalFrontendFiles implements FallibleCommand {
      * (by default 'src/main/resources/META-INF/resources/frontend'). This
      * enables running jar projects locally.
      *
-     * @param npmFolder
-     *            target directory for the discovered files
+     * @param flowResourcesFolder
+     *     target directory for the discovered files
+     * @param localResourcesFolder
+     *     local folder containing resources to copy
      */
     TaskCopyLocalFrontendFiles(File flowResourcesFolder,
             File localResourcesFolder) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGeneratePackageJson.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGeneratePackageJson.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 
 import elemental.json.JsonObject;
-
 import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FORM_NPM_PACKAGE_NAME;
 import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
@@ -57,15 +56,17 @@ public class TaskGeneratePackageJson extends NodeUpdater {
                 writePackageFile(mainContent);
             }
 
-            if (flowResourcesFolder != null && !new File(npmFolder,
-                    NODE_MODULES + FLOW_NPM_PACKAGE_NAME)
-                            .equals(flowResourcesFolder)) {
+            if(flowResourcesFolder == null) {
+                return;
+            }
+
+            if (!new File(npmFolder, NODE_MODULES + FLOW_NPM_PACKAGE_NAME)
+                .equals(flowResourcesFolder)) {
                 writeResourcesPackageFile(getResourcesPackageJson());
             }
 
-            if (formResourcesFolder != null && !new File(npmFolder,
-                    NODE_MODULES + FORM_NPM_PACKAGE_NAME)
-                            .equals(formResourcesFolder)) {
+            if (!new File(npmFolder, NODE_MODULES + FORM_NPM_PACKAGE_NAME)
+                .equals(formResourcesFolder)) {
                 writeFormResourcesPackageFile(getFormResourcesPackageJson());
             }
         } catch (IOException e) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -311,36 +311,6 @@ public class TaskUpdateImports extends NodeUpdater {
      *            a directory with project's frontend files
      * @param tokenFile
      *            the token (flow-build-info.json) path, may be {@code null}
-     * @param disablePnpm
-     *            if {@code true} then npm is used instead of pnpm, otherwise
-     *            pnpm is used
-     */
-    TaskUpdateImports(ClassFinder finder,
-            FrontendDependenciesScanner frontendDepScanner,
-            SerializableFunction<ClassFinder, FrontendDependenciesScanner> fallBackScannerProvider,
-            File npmFolder, File generatedPath, File frontendDirectory,
-            File tokenFile, boolean disablePnpm) {
-        this(finder, frontendDepScanner, fallBackScannerProvider, npmFolder,
-                generatedPath, frontendDirectory, tokenFile, null, disablePnpm);
-    }
-
-    /**
-     * Create an instance of the updater given all configurable parameters.
-     *
-     * @param finder
-     *            a reusable class finder
-     * @param frontendDepScanner
-     *            a reusable frontend dependencies scanner
-     * @param fallBackScannerProvider
-     *            fallback scanner provider, not {@code null}
-     * @param npmFolder
-     *            folder with the `package.json` file
-     * @param generatedPath
-     *            folder where flow generated files will be placed.
-     * @param frontendDirectory
-     *            a directory with project's frontend files
-     * @param tokenFile
-     *            the token (flow-build-info.json) path, may be {@code null}
      * @param tokenFileData
      *            object to fill with token file data, may be {@code null}
      * @param disablePnpm

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -323,8 +323,7 @@ public class DevModeInitializer
         File target = new File(baseDir, TARGET);
         builder.withWebpack(new File(target, VAADIN_WEBAPP_RESOURCES),
                 new File(target, VAADIN_SERVLET_RESOURCES),
-                FrontendUtils.WEBPACK_CONFIG, FrontendUtils.WEBPACK_GENERATED,
-                FrontendUtils.SERVICE_WORKER_SRC);
+                FrontendUtils.WEBPACK_CONFIG, FrontendUtils.WEBPACK_GENERATED);
 
         builder.useV14Bootstrap(config.useV14Bootstrap());
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksTest.java
@@ -148,7 +148,7 @@ public class NodeTasksTest {
                         .enablePackagesUpdate(false)
                         .withWebpack(new File(userDir, TARGET + "webapp"),
                                 new File(userDir, TARGET + "classes"),
-                                WEBPACK_CONFIG, WEBPACK_GENERATED, SERVICE_WORKER_SRC)
+                                WEBPACK_CONFIG, WEBPACK_GENERATED)
                         .enableImportsUpdate(true).runNpmInstall(false)
                         .withEmbeddableWebComponents(false)
                         .useV14Bootstrap(false).withFlowResourcesFolder(

--- a/fusion-endpoint/src/test/java/com/vaadin/flow/server/startup/fusion/DevModeInitializerEndpointTest.java
+++ b/fusion-endpoint/src/test/java/com/vaadin/flow/server/startup/fusion/DevModeInitializerEndpointTest.java
@@ -35,7 +35,6 @@ import com.vaadin.flow.server.startup.DevModeInitializer;
 
 import static com.vaadin.flow.server.Constants.CONNECT_JAVA_SOURCE_FOLDER_TOKEN;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE;
-import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_CONNECT_GENERATED_TS_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_CONNECT_JAVA_SOURCE_FOLDER;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_CONNECT_OPENAPI_JSON_FILE;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;

--- a/fusion-endpoint/src/test/java/com/vaadin/flow/server/startup/fusion/DevModeInitializerEndpointTest.java
+++ b/fusion-endpoint/src/test/java/com/vaadin/flow/server/startup/fusion/DevModeInitializerEndpointTest.java
@@ -2,17 +2,17 @@ package com.vaadin.flow.server.startup.fusion;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletRegistration;
-
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
 
 import net.jcip.annotations.NotThreadSafe;
 import org.apache.commons.io.FileUtils;
@@ -34,18 +34,17 @@ import com.vaadin.flow.server.startup.ApplicationConfiguration;
 import com.vaadin.flow.server.startup.DevModeInitializer;
 
 import static com.vaadin.flow.server.Constants.CONNECT_JAVA_SOURCE_FOLDER_TOKEN;
-import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE;
-import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_REUSE_DEV_SERVER;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_CONNECT_GENERATED_TS_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_CONNECT_JAVA_SOURCE_FOLDER;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_CONNECT_OPENAPI_JSON_FILE;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @NotThreadSafe
 public class DevModeInitializerEndpointTest {
-    private final AtomicReference<DevModeHandler> atomicHandler = new AtomicReference<>();
 
     String baseDir;
     ServletContext servletContext;
@@ -62,10 +61,20 @@ public class DevModeInitializerEndpointTest {
     @Before
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public void setup() throws Exception {
-        assertNull(getDevModeHandler());
+        assertNull("No DevModeHandler should be available at test start",
+            DevModeHandler.getDevModeHandler());
 
         temporaryFolder.create();
         baseDir = temporaryFolder.getRoot().getPath();
+
+        Files.write(new File(baseDir, "package.json").toPath(),
+            "{}".getBytes(StandardCharsets.UTF_8));
+
+        final File generatedDirectory = new File(baseDir, DEFAULT_GENERATED_DIR);
+        FileUtils.forceMkdir(generatedDirectory);
+
+        Files.write(new File(generatedDirectory, "package.json").toPath(),
+            "{}".getBytes(StandardCharsets.UTF_8));
 
         appConfig = Mockito.mock(ApplicationConfiguration.class);
         Mockito.when(appConfig.getStringProperty(Mockito.anyString(),
@@ -75,6 +84,10 @@ public class DevModeInitializerEndpointTest {
         Mockito.when(appConfig.getStringProperty(FrontendUtils.PROJECT_BASEDIR,
                 null)).thenReturn(baseDir);
         Mockito.when(appConfig.enableDevServer()).thenReturn(true);
+        Mockito.when(appConfig.isPnpmEnabled()).thenReturn(true);
+        Mockito.when(appConfig
+            .getBooleanProperty(Mockito.matches(SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE),
+                Mockito.anyBoolean())).thenReturn(false);
 
         servletContext = mockServletContext();
         ServletRegistration vaadinServletRegistration = Mockito
@@ -118,14 +131,16 @@ public class DevModeInitializerEndpointTest {
     }
 
     @After
-    public void teardown() throws Exception, SecurityException {
-        System.clearProperty("vaadin." + SERVLET_PARAMETER_PRODUCTION_MODE);
-        System.clearProperty("vaadin." + SERVLET_PARAMETER_REUSE_DEV_SERVER);
-        System.clearProperty("vaadin." + CONNECT_JAVA_SOURCE_FOLDER_TOKEN);
-
+    public void teardown() throws Exception {
         temporaryFolder.delete();
-        if (getDevModeHandler() != null) {
-            getDevModeHandler().stop();
+
+        final DevModeHandler devModeHandler = DevModeHandler.getDevModeHandler();
+        if (devModeHandler != null) {
+            devModeHandler.stop();
+            // Wait until dev mode handler has stopped.
+            while(DevModeHandler.getDevModeHandler() != null) {
+                Thread.sleep(200);
+            }
         }
     }
 
@@ -157,6 +172,7 @@ public class DevModeInitializerEndpointTest {
 
         Assert.assertFalse(generatedOpenApiJson.exists());
         devModeInitializer.process(classes, servletContext);
+        waitForDevModeServer();
         Assert.assertFalse(
                 "Should not generate OpenAPI spec if Endpoint is not used.",
                 generatedOpenApiJson.exists());
@@ -189,18 +205,9 @@ public class DevModeInitializerEndpointTest {
         assertTrue(ts2.exists());
     }
 
-    /**
-     * Get the instantiated DevModeHandler.
-     *
-     * @return devModeHandler or {@code null} if not started
-     */
-    private DevModeHandler getDevModeHandler() {
-        return atomicHandler.get();
-    }
-
     private void waitForDevModeServer()
             throws NoSuchMethodException, IllegalAccessException,
-            InvocationTargetException, InterruptedException {
+            InvocationTargetException {
         DevModeHandler handler = DevModeHandler.getDevModeHandler();
         Assert.assertNotNull(handler);
         Method join = DevModeHandler.class.getDeclaredMethod("join");


### PR DESCRIPTION
Re-order some of the commands
so they don't by mistake fail due to
missing initializations.

Clean un-used code.

Add checks to not add commands
if missing required information.

Update old JavaDocs

Closes #9839