### PR TITLE
fix: avoid exposing ServletContext resources via StaticFileServer

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
@@ -20,6 +20,7 @@ import javax.servlet.ServletOutputStream;
 import javax.servlet.WriteListener;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -47,9 +48,9 @@ import org.mockito.Mockito;
 import com.vaadin.flow.function.DeploymentConfiguration;
 
 import static com.vaadin.flow.server.Constants.POLYFILLS_DEFAULT_VALUE;
-import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_STATISTICS_JSON;
 import static com.vaadin.flow.server.Constants.STATISTICS_JSON_DEFAULT;
 import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_STATISTICS_JSON;
 
 public class StaticFileServerTest implements Serializable {
 
@@ -125,6 +126,11 @@ public class StaticFileServerTest implements Serializable {
                 return overrideCacheTime;
             }
             return super.getCacheTime(filenameWithPath);
+        }
+
+        @Override
+        protected URL getStaticResource(String path) {
+            return super.getStaticResource(path);
         }
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/EnableOSGiRunner.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/EnableOSGiRunner.java
@@ -22,16 +22,16 @@ import java.net.URLClassLoader;
 import java.util.HashMap;
 import java.util.Map;
 
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.dynamic.DynamicType.Builder;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import org.apache.commons.io.IOUtils;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.InitializationError;
 
 import com.vaadin.flow.server.VaadinServlet;
-
-import net.bytebuddy.ByteBuddy;
-import net.bytebuddy.dynamic.DynamicType.Builder;
-import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
+import com.vaadin.tests.util.MockDeploymentConfiguration;
 
 public class EnableOSGiRunner extends BlockJUnit4ClassRunner {
 
@@ -54,6 +54,10 @@ public class EnableOSGiRunner extends BlockJUnit4ClassRunner {
                     .getName();
             vaadinPackagePrefix = vaadinPackagePrefix.substring(0,
                     vaadinPackagePrefix.lastIndexOf('.'));
+
+            String testUtilsPrefix = MockDeploymentConfiguration.class
+                    .getPackage().getName();
+
             if (name.equals("org.osgi.framework.FrameworkUtil")) {
                 Builder<Object> builder = new ByteBuddy()
                         .subclass(Object.class);
@@ -62,7 +66,8 @@ public class EnableOSGiRunner extends BlockJUnit4ClassRunner {
                         .load(this, ClassLoadingStrategy.Default.WRAPPER)
                         .getLoaded();
                 return fwUtil;
-            } else if (name.startsWith(vaadinPackagePrefix)) {
+            } else if (name.startsWith(vaadinPackagePrefix)
+                    || name.startsWith(testUtilsPrefix)) {
                 String path = name.replace('.', '/').concat(".class");
                 URL resource = Thread.currentThread().getContextClassLoader()
                         .getResource(path);

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ServletContextResourceIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ServletContextResourceIT.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ServletContextResourceIT extends ChromeBrowserTest {
+
+    @Override
+    protected String getTestPath() {
+        return "/view/" + getPath();
+    }
+
+    @Test
+    public void classResourceIsNotAvailable() throws IOException {
+        URL url = new URL(getRootURL() + "/view/" + getPath());
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        if (HttpURLConnection.HTTP_NOT_FOUND != connection.getResponseCode()) {
+            open();
+
+            WebElement body = findElement(By.tagName("body"));
+            assertThat(body.getText().trim(), CoreMatchers
+                    .startsWith("Could not navigate to '" + getPath() + "'"));
+        }
+    }
+
+    private String getPath() {
+        Class<?> clazz = BaseHrefView.class;
+        return clazz.getPackage().getName().replace('.', '/') + "/"
+                + clazz.getSimpleName() + ".class";
+    }
+
+}


### PR DESCRIPTION
(#10261)

* fix: avoid exposing ServletContext resources via StaticFileServer in
OSGi

fixes #10260
