### PR TITLE
fix: set default PWA start_url as "." instead of ""

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/PWA.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PWA.java
@@ -112,7 +112,8 @@ public @interface PWA {
      *
      * @return application start url
      */
-    String startPath() default "";
+    String startPath() default PwaConfiguration.DEFAULT_START_URL;
+
 
     /**
      * Name of the application.

--- a/flow-server/src/main/java/com/vaadin/flow/server/PwaConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PwaConfiguration.java
@@ -57,7 +57,7 @@ public class PwaConfiguration implements Serializable {
     public PwaConfiguration() {
         this(false, DEFAULT_NAME, "Flow PWA", "", DEFAULT_BACKGROUND_COLOR,
                 DEFAULT_THEME_COLOR, DEFAULT_ICON, DEFAULT_PATH,
-                DEFAULT_OFFLINE_PATH, DEFAULT_DISPLAY, "", new String[] {});
+                DEFAULT_OFFLINE_PATH, DEFAULT_DISPLAY, ".", new String[] {});
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/PwaConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PwaConfiguration.java
@@ -36,6 +36,7 @@ public class PwaConfiguration implements Serializable {
     public static final String DEFAULT_BACKGROUND_COLOR = "#f2f2f2";
     public static final String DEFAULT_DISPLAY = "standalone";
     public static final String DEFAULT_OFFLINE_PATH = "offline.html";
+    public static final String DEFAULT_START_URL = ".";
 
     private final String appName;
     private final String shortName;
@@ -57,7 +58,8 @@ public class PwaConfiguration implements Serializable {
     public PwaConfiguration() {
         this(false, DEFAULT_NAME, "Flow PWA", "", DEFAULT_BACKGROUND_COLOR,
                 DEFAULT_THEME_COLOR, DEFAULT_ICON, DEFAULT_PATH,
-                DEFAULT_OFFLINE_PATH, DEFAULT_DISPLAY, ".", new String[] {});
+                DEFAULT_OFFLINE_PATH, DEFAULT_DISPLAY, DEFAULT_START_URL, 
+                new String[] {});
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/server/PwaConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/PwaConfigurationTest.java
@@ -1,0 +1,13 @@
+package com.vaadin.flow.server;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PwaConfigurationTest {
+    @Test
+    // For https://github.com/vaadin/flow/issues/10148
+    public void pwaDefaultStartUrl_should_BeDotInsteadOfEmptyString(){
+        PwaConfiguration pwaConfiguration = new PwaConfiguration();
+        Assert.assertEquals(PwaConfiguration.DEFAULT_START_URL, pwaConfiguration.getStartUrl());
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/vaadin/flow/issues/10148

No ITs, since the install workflow is to be tested manually. One can follow [this article](https://support.google.com/chrome/answer/9658361?co=GENIE.Platform%3DDesktop&hl=en) to install an PWA app  to Chrome. Note the icon is a bit different compare to the article, instead of a + icon, it's a ![Screenshot 2021-03-04 at 15 33 31](https://user-images.githubusercontent.com/30408303/109971509-03f7ac80-7cff-11eb-8585-1e4766681907.png)
