### PR TITLE
feat: global CSS loader

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/types.d.ts
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/types.d.ts
@@ -11,7 +11,19 @@ declare module '*.shadow.css' {
 
 declare module '*.css' {
     import { CSSResult } from 'lit-element';
-    /** @deprecated */
+    /**
+     * @deprecated For CSS files that should be imported as a `CssResult`
+     *   (for usage in a `static get styles()` method for example),
+     *   you should use a file name suffix of `*.shadow.css` to keep your import
+     *   forwards compatible.
+     *   
+     *   In a future version we will change the default CSS loader to inject the
+     *   CSS as a stylesheet into document scope instead of exporting it as
+     *   a `CssResult` and the old behaviour of exporting `CssResult` will be
+     *   available via a separate loader that only applies to `*.shadow.css` files.
+     *   
+     *   See https://github.com/vaadin/flow/issues/9970 for more info.
+     */
     const content: CSSResult;
     export default content;
 }

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/types.d.ts
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/types.d.ts
@@ -3,8 +3,15 @@
 // This is needed for TypeScript compiler to declare and export as a TypeScript module.
 // It is recommended to commit this file to the VCS.
 // You might want to change the configurations to fit your preferences
+declare module '*.shadow.css' {
+    import { CSSResult } from 'lit-element';
+    const content: CSSResult;
+    export default content;
+}
+
 declare module '*.css' {
-    import {CSSResult} from "lit-element";
+    import { CSSResult } from 'lit-element';
+    /** @deprecated */
     const content: CSSResult;
     export default content;
 }

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -187,6 +187,30 @@ exports = {
   confFolder: `${confFolder}`
 };
 
+const baseCssLoaders = [
+  {
+    loader: 'css-loader',
+    options: {
+      url: (url, resourcePath) => {
+        // Only translate files from node_modules
+        const resolve = resourcePath.match(/(\\|\/)node_modules\1/);
+        const themeResource = resourcePath.match(themePartRegex) && url.match(/^themes\/[\s\S]*?\//);
+        return resolve || themeResource;
+      },
+      // use theme-loader to also handle any imports in css files
+      importLoaders: 1
+    },
+  },
+  {
+    // theme-loader will change any url starting with './' to start with 'VAADIN/static' instead
+    // NOTE! this loader should be here so it's run before css-loader as loaders are applied Right-To-Left
+    loader: '@vaadin/theme-loader',
+    options: {
+      devMode: devMode
+    }
+  }
+];
+
 module.exports = {
   mode: 'production',
   context: frontendFolder,
@@ -242,34 +266,24 @@ module.exports = {
       },
       {
         test: /\.css$/i,
+        exclude: /\.global\.css$/i,
         use: [
           {
-            loader: "lit-css-loader"
+            loader: 'lit-css-loader'
           },
           {
-            loader: "extract-loader"
+            loader: 'extract-loader'
           },
+          ...baseCssLoaders
+        ],
+      },
+      {
+        test: /\.global\.css$/i,
+        use: [
           {
-            loader: 'css-loader',
-            options: {
-              url: (url, resourcePath) => {
-                // Only translate files from node_modules
-                const resolve = resourcePath.match(/(\\|\/)node_modules\1/);
-                const themeResource = resourcePath.match(themePartRegex) && url.match(/^themes\/[\s\S]*?\//);
-                return resolve || themeResource;
-              },
-              // use theme-loader to also handle any imports in css files
-              importLoaders: 1
-            },
+            loader: 'style-loader'
           },
-          {
-            // theme-loader will change any url starting with './' to start with 'VAADIN/static' instead
-            // NOTE! this loader should be here so it's run before css-loader as loaders are applied Right-To-Left
-            loader: '@vaadin/theme-loader',
-            options: {
-              devMode: devMode
-            }
-          }
+          ...baseCssLoaders
         ],
       },
       {


### PR DESCRIPTION
This makes it so that you can import a CSS file into document scope with an import like:

```ts
import './about-view.global.css';
```

(using a `*.global.css` filename suffix)
instead of needing something like:

```ts
import '!style-loader!css-loader!./about-view.css';
```

It also makes it so that using a `CssResult` imported like:

```ts
import styles from './my-component.css';
```

will show a deprecation warning (based on an update to `types.d.ts`).
To avoid the deprecation and future proof your import you need to use a filename suffix `*.shadow.css` when you need to import a CSS file as a `CssResult` like this:

```ts
import styles from './my-component.shadow.css';
```

It's intended that in the next major version (after this has been released) the default behaviour for `*.css` will change so that you no longer need the `.global.css` suffix to import styles to document scope but keeping global in the filename will still keep working.

Closes #9970