### PR TITLE
fix: Tasks are sorted for execution

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -724,6 +724,6 @@ public class NodeTasks implements FallibleCommand {
         return IntStream.range(0, commandOrder.size())
                 .filter(i -> commandOrder.get(i)
                         .isAssignableFrom(command.getClass())).findFirst()
-                .orElse(-1);
+                .orElseThrow(() -> new UnknownTaskException(command));
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/UnknownTaskException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/UnknownTaskException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.frontend;
+
+/**
+ * Exception thrown for when a node task that is not in the
+ * task list is encountered.
+ */
+public class UnknownTaskException extends RuntimeException {
+
+    /**
+     * Exception constructor.
+     *
+     * @param command
+     *         command that was not found
+     */
+    public UnknownTaskException(FallibleCommand command) {
+        super("Could not find position for task " + command.getClass());
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksExecutionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksExecutionTest.java
@@ -1,0 +1,97 @@
+package com.vaadin.flow.server.frontend;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.server.ExecutionFailedException;
+
+/**
+ * Test that commands in NodeTasks are always executed in a predefined order.
+ */
+public class NodeTasksExecutionTest {
+
+    @Test
+    public void nodeTasks_alwaysExecutedInDefinedOrder() throws Exception {
+
+        // Make a builder that doesn't add any commands.
+        NodeTasks.Builder builder = new NodeTasks.Builder(
+                Mockito.mock(Lookup.class), null);
+        builder.useV14Bootstrap(true);
+
+        final NodeTasks nodeTasks = builder.build();
+
+        // get the private list of task execution order
+        final Field commandOrderField = NodeTasks.class
+                .getDeclaredField("commandOrder");
+        commandOrderField.setAccessible(true);
+        final List<Class<? extends FallibleCommand>> commandsOrder = (List<Class<? extends FallibleCommand>>) commandOrderField
+                .get(nodeTasks);
+
+        List<Class<? extends FallibleCommand>> executionOrder = new ArrayList<>(
+                commandsOrder.size());
+        List<FallibleCommand> commandsMock = mockCommandsRandomOrder(
+                commandsOrder, executionOrder);
+
+        // get the private commands list
+        final Field commandsField = NodeTasks.class
+                .getDeclaredField("commands");
+        commandsField.setAccessible(true);
+        final List<FallibleCommand> commands = (List<FallibleCommand>) commandsField
+                .get(nodeTasks);
+
+        Assert.assertEquals("No commands should be added initially, "
+                        + "update mock builder so that we don't automatically add any tasks!",
+                0, commands.size());
+
+        // Assemble the command list with random order
+        commands.addAll(commandsMock);
+
+        nodeTasks.execute();
+
+        Assert.assertEquals("Amount of tasks executed was more than expected",
+                commandsOrder.size(), executionOrder.size());
+        Assert.assertEquals("Tasks were executed in an unexpected order",
+                commandsOrder, executionOrder);
+    }
+
+    /**
+     * Generate mocks for each command and shuffle the list to simulate random
+     * add order in NodeTasks.
+     *
+     * @param commandsOrder
+     *         commands to execute array
+     * @param executionOrder
+     *         array to add execution into
+     * @return shuffled list of FallibleCommands to execute
+     * @throws ExecutionFailedException
+     *         thrown by actual commands
+     */
+    private List<FallibleCommand> mockCommandsRandomOrder(
+            List<Class<? extends FallibleCommand>> commandsOrder,
+            List<Class<? extends FallibleCommand>> executionOrder)
+            throws ExecutionFailedException {
+
+        List<FallibleCommand> commands = new ArrayList<>(commandsOrder.size());
+
+        for (Class<? extends FallibleCommand> command : commandsOrder) {
+            final FallibleCommand mock = Mockito.mock(command);
+            commands.add(mock);
+            // When execute() is called add executing command to execution list.
+            Mockito.doAnswer(invocation -> {
+                executionOrder.add(command);
+                return null;
+            }).when(mock).execute();
+        }
+
+        Collections.shuffle(commands);
+
+        return commands;
+    }
+}


### PR DESCRIPTION
NodeTasks are now sorted before
execution so that they are always
executed in a predefined order.

Fixes #9893