### PR TITLE
fix: force pnpm version <= 5

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -52,7 +52,7 @@ public class FrontendTools {
 
     public static final String DEFAULT_NODE_VERSION = "v14.15.4";
 
-    public static final String DEFAULT_PNPM_VERSION = "5.15.1";
+    public static final String DEFAULT_PNPM_VERSION = "5";
 
     public static final String INSTALL_NODE_LOCALLY = "%n  $ mvn com.github.eirslett:frontend-maven-plugin:1.10.0:install-node-and-npm "
             + "-DnodeVersion=\"" + DEFAULT_NODE_VERSION + "\" ";
@@ -583,9 +583,13 @@ public class FrontendTools {
     }
 
     List<String> getSuitablePnpm() {
+        // install pnpm version < 6.0.0, later requires ensuring
+        // NodeJS >= 12.17
+        final String pnpmSpecifier = ignoreVersionChecks ?
+                "pnpm" :
+                "pnpm@" + DEFAULT_PNPM_VERSION;
         List<String> pnpmCommand = Stream
-                // first try default pnpm, followed by known supported version
-                .of("pnpm", "pnpm@" + DEFAULT_PNPM_VERSION)
+                .of(pnpmSpecifier)
                 // do NOT modify the order of the --yes and --quiet flags, as it
                 // changes the behavior of npx
                 .map(pnpm -> getNpmCliToolExecutable(NpmCliTool.NPX, "--yes",

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -476,7 +476,7 @@ public class FrontendToolsTest {
         createStubNode(false, true, baseDir);
         createFakePnpm("5.15.1");
         List<String> pnpmCommand = tools.getSuitablePnpm();
-        Assert.assertEquals("expected pnpm version 5.15.1 accepted", "pnpm",
+        Assert.assertEquals("expected pnpm version 5.15.1 accepted", "pnpm@5",
                 pnpmCommand.get(pnpmCommand.size() - 1));
     }
 


### PR DESCRIPTION
pnpm >= 6.0.0 requires at least Node.js v12.17. This requirement may not be satisfied as framework current accepts Node.js 10.

pnpm 6.0 can be used with newer Node.js versions if the versions check is disabled with `vaadin.ignoreVersionChecks=true`. But in pnpm 6 the pnpmfile.js is renamed to .pnpmfile.cjs and thus the Flow generated pnpmfile.js will not be used by pnpm - meaning that versions are not locked.

Fixes #10571