### PR TITLE
fix: remember original state after LOADING

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/Connect.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Connect.ts
@@ -373,15 +373,14 @@ export class ConnectClient {
     // this way makes the folding down below more concise.
     const fetchNext: MiddlewareNext =
       async (context: MiddlewareContext): Promise<Response> => {
-        this.loadingStarted();
+        $wnd.Vaadin.connectionState.loadingStarted();
         return fetch(context.request)
           .then(response => {
-            this.loadingFinished();
+            $wnd.Vaadin.connectionState.loadingFinished();
             return response;
           })
           .catch(error => {
-            this.loadingFinished();
-            $wnd.Vaadin.connectionState.state = ConnectionState.CONNECTION_LOST;
+            $wnd.Vaadin.connectionState.loadingFailed();
             return Promise.reject(error);
           });
       };
@@ -412,28 +411,7 @@ export class ConnectClient {
     return chain(initialContext);
   }
 
-
   private isFlowLoaded(): boolean {
     return $wnd.Vaadin.Flow?.clients?.TypeScript !== undefined;
-  }
-
-  private loadingStarted() {
-    if (this.isFlowLoaded()) {
-      // call Flow.loadingStarted to pause TestBench tests while backend
-      // requests are ongoing
-      $wnd.Vaadin.Flow.clients?.TypeScript?.loadingStarted();
-    } else {
-      $wnd.Vaadin.connectionState.loadingStarted();
-    }
-  }
-
-  private loadingFinished() {
-    if (this.isFlowLoaded()) {
-      // call Flow.loadingFinished to pause TestBench tests while backend
-      // requests are ongoing
-      $wnd.Vaadin.Flow.clients?.TypeScript?.loadingFinished();
-    } else {
-      $wnd.Vaadin.connectionState.loadingFinished();
-    }
   }
 }

