### PR TITLE
fix: windows drive can be upper or lower case

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -360,7 +360,7 @@
             <plugin>
                 <groupId>org.commonjava.maven.plugins</groupId>
                 <artifactId>directory-maven-plugin</artifactId>
-                <version>0.1</version>
+                <version>0.3.1</version>
                 <executions>
                     <execution>
                         <id>set-root-dir-for-common-lifecycle</id>


### PR DESCRIPTION
Update the directory-maven-plugin to not
fail the build on windows when the CWD
drive letter is lower case.

Closes #8959