### PR TITLE
perf: Cache stats.json loaded from class path (#10244)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -410,6 +410,10 @@ public class FrontendUtils {
     /**
      * Gets the content of the <code>stats.json</code> file produced by webpack.
      *
+     * Note: Caches the <code>stats.json</code> when external stats is enabled or
+     * <code>stats.json</code> is provided from the class path. To clear the
+     * cache use {@link #clearCachedStatsContent(VaadinService)}.
+     *
      * @param service
      *            the vaadin service.
      * @return the content of the file as a string, null if not found.
@@ -436,6 +440,16 @@ public class FrontendUtils {
         return content != null
                 ? IOUtils.toString(content, StandardCharsets.UTF_8)
                 : null;
+    }
+
+    /**
+     * Clears the <code>stats.json</code> cache within this {@link VaadinContext}.
+     *
+     * @param service
+     *            the vaadin service.
+     */
+    public static void clearCachedStatsContent(VaadinService service) {
+        service.getContext().removeAttribute(Stats.class);
     }
 
     /**
@@ -560,7 +574,7 @@ public class FrontendUtils {
                         .toLocalDateTime();
                 Stats statistics = context.getAttribute(Stats.class);
                 if (statistics == null
-                        || modified.isAfter(statistics.getLastModified())) {
+                  || modified.isAfter(statistics.getLastModified().orElse(LocalDateTime.MIN))) {
                     statistics = new Stats(
                             streamToString(connection.getInputStream()),
                             lastModified);
@@ -592,6 +606,13 @@ public class FrontendUtils {
     }
 
     private static InputStream getStatsFromClassPath(VaadinService service) {
+        Stats statistics = service.getContext().getAttribute(Stats.class);
+
+        if (statistics != null) {
+            return new ByteArrayInputStream(
+              statistics.statsJson.getBytes(StandardCharsets.UTF_8));
+        }
+
         String stats = service.getDeploymentConfiguration()
                 .getStringProperty(SERVLET_PARAMETER_STATISTICS_JSON,
                         VAADIN_SERVLET_RESOURCES + STATISTICS_JSON_DEFAULT)
@@ -599,7 +620,12 @@ public class FrontendUtils {
                 .replaceFirst("^/", "");
         InputStream stream = service.getClassLoader()
                 .getResourceAsStream(stats);
-        if (stream == null) {
+        if (stream != null) {
+            statistics = new Stats(streamToString(stream), null);
+            service.getContext().setAttribute(statistics);
+            stream = new ByteArrayInputStream(
+                    statistics.statsJson.getBytes(StandardCharsets.UTF_8));
+        } else {
             getLogger().error(
                     "Cannot get the 'stats.json' from the classpath '{}'",
                     stats);
@@ -614,9 +640,13 @@ public class FrontendUtils {
     }
 
     /**
-     * Load the asset chunks from stats.json. We will only read the file until
-     * we have reached the assetsByChunkName json and return that as a json
-     * object string.
+     * Load the asset chunks from <code>stats.json</code>. We will only read the
+     * file until we have reached the assetsByChunkName json and return that as
+     * a json object string.
+     *
+     * Note: The <code>stats.json</code> is cached when external stats is enabled
+     * or <code>stats.json</code> is provided from the class path. To clear the
+     * cache use {@link #clearCachedStatsContent(VaadinService)}.
      *
      * @param service
      *            the Vaadin service.
@@ -1002,10 +1032,13 @@ public class FrontendUtils {
          *
          * @return timestamp as LocalDateTime
          */
-        public LocalDateTime getLastModified() {
-            return ZonedDateTime
+        public Optional<LocalDateTime> getLastModified() {
+            if (lastModified == null) {
+                return Optional.empty();
+            }
+            return Optional.of(ZonedDateTime
                     .parse(lastModified, DateTimeFormatter.RFC_1123_DATE_TIME)
-                    .toLocalDateTime();
+                    .toLocalDateTime());
         }
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -37,17 +37,30 @@ import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.ServiceException;
 import com.vaadin.flow.server.VaadinService;
 
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_STATISTICS_JSON;
 import static com.vaadin.flow.server.Constants.STATISTICS_JSON_DEFAULT;
 import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class FrontendUtilsTest {
 
     private static final String USER_HOME = "user.home";
+
+    private static Class<?> CACHE_KEY;
+
+    static {
+        try {
+            CACHE_KEY = Class.forName("com.vaadin.flow.server.frontend.FrontendUtils$Stats");
+        } catch (ClassNotFoundException e) {
+            Assert.fail("Could not access cache key for stats.json!");
+        }
+    }
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
@@ -262,6 +275,56 @@ public class FrontendUtilsTest {
         Assert.assertEquals("\n" + "./node/node \\ \n"
                 + "    ./node_modules/webpack-dev-server/bin/webpack-dev-server.js \n",
                 wrappedCommand);
+    }
+
+    @Test
+    public void getStatsContent_getStatsFromClassPath_populatesStatsCache()
+            throws IOException, ServiceException {
+        VaadinService service = setupStatsAssetMocks("ValidStats.json");
+
+        assertNull("Stats cache should not be present",
+                service.getContext().getAttribute(CACHE_KEY));
+
+        // Populates cache
+        FrontendUtils.getStatsContent(service);
+
+        assertNotNull("Stats cache should be created",
+                service.getContext().getAttribute(CACHE_KEY));
+    }
+
+    @Test
+    public void getStatsAssetsByChunkName_getStatsFromClassPath_populatesStatsCache()
+            throws IOException, ServiceException {
+        VaadinService service = setupStatsAssetMocks("ValidStats.json");
+
+        assertNull("Stats cache should not be present",
+                service.getContext().getAttribute(CACHE_KEY));
+
+        // Populates cache
+        FrontendUtils.getStatsAssetsByChunkName(service);
+
+        assertNotNull("Stats cache should be created",
+                service.getContext().getAttribute(CACHE_KEY));
+    }
+
+    @Test
+    public void clearCachedStatsContent_clearsCache()
+            throws IOException, ServiceException {
+        VaadinService service = setupStatsAssetMocks("ValidStats.json");
+
+        assertNull("Stats cache should not be present",
+                service.getContext().getAttribute(CACHE_KEY));
+        // Can be invoked without cache - throws no exception
+        FrontendUtils.clearCachedStatsContent(service);
+
+        // Populates cache
+        FrontendUtils.getStatsContent(service);
+
+        // Clears cache
+        FrontendUtils.clearCachedStatsContent(service);
+
+        assertNull("Stats cache should not be present",
+                service.getContext().getAttribute(CACHE_KEY));
     }
 
     private VaadinService setupStatsAssetMocks(String statsFile)


### PR DESCRIPTION
Caches stats.json file loaded from class path and improves the performance by not being opening too many stats.json files under the load.

Fixes #10116

(cherry picked from commit 767165bb2d987a489250460e822522baa7b948d5)