### PR TITLE
fix: level up namespace of devModeGizmo and theming objects to Vaadin

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.ts
@@ -752,8 +752,8 @@ export class VaadinDevmodeGizmo extends LitElement {
     this.transitionDuration = parseInt(window.getComputedStyle(this)
         .getPropertyValue('--gizmo-transition-duration'), 10);
 
-    if ((window as any).Vaadin && (window as any).Vaadin.Flow) {
-      (window as any).Vaadin.Flow.devModeGizmo = this;
+    if ((window as any).Vaadin) {
+      (window as any).Vaadin.devModeGizmo = this;
     }
   }
 

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -963,7 +963,7 @@ public abstract class AbstractNavigationStateRenderer
         if (!configuration.isProductionMode()
                 && configuration.isDevModeLiveReloadEnabled()) {
             ui.getPage().executeJs(
-                    "Vaadin.Flow.devModeGizmo.showNotification('warning', '@PreserveOnRefresh enabled', 'When refreshing the page in the browser, the server-side Java view instance is reused rather than being recreated.', null, 'preserveOnRefreshWarning')");
+                    "Vaadin.devModeGizmo.showNotification('warning', '@PreserveOnRefresh enabled', 'When refreshing the page in the browser, the server-side Java view instance is reused rather than being recreated.', null, 'preserveOnRefreshWarning')");
         }
     }
 }

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
@@ -220,18 +220,17 @@ function generateThemeFile(themeFolder, themeName, themeProperties, productionMo
   themeFile += imports.join('');
   themeFile += `
 window.Vaadin = window.Vaadin || {};
-window.Vaadin.Flow = window.Vaadin.Flow || {};
-window.Vaadin.Flow['${globalCssFlag}'] = window.Vaadin.Flow['${globalCssFlag}'] || [];
+window.Vaadin['${globalCssFlag}'] = window.Vaadin['${globalCssFlag}'] || [];
 `;
 
 // Don't format as the generated file formatting will get wonky!
 // If targets check that we only register the style parts once, checks exist for global css and component css
   const themeFileApply = `export const applyTheme = (target) => {
   ${parentTheme}
-  const injectGlobal = (window.Vaadin.Flow['${globalCssFlag}'].length === 0) || (!window.Vaadin.Flow['${globalCssFlag}'].includes(target) && target !== document);
+  const injectGlobal = (window.Vaadin['${globalCssFlag}'].length === 0) || (!window.Vaadin['${globalCssFlag}'].includes(target) && target !== document);
   if (injectGlobal) {
     ${globalCssCode.join('')}
-    window.Vaadin.Flow['${globalCssFlag}'].push(target);
+    window.Vaadin['${globalCssFlag}'].push(target);
   }
   if (!document['${componentCssFlag}']) {
     ${componentCssCode.join('')}


### PR DESCRIPTION
TestBench wait logic is based the existence of Flow object
and in Fusion Only apps Flow object should not be initialized.
moving _vaadintheme_something and devModeGizmo to Vaadin 
namespace fixes the TB wait logic in Fusion Only apps.

Fixes: #9905