### PR TITLE
fix: close InputStream in FrontendUtils

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -459,21 +459,25 @@ public class FrontendUtils {
         DeploymentConfiguration config = service.getDeploymentConfiguration();
         InputStream content = null;
 
-        if (!config.isProductionMode() && config.enableDevServer()) {
-            content = getStatsFromWebpack();
-        }
+        try {
+            if (!config.isProductionMode() && config.enableDevServer()) {
+                content = getStatsFromWebpack();
+            }
 
-        if (config.isStatsExternal()) {
-            content = getStatsFromExternalUrl(config.getExternalStatsUrl(),
-                    service.getContext());
-        }
+            if (config.isStatsExternal()) {
+                content = getStatsFromExternalUrl(config.getExternalStatsUrl(),
+                  service.getContext());
+            }
 
-        if (content == null) {
-            content = getStatsFromClassPath(service);
+            if (content == null) {
+                content = getStatsFromClassPath(service);
+            }
+            return content != null
+                   ? IOUtils.toString(content, StandardCharsets.UTF_8)
+                   : null;
+        } finally {
+            IOUtils.closeQuietly(content);
         }
-        return content != null
-                ? IOUtils.toString(content, StandardCharsets.UTF_8)
-                : null;
     }
 
     /**
@@ -513,14 +517,18 @@ public class FrontendUtils {
         DeploymentConfiguration config = service.getDeploymentConfiguration();
         InputStream content = null;
 
-        if (!config.isProductionMode() && config.enableDevServer()) {
-            content = getFileFromWebpack(path);
-        }
+        try {
+            if (!config.isProductionMode() && config.enableDevServer()) {
+                content = getFileFromWebpack(path);
+            }
 
-        if (content == null) {
-            content = getFileFromClassPath(service, path);
+            if (content == null) {
+                content = getFileFromClassPath(service, path);
+            }
+            return content != null ? streamToString(content) : null;
+        } finally {
+            IOUtils.closeQuietly(content);
         }
-        return content != null ? streamToString(content) : null;
     }
 
     private static InputStream getFileFromClassPath(VaadinService service,


### PR DESCRIPTION
fixes #9366

Instead of wrapping only the return, I wrapped the whole method to make sure random exception are closing the stream as well. 

Reasoning behind the change:

>  Wherever possible, the methods in this class do not flush or close the stream. This is to avoid making non-portable assumptions about the streams' origin and further use. Thus the caller is still responsible for closing streams after use. 

Source: http://commons.apache.org/proper/commons-io/javadocs/api-release/org/apache/commons/io/IOUtils.html