### PR TITLE
chore: automatic end-of-line for prettier

### DIFF
--- a/flow-client/.prettierrc.js
+++ b/flow-client/.prettierrc.js
@@ -1,5 +1,6 @@
 module.exports = {
 	"singleQuote": true,
 	"printWidth": 120,
-	"trailingComma": "none"
+	"trailingComma": "none",
+	"endOfLine": "auto"
 }


### PR DESCRIPTION
Prettier by default enforces Linux-style LF line endings. Modify the config to accept CRLF after checkout on Windows.