### PR TITLE
Do not include test sources in 'target'

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -242,26 +242,6 @@
                 </configuration>
             </plugin>
 
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>add-resource</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>add-test-resource</goal>
-                        </goals>
-                        <configuration>
-                            <resources>
-                                <resource>
-                                    <directory>src/test/java</directory>
-                                </resource>
-                            </resources>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
 
             <plugin>
                 <groupId>org.apache.karaf.tooling</groupId>


### PR DESCRIPTION
It seemingly serves no purpose and breaks linking to source files in VS Code in some cases (VS Code links to the file in the target folder instead)