### PR TITLE
Actually create 'export' bundle only when there are exported web components

### DIFF
--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -112,7 +112,7 @@ if (useClientSideIndexFileForBootstrapping) {
   webPackEntries.bundle = clientSideIndexEntryPoint;
   const dirName = path.dirname(fileNameOfTheFlowGeneratedMainEntryPoint);
   const baseName = path.basename(fileNameOfTheFlowGeneratedMainEntryPoint, '.js');
-  if (fs.readdirSync(dirName).filter(fileName => !fileName.startsWith(baseName)).length) {
+  if (fs.readdirSync(dirName).filter(fileName => !fileName.startsWith(baseName) && fileName.endsWith(".js") && fileName.includes("-")).length) {
     // if there are vaadin exported views, add a second entry
     webPackEntries.export = fileNameOfTheFlowGeneratedMainEntryPoint;
   }


### PR DESCRIPTION


Earlier was always created because of a version.json file in the folder

Fixes #10155