### PR TITLE
fix: fix shortcuts when listenOn is a dialog

### DIFF
--- a/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/NativeButtonElement.java
+++ b/flow-html-components-testbench/src/main/java/com/vaadin/flow/component/html/testbench/NativeButtonElement.java
@@ -27,3 +27,4 @@ import com.vaadin.testbench.elementsbase.Element;
 public class NativeButtonElement extends TestBenchElement {
 
 }
+

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
@@ -17,6 +17,7 @@
 package com.vaadin.flow.component;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.Assert;
@@ -27,10 +28,12 @@ import org.junit.rules.ExpectedException;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
+import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.ExecutionContext;
 import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
+import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.shared.Registration;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -273,7 +276,7 @@ public class ShortcutRegistrationTest {
         }, Key.KEY_A);
 
         UI newUI = Mockito.spy(UI.class);
-        // close the prevopus UI
+        // close the previous UI
         ui.close();
         components[0] = newUI;
 
@@ -360,6 +363,56 @@ public class ShortcutRegistrationTest {
         clientResponse();
 
         assertTrue(registration.isShortcutActive());
+    }
+
+    @Test
+    public void listenOnComponentHasElementLocatorJs_jsExecutionScheduled() {
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        Mockito.when(session.hasLock()).thenReturn(true);
+        UI ui = Mockito.spy(UI.class);
+        ui.getInternals().setSession(session);
+
+        Component owner = new FakeComponent();
+        Component initialComponentToListenOn = new FakeComponent();
+
+        Component[] components = new Component[] { initialComponentToListenOn };
+
+        ui.add(owner);
+        ui.add(initialComponentToListenOn);
+
+        final String elementLocatorJs = "foobar";
+        final Registration registration = Shortcuts
+                .setShortcutListenOnElement(elementLocatorJs,
+                        initialComponentToListenOn);
+
+        new ShortcutRegistration(owner, () -> components, event -> {
+        }, Key.KEY_A);
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        List<PendingJavaScriptInvocation> pendingJavaScriptInvocations = ui
+                .getInternals().dumpPendingJavaScriptInvocations();
+        Assert.assertEquals(1, pendingJavaScriptInvocations.size());
+
+        final PendingJavaScriptInvocation js = pendingJavaScriptInvocations
+                .get(0);
+        final String expectedExecutionString = "return (function() { "
+                + String.format(ShortcutRegistration.ELEMENT_LOCATOR_JS,
+                        elementLocatorJs)
+                + "}).apply($0)";
+        Assert.assertEquals(expectedExecutionString,
+                js.getInvocation().getExpression());
+
+        registration.remove();
+
+        new ShortcutRegistration(owner, () -> components, event -> {
+        }, Key.KEY_A);
+
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+
+        pendingJavaScriptInvocations = ui.getInternals()
+                .dumpPendingJavaScriptInvocations();
+        Assert.assertEquals(0, pendingJavaScriptInvocations.size());
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutsTest.java
@@ -24,6 +24,9 @@ import java.util.stream.Stream;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.vaadin.flow.router.RouterLink;
+import com.vaadin.flow.shared.Registration;
+
 public class ShortcutsTest {
 
     @Test
@@ -36,9 +39,50 @@ public class ShortcutsTest {
                         method.getName(),
                         Stream.of(method.getParameterTypes())
                                 .map(Class::getSimpleName)
-                                .collect(Collectors.joining(", "))
-                ));
+                                .collect(Collectors.joining(", "))));
             }
         }
