### PR TITLE
fix: do not serve appshell/offline page for cached resource

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/sw.ts
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/sw.ts
@@ -45,6 +45,13 @@ const offlinePath = OFFLINE_PATH_ENABLED ? OFFLINE_PATH : appShellPath;
 const networkOnly = new NetworkOnly();
 let connectionLost = false;
 const navigationFallback = new NavigationRoute(async (context: RouteHandlerCallbackOptions) => {
+  // serve any file in the manifest directly from cache
+  const path = context.url.pathname;
+  const pathNoLeadingSlash = path.replace(/^\/+/, '');;
+  if (manifestEntries.some(({url}) => url === pathNoLeadingSlash)) {
+    return await matchPrecache(pathNoLeadingSlash);
+  }
+
   // Use offlinePath fallback if offline was detected
   if (!self.navigator.onLine) {
     const offlinePathPrecachedResponse = await matchPrecache(offlinePath);
@@ -68,7 +75,7 @@ const navigationFallback = new NavigationRoute(async (context: RouteHandlerCallb
 
 registerRoute(navigationFallback);
 
-let manifestEntries = self.__WB_MANIFEST;
+let manifestEntries: Array<PrecacheEntry> = self.__WB_MANIFEST;
 if (self.additionalManifestEntries && self.additionalManifestEntries.length) {
   manifestEntries = [...manifestEntries, ...self.additionalManifestEntries];
 }

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/sw.ts
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/sw.ts
@@ -47,9 +47,12 @@ let connectionLost = false;
 const navigationFallback = new NavigationRoute(async (context: RouteHandlerCallbackOptions) => {
   // serve any file in the manifest directly from cache
   const path = context.url.pathname;
-  const pathNoLeadingSlash = path.replace(/^\/+/, '');;
-  if (manifestEntries.some(({url}) => url === pathNoLeadingSlash)) {
-    return await matchPrecache(pathNoLeadingSlash);
+  const scopePath = new URL(self.registration.scope).pathname;
+  if (path.startsWith(scopePath)) {
+    const pathRelativeToScope = path.substr(scopePath.length);
+    if (manifestEntries.some(({url}) => url === pathRelativeToScope)) {
+      return await matchPrecache(pathRelativeToScope);
+    }
   }
 
   // Use offlinePath fallback if offline was detected

--- a/flow-tests/test-ccdm-flow-navigation/src/test/java/com/vaadin/flow/navigate/ServiceWorkerIT.java
+++ b/flow-tests/test-ccdm-flow-navigation/src/test/java/com/vaadin/flow/navigate/ServiceWorkerIT.java
@@ -28,6 +28,8 @@ import org.openqa.selenium.mobile.NetworkConnection;
 
 import com.vaadin.flow.testutil.ChromeDeviceTest;
 
+import elemental.json.Json;
+import elemental.json.JsonObject;
 import static com.vaadin.flow.navigate.HelloWorldView.NAVIGATE_ABOUT;
 
 public class ServiceWorkerIT extends ChromeDeviceTest {
@@ -278,6 +280,27 @@ public class ServiceWorkerIT extends ChromeDeviceTest {
 
             waitForElementNotPresent(By.tagName("vaadin-offline-stub"));
             Assert.assertNotNull(findElement(By.id(NAVIGATE_ABOUT)));
+        } finally {
+            setConnectionType(NetworkConnection.ConnectionType.ALL);
+        }
+    }
+
+    @Test
+    public void offline_cachedResourceRequest_resourceLoaded()
+            throws IOException {
+        getDriver().get(getRootURL());
+        waitForDevServer();
+        waitForServiceWorkerReady();
+        setConnectionType(NetworkConnection.ConnectionType.AIRPLANE_MODE);
+        try {
+            // verify that we can retrieve a cached file (manifest.webmanifest)
+            driver.get(getRootURL() + "/manifest.webmanifest");
+
+            // expect JSON contents wrapped in <pre>
+            String jsonString = findElement(By.tagName("pre")).getText();
+            JsonObject json = Json.parse(jsonString);
+            Assert.assertTrue(json.hasKey("name"));
+            Assert.assertTrue(json.hasKey("short_name"));
         } finally {
             setConnectionType(NetworkConnection.ConnectionType.ALL);
         }


### PR DESCRIPTION
If offline and the file requested is in the precache manifest, then serve it as is.
Fixes #10031 