### PR TITLE
test: Fix flaky tests in WebComponentIT

### DIFF
--- a/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/WebComponentIT.java
+++ b/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/WebComponentIT.java
@@ -40,11 +40,8 @@ public class WebComponentIT extends ChromeBrowserTest implements HasById {
         waitForElementVisible(By.id("show-message"));
 
         TestBenchElement showMessage = byId("show-message");
-        waitUntil(driver -> {
-            List<WebElement> selects = findInShadowRoot(showMessage, By.tagName(
-                    "select"));
-            return selects != null && !selects.isEmpty();
-        });
+        waitUntil(driver -> isPresentInShadowRoot(showMessage,
+                By.tagName("select")));
         TestBenchElement select = showMessage.$("select").first();
 
         // Selection is visibly changed and event manually dispatched
@@ -75,10 +72,7 @@ public class WebComponentIT extends ChromeBrowserTest implements HasById {
 
         waitForElementVisible(By.id("show-message"));
         TestBenchElement showMessage = byId("show-message");
-        waitUntil(driver -> {
-            List<WebElement> links = findInShadowRoot(showMessage, By.id("link"));
-            return links != null && !links.isEmpty();
-        });
+        waitUntil(driver -> isPresentInShadowRoot(showMessage, By.id("link")));
         TestBenchElement link = showMessage.$("a").id("link");
         String href = link.getAttribute("href");
         // self check

--- a/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/WebComponentIT.java
+++ b/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/WebComponentIT.java
@@ -15,10 +15,13 @@
  */
 package com.vaadin.flow.webcomponent;
 
+import java.util.List;
+
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
@@ -37,6 +40,11 @@ public class WebComponentIT extends ChromeBrowserTest implements HasById {
         waitForElementVisible(By.id("show-message"));
 
         TestBenchElement showMessage = byId("show-message");
+        waitUntil(driver -> {
+            List<WebElement> selects = findInShadowRoot(showMessage, By.tagName(
+                    "select"));
+            return selects != null && !selects.isEmpty();
+        });
         TestBenchElement select = showMessage.$("select").first();
 
         // Selection is visibly changed and event manually dispatched
@@ -67,6 +75,10 @@ public class WebComponentIT extends ChromeBrowserTest implements HasById {
 
         waitForElementVisible(By.id("show-message"));
         TestBenchElement showMessage = byId("show-message");
+        waitUntil(driver -> {
+            List<WebElement> links = findInShadowRoot(showMessage, By.id("link"));
+            return links != null && !links.isEmpty();
+        });
         TestBenchElement link = showMessage.$("a").id("link");
         String href = link.getAttribute("href");
         // self check


### PR DESCRIPTION
Waits for the elements in 'show-message' web component shadow-dom to be appear before testing them.

Fixes https://github.com/vaadin/flow/issues/10364