### PR TITLE
chore: deploy flow-buildtools in order to be used in other projects

### DIFF
--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -8,11 +8,10 @@
         <version>7.0-SNAPSHOT</version>
     </parent>
     <artifactId>flow-buildtools</artifactId>
-    <name>vaadin-buildhelpers</name>
+    <name>Flow Build Tools</name>
     <packaging>jar</packaging>
 
     <url>https://vaadin.com/</url>
-    <description>Flow build helpers</description>
 
     <build>
         <resources>
@@ -23,16 +22,6 @@
                 <targetPath>eclipse</targetPath>
             </resource>
         </resources>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <version>${maven.deploy.plugin.version}</version>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-        </plugins>
 
         <!-- Skip sources jar -->
         <pluginManagement>


### PR DESCRIPTION
We need this artefact in other projects that follow flow formatting rules like in flow-components