+    }
+
+    @Test
+    public void setShortcutListenOnElementLocatorJs_storesLocatorOnComponentData() {
+        final RouterLink routerLink = new RouterLink();
+        final String locator = "foobar";
+        final Registration registration = Shortcuts
+                .setShortcutListenOnElement(locator, routerLink);
+
+        Assert.assertEquals(locator, ComponentUtil.getData(routerLink,
+                Shortcuts.ELEMENT_LOCATOR_JS_KEY));
+
+        registration.remove();
+
+        Assert.assertNull(ComponentUtil.getData(routerLink,
+                Shortcuts.ELEMENT_LOCATOR_JS_KEY));
+    }
+
+    @Test
+    public void setShortcutListenOnElementLocatorJs_registrationDoesNotRemoveModifiedData_nullClearsAlways() {
+        final RouterLink routerLink = new RouterLink();
+        final String locator = "foobar";
+        final Registration registration = Shortcuts
+                .setShortcutListenOnElement(locator, routerLink);
+
+        Assert.assertEquals(locator, ComponentUtil.getData(routerLink,
+                Shortcuts.ELEMENT_LOCATOR_JS_KEY));
+
+        Shortcuts.setShortcutListenOnElement("another", routerLink);
+
+        registration.remove();
+
+        Assert.assertEquals("another", ComponentUtil.getData(routerLink,
+                Shortcuts.ELEMENT_LOCATOR_JS_KEY));
+
+        final Registration nullRegistration = Shortcuts
+                .setShortcutListenOnElement(null, routerLink);
+
+        Assert.assertNull(ComponentUtil.getData(routerLink,
+                Shortcuts.ELEMENT_LOCATOR_JS_KEY));
+
+        nullRegistration.remove();
     }
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ComplexDialogShortcutView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ComplexDialogShortcutView.java
@@ -1,0 +1,45 @@
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.Shortcuts;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.PreserveOnRefresh;
+import com.vaadin.flow.router.Route;
+
+@PreserveOnRefresh
+@Route(value = "com.vaadin.flow.uitest.ui.ComplexDialogShortcutView")
+public class ComplexDialogShortcutView extends DialogShortcutView {
+
+    public static final String OVERLAY_ID = "overlay";
+    private Div fakeOverlayElement;
+
+    public ComplexDialogShortcutView() {
+    }
+
+    @Override
+    public void open(Dialog dialog) {
+        super.open(dialog);
+        // the shortcut listener is not added yet, add the element locator data
+        final String overlayId = OVERLAY_ID + dialog.index;
+        final String overlayFetchJS = "document.getElementById('" + overlayId
+                + "')";
+        Shortcuts.setShortcutListenOnElement(overlayFetchJS,
+                dialog);
+        // simulate a fake overlay element
+        fakeOverlayElement = new Div();
+        fakeOverlayElement.setId(overlayId);
+        getUI().ifPresent(ui -> ui.add(fakeOverlayElement));
+        // transport the dialog contents to overlay element
+        dialog.getElement().executeJs(
+                overlayFetchJS + ".appendChild(this.firstElementChild);");
+        dialog.content.getStyle().set("position", "fixed").set("inset",
+                "calc(50% + " + (dialog.index * 100) + "px)");
+    }
+
+    @Override
+    public void close(Dialog dialog) {
+        super.close(dialog);
+
+        fakeOverlayElement.getUI()
+                .ifPresent(ui -> ui.remove(fakeOverlayElement));
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DialogShortcutView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DialogShortcutView.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.uitest.ui;
+
+import java.util.EventObject;
+
+import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.ClickEvent;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.Key;
+import com.vaadin.flow.component.Shortcuts;
+import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Input;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "com.vaadin.flow.uitest.ui.DialogShortcutView")
+public class DialogShortcutView extends Div {
+
+    public static final String EVENT_LOG_ID = "event-log";
+    public static final String UI_BUTTON = "ui-button";
+    public static final String OPEN_BUTTON = "open-button";
+    public static final String DIALOG_BUTTON = "dialog-button";
+    public static final String DIALOG_CLOSE_BUTTON = "dialog-close-button";
+    public static final String DIALOG_ID = "DIALOG";
+    public static final String LISTEN_ON_UI_BUTTON = "listen-on-ui-button";
+    public static final String LISTEN_ON_DIALOG_BUTTON = "listen-on-dialog-button";
+    public static final String LISTEN_CLICK_ON_UI_BUTTON = "listen-click-on-ui-button";
+    public static final String LISTEN_CLICK_ON_DIALOG_BUTTON = "listen-click-on-dialog-button";
+    public static final String UI_ID = "UI-ID";
+    public static final String CONTENT_ID = "CONTENT";
+    public static final Key SHORTCUT_KEY = Key.KEY_X;
+    public static final String REUSABLE_DIALOG = "reusable-dialog";
+
+    private int dialogCounter = 0;
+    private int eventCounter;
+    private final Div eventLog;
+
+    private Dialog reusedDialog;
+
+    public DialogShortcutView() {
+        eventLog = new Div(new Text("Click events and their sources:"));
+        eventLog.setId(EVENT_LOG_ID);
+
+        final NativeButton testButton = createButton(
+                "UI level button with shortcut",
+                this::logClickEvent);
+        testButton.setId(UI_BUTTON);
+        testButton.addClickShortcut(SHORTCUT_KEY);
+
+        add(new Div(new Text("Shortcut key: "
+                + SHORTCUT_KEY.getKeys().stream().findFirst().orElse(""))),
+                createOpenDialogButton(OPEN_BUTTON), testButton,
+                eventLog);
+        setId("main-div");
+
+        final NativeButton reusableDialogButton = new NativeButton(
+                "Open reusable dialog", event -> {
+                    if (reusedDialog == null) {
+                        reusedDialog = new Dialog();
+                    }
+                    open(reusedDialog);
+                });
+        reusableDialogButton.setId(REUSABLE_DIALOG);
+        add(reusableDialogButton);
+    }
+
+    private void logClickEvent(EventObject event) {
+        eventLog.addComponentAsFirst(new Div(new Text((eventCounter++) + "-"
+                + ((Component) event.getSource()).getId()
+                        .orElse("NO-SOURCE-ID"))));
+    }
+
+    private Component createOpenDialogButton(String id) {
+        final NativeButton button = createButton(
+                "Open dialog",
+                event -> {
+                    final Dialog dialog = new Dialog();
+                    open(dialog);
+                });
+        button.setId(id);
+        return button;
+    }
+
+    private NativeButton createButton(String caption,
+            ComponentEventListener<ClickEvent<NativeButton>> listener) {
+        final NativeButton button = new NativeButton();
+        button.setText(caption);
+        button.addClickListener(listener);
+        button.getStyle().set("border", "1px solid black");
+        button.setWidth("100px");
+        return button;
+    }
+
+    public class Dialog extends Div {
+
+        public final int index;
+        public final Div content;
+
+        public Dialog() {
+            index = dialogCounter++;
+            final NativeButton testButton = createButton(
+                    "Test button with shortcut",
+                    DialogShortcutView.this::logClickEvent);
+            testButton.setId(DIALOG_BUTTON + index);
+            final NativeButton uiScopeClickShortcutButton = new NativeButton(
+                    "Add button click shortcut with listenOn(UI) (default)",
+                    event -> {
+                        testButton.addClickShortcut(SHORTCUT_KEY);
+                        event.getSource().setEnabled(false);
+                    });
+            uiScopeClickShortcutButton.setId(LISTEN_CLICK_ON_UI_BUTTON + index);
+            final NativeButton dialogScopeClickShortcutButton = new NativeButton(
+                    "Add button click shortcut with listenOn(Dialog)",
+                    event -> {
+                        testButton.addClickShortcut(SHORTCUT_KEY)
+                                .listenOn(Dialog.this);
+                        event.getSource().setEnabled(false);
+                    });
+            dialogScopeClickShortcutButton
+                    .setId(LISTEN_CLICK_ON_DIALOG_BUTTON + index);
+            final NativeButton uiScopeShortcutButton = new NativeButton(
+                    "Add shortcut with listenOn(UI) (default)", event -> {
+                        Shortcuts.addShortcutListener(Dialog.this,
+                                DialogShortcutView.this::logClickEvent,
+                                SHORTCUT_KEY);
+                        event.getSource().setEnabled(false);
+                    });
+            uiScopeShortcutButton.setId(LISTEN_ON_UI_BUTTON + index);
+            final NativeButton dialogScopeShortcutButton = new NativeButton(
+                    "Add shortcut with listenOn(Dialog)", event -> {
+                        Shortcuts.addShortcutListener(Dialog.this,
+                                DialogShortcutView.this::logClickEvent,
+                                SHORTCUT_KEY).listenOn(Dialog.this);
+                        event.getSource().setEnabled(false);
+                    });
+            dialogScopeShortcutButton.setId(LISTEN_ON_DIALOG_BUTTON + index);
+
+            final Component closeButton = createButton("Close",
+                    event -> close(this));
+            closeButton.setId(DIALOG_CLOSE_BUTTON + index);
+            content = new Div(new Input(), new Div(), closeButton, new Div(),
+                    uiScopeShortcutButton, dialogScopeShortcutButton, new Div(),
+                    uiScopeClickShortcutButton, dialogScopeClickShortcutButton,
+                    new Div(), testButton);
+            content.getStyle().set("border", "1px solid black").set("margin",
+                    "10px");
+            content.setId(CONTENT_ID + index);
+            add(content);
+
+            setId(DIALOG_ID + index);
+        }
+    }
+
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        super.onAttach(attachEvent);
+        attachEvent.getUI().setId(UI_ID);
+    }
+
+    public void open(Dialog dialog) {
+        // final UI ui = DialogShortcutView.this.getUI().get();
+        // ui.add(this);
+        add(dialog);
+    }
+
+    public void close(Dialog dialog) {
+        // final UI ui = DialogShortcutView.this.getUI().get();
+        // ui.remove(this);
+        remove(dialog);
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DialogShortcutView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DialogShortcutView.java
@@ -175,14 +175,10 @@ public class DialogShortcutView extends Div {
     }
 
     public void open(Dialog dialog) {
-        // final UI ui = DialogShortcutView.this.getUI().get();
-        // ui.add(this);
         add(dialog);
     }
 
     public void close(Dialog dialog) {
-        // final UI ui = DialogShortcutView.this.getUI().get();
-        // ui.remove(this);
         remove(dialog);
     }
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ComplexDialogShortcutIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ComplexDialogShortcutIT.java
@@ -1,0 +1,42 @@
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+public class ComplexDialogShortcutIT extends DialogShortcutIT {
+
+    @Test
+    public void dialogWithShortcutListenOnAndPreserveOnRefresh_refreshWhenDialogOpened_shortcutScopingWorks() {
+        openNewDialog();
+
+        listenToShortcutOnDialog(0);
+        pressShortcutKey(getFirstDialogInput());
+        // focus on dialog -> only dialog shortcut occurs
+        validateLatestShortcutEvent(0, DialogShortcutView.DIALOG_ID + 0);
+
+        init(); // need to reset elements too
+
+        pressShortcutKey(getFirstDialogInput());
+        // focus on dialog -> only dialog shortcut occurs
+        validateLatestShortcutEvent(1, DialogShortcutView.DIALOG_ID + 0);
+    }
+
+    @Override
+    protected void openReusedDialog() {
+        super.openReusedDialog();
+        waitForTransport(0);
+    }
+
+    @Override
+    protected void openNewDialog() {
+        super.openNewDialog();
+        waitForTransport(dialogCounter);
+    }
+
+    private void waitForTransport(int expectedDialogCounter) {
+        waitForElementPresent(By.id(
+                ComplexDialogShortcutView.OVERLAY_ID + expectedDialogCounter));
+        waitForElementPresent(By.id(
+                ComplexDialogShortcutView.CONTENT_ID + expectedDialogCounter));
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DialogShortcutIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DialogShortcutIT.java
@@ -1,0 +1,191 @@
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.html.testbench.DivElement;
+import com.vaadin.flow.component.html.testbench.NativeButtonElement;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+import com.vaadin.testbench.TestBenchElement;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+public class DialogShortcutIT extends ChromeBrowserTest {
+
+    private TestBenchElement eventLog;
+    private TestBenchElement openDialogButton;
+    private NativeButtonElement uiLevelButton;
+    protected int dialogCounter = -1; // first one will get id 0
+
+    @Before
+    public void init() {
+        open();
+        eventLog = $(DivElement.class).id(DialogShortcutView.EVENT_LOG_ID);
+        openDialogButton = $(NativeButtonElement.class)
+                .id(DialogShortcutView.OPEN_BUTTON);
+        uiLevelButton = $(NativeButtonElement.class)
+                .id(DialogShortcutView.UI_BUTTON);
+    }
+
+    // #7799
+    @Test
+    public void dialogOpenedWithListenOnShortcut_sameShortcutListeningOnUi_focusDecidesWhichIsExecuted() {
+        pressShortcutKey(
+                uiLevelButton);
+        validateLatestShortcutEvent(0, DialogShortcutView.UI_BUTTON);
+
+        openNewDialog();
+        pressShortcutKey(getFirstDialogInput());
+        // no shortcut in dialog -> ui still gets the shortcut
+        validateLatestShortcutEvent(1, DialogShortcutView.UI_BUTTON);
+
+        listenToShortcutOnDialog(0);
+        pressShortcutKey(getFirstDialogInput());
+        // focus on dialog -> only dialog shortcut occurs
+        validateLatestShortcutEvent(2, DialogShortcutView.DIALOG_ID + 0);
+
+        // focus outside dialog -> ui level shortcut occurs
+        pressShortcutKey(uiLevelButton);
+        validateLatestShortcutEvent(3, DialogShortcutView.UI_BUTTON);
+    }
+
+    @Test
+    public void dialogOpenedWithShortcutNoListenOn_sameShortcutListeningOnUi_bothExecuted() {
+        pressShortcutKey(
+                uiLevelButton);
+        validateLatestShortcutEvent(0, DialogShortcutView.UI_BUTTON);
+
+        openNewDialog();
+        pressShortcutKey(getFirstDialogInput());
+        // no shortcut in dialog -> ui still gets the shortcut
+        validateLatestShortcutEvent(1, DialogShortcutView.UI_BUTTON);
+
+        listenToShortcutOnUI(0);
+        pressShortcutKey(getFirstDialogInput());
+        // last even is on dialog
+        validateLatestShortcutEvent(3, DialogShortcutView.UI_ID);
+        validateShortcutEvent(1, 2, DialogShortcutView.UI_BUTTON);
+
+        closeDialog(0);
+        pressShortcutKey(
+                $(NativeButtonElement.class).id(DialogShortcutView.UI_BUTTON));
+        validateLatestShortcutEvent(4, DialogShortcutView.UI_BUTTON);
+    }
+
+    @Test
+    public void dialogOpenedWithListenOnShortcut_dialogReopened_oldShortcutStillWorks() {
+        openReusedDialog();
+
+        pressShortcutKey(getFirstDialogInput());
+        // no shortcut in dialog -> ui still gets the shortcut
+        validateLatestShortcutEvent(0, DialogShortcutView.UI_BUTTON);
+
+        listenToShortcutOnDialog(0);
+
+        pressShortcutKey(getFirstDialogInput());
+        validateLatestShortcutEvent(1, DialogShortcutView.DIALOG_ID + 0);
+
+        pressShortcutKey(uiLevelButton);
+        validateLatestShortcutEvent(2, DialogShortcutView.UI_BUTTON);
+
+        closeDialog(0);
+
+        pressShortcutKey(uiLevelButton);
+        validateLatestShortcutEvent(3, DialogShortcutView.UI_BUTTON);
+
+        openReusedDialog();
+
+        pressShortcutKey(getFirstDialogInput());
+        validateLatestShortcutEvent(4, DialogShortcutView.DIALOG_ID + 0);
+    }
+
+    // vaadin/vaadin-dialog#229
+    @Test
+    public void twoDialogsOpenedWithSameShortcutKeyOnListenOn_dialogWithFocusExecuted() {
+        openNewDialog();
+        listenToShortcutOnDialog(0);
+        openNewDialog();
+        listenToShortcutOnDialog(1);
+
+        pressShortcutKey(
+                getFirstDialogInput());
+        validateLatestShortcutEvent(0, DialogShortcutView.DIALOG_ID + 0);
+
+        pressShortcutKey(
+                getDialogInput(1));
+        validateLatestShortcutEvent(1, DialogShortcutView.DIALOG_ID + 1);
+
+        pressShortcutKey(
+                getFirstDialogInput());
+        validateLatestShortcutEvent(2, DialogShortcutView.DIALOG_ID + 0);
+
+        pressShortcutKey(uiLevelButton);
+        validateLatestShortcutEvent(3, DialogShortcutView.UI_BUTTON);
+    }
+    protected void openReusedDialog() {
+        findElement(By.id(DialogShortcutView.REUSABLE_DIALOG)).click();
+        dialogCounter++;
+    }
+
+    protected void openNewDialog() {
+        openDialogButton.click();
+        dialogCounter++;
+    }
+
+    private void closeDialog(int dialogIndex) {
+        $(NativeButtonElement.class)
+                .id(DialogShortcutView.DIALOG_CLOSE_BUTTON + dialogIndex)
+                .click();
+    }
+
+    protected void validateLatestShortcutEvent(int eventCounter,
+            String eventSourceId) {
+        validateShortcutEvent(0, eventCounter, eventSourceId);
+    }
+
+    private void validateShortcutEvent(int indexFromTop, int eventCounter,
+            String eventSourceId) {
+        final WebElement latestEvent = eventLog.findElements(By.tagName("div"))
+                .get(indexFromTop);
+        Assert.assertEquals("Invalid latest event",
+                eventCounter + "-" + eventSourceId, latestEvent.getText());
+    }
+
+    protected void pressShortcutKey(TestBenchElement elementToFocus) {
+        elementToFocus.focus();
+        elementToFocus.sendKeys("x");
+    }
+
+    protected TestBenchElement getFirstDialogInput() {
+        return getDialogInput(0);
+    }
+
+    private TestBenchElement getDialogInput(int dialogIndex) {
+        return $(DivElement.class).id(DialogShortcutView.CONTENT_ID + dialogIndex)
+                .$("input").first();
+    }
+
+    private void listenToShortcutOnUI(int dialogIndex) {
+        $(NativeButtonElement.class)
+                .id(DialogShortcutView.LISTEN_ON_UI_BUTTON + dialogIndex)
+                .click();
+    }
+
+    protected void listenToShortcutOnDialog(int dialogIndex) {
+        $(NativeButtonElement.class)
+                .id(DialogShortcutView.LISTEN_ON_DIALOG_BUTTON + dialogIndex)
+                .click();
+    }
+
+    private void listenToButtonShortcutOnUI(int dialogIndex) {
+        $(NativeButtonElement.class)
+                .id(DialogShortcutView.LISTEN_CLICK_ON_UI_BUTTON + dialogIndex)
+                .click();
+    }
+
+    private void listenToButtonShortcutOnDialog(int dialogIndex) {
+        $(NativeButtonElement.class).id(
+                DialogShortcutView.LISTEN_CLICK_ON_DIALOG_BUTTON + dialogIndex)
+                .click();
+    }
+}


### PR DESCRIPTION
This makes it possible for a component to specify a client side only
element that should be used for listening keydown events on when the
component is setup as the listenOn target for a Shortcut. This is needed
for components like Vaadin Dialog which transport the dialog contents
inside an overlay that only exists on the client side and thus breaks
shortcut event handling.

Related to #7799, vaadin/vaadin-dialog#229