### PR TITLE
chore: use another compression plugin which uses only gzip (not brotli)

### DIFF
--- a/flow-client/pom.xml
+++ b/flow-client/pom.xml
@@ -193,12 +193,12 @@
 
             <plugin>
                 <groupId>com.github.ryanholdren</groupId>
-                <artifactId>resourcecompressor</artifactId>
-                <version>2017-06-24</version>
+                <artifactId>resourcegzipper</artifactId>
+                <version>2016-02-10</version>
                 <executions>
                     <execution>
                         <goals>
-                            <goal>compress</goal>
+                            <goal>gzip</goal>
                         </goals>
                         <phase>prepare-package</phase>
                         <configuration>


### PR DESCRIPTION
ResourceCompressor plugin requires jbrotli which is not available
anymore. So the plugin which doesn't apply brotli compression via
jbrotli should be used.