### PR TITLE
Chore: skip functionalTests for gradle

### DIFF
--- a/flow-plugins/flow-gradle-plugin/pom.xml
+++ b/flow-plugins/flow-gradle-plugin/pom.xml
@@ -70,6 +70,8 @@
                             <arguments>
                                 <argument>clean</argument>
                                 <argument>build</argument>
+                                <argument>-x</argument>
+                                <argument>functionalTest</argument>
                                 <argument>-S</argument>
                             </arguments>
                         </configuration>


### PR DESCRIPTION
As there is some problem with running
the functional tests in the CI
we will skip them for the time being