### PR TITLE
fix: Log webpack output on failure

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
@@ -109,6 +109,8 @@ public final class DevModeHandler implements RequestHandler {
 
     private boolean notified = false;
 
+    private StringBuilder cumulativeOutput = new StringBuilder();
+
     private volatile String failedOutput;
 
     private AtomicBoolean isDevServerFailedToStart = new AtomicBoolean();
@@ -469,6 +471,9 @@ public final class DevModeHandler implements RequestHandler {
                 output.append(cleanLine).append(System.lineSeparator());
             }
 
+            // save output so as it can be used to log exception if run fails
+            cumulativeOutput.append(cleanLine).append(System.lineSeparator());
+
             boolean succeed = success.matcher(line).find();
             boolean failed = failure.matcher(line).find();
             // We found the success or failure pattern in stream
@@ -478,6 +483,7 @@ public final class DevModeHandler implements RequestHandler {
                 failedOutput = failed ? output.toString() : null;
                 // reset output and logger for the next compilation
                 output = getOutputBuilder();
+                cumulativeOutput = new StringBuilder();
                 log = info;
                 // Notify DevModeHandler to continue
                 doNotify();
@@ -654,6 +660,9 @@ public final class DevModeHandler implements RequestHandler {
             }
 
             if (!webpackProcess.get().isAlive()) {
+                getLogger().error(
+                    String.format("Webpack failed with the exception:%n%s",
+                        cumulativeOutput.toString()));
                 throw new IllegalStateException("Webpack exited prematurely");
             }
 


### PR DESCRIPTION
Log as error any output from webpack when
webpack exits prematurely.

Closes #7472