### PR TITLE
fix: Do not use hardcoded target directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ flow-tests/**/types.d.ts
 /flow-tests/**/generated/**
 flow-tests/**/pnpmfile.js
 flow-tests/*/*.npmrc
+*.npmrc

--- a/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/BundleLitParser.java
+++ b/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/BundleLitParser.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.internal.StringUtil;
 import com.vaadin.flow.server.VaadinService;
-import com.vaadin.flow.server.startup.ApplicationConfiguration;
 
 import elemental.json.Json;
 import elemental.json.JsonArray;

--- a/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/internal/LitTemplateParserImpl.java
+++ b/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/internal/LitTemplateParserImpl.java
@@ -206,7 +206,7 @@ public class LitTemplateParserImpl implements LitTemplateParser {
             }
             if (!cache.containsKey(url) && jsonStats != null) {
                 cache.put(url, BundleLitParser.getSourceFromStatistics(url,
-                        jsonStats));
+                        jsonStats, service));
             }
             return cache.get(url);
         } finally {

--- a/flow-lit-template/src/test/java/com/vaadin/flow/component/littemplate/internal/LitTemplateParserImplTest.java
+++ b/flow-lit-template/src/test/java/com/vaadin/flow/component/littemplate/internal/LitTemplateParserImplTest.java
@@ -36,6 +36,7 @@ import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.di.ResourceProvider;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.server.MockVaadinServletService;
+import com.vaadin.flow.server.frontend.FrontendUtils;
 
 import static com.vaadin.flow.server.Constants.STATISTICS_JSON_DEFAULT;
 import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
@@ -57,6 +58,8 @@ public class LitTemplateParserImplTest {
 
         Properties properties = new Properties();
         Mockito.when(configuration.getInitParameters()).thenReturn(properties);
+        Mockito.when(configuration.getFlowResourcesFolder()).thenReturn(
+                "target/" + FrontendUtils.DEFAULT_FLOW_RESOURCES_FOLDER);
 
         Instantiator instantiator = Mockito.mock(Instantiator.class);
         Mockito.when(instantiator.getServiceInitListeners())

--- a/flow-plugins/flow-gradle-plugin/pom.xml
+++ b/flow-plugins/flow-gradle-plugin/pom.xml
@@ -144,7 +144,7 @@
                 </os>
             </activation>
             <properties>
-                <gradle.executable>./gradlew.bat</gradle.executable>
+                <gradle.executable>gradlew.bat</gradle.executable>
             </properties>
         </profile>
 

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
@@ -78,13 +78,10 @@ class MiscSingleModuleTest : AbstractGradleTest() {
                 providedCompile("javax.servlet:javax.servlet-api:3.1.0")
                 compile("org.slf4j:slf4j-simple:1.7.30")
             }
-            vaadin {
-                pnpmEnable = true
-            }
         """.trimIndent()
         )
 
-        val build: BuildResult = testProject.build("clean", "build")
+        val build: BuildResult = testProject.build("build")
         // vaadinBuildFrontend should NOT have been executed automatically
         build.expectTaskNotRan("vaadinBuildFrontend")
 
@@ -110,9 +107,6 @@ class MiscSingleModuleTest : AbstractGradleTest() {
                 jcenter()
                 maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
             }
-            vaadin {
-                pnpmEnable = true
-            }
             dependencies {
                 compile("com.vaadin:flow:$flowVersion")
                 providedCompile("javax.servlet:javax.servlet-api:3.1.0")
@@ -122,7 +116,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
         )
 
         val build: BuildResult =
-            testProject.build("-Pvaadin.productionMode", "clean", "build")
+            testProject.build("-Pvaadin.productionMode", "build")
         // vaadinBuildFrontend should have been executed automatically
         build.expectTaskSucceded("vaadinBuildFrontend")
 
@@ -147,9 +141,6 @@ class MiscSingleModuleTest : AbstractGradleTest() {
                 maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
             }
             def jettyVersion = "9.4.20.v20190813"
-            vaadin {
-                pnpmEnable = true
-            }
             dependencies {
                 compile("com.vaadin:flow:$flowVersion")
                 compile("org.slf4j:slf4j-simple:1.7.30")
@@ -165,7 +156,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
         """.trimIndent()
         )
 
-        val build: BuildResult = testProject.build("clean", "build")
+        val build: BuildResult = testProject.build( "build")
         // vaadinBuildFrontend should NOT have been executed automatically
         expect(null) { build.task(":vaadinBuildFrontend") }
 
@@ -209,7 +200,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
         )
 
         val build: BuildResult =
-            testProject.build("-Pvaadin.productionMode", "clean", "build")
+            testProject.build("-Pvaadin.productionMode", "build")
         build.expectTaskSucceded("vaadinPrepareFrontend")
         build.expectTaskSucceded("vaadinBuildFrontend")
 
@@ -268,10 +259,6 @@ class MiscSingleModuleTest : AbstractGradleTest() {
                 imports {
                     mavenBom "com.vaadin:flow:$flowVersion"
                 }
-            }
-
-            vaadin {
-                pnpmEnable = true
             }
         """
         )
@@ -363,15 +350,11 @@ class MiscSingleModuleTest : AbstractGradleTest() {
             jar {
               from sourceSets.guiceConfig.output
             }
-
-            vaadin {
-                pnpmEnable = true
-            }
         """.trimIndent()
         )
 
         val build: BuildResult =
-            testProject.build("-Pvaadin.productionMode", "clean", "build")
+            testProject.build("-Pvaadin.productionMode", "build")
         build.expectTaskSucceded("vaadinPrepareFrontend")
         build.expectTaskSucceded("vaadinBuildFrontend")
 
@@ -452,9 +435,6 @@ class MiscSingleModuleTest : AbstractGradleTest() {
             }
             dependencies {
                 compile("com.vaadin:flow:$flowVersion")
-            }
-            vaadin {
-                pnpmEnable = true
             }
         """
         )

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
@@ -168,4 +168,11 @@ internal class GradlePluginAdapter(val project: Project, private val isBeforePro
     override fun webpackGeneratedTemplate(): String = extension.webpackGeneratedTemplate
 
     override fun webpackTemplate(): String = extension.webpackTemplate
+
+    override fun buildFolder(): String {
+        if (extension.projectBuildDir.startsWith(project.projectDir.toString())) {
+            return File(extension.projectBuildDir).relativeTo(project.projectDir).toString()
+        }
+        return extension.projectBuildDir
+    }
 }

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
@@ -59,10 +59,8 @@ public open class VaadinFlowPluginExtension(project: Project) {
     /**
      * The folder where flow will put generated files that will be used by
      * webpack.
-     *
-     * @todo mavi we should move this to `build/frontend/` but in order to do that we need Flow 2.2 or higher. Leaving as-is for now.
      */
-    public var generatedFolder: File = File(project.projectDir, "target/frontend")
+    public var generatedFolder: File = File(project.buildDir, "frontend")
     /**
      * A directory with project's frontend source files.
      */
