### PR TITLE
fix: Provide info on file name when Json parsing fails

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -37,6 +37,7 @@ import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 
 import elemental.json.Json;
+import elemental.json.JsonException;
 import elemental.json.JsonObject;
 import elemental.json.JsonValue;
 
@@ -244,7 +245,14 @@ public abstract class NodeUpdater implements FallibleCommand {
         if (packageFile.exists()) {
             String fileContent = FileUtils.readFileToString(packageFile,
                     UTF_8.name());
-            jsonContent = Json.parse(fileContent);
+            try {
+                jsonContent = Json.parse(fileContent);
+            } catch (JsonException e) {
+                throw new RuntimeException(
+                        "Cannot parse package file located in path: "
+                                + packageFile,
+                        e);
+            }
         }
         return jsonContent;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -248,10 +248,8 @@ public abstract class NodeUpdater implements FallibleCommand {
             try {
                 jsonContent = Json.parse(fileContent);
             } catch (JsonException e) {
-                throw new RuntimeException(
-                        "Cannot parse package file located in path: "
-                                + packageFile,
-                        e);
+                throw new JsonException(String.format(
+                        "Cannot parse package file '%s'", packageFile));
             }
         }
         return jsonContent;


### PR DESCRIPTION
Adds a package file name to exception message in case of JsonException in order to provide clean explanation where to look into.

Fixes #10323