### PR TITLE
fix: cannot login to authentication protected view

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/Authentication.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Authentication.ts
@@ -12,6 +12,9 @@ export interface LoginResult {
 export interface LoginOptions {
   loginProcessingUrl?: string;
   failureUrl?: string;
+  /**
+   * @deprecated The `defaultSuccessUrl` is not used anymore.
+   */
   defaultSuccessUrl?: string;
 }
 

--- a/flow-client/src/main/resources/META-INF/resources/frontend/Authentication.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Authentication.ts
@@ -7,7 +7,6 @@ export interface LoginResult {
   token?: string;
   errorTitle?: string;
   errorMessage?: string;
-  redirectUrl?: string;
 }
 
 export interface LoginOptions {
@@ -38,7 +37,6 @@ export async function login(username: string, password: string, options?: LoginO
     const response = await fetch(loginProcessingUrl, { method: 'POST', body: data, headers });
 
     const failureUrl = options && options.failureUrl ? options.failureUrl : '/login?error';
-    // const defaultSuccessUrl = options && options.defaultSuccessUrl ? options.defaultSuccessUrl : '/';
     // this assumes the default Spring Security form login configuration (handler URL and responses)
     if (response.ok && response.redirected) {
       if (response.url.endsWith(failureUrl)) {
@@ -52,15 +50,7 @@ export async function login(username: string, password: string, options?: LoginO
         if (vaadinCsrfToken) {
           result = {
             error: false,
-            redirectUrl: response.redirected ? response.url : undefined,
             token: vaadinCsrfToken
-          };
-        } else {
-          result = {
-            error: true,
-            redirectUrl: response.redirected ? response.url : undefined,
-            errorTitle: 'Incorrect username or password.',
-            errorMessage: 'Check that you have entered the correct username and password and try again.'
           };
         }
       }

--- a/flow-client/src/test/frontend/AuthenticationTests.ts
+++ b/flow-client/src/test/frontend/AuthenticationTests.ts
@@ -71,13 +71,13 @@ describe('Authentication', () => {
     it('should return a CSRF token on valid credentials', async () => {
       fetchMock.post('/login', {
         body: happyCaseResponseText,
-        redirectUrl: '/'
+        redirectUrl: 'localhost:8080/'
       }, { headers });
       const result = await login('valid-username', 'valid-password');
       const expectedResult = {
         error: false,
         token: vaadinCsrfToken,
-        redirectUrl: '/'
+        redirectUrl: 'localhost:8080/'
       };
 
       expect(fetchMock.calls()).to.have.lengthOf(1);
@@ -113,13 +113,13 @@ describe('Authentication', () => {
         body: happyCaseResponseText,
         // mock the unthenticated attempt, which would be 
         // saved by the default request cache
-        redirectUrl: '/protected-view'
+        redirectUrl: 'localhost:8080/protected-view'
       }, { headers });
       const result = await login('valid-username', 'valid-password');
       const expectedResult = {
         error: false,
         token: vaadinCsrfToken,
-        redirectUrl: '/protected-view'
+        redirectUrl: 'localhost:8080/protected-view'
       };
 
       expect(fetchMock.calls()).to.have.lengthOf(1);

--- a/flow-client/src/test/frontend/AuthenticationTests.ts
+++ b/flow-client/src/test/frontend/AuthenticationTests.ts
@@ -76,9 +76,8 @@ describe('Authentication', () => {
       const result = await login('valid-username', 'valid-password');
       const expectedResult = {
         error: false,
-        errorTitle: '',
-        errorMessage: '',
-        token: vaadinCsrfToken
+        token: vaadinCsrfToken,
+        redirectUrl: '/'
       };
 
       expect(fetchMock.calls()).to.have.lengthOf(1);
@@ -100,6 +99,27 @@ describe('Authentication', () => {
         error: true,
         errorTitle: 'Error',
         errorMessage: 'Something went wrong when trying to login.'
+      };
+
+      expect(fetchMock.calls()).to.have.lengthOf(1);
+      expect(result).to.deep.equal(expectedResult);
+    })
+
+    it('should redirect based on request cache after login', async () => {
+      // An unthenticated request attempt would be captured by the default
+      // request cache, so after login, it should redirect the user to that 
+      // request
+      fetchMock.post('/login', {
+        body: happyCaseResponseText,
+        // mock the unthenticated attempt, which would be 
+        // saved by the default request cache
+        redirectUrl: '/protected-view'
+      }, { headers });
+      const result = await login('valid-username', 'valid-password');
+      const expectedResult = {
+        error: false,
+        token: vaadinCsrfToken,
+        redirectUrl: '/protected-view'
       };
 
       expect(fetchMock.calls()).to.have.lengthOf(1);

--- a/flow-client/src/test/frontend/AuthenticationTests.ts
+++ b/flow-client/src/test/frontend/AuthenticationTests.ts
@@ -76,8 +76,7 @@ describe('Authentication', () => {
       const result = await login('valid-username', 'valid-password');
       const expectedResult = {
         error: false,
-        token: vaadinCsrfToken,
-        redirectUrl: 'localhost:8080/'
+        token: vaadinCsrfToken
       };
 
       expect(fetchMock.calls()).to.have.lengthOf(1);
@@ -105,6 +104,19 @@ describe('Authentication', () => {
       expect(result).to.deep.equal(expectedResult);
     })
 
+    it('should return an error when response is missing CSRF token', async () => {
+      fetchMock.post('/login', 'I am mock response without CSRF token', { headers });
+      const result = await login('valid-username', 'valid-password');
+      const expectedResult = {
+        error: true,
+        errorTitle: 'Error',
+        errorMessage: 'Something went wrong when trying to login.'
+      };
+
+      expect(fetchMock.calls()).to.have.lengthOf(1);
+      expect(result).to.deep.equal(expectedResult);
+    })
+
     it('should redirect based on request cache after login', async () => {
       // An unthenticated request attempt would be captured by the default
       // request cache, so after login, it should redirect the user to that 
@@ -118,8 +130,7 @@ describe('Authentication', () => {
       const result = await login('valid-username', 'valid-password');
       const expectedResult = {
         error: false,
-        token: vaadinCsrfToken,
-        redirectUrl: 'localhost:8080/protected-view'
+        token: vaadinCsrfToken
       };
 
       expect(fetchMock.calls()).to.have.lengthOf(1);

--- a/scripts/cherryPick.js
+++ b/scripts/cherryPick.js
@@ -106,12 +106,12 @@ async function cherryPickCommits(){
     try{
       let {stdout, stderr} = await exec(`git cherry-pick ${arrSHA[i]}`);
     } catch (err) {
-      await exec(`git cherry-pick --abort`);
       console.error(`Cannot Pick the Commit:${arrSHA[i]} to ${arrBranch[i]}, error :${err}`);
+      await labelCommit(arrURL[i], `need to pick manually ${arrBranch[i]}`);
+      await postComment(arrURL[i], arrUser[i], arrBranch[i], ${err});
+      await exec(`git cherry-pick --abort`);
       await exec(`git checkout master`);
       await exec(`git branch -D ${branchName}`);
-      await labelCommit(arrURL[i], `need to pick manually ${arrBranch[i]}`);
-      await postComment(arrURL[i], arrUser[i], arrBranch[i]);
       continue;
     }
     await exec(`git push origin HEAD:${branchName}`);
@@ -135,7 +135,7 @@ async function labelCommit(url, label){
   await axios.post(issueURL, {"labels":[label]}, options);
 }
 
-async function postComment(url, userName, branch){
+async function postComment(url, userName, branch, message){
   let issueURL = url.replace("pulls", "issues") + "/comments";
   const options = {
     headers:{
@@ -144,7 +144,7 @@ async function postComment(url, userName, branch){
     }
   };
 
-  await axios.post(issueURL, {"body":`Hi ${userName} , this commit cannot be picked to ${branch} by this bot, can you take a look and pick it manually?`}, options);
+  await axios.post(issueURL, {"body":`Hi ${userName} , this commit cannot be picked to ${branch} by this bot, can you take a look and pick it manually?\n Error Message: ${message}`}, options);
 }
 
 


### PR DESCRIPTION
The [Vaadin security helper](https://github.com/vaadin/spring/blob/master/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurityConfigurerAdapter.java) now has a request cache by default, which means that if a user tries to access an authentication protected view, the request will be saved and has it as a `redirectUrl` in the response. 
The logic in the `login()` helper didn't take this request cache into account.

Part of #10357, which fixes the bug.