### PR TITLE
fix: Extract theme name from proper folder and skip generated files

### DIFF
--- a/flow-server/src/main/resources/plugins/theme-live-reload-plugin/package.json
+++ b/flow-server/src/main/resources/plugins/theme-live-reload-plugin/package.json
@@ -7,7 +7,7 @@
   ],
   "repository": "vaadin/flow",
   "name": "@vaadin/theme-live-reload-plugin",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "main": "theme-live-reload-plugin.js",
   "author": "Vaadin Ltd",
   "license": "Apache-2.0",

--- a/flow-server/src/main/resources/plugins/theme-live-reload-plugin/theme-live-reload-plugin.js
+++ b/flow-server/src/main/resources/plugins/theme-live-reload-plugin/theme-live-reload-plugin.js
@@ -22,16 +22,11 @@ class ThemeLiveReloadPlugin {
 
     /**
      * Create a new instance of ThemeLiveReloadPlugin
-     * @param themeName current theme name
      * @param processThemeResourcesCallback callback which is called on
      * adding/deleting of theme resource files to re-generate theme meta
      * data and apply theme changes to application.
      */
-    constructor(themeName, processThemeResourcesCallback) {
-      if (!themeName) {
-        throw new Error("Missing theme name");
-      }
-      this.themeName = themeName;
+    constructor(processThemeResourcesCallback) {
       if (!processThemeResourcesCallback || typeof processThemeResourcesCallback !== 'function') {
         throw new Error("Couldn't instantiate a ThemeLiveReloadPlugin" +
           " instance, because theme resources process callback is not set" +
@@ -52,7 +47,15 @@ class ThemeLiveReloadPlugin {
           const changedFilesPaths = Object.keys(changedFilesMap);
           logger.debug("Detected changes in the following files " + changedFilesPaths);
           changedFilesPaths.map(file => `${file}`).forEach(file => {
-              if (file.indexOf(this.themeName + '.generated.js') > -1) {
+              // Webpack watches to the changes in theme-[my-theme].generated.js
+              // because it is referenced from theme.js. Changes in this file
+              // should not trigger the theme handling callback (which
+              // re-generates theme-[my-theme].generated.js),
+              // otherwise it will get into infinite re-compilation loop.
+              // There might be several theme generated files in the
+              // generated folder, so the condition does not contain the exact
+              // theme name
+              if (file.match(/theme-[\s\S]*?\.generated\.js$/)) {
                 themeGeneratedFileChanged = true;
               }
             });

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -171,7 +171,12 @@ if (devMode) {
 }
 
 const flowFrontendThemesFolder = path.resolve(flowFrontendFolder, 'themes');
-const themeName = extractThemeName(flowFrontendThemesFolder);
+let themeName = undefined;
+if (devMode) {
+  // Current theme name is being extracted from theme.js located in frontend
+  // generated folder
+  themeName = extractThemeName(frontendGeneratedFolder);
+}
 const themeOptions = {
   devMode: devMode,
   // The following matches folder 'target/flow-frontend/themes/'
@@ -305,14 +310,15 @@ module.exports = {
 
     new ApplicationThemePlugin(themeOptions),
 
-    devMode && themeName && new ExtraWatchWebpackPlugin({
+    ...(devMode && themeName ? [new ExtraWatchWebpackPlugin({
       files: [],
-      dirs: [path.resolve(__dirname, 'frontend', 'themes', themeName),
-        path.resolve(__dirname, 'src', 'main', 'resources', 'META-INF', 'resources', 'themes', themeName),
-        path.resolve(__dirname, 'src', 'main', 'resources', 'static', 'themes', themeName)]
-    }),
-
-    devMode && themeName && new ThemeLiveReloadPlugin(themeName, processThemeResourcesCallback),
+      // Watch the components folder for component styles update.
+      // Other folders or CSS files except 'styles.css' should be
+      // referenced from `styles.css` anyway, so no need to watch them.
+      dirs: [path.resolve(__dirname, 'frontend', 'themes', themeName, 'components'),
+        path.resolve(__dirname, 'src', 'main', 'resources', 'META-INF', 'resources', 'themes', themeName, 'components'),
+        path.resolve(__dirname, 'src', 'main', 'resources', 'static', 'themes', themeName, 'components')]
+    }), new ThemeLiveReloadPlugin(processThemeResourcesCallback)] : []),
 
     new StatsPlugin({
       devMode: devMode,


### PR DESCRIPTION
Extracts the custom theme name from frontend generated folder and skips theme handling when the theme generated file is being created/updated.

Related-to #10451, #10544

IT test to cover component styles live reload is being worked in a separate PR https://github.com/vaadin/flow/pull/10584, it is flaky still.
IT test to cover themes switch is under work still.