### PR TITLE
feat: enable fetching browser URL

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -618,11 +618,18 @@ public class Page implements Serializable {
     }
 
     /**
-     * This method can be used to retrieve the current url from the browser.
+     * Retrieves the current url from the browser. The URL is fetched from the
+     * browser in another request asynchronously and passed to the callback. The
+     * URL is the full URL that the user sees in the browser (including hash #)
+     * and works even when client side routing is used or there is a reverse
+     * proxy between the client and the server.
      * <p>
      * In case you need more control over the execution you can use
      * {@link #executeJs(String, Serializable...)} by passing
      * {@code return window.location.href}.
+     * <p>
+     * <em>NOTE: </em> the URL is not escaped, use {@link URL#toURI()} to escape
+     * it.
      * 
      * @param callback
      *            to be notified when the url is resolved.

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -20,7 +20,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Serializable;
+import java.net.MalformedURLException;
 import java.net.URI;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.function.Function;
@@ -615,4 +617,25 @@ public class Page implements Serializable {
                         getStringElseNull.apply("v-np")));
     }
 
+    /**
+     * This method can be used to retrieve the current url from the browser.
+     * <p>
+     * In case you need more control over the execution you can use
+     * {@link #executeJs(String, Serializable...)} by passing
+     * {@code return window.location.href}.
+     * 
+     * @param callback
+     *            to be notified when the url is resolved.
+     */
+    public void fetchCurrentURL(SerializableConsumer<URL> callback) {
+        Objects.requireNonNull(callback, "Url consumer callback should not be null.");
+        final String js = "return window.location.href";
+        executeJs(js).then(String.class, urlString -> {
+            try {
+                callback.accept(new URL(urlString));
+            } catch (MalformedURLException e) {
+                throw new IllegalStateException("Error while encoding the URL from client", e);
+            }
+        });
+    }
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PageView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PageView.java
@@ -3,6 +3,7 @@ package com.vaadin.flow.uitest.ui;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.IFrame;
 import com.vaadin.flow.component.html.Input;
+import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.VaadinRequest;
@@ -10,6 +11,8 @@ import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 
 import javax.servlet.http.HttpServletRequest;
+
+import org.slf4j.LoggerFactory;
 
 @Route(value = "com.vaadin.flow.uitest.ui.PageView", layout = ViewTestLayout.class)
 public class PageView extends AbstractDivView {
@@ -66,8 +69,14 @@ public class PageView extends AbstractDivView {
         openButton2.setText("Open url in an IFrame");
         openButton2.addClickListener(e -> getPage().open(url, "newWindow"));
 
+
         add(input, updateButton, overrideButton, reloadButton,
                 setLocationButton, openButton, openButton2, frame);
+        add(new NativeButton("page.fetchURL", onClickEvent -> {
+            getUI().ifPresent(ui -> ui.getPage().fetchCurrentURL(currentUrl -> {
+                LoggerFactory.getLogger(PageView.class.getName()).info(currentUrl.toString());
+            }));
+        }));
     }
 
 }


### PR DESCRIPTION
Page::fetchCurrentUrl can be used to asynchronously get the current url from the browser.

Closes https://github.com/vaadin/flow/issues/1897