### PR TITLE
fix: avoid log an error if frontend tool can't be found

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsLocator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsLocator.java
@@ -119,7 +119,13 @@ public class FrontendToolsLocator implements Serializable {
             process = FrontendUtils
                     .createProcessBuilder(Arrays.asList(commandParts)).start();
         } catch (IOException e) {
-            log().error("Failed to execute the command '{}'", commandString, e);
+            if (logErrorOnFail) {
+                log().error("Failed to execute the command '{}'", commandString,
+                        e);
+            } else if (log().isDebugEnabled()) {
+                log().debug("Failed to execute the command '{}'", commandString,
+                        e);
+            }
             return Optional.empty();
         }
 


### PR DESCRIPTION
fixes #9212