### PR TITLE
fix: Exclude theme name from plugin parameters

### DIFF
--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -272,7 +272,7 @@ module.exports = {
       dirs: [path.resolve(__dirname, 'frontend', 'themes', themeName, 'components'),
         path.resolve(__dirname, 'src', 'main', 'resources', 'META-INF', 'resources', 'themes', themeName, 'components'),
         path.resolve(__dirname, 'src', 'main', 'resources', 'static', 'themes', themeName, 'components')]
-    }), new ThemeLiveReloadPlugin(themeName, processThemeResourcesCallback)] : []),
+    }), new ThemeLiveReloadPlugin(processThemeResourcesCallback)] : []),
 
     new StatsPlugin({
       devMode: devMode,


### PR DESCRIPTION
Removes overlooked unused themeName parameter for theme live reload plugin.

Related-to: https://github.com/vaadin/flow/issues/10451