### PR TITLE
fix: check if Flow is initiated for connection indicator

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/Connect.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Connect.ts
@@ -414,7 +414,7 @@ export class ConnectClient {
 
 
   private isFlowLoaded(): boolean {
-    return $wnd.Vaadin.Flow !== undefined;
+    return $wnd.Vaadin.Flow?.clients?.TypeScript !== undefined;
   }
 
   private loadingStarted() {

--- a/flow-client/src/test/frontend/ConnectTests.ts
+++ b/flow-client/src/test/frontend/ConnectTests.ts
@@ -54,9 +54,20 @@ describe('ConnectClient', () => {
     expect((window as any).Vaadin.connectionIndicator).is.not.undefined;
   });
 
-  it('should transition to CONNECTION_LOST on offline and to CONNECTED on subsequent online if Flow not loaded', async() => {
+  it('should transition to CONNECTION_LOST on offline and to CONNECTED on subsequent online if Flow.client.TypeScript not loaded', async() => {
     new ConnectClient();
     let $wnd = (window as any);
+    expect($wnd.Vaadin.connectionState.state).to.equal(ConnectionState.CONNECTED);
+    $wnd.dispatchEvent(new Event('offline'));
+    expect($wnd.Vaadin.connectionState.state).to.equal(ConnectionState.CONNECTION_LOST);
+    $wnd.dispatchEvent(new Event('online'));
+    expect($wnd.Vaadin.connectionState.state).to.equal(ConnectionState.CONNECTED);
+  });
+
+  it('should transition to CONNECTION_LOST on offline and to CONNECTED on subsequent online if Flow is loaded but Flow.client.TypeScript not loaded', async() => {
+    new ConnectClient();
+    let $wnd = (window as any);
+    $wnd.Vaadin.Flow = {};
     expect($wnd.Vaadin.connectionState.state).to.equal(ConnectionState.CONNECTED);
     $wnd.dispatchEvent(new Event('offline'));
     expect($wnd.Vaadin.connectionState.state).to.equal(ConnectionState.CONNECTION_LOST);
@@ -68,6 +79,8 @@ describe('ConnectClient', () => {
     new ConnectClient();
     let $wnd = (window as any);
     $wnd.Vaadin.Flow = {};
+    $wnd.Vaadin.Flow.clients = {};
+    $wnd.Vaadin.Flow.clients.TypeScript = {};
     expect($wnd.Vaadin.connectionState.state).to.equal(ConnectionState.CONNECTED);
     $wnd.dispatchEvent(new Event('offline'));
     expect($wnd.Vaadin.connectionState.state).to.equal(ConnectionState.CONNECTED);


### PR DESCRIPTION
The `isFlowLoaded()` only checks if `$wnd.Vaadin.Flow` is defined. The `project-name.generated.js` file in a SVC project would also define Flow with
```
window.Vaadin = window.Vaadin || {};
window.Vaadin.Flow = window.Vaadin.Flow || {};
window.Vaadin.Flow['_vaadintheme_fusion-with-endpiont_globalCss'] = window.Vaadin.Flow['_vaadintheme_fusion-with-endpiont_globalCss'] || [];
```
So updated the check to see if `Flow.clients.TypeScript` is defined.