### PR TITLE
chore: removed hasClientIssue(8236) guard

### DIFF
--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/FragmentLinkIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/FragmentLinkIT.java
@@ -15,10 +15,6 @@ public class FragmentLinkIT extends ChromeBrowserTest {
     public void testInsidePageNavigation_noRouterLinkHandling() {
         open();
 
-        if (hasClientIssue("8236")) {
-            return;
-        }
-
         clickScrollerLink2();
 
         verifyInsideServletLocation(


### PR DESCRIPTION
Remove hasClientIssue(8236) guards for ITs that now pass. Related to #10327.