### PR TITLE
chore: Revert test categories

### DIFF
--- a/flow-test-util/src/main/java/com/vaadin/flow/testcategory/ThemeLiveReloadTests.java
+++ b/flow-test-util/src/main/java/com/vaadin/flow/testcategory/ThemeLiveReloadTests.java
@@ -1,9 +1,0 @@
-package com.vaadin.flow.testcategory;
-
-/**
- * Theme Live Reload tests should be annotated with
- * {@code Category(ThemeLiveReloadTests.class} so they can be excluded from
- * the build and added to a separate profile.
- */
-public interface ThemeLiveReloadTests extends TestCategory {
-}

--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -112,7 +112,6 @@
                         </webdriver.chrome.driver>
                     </systemPropertyVariables>
                     <excludedGroups>${test.excludegroup}</excludedGroups>
-                    <groups>${test.includegroup}</groups>
                     <excludes>
                         <exclude>**/*$*</exclude>
                         <exclude>${exclude.it.tests}</exclude>
@@ -310,14 +309,6 @@
             </modules>
         </profile>
         <profile>
-            <id>theme-live-reload-tests</id>
-            <properties>
-                <test.includegroup>
-                    com.vaadin.flow.testcategory.ThemeLiveReloadTests
-                </test.includegroup>
-            </properties>
-        </profile>
-        <profile>
             <id>run-tests</id>
             <activation>
                 <property>
@@ -413,9 +404,6 @@
             <id>validation</id>
             <properties>
                 <maven.javadoc.skip>true</maven.javadoc.skip>
-                <test.excludegroup>
-                    com.vaadin.flow.testcategory.ThemeLiveReloadTests
-                </test.excludegroup>
             </properties>
         </profile>
         <profile>
@@ -425,8 +413,7 @@
             </activation>
             <properties>
                 <test.excludegroup>com.vaadin.flow.testcategory.ScreenshotTests,
-                    com.vaadin.flow.testcategory.PushTests,
-                    com.vaadin.flow.testcategory.ThemeLiveReloadTests
+                    com.vaadin.flow.testcategory.PushTests
                 </test.excludegroup>
             </properties>
         </profile>
@@ -450,8 +437,7 @@
             </activation>
             <properties>
                 <test.excludegroup>com.vaadin.flow.testcategory.IgnoreIE11,
-                    com.vaadin.flow.testcategory.PushTests,
-                    com.vaadin.flow.testcategory.ThemeLiveReloadTests
+                    com.vaadin.flow.testcategory.PushTests
                 </test.excludegroup>
             </properties>
         </profile>

--- a/flow-tests/test-application-theme/test-theme-component-live-reload/src/test/java/com/vaadin/flow/uitest/ui/ComponentThemeLiveReloadIT.java
+++ b/flow-tests/test-application-theme/test-theme-component-live-reload/src/test/java/com/vaadin/flow/uitest/ui/ComponentThemeLiveReloadIT.java
@@ -26,7 +26,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.StaleElementReferenceException;
@@ -34,14 +33,12 @@ import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 
 import com.vaadin.flow.component.html.testbench.DivElement;
-import com.vaadin.flow.testcategory.ThemeLiveReloadTests;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
 import static com.vaadin.flow.uitest.ui.ComponentThemeLiveReloadView.ATTACH_IDENTIFIER;
 import static com.vaadin.flow.uitest.ui.ComponentThemeLiveReloadView.THEMED_COMPONENT_ID;
 
-@Category(ThemeLiveReloadTests.class)
 @NotThreadSafe
 public class ComponentThemeLiveReloadIT extends ChromeBrowserTest {
 

--- a/flow-tests/test-application-theme/test-theme-live-reload/src/test/java/com/vaadin/flow/uitest/ui/ThemeLiveReloadIT.java
+++ b/flow-tests/test-application-theme/test-theme-live-reload/src/test/java/com/vaadin/flow/uitest/ui/ThemeLiveReloadIT.java
@@ -26,15 +26,12 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.openqa.selenium.By;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.flow.testcategory.ThemeLiveReloadTests;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
-@Category(ThemeLiveReloadTests.class)
 @NotThreadSafe
 public class ThemeLiveReloadIT extends ChromeBrowserTest {
 

--- a/pom.xml
+++ b/pom.xml
@@ -605,17 +605,6 @@
     </build>
     <profiles>
         <profile>
-            <id>default</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-                <test.excludegroup>
-                    com.vaadin.flow.testcategory.ThemeLiveReloadTests
-                </test.excludegroup>
-            </properties>
-        </profile>
-        <profile>
             <id>validation</id>
             <properties>
                 <maven.javadoc.skip>false</maven.javadoc.skip>


### PR DESCRIPTION
Reverts adding overcomplicated test categories approach, because test reordering can be done easily in `run-tests` profile.

`run-tests` was changed here https://github.com/vaadin/flow/pull/10629