### PR TITLE
test: Remove the test because it relies on Webpack startup time

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
@@ -384,7 +384,14 @@ public final class DevModeHandler implements RequestHandler {
         return true;
     }
 
-    private boolean checkWebpackConnection() {
+    /**
+     * Checks the status of connection with Webpack dev server.
+     * 
+     * @return <code>true</code> if connection established, <code>false</code>
+     *         otherwise.
+     */
+    // Non-private for testing purposes
+    boolean checkWebpackConnection() {
         try {
             readManifestPaths();
             return true;

--- a/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
@@ -384,14 +384,7 @@ public final class DevModeHandler implements RequestHandler {
         return true;
     }
 
-    /**
-     * Checks the status of connection with Webpack dev server.
-     * 
-     * @return <code>true</code> if connection established, <code>false</code>
-     *         otherwise.
-     */
-    // Non-private for testing purposes
-    boolean checkWebpackConnection() {
+    private boolean checkWebpackConnection() {
         try {
             readManifestPaths();
             return true;

--- a/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
@@ -582,45 +582,6 @@ public class DevModeHandlerTest {
     }
 
     @Test
-    public void startTwoInstances_secondInstanceStartsWhenWebpackStarts_secondInstanceUsesSamePort()
-            throws Exception {
-
-        // start the first instance
-        DevModeHandler handler = DevModeHandler.start(0, createDevModeLookup(),
-                npmFolder, CompletableFuture.completedFuture(null));
-
-        // remove the "singleton" instance to be able to start another one
-        removeDevModeHandlerInstance();
-
-        Assert.assertNotNull(
-                "Not expected null instance of started dev mode handler",
-                handler);
-
-        // Waits until first handler starts web pack server, which means that
-        // the port should have already been saved into the local file. Thus,
-        // the second handler should be able to read this file, reuse the
-        // port and not to start another web pack server.
-        while (!handler.checkWebpackConnection()) {
-            Thread.sleep(100);
-        }
-
-        // since the timeout is quite big the server port still should be
-        // available and the second instance should try to reuse it
-        DevModeHandler anotherHandler = DevModeHandler.start(0,
-                createDevModeLookup(), npmFolder,
-                CompletableFuture.completedFuture(null));
-
-        int firstPort = handler.getPort();
-
-        anotherHandler.join();
-
-        int secondPort = anotherHandler.getPort();
-
-        // the second instance was able to start with the same port value
-        Assert.assertEquals(firstPort, secondPort);
-    }
-
-    @Test
     public void start_serverPortDoesNotWork_throws() throws Exception {
         exception.expect(CompletionException.class);
         exception.expectCause(Matchers.instanceOf(IllegalStateException.class));


### PR DESCRIPTION
Removes DevModeHandlerTest::start_twoInstances_secondInstanceUsesAnotherPort because it relies on web pack startup time: if it starts fast enough, then the second handler instance may see that it occupies the port and just reuse that port, test will fail then. If webpack is starting slowly, the second handler sees that the port is not used by webpack and starts another instance of webpack. Then the tests passes.

Fixes #10101
Related-to #9061