### PR TITLE
Add getService() to BootstrapContext

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -214,6 +214,15 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
         }
 
         /**
+         * Gets the Vaadin service.
+         *
+         * @return the Vaadin/HTTP service
+         */
+        public VaadinService getService() {
+            return request.getService();
+        }
+
+        /**
          * Gets the Vaadin session.
          *
          * @return the Vaadin session
@@ -241,12 +250,12 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
 
                 pushMode = getUI().getPushConfiguration().getPushMode();
                 if (pushMode == null) {
-                    pushMode = getRequest().getService()
-                            .getDeploymentConfiguration().getPushMode();
+                    pushMode = getService().getDeploymentConfiguration()
+                            .getPushMode();
                 }
 
                 if (pushMode.isEnabled()
-                        && !getRequest().getService().ensurePushAvailable()) {
+                        && !getService().ensurePushAvailable()) {
                     /*
                      * Fall back if not supported (ensurePushAvailable will log
                      * information to the developer the first time this happens)
@@ -267,8 +276,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          */
         public String getAppId() {
             if (appId == null) {
-                appId = getRequest().getService().getMainDivId(getSession(),
-                        getRequest());
+                appId = getService().getMainDivId(getSession(), getRequest());
             }
             return appId;
         }
@@ -307,8 +315,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          *         otherwise.
          */
         public boolean isProductionMode() {
-            return request.getService().getDeploymentConfiguration()
-                    .isProductionMode();
+            return getService().getDeploymentConfiguration().isProductionMode();
         }
 
         /**
@@ -1386,7 +1393,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
         // Parameter appended to JS to bypass caches after version upgrade.
         String versionQueryParam = "?v=" + Version.getFullVersion();
         // Load client-side dependencies for push support
-        String pushJSPath = context.getRequest().getService()
+        String pushJSPath = context.getService()
                 .getContextRootRelativePath(request);
 
         if (request.getService().getDeploymentConfiguration()

--- a/flow-server/src/main/java/com/vaadin/flow/server/InlineTargets.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InlineTargets.java
@@ -48,8 +48,23 @@ public class InlineTargets {
      *            inline dependency to add to bootstrap page
      * @param request
      *            the request that is handled
+     * @deprecated use {@link #addInlineDependency(Inline, VaadinService)}
+     *             instead
      */
+    @Deprecated
     public void addInlineDependency(Inline inline, VaadinRequest request) {
+        addInlineDependency(inline, request.getService());
+    }
+
+    /**
+     * Inline contents from classpath file to head of initial page.
+     *
+     * @param inline
+     *            inline dependency to add to bootstrap page
+     * @param service
+     *            the service that can find the dependency
+     */
+    public void addInlineDependency(Inline inline, VaadinService service) {
         Inline.Wrapping type;
         // Determine the type as given or try to automatically decide
         if (inline.wrapping().equals(Inline.Wrapping.AUTOMATIC)) {
@@ -62,8 +77,8 @@ public class InlineTargets {
         dependency.put(Dependency.KEY_TYPE, type.toString());
         dependency.put("LoadMode", LoadMode.INLINE.toString());
 
-        dependency.put(Dependency.KEY_CONTENTS, BootstrapUtils
-                .getDependencyContents(request.getService(), inline.value()));
+        dependency.put(Dependency.KEY_CONTENTS,
+                BootstrapUtils.getDependencyContents(service, inline.value()));
 
         // Add to correct element target
         if (inline.target() == TargetElement.BODY) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
@@ -83,7 +83,7 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
         public <T extends Annotation> Optional<T> getPageConfigurationAnnotation(
                 Class<T> annotationType) {
             WebComponentConfigurationRegistry registry = WebComponentConfigurationRegistry
-                    .getInstance(getRequest().getService().getContext());
+                    .getInstance(getService().getContext());
             return registry.getEmbeddedApplicationAnnotation(annotationType);
         }
 


### PR DESCRIPTION
This is what is mostly needed for all implementations and getting it through
the request is more a workaround. The request is typically not needed at all
and relying on the internals of the request is problematic if we change how the
request is done, as is being done in e.g. #10431
