### PR TITLE
chore: disable gradle daemon thread

### DIFF
--- a/flow-plugins/flow-gradle-plugin/gradle.properties
+++ b/flow-plugins/flow-gradle-plugin/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false


### PR DESCRIPTION
As we use gradle for a single module build,
keeping a long-running gradle process, which
is not being stopped after the build completes,
would not have much impact to improve the 
performance. Disabling it may alleviate the 
insufficient memory errors and JVM crashes on
the CI.