### PR TITLE
fix: add missing plugin property

### DIFF
--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -102,6 +102,7 @@ if (devMode) {
   themeName = extractThemeName(flowFrontendThemesFolder);
 }
 const themeOptions = {
+  devMode: devMode,
   // The following matches target/frontend/themes/theme-generated.js
   // and for theme in JAR that is copied to target/frontend/themes/
   themeResourceFolder: flowFrontendThemesFolder,


### PR DESCRIPTION
Add the devMode plugin property that
is missing from the themeOptions

Closes #10621