### PR TITLE
chore: disable flaky theme component test

### DIFF
--- a/flow-tests/test-embedding/test-embedding-reusable-theme/src/test/java/com/vaadin/flow/webcomponent/ApplicationThemeComponentIT.java
+++ b/flow-tests/test-embedding/test-embedding-reusable-theme/src/test/java/com/vaadin/flow/webcomponent/ApplicationThemeComponentIT.java
@@ -96,6 +96,7 @@ public class ApplicationThemeComponentIT extends ChromeBrowserTest {
                 handElement.getCssValue("color"));
     }
 
+    @Ignore("Flaky test: #10331")
     @Test
     public void componentThemeIsApplied_forPolymerAndLit() {
         open();

--- a/flow-tests/test-embedding/test-embedding-reusable-theme/src/test/java/com/vaadin/flow/webcomponent/ApplicationThemeComponentIT.java
+++ b/flow-tests/test-embedding/test-embedding-reusable-theme/src/test/java/com/vaadin/flow/webcomponent/ApplicationThemeComponentIT.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.webcomponent;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;


### PR DESCRIPTION
Disables the flaky test in ApplicationThemeComponentIT of test-embedding-reusable-theme module.

Temporary solution for #10331