### PR TITLE
fix: Prevent NPE when writing field value to bean

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -1294,7 +1294,7 @@ public class Binder<BEAN> implements Serializable {
                     setter.accept(bean, value);
                     if (convertBackToPresentation && value != null) {
                         FIELDVALUE converted = convertToFieldType(value);
-                        if (!field.getValue().equals(converted)) {
+                        if (!Objects.equals(field.getValue(), converted)) {
                             getField().setValue(converted);
                         }
                     }


### PR DESCRIPTION
Forward port vaadin/framework#12230