@@ -175,6 +173,13 @@ public open class VaadinFlowPluginExtension(project: Project) {
      * The `flow-build-info.json` file is generated here.
      */
     public var resourceOutputDirectory: File = File(project.buildDir, "vaadin-generated")
+
+    /**
+     * Defines the output folder used by the project.
+     *
+     * Default value is the `project.buildDir` and should not need to be changed.
+     */
+    public var projectBuildDir: String = project.buildDir.toString()
 
     public companion object {
         public fun get(project: Project): VaadinFlowPluginExtension =

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinPlugin.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinPlugin.kt
@@ -37,9 +37,6 @@ public class VaadinPlugin : Plugin<Project> {
         project.extensions.create(extensionName, VaadinFlowPluginExtension::class.java, project)
 
         project.tasks.apply {
-            getByPath("clean").doLast {
-                project.delete("${project.projectDir}/target")
-            }
             register("vaadinClean", VaadinCleanTask::class.java)
             register("vaadinPrepareFrontend", VaadinPrepareFrontendTask::class.java)
             register("vaadinBuildFrontend", VaadinBuildFrontendTask::class.java)

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -178,6 +179,12 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
     @Parameter(defaultValue = "${project.build.outputDirectory}/"
             + VAADIN_WEBAPP_RESOURCES)
     private File webpackOutputDirectory;
+
+    /**
+     * Build directory for the project.
+     */
+    @Parameter(property = "build.folder", defaultValue = "${project.build.directory}")
+    private String projectBuildDir;
 
     /**
      * Generates a List of ClasspathElements (Run and CompileTime) from a
@@ -371,5 +378,14 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
     @Override
     public boolean isJarProject() {
         return "jar".equals(project.getPackaging());
+    }
+
+    @Override
+    public String buildFolder() {
+        if (projectBuildDir.startsWith(projectBasedir.toString())) {
+            return projectBaseDirectory().relativize(Paths.get(projectBuildDir))
+                    .toString();
+        }
+        return projectBuildDir;
     }
 }

--- a/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
+++ b/flow-plugins/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojoTest.java
@@ -19,6 +19,7 @@ package com.vaadin.flow.plugin.maven;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -35,6 +36,7 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.plugin.TestUtils;
 import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.frontend.FrontendTools;
 import com.vaadin.flow.server.frontend.installer.NodeInstaller;
 
@@ -46,9 +48,9 @@ import static com.vaadin.flow.plugin.maven.BuildFrontendMojoTest.assertContainsP
 import static com.vaadin.flow.plugin.maven.BuildFrontendMojoTest.getPackageJson;
 import static com.vaadin.flow.plugin.maven.BuildFrontendMojoTest.setProject;
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_ENABLE_DEV_SERVER;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_PRODUCTION_MODE;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_USE_V14_BOOTSTRAP;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_ENABLE_DEV_SERVER;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_USE_V14_BOOTSTRAP;
 import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
 import static com.vaadin.flow.server.Constants.VAADIN_WEBAPP_RESOURCES;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FLOW_RESOURCES_FOLDER;
@@ -84,7 +86,7 @@ public class PrepareFrontendMojoTest {
         Mockito.when(project.getBasedir()).thenReturn(projectBase);
 
         flowResourcesFolder = new File(projectBase,
-                DEFAULT_FLOW_RESOURCES_FOLDER);
+                "target/" + DEFAULT_FLOW_RESOURCES_FOLDER);
         packageJson = new File(projectBase, PACKAGE_JSON).getAbsolutePath();
         webpackOutputDirectory = new File(projectBase, VAADIN_WEBAPP_RESOURCES);
         resourceOutputDirectory = new File(projectBase,
@@ -121,6 +123,10 @@ public class PrepareFrontendMojoTest {
                 FrontendTools.DEFAULT_NODE_VERSION);
         ReflectionUtils.setVariableValueInObject(mojo, "nodeDownloadRoot",
                 NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT);
+        ReflectionUtils.setVariableValueInObject(mojo, "projectBasedir",
+                projectBase);
+        ReflectionUtils.setVariableValueInObject(mojo, "projectBuildDir",
+                Paths.get(projectBase.toString(), "target").toString());
 
         Assert.assertTrue(flowResourcesFolder.mkdirs());
         setProject(mojo, projectBase);
@@ -181,16 +187,18 @@ public class PrepareFrontendMojoTest {
         JsonObject buildInfo = JsonUtil.parse(json);
 
         Assert.assertTrue(
-                Constants.SERVLET_PARAMETER_ENABLE_PNPM
+                InitParameters.SERVLET_PARAMETER_ENABLE_PNPM
                         + "should have been written",
-                buildInfo.getBoolean(Constants.SERVLET_PARAMETER_ENABLE_PNPM));
+                buildInfo.getBoolean(
+                        InitParameters.SERVLET_PARAMETER_ENABLE_PNPM));
         Assert.assertTrue(
-                Constants.REQUIRE_HOME_NODE_EXECUTABLE
+                InitParameters.REQUIRE_HOME_NODE_EXECUTABLE
                         + "should have been written",
-                buildInfo.getBoolean(Constants.REQUIRE_HOME_NODE_EXECUTABLE));
+                buildInfo.getBoolean(
+                        InitParameters.REQUIRE_HOME_NODE_EXECUTABLE));
 
-        Assert.assertFalse(buildInfo
-                .hasKey(Constants.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE));
+        Assert.assertFalse(buildInfo.hasKey(
+                InitParameters.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE));
     }
 
     @Test

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -15,21 +15,6 @@
  */
 package com.vaadin.flow.plugin.base;
 
-import static com.vaadin.flow.server.Constants.CONNECT_APPLICATION_PROPERTIES_TOKEN;
-import static com.vaadin.flow.server.Constants.CONNECT_JAVA_SOURCE_FOLDER_TOKEN;
-import static com.vaadin.flow.server.Constants.CONNECT_OPEN_API_FILE_TOKEN;
-import static com.vaadin.flow.server.Constants.FRONTEND_TOKEN;
-import static com.vaadin.flow.server.Constants.GENERATED_TOKEN;
-import static com.vaadin.flow.server.Constants.NPM_TOKEN;
-import static com.vaadin.flow.server.Constants.PROJECT_FRONTEND_GENERATED_DIR_TOKEN;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_ENABLE_DEV_SERVER;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_INITIAL_UIDL;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_PRODUCTION_MODE;
-import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_USE_V14_BOOTSTRAP;
-import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FLOW_RESOURCES_FOLDER;
-import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
-import static com.vaadin.flow.server.frontend.FrontendUtils.TOKEN_FILE;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -61,6 +46,20 @@ import com.vaadin.flow.utils.FlowFileUtils;
 import elemental.json.Json;
 import elemental.json.JsonObject;
 import elemental.json.impl.JsonUtil;
+import static com.vaadin.flow.server.Constants.CONNECT_APPLICATION_PROPERTIES_TOKEN;
+import static com.vaadin.flow.server.Constants.CONNECT_JAVA_SOURCE_FOLDER_TOKEN;
+import static com.vaadin.flow.server.Constants.CONNECT_OPEN_API_FILE_TOKEN;
+import static com.vaadin.flow.server.Constants.FRONTEND_TOKEN;
+import static com.vaadin.flow.server.Constants.GENERATED_TOKEN;
+import static com.vaadin.flow.server.Constants.NPM_TOKEN;
+import static com.vaadin.flow.server.Constants.PROJECT_FRONTEND_GENERATED_DIR_TOKEN;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_ENABLE_DEV_SERVER;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_INITIAL_UIDL;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_USE_V14_BOOTSTRAP;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FLOW_RESOURCES_FOLDER;
+import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
+import static com.vaadin.flow.server.frontend.FrontendUtils.TOKEN_FILE;
 
 /**
  * Util class provides all methods a Plugin will need.
@@ -194,9 +193,9 @@ public class BuildFrontendUtil {
         buildInfo.put(PROJECT_FRONTEND_GENERATED_DIR_TOKEN,
                 adapter.generatedTsFolder().getAbsolutePath());
 
-        buildInfo.put(Constants.SERVLET_PARAMETER_ENABLE_PNPM,
+        buildInfo.put(InitParameters.SERVLET_PARAMETER_ENABLE_PNPM,
                 adapter.pnpmEnable());
-        buildInfo.put(Constants.REQUIRE_HOME_NODE_EXECUTABLE,
+        buildInfo.put(InitParameters.REQUIRE_HOME_NODE_EXECUTABLE,
                 adapter.requireHomeNodeExec());
 
         buildInfo.put(InitParameters.BUILD_FOLDER, adapter.buildFolder());

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -37,6 +37,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -49,6 +50,7 @@ import org.zeroturnaround.exec.ProcessExecutor;
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.ExecutionFailedException;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.frontend.FrontendTools;
 import com.vaadin.flow.server.frontend.FrontendUtils;
 import com.vaadin.flow.server.frontend.NodeTasks;
@@ -130,12 +132,13 @@ public class BuildFrontendUtil {
                     e);
         }
         File flowResourcesFolder = new File(adapter.npmFolder(),
-                FrontendUtils.DEFAULT_FLOW_RESOURCES_FOLDER);
+                Paths.get(adapter.buildFolder(), DEFAULT_FLOW_RESOURCES_FOLDER)
+                        .toString());
         ClassFinder classFinder = adapter.getClassFinder();
         Lookup lookup = adapter.createLookup(classFinder);
         NodeTasks.Builder builder = new NodeTasks.Builder(lookup,
                 adapter.npmFolder(), adapter.generatedFolder(),
-                adapter.frontendDirectory())
+                adapter.frontendDirectory(), adapter.buildFolder())
                         .useV14Bootstrap(
                                 adapter.isUseDeprecatedV14Bootstrapping())
                         .withFlowResourcesFolder(flowResourcesFolder)
@@ -196,6 +199,8 @@ public class BuildFrontendUtil {
         buildInfo.put(Constants.REQUIRE_HOME_NODE_EXECUTABLE,
                 adapter.requireHomeNodeExec());
 
+        buildInfo.put(InitParameters.BUILD_FOLDER, adapter.buildFolder());
+
         try {
             FileUtils.forceMkdir(token.getParentFile());
             FileUtils.write(token, JsonUtil.stringify(buildInfo, 2) + "\n",
@@ -239,7 +244,8 @@ public class BuildFrontendUtil {
 
         Set<File> jarFiles = adapter.getJarFiles();
         File flowResourcesFolder = new File(adapter.npmFolder(),
-                DEFAULT_FLOW_RESOURCES_FOLDER);
+                Paths.get(adapter.buildFolder(), DEFAULT_FLOW_RESOURCES_FOLDER)
+                        .toString());
         final URI nodeDownloadRootURI;
 
         nodeDownloadRootURI = adapter.nodeDownloadRoot();
@@ -248,7 +254,8 @@ public class BuildFrontendUtil {
         Lookup lookup = adapter.createLookup(classFinder);
 
         new NodeTasks.Builder(lookup, adapter.npmFolder(),
-                adapter.generatedFolder(), adapter.frontendDirectory())
+                adapter.generatedFolder(), adapter.frontendDirectory(),
+                adapter.buildFolder())
                         .runNpmInstall(adapter.runNpmInstall())
                         .withWebpack(adapter.webpackOutputDirectory(),
                                 adapter.servletResourceOutputDirectory(),
@@ -380,6 +387,7 @@ public class BuildFrontendUtil {
             buildInfo.remove(Constants.CONNECT_JAVA_SOURCE_FOLDER_TOKEN);
             buildInfo.remove(Constants.CONNECT_OPEN_API_FILE_TOKEN);
             buildInfo.remove(Constants.PROJECT_FRONTEND_GENERATED_DIR_TOKEN);
+            buildInfo.remove(InitParameters.BUILD_FOLDER);
 
             buildInfo.put(SERVLET_PARAMETER_ENABLE_DEV_SERVER, false);
             FileUtils.write(tokenFile, JsonUtil.stringify(buildInfo, 2) + "\n",

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBase.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBase.java
@@ -277,4 +277,10 @@ public interface PluginAdapterBase {
      */
     File webpackOutputDirectory();
 
+    /**
+     * The folder where everything is built into.
+     *
+     * @return build folder
+     */
+    String buildFolder();
 }

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/BundleParser.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/BundleParser.java
@@ -33,7 +33,6 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.internal.StringUtil;
 import com.vaadin.flow.server.VaadinService;
-import com.vaadin.flow.server.startup.ApplicationConfiguration;
 
 import elemental.json.Json;
 import elemental.json.JsonArray;

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/BundleParser.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/BundleParser.java
@@ -15,11 +15,6 @@
  */
 package com.vaadin.flow.component.polymertemplate;
 
-import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
-import static elemental.json.JsonType.ARRAY;
-import static elemental.json.JsonType.OBJECT;
-import static elemental.json.JsonType.STRING;
-
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -38,6 +33,10 @@ import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 import elemental.json.JsonType;
+import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
+import static elemental.json.JsonType.ARRAY;
+import static elemental.json.JsonType.OBJECT;
+import static elemental.json.JsonType.STRING;
 
 /**
  * Parse statistics data provided by webpack.

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/NpmTemplateParser.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/NpmTemplateParser.java
@@ -227,8 +227,8 @@ public class NpmTemplateParser implements TemplateParser {
             lock.unlock();
         }
         if (!cache.containsKey(url) && jsonStats != null) {
-            cache.put(url,
-                    BundleParser.getSourceFromStatistics(url, jsonStats));
+            cache.put(url, BundleParser.getSourceFromStatistics(url, jsonStats,
+                    service));
         }
         return cache.get(url);
     }

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/NpmTemplateParserTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/NpmTemplateParserTest.java
@@ -38,6 +38,7 @@ import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.di.ResourceProvider;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.server.MockVaadinServletService;
+import com.vaadin.flow.server.frontend.FrontendUtils;
 import com.vaadin.flow.templatemodel.TemplateModel;
 
 import static com.vaadin.flow.server.Constants.STATISTICS_JSON_DEFAULT;
@@ -59,6 +60,8 @@ public class NpmTemplateParserTest {
                 Mockito.anyString()))
                 .thenAnswer(invocation -> invocation.getArgumentAt(1,
                         String.class));
+        Mockito.when(configuration.getFlowResourcesFolder()).thenReturn(
+                "target/" + FrontendUtils.DEFAULT_FLOW_RESOURCES_FOLDER);
 
         Properties properties = new Properties();
         Mockito.when(configuration.getInitParameters()).thenReturn(properties);

--- a/flow-server/src/main/java/com/vaadin/flow/server/AbstractConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AbstractConfiguration.java
@@ -16,6 +16,9 @@
 package com.vaadin.flow.server;
 
 import java.io.Serializable;
+import java.nio.file.Paths;
+
+import com.vaadin.flow.server.frontend.FrontendUtils;
 
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DISABLE_XSRF_PROTECTION;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_USE_V14_BOOTSTRAP;
@@ -117,4 +120,12 @@ public interface AbstractConfiguration extends Serializable {
                 false);
     }
 
+    default String getBuildFolder() {
+        return getStringProperty(InitParameters.BUILD_FOLDER, Constants.TARGET);
+    }
+
+    default String getFlowResourcesFolder() {
+        return Paths.get(getBuildFolder(),
+                FrontendUtils.DEFAULT_FLOW_RESOURCES_FOLDER).toString();
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -230,7 +230,7 @@ public final class Constants implements Serializable {
     public static final String PACKAGE_JSON = "package.json";
 
     /**
-     *
+     * Target folder constant.
      */
     public static final String TARGET = "target";
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -230,6 +230,11 @@ public final class Constants implements Serializable {
     public static final String PACKAGE_JSON = "package.json";
 
     /**
+     *
+     */
+    public static final String TARGET = "target";
+
+    /**
      * Location for the frontend resources in jar files for compatibility mode
      * (also obsolete but supported for NPM mode).
      */

--- a/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
@@ -34,7 +34,6 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.INDEX_HTML;
 import static com.vaadin.flow.server.frontend.FrontendUtils.INDEX_JS;
 import static com.vaadin.flow.server.frontend.FrontendUtils.INDEX_TS;
 import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_FRONTEND_DIR;
-import static com.vaadin.flow.server.frontend.FrontendUtils.TARGET;
 
 /**
  * The default implementation of {@link DeploymentConfiguration} based on a base
@@ -342,8 +341,8 @@ public class DefaultDeploymentConfiguration
         String entryPointMessage;
         if (!indexEntry.exists() && !indexEntryTs.exists()) {
             entryPointMessage = String.format(INDEX_NOT_FOUND,
-                    indexEntryTs.getName(), indexEntryTs.getPath(), TARGET,
-                    indexEntryTs.getName(),
+                    indexEntryTs.getName(), indexEntryTs.getPath(),
+                    getBuildFolder(), indexEntryTs.getName(),
                     indexEntryTs.getParentFile().getPath());
         } else {
             String fileName = indexEntry.exists() ? "index.js" : "index.ts";
@@ -361,7 +360,7 @@ public class DefaultDeploymentConfiguration
         String indexHTMLMessage;
         if (!indexHTML.exists()) {
             indexHTMLMessage = String.format(INDEX_NOT_FOUND,
-                    indexHTML.getName(), indexHTML.getPath(), TARGET,
+                    indexHTML.getName(), indexHTML.getPath(), getBuildFolder(),
                     indexHTML.getName(), indexHTML.getParentFile().getPath());
         } else {
             indexHTMLMessage = String.format("Using 'index.html' from '%s'",

--- a/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
@@ -17,6 +17,7 @@
 package com.vaadin.flow.server;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -72,7 +73,7 @@ public class DefaultDeploymentConfiguration
             + "and \"automatic\". The default of \"disabled\" will be used.";
 
     private static final String INDEX_NOT_FOUND = "'%s' is not found from '%s'.%n"
-            + "Generating a default one in '%s%s'. "
+            + "Generating a default one in '%s'. "
             + "Move it to the '%s' folder if you want to customize it.";
 
     /**
@@ -342,7 +343,8 @@ public class DefaultDeploymentConfiguration
         if (!indexEntry.exists() && !indexEntryTs.exists()) {
             entryPointMessage = String.format(INDEX_NOT_FOUND,
                     indexEntryTs.getName(), indexEntryTs.getPath(),
-                    getBuildFolder(), indexEntryTs.getName(),
+                    Paths.get(getBuildFolder(), indexEntryTs.getName())
+                            .toString(),
                     indexEntryTs.getParentFile().getPath());
         } else {
             String fileName = indexEntry.exists() ? "index.js" : "index.ts";
@@ -360,8 +362,9 @@ public class DefaultDeploymentConfiguration
         String indexHTMLMessage;
         if (!indexHTML.exists()) {
             indexHTMLMessage = String.format(INDEX_NOT_FOUND,
-                    indexHTML.getName(), indexHTML.getPath(), getBuildFolder(),
-                    indexHTML.getName(), indexHTML.getParentFile().getPath());
+                    indexHTML.getName(), indexHTML.getPath(),
+                    Paths.get(getBuildFolder(), indexHTML.getName()).toString(),
+                    indexHTML.getParentFile().getPath());
         } else {
             indexHTMLMessage = String.format("Using 'index.html' from '%s'",
                     indexHTML.getPath());

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -158,4 +158,11 @@ public class InitParameters implements Serializable {
      * component UI imports them as dependencies.
      */
     public static final String COMPILED_WEB_COMPONENTS_PATH = "compiled.web.components.path";
+
+    /**
+     * Configuration name for the build folder.
+     *
+     * @since
+     */
+    public static final String BUILD_FOLDER = "build.folder";
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
@@ -190,6 +190,16 @@ public class PropertyDeploymentConfiguration
     }
 
     @Override
+    public String getBuildFolder() {
+        return super.getBuildFolder();
+    }
+
+    @Override
+    public String getFlowResourcesFolder() {
+        return super.getFlowResourcesFolder();
+    }
+
+    @Override
     public boolean isSyncIdCheckEnabled() {
         return getBooleanProperty(SERVLET_PARAMETER_SYNC_ID_CHECK, true);
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
@@ -26,6 +26,7 @@ import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.server.startup.ApplicationConfiguration;
 import com.vaadin.flow.shared.communication.PushMode;
 
+import static com.vaadin.flow.server.InitParameters.BUILD_FOLDER;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_CLOSE_IDLE_SESSIONS;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_ENABLE_LIVE_RELOAD;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DISABLE_XSRF_PROTECTION;
@@ -191,7 +192,10 @@ public class PropertyDeploymentConfiguration
 
     @Override
     public String getBuildFolder() {
-        return super.getBuildFolder();
+        if (isOwnProperty(BUILD_FOLDER)) {
+            return super.getBuildFolder();
+        }
+        return parentConfig.getBuildFolder();
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -130,11 +130,6 @@ public class FrontendUtils {
     public static final String SERVICE_WORKER_SRC_JS = "sw.js";
 
     /**
-     * Default target folder for the java project.
-     */
-    public static final String TARGET = "target/";
-
-    /**
      * The NPM package name that will be used for the javascript files present
      * in jar resources that will to be copied to the npm folder so as they are
      * accessible to webpack.
@@ -151,15 +146,15 @@ public class FrontendUtils {
             + "/";
 
     /**
-     * Default folder for copying front-end resources present in the classpath
-     * jars.
+     * Default folder where front-end resources present in the classpath jars
+     * are copied to.
+     * Relative to the {@link com.vaadin.flow.server.InitParameters#BUILD_FOLDER}.
      */
-    public static final String DEFAULT_FLOW_RESOURCES_FOLDER = TARGET
-            + "flow-frontend";
+    public static final String DEFAULT_FLOW_RESOURCES_FOLDER = "flow-frontend";
 
     /**
-     * Default folder for copying front-end resources present in the classpath
-     * jars.
+     * Default folder under build folder for copying front-end resources present
+     * in the classpath jars.
      *
      * @deprecated This is deprecated due to a typo. Use
      *             DEFAULT_FLOW_RESOURCES_FOLDER instead.
@@ -170,9 +165,9 @@ public class FrontendUtils {
 
     /**
      * Default folder name for flow generated stuff relative to the
-     * {@link FrontendUtils#TARGET}.
+     * {@link com.vaadin.flow.server.InitParameters#BUILD_FOLDER}.
      */
-    public static final String DEFAULT_GENERATED_DIR = TARGET + FRONTEND;
+    public static final String DEFAULT_GENERATED_DIR = FRONTEND;
 
     /**
      * Name of the file that contains application imports, javascript, theme and
@@ -225,8 +220,7 @@ public class FrontendUtils {
     /**
      * Default generated path for OpenAPI spec file.
      */
-    public static final String DEFAULT_CONNECT_OPENAPI_JSON_FILE = TARGET
-            + "generated-resources/openapi.json";
+    public static final String DEFAULT_CONNECT_OPENAPI_JSON_FILE = "generated-resources/openapi.json";
 
     /**
      * Default generated path for generated frontend files.

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -19,6 +19,7 @@ package com.vaadin.flow.server.frontend;
 import java.io.File;
 import java.io.Serializable;
 import java.net.URI;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -54,6 +55,8 @@ public class NodeTasks implements FallibleCommand {
      * Build a <code>NodeExecutor</code> instance.
      */
     public static class Builder implements Serializable {
+
+        private final String buildDirectory;
 
         private final ClassFinder classFinder;
 
@@ -106,12 +109,12 @@ public class NodeTasks implements FallibleCommand {
         /**
          * Directory for npm and folders and files.
          */
-        public final File npmFolder;
+        private final File npmFolder;
 
         /**
          * Directory where generated files are written.
          */
-        public final File generatedFolder;
+        private final File generatedFolder;
 
         /**
          * Is in client-side bootstrapping mode.
@@ -143,10 +146,16 @@ public class NodeTasks implements FallibleCommand {
          *            a {@link Lookup} to discover services used by Flow (SPI)
          * @param npmFolder
          *            folder with the `package.json` file
+         * @param buildDirectory
+         *            project build directory
          */
-        public Builder(Lookup lookup, File npmFolder) {
-            this(lookup, npmFolder, new File(npmFolder, System
-                    .getProperty(PARAM_GENERATED_DIR, DEFAULT_GENERATED_DIR)));
+        public Builder(Lookup lookup, File npmFolder, String buildDirectory) {
+            this(lookup, npmFolder,
+                    new File(npmFolder,
+                            System.getProperty(PARAM_GENERATED_DIR,
+                                    Paths.get(buildDirectory,
+                                            DEFAULT_GENERATED_DIR).toString())),
+                    buildDirectory);
         }
 
         /**
@@ -159,9 +168,11 @@ public class NodeTasks implements FallibleCommand {
          * @param generatedPath
          *            folder where flow generated files will be placed.
          */
-        public Builder(Lookup lookup, File npmFolder, File generatedPath) {
+        public Builder(Lookup lookup, File npmFolder, File generatedPath,
+                String buildDirectory) {
             this(lookup, npmFolder, generatedPath, new File(npmFolder, System
-                    .getProperty(PARAM_FRONTEND_DIR, DEFAULT_FRONTEND_DIR)));
+                    .getProperty(PARAM_FRONTEND_DIR, DEFAULT_FRONTEND_DIR)),
+                    buildDirectory);
         }
 
         /**
@@ -177,7 +188,7 @@ public class NodeTasks implements FallibleCommand {
          *            a directory with project's frontend files
          */
         public Builder(Lookup lookup, File npmFolder, File generatedPath,
-                File frontendDirectory) {
+                File frontendDirectory, String buildDirectory) {
             this.lookup = lookup;
             this.classFinder = lookup.lookup(ClassFinder.class);
             this.npmFolder = npmFolder;
@@ -186,6 +197,7 @@ public class NodeTasks implements FallibleCommand {
             this.frontendDirectory = frontendDirectory.isAbsolute()
                     ? frontendDirectory
                     : new File(npmFolder, frontendDirectory.getPath());
+            this.buildDirectory = buildDirectory;
         }
 
         /**
@@ -509,6 +521,24 @@ public class NodeTasks implements FallibleCommand {
             this.nodeDownloadRoot = Objects.requireNonNull(nodeDownloadRoot);
             return this;
         }
+
+        /**
+         * Get the npm folder used for this build.
+         * 
+         * @return npmFolder
+         */
+        public File getNpmFolder() {
+            return npmFolder;
+        }
+
+        /**
+         * Get the generated folder for this build.
+         * 
+         * @return generatedFolder
+         */
+        public File getGeneratedFolder() {
+            return generatedFolder;
+        }
     }
 
     private final List<FallibleCommand> commands = new ArrayList<>();
@@ -587,7 +617,7 @@ public class NodeTasks implements FallibleCommand {
             }
 
             commands.add(new TaskGenerateBootstrap(frontendDependencies,
-                    builder.frontendDirectory));
+                    builder.frontendDirectory, builder.buildDirectory));
         }
 
         if (builder.jarFiles != null && builder.flowResourcesFolder != null) {
@@ -611,7 +641,7 @@ public class NodeTasks implements FallibleCommand {
                     new File(builder.generatedFolder, IMPORTS_NAME),
                     builder.useDeprecatedV14Bootstrapping,
                     builder.flowResourcesFolder, pwaConfiguration,
-                    builder.connectClientTsApiFolder));
+                    builder.connectClientTsApiFolder, builder.buildDirectory));
         }
 
         if (builder.enableImportsUpdate) {
@@ -632,7 +662,7 @@ public class NodeTasks implements FallibleCommand {
     private void addBootstrapTasks(Builder builder,
             FrontendDependenciesScanner frontendDependencies) {
         File outputDirectory = new File(builder.npmFolder,
-                FrontendUtils.TARGET);
+                builder.buildDirectory);
         TaskGenerateIndexHtml taskGenerateIndexHtml = new TaskGenerateIndexHtml(
                 builder.frontendDirectory, outputDirectory);
         commands.add(taskGenerateIndexHtml);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -167,6 +167,8 @@ public class NodeTasks implements FallibleCommand {
          *            folder with the `package.json` file
          * @param generatedPath
          *            folder where flow generated files will be placed.
+         * @param buildDirectory
+         *            project build directory
          */
         public Builder(Lookup lookup, File npmFolder, File generatedPath,
                 String buildDirectory) {
@@ -186,6 +188,8 @@ public class NodeTasks implements FallibleCommand {
          *            folder where flow generated files will be placed.
          * @param frontendDirectory
          *            a directory with project's frontend files
+         * @param buildDirectory
+         *            project build directory
          */
         public Builder(Lookup lookup, File npmFolder, File generatedPath,
                 File frontendDirectory, String buildDirectory) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrap.java
@@ -29,7 +29,6 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.BOOTSTRAP_FILE_NAME;
 import static com.vaadin.flow.server.frontend.FrontendUtils.GENERATED;
 import static com.vaadin.flow.server.frontend.FrontendUtils.INDEX_JS;
 import static com.vaadin.flow.server.frontend.FrontendUtils.INDEX_TS;
-import static com.vaadin.flow.server.frontend.FrontendUtils.TARGET;
 
 /**
  * A task for generating the bootstrap file
@@ -42,13 +41,15 @@ public class TaskGenerateBootstrap extends AbstractTaskClientGenerator {
     private final FrontendDependenciesScanner frontDeps;
     private final File connectClientTsApiFolder;
     private final File frontendDirectory;
+    private final String buildDirectory;
 
     TaskGenerateBootstrap(FrontendDependenciesScanner frontDeps,
-            File frontendDirectory) {
+            File frontendDirectory, String buildDirectory) {
         this.frontDeps = frontDeps;
         this.frontendDirectory = frontendDirectory;
         this.connectClientTsApiFolder = new File(
                 Paths.get(frontendDirectory.getPath(), GENERATED).toString());
+        this.buildDirectory = buildDirectory;
     }
 
     @Override
@@ -74,15 +75,16 @@ public class TaskGenerateBootstrap extends AbstractTaskClientGenerator {
         boolean exists = new File(frontendDirectory, INDEX_TS).exists()
                 || new File(frontendDirectory, INDEX_JS).exists();
         Path path = exists ? Paths.get(frontendDirectory.getPath(), INDEX_TS)
-                : Paths.get(frontendDirectory.getParentFile().getPath(), TARGET,
-                        INDEX_TS);
+                : Paths.get(frontendDirectory.getParentFile().getPath(),
+                        buildDirectory, INDEX_TS);
 
         // The index.ts path must be relativized with the bootstrap file path
         // so it can be used in `import` statement. The bootstrap file is
         // ${project.root}/frontend/generated/vaadin.ts.
         // The index file paths are:
         // * project_root/frontend/index.ts => ../index.ts
-        // * project_root/target/index.ts => ../../target/index.ts
+        // * project_root/{build_directory}/index.ts =>
+        // ../../{build_directory}/index.ts
         String relativePath = FrontendUtils
                 .getUnixRelativePath(connectClientTsApiFolder.toPath(), path);
         return relativePath.replaceFirst("\\.[tj]s$", "");

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrap.java
@@ -47,8 +47,7 @@ public class TaskGenerateBootstrap extends AbstractTaskClientGenerator {
             File frontendDirectory, String buildDirectory) {
         this.frontDeps = frontDeps;
         this.frontendDirectory = frontendDirectory;
-        this.connectClientTsApiFolder = new File(
-                Paths.get(frontendDirectory.getPath(), GENERATED).toString());
+        this.connectClientTsApiFolder = new File(frontendDirectory, GENERATED);
         this.buildDirectory = buildDirectory;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateWebpack.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateWebpack.java
@@ -38,7 +38,6 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.GENERATED;
 import static com.vaadin.flow.server.frontend.FrontendUtils.INDEX_HTML;
 import static com.vaadin.flow.server.frontend.FrontendUtils.SERVICE_WORKER_SRC;
 import static com.vaadin.flow.server.frontend.FrontendUtils.SERVICE_WORKER_SRC_JS;
-import static com.vaadin.flow.server.frontend.FrontendUtils.TARGET;
 import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_CONFIG;
 import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_GENERATED;
 import static com.vaadin.flow.shared.ApplicationConstants.VAADIN_STATIC_FILES_PATH;
@@ -65,6 +64,7 @@ public class TaskUpdateWebpack implements FallibleCommand {
     private final PwaConfiguration pwaConfiguration;
     private final Path resourceFolder;
     private final Path frontendGeneratedFolder;
+    private final String buildFolder;
 
     /**
      * Create an instance of the updater given all configurable parameters.
@@ -92,6 +92,8 @@ public class TaskUpdateWebpack implements FallibleCommand {
      *            relative path to `flow-frontend` package
      * @param frontendGeneratedFolder
      *            the folder with frontend auto-generated files
+     * @param buildFolder
+     *            build target forlder
      */
     @SuppressWarnings("squid:S00107")
     TaskUpdateWebpack(File frontendDirectory, File webpackConfigFolder,
@@ -99,7 +101,7 @@ public class TaskUpdateWebpack implements FallibleCommand {
             String webpackTemplate, String webpackGeneratedTemplate,
             File generatedFlowImports, boolean useV14Bootstrapping,
             File flowResourcesFolder, PwaConfiguration pwaConfiguration,
-            File frontendGeneratedFolder) {
+            File frontendGeneratedFolder, String buildFolder) {
         this.frontendDirectory = frontendDirectory.toPath();
         this.webpackTemplate = webpackTemplate;
         this.webpackGeneratedTemplate = webpackGeneratedTemplate;
@@ -113,6 +115,7 @@ public class TaskUpdateWebpack implements FallibleCommand {
         this.resourceFolder = new File(webpackOutputDirectory,
                 VAADIN_STATIC_FILES_PATH).toPath();
         this.frontendGeneratedFolder = frontendGeneratedFolder.toPath();
+        this.buildFolder = buildFolder;
     }
 
     @Override
@@ -227,8 +230,8 @@ public class TaskUpdateWebpack implements FallibleCommand {
                 .exists();
         if (!exists) {
             Path path = Paths.get(
-                    getEscapedRelativeWebpackPath(webpackConfigPath), TARGET,
-                    INDEX_HTML);
+                    getEscapedRelativeWebpackPath(webpackConfigPath),
+                    buildFolder, INDEX_HTML);
             return formatPathResolve(getEscapedRelativeWebpackPath(path));
         } else {
             return "'./" + INDEX_HTML + "'";
@@ -248,8 +251,8 @@ public class TaskUpdateWebpack implements FallibleCommand {
                         .exists();
         if (!exists) {
             Path path = Paths.get(
-                    getEscapedRelativeWebpackPath(webpackConfigPath), TARGET,
-                    SERVICE_WORKER_SRC);
+                    getEscapedRelativeWebpackPath(webpackConfigPath),
+                    buildFolder, SERVICE_WORKER_SRC);
             return formatPathResolve(getEscapedRelativeWebpackPath(path)
                     .replaceFirst("\\.[tj]s$", ""));
         } else {

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractConfigurationFactory.java
@@ -42,6 +42,7 @@ import static com.vaadin.flow.server.Constants.FRONTEND_TOKEN;
 import static com.vaadin.flow.server.Constants.NPM_TOKEN;
 import static com.vaadin.flow.server.Constants.PROJECT_FRONTEND_GENERATED_DIR_TOKEN;
 import static com.vaadin.flow.server.Constants.VAADIN_PREFIX;
+import static com.vaadin.flow.server.InitParameters.BUILD_FOLDER;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_ENABLE_DEV_SERVER;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_INITIAL_UIDL;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE;
@@ -151,6 +152,9 @@ public class AbstractConfigurationFactory implements Serializable {
         if (buildInfo.hasKey(PROJECT_FRONTEND_GENERATED_DIR_TOKEN)) {
             params.put(PROJECT_FRONTEND_GENERATED_DIR_TOKEN,
                     buildInfo.getString(PROJECT_FRONTEND_GENERATED_DIR_TOKEN));
+        }
+        if (buildInfo.hasKey(BUILD_FOLDER)) {
+            params.put(BUILD_FOLDER, buildInfo.getString(BUILD_FOLDER));
         }
 
         setDevModePropertiesUsingTokenData(params, buildInfo);

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -71,7 +71,6 @@ import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.PWA;
 import com.vaadin.flow.server.UIInitListener;
 import com.vaadin.flow.server.VaadinContext;
-import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServiceInitListener;
 import com.vaadin.flow.server.VaadinServletContext;
 import com.vaadin.flow.server.frontend.EndpointGeneratorTaskFactory;

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdateImportsTest.java
@@ -51,6 +51,7 @@ import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 import com.vaadin.flow.server.startup.VaadinAppShellInitializer;
 
+import static com.vaadin.flow.server.Constants.TARGET;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
@@ -94,7 +95,8 @@ public abstract class AbstractNodeUpdateImportsTest extends NodeUpdateTestUtil {
 
         frontendDirectory = new File(tmpRoot, DEFAULT_FRONTEND_DIR);
         nodeModulesPath = new File(tmpRoot, NODE_MODULES);
-        generatedPath = new File(tmpRoot, DEFAULT_GENERATED_DIR);
+        generatedPath = new File(tmpRoot,
+                Paths.get(TARGET, DEFAULT_GENERATED_DIR).toString());
         importsFile = new File(generatedPath, IMPORTS_NAME);
 
         ClassFinder classFinder = getClassFinder();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
@@ -20,6 +20,7 @@ package com.vaadin.flow.server.frontend;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -42,6 +43,7 @@ import elemental.json.Json;
 import elemental.json.JsonObject;
 import elemental.json.JsonValue;
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
+import static com.vaadin.flow.server.Constants.TARGET;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FLOW_RESOURCES_FOLDER;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.NodeUpdater.DEP_NAME_FLOW_DEPS;
@@ -81,8 +83,10 @@ public abstract class AbstractNodeUpdatePackagesTest
     public void setup() throws Exception {
         baseDir = temporaryFolder.getRoot();
 
-        generatedDir = new File(baseDir, DEFAULT_GENERATED_DIR);
-        resourcesDir = new File(baseDir, DEFAULT_FLOW_RESOURCES_FOLDER);
+        generatedDir = new File(baseDir,
+                Paths.get(TARGET, DEFAULT_GENERATED_DIR).toString());
+        resourcesDir = new File(baseDir,
+                Paths.get(TARGET, DEFAULT_FLOW_RESOURCES_FOLDER).toString());
 
         NodeUpdateTestUtil.createStubNode(true, true,
                 baseDir.getAbsolutePath());

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
@@ -63,6 +63,7 @@ import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 import com.vaadin.flow.theme.AbstractTheme;
 import com.vaadin.flow.theme.ThemeDefinition;
 
+import static com.vaadin.flow.server.Constants.TARGET;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
@@ -186,7 +187,8 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
 
         frontendDirectory = new File(tmpRoot, DEFAULT_FRONTEND_DIR);
         nodeModulesPath = new File(tmpRoot, NODE_MODULES);
-        generatedPath = new File(tmpRoot, DEFAULT_GENERATED_DIR);
+        generatedPath = new File(tmpRoot,
+                Paths.get(TARGET, DEFAULT_GENERATED_DIR).toString());
         File tokenFile = new File(tmpRoot, TOKEN_FILE);
 
         ClassFinder classFinder = getClassFinder();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendResourcesAreCopiedAfterCleaningTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendResourcesAreCopiedAfterCleaningTest.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.server.frontend;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 
@@ -33,6 +34,7 @@ import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 
+import static com.vaadin.flow.server.Constants.TARGET;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FLOW_RESOURCES_FOLDER;
 
 public class FrontendResourcesAreCopiedAfterCleaningTest {
@@ -68,7 +70,8 @@ public class FrontendResourcesAreCopiedAfterCleaningTest {
 
     private void assertCopiedFrontendFileAmount(int fileCount)
             throws IOException {
-        File dir = new File(npmFolder, DEFAULT_FLOW_RESOURCES_FOLDER);
+        File dir = new File(npmFolder,
+                Paths.get(TARGET, DEFAULT_FLOW_RESOURCES_FOLDER).toString());
         FileUtils.forceMkdir(dir);
         List<String> files = TestUtils.listFilesRecursively(dir);
 
@@ -83,10 +86,10 @@ public class FrontendResourcesAreCopiedAfterCleaningTest {
         Lookup mockLookup = Mockito.mock(Lookup.class);
         Mockito.doReturn(classFinder).when(mockLookup)
                 .lookup(ClassFinder.class);
-        NodeTasks.Builder builder = new NodeTasks.Builder(mockLookup,
-                npmFolder);
+        NodeTasks.Builder builder = new NodeTasks.Builder(mockLookup, npmFolder,
+                TARGET);
         File resourcesFolder = new File(npmFolder,
-                DEFAULT_FLOW_RESOURCES_FOLDER);
+                Paths.get(TARGET, DEFAULT_FLOW_RESOURCES_FOLDER).toString());
         builder.withEmbeddableWebComponents(false).enableImportsUpdate(false)
                 .createMissingPackageJson(true).enableImportsUpdate(true)
                 .runNpmInstall(false).enablePackagesUpdate(true)
@@ -102,10 +105,10 @@ public class FrontendResourcesAreCopiedAfterCleaningTest {
         Lookup mockLookup = Mockito.mock(Lookup.class);
         Mockito.doReturn(classFinder).when(mockLookup)
                 .lookup(ClassFinder.class);
-        NodeTasks.Builder builder = new NodeTasks.Builder(mockLookup,
-                npmFolder);
+        NodeTasks.Builder builder = new NodeTasks.Builder(mockLookup, npmFolder,
+                TARGET);
         File resourcesFolder = new File(npmFolder,
-                DEFAULT_FLOW_RESOURCES_FOLDER);
+                Paths.get(TARGET, DEFAULT_FLOW_RESOURCES_FOLDER).toString());
         builder.withEmbeddableWebComponents(false).enableImportsUpdate(false)
                 .createMissingPackageJson(true).enableImportsUpdate(true)
                 .runNpmInstall(false).enableNpmFileCleaning(true)

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksExecutionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksExecutionTest.java
@@ -13,6 +13,8 @@ import org.mockito.Mockito;
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.server.ExecutionFailedException;
 
+import static com.vaadin.flow.server.Constants.TARGET;
+
 /**
  * Test that commands in NodeTasks are always executed in a predefined order.
  */
@@ -29,7 +31,7 @@ public class NodeTasksExecutionTest {
 
         // Make a builder that doesn't add any commands.
         NodeTasks.Builder builder = new NodeTasks.Builder(
-                Mockito.mock(Lookup.class), null);
+                Mockito.mock(Lookup.class), null, TARGET);
         builder.useV14Bootstrap(true);
 
         nodeTasks = builder.build();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksTest.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.stream.Collectors;
 
 import org.junit.AfterClass;
@@ -36,13 +37,13 @@ import com.vaadin.flow.server.frontend.NodeTasks.Builder;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder.DefaultClassFinder;
 
+import static com.vaadin.flow.server.Constants.TARGET;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_PROJECT_FRONTEND_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.IMPORTS_NAME;
 import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_FRONTEND_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_GENERATED_DIR;
-import static com.vaadin.flow.server.frontend.FrontendUtils.TARGET;
 import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_CONFIG;
 import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_GENERATED;
 
@@ -87,7 +88,7 @@ public class NodeTasksTest {
         Mockito.doReturn(
                 new DefaultClassFinder(this.getClass().getClassLoader()))
                 .when(mockedLookup).lookup(ClassFinder.class);
-        Builder builder = new Builder(mockedLookup, new File(userDir))
+        Builder builder = new Builder(mockedLookup, new File(userDir), TARGET)
                 .enablePackagesUpdate(false).enableImportsUpdate(true)
                 .runNpmInstall(false).withEmbeddableWebComponents(false);
 
@@ -96,14 +97,15 @@ public class NodeTasksTest {
                 ((File) getFieldValue(builder, "frontendDirectory"))
                         .getAbsolutePath());
         Assert.assertEquals(
-                new File(userDir, DEFAULT_GENERATED_DIR).getAbsolutePath(),
+                Paths.get(userDir, TARGET, DEFAULT_GENERATED_DIR).toFile()
+                        .getAbsolutePath(),
                 ((File) getFieldValue(builder, "generatedFolder"))
                         .getAbsolutePath());
 
         builder.build().execute();
         Assert.assertTrue(
-                new File(userDir, DEFAULT_GENERATED_DIR + IMPORTS_NAME)
-                        .exists());
+                Paths.get(userDir, TARGET, DEFAULT_GENERATED_DIR, IMPORTS_NAME)
+                        .toFile().exists());
     }
 
     @Test
@@ -112,7 +114,7 @@ public class NodeTasksTest {
         Mockito.doReturn(
                 new DefaultClassFinder(this.getClass().getClassLoader()))
                 .when(mockedLookup).lookup(ClassFinder.class);
-        Builder builder = new Builder(mockedLookup, new File(userDir))
+        Builder builder = new Builder(mockedLookup, new File(userDir), TARGET)
                 .enablePackagesUpdate(false).enableImportsUpdate(true)
                 .runNpmInstall(false).withEmbeddableWebComponents(false);
 
@@ -121,13 +123,14 @@ public class NodeTasksTest {
                 ((File) getFieldValue(builder, "frontendDirectory"))
                         .getAbsolutePath());
         Assert.assertEquals(
-                new File(userDir, DEFAULT_GENERATED_DIR).getAbsolutePath(),
+                new File(new File(userDir, TARGET), DEFAULT_GENERATED_DIR)
+                        .getAbsolutePath(),
                 ((File) getFieldValue(builder, "generatedFolder"))
                         .getAbsolutePath());
 
         builder.build().execute();
-        Assert.assertTrue(
-                new File(userDir, DEFAULT_GENERATED_DIR + IMPORTS_NAME)
+        Assert.assertTrue(new File(userDir, Paths
+                .get(TARGET, DEFAULT_GENERATED_DIR, IMPORTS_NAME).toString())
                         .exists());
     }
 
@@ -140,7 +143,7 @@ public class NodeTasksTest {
         Mockito.doReturn(
                 new DefaultClassFinder(this.getClass().getClassLoader()))
                 .when(mockedLookup).lookup(ClassFinder.class);
-        Builder builder = new Builder(mockedLookup, new File(userDir))
+        Builder builder = new Builder(mockedLookup, new File(userDir), TARGET)
                 .enablePackagesUpdate(false).enableImportsUpdate(true)
                 .runNpmInstall(false).withEmbeddableWebComponents(false);
 
@@ -167,7 +170,7 @@ public class NodeTasksTest {
         Mockito.doReturn(
                 new DefaultClassFinder(this.getClass().getClassLoader()))
                 .when(mockedLookup).lookup(ClassFinder.class);
-        Builder builder = new Builder(mockedLookup, new File(userDir))
+        Builder builder = new Builder(mockedLookup, new File(userDir), TARGET)
                 .enablePackagesUpdate(false)
                 .withWebpack(new File(userDir, TARGET + "webapp"),
                         new File(userDir, TARGET + "classes"), WEBPACK_CONFIG,

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateImportsTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URLClassLoader;
 import java.nio.charset.Charset;
+import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -44,6 +45,7 @@ import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 
+import static com.vaadin.flow.server.Constants.TARGET;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
@@ -78,7 +80,8 @@ public class NodeUpdateImportsTest extends NodeUpdateTestUtil {
 
         frontendDirectory = new File(tmpRoot, DEFAULT_FRONTEND_DIR);
         nodeModulesPath = new File(tmpRoot, NODE_MODULES);
-        generatedPath = new File(tmpRoot, DEFAULT_GENERATED_DIR);
+        generatedPath = new File(tmpRoot,
+                Paths.get(TARGET, DEFAULT_GENERATED_DIR).toString());
         importsFile = new File(generatedPath, IMPORTS_NAME);
         importsDefinitionFile = new File(generatedPath, IMPORTS_D_TS_NAME);
         fallBackImportsFile = new File(generatedPath,

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrapTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrapTest.java
@@ -36,6 +36,7 @@ import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 import com.vaadin.flow.theme.AbstractTheme;
 import com.vaadin.flow.theme.ThemeDefinition;
 
+import static com.vaadin.flow.server.Constants.TARGET;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FRONTEND;
 import static com.vaadin.flow.server.frontend.FrontendUtils.GENERATED;
 import static com.vaadin.flow.server.frontend.FrontendUtils.INDEX_TS;
@@ -60,7 +61,7 @@ public class TaskGenerateBootstrapTest {
         frontendFolder = temporaryFolder.newFolder(FRONTEND);
         generatedFolder = temporaryFolder.newFolder(FRONTEND, GENERATED);
         taskGenerateBootstrap = new TaskGenerateBootstrap(frontDeps,
-                frontendFolder);
+                frontendFolder, TARGET);
     }
 
     @Test
@@ -83,7 +84,7 @@ public class TaskGenerateBootstrapTest {
     public void should_load_AppTheme()
             throws MalformedURLException, ExecutionFailedException {
         taskGenerateBootstrap = new TaskGenerateBootstrap(getThemedDependency(),
-                frontendFolder);
+                frontendFolder, TARGET);
         taskGenerateBootstrap.execute();
         String content = taskGenerateBootstrap.getFileContent();
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateIndexTsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateIndexTsTest.java
@@ -29,10 +29,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import static com.vaadin.flow.server.Constants.TARGET;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FRONTEND;
 import static com.vaadin.flow.server.frontend.FrontendUtils.INDEX_JS;
 import static com.vaadin.flow.server.frontend.FrontendUtils.INDEX_TS;
-import static com.vaadin.flow.server.frontend.FrontendUtils.TARGET;
 
 public class TaskGenerateIndexTsTest {
     @Rule

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateWebpackTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateWebpackTest.java
@@ -173,7 +173,7 @@ public class TaskUpdateWebpackTest extends NodeUpdateTestUtil {
                 new File(baseDir,
                         Paths.get(TARGET, DEFAULT_FLOW_RESOURCES_FOLDER)
                                 .toString()),
-                pwaConfiguration, frontendGeneratedFolder, "target");
+                pwaConfiguration, frontendGeneratedFolder, TARGET);
 
         newUpdater.execute();
 
@@ -316,8 +316,8 @@ public class TaskUpdateWebpackTest extends NodeUpdateTestUtil {
 
     protected void createWebpackUpdater() {
         webpackUpdater = new TaskUpdateWebpack(frontendFolder, baseDir,
-                new File(baseDir, "target/webapp"),
-                new File(baseDir, "target/classes"), WEBPACK_CONFIG,
+                new File(baseDir, TARGET + "/webapp"),
+                new File(baseDir, TARGET + "/classes"), WEBPACK_CONFIG,
                 WEBPACK_GENERATED,
                 new File(baseDir,
                         Paths.get(Constants.TARGET, DEFAULT_GENERATED_DIR,
@@ -326,7 +326,7 @@ public class TaskUpdateWebpackTest extends NodeUpdateTestUtil {
                 new File(baseDir,
                         Paths.get(Constants.TARGET,
                                 DEFAULT_FLOW_RESOURCES_FOLDER).toString()),
-                pwaConfiguration, frontendGeneratedFolder, "target");
+                pwaConfiguration, frontendGeneratedFolder, TARGET);
     }
 
     private void assertWebpackGeneratedConfigContent(String entryPoint,

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateWebpackTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateWebpackTest.java
@@ -20,6 +20,7 @@ package com.vaadin.flow.server.frontend;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -33,16 +34,17 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.PWA;
 import com.vaadin.flow.server.PwaConfiguration;
 
+import static com.vaadin.flow.server.Constants.TARGET;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_PROJECT_FRONTEND_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FLOW_RESOURCES_FOLDER;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.IMPORTS_NAME;
 import static com.vaadin.flow.server.frontend.FrontendUtils.SERVICE_WORKER_SRC;
 import static com.vaadin.flow.server.frontend.FrontendUtils.SERVICE_WORKER_SRC_JS;
-import static com.vaadin.flow.server.frontend.FrontendUtils.TARGET;
 import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_CONFIG;
 import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_GENERATED;
 
@@ -167,8 +169,11 @@ public class TaskUpdateWebpackTest extends NodeUpdateTestUtil {
         TaskUpdateWebpack newUpdater = new TaskUpdateWebpack(frontendFolder,
                 baseDir, new File(baseDir, "baz"), new File(baseDir, "foo"),
                 WEBPACK_CONFIG, WEBPACK_GENERATED, new File(baseDir, "bar"),
-                false, new File(baseDir, DEFAULT_FLOW_RESOURCES_FOLDER),
-                pwaConfiguration, frontendGeneratedFolder);
+                false,
+                new File(baseDir,
+                        Paths.get(TARGET, DEFAULT_FLOW_RESOURCES_FOLDER)
+                                .toString()),
+                pwaConfiguration, frontendGeneratedFolder, "target");
 
         newUpdater.execute();
 
@@ -311,13 +316,17 @@ public class TaskUpdateWebpackTest extends NodeUpdateTestUtil {
 
     protected void createWebpackUpdater() {
         webpackUpdater = new TaskUpdateWebpack(frontendFolder, baseDir,
-                new File(baseDir, TARGET + "webapp"),
-                new File(baseDir, TARGET + "classes"), WEBPACK_CONFIG,
+                new File(baseDir, "target/webapp"),
+                new File(baseDir, "target/classes"), WEBPACK_CONFIG,
                 WEBPACK_GENERATED,
-                new File(baseDir, DEFAULT_GENERATED_DIR + IMPORTS_NAME),
+                new File(baseDir,
+                        Paths.get(Constants.TARGET, DEFAULT_GENERATED_DIR,
+                                IMPORTS_NAME).toString()),
                 useV14Bootstrapping,
-                new File(baseDir, DEFAULT_FLOW_RESOURCES_FOLDER),
-                pwaConfiguration, frontendGeneratedFolder);
+                new File(baseDir,
+                        Paths.get(Constants.TARGET,
+                                DEFAULT_FLOW_RESOURCES_FOLDER).toString()),
+                pwaConfiguration, frontendGeneratedFolder, "target");
     }
 
     private void assertWebpackGeneratedConfigContent(String entryPoint,

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/UpdateThemedImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/UpdateThemedImportsTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -42,6 +43,7 @@ import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
 import com.vaadin.flow.theme.AbstractTheme;
 import com.vaadin.flow.theme.ThemeDefinition;
 
+import static com.vaadin.flow.server.Constants.TARGET;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.IMPORTS_NAME;
@@ -84,7 +86,8 @@ public class UpdateThemedImportsTest extends NodeUpdateTestUtil {
 
         frontendDirectory = new File(tmpRoot, DEFAULT_FRONTEND_DIR);
         nodeModulesPath = new File(tmpRoot, NODE_MODULES);
-        generatedPath = new File(tmpRoot, DEFAULT_GENERATED_DIR);
+        generatedPath = new File(tmpRoot,
+                Paths.get(TARGET, DEFAULT_GENERATED_DIR).toString());
         importsFile = new File(generatedPath, IMPORTS_NAME);
 
         Assert.assertTrue(nodeModulesPath.mkdirs());

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerClassLoaderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerClassLoaderTest.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Paths;
 import java.util.List;
 
 import org.junit.Assert;
@@ -12,6 +13,7 @@ import org.junit.Test;
 
 import com.vaadin.flow.server.frontend.TestUtils;
 
+import static com.vaadin.flow.server.Constants.TARGET;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FLOW_RESOURCES_FOLDER;
 
 public class DevModeInitializerClassLoaderTest {
@@ -53,8 +55,8 @@ public class DevModeInitializerClassLoaderTest {
 
         customLoader.close();
 
-        List<String> files = TestUtils.listFilesRecursively(
-                new File(baseDir, DEFAULT_FLOW_RESOURCES_FOLDER));
+        List<String> files = TestUtils.listFilesRecursively(Paths
+                .get(baseDir, TARGET, DEFAULT_FLOW_RESOURCES_FOLDER).toFile());
         Assert.assertEquals(5, files.size());
 
         Assert.assertTrue("A package.json file should be created",

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTest.java
@@ -45,6 +45,7 @@ import static com.vaadin.flow.server.Constants.COMPATIBILITY_RESOURCES_FRONTEND_
 import static com.vaadin.flow.server.Constants.CONNECT_JAVA_SOURCE_FOLDER_TOKEN;
 import static com.vaadin.flow.server.Constants.RESOURCES_FRONTEND_DEFAULT;
 import static com.vaadin.flow.server.Constants.RESOURCES_THEME_JAR_DEFAULT;
+import static com.vaadin.flow.server.Constants.TARGET;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_CONNECT_OPENAPI_JSON_FILE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -316,7 +317,8 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
             throws Exception {
         String originalJavaSourceFolder = null;
         File generatedOpenApiJson = Paths
-                .get(baseDir, DEFAULT_CONNECT_OPENAPI_JSON_FILE).toFile();
+                .get(baseDir, TARGET, DEFAULT_CONNECT_OPENAPI_JSON_FILE)
+                .toFile();
         try {
             originalJavaSourceFolder = System
                     .getProperty("vaadin." + CONNECT_JAVA_SOURCE_FOLDER_TOKEN);
@@ -351,7 +353,8 @@ public class DevModeInitializerTest extends DevModeInitializerTestBase {
             throws Exception {
         String originalJavaSourceFolder = null;
         File generatedOpenApiJson = Paths
-                .get(baseDir, DEFAULT_CONNECT_OPENAPI_JSON_FILE).toFile();
+                .get(baseDir, TARGET, DEFAULT_CONNECT_OPENAPI_JSON_FILE)
+                .toFile();
         try {
             originalJavaSourceFolder = System
                     .getProperty("vaadin." + CONNECT_JAVA_SOURCE_FOLDER_TOKEN);

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTestBase.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/DevModeInitializerTestBase.java
@@ -8,6 +8,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -27,7 +28,9 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.di.ResourceProvider;
+import com.vaadin.flow.server.AbstractConfiguration;
 import com.vaadin.flow.server.DevModeHandler;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.VaadinServlet;
 import com.vaadin.flow.server.frontend.EndpointGeneratorTaskFactory;
 import com.vaadin.flow.server.frontend.FrontendUtils;
@@ -39,6 +42,7 @@ import elemental.json.JsonObject;
 
 import static com.vaadin.flow.server.Constants.CONNECT_JAVA_SOURCE_FOLDER_TOKEN;
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
+import static com.vaadin.flow.server.Constants.TARGET;
 import static com.vaadin.flow.server.DevModeHandler.getDevModeHandler;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_REUSE_DEV_SERVER;
@@ -235,6 +239,10 @@ public class DevModeInitializerTestBase {
 
         Mockito.when(appConfig.getStringProperty(FrontendUtils.PROJECT_BASEDIR,
                 null)).thenReturn(baseDir);
+        Mockito.when(appConfig.getBuildFolder()).thenReturn(TARGET);
+        Mockito.when(appConfig.getFlowResourcesFolder()).thenReturn(
+                Paths.get(TARGET, FrontendUtils.DEFAULT_FLOW_RESOURCES_FOLDER)
+                        .toString());
     }
 
     static List<URL> getClasspathURLs() {

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/StatsContentTest.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/StatsContentTest.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -35,6 +36,7 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DI
 import static com.vaadin.flow.server.frontend.FrontendUtils.FALLBACK_IMPORTS_NAME;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
 import static com.vaadin.flow.server.frontend.FrontendUtils.IMPORTS_NAME;
+import static com.vaadin.flow.server.Constants.TARGET;
 
 public class StatsContentTest {
 
@@ -44,7 +46,8 @@ public class StatsContentTest {
     public void init() {
 
         final File baseDir = new File(System.getProperty("user.dir", "."));
-        generatedFrontend = new File(baseDir, DEFAULT_GENERATED_DIR);
+        generatedFrontend = new File(baseDir,
+                Paths.get(TARGET, DEFAULT_GENERATED_DIR).toString());
     }
 
     @Test
@@ -96,7 +99,7 @@ public class StatsContentTest {
                 .filter(in -> in.startsWith("import"))
                 .map(in -> in.replace("import '", "")
                         .replace(FLOW_NPM_PACKAGE_NAME,
-                                String.format("../%s/",
+                                String.format("../%s/%s/", TARGET,
                                         DEFAULT_FLOW_RESOURCES_FOLDER))
                         .replace("//", "/").replace("Frontend/", "./")
                         .replace("';", ""))

--- a/fusion-endpoint/src/test/java/com/vaadin/flow/server/connect/generator/tsmodel/TsFormTest.java
+++ b/fusion-endpoint/src/test/java/com/vaadin/flow/server/connect/generator/tsmodel/TsFormTest.java
@@ -101,8 +101,15 @@ public class TsFormTest extends AbstractEndpointGeneratorBaseTest {
                         .toPath())
                 .collect(Collectors.toList());
 
-        content.replaceAll(line -> line.replaceAll("file://.*/fusion-endpoint",
-                "file:///.../fusion-endpoint"));
+        // Path separators for files need to be changed on windows.
+        content.replaceAll(line -> {
+            if (line.contains("file://")) {
+                return line.replace('\\', '/').replaceAll(
+                        "file://.*/fusion-endpoint",
+                        "file:///.../fusion-endpoint");
+            }
+            return line;
+        });
         assertEquals("Rows in generated and expected files differ",
                 expected.size(), content.size());
 

--- a/fusion-endpoint/src/test/java/com/vaadin/flow/server/frontend/fusion/NodeTasksEndpointTest.java
+++ b/fusion-endpoint/src/test/java/com/vaadin/flow/server/frontend/fusion/NodeTasksEndpointTest.java
@@ -1,5 +1,6 @@
 package com.vaadin.flow.server.frontend.fusion;
 
+import static com.vaadin.flow.server.Constants.TARGET;
 import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_FRONTEND_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_GENERATED_DIR;
 import static org.junit.Assert.assertTrue;
@@ -52,7 +53,7 @@ public class NodeTasksEndpointTest {
         Mockito.doReturn(new DefaultClassFinder(
                 Collections.singleton(ConnectEndpointsForTesting.class)))
                 .when(mockLookup).lookup(ClassFinder.class);
-        Builder builder = new Builder(mockLookup, dir)
+        Builder builder = new Builder(mockLookup, dir, TARGET)
                 .enablePackagesUpdate(false).enableImportsUpdate(false)
                 .withEmbeddableWebComponents(false)
                 .withConnectJavaSourceFolder(src)


### PR DESCRIPTION
Any code writing to the build directory should
not depend on a hardcoded `target` directory
as for instance gradle uses `build` and it may
be configured also in Maven.

Fixes #10335