### PR TITLE
fix: don't use ErrorHandler for IOExceptions in StreamReceiverHandler

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
@@ -193,7 +193,7 @@ public class StreamReceiverHandler implements Serializable {
         } catch (Exception exception) {
             session.lock();
             try {
-                // Report not IO exceptions (which are mistakes) via
+                // Report other than IO exceptions, which are mistakes, via
                 // ErrorHandler
                 session.getErrorHandler().error(new ErrorEvent(exception));
             } finally {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
@@ -189,7 +189,7 @@ public class StreamReceiverHandler implements Serializable {
             }
         } catch (IOException exception) {
             // do not report IO exceptions via ErrorHandler
-            getLogger().warn("IO Exception during file upload", exception);
+            getLogger().warn("IO Exception during file upload, fired as StreamingErrorEvent", exception);
         } catch (Exception exception) {
             session.lock();
             try {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
@@ -189,7 +189,9 @@ public class StreamReceiverHandler implements Serializable {
             }
         } catch (IOException exception) {
             // do not report IO exceptions via ErrorHandler
-            getLogger().warn("IO Exception during file upload, fired as StreamingErrorEvent", exception);
+            getLogger().warn(
+                    "IO Exception during file upload, fired as StreamingErrorEvent",
+                    exception);
         } catch (Exception exception) {
             session.lock();
             try {
@@ -530,12 +532,12 @@ public class StreamReceiverHandler implements Serializable {
         } catch (UploadInterruptedException | IOException e) {
             // Download is either interrupted by application code or some
             // IOException happens
-            fireStreamingFailedEvent(session, filename, type, contentLength,
+            onStreamingFailed(session, filename, type, contentLength,
                     streamVariable, out, totalBytes, e);
             // Interrupted exception and IOEXception are not thrown forward:
             // it's enough to fire them via streamVariable
         } catch (final Exception e) {
-            fireStreamingFailedEvent(session, filename, type, contentLength,
+            onStreamingFailed(session, filename, type, contentLength,
                     streamVariable, out, totalBytes, e);
             // Throw not IOException and interrupted exception for terminal to
             // be handled (to be passed to terminalErrorHandler): such
@@ -547,10 +549,9 @@ public class StreamReceiverHandler implements Serializable {
                 success ? UploadStatus.OK : UploadStatus.ERROR);
     }
 
-    private void fireStreamingFailedEvent(VaadinSession session,
-            String filename, String type, long contentLength,
-            StreamVariable streamVariable, OutputStream out, long totalBytes,
-            final Exception exception) {
+    private void onStreamingFailed(VaadinSession session, String filename,
+            String type, long contentLength, StreamVariable streamVariable,
+            OutputStream out, long totalBytes, final Exception exception) {
         tryToCloseStream(out);
         session.lock();
         try {

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/StreamReceiverHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/StreamReceiverHandlerTest.java
@@ -34,6 +34,7 @@ import com.vaadin.flow.server.MockVaadinServletService;
 import com.vaadin.flow.server.StreamReceiver;
 import com.vaadin.flow.server.StreamResourceRegistry;
 import com.vaadin.flow.server.StreamVariable;
+import com.vaadin.flow.server.UploadException;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
 import com.vaadin.flow.server.VaadinServletRequest;
@@ -71,6 +72,8 @@ public class StreamReceiverHandlerTest {
     private StreamReceiver streamReceiver;
     @Mock
     private StreamResourceRegistry registry;
+    @Mock
+    private ErrorHandler errorHandler;
 
     private VaadinServletService mockService;
 
@@ -400,4 +403,32 @@ public class StreamReceiverHandlerTest {
                 ApplicationConstants.CONTENT_TYPE_TEXT_HTML_UTF_8);
         Mockito.verify(response, Mockito.times(0)).setStatus(Mockito.anyInt());
     }
+
+    @Test
+    public void handleFileUploadValidationAndData_inputStreamThrowsIOException_exceptionIsNotRethrown_exceptionIsNotHandlerByErrorHandler()
+            throws UploadException {
+        InputStream inputStream = new InputStream() {
+
+            @Override
+            public int read() throws IOException {
+                throw new IOException();
+            }
+        };
+        handler.handleFileUploadValidationAndData(session, inputStream,
+                streamReceiver, null, null, 0, stateNode);
+
+        verifyZeroInteractions(errorHandler);
+        verify(streamVariable).streamingFailed(Mockito.any());
+    }
+
+    @Test
+    public void doHandleMultipartFileUpload_IOExceptionIsThrown_exceptionIsNotRethrown_exceptionIsNotHandlerByErrorHandler()
+            throws IOException, ServletException {
+        VaadinServletRequest request = Mockito.mock(VaadinServletRequest.class);
+        Mockito.doThrow(IOException.class).when(request).getParts();
+        handler.doHandleMultipartFileUpload(session, request, response,
+                streamReceiver, stateNode);
+        verifyZeroInteractions(errorHandler);
+    }
+
 }


### PR DESCRIPTION
fixes #10351