### PR TITLE
perf: Cache stats.json loaded from class path

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -444,6 +444,10 @@ public class FrontendUtils {
     /**
      * Gets the content of the <code>stats.json</code> file produced by webpack.
      *
+     * Note: Caches the <code>stats.json</code> when external stats is enabled or
+     * <code>stats.json</code> is provided from the class path. To clear the
+     * cache use {@link #clearCachedStatsContent(VaadinService)}.
+     *
      * @param service
      *            the vaadin service.
      * @return the content of the file as a string, null if not found.
@@ -470,6 +474,16 @@ public class FrontendUtils {
         return content != null
                 ? IOUtils.toString(content, StandardCharsets.UTF_8)
                 : null;
+    }
+
+    /**
+     * Clears the <code>stats.json</code> cache within this {@link VaadinContext}.
+     *
+     * @param service
+     *            the vaadin service.
+     */
+    public static void clearCachedStatsContent(VaadinService service) {
+        service.getContext().removeAttribute(Stats.class);
     }
 
     /**
@@ -672,9 +686,13 @@ public class FrontendUtils {
     }
 
     /**
-     * Load the asset chunks from stats.json. We will only read the file until
-     * we have reached the assetsByChunkName json and return that as a json
-     * object string.
+     * Load the asset chunks from <code>stats.json</code>. We will only read the
+     * file until we have reached the assetsByChunkName json and return that as
+     * a json object string.
+     *
+     * Note: The <code>stats.json</code> is cached when external stats is enabled
+     * or <code>stats.json</code> is provided from the class path. To clear the
+     * cache use {@link #clearCachedStatsContent(VaadinService)}.
      *
      * @param service
      *            the Vaadin service.

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -609,8 +609,7 @@ public class FrontendUtils {
                         .toLocalDateTime();
                 Stats statistics = context.getAttribute(Stats.class);
                 if (statistics == null
-                        || statistics.getLastModified() == null
-                        || modified.isAfter(statistics.getLastModified())) {
+                  || modified.isAfter(statistics.getLastModified().orElse(LocalDateTime.MIN))) {
                     statistics = new Stats(
                             streamToString(connection.getInputStream()),
                             lastModified);
@@ -1071,13 +1070,13 @@ public class FrontendUtils {
          *
          * @return timestamp as LocalDateTime
          */
-        public LocalDateTime getLastModified() {
+        public Optional<LocalDateTime> getLastModified() {
             if (lastModified == null) {
-                return null;
+                return Optional.empty();
             }
-            return ZonedDateTime
+            return Optional.of(ZonedDateTime
                     .parse(lastModified, DateTimeFormatter.RFC_1123_DATE_TIME)
-                    .toLocalDateTime();
+                    .toLocalDateTime());
         }
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -64,7 +64,7 @@ public class FrontendUtilsTest {
         try {
             CACHE_KEY = Class.forName("com.vaadin.flow.server.frontend.FrontendUtils$Stats");
         } catch (ClassNotFoundException e) {
-            System.err.println("Could not access cache key for stats.json!");
+            Assert.fail("Could not access cache key for stats.json!");
         }
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -51,6 +51,7 @@ import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_STATISTICS_JSON;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class FrontendUtilsTest {
@@ -326,6 +327,11 @@ public class FrontendUtilsTest {
       throws IOException, ClassNotFoundException, ServiceException {
         VaadinService service = setupStatsAssetMocks("ValidStats.json");
 
+        assertNull("Stats cache should not be present", service.getContext().getAttribute(
+          Class.forName("com.vaadin.flow.server.frontend.FrontendUtils$Stats")
+        ));
+
+        // Populates cache
         FrontendUtils.getStatsContent(service);
 
         assertNotNull("Stats cache should be created", service.getContext().getAttribute(
@@ -338,6 +344,11 @@ public class FrontendUtilsTest {
       throws IOException, ClassNotFoundException, ServiceException {
         VaadinService service = setupStatsAssetMocks("ValidStats.json");
 
+        assertNull("Stats cache should not be present", service.getContext().getAttribute(
+          Class.forName("com.vaadin.flow.server.frontend.FrontendUtils$Stats")
+        ));
+
+        // Populates cache
         FrontendUtils.getStatsAssetsByChunkName(service);
 
         assertNotNull("Stats cache should be created", service.getContext().getAttribute(
@@ -345,6 +356,27 @@ public class FrontendUtilsTest {
         ));
     }
 
+    @Test
+    public void clearCachedStatsContent_clearsCache()
+      throws IOException, ClassNotFoundException, ServiceException {
+        VaadinService service = setupStatsAssetMocks("ValidStats.json");
+
+        assertNull("Stats cache should not be present", service.getContext().getAttribute(
+          Class.forName("com.vaadin.flow.server.frontend.FrontendUtils$Stats")
+        ));
+        // Can be invoked without cache - throws no exception
+        FrontendUtils.clearCachedStatsContent(service);
+
+        // Populates cache
+        FrontendUtils.getStatsContent(service);
+
+        // Clears cache
+        FrontendUtils.clearCachedStatsContent(service);
+
+        assertNull("Stats cache should not be present", service.getContext().getAttribute(
+          Class.forName("com.vaadin.flow.server.frontend.FrontendUtils$Stats")
+        ));
+    }
     private ResourceProvider mockResourceProvider(VaadinService service) {
         DeploymentConfiguration config = Mockito
                 .mock(DeploymentConfiguration.class);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -58,6 +58,16 @@ public class FrontendUtilsTest {
 
     private static final String USER_HOME = "user.home";
 
+    private static Class<?> CACHE_KEY;
+
+    static {
+        try {
+            CACHE_KEY = Class.forName("com.vaadin.flow.server.frontend.FrontendUtils$Stats");
+        } catch (ClassNotFoundException e) {
+            System.err.println("Could not access cache key for stats.json!");
+        }
+    }
+
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
@@ -324,46 +334,41 @@ public class FrontendUtilsTest {
 
     @Test
     public void getStatsContent_getStatsFromClassPath_populatesStatsCache()
-      throws IOException, ClassNotFoundException, ServiceException {
+      throws IOException, ServiceException {
         VaadinService service = setupStatsAssetMocks("ValidStats.json");
 
-        assertNull("Stats cache should not be present", service.getContext().getAttribute(
-          Class.forName("com.vaadin.flow.server.frontend.FrontendUtils$Stats")
-        ));
+        assertNull("Stats cache should not be present",
+          service.getContext().getAttribute(CACHE_KEY));
 
         // Populates cache
         FrontendUtils.getStatsContent(service);
 
-        assertNotNull("Stats cache should be created", service.getContext().getAttribute(
-          Class.forName("com.vaadin.flow.server.frontend.FrontendUtils$Stats")
-        ));
+        assertNotNull("Stats cache should be created",
+          service.getContext().getAttribute(CACHE_KEY));
     }
 
     @Test
     public void getStatsAssetsByChunkName_getStatsFromClassPath_populatesStatsCache()
-      throws IOException, ClassNotFoundException, ServiceException {
+      throws IOException, ServiceException {
         VaadinService service = setupStatsAssetMocks("ValidStats.json");
 
-        assertNull("Stats cache should not be present", service.getContext().getAttribute(
-          Class.forName("com.vaadin.flow.server.frontend.FrontendUtils$Stats")
-        ));
+        assertNull("Stats cache should not be present",
+          service.getContext().getAttribute(CACHE_KEY));
 
         // Populates cache
         FrontendUtils.getStatsAssetsByChunkName(service);
 
-        assertNotNull("Stats cache should be created", service.getContext().getAttribute(
-          Class.forName("com.vaadin.flow.server.frontend.FrontendUtils$Stats")
-        ));
+        assertNotNull("Stats cache should be created",
+          service.getContext().getAttribute(CACHE_KEY));
     }
 
     @Test
     public void clearCachedStatsContent_clearsCache()
-      throws IOException, ClassNotFoundException, ServiceException {
+      throws IOException, ServiceException {
         VaadinService service = setupStatsAssetMocks("ValidStats.json");
 
-        assertNull("Stats cache should not be present", service.getContext().getAttribute(
-          Class.forName("com.vaadin.flow.server.frontend.FrontendUtils$Stats")
-        ));
+        assertNull("Stats cache should not be present",
+          service.getContext().getAttribute(CACHE_KEY));
         // Can be invoked without cache - throws no exception
         FrontendUtils.clearCachedStatsContent(service);
 
@@ -373,10 +378,10 @@ public class FrontendUtilsTest {
         // Clears cache
         FrontendUtils.clearCachedStatsContent(service);
 
-        assertNull("Stats cache should not be present", service.getContext().getAttribute(
-          Class.forName("com.vaadin.flow.server.frontend.FrontendUtils$Stats")
-        ));
+        assertNull("Stats cache should not be present",
+          service.getContext().getAttribute(CACHE_KEY));
     }
+
     private ResourceProvider mockResourceProvider(VaadinService service) {
         DeploymentConfiguration config = Mockito
                 .mock(DeploymentConfiguration.class);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -50,6 +50,7 @@ import static com.vaadin.flow.server.Constants.STATISTICS_JSON_DEFAULT;
 import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_STATISTICS_JSON;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class FrontendUtilsTest {
@@ -292,6 +293,7 @@ public class FrontendUtilsTest {
                 manifestPaths.contains("/index.html"));
     }
 
+    @Test
     public void getStatsContent_getStatsFromClassPath_delegateToGetApplicationResource()
             throws IOException {
         VaadinServletService service = mockServletService();
@@ -317,6 +319,30 @@ public class FrontendUtilsTest {
         VaadinServlet servlet = service.getServlet();
 
         Mockito.verify(provider).getApplicationResource("foo");
+    }
+
+    @Test
+    public void getStatsContent_getStatsFromClassPath_populatesStatsCache()
+      throws IOException, ClassNotFoundException, ServiceException {
+        VaadinService service = setupStatsAssetMocks("ValidStats.json");
+
+        FrontendUtils.getStatsContent(service);
+
+        assertNotNull("Stats cache should be created", service.getContext().getAttribute(
+          Class.forName("com.vaadin.flow.server.frontend.FrontendUtils$Stats")
+        ));
+    }
+
+    @Test
+    public void getStatsAssetsByChunkName_getStatsFromClassPath_populatesStatsCache()
+      throws IOException, ClassNotFoundException, ServiceException {
+        VaadinService service = setupStatsAssetMocks("ValidStats.json");
+
+        FrontendUtils.getStatsAssetsByChunkName(service);
+
+        assertNotNull("Stats cache should be created", service.getContext().getAttribute(
+          Class.forName("com.vaadin.flow.server.frontend.FrontendUtils$Stats")
+        ));
     }
 
     private ResourceProvider mockResourceProvider(VaadinService service) {


### PR DESCRIPTION
Caches stats.json file loaded from class path and improves the performance by not being opening too many stats.json files under the load.

Fixes #10116 