### PR TITLE
fix: remember original state after LOADING (#10099)

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/Connect.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Connect.ts
@@ -347,15 +347,14 @@ export class ConnectClient {
     // chain item for our convenience. Always having an ending of the chain
     // this way makes the folding down below more concise.
     const fetchNext: MiddlewareNext = async (context: MiddlewareContext): Promise<Response> => {
-      this.loadingStarted();
+      $wnd.Vaadin.connectionState.loadingStarted();
       return fetch(context.request)
         .then((response) => {
-          this.loadingFinished();
+          $wnd.Vaadin.connectionState.loadingFinished();
           return response;
         })
         .catch((error) => {
-          this.loadingFinished();
-          $wnd.Vaadin.connectionState.state = ConnectionState.CONNECTION_LOST;
+          $wnd.Vaadin.connectionState.loadingFailed();
           return Promise.reject(error);
         });
     };
@@ -388,25 +387,5 @@ export class ConnectClient {
 
   private isFlowLoaded(): boolean {
     return $wnd.Vaadin.Flow?.clients?.TypeScript !== undefined;
-  }
-
-  private loadingStarted() {
-    if (this.isFlowLoaded()) {
-      // call Flow.loadingStarted to pause TestBench tests while backend
-      // requests are ongoing
-      $wnd.Vaadin.Flow.clients?.TypeScript?.loadingStarted();
-    } else {
-      $wnd.Vaadin.connectionState.loadingStarted();
-    }
-  }
-
-  private loadingFinished() {
-    if (this.isFlowLoaded()) {
-      // call Flow.loadingFinished to pause TestBench tests while backend
-      // requests are ongoing
-      $wnd.Vaadin.Flow.clients?.TypeScript?.loadingFinished();
-    } else {
-      $wnd.Vaadin.connectionState.loadingFinished();
-    }
   }
 }

--- a/flow-client/src/main/resources/META-INF/resources/frontend/ConnectionState.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/ConnectionState.ts
@@ -70,10 +70,18 @@ export class ConnectionStateStore {
   }
 
   loadingFinished(): void {
+    this.decreaseLoadingCount(ConnectionState.CONNECTED);
+  }
+
+  loadingFailed(): void {
+    this.decreaseLoadingCount(ConnectionState.CONNECTION_LOST);
+  }
+
+  private decreaseLoadingCount(finalState: ConnectionState) {
     if (this.loadingCount > 0) {
       this.loadingCount -= 1;
       if (this.loadingCount === 0) {
-        this.state = ConnectionState.CONNECTED;
+        this.state = finalState;
       }
     }
   }

--- a/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Flow.ts
@@ -87,9 +87,7 @@ export class Flow {
     $wnd.Vaadin.Flow = $wnd.Vaadin.Flow || {};
     $wnd.Vaadin.Flow.clients = {
       TypeScript: {
-        isActive: () => this.isActive,
-        loadingStarted: () => this.loadingStarted(),
-        loadingFinished: () => this.loadingFinished()
+        isActive: () => this.isActive
       }
     };
 

--- a/flow-client/src/test/frontend/ConnectTests.ts
+++ b/flow-client/src/test/frontend/ConnectTests.ts
@@ -179,40 +179,19 @@ describe('ConnectClient', () => {
       expect(fetchMock.lastOptions()).to.include({method: 'POST'});
     });
 
-    it('should set CONNECTED followed by ConnectionState.loadingFinished when Flow is not loaded', async() => {
+    it('should set connection state to LOADING followed by CONNECTED on successful fetch', async() => {
       let $wnd = (window as any);
-      let states: Array<ConnectionState> = [];
-      $wnd.Vaadin.connectionState.addStateChangeListener(
-        (_, state) => states.push(state));
+      const stateChangeListener = sinon.fake();
+      $wnd.Vaadin.connectionState.addStateChangeListener(stateChangeListener);
+
       await client.call('FooEndpoint', 'fooMethod');
-      expect(states).to.deep.equal([ConnectionState.LOADING, ConnectionState.CONNECTED]);
+      (expect(stateChangeListener).to.be as any).calledWithExactly(ConnectionState.LOADING, ConnectionState.CONNECTED);
     });
 
-    it('should call Flow.loadingStarted followed by Flow.loadingFinished when Flow is loaded', async() => {
-      let calls: Array<boolean> = [];
-      (window as any).Vaadin.Flow = {
-        clients: {
-          TypeScript: {
-            loadingStarted: () => calls.push(true),
-            loadingFinished: () => calls.push(false)
-          }
-        }
-      };
-      await client.call('FooEndpoint', 'fooMethod');
-      expect(calls).to.deep.equal([true, false]);
-    });
-
-    it('should call Flow.loadingFinished and transition to CONNECTION_LOST upon network failure', async() => {
-      let calls: Array<boolean> = [];
-      (window as any).Vaadin.Flow = {
-        clients: {
-          TypeScript: {
-            loadingStarted: () => calls.push(true),
-            loadingFinished: () => calls.push(false)
-          }
-        }
-      };
-
+    it('should set connection state to CONNECTION_LOST on network failure', async() => {
+      let $wnd = (window as any);
+      const stateChangeListener = sinon.fake();
+      $wnd.Vaadin.connectionState.addStateChangeListener(stateChangeListener);
       fetchMock.post(
         base + '/connect/FooEndpoint/reject',
         Promise.reject(new TypeError('Network failure'))
@@ -222,12 +201,12 @@ describe('ConnectClient', () => {
       } catch (error) {
         // expected
       } finally {
-        expect(calls).to.deep.equal([true, false]);
-        expect((window as any).Vaadin.connectionState.state).to.equal(ConnectionState.CONNECTION_LOST);
+        (expect(stateChangeListener).to.be as any).calledWithExactly(ConnectionState.LOADING, ConnectionState.CONNECTION_LOST);
       }
     });
 
-    it('should call Flow.loadingFinished upon server error', async() => {
+    it('should  set connection state to CONNECTED upon server error', async() => {
+      let $wnd = (window as any);
       const body = 'Unexpected error';
       const errorResponse = new Response(
         body,
@@ -238,21 +217,12 @@ describe('ConnectClient', () => {
       );
       fetchMock.post(base + '/connect/FooEndpoint/vaadinConnectResponse', errorResponse);
 
-      let calls: Array<boolean> = [];
-      (window as any).Vaadin.Flow = {
-        clients: {
-          TypeScript: {
-            loadingStarted: () => calls.push(true),
-            loadingFinished: () => calls.push(false)
-          }
-        }
-      };
       try {
         await client.call('FooEndpoint', 'vaadinConnectResponse');
       } catch (error) {
         // expected
       } finally {
-        expect(calls).to.deep.equal([true, false]);
+        expect($wnd.Vaadin.connectionState.state).to.equal(ConnectionState.CONNECTED);
       }
     });
 

--- a/flow-client/src/test/frontend/FlowTests.ts
+++ b/flow-client/src/test/frontend/FlowTests.ts
@@ -323,10 +323,6 @@ suite("Flow", () => {
     assert.isDefined($wnd.Vaadin.Flow.clients.TypeScript.isActive);
     assert.isFalse($wnd.Vaadin.Flow.clients.TypeScript.isActive());
 
-    // Check that loadingStarted and loadingFinished are exposed
-    assert.isDefined($wnd.Vaadin.Flow.clients.TypeScript.loadingStarted);
-    assert.isDefined($wnd.Vaadin.Flow.clients.TypeScript.loadingFinished);
-
     const route = flow.serverSideRoutes[0];
 
     sinon.spy(flow, 'loadingStarted');


### PR DESCRIPTION
Added method loadingFailed transitioning to CONNECTION_LOST if it
is the last active loading. Also removed the exposed
Vaadin.Flow.clients.TypeScript.loadingStarted / loadingFinished pair, as
blocking TB is anyway not working for multiple ongoing backend calls
(and it would be better handled by register ConnectionState as a Flow
client with isActive flag).