### PR TITLE
fix: flow-client build on Windows

### DIFF
--- a/flow-client/package.json
+++ b/flow-client/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/vaadin/flow/issues"
   },
   "scripts": {
-    "lint": "eslint 'src/main/frontend'",
+    "lint": "eslint \"src/main/frontend\"",
     "client": "node scripts/client.js",
     "version": "node scripts/version.js",
     "webpack": "webpack --config=webpack.tests.config.js",


### PR DESCRIPTION
The build was broken on Windows due to using single quotes instead of double quotes to wrap a path in an npm script. The problem was introduced by #10765.