### PR TITLE
test: ignore the file path comparison in comment of generated ts model

### DIFF
--- a/fusion-endpoint/src/test/java/com/vaadin/flow/server/connect/generator/tsmodel/TsFormTest.java
+++ b/fusion-endpoint/src/test/java/com/vaadin/flow/server/connect/generator/tsmodel/TsFormTest.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.vaadin.flow.server.connect.generator.endpoints.AbstractEndpointGeneratorBaseTest;
@@ -116,11 +117,14 @@ public class TsFormTest extends AbstractEndpointGeneratorBaseTest {
         int line = 0;
         List<String> faultyLines = new ArrayList<>();
         for (String expectedLine : expected) {
+            String actualLine = content.get(line);
             // ignore the line for file reference, as the file path syntax is different on Windows
-            if (!expectedLine.contains("@see {@link file:///...") &&
-                !expectedLine.equals(content.get(line))) {
+            if (isFileRefenreceLine(expectedLine)) {
+                Assert.assertTrue("should have the file reference", 
+                        isFileRefenreceLine(actualLine)); 
+            } else if (!expectedLine.equals(actualLine)) {
                 faultyLines.add(String.format("L%d :: expected: [%s] got [%s]",
-                        line + 1, expectedLine, content.get(line)));
+                        line + 1, expectedLine, actualLine));
             }
             line++;
         }
@@ -128,5 +132,9 @@ public class TsFormTest extends AbstractEndpointGeneratorBaseTest {
                 "Found differences in generated file: " + faultyLines.stream()
                         .collect(Collectors.joining("\n")),
                 faultyLines.isEmpty());
+    }
+
+    private boolean isFileRefenreceLine(String line) {
+        return line.contains("@see {@link file:");
     }
 }

--- a/fusion-endpoint/src/test/java/com/vaadin/flow/server/connect/generator/tsmodel/TsFormTest.java
+++ b/fusion-endpoint/src/test/java/com/vaadin/flow/server/connect/generator/tsmodel/TsFormTest.java
@@ -116,7 +116,9 @@ public class TsFormTest extends AbstractEndpointGeneratorBaseTest {
         int line = 0;
         List<String> faultyLines = new ArrayList<>();
         for (String expectedLine : expected) {
-            if (!expectedLine.equals(content.get(line))) {
+            // ignore the line for file reference, as the file path syntax is different on Windows
+            if (!expectedLine.contains("@see {@link file:///...") &&
+                !expectedLine.equals(content.get(line))) {
                 faultyLines.add(String.format("L%d :: expected: [%s] got [%s]",
                         line + 1, expectedLine, content.get(line)));
             }

--- a/fusion-endpoint/src/test/java/com/vaadin/flow/server/startup/fusion/DevModeInitializerEndpointTest.java
+++ b/fusion-endpoint/src/test/java/com/vaadin/flow/server/startup/fusion/DevModeInitializerEndpointTest.java
@@ -167,7 +167,6 @@ public class DevModeInitializerEndpointTest {
         DevModeInitializer devModeInitializer = new DevModeInitializer();
         devModeInitializer.onStartup(classes, servletContext);
         waitForDevModeServer();
-        Thread.sleep(200);
         Assert.assertTrue("Should generate OpenAPI spec if Endpoint is used.",
                 generatedOpenApiJson.exists());
     }

--- a/fusion-endpoint/src/test/java/com/vaadin/flow/server/startup/fusion/DevModeInitializerEndpointTest.java
+++ b/fusion-endpoint/src/test/java/com/vaadin/flow/server/startup/fusion/DevModeInitializerEndpointTest.java
@@ -165,7 +165,7 @@ public class DevModeInitializerEndpointTest {
 
         Assert.assertFalse(generatedOpenApiJson.exists());
         DevModeInitializer devModeInitializer = new DevModeInitializer();
-        devModeInitializer.process(classes, servletContext);
+        devModeInitializer.onStartup(classes, servletContext);
         waitForDevModeServer();
         Thread.sleep(200);
         Assert.assertTrue("Should generate OpenAPI spec if Endpoint is used.",
@@ -180,7 +180,7 @@ public class DevModeInitializerEndpointTest {
                 .toFile();
 
         Assert.assertFalse(generatedOpenApiJson.exists());
-        devModeInitializer.process(classes, servletContext);
+        devModeInitializer.onStartup(classes, servletContext);
         waitForDevModeServer();
         Assert.assertFalse(
                 "Should not generate OpenAPI spec if Endpoint is not used.",
@@ -208,7 +208,7 @@ public class DevModeInitializerEndpointTest {
 
         assertFalse(ts1.exists());
         assertFalse(ts2.exists());
-        devModeInitializer.process(classes, servletContext);
+        devModeInitializer.onStartup(classes, servletContext);
         waitForDevModeServer();
         assertTrue(ts1.exists());
         assertTrue(ts2.exists());


### PR DESCRIPTION
Fixes #10545 
The `TsFormTest` was ignored in the Window build steps, now reenabled.