### PR TITLE
chore: write package json for default changes (#10081)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCreatePackageJson.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskCreatePackageJson.java
@@ -46,9 +46,7 @@ public class TaskCreatePackageJson extends NodeUpdater {
             modified = false;
             JsonObject mainContent = getPackageJson();
             modified = updateDefaultDependencies(mainContent);
-            if (modified) {
-                writePackageFile(mainContent);
-            }
+            writePackageFile(mainContent);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }


### PR DESCRIPTION
Always write the package json after
updateDefaultDependencies as even if
the dependencies are not updated the
defaults may be updated.

Fixes #10032