### PR TITLE
fix: Lock versions to what is set in package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ flow-client/src/main/resources/META-INF/resources/frontend/FlowClient.js
 flow-tests/**/types.d.ts
 /flow-tests/**/*.generated.js
 /flow-tests/**/generated/**
+flow-tests/**/pnpmfile.js

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -44,6 +44,8 @@ import elemental.json.Json;
 import elemental.json.JsonObject;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
 import static com.vaadin.flow.server.frontend.FrontendUtils.commandToString;
+import static com.vaadin.flow.server.frontend.NodeUpdater.DEPENDENCIES;
+import static com.vaadin.flow.server.frontend.NodeUpdater.DEV_DEPENDENCIES;
 import static com.vaadin.flow.server.frontend.NodeUpdater.HASH_KEY;
 import static com.vaadin.flow.server.frontend.NodeUpdater.VAADIN_DEP_KEY;
 import static elemental.json.impl.JsonUtil.stringify;
@@ -188,7 +190,23 @@ public class TaskRunNpmInstall implements FallibleCommand {
 
             JsonObject versionsJson = getVersions(content);
             if (versionsJson == null) {
-                return null;
+                versionsJson = Json.createObject();
+                // if we don't have versionsJson lock package dependency versions.
+                final JsonObject packageJson = packageUpdater.getPackageJson();
+                final JsonObject dependencies = packageJson
+                    .getObject(DEPENDENCIES);
+                final JsonObject devDependencies = packageJson
+                    .getObject(DEV_DEPENDENCIES);
+                if (dependencies != null) {
+                    for (String key : dependencies.keys()) {
+                        versionsJson.put(key, dependencies.getString(key));
+                    }
+                }
+                if (devDependencies != null) {
+                    for (String key : devDependencies.keys()) {
+                        versionsJson.put(key, devDependencies.getString(key));
+                    }
+                }
             }
             FileUtils.write(versions, stringify(versionsJson, 2) + "\n",
                     StandardCharsets.UTF_8);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -190,7 +190,7 @@ public class TaskRunNpmInstall implements FallibleCommand {
 
             JsonObject versionsJson = getVersions(content);
             if (versionsJson == null) {
-                versionsJson = generateVersionsFormPackageJson();
+                versionsJson = generateVersionsFromPackageJson();
             }
             FileUtils.write(versions, stringify(versionsJson, 2) + "\n",
                     StandardCharsets.UTF_8);
@@ -213,7 +213,7 @@ public class TaskRunNpmInstall implements FallibleCommand {
      * @throws IOException
      *     If reading package.json fails
      */
-    private JsonObject generateVersionsFormPackageJson() throws IOException {
+    private JsonObject generateVersionsFromPackageJson() throws IOException {
         JsonObject versionsJson = Json.createObject();
         // if we don't have versionsJson lock package dependency versions.
         final JsonObject packageJson = packageUpdater.getPackageJson();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -62,8 +62,6 @@ public class TaskRunNpmInstallTest {
 
     private Logger logger = Mockito.mock(Logger.class);
 
-    private File generatedFolder;
-
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
@@ -72,7 +70,7 @@ public class TaskRunNpmInstallTest {
         npmFolder = temporaryFolder.newFolder();
         nodeUpdater = new NodeUpdater(Mockito.mock(ClassFinder.class),
                 Mockito.mock(FrontendDependencies.class), npmFolder,
-                getGeneratedFolder(), null) {
+                null, null) {
 
             @Override
             public void execute() {
@@ -88,7 +86,7 @@ public class TaskRunNpmInstallTest {
     }
 
     protected TaskRunNpmInstall createTask() {
-        return new TaskRunNpmInstall(getClassFinder(), nodeUpdater, false,
+        return new TaskRunNpmInstall(getClassFinder(), getNodeUpdater(), false,
                 false, FrontendTools.DEFAULT_NODE_VERSION,
                 URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT));
     }
@@ -98,7 +96,7 @@ public class TaskRunNpmInstallTest {
             throws ExecutionFailedException {
         File nodeModules = getNodeUpdater().nodeModulesFolder;
         nodeModules.mkdir();
-        nodeUpdater.modified = false;
+        getNodeUpdater().modified = false;
         task.execute();
 
         Mockito.verify(logger).info(getRunningMsg());
@@ -111,7 +109,7 @@ public class TaskRunNpmInstallTest {
         nodeModules.mkdir();
         File staging = new File(nodeModules, ".staging");
         staging.mkdir();
-        nodeUpdater.modified = false;
+        getNodeUpdater().modified = false;
         task.execute();
 
         Mockito.verify(logger).info(getRunningMsg());
@@ -123,7 +121,7 @@ public class TaskRunNpmInstallTest {
         File nodeModules = getNodeUpdater().nodeModulesFolder;
         nodeModules.mkdir();
 
-        nodeUpdater.modified = true;
+        getNodeUpdater().modified = true;
         File yaml = new File(nodeModules, ".modules.yaml");
         yaml.createNewFile();
         task.execute();
@@ -137,7 +135,7 @@ public class TaskRunNpmInstallTest {
         File nodeModules = getNodeUpdater().nodeModulesFolder;
         nodeModules.mkdir();
 
-        nodeUpdater.modified = true;
+        getNodeUpdater().modified = true;
         File fakeFile = new File(nodeModules, ".fake.file");
         fakeFile.createNewFile();
         task.execute();
@@ -151,7 +149,7 @@ public class TaskRunNpmInstallTest {
         File nodeModules = getNodeUpdater().nodeModulesFolder;
         nodeModules.mkdir();
         new File(nodeModules, "foo").createNewFile();
-        nodeUpdater.modified = false;
+        getNodeUpdater().modified = false;
         task.execute();
 
         Mockito.verify(logger).info(getRunningMsg());
@@ -164,7 +162,7 @@ public class TaskRunNpmInstallTest {
         nodeModules.mkdir();
         new File(nodeModules, "foo").createNewFile();
         writeLocalHash("faulty");
-        nodeUpdater.modified = false;
+        getNodeUpdater().modified = false;
         task.execute();
 
         Mockito.verify(logger).info(getRunningMsg());
@@ -179,7 +177,7 @@ public class TaskRunNpmInstallTest {
         new File(nodeModules, "foo").createNewFile();
 
         writeLocalHash("");
-        nodeUpdater.modified = false;
+        getNodeUpdater().modified = false;
         task.execute();
 
         ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
@@ -199,7 +197,7 @@ public class TaskRunNpmInstallTest {
         nodeModules.mkdir();
 
         writeLocalHash("");
-        nodeUpdater.modified = false;
+        getNodeUpdater().modified = false;
         task.execute();
 
         Mockito.verify(logger).info(getRunningMsg());
@@ -221,7 +219,7 @@ public class TaskRunNpmInstallTest {
         File nodeModules = getNodeUpdater().nodeModulesFolder;
         nodeModules.mkdir();
         new File(nodeModules, "@vaadin/flow-frontend/").mkdirs();
-        nodeUpdater.modified = false;
+        getNodeUpdater().modified = false;
         task.execute();
 
         Mockito.verify(logger).info(getRunningMsg());
@@ -230,7 +228,7 @@ public class TaskRunNpmInstallTest {
     @Test
     public void runNpmInstall_modified_npmInstallIsExecuted()
             throws ExecutionFailedException {
-        nodeUpdater.modified = true;
+        getNodeUpdater().modified = true;
         task.execute();
 
         Mockito.verify(logger).info(getRunningMsg());
@@ -242,7 +240,7 @@ public class TaskRunNpmInstallTest {
         exception.expectMessage(
                 "it's either not a file or not a 'node' executable.");
         assertRunNpmInstallThrows_vaadinHomeNodeIsAFolder(new TaskRunNpmInstall(
-                getClassFinder(), nodeUpdater, false, true,
+                getClassFinder(), getNodeUpdater(), false, true,
                 FrontendTools.DEFAULT_NODE_VERSION,
                 URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT)));
     }
@@ -250,7 +248,7 @@ public class TaskRunNpmInstallTest {
     @Test
     public void runNpmInstall_externalUpdateOfPackages_npmInstallIsRerun()
             throws ExecutionFailedException, IOException {
-        nodeUpdater.modified = true;
+        getNodeUpdater().modified = true;
 
         // manually fake TaskUpdatePackages.
         JsonObject packageJson = getNodeUpdater().getPackageJson();
@@ -357,7 +355,4 @@ public class TaskRunNpmInstallTest {
         return "npm";
     }
 
-    protected File getGeneratedFolder() {
-        return generatedFolder;
-    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -68,9 +68,11 @@ public class TaskRunNpmInstallTest {
     @Before
     public void setUp() throws IOException {
         npmFolder = temporaryFolder.newFolder();
+        File generatedPath = new File(npmFolder, "generated");
+        generatedPath.mkdir();
         nodeUpdater = new NodeUpdater(Mockito.mock(ClassFinder.class),
                 Mockito.mock(FrontendDependencies.class), npmFolder,
-                null, null) {
+            generatedPath, null) {
 
             @Override
             public void execute() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -447,7 +447,7 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         final String versions = task.generateVersionsJson();
         Assert.assertNotNull(versions);
 
-        File generatedVersionsFile = new File(versions);
+        File generatedVersionsFile = new File(getNodeUpdater().npmFolder, versions);
         final JsonObject versionsJson = Json.parse(FileUtils
             .readFileToString(generatedVersionsFile, StandardCharsets.UTF_8));
         Assert.assertEquals("{}", versionsJson.toJson());
@@ -562,7 +562,7 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
 
         String path = task.generateVersionsJson();
 
-        File generatedVersionsFile = new File(path);
+        File generatedVersionsFile = new File(getNodeUpdater().npmFolder, path);
         return Json.parse(FileUtils.readFileToString(generatedVersionsFile,
                 StandardCharsets.UTF_8));
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -17,13 +17,9 @@ package com.vaadin.flow.server.frontend;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
-import javax.validation.constraints.AssertTrue;
-
-import com.vaadin.flow.server.frontend.installer.NodeInstaller;
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
@@ -33,11 +29,11 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.ExecutionFailedException;
+import com.vaadin.flow.server.frontend.installer.NodeInstaller;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 
 import elemental.json.Json;
 import elemental.json.JsonObject;
-
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 
 public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
@@ -455,6 +451,59 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         final JsonObject versionsJson = Json.parse(FileUtils
             .readFileToString(generatedVersionsFile, StandardCharsets.UTF_8));
         Assert.assertEquals("{}", versionsJson.toJson());
+    }
+
+    @Test
+    public void generateVersionsJson_versionsGeneratedFromPackageJson_containsBothDepsAndDevDeps()
+            throws IOException {
+
+        File packageJson = new File(getNodeUpdater().npmFolder, PACKAGE_JSON);
+        packageJson.createNewFile();
+
+        // Write package json file
+        // @formatter:off
+        FileUtils.write(packageJson,
+            "{"
+                + "\"vaadin\": {"
+                  + "\"dependencies\": {"
+                    + "\"lit-element\": \"2.3.1\","
+                    + "\"@vaadin/router\": \"1.7.2\","
+                    + "\"@polymer/polymer\": \"3.2.0\","
+                  + "},"
+                  + "\"devDependencies\": {"
+                    + "\"css-loader\": \"4.2.1\","
+                    + "\"file-loader\": \"6.1.0\""
+                  + "}"
+                + "},"
+                + "\"dependencies\": {"
+                  + "\"lit-element\": \"2.3.1\","
+                  + "\"@vaadin/router\": \"1.7.2\","
+                  + "\"@polymer/polymer\": \"3.2.0\","
+                + "},"
+                + "\"devDependencies\": {"
+                  + "\"css-loader\": \"4.2.1\","
+                  + "\"file-loader\": \"6.1.0\""
+                + "}"
+            + "}", StandardCharsets.UTF_8);
+        // @formatter:on
+
+        TaskRunNpmInstall task = createTask();
+
+        final String versions = task.generateVersionsJson();
+        Assert.assertNotNull(versions);
+
+        File generatedVersionsFile = new File(getNodeUpdater().npmFolder, versions);
+        final JsonObject versionsJson = Json.parse(FileUtils
+            .readFileToString(generatedVersionsFile, StandardCharsets.UTF_8));
+        Assert.assertEquals(
+            "{"
+                + "\"lit-element\":\"2.3.1\","
+                + "\"@vaadin/router\":\"1.7.2\","
+                + "\"@polymer/polymer\":\"3.2.0\","
+                + "\"css-loader\":\"4.2.1\","
+                + "\"file-loader\":\"6.1.0\""
+                + "}",
+            versionsJson.toJson());
     }
 
     @Override


### PR DESCRIPTION
Even without platform versions we should
manage the used versions by using exactly
what is defined in the package.json
as if we had a platform versions file.