### PR TITLE
fix: only use the export chunk for exported web components if it is found

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
@@ -23,6 +23,7 @@ import java.lang.annotation.Annotation;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -97,7 +98,14 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
             extends BootstrapPageBuilder {
         @Override
         protected List<String> getChunkKeys(JsonObject chunks) {
-            return Collections.singletonList(EXPORT_CHUNK);
+            boolean hasExportChunk = Arrays.stream(chunks.keys())
+                    .anyMatch(s -> EXPORT_CHUNK.equals(s));
+
+            if (hasExportChunk) {
+                return Collections.singletonList(EXPORT_CHUNK);
+            } else {
+                return super.getChunkKeys(chunks);
+            }
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
@@ -98,10 +98,7 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
             extends BootstrapPageBuilder {
         @Override
         protected List<String> getChunkKeys(JsonObject chunks) {
-            boolean hasExportChunk = Arrays.stream(chunks.keys())
-                    .anyMatch(s -> EXPORT_CHUNK.equals(s));
-
-            if (hasExportChunk) {
+            if (chunks.hasKey(EXPORT_CHUNK)) {
                 return Collections.singletonList(EXPORT_CHUNK);
             } else {
                 return super.getChunkKeys(chunks);

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
@@ -23,7 +23,6 @@ import java.lang.annotation.Annotation;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandlerTest.java
@@ -259,6 +259,38 @@ public class WebComponentBootstrapHandlerTest {
     }
 
     @Test
+    public void writeBootstrapPage_withExportChunk()
+            throws IOException, ServiceException {
+        TestWebComponentBootstrapHandler handler = new TestWebComponentBootstrapHandler();
+        VaadinServletService service = new MockVaadinServletService();
+
+        initLookup(service);
+
+        VaadinSession session = new MockVaadinSession(service);
+        session.lock();
+        session.setConfiguration(service.getDeploymentConfiguration());
+        MockDeploymentConfiguration config = (MockDeploymentConfiguration) service
+                .getDeploymentConfiguration();
+        config.setEnableDevServer(false);
+
+        VaadinServletRequest request = Mockito.mock(VaadinServletRequest.class);
+        Mockito.when(request.getService()).thenReturn(service);
+        Mockito.when(request.getServletPath()).thenReturn("/");
+        VaadinResponse response = getMockResponse(null);
+
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        Mockito.when(response.getOutputStream()).thenReturn(stream);
+
+        handler.synchronizedHandleRequest(session, request, response);
+
+        String result = stream.toString(StandardCharsets.UTF_8.name());
+        Assert.assertTrue(
+                result.contains("VAADIN/build/vaadin-export-2222.cache.js"));
+        Assert.assertFalse(
+                result.contains("VAADIN/build/vaadin-bundle-1111.cache.js"));
+    }
+
+    @Test
     public void writeBootstrapPage_noExportChunk()
             throws IOException, ServiceException {
         TestWebComponentBootstrapHandler handler = new TestWebComponentBootstrapHandler();

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandlerTest.java
@@ -31,7 +31,6 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.di.ResourceProvider;
-import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.MockVaadinServletService;
 import com.vaadin.flow.server.MockVaadinSession;
 import com.vaadin.flow.server.PwaConfiguration;
@@ -50,6 +49,8 @@ import com.vaadin.flow.server.webcomponent.WebComponentConfigurationRegistry;
 import com.vaadin.flow.shared.ApplicationConstants;
 import com.vaadin.tests.util.MockDeploymentConfiguration;
 
+import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_STATISTICS_JSON;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 
@@ -257,6 +258,39 @@ public class WebComponentBootstrapHandlerTest {
         Assert.assertTrue(handler.canHandleRequest(request));
     }
 
+    @Test
+    public void writeBootstrapPage_noExportChunk()
+            throws IOException, ServiceException {
+        TestWebComponentBootstrapHandler handler = new TestWebComponentBootstrapHandler();
+        VaadinServletService service = new MockVaadinServletService();
+
+        initLookup(service);
+
+        VaadinSession session = new MockVaadinSession(service);
+        session.lock();
+        session.setConfiguration(service.getDeploymentConfiguration());
+        MockDeploymentConfiguration config = (MockDeploymentConfiguration) service
+                .getDeploymentConfiguration();
+        config.setApplicationOrSystemProperty(SERVLET_PARAMETER_STATISTICS_JSON,
+                VAADIN_SERVLET_RESOURCES + "config/stats_no_export.json");
+        config.setEnableDevServer(false);
+
+        VaadinServletRequest request = Mockito.mock(VaadinServletRequest.class);
+        Mockito.when(request.getService()).thenReturn(service);
+        Mockito.when(request.getServletPath()).thenReturn("/");
+        VaadinResponse response = getMockResponse(null);
+
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        Mockito.when(response.getOutputStream()).thenReturn(stream);
+
+        handler.synchronizedHandleRequest(session, request, response);
+
+        // no "export" chunk, expect "bundle" in result instead
+        String result = stream.toString(StandardCharsets.UTF_8.name());
+        Assert.assertTrue(
+                result.contains("VAADIN/build/vaadin-bundle-1111.cache.js"));
+    }
+
     private VaadinRequest mockRequest(boolean hasConfig) {
         VaadinContext context = Mockito.mock(VaadinContext.class);
         VaadinService service = Mockito.mock(VaadinService.class);
@@ -291,12 +325,10 @@ public class WebComponentBootstrapHandlerTest {
                 .getClass();
 
         Mockito.when(provider
-                .getApplicationResource(Constants.VAADIN_SERVLET_RESOURCES
-                        + Constants.STATISTICS_JSON_DEFAULT))
-                .thenReturn(
+                .getApplicationResource(Mockito.anyString()))
+                .thenAnswer(answer ->
                         WebComponentBootstrapHandlerTest.class.getClassLoader()
-                                .getResource(Constants.VAADIN_SERVLET_RESOURCES
-                                        + Constants.STATISTICS_JSON_DEFAULT));
+                                .getResource(answer.getArgumentAt(0, String.class)));
 
         Mockito.when(provider.getClientResourceAsStream(
                 "META-INF/resources/" + ApplicationConstants.CLIENT_ENGINE_PATH

--- a/flow-server/src/test/resources/META-INF/VAADIN/config/stats_no_export.json
+++ b/flow-server/src/test/resources/META-INF/VAADIN/config/stats_no_export.json
@@ -1,0 +1,8 @@
+{
+  "hash": "64bb80639ef116681818",
+  "assetsByChunkName" :{
+    "bundle": "VAADIN/build/vaadin-bundle-1111.cache.js"
+  },
+  "modules": [],
+  "chunks" : []
+}


### PR DESCRIPTION
Makes it possible to reconfigure webpack to put exported wcs elsewhere