### PR TITLE
Use the same bundle for exported wcs and the application

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -84,7 +84,6 @@ import elemental.json.JsonValue;
 import elemental.json.impl.JsonUtil;
 
 import static com.vaadin.flow.server.Constants.VAADIN_MAPPING;
-import static com.vaadin.flow.server.frontend.FrontendUtils.EXPORT_CHUNK;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
@@ -802,7 +801,6 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             // include all chunks but the one used for exported
             // components.
             return Arrays.stream(chunks.keys())
-                    .filter(s -> !EXPORT_CHUNK.equals(s))
                     .collect(Collectors.toList());
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
@@ -53,7 +53,6 @@ import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 
-import static com.vaadin.flow.server.frontend.FrontendUtils.EXPORT_CHUNK;
 import static com.vaadin.flow.shared.ApplicationConstants.CONTENT_TYPE_TEXT_JAVASCRIPT_UTF_8;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -92,19 +91,11 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
         }
     }
 
-    private static class WebComponentBootstrapPageBuilder
-            extends BootstrapPageBuilder {
-        @Override
-        protected List<String> getChunkKeys(JsonObject chunks) {
-            return Collections.singletonList(EXPORT_CHUNK);
-        }
-    }
-
     /**
      * Creates a new bootstrap handler with default page builder.
      */
     public WebComponentBootstrapHandler() {
-        super(new WebComponentBootstrapPageBuilder());
+        super();
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -285,11 +285,6 @@ public class FrontendUtils {
     public static final String FALLBACK = "fallback";
 
     /**
-     * The entry-point key used for the exported bundle.
-     */
-    public static final String EXPORT_CHUNK = "export";
-
-    /**
      * A key in a Json object for css imports data.
      */
     public static final String CSS_IMPORTS = "cssImports";

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -114,7 +114,7 @@ if (useClientSideIndexFileForBootstrapping) {
   const baseName = path.basename(fileNameOfTheFlowGeneratedMainEntryPoint, '.js');
   if (fs.readdirSync(dirName).filter(fileName => !fileName.startsWith(baseName)).length) {
     // if there are vaadin exported views, add a second entry
-    webPackEntries.export = fileNameOfTheFlowGeneratedMainEntryPoint;
+    webPackEntries.bundle = [webPackEntries.bundle, fileNameOfTheFlowGeneratedMainEntryPoint];
   }
 } else {
   webPackEntries.bundle = fileNameOfTheFlowGeneratedMainEntryPoint;

--- a/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
@@ -1352,25 +1352,6 @@ public class BootstrapHandlerTest {
         Assert.assertFalse(bundle.hasAttr("defer"));
     }
 
-    @Test
-    public void getBootstrapPage_removesExportScript() throws ServiceException {
-        initUI(testUI);
-
-        BootstrapContext bootstrapContext = new BootstrapContext(request, null,
-                session, testUI, this::contextRootRelativePath);
-        Document page = pageBuilder.getBootstrapPage(bootstrapContext);
-
-        Elements scripts = page.head().getElementsByTag("script");
-
-        Assert.assertTrue(scripts.stream()
-                .filter(el -> el.attr("src")
-                        .equals("./VAADIN/build/vaadin-bundle-1111.cache.js"))
-                .findFirst().isPresent());
-        Assert.assertFalse(scripts.stream()
-                .filter(el -> el.attr("src")
-                        .equals("./VAADIN/build/vaadin-export-2222.cache.js"))
-                .findFirst().isPresent());
-    }
 
     @Test // #7158
     public void getBootstrapPage_assetChunksIsAnARRAY_bootstrapParsesOk()


### PR DESCRIPTION
This allows embedding exported wcs inside the same application that exports them, e.g. a Fusion view embedding a Flow exported wc.

In case you have only exported wcs and no application, it should make no difference to the users.
In case you have only an application and no exported wcs, it should make no difference to the users.

In case you have an application and exported wcs, the users will load a slightly larger bundle. This can be fixed by putting the exported wcs in a separate project.