### PR TITLE
set deploy-file config url to flow.release.repo.url property

### DIFF
--- a/flow-plugins/flow-gradle-plugin/pom.xml
+++ b/flow-plugins/flow-gradle-plugin/pom.xml
@@ -134,7 +134,7 @@
                         <configuration>
                             <packaging>jar</packaging>
                             <generatePom>true</generatePom>
-                            <url>${project.distributionManagement.repository.url}</url>
+                            <url>${flow.release.repo.url}</url>
                             <artifactId>${project.artifactId}</artifactId>
                             <groupId>${project.groupId}</groupId>
                             <version>${project.version}</version>


### PR DESCRIPTION
The property is defined in flow/pom.xml and
points to the correct prerelease repo.