### PR TITLE
chore: remove license header from build.gradle

### DIFF
--- a/flow-plugins/flow-gradle-plugin/build.gradle
+++ b/flow-plugins/flow-gradle-plugin/build.gradle
@@ -1,20 +1,3 @@
-/*
- * Copyright 2018-2019 Devsoap Inc.
- * Copyright 2019-2021 Vaadin Ltd.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 /***********************************************************************************************************************
  *
  * Plugins


### PR DESCRIPTION
As build.gradle script is just a build-related
file, it does not need a license header.