--- a/flow-client/src/main/resources/META-INF/resources/frontend/ConnectionState.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/ConnectionState.ts
@@ -38,8 +38,6 @@ export class ConnectionStateStore {
 
   private loadingCount: number = 0;
 
-  private stateBeforeLoading?: ConnectionState;
-
   constructor(initialState: ConnectionState) {
     this.connectionState = initialState;
   }
@@ -53,18 +51,23 @@ export class ConnectionStateStore {
   }
 
   loadingStarted(): void {
-    if (this.loadingCount === 0) {
-      this.stateBeforeLoading = this.connectionState;
-    }
     this.state = ConnectionState.LOADING;
     this.loadingCount += 1;
   }
 
   loadingFinished(): void {
+    this.decreaseLoadingCount(ConnectionState.CONNECTED);
+  }
+
+  loadingFailed(): void {
+    this.decreaseLoadingCount(ConnectionState.CONNECTION_LOST);
+  }
+
+  private decreaseLoadingCount(finalState: ConnectionState) {
     if (this.loadingCount > 0) {
       this.loadingCount -= 1;
       if (this.loadingCount === 0) {
-        this.state = this.stateBeforeLoading!;
+        this.state = finalState;
       }
     }
   }

--- a/flow-client/src/main/resources/META-INF/resources/frontend/ConnectionState.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/ConnectionState.ts
@@ -38,8 +38,10 @@ export class ConnectionStateStore {
 
   private loadingCount: number = 0;
 
+  private stateBeforeLoading?: ConnectionState;
+
   constructor(initialState: ConnectionState) {
-      this.connectionState = initialState;
+    this.connectionState = initialState;
   }
 
   addStateChangeListener(listener: ConnectionStateChangeListener): void {
@@ -51,6 +53,9 @@ export class ConnectionStateStore {
   }
 
   loadingStarted(): void {
+    if (this.loadingCount === 0) {
+      this.stateBeforeLoading = this.connectionState;
+    }
     this.state = ConnectionState.LOADING;
     this.loadingCount += 1;
   }
@@ -59,7 +64,7 @@ export class ConnectionStateStore {
     if (this.loadingCount > 0) {
       this.loadingCount -= 1;
       if (this.loadingCount === 0) {
-        this.state = ConnectionState.CONNECTED;
+        this.state = this.stateBeforeLoading!;
       }
     }
   }

--- a/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
@@ -87,9 +87,7 @@ export class Flow {
     $wnd.Vaadin.Flow = $wnd.Vaadin.Flow || {};
     $wnd.Vaadin.Flow.clients = {
       TypeScript: {
-        isActive: () => this.isActive,
-        loadingStarted: () => this.loadingStarted(),
-        loadingFinished: () => this.loadingFinished()
+        isActive: () => this.isActive
       }
     };
 

--- a/flow-client/src/test/frontend/ConnectTests.ts
+++ b/flow-client/src/test/frontend/ConnectTests.ts
@@ -202,7 +202,6 @@ describe('ConnectClient', () => {
         // expected
       } finally {
         (expect(stateChangeListener).to.be as any).calledWithExactly(ConnectionState.LOADING, ConnectionState.CONNECTION_LOST);
-        // expect((window as any).Vaadin.connectionState.state).to.equal(ConnectionState.CONNECTION_LOST);
       }
     });
 

--- a/flow-client/src/test/frontend/ConnectTests.ts
+++ b/flow-client/src/test/frontend/ConnectTests.ts
@@ -179,40 +179,19 @@ describe('ConnectClient', () => {
       expect(fetchMock.lastOptions()).to.include({method: 'POST'});
     });
 
-    it('should set CONNECTED followed by ConnectionState.loadingFinished when Flow is not loaded', async() => {
+    it('should set connection state to LOADING followed by CONNECTED on successful fetch', async() => {
       let $wnd = (window as any);
-      let states: Array<ConnectionState> = [];
-      $wnd.Vaadin.connectionState.addStateChangeListener(
-        (_, state) => states.push(state));
+      const stateChangeListener = sinon.fake();
+      $wnd.Vaadin.connectionState.addStateChangeListener(stateChangeListener);
+
       await client.call('FooEndpoint', 'fooMethod');
-      expect(states).to.deep.equal([ConnectionState.LOADING, ConnectionState.CONNECTED]);
+      (expect(stateChangeListener).to.be as any).calledWithExactly(ConnectionState.LOADING, ConnectionState.CONNECTED);
     });
 
-    it('should call Flow.loadingStarted followed by Flow.loadingFinished when Flow is loaded', async() => {
-      let calls: Array<boolean> = [];
-      (window as any).Vaadin.Flow = {
-        clients: {
-          TypeScript: {
-            loadingStarted: () => calls.push(true),
-            loadingFinished: () => calls.push(false)
-          }
-        }
-      };
-      await client.call('FooEndpoint', 'fooMethod');
-      expect(calls).to.deep.equal([true, false]);
-    });
-
-    it('should call Flow.loadingFinished and transition to CONNECTION_LOST upon network failure', async() => {
-      let calls: Array<boolean> = [];
-      (window as any).Vaadin.Flow = {
-        clients: {
-          TypeScript: {
-            loadingStarted: () => calls.push(true),
-            loadingFinished: () => calls.push(false)
-          }
-        }
-      };
-
+    it('should set connection state to CONNECTION_LOST on network failure', async() => {
+      let $wnd = (window as any);
+      const stateChangeListener = sinon.fake();
+      $wnd.Vaadin.connectionState.addStateChangeListener(stateChangeListener);
       fetchMock.post(
         base + '/connect/FooEndpoint/reject',
         Promise.reject(new TypeError('Network failure'))
@@ -222,12 +201,13 @@ describe('ConnectClient', () => {
       } catch (error) {
         // expected
       } finally {
-        expect(calls).to.deep.equal([true, false]);
-        expect((window as any).Vaadin.connectionState.state).to.equal(ConnectionState.CONNECTION_LOST);
+        (expect(stateChangeListener).to.be as any).calledWithExactly(ConnectionState.LOADING, ConnectionState.CONNECTION_LOST);
+        // expect((window as any).Vaadin.connectionState.state).to.equal(ConnectionState.CONNECTION_LOST);
       }
     });
 
-    it('should call Flow.loadingFinished upon server error', async() => {
+    it('should  set connection state to CONNECTED upon server error', async() => {
+      let $wnd = (window as any);
       const body = 'Unexpected error';
       const errorResponse = new Response(
         body,
@@ -238,21 +218,12 @@ describe('ConnectClient', () => {
       );
       fetchMock.post(base + '/connect/FooEndpoint/vaadinConnectResponse', errorResponse);
 
-      let calls: Array<boolean> = [];
-      (window as any).Vaadin.Flow = {
-        clients: {
-          TypeScript: {
-            loadingStarted: () => calls.push(true),
-            loadingFinished: () => calls.push(false)
-          }
-        }
-      };
       try {
         await client.call('FooEndpoint', 'vaadinConnectResponse');
       } catch (error) {
         // expected
       } finally {
-        expect(calls).to.deep.equal([true, false]);
+        expect($wnd.Vaadin.connectionState.state).to.equal(ConnectionState.CONNECTED);
       }
     });
 

--- a/flow-client/src/test/frontend/ConnectionStateTests.ts
+++ b/flow-client/src/test/frontend/ConnectionStateTests.ts
@@ -69,11 +69,12 @@ describe('ConnectionStateStore', () => {
     store.loadingFinished();
     store.loadingFinished();
 
-    assert.equal(stateChangeListener.callCount, 2)
-    assert.isTrue(stateChangeListener.getCall(0).calledWithExactly(
-      ConnectionState.CONNECTED, ConnectionState.LOADING))
-    assert.isTrue(stateChangeListener.getCall(1).calledWithExactly(
-      ConnectionState.LOADING, ConnectionState.CONNECTED))
+    assert.equal(stateChangeListener.callCount, 2);
+
+    (expect(stateChangeListener.getCall(0)).to.be as any).calledWithExactly(
+      ConnectionState.CONNECTED, ConnectionState.LOADING);
+    (expect(stateChangeListener.getCall(1)).to.be as any).calledWithExactly(
+      ConnectionState.LOADING, ConnectionState.CONNECTED);
   });
 
   it('loading count should reset when state forced', () => {
@@ -86,29 +87,30 @@ describe('ConnectionStateStore', () => {
     store.loadingStarted();
     store.loadingFinished();
 
-    assert.equal(stateChangeListener.callCount, 4)
-    assert.isTrue(stateChangeListener.getCall(0).calledWithExactly(
-      ConnectionState.CONNECTED, ConnectionState.LOADING))
-    assert.isTrue(stateChangeListener.getCall(1).calledWithExactly(
-      ConnectionState.LOADING, ConnectionState.CONNECTION_LOST))
-    assert.isTrue(stateChangeListener.getCall(2).calledWithExactly(
-      ConnectionState.CONNECTION_LOST, ConnectionState.LOADING))
-    assert.isTrue(stateChangeListener.getCall(3).calledWithExactly(
-      ConnectionState.LOADING, ConnectionState.CONNECTION_LOST))
+    assert.equal(stateChangeListener.callCount, 4);
+
+    (expect(stateChangeListener.getCall(0)).to.be as any).calledWithExactly(
+      ConnectionState.CONNECTED, ConnectionState.LOADING);
+    (expect(stateChangeListener.getCall(1)).to.be as any).calledWithExactly(
+      ConnectionState.LOADING, ConnectionState.CONNECTION_LOST);
+    (expect(stateChangeListener.getCall(2)).to.be as any).calledWithExactly(
+      ConnectionState.CONNECTION_LOST, ConnectionState.LOADING);
+    (expect(stateChangeListener.getCall(3)).to.be as any).calledWithExactly(
+      ConnectionState.LOADING, ConnectionState.CONNECTED);
   });
 
-  it('should return to original state after LOADING count reaches zero', () => {
+  it('loadingFailed should set state to CONNECTION_LOST', () => {
     const store = new ConnectionStateStore(ConnectionState.CONNECTION_LOST);
     const stateChangeListener = sinon.fake();
     store.addStateChangeListener(stateChangeListener);
 
     store.loadingStarted();
-    store.loadingFinished();
+    store.loadingFailed();
 
-    assert.equal(stateChangeListener.callCount, 2)
-    assert.isTrue(stateChangeListener.getCall(0).calledWithExactly(
-      ConnectionState.CONNECTION_LOST, ConnectionState.LOADING))
-    assert.isTrue(stateChangeListener.getCall(1).calledWithExactly(
-      ConnectionState.LOADING, ConnectionState.CONNECTION_LOST))
+    assert.equal(stateChangeListener.callCount, 2);
+    (expect(stateChangeListener.getCall(0)).to.be as any).calledWithExactly(
+      ConnectionState.CONNECTION_LOST, ConnectionState.LOADING);
+    (expect(stateChangeListener.getCall(1)).to.be as any).calledWithExactly(
+      ConnectionState.LOADING, ConnectionState.CONNECTION_LOST);
   });
 });

--- a/flow-client/src/test/frontend/FlowTests.ts
+++ b/flow-client/src/test/frontend/FlowTests.ts
@@ -323,10 +323,6 @@ suite("Flow", () => {
     assert.isDefined($wnd.Vaadin.Flow.clients.TypeScript.isActive);
     assert.isFalse($wnd.Vaadin.Flow.clients.TypeScript.isActive());
 
-    // Check that loadingStarted and loadingFinished are exposed
-    assert.isDefined($wnd.Vaadin.Flow.clients.TypeScript.loadingStarted);
-    assert.isDefined($wnd.Vaadin.Flow.clients.TypeScript.loadingFinished);
-
     const route = flow.serverSideRoutes[0];
 
     sinon.spy(flow, 'loadingStarted');


### PR DESCRIPTION
When transitioning back from `LOADING`, don't assume `CONNECTED`.