### PR TITLE
fix: don't clean registry on every new routes set (#10162)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/di/LookupInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/di/LookupInitializer.java
@@ -207,6 +207,16 @@ public class LookupInitializer implements AbstractLookupInitializer {
 
     }
 
+    private static class RegularOneTimeInitializerPredicate
+            implements OneTimeInitializerPredicate {
+
+        @Override
+        public boolean runOnce() {
+            return true;
+        }
+
+    }
+
     /**
      * Default implementation of {@link AppShellPredicate}.
      * 
@@ -244,6 +254,8 @@ public class LookupInitializer implements AbstractLookupInitializer {
             Map<Class<?>, Collection<Class<?>>> services,
             VaadinApplicationInitializationBootstrap bootstrap)
             throws ServletException {
+        services.put(OneTimeInitializerPredicate.class, Collections
+                .singleton(RegularOneTimeInitializerPredicate.class));
         ensureService(services, ResourceProvider.class,
                 ResourceProviderImpl.class);
         ensureService(services, AppShellPredicate.class,
@@ -304,12 +316,10 @@ public class LookupInitializer implements AbstractLookupInitializer {
     }
 
     private <T> T instantiate(Class<T> serviceClass, Class<?> implementation) {
-        if (ResourceProviderImpl.class.equals(implementation)) {
-            return serviceClass.cast(new ResourceProviderImpl());
-        } else {
-            return serviceClass
-                    .cast(ReflectTools.createInstance(implementation));
+        if (RegularOneTimeInitializerPredicate.class.equals(implementation)) {
+            return serviceClass.cast(new RegularOneTimeInitializerPredicate());
         }
+        return serviceClass.cast(ReflectTools.createInstance(implementation));
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/di/OneTimeInitializerPredicate.java
+++ b/flow-server/src/main/java/com/vaadin/flow/di/OneTimeInitializerPredicate.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.di;
+
+import javax.servlet.ServletContainerInitializer;
+
+/**
+ * The presence of the service implementing this interface with
+ * {@link #runOnce()} returning {@code true} means that
+ * {@link ServletContainerInitializer}s are executed only once and the
+ * implementation doesn't have to care about cleaning up data collected based on
+ * previous call.
+ * <p>
+ * In some cases (e.g. OSGi) the
+ * {@link ServletContainerInitializer#onStartup(java.util.Set, javax.servlet.ServletContext)}
+ * method may be called several times for the application (with different
+ * classes provided). In this case the initializer logic should reset the data
+ * passed on the previous call and set the new data. To be able to reset the
+ * data correctly the {@link ServletContainerInitializer} implementation may
+ * need to store additional data between calls which is excessive if the
+ * {@link ServletContainerInitializer#onStartup(java.util.Set, javax.servlet.ServletContext)}
+ * is executed only once.
+ * 
+ * @author Vaadin Ltd
+ * @since
+ *
+ */
+@FunctionalInterface
+public interface OneTimeInitializerPredicate {
+
+    /**
+     * Checks whether the {@link ServletContainerInitializer}s requires reset to
+     * the previous state on
+     * {@link ServletContainerInitializer#onStartup(java.util.Set, javax.servlet.ServletContext)}
+     * call.
+     * 
+     * @return {@code true} if {@link ServletContainerInitializer}s are executed
+     *         only once, {@code false} otherwise
+     */
+    boolean runOnce();
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ClassLoaderAwareServletContainerInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ClassLoaderAwareServletContainerInitializer.java
@@ -92,9 +92,8 @@ public interface ClassLoaderAwareServletContainerInitializer
                         .filter(method -> !method.isDefault()
                                 && !method.isSynthetic())
                         .findFirst().get().getName();
-                Method operation = Stream.of(initializer.getMethods())
-                        .filter(method -> method.getName()
-                                .equals(processMethodName))
+                Method operation = Stream.of(initializer.getMethods()).filter(
+                        method -> method.getName().equals(processMethodName))
                         .findFirst().get();
                 operation.invoke(initializer.newInstance(),
                         new Object[] { set, ctx });
@@ -146,13 +145,14 @@ public interface ClassLoaderAwareServletContainerInitializer
      *
      * @param context
      *            the <tt>ServletContext</tt> of the web application that is
-     *            being started and in which the classes contained in <tt>classSet</tt>
-     *            were found
+     *            being started and in which the classes contained in
+     *            <tt>classSet</tt> were found
      *
      * @throws ServletException
      *             if an error has occurred
      *
      * @see #onStartup(Set, ServletContext)
      */
-    void process(Set<Class<?>> classSet, ServletContext context) throws ServletException;
+    void process(Set<Class<?>> classSet, ServletContext context)
+            throws ServletException;
 }

--- a/flow-server/src/test/java/com/vaadin/flow/di/LookupIntializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/di/LookupIntializerTest.java
@@ -90,6 +90,19 @@ public class LookupIntializerTest {
     }
 
     @Test
