### PR TITLE
chore: Move theme live reload tests to it's own profile

### DIFF
--- a/flow-test-util/src/main/java/com/vaadin/flow/testcategory/ThemeLiveReloadTests.java
+++ b/flow-test-util/src/main/java/com/vaadin/flow/testcategory/ThemeLiveReloadTests.java
@@ -1,0 +1,9 @@
+package com.vaadin.flow.testcategory;
+
+/**
+ * Theme Live Reload tests should be annotated with
+ * {@code Category(ThemeLiveReloadTests.class} so they can be excluded from
+ * the build and added to a separate profile.
+ */
+public interface ThemeLiveReloadTests extends TestCategory {
+}

--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -112,6 +112,7 @@
                         </webdriver.chrome.driver>
                     </systemPropertyVariables>
                     <excludedGroups>${test.excludegroup}</excludedGroups>
+                    <groups>${test.includegroup}</groups>
                     <excludes>
                         <exclude>**/*$*</exclude>
                         <exclude>${exclude.it.tests}</exclude>
@@ -309,6 +310,14 @@
             </modules>
         </profile>
         <profile>
+            <id>theme-live-reload-tests</id>
+            <properties>
+                <test.includegroup>
+                    com.vaadin.flow.testcategory.ThemeLiveReloadTests
+                </test.includegroup>
+            </properties>
+        </profile>
+        <profile>
             <id>run-tests</id>
             <activation>
                 <property>
@@ -401,6 +410,9 @@
             <id>validation</id>
             <properties>
                 <maven.javadoc.skip>true</maven.javadoc.skip>
+                <test.excludegroup>
+                    com.vaadin.flow.testcategory.ThemeLiveReloadTests
+                </test.excludegroup>
             </properties>
         </profile>
         <profile>
@@ -410,7 +422,8 @@
             </activation>
             <properties>
                 <test.excludegroup>com.vaadin.flow.testcategory.ScreenshotTests,
-                    com.vaadin.flow.testcategory.PushTests
+                    com.vaadin.flow.testcategory.PushTests,
+                    com.vaadin.flow.testcategory.ThemeLiveReloadTests
                 </test.excludegroup>
             </properties>
         </profile>
@@ -434,7 +447,8 @@
             </activation>
             <properties>
                 <test.excludegroup>com.vaadin.flow.testcategory.IgnoreIE11,
-                    com.vaadin.flow.testcategory.PushTests
+                    com.vaadin.flow.testcategory.PushTests,
+                    com.vaadin.flow.testcategory.ThemeLiveReloadTests
                 </test.excludegroup>
             </properties>
         </profile>

--- a/flow-tests/test-application-theme/test-theme-component-live-reload/src/test/java/com/vaadin/flow/uitest/ui/ComponentThemeLiveReloadIT.java
+++ b/flow-tests/test-application-theme/test-theme-component-live-reload/src/test/java/com/vaadin/flow/uitest/ui/ComponentThemeLiveReloadIT.java
@@ -26,6 +26,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.StaleElementReferenceException;
@@ -33,12 +34,14 @@ import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 
 import com.vaadin.flow.component.html.testbench.DivElement;
+import com.vaadin.flow.testcategory.ThemeLiveReloadTests;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
 import static com.vaadin.flow.uitest.ui.ComponentThemeLiveReloadView.ATTACH_IDENTIFIER;
 import static com.vaadin.flow.uitest.ui.ComponentThemeLiveReloadView.THEMED_COMPONENT_ID;
 
+@Category(ThemeLiveReloadTests.class)
 @NotThreadSafe
 public class ComponentThemeLiveReloadIT extends ChromeBrowserTest {
 

--- a/flow-tests/test-application-theme/test-theme-live-reload/src/test/java/com/vaadin/flow/uitest/ui/ThemeLiveReloadIT.java
+++ b/flow-tests/test-application-theme/test-theme-live-reload/src/test/java/com/vaadin/flow/uitest/ui/ThemeLiveReloadIT.java
@@ -26,12 +26,15 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 
+import com.vaadin.flow.testcategory.ThemeLiveReloadTests;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
+@Category(ThemeLiveReloadTests.class)
 @NotThreadSafe
 public class ThemeLiveReloadIT extends ChromeBrowserTest {
 


### PR DESCRIPTION
Adds a new category for theme live reload tests and skips them by default.
Creates a new profile for running only those tests separately.