### PR TITLE
chore: Open a view before testing.

### DIFF
--- a/flow-tests/test-dev-mode/src/test/java/com/vaadin/flow/uitest/ui/UrlValidationIT.java
+++ b/flow-tests/test-dev-mode/src/test/java/com/vaadin/flow/uitest/ui/UrlValidationIT.java
@@ -26,18 +26,31 @@ import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.vaadin.flow.component.html.testbench.LabelElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
 public class UrlValidationIT extends ChromeBrowserTest {
+    @Override
+    protected String getTestPath() {
+        return "/view/com.vaadin.flow.uitest.ui.frontend.BrowserLoggingView";
+    }
 
     @Test
     public void devModeUriValidation_uriWithDirectoryChange_statusForbidden() throws Exception {
+        // open a view and wait till the expected label is displayed
+        open();
+        waitUntil(input -> $(LabelElement.class).id("elementId").isDisplayed());
+        // check the forbidden url
         sendRequestAndValidateResponseStatusForbidden(
                 "/VAADIN/build/%252E%252E/");
     }
 
     @Test
     public void staticResourceUriValidation_uriWithDirectoryChange_statusForbidden() throws Exception {
+        // open a view and wait till the expected label is displayed
+        open();
+        waitUntil(input -> $(LabelElement.class).id("elementId").isDisplayed());
+        // check the forbidden url
         sendRequestAndValidateResponseStatusForbidden(
                 "/VAADIN/build/%252E%252E/some-resource.css");
     }
@@ -45,10 +58,6 @@ public class UrlValidationIT extends ChromeBrowserTest {
     private void sendRequestAndValidateResponseStatusForbidden(String pathToResource) throws Exception {
         final String urlString = getRootURL() + "/view" + pathToResource;
         URL url = new URL(urlString);
-
-        // not using chromedriver, so we need to look at the response body
-        // to know if the frontend is ready
-        waitForFrontendCompilation(url);
 
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();
         connection.setRequestMethod("GET");


### PR DESCRIPTION
To not be in a loop we wait until
a view with a component can be opened
and then test the forbidden response.