### PR TITLE
chore: Update how input field is gotten

### DIFF
--- a/flow-tests/test-application-theme/test-reusable-as-parent/src/test/java/com/vaadin/flow/uitest/ui/theme/ParentThemeIT.java
+++ b/flow-tests/test-application-theme/test-reusable-as-parent/src/test/java/com/vaadin/flow/uitest/ui/theme/ParentThemeIT.java
@@ -21,6 +21,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebElement;
 
+import com.vaadin.flow.component.html.testbench.DivElement;
 import com.vaadin.flow.component.html.testbench.ImageElement;
 import com.vaadin.flow.component.html.testbench.SpanElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
@@ -65,8 +66,9 @@ public class ParentThemeIT extends ChromeBrowserTest {
     public void componentThemeIsApplied_childThemeTextColorIsApplied() {
         open();
         TestBenchElement myField = $(TestBenchElement.class).id(MY_POLYMER_ID);
-        TestBenchElement input = myField.$(TestBenchElement.class)
-            .id("vaadin-text-field-input-0");
+        TestBenchElement input = myField.$(DivElement.class)
+                .attribute("class", "vaadin-text-field-container").first()
+                .$(DivElement.class).attribute("part", "input-field").first();
         Assert.assertEquals("Polymer text field should have red background",
             "rgba(255, 0, 0, 1)", input.getCssValue("background-color"));
 

--- a/flow-tests/test-application-theme/test-theme-reusable/src/test/java/com/vaadin/flow/uitest/ui/theme/ReusableThemeIT.java
+++ b/flow-tests/test-application-theme/test-theme-reusable/src/test/java/com/vaadin/flow/uitest/ui/theme/ReusableThemeIT.java
@@ -21,6 +21,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebElement;
 
+import com.vaadin.flow.component.html.testbench.DivElement;
 import com.vaadin.flow.component.html.testbench.ImageElement;
 import com.vaadin.flow.component.html.testbench.SpanElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
@@ -93,8 +94,9 @@ public class ReusableThemeIT extends ChromeBrowserTest {
     public void componentThemeIsApplied_forPolymerAndLit() {
         open();
         TestBenchElement myField = $(TestBenchElement.class).id(MY_POLYMER_ID);
-        TestBenchElement input = myField.$(TestBenchElement.class)
-            .id("vaadin-text-field-input-0");
+        TestBenchElement input = myField.$(DivElement.class)
+                .attribute("class", "vaadin-text-field-container").first()
+                .$(DivElement.class).attribute("part", "input-field").first();
         Assert.assertEquals("Polymer text field should have red background",
             "rgba(255, 0, 0, 1)", input.getCssValue("background-color"));
 

--- a/flow-tests/test-embedding/test-embedding-application-theme/src/test/java/com/vaadin/flow/webcomponent/ApplicationThemeComponentIT.java
+++ b/flow-tests/test-embedding/test-embedding-application-theme/src/test/java/com/vaadin/flow/webcomponent/ApplicationThemeComponentIT.java
@@ -97,7 +97,6 @@ public class ApplicationThemeComponentIT extends ChromeBrowserTest {
                 handElement.getCssValue("color"));
     }
 
-    @Ignore("https://github.com/vaadin/flow/issues/10065")
     @Test
     public void componentThemeIsApplied_forPolymerAndLit() {
         open();
@@ -108,8 +107,9 @@ public class ApplicationThemeComponentIT extends ChromeBrowserTest {
 
         TestBenchElement myField = embeddedComponent.$(TestBenchElement.class)
             .id(MY_POLYMER_ID);
-        TestBenchElement input = myField.$(TestBenchElement.class)
-            .id("vaadin-text-field-input-0");
+        TestBenchElement input = myField.$(DivElement.class)
+                .attribute("class", "vaadin-text-field-container").first()
+                .$(DivElement.class).attribute("part", "input-field").first();
         Assert.assertEquals("Polymer text field should have red background",
             "rgba(255, 0, 0, 1)", input.getCssValue("background-color"));
 

--- a/flow-tests/test-embedding/test-embedding-reusable-theme/src/test/java/com/vaadin/flow/webcomponent/ApplicationThemeComponentIT.java
+++ b/flow-tests/test-embedding/test-embedding-reusable-theme/src/test/java/com/vaadin/flow/webcomponent/ApplicationThemeComponentIT.java
@@ -106,8 +106,9 @@ public class ApplicationThemeComponentIT extends ChromeBrowserTest {
 
         TestBenchElement myField = embeddedComponent.$(TestBenchElement.class)
             .id(MY_POLYMER_ID);
-        TestBenchElement input = myField.$(TestBenchElement.class)
-            .id("vaadin-text-field-input-0");
+        TestBenchElement input = myField.$(DivElement.class)
+                .attribute("class", "vaadin-text-field-container").first()
+                .$(DivElement.class).attribute("part", "input-field").first();
         Assert.assertEquals("Polymer text field should have red background",
             "rgba(255, 0, 0, 1)", input.getCssValue("background-color"));
 

--- a/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
+++ b/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
@@ -21,6 +21,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebElement;
 
+import com.vaadin.flow.component.html.testbench.DivElement;
 import com.vaadin.flow.component.html.testbench.ImageElement;
 import com.vaadin.flow.component.html.testbench.SpanElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
@@ -148,8 +149,10 @@ public class ThemeIT extends ChromeBrowserTest {
                 .getCssValue("padding"));
 
         TestBenchElement myField = $(TestBenchElement.class).id(MY_POLYMER_ID);
-        TestBenchElement input = myField.$(TestBenchElement.class)
-            .id("vaadin-text-field-input-0");
+
+        TestBenchElement input = myField.$(DivElement.class)
+                .attribute("class", "vaadin-text-field-container").first()
+                .$(DivElement.class).attribute("part", "input-field").first();
         Assert.assertEquals("Polymer text field should get parent border radius",
             "0px", input.getCssValue("border-radius"));
 
@@ -161,8 +164,9 @@ public class ThemeIT extends ChromeBrowserTest {
     public void componentThemeIsApplied_forPolymerAndLit() {
         open();
         TestBenchElement myField = $(TestBenchElement.class).id(MY_POLYMER_ID);
-        TestBenchElement input = myField.$(TestBenchElement.class)
-            .id("vaadin-text-field-input-0");
+        TestBenchElement input = myField.$(DivElement.class)
+                .attribute("class", "vaadin-text-field-container").first()
+                .$(DivElement.class).attribute("part", "input-field").first();
         Assert.assertEquals("Polymer text field should have red background",
             "rgba(255, 0, 0, 1)", input.getCssValue("background-color"));
 


### PR DESCRIPTION
Update the way we get the text-field input
field as the original way has problems
when multiple fields exist on the page as the
id will depend on initialization order.
This was only apparent on the embedded test side.

Fxes #10065