+    public void initialize_hasOneTimeInitializerPredicate_predicateReturnsTrue()
+            throws ServletException, IOException {
+        AtomicReference<Lookup> capture = new AtomicReference<>();
+        initializer.initialize(null, new HashMap<>(), capture::set);
+
+        Lookup lookup = capture.get();
+        OneTimeInitializerPredicate predicate = lookup
+                .lookup(OneTimeInitializerPredicate.class);
+        Assert.assertNotNull(predicate);
+        Assert.assertTrue(predicate.runOnce());
+    }
+
+    @Test
     public void ensureResourceProvider_defaultImplClassIsStoredAsAService() {
         HashMap<Class<?>, Collection<Class<?>>> map = new HashMap<>();
         initializer.ensureService(map, ResourceProvider.class,

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/RouteRegistryInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/RouteRegistryInitializerTest.java
@@ -17,21 +17,32 @@ package com.vaadin.flow.server.startup;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
+
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.page.BodySize;
 import com.vaadin.flow.component.page.Inline;
 import com.vaadin.flow.component.page.Viewport;
+import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.di.OneTimeInitializerPredicate;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.BeforeEvent;
 import com.vaadin.flow.router.ErrorParameter;
@@ -46,7 +57,6 @@ import com.vaadin.flow.router.RouteAlias;
 import com.vaadin.flow.router.RouteAliasData;
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.flow.router.RouteData;
-import com.vaadin.flow.router.RouteParameterFormatOption;
 import com.vaadin.flow.router.RouteParameterRegex;
 import com.vaadin.flow.router.RoutePrefix;
 import com.vaadin.flow.router.RouterLayout;
@@ -54,17 +64,12 @@ import com.vaadin.flow.router.RouterTest.FileNotFound;
 import com.vaadin.flow.router.TestRouteRegistry;
 import com.vaadin.flow.router.internal.ErrorTargetEntry;
 import com.vaadin.flow.router.internal.HasUrlParameterFormat;
+import com.vaadin.flow.router.internal.PathUtil;
 import com.vaadin.flow.server.InitialPageSettings;
 import com.vaadin.flow.server.InvalidRouteConfigurationException;
 import com.vaadin.flow.server.InvalidRouteLayoutConfigurationException;
 import com.vaadin.flow.server.PageConfigurator;
 import com.vaadin.flow.server.VaadinServletContext;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.mockito.Mockito;
 
 /**
  * Unit tests for RouteRegistryInitializer and RouteRegistry.
@@ -75,12 +80,16 @@ public class RouteRegistryInitializerTest {
     private ApplicationRouteRegistry registry;
     private ServletContext servletContext;
     private VaadinServletContext vaadinContext;
+    private Lookup lookup;
 
     @Before
     public void init() {
         routeRegistryInitializer = new RouteRegistryInitializer();
         registry = new TestRouteRegistry();
         servletContext = Mockito.mock(ServletContext.class);
+        lookup = Mockito.mock(Lookup.class);
+        Mockito.when(servletContext.getAttribute(Lookup.class.getName()))
+                .thenReturn(lookup);
         vaadinContext = new VaadinServletContext(servletContext);
         registry = ApplicationRouteRegistry.getInstance(vaadinContext);
 
@@ -1403,6 +1412,144 @@ public class RouteRegistryInitializerTest {
         routeRegistryInitializer.process(classes, servletContext);
     }
 
+    @Test
+    public void initialize_predicateReturnsTrue_noPrevopusStaticRoutes_cleanIsNotCalled_removeMethodIsNotCalled()
+            throws VaadinInitializerException {
+        Mockito.when(lookup.lookup(OneTimeInitializerPredicate.class))
+                .thenReturn(() -> true);
+        TestApplicationRouteRegistry registry = new TestApplicationRouteRegistry();
+        Mockito.when(servletContext
+                .getAttribute(registry.wrapper.getClass().getName()))
+                .thenReturn(registry.wrapper);
+
+        routeRegistryInitializer.initialize(
+                Collections.singleton(BaseRouteTarget.class), vaadinContext);
+        Assert.assertFalse(registry.cleanCalled);
+        Assert.assertFalse(registry.removeCalled);
+    }
+
+    @Test
+    public void initialize_noPredicate_noPrevopusStaticRoutes_cleanIsNotCalled_removeMethodIsNotCalled()
+            throws VaadinInitializerException {
+        TestApplicationRouteRegistry registry = new TestApplicationRouteRegistry();
+        Mockito.when(servletContext
+                .getAttribute(registry.wrapper.getClass().getName()))
+                .thenReturn(registry.wrapper);
+
+        routeRegistryInitializer.initialize(
+                Collections.singleton(BaseRouteTarget.class), vaadinContext);
+        Assert.assertFalse(registry.cleanCalled);
+        Assert.assertFalse(registry.removeCalled);
+    }
+
+    @Test
+    public void initialize_noPredicate_hasPrevopusStaticRoutes_previousRoutesAreRemoved()
+            throws VaadinInitializerException {
+        ApplicationRouteRegistry registry = firstInitRouteRegistry();
+
+        // second time initialization
+
+        routeRegistryInitializer.initialize(
+                Collections.singleton(BaseRouteTarget.class), vaadinContext);
+        Assert.assertEquals(1, registry.getRegisteredRoutes().size());
+        Assert.assertTrue(
+                registry.getTemplate(BaseRouteTarget.class).isPresent());
+    }
+
+    @Test
+    public void initialize_noPredicate_hasPrevopusStaticRoutes_addRouteManually_previousRoutesAreRemoved_addedRouteIsPreserved()
+            throws VaadinInitializerException {
+        ApplicationRouteRegistry registry = firstInitRouteRegistry();
+
+        // now add a route via registry API without registry initializer
+
+        registry.setRoute("manual-route", Component.class,
+                Collections.emptyList());
+
+        // second time initialization
+
+        routeRegistryInitializer.initialize(
+                Collections.singleton(BaseRouteTarget.class), vaadinContext);
+        // two routes: manually added and set during init phase
+
+        Assert.assertTrue(
+                registry.getTemplate(BaseRouteTarget.class).isPresent());
+        Assert.assertTrue(registry.getNavigationTarget(
+                PathUtil.getPath("manual-route", Collections.emptyList()))
+                .isPresent());
+    }
+
+    private ApplicationRouteRegistry firstInitRouteRegistry()
+            throws VaadinInitializerException {
+        vaadinContext = new VaadinServletContext(servletContext) {
+
+            private Map<Class<?>, Object> map = new HashMap<>();
+
+            @Override
+            public <T> T getAttribute(Class<T> type) {
+                if (Lookup.class.equals(type)) {
+                    return type.cast(lookup);
+                } else {
+                    return type.cast(map.get(type));
+                }
+            }
+
+            @Override
+            public <T> void setAttribute(Class<T> clazz, T value) {
+                map.put(clazz, value);
+            }
+        };
+        // first time initialization
+        routeRegistryInitializer.initialize(
+                Collections.singleton(OldRouteTarget.class), vaadinContext);
+
+        ApplicationRouteRegistry registry = ApplicationRouteRegistry
+                .getInstance(vaadinContext);
+        List<RouteData> routes = registry.getRegisteredRoutes();
+        // self check
+
+        Assert.assertEquals(1, routes.size());
+        RouteData data = routes.get(0);
+        Assert.assertEquals("foo-bar", data.getTemplate());
+        List<RouteAliasData> aliases = data.getRouteAliases();
+        Assert.assertEquals(1, aliases.size());
+        RouteAliasData alias = aliases.get(0);
+        Assert.assertEquals("baz", alias.getTemplate());
+        return registry;
+    }
+
+    private static class TestApplicationRouteRegistry
+            extends ApplicationRouteRegistry {
+
+        ApplicationRouteRegistryWrapper wrapper = new ApplicationRouteRegistryWrapper(
+                this);
+
+        boolean cleanCalled;
+
+        boolean removeCalled;
+
+        @Override
+        public void clean() {
+            cleanCalled = true;
+        }
+
+        @Override
+        public void removeRoute(Class<? extends Component> navigationTarget) {
+            removeCalled = true;
+        }
+
+        @Override
+        public void removeRoute(String path) {
+            removeCalled = true;
+        }
+
+        @Override
+        public void removeRoute(String path,
+                Class<? extends Component> navigationTarget) {
+            removeCalled = true;
+        }
+    }
+
     @Tag(Tag.DIV)
     @Route("foo")
     private abstract static class AbstractRouteTarget extends Component {
@@ -1424,6 +1571,13 @@ public class RouteRegistryInitializerTest {
     @Tag(Tag.DIV)
     @Route("foo")
     private static class OtherRouteTarget extends Component {
+
+    }
+
+    @Tag(Tag.DIV)
+    @Route("foo-bar")
+    @RouteAlias("baz")
+    private static class OldRouteTarget extends AbstractRouteTarget {
 
     }
 }

--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
@@ -77,6 +77,7 @@ public abstract class ClassesSerializableTest extends ClassFinder {
                 "com\\.vaadin\\.flow\\.di\\.ResourceProvider",
                 "com\\.vaadin\\.flow\\.di\\.AbstractLookupInitializer",
                 "com\\.vaadin\\.flow\\.di\\.LookupInitializer(\\$.*)?",
+                "com\\.vaadin\\.flow\\.di\\.OneTimeInitializerPredicate",
                 "com\\.vaadin\\.flow\\.dom\\.ElementConstants",
                 "com\\.vaadin\\.flow\\.component\\.board\\.internal\\.FunctionCaller",
                 "com\\.vaadin\\.flow\\.component\\.grid\\.ColumnGroupHelpers",


### PR DESCRIPTION
RouteRegsitry should not be cleaned up every time when new routes are
set: there may be interim registry modification which adds routes. Such
routes should not be removed but they should stay in the registry.

fixes #10109