### PR TITLE
fix: Accept newer framework managed versions

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -425,7 +425,7 @@ public class TaskRunNpmInstall implements FallibleCommand {
                 String stdoutLine;
                 while ((stdoutLine = reader.readLine()) != null) {
                     packageUpdater.log().debug(stdoutLine);
-                    toolOutput.append(stdoutLine);
+                    toolOutput.append(stdoutLine).append(System.lineSeparator());
                 }
             }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonFilter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonFilter.java
@@ -86,14 +86,7 @@ class VersionsJsonFilter {
      */
     private JsonObject collectUserManagedDependencies(JsonObject packageJson) {
         JsonObject json = Json.createObject();
-        JsonObject vaadinDep;
-        if (packageJson.hasKey(VAADIN_DEP_KEY) && packageJson
-                .getObject(VAADIN_DEP_KEY).hasKey(dependenciesKey)) {
-            vaadinDep = packageJson.getObject(VAADIN_DEP_KEY)
-                    .getObject(dependenciesKey);
-        } else {
-            vaadinDep = Json.createObject();
-        }
+        JsonObject vaadinDep = collectFrameworkVersions(packageJson);
 
         if (packageJson.hasKey(dependenciesKey)) {
             JsonObject dependencies = packageJson.getObject(dependenciesKey);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonFilter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonFilter.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.server.frontend;
 
+import org.slf4j.LoggerFactory;
+
 import elemental.json.Json;
 import elemental.json.JsonObject;
 
@@ -33,6 +35,8 @@ class VersionsJsonFilter {
 
     private final String dependenciesKey;
 
+    private final String OLDER_VERSION_WARNING = "Using user pinned version '{}' of '{}' which is older than the current platform version '{}'";
+
     VersionsJsonFilter(JsonObject packageJson, String dependenciesKey) {
         this.dependenciesKey = dependenciesKey;
         userManagedDependencies = collectUserManagedDependencies(packageJson);
@@ -49,6 +53,13 @@ class VersionsJsonFilter {
         JsonObject json = Json.createObject();
         for (String key : versions.keys()) {
             if (userManagedDependencies.hasKey(key)) {
+                if (isNewer(versions.getString(key),
+                        userManagedDependencies.getString(key))) {
+                    LoggerFactory.getLogger("Versions").warn(
+                            OLDER_VERSION_WARNING,
+                            userManagedDependencies.getString(key), key,
+                            versions.getString(key));
+                }
                 json.put(key, userManagedDependencies.getString(key));
             } else if (vaadinVersions.hasKey(key) && isNewer(
                     vaadinVersions.getString(key), versions.getString(key))) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -598,7 +598,7 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
     }
 
     @Test
-    public void runPnpmInstall_vaadinVersionNewerThanPinned_installedOverlayVersionIsNotSpecifiedByPlatform()
+    public void runPnpmInstall_frameworkCollectedVersionNewerThanPinned_installedOverlayVersionIsNotSpecifiedByPlatform()
             throws IOException, ExecutionFailedException {
         File packageJson = new File(getNodeUpdater().npmFolder, PACKAGE_JSON);
         packageJson.createNewFile();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -590,8 +590,7 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         File overlayPackageJson = new File(getNodeUpdater().nodeModulesFolder,
                 "@vaadin/vaadin-overlay/package.json");
 
-        // The resulting version should be the one specified via platform
-        // versions file
+        // The resulting version should be the one specified by the user
         JsonObject overlayPackage = Json.parse(FileUtils
                 .readFileToString(overlayPackageJson, StandardCharsets.UTF_8));
         Assert.assertEquals(customOverlayVersion,
@@ -638,8 +637,8 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         File overlayPackageJson = new File(getNodeUpdater().nodeModulesFolder,
                 "@vaadin/vaadin-overlay/package.json");
 
-        // The resulting version should be the one specified via platform
-        // versions file
+        // The resulting version should be the one collected from the
+        // annotations in the project
         JsonObject overlayPackage = Json.parse(FileUtils
                 .readFileToString(overlayPackageJson, StandardCharsets.UTF_8));
         Assert.assertEquals(customOverlayVersion,

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -19,7 +19,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.CoreMatchers;
@@ -556,6 +555,95 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         String content = FileUtils.readFileToString(newNpmRcFile,
                 StandardCharsets.UTF_8);
         Assert.assertEquals(originalContent, content);
+    }
+
+    @Test
+    public void runPnpmInstall_userVersionNewerThanPinned_installedOverlayVersionIsNotSpecifiedByPlatform()
+            throws IOException, ExecutionFailedException {
+        File packageJson = new File(getNodeUpdater().npmFolder, PACKAGE_JSON);
+        packageJson.createNewFile();
+
+        // Write package json file
+        final String customOverlayVersion = "3.3.0";
+        // @formatter:off
+        final String packageJsonContent =
+            "{"
+                + "\"dependencies\": {"
+                    + "\"@vaadin/vaadin-dialog\": \"2.3.0\","
+                    + "\"@vaadin/vaadin-overlay\": \"" + customOverlayVersion + "\""
+                + "}"
+            + "}";
+        // @formatter:on
+        FileUtils.write(packageJson, packageJsonContent,
+                StandardCharsets.UTF_8);
+
+        final VersionsJsonFilter versionsJsonFilter = new VersionsJsonFilter(
+                Json.parse(packageJsonContent), NodeUpdater.DEPENDENCIES);
+        // Platform defines a pinned version
+        TaskRunNpmInstall task = createTask(
+                versionsJsonFilter.getFilteredVersions(
+                        Json.parse("{ \"@vaadin/vaadin-overlay\":\""
+                                + PINNED_VERSION + "\"}"))
+                        .toJson());
+        task.execute();
+
+        File overlayPackageJson = new File(getNodeUpdater().nodeModulesFolder,
+                "@vaadin/vaadin-overlay/package.json");
+
+        // The resulting version should be the one specified via platform
+        // versions file
+        JsonObject overlayPackage = Json.parse(FileUtils
+                .readFileToString(overlayPackageJson, StandardCharsets.UTF_8));
+        Assert.assertEquals(customOverlayVersion,
+                overlayPackage.getString("version"));
+    }
+
+    @Test
+    public void runPnpmInstall_vaadinVersionNewerThanPinned_installedOverlayVersionIsNotSpecifiedByPlatform()
+            throws IOException, ExecutionFailedException {
+        File packageJson = new File(getNodeUpdater().npmFolder, PACKAGE_JSON);
+        packageJson.createNewFile();
+
+        // Write package json file
+        final String customOverlayVersion = "3.3.0";
+        // @formatter:off
+        final String packageJsonContent =
+            "{"
+                + "\"vaadin\": {"
+                    + "\"dependencies\": {"
+                        + "\"@vaadin/vaadin-dialog\": \"2.3.0\","
+                        + "\"@vaadin/vaadin-overlay\": \"" + customOverlayVersion + "\""
+                    + "}"
+                + "},"
+                + "\"dependencies\": {"
+                    + "\"@vaadin/vaadin-dialog\": \"2.3.0\","
+                    + "\"@vaadin/vaadin-overlay\": \"" + customOverlayVersion + "\""
+                + "}"
+            + "}";
+        // @formatter:on
+
+        FileUtils.write(packageJson, packageJsonContent,
+                StandardCharsets.UTF_8);
+
+        final VersionsJsonFilter versionsJsonFilter = new VersionsJsonFilter(
+                Json.parse(packageJsonContent), NodeUpdater.DEPENDENCIES);
+        // Platform defines a pinned version
+        TaskRunNpmInstall task = createTask(
+                versionsJsonFilter.getFilteredVersions(
+                        Json.parse("{ \"@vaadin/vaadin-overlay\":\""
+                                + PINNED_VERSION + "\"}"))
+                        .toJson());
+        task.execute();
+
+        File overlayPackageJson = new File(getNodeUpdater().nodeModulesFolder,
+                "@vaadin/vaadin-overlay/package.json");
+
+        // The resulting version should be the one specified via platform
+        // versions file
+        JsonObject overlayPackage = Json.parse(FileUtils
+                .readFileToString(overlayPackageJson, StandardCharsets.UTF_8));
+        Assert.assertEquals(customOverlayVersion,
+                overlayPackage.getString("version"));
     }
 
     @Override

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/VersionsJsonFilterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/VersionsJsonFilterTest.java
@@ -162,11 +162,15 @@ public class VersionsJsonFilterTest {
         Assert.assertTrue(filteredJson.hasKey("@vaadin/vaadin-upload"));
         Assert.assertTrue(filteredJson.hasKey("@polymer/iron-list"));
 
-        Assert.assertEquals("1.1.2",
-                filteredJson.getString("@vaadin/vaadin-progress-bar"));
-        Assert.assertEquals("4.2.2",
+        Assert.assertEquals(
+                "'progress-bar' should be the same in package and versions",
+                "1.1.2", filteredJson.getString("@vaadin/vaadin-progress-bar"));
+        Assert.assertEquals(
+                "'upload' should be the same in package and versions", "4.2.2",
                 filteredJson.getString("@vaadin/vaadin-upload"));
-        Assert.assertEquals("2.0.19",
-                filteredJson.getString("@polymer/iron-list"));
+        Assert.assertEquals("'enforced' version should come from platform",
+                "1.5.0", filteredJson.getString("enforced"));
+        Assert.assertEquals("'iron-list' should be framework defined version",
+                "3.0.2", filteredJson.getString("@polymer/iron-list"));
     }
 }

--- a/flow-server/src/test/resources/versions/package.json
+++ b/flow-server/src/test/resources/versions/package.json
@@ -5,6 +5,7 @@
     "dependencies": {
       "@vaadin/vaadin-upload": "4.2.2",
       "@vaadin/vaadin-progress-bar": "1.1.2",
+      "enforced": "1.2.0",
       "@polymer/iron-list": "3.0.2"
     },
     "devDependencies": {
@@ -17,6 +18,7 @@
   "dependencies": {
     "@polymer/iron-list": "3.0.2",
     "@vaadin/vaadin-progress-bar": "1.1.2",
+    "enforced": "1.2.0",
     "@vaadin/vaadin-upload": "4.2.2"
   },
   "devDependencies": {

--- a/flow-server/src/test/resources/versions/versions.json
+++ b/flow-server/src/test/resources/versions/versions.json
@@ -2,5 +2,6 @@
   "@vaadin/vaadin-progress-bar": "1.1.2",
   "@vaadin/vaadin-upload":  "4.2.2",
   "@polymer/iron-list":  "2.0.19",
+  "enforced": "1.5.0",
   "platform": "foo"
 }


### PR DESCRIPTION
Any framework managed version that is newer
than the version in platform versions should be
left as is as the version probably is from an updated
annotation.

Fixes #9793