### PR TITLE
build: enable reuse of forks during unit tests

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/UsageStatistics.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/UsageStatistics.java
@@ -68,7 +68,7 @@ public class UsageStatistics {
         }
     }
 
-    private static ConcurrentHashMap<String, UsageEntry> entires = new ConcurrentHashMap<>();
+    private static ConcurrentHashMap<String, UsageEntry> entries = new ConcurrentHashMap<>();
     static {
         String version = System.getProperty("java.version");
 
@@ -95,7 +95,7 @@ public class UsageStatistics {
     public static void markAsUsed(String name, String version) {
         assert name != null;
 
-        entires.computeIfAbsent(name, ignore -> new UsageEntry(name, version));
+        entries.computeIfAbsent(name, ignore -> new UsageEntry(name, version));
     }
 
     /**
@@ -104,7 +104,7 @@ public class UsageStatistics {
      * @return a stream of entries, not <code>null</code>
      */
     public static Stream<UsageEntry> getEntries() {
-        return entires.values().stream();
+        return entries.values().stream();
     }
 
     /**
@@ -115,6 +115,13 @@ public class UsageStatistics {
      *            want to be removed, not <code>null</code>
      */
     public static void removeEntry(String name) {
-        entires.remove(name);
+        entries.remove(name);
+    }
+
+    /**
+     * Clear the usage entries.
+     */
+    public static void clearEntries() {
+        entries.clear();
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
@@ -40,11 +40,13 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.internal.CurrentInstance;
 
 import static com.vaadin.flow.server.Constants.POLYFILLS_DEFAULT_VALUE;
 import static com.vaadin.flow.server.Constants.STATISTICS_JSON_DEFAULT;
@@ -89,6 +91,12 @@ public class StaticFileServerTest implements Serializable {
             }
         });
 
+    }
+
+    @BeforeClass
+    public static void beforeClass() {
+        // must be cleared before running this class
+        CurrentInstance.clearAll();
     }
 
     @Before

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServiceTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServiceTest.java
@@ -81,6 +81,11 @@ public class VaadinServiceTest {
 
     @Test
     public void should_reported_routing_server() {
+
+        // this test needs a fresh empty statistics, so we need to clear
+        // them for resusing forks for unit tests
+        UsageStatistics.clearEntries();
+
         VaadinServiceInitListener initListener = event -> {
             RouteConfiguration.forApplicationScope().setRoute("test",
                     TestView.class);

--- a/pom.xml
+++ b/pom.xml
@@ -491,7 +491,9 @@
                     <version>${maven.surefire.plugin.version}</version>
                     <configuration>
                         <trimStackTrace>false</trimStackTrace>
+                        <!--
                         <reuseForks>false</reuseForks>
+                        -->
                         <excludes>
                             <exclude>${exclude.windows.failed.tests}</exclude>
                         </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -491,9 +491,6 @@
                     <version>${maven.surefire.plugin.version}</version>
                     <configuration>
                         <trimStackTrace>false</trimStackTrace>
-                        <!--
-                        <reuseForks>false</reuseForks>
-                        -->
                         <excludes>
                             <exclude>${exclude.windows.failed.tests}</exclude>
                         </excludes>


### PR DESCRIPTION
Several changes which enable reusing forks during the surefire (unit tests) phase. As a result, a new jvm is not started for each unit test class and a 5 minute build time gain is experienced for the full build.

Fixes: #9885