### PR TITLE
fix: remove obsoleted client engine pre-compression

### DIFF
--- a/flow-client/pom.xml
+++ b/flow-client/pom.xml
@@ -199,23 +199,6 @@
                 </configuration>
             </plugin>
 
-            <plugin>
-                <groupId>com.github.ryanholdren</groupId>
-                <artifactId>resourcecompressor</artifactId>
-                <version>2017-06-24</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>compress</goal>
-                        </goals>
-                        <phase>prepare-package</phase>
-                        <configuration>
-                            <directory>${gwt.module.output}/client/</directory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
             <!-- Include separate source dir for GWT tests -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/flow-client/src/main/resources/com/vaadin/ClientEngineXSI.gwt.xml
+++ b/flow-client/src/main/resources/com/vaadin/ClientEngineXSI.gwt.xml
@@ -13,7 +13,6 @@
 	<inherits name="com.google.gwt.http.HTTP" />
 
 	<inherits name="com.google.gwt.useragent.UserAgent" />
-	<inherits name="com.google.gwt.precompress.Precompress" />
 
 	<source path="client" />
 	<source path="flow/shared" />

--- a/flow-client/src/test/java/com/vaadin/client/flow/ClientEngineSizeIT.java
+++ b/flow-client/src/test/java/com/vaadin/client/flow/ClientEngineSizeIT.java
@@ -21,7 +21,6 @@ public class ClientEngineSizeIT {
         }
 
         boolean cacheJsReported = false;
-        boolean cacheJsGzReported = false;
 
         for (File f : compiledModuleFolder.listFiles()) {
             if (f.getName().endsWith(".cache.js")) {
@@ -31,20 +30,10 @@ public class ClientEngineSizeIT {
                 }
                 printTeamcityStats("clientEngine", f.length());
                 cacheJsReported = true;
-            } else if (f.getName().endsWith(".cache.js.gz")) {
-                if (cacheJsGzReported) {
-                    throw new IOException(
-                            "Multiple compressed cache.js.gz files found!");
-                }
-                printTeamcityStats("clientEngineGzipped", f.length());
-                cacheJsGzReported = true;
             }
         }
         if (!cacheJsReported) {
             throw new IOException("Uncompressed cache.js file not found!");
-        }
-        if (!cacheJsGzReported) {
-            throw new IOException("Compressed cache.js.gz file not found!");
         }
     }
 


### PR DESCRIPTION
Since 15 all goes through webpack tooling and gets compressed there.

Also fixes build on arm based macs, due the issues with abandoned jbrotly project