### PR TITLE
fix: Skip any generated files in theme live reload plugin

### DIFF
--- a/flow-server/src/main/resources/plugins/theme-live-reload-plugin/package.json
+++ b/flow-server/src/main/resources/plugins/theme-live-reload-plugin/package.json
@@ -7,7 +7,7 @@
   ],
   "repository": "vaadin/flow",
   "name": "@vaadin/theme-live-reload-plugin",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "main": "theme-live-reload-plugin.js",
   "author": "Vaadin Ltd",
   "license": "Apache-2.0",

--- a/flow-server/src/main/resources/plugins/theme-live-reload-plugin/theme-live-reload-plugin.js
+++ b/flow-server/src/main/resources/plugins/theme-live-reload-plugin/theme-live-reload-plugin.js
@@ -22,16 +22,11 @@ class ThemeLiveReloadPlugin {
 
     /**
      * Create a new instance of ThemeLiveReloadPlugin
-     * @param themeName current theme name
      * @param processThemeResourcesCallback callback which is called on
      * adding/deleting of theme resource files to re-generate theme meta
      * data and apply theme changes to application.
      */
-    constructor(themeName, processThemeResourcesCallback) {
-      if (!themeName) {
-        throw new Error("Missing theme name");
-      }
-      this.themeName = themeName;
+    constructor(processThemeResourcesCallback) {
       if (!processThemeResourcesCallback || typeof processThemeResourcesCallback !== 'function') {
         throw new Error("Couldn't instantiate a ThemeLiveReloadPlugin" +
           " instance, because theme resources process callback is not set" +
@@ -52,10 +47,15 @@ class ThemeLiveReloadPlugin {
           const changedFilesPaths = Object.keys(changedFilesMap);
           logger.debug("Detected changes in the following files " + changedFilesPaths);
           changedFilesPaths.map(file => `${file}`).forEach(file => {
-              if (file.indexOf(this.themeName + '.generated.js') > -1) {
-                themeGeneratedFileChanged = true;
-              }
-            });
+            // Webpack watches to the changes in [my-theme].generated.js
+            // because it is referenced from theme-generated.js. Changes in
+            // this file should not trigger the theme handling callback (which
+            // re-generates [my-theme].generated.js),
+            // otherwise it will get into infinite re-compilation loop.
+            if (file.endsWith('.generated.js')) {
+              themeGeneratedFileChanged = true;
+            }
+          });
           if (!themeGeneratedFileChanged) {
             this.processThemeResourcesCallback(logger);
           }


### PR DESCRIPTION
Switching the theme name in `@Theme` annotation triggered/created a new [other-theme].generated.js file, which is being watched by webpack and trigger another live-reload in turn. 
Thus, the endless loop took place. 
This fix skips the live reload for all generated theme files, no matter which name it has.

Related-to #10451