### PR TITLE
fix: Provide info on file name when Json parsing fails (#10423) (CP 2.5)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -37,6 +37,7 @@ import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 
 import elemental.json.Json;
+import elemental.json.JsonException;
 import elemental.json.JsonObject;
 import elemental.json.JsonValue;
 
@@ -206,7 +207,12 @@ public abstract class NodeUpdater implements FallibleCommand {
         if (packageFile.exists()) {
             String fileContent = FileUtils.readFileToString(packageFile,
                     UTF_8.name());
-            jsonContent = Json.parse(fileContent);
+            try {
+                jsonContent = Json.parse(fileContent);
+            } catch (JsonException e) {
+                throw new JsonException(String.format(
+                        "Cannot parse package file '%s'", packageFile));
+            }
         }
         return jsonContent;
     }


### PR DESCRIPTION
Adds the package file name to exception message in case of JsonException in order to provide clean explanation where to look into.

Fixes #10323

(cherry picked from commit 1ea4ceffefc8f364261abea7f3d925c9f31e94a6)