### PR TITLE
fix: Only override older package versions

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -425,7 +425,7 @@ public class TaskRunNpmInstall implements FallibleCommand {
                 String stdoutLine;
                 while ((stdoutLine = reader.readLine()) != null) {
                     packageUpdater.log().debug(stdoutLine);
-                    toolOutput.append(stdoutLine);
+                    toolOutput.append(stdoutLine).append(System.lineSeparator());
                 }
             }
 

--- a/flow-server/src/main/resources/pnpmfile.js
+++ b/flow-server/src/main/resources/pnpmfile.js
@@ -25,9 +25,13 @@ function readPackage(pkg) {
   const {dependencies} = pkg;
   
   if (dependencies) {
-    for (let k in versions) {
-      if (dependencies[k] && dependencies[k] !== versions[k]) {
-        pkg.dependencies[k] = versions[k];
+    for (let key in versions) {
+      if (dependencies[key]) {
+        if (dependencies[key].startsWith('./') || compareVersions(dependencies[key], versions[key]) === -1) {
+          // only rewrite to versions version if dependency older
+          console.debug("Updating " + key + " to " + versions[key] + " from " + pkg.dependencies[key]);
+          pkg.dependencies[key] = versions[key];
+        }
       }
     }
   }
@@ -39,4 +43,78 @@ function readPackage(pkg) {
   }
 
   return pkg;
+}
+
+const semver = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/i;
+
+function indexOrEnd(str, q) {
+  return str.indexOf(q) === -1 ? str.length : str.indexOf(q);
+}
+
+function normalize(version) {
+  if (version.startsWith('~')) {
+    return version.replace('~', '');
+  }
+  if (version.startsWith('^')) {
+    return version.replace('^', '');
+  }
+  return version;
+}
+
+function split(version) {
+  const cleaned = version.replace(/^v/, '').replace(/\+.*$/, '');
+  const patchIndex = indexOrEnd(cleaned, '-');
+  const arr = cleaned.substring(0, patchIndex).split('.');
+  arr.push(cleaned.substring(patchIndex + 1));
+  return arr;
+}
+
+function tryParse(v) {
+  return isNaN(Number(v)) ? v : Number(v);
+}
+
+function validate(version) {
+  if (typeof version !== 'string') {
+    throw new TypeError('Invalid argument expected string got ' + version);
+  }
+  if (!semver.test(version)) {
+    throw new Error('Invalid argument not valid semver (\'' + version + '\' received)');
+  }
+}
+
+function compareVersions(version1, version2) {
+  version1 = normalize(version1);
+  version2 = normalize(version2);
+  [version1, version2].forEach(validate);
+
+  const v1Array = split(version1);
+  const v2Array = split(version2);
+
+  for (let i = 0; i < Math.max(v1Array.length - 1, v2Array.length - 1); i++) {
+    const number1 = parseInt(v1Array[i] || 0, 10);
+    const number2 = parseInt(v2Array[i] || 0, 10);
+
+    if (number1 > number2) return 1;
+    if (number2 > number1) return -1;
+  }
+
+  const sp1 = v1Array[v1Array.length - 1];
+  const sp2 = v2Array[v2Array.length - 1];
+
+  if (sp1 && sp2) {
+    const p1 = sp1.split('.').map(tryParse);
+    const p2 = sp2.split('.').map(tryParse);
+
+    for (let i = 0; i < Math.max(p1.length, p2.length); i++) {
+      if (p1[i] === undefined || typeof p2[i] === 'string' && typeof p1[i] === 'number') return -1;
+      if (p2[i] === undefined || typeof p1[i] === 'string' && typeof p2[i] === 'number') return 1;
+
+      if (p1[i] > p2[i]) return 1;
+      if (p2[i] > p1[i]) return -1;
+    }
+  } else if (sp1 || sp2) {
+    return sp1 ? -1 : 1;
+  }
+
+  return 0;
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -558,6 +558,122 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         Assert.assertEquals(originalContent, content);
     }
 
+    @Test
+    public void runPnpmInstall_userVersionNewerThanPinned_installedOverlayVersionIsNotSpecifiedByPlatform()
+        throws IOException, ExecutionFailedException {
+        File packageJson = new File(getNodeUpdater().npmFolder, PACKAGE_JSON);
+        packageJson.createNewFile();
+
+        // Write package json file
+        final String customOverlayVersion = "3.3.0";
+        FileUtils.write(packageJson,
+            "{\"dependencies\": {"
+                + "\"@vaadin/vaadin-dialog\": \"2.3.0\","
+                + "\"@vaadin/vaadin-overlay\": \"" + customOverlayVersion + "\"}"
+                + "}",
+            StandardCharsets.UTF_8);
+
+        // Platform defines a pinned version
+        TaskRunNpmInstall task = createTask(
+            "{ \"@vaadin/vaadin-overlay\":\"" + PINNED_VERSION + "\"}");
+        task.execute();
+
+        File overlayPackageJson = new File(getNodeUpdater().nodeModulesFolder,
+            "@vaadin/vaadin-overlay/package.json");
+
+        // The resulting version should be the one specified via platform
+        // versions file
+        JsonObject overlayPackage = Json.parse(FileUtils
+            .readFileToString(overlayPackageJson, StandardCharsets.UTF_8));
+        Assert.assertEquals(customOverlayVersion,
+            overlayPackage.getString("version"));
+    }
+
+    @Test
+    public void runPnpmInstall_userVersionOlderThanPinned_installedOverlayVersionIsSpecifiedByPlatform()
+        throws IOException, ExecutionFailedException {
+        File packageJson = new File(getNodeUpdater().npmFolder, PACKAGE_JSON);
+        packageJson.createNewFile();
+
+        // Write package json file
+        final String customOverlayVersion = "3.0.0";
+        FileUtils.write(packageJson,
+            "{\"dependencies\": {"
+                + "\"@vaadin/vaadin-dialog\": \"2.3.0\","
+                + "\"@vaadin/vaadin-overlay\": \"" + customOverlayVersion + "\"}"
+                + "}",
+            StandardCharsets.UTF_8);
+
+        // Platform defines a pinned version
+        TaskRunNpmInstall task = createTask(
+            "{ \"@vaadin/vaadin-overlay\":\"" + PINNED_VERSION + "\"}");
+        task.execute();
+
+        File overlayPackageJson = new File(getNodeUpdater().nodeModulesFolder,
+            "@vaadin/vaadin-overlay/package.json");
+
+        // The resulting version should be the one specified via platform
+        // versions file
+        JsonObject overlayPackage = Json.parse(FileUtils
+            .readFileToString(overlayPackageJson, StandardCharsets.UTF_8));
+        Assert.assertEquals(PINNED_VERSION,
+            overlayPackage.getString("version"));
+    }
+
+    @Test
+    public void runPnpmInstall_userDefinedVersions_versionOnlyUpdatedWhenNewer()
+        throws IOException, ExecutionFailedException {
+        File packageJson = new File(getNodeUpdater().npmFolder, PACKAGE_JSON);
+        packageJson.createNewFile();
+
+        // Write package json file
+        String loginVersion = "1.1.0-alpha1";
+        String menuVersion = "1.1.0-alpha2";
+        String notificationVersion = "1.4.0";
+        String uploadVersion = "4.2.0";
+        FileUtils.write(packageJson, String.format(
+            "{\"dependencies\": {" + "\"@vaadin/vaadin-login\": \"%s\","
+                + "\"@vaadin/vaadin-menu-bar\": \"%s\","
+                + "\"@vaadin/vaadin-notification\": \"%s\","
+                + "\"@vaadin/vaadin-upload\": \"%s\"}" + "}",
+            loginVersion, menuVersion, notificationVersion, uploadVersion),
+            StandardCharsets.UTF_8);
+
+        // Platform defines a pinned version
+
+        String versionsLoginVersion = "1.1.0-alpha1";
+        String versionsMenuBarVersion = "1.1.0-alpha1";
+        String versionsNotificationVersion = "1.5.0-alpha1";
+        String versionsUploadVersion = "4.2.0-beta2";
+
+        TaskRunNpmInstall task = createTask(String.format(
+            "{ \"@vaadin/vaadin-login\":\"%s\","
+                + "\"@vaadin/vaadin-menu-bar\":\"%s\","
+                + "\"@vaadin/vaadin-notification\": \"%s\","
+                + "\"@vaadin/vaadin-upload\": \"%s\" }",
+            versionsLoginVersion, versionsMenuBarVersion,
+            versionsNotificationVersion, versionsUploadVersion));
+        task.execute();
+
+        verifyVersion("Login version is the same for user and platform.",
+            "vaadin-login", loginVersion);
+        verifyVersion("Menu Bar should use user defined version.",
+            "vaadin-menu-bar", menuVersion);
+        verifyVersion("Notification should use platform version.",
+            "vaadin-notification", versionsNotificationVersion);
+        verifyVersion("Upload should use user defined release version.",
+            "vaadin-upload", uploadVersion);
+    }
+
+    private void verifyVersion(String assertMessage, String packageName, String expectedVersion)
+        throws IOException {
+        File uploadJson = new File(getNodeUpdater().nodeModulesFolder,
+            String.format("@vaadin/%s/package.json", packageName));
+        final JsonObject json = Json.parse(FileUtils
+            .readFileToString(uploadJson, StandardCharsets.UTF_8));
+        Assert.assertEquals(assertMessage, expectedVersion, json.getString("version"));
+    }
+
     @Override
     protected String getToolName() {
         return "pnpm";


### PR DESCRIPTION
If package dependency version in
package json is newer than in versions.json
then we leave the newer version unchanged.

Fixes #9793 