### PR TITLE
test: enable logging for TaskRunNpmInstall tests

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -30,6 +30,7 @@ import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.ExecutionFailedException;
@@ -60,7 +61,8 @@ public class TaskRunNpmInstallTest {
 
     private ClassFinder finder = Mockito.mock(ClassFinder.class);
 
-    private Logger logger = Mockito.mock(Logger.class);
+    private Logger logger =
+            Mockito.spy(LoggerFactory.getLogger(NodeUpdater.class));
 
     @Rule
     public ExpectedException exception = ExpectedException.none();


### PR DESCRIPTION
When troubleshooting TaskRunNpmInstall tests, having debug output logged
is very useful. Mocking the logger in the tests used to eat up all the
log.

This change makes use of spy instead of mock as a test logger to enable
logging the tested task output.