### PR TITLE
Clarify CSRF token comments

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/MessageHandler.java
@@ -701,8 +701,8 @@ public class MessageHandler {
     }
 
     /**
-     * Gets the token (aka double submit cookie) that the server uses to protect
-     * against Cross Site Request Forgery attacks.
+     * Gets the token (synchronizer token pattern) that the server uses to
+     * protect against CSRF (Cross Site Request Forgery) attacks.
      *
      * @return the CSRF token string
      */

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -1185,7 +1185,7 @@ public class UI extends Component
     }
 
     /**
-     * Gets the CSRF token (aka double submit cookie) that is used to protect
+     * Gets the CSRF token (synchronizer token pattern) that is used to protect
      * against Cross Site Request Forgery attacks.
      *
      * @return the csrf token string

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -1940,7 +1940,7 @@ public abstract class VaadinService implements Serializable {
     }
 
     /**
-     * Verifies that the given CSRF token (aka double submit cookie) is valid
+     * Verifies that the given CSRF token (synchronizer token pattern) is valid
      * for the given UI. This is used to protect against Cross Site Request
      * Forgery attacks.
      * <p>

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
@@ -1039,7 +1039,7 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
     }
 
     /**
-     * Gets the CSRF token (aka double submit cookie) that is used to protect
+     * Gets the CSRF token (synchronizer token pattern) that is used to protect
      * against Cross Site Request Forgery attacks.
      *
      * @return the csrf token string

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/ServerRpcHandler.java
@@ -126,7 +126,8 @@ public class ServerRpcHandler implements Serializable {
         }
 
         /**
-         * Gets the CSRF security token (double submit cookie) for this request.
+         * Gets the CSRF security token (synchronizer token pattern) for this
+         * request.
          *
          * @return the CSRF security token for this current change request
          */


### PR DESCRIPTION
CSRF tokens in Vaadin follow the "synchronizer token pattern" rather
than the double submit cookie that some code comments refer to. Existing
comments are clarified to avoid confusion for anyone reviewing our
security practices.