### PR TITLE
Do not clear all children client side for empty template elements

### DIFF
--- a/flow-lit-template/src/test/java/com/vaadin/flow/component/littemplate/InjectableLitElementInitializerTest.java
+++ b/flow-lit-template/src/test/java/com/vaadin/flow/component/littemplate/InjectableLitElementInitializerTest.java
@@ -134,14 +134,6 @@ public class InjectableLitElementInitializerTest {
 
         Assert.assertEquals("foo bar", element.getText());
     }
-    @Test
-    public void initializeElement_setText_emptyTextIsNotSet() {
-        element.appendChild(new Element("child"));
-        initializer.accept(Collections.singletonMap(
-                AbstractInjectableElementInitializer.TEXT_DATA, ""));
-
-        Assert.assertEquals("child", element.getChild(0).getTag());
-    }
 
     @Tag(Tag.DIV)
     public static class TestComponent extends Component implements HasStyle {

--- a/flow-lit-template/src/test/java/com/vaadin/flow/component/littemplate/InjectableLitElementInitializerTest.java
+++ b/flow-lit-template/src/test/java/com/vaadin/flow/component/littemplate/InjectableLitElementInitializerTest.java
@@ -134,6 +134,14 @@ public class InjectableLitElementInitializerTest {
 
         Assert.assertEquals("foo bar", element.getText());
     }
+    @Test
+    public void initializeElement_setText_emptyTextIsNotSet() {
+        element.appendChild(new Element("child"));
+        initializer.accept(Collections.singletonMap(
+                AbstractInjectableElementInitializer.TEXT_DATA, ""));
+
+        Assert.assertEquals("child", element.getChild(0).getTag());
+    }
 
     @Tag(Tag.DIV)
     public static class TestComponent extends Component implements HasStyle {

--- a/flow-lit-template/src/test/java/com/vaadin/flow/component/littemplate/InjectableLitElementInitializerTest.java
+++ b/flow-lit-template/src/test/java/com/vaadin/flow/component/littemplate/InjectableLitElementInitializerTest.java
@@ -31,6 +31,7 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.template.internal.AbstractInjectableElementInitializer;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementFactory;
+import com.vaadin.flow.internal.nodefeature.ElementChildrenList;
 
 public class InjectableLitElementInitializerTest {
 
@@ -129,10 +130,12 @@ public class InjectableLitElementInitializerTest {
 
     @Test
     public void initializeElement_setText_textIsSet() {
-        initializer.accept(Collections.singletonMap(
-                AbstractInjectableElementInitializer.TEXT_DATA, "foo bar"));
+        initializer.accept(Collections.singletonMap(AbstractInjectableElementInitializer.TEXT_DATA, "foo bar"));
 
         Assert.assertEquals("foo bar", element.getText());
+        ElementChildrenList children = element.getNode().getFeature(ElementChildrenList.class);
+        Assert.assertEquals(1, children.size());
+        Assert.assertEquals(0, children.getChangeTracker().size());
     }
 
     @Tag(Tag.DIV)

--- a/flow-server/src/main/java/com/vaadin/flow/component/template/internal/TextInitializationStrategy.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/template/internal/TextInitializationStrategy.java
@@ -36,13 +36,13 @@ class TextInitializationStrategy implements ElementInitializationStrategy, Seria
     public void initialize(Element element, String name, String value) {
         // Set the text only for the server side, do not send the change to the client
         // so that it does not overwrite what is in the DOM
-        ElementChildrenList children = element.getNode().getFeature(ElementChildrenList.class);
-        List<AbstractListChange<StateNode>> changeTracker = children.getChangeTracker();
-        int changesBefore = changeTracker.size();
         element.setText(value);
-        while (changeTracker.size() > changesBefore) {
-            changeTracker.remove(changeTracker.size() - 1);
-        }
+
+        // Remove the "clear" and "add child" events
+        ElementChildrenList children = element.getNode().getFeature(ElementChildrenList.class);
+        children.collectChanges(change -> {
+        });
+        children.getChangeTracker().clear();
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/template/internal/TextInitializationStrategy.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/template/internal/TextInitializationStrategy.java
@@ -31,9 +31,7 @@ class TextInitializationStrategy
 
     @Override
     public void initialize(Element element, String name, String value) {
-        if (value != null && !"".equals(value)) {
-            element.setText(value);
-        }
+        element.setText(value);
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/template/internal/TextInitializationStrategy.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/template/internal/TextInitializationStrategy.java
@@ -16,8 +16,12 @@
 package com.vaadin.flow.component.template.internal;
 
 import java.io.Serializable;
+import java.util.List;
 
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.internal.StateNode;
+import com.vaadin.flow.internal.change.AbstractListChange;
+import com.vaadin.flow.internal.nodefeature.ElementChildrenList;
 
 /**
  * Initializes Element via setting a text value.
@@ -26,12 +30,19 @@ import com.vaadin.flow.dom.Element;
  * @since
  *
  */
-class TextInitializationStrategy
-        implements ElementInitializationStrategy, Serializable {
+class TextInitializationStrategy implements ElementInitializationStrategy, Serializable {
 
     @Override
     public void initialize(Element element, String name, String value) {
+        // Set the text only for the server side, do not send the change to the client
+        // so that it does not overwrite what is in the DOM
+        ElementChildrenList children = element.getNode().getFeature(ElementChildrenList.class);
+        List<AbstractListChange<StateNode>> changeTracker = children.getChangeTracker();
+        int changesBefore = changeTracker.size();
         element.setText(value);
+        while (changeTracker.size() > changesBefore) {
+            changeTracker.remove(changeTracker.size() - 1);
+        }
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/template/internal/TextInitializationStrategy.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/template/internal/TextInitializationStrategy.java
@@ -31,7 +31,9 @@ class TextInitializationStrategy
 
     @Override
     public void initialize(Element element, String name, String value) {
-        element.setText(value);
+        if (value != null && !"".equals(value)) {
+            element.setText(value);
+        }
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/NodeList.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/NodeList.java
@@ -269,7 +269,7 @@ public abstract class NodeList<T extends Serializable> extends NodeFeature {
      *
      * @return the list to track changes in
      */
-    protected List<AbstractListChange<T>> getChangeTracker() {
+    public List<AbstractListChange<T>> getChangeTracker() {
         return getNode().getChangeTracker(this, ArrayList::new);
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/ListFeatureSetViewTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/ListFeatureSetViewTest.java
@@ -43,7 +43,7 @@ public class ListFeatureSetViewTest {
         }
 
         @Override
-        protected List<AbstractListChange<String>> getChangeTracker() {
+        public List<AbstractListChange<String>> getChangeTracker() {
             // Default implementation calls unmocked method in StateNode
             return changes;
         }


### PR DESCRIPTION
The default value of Element.getText() is "" so setting "" should not be necessary

Fixes #10106