### PR TITLE
fix: include redirectUrl in the return value of login()

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/Authentication.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/Authentication.ts
@@ -55,7 +55,7 @@ export async function login(username: string, password: string, options?: LoginO
           result = {
             error: false,
             token: vaadinCsrfToken,
-            redirectUrl: response.url,
+            redirectUrl: response.url
           };
         }
       }

--- a/flow-client/src/test/frontend/AuthenticationTests.ts
+++ b/flow-client/src/test/frontend/AuthenticationTests.ts
@@ -71,13 +71,13 @@ describe('Authentication', () => {
     it('should return a CSRF token on valid credentials', async () => {
       fetchMock.post('/login', {
         body: happyCaseResponseText,
-        redirectUrl: '/'
+        redirectUrl: 'localhost:8080/'
       }, { headers });
       const result = await login('valid-username', 'valid-password');
       const expectedResult = {
         error: false,
         token: vaadinCsrfToken,
-        redirectUrl: '/'
+        redirectUrl: 'localhost:8080/'
       };
 
       expect(fetchMock.calls()).to.have.lengthOf(1);
@@ -113,13 +113,13 @@ describe('Authentication', () => {
         body: happyCaseResponseText,
         // mock the unthenticated attempt, which would be 
         // saved by the default request cache
-        redirectUrl: '/protected-view'
+        redirectUrl: 'localhost:8080/protected-view'
       }, { headers });
       const result = await login('valid-username', 'valid-password');
       const expectedResult = {
         error: false,
         token: vaadinCsrfToken,
-        redirectUrl: '/protected-view'
+        redirectUrl: 'localhost:8080/protected-view'
       };
 
       expect(fetchMock.calls()).to.have.lengthOf(1);

--- a/flow-client/src/test/frontend/AuthenticationTests.ts
+++ b/flow-client/src/test/frontend/AuthenticationTests.ts
@@ -76,9 +76,8 @@ describe('Authentication', () => {
       const result = await login('valid-username', 'valid-password');
       const expectedResult = {
         error: false,
-        errorTitle: '',
-        errorMessage: '',
-        token: vaadinCsrfToken
+        token: vaadinCsrfToken,
+        redirectUrl: '/'
       };
 
       expect(fetchMock.calls()).to.have.lengthOf(1);
@@ -100,6 +99,27 @@ describe('Authentication', () => {
         error: true,
         errorTitle: 'Error',
         errorMessage: 'Something went wrong when trying to login.'
+      };
+
+      expect(fetchMock.calls()).to.have.lengthOf(1);
+      expect(result).to.deep.equal(expectedResult);
+    })
+
+    it('should redirect based on request cache after login', async () => {
+      // An unthenticated request attempt would be captured by the default
+      // request cache, so after login, it should redirect the user to that 
+      // request
+      fetchMock.post('/login', {
+        body: happyCaseResponseText,
+        // mock the unthenticated attempt, which would be 
+        // saved by the default request cache
+        redirectUrl: '/protected-view'
+      }, { headers });
+      const result = await login('valid-username', 'valid-password');
+      const expectedResult = {
+        error: false,
+        token: vaadinCsrfToken,
+        redirectUrl: '/protected-view'
       };
 
       expect(fetchMock.calls()).to.have.lengthOf(1);


### PR DESCRIPTION
It includes the `redirectUrl` in the return value of the `login()` helper. So that if the user has defined a request cache or a defaultSuccessUrl in the Spring Security configuration, user can use the `redirectUrl` in `LoginResult` to redirect instead of maintaining a `returnUrl` manually as in the current doc, which also doesn't work when a request cache or a defaultSuccessUrl is configured. 

Part of https://github.com/vaadin/flow/issues/10357