### PR TITLE
fix: Warn to delete component CSS with theme generated in one run

### DIFF
--- a/flow-tests/test-application-theme/test-theme-component-live-reload/frontend/themes/app-theme/components/empty
+++ b/flow-tests/test-application-theme/test-theme-component-live-reload/frontend/themes/app-theme/components/empty
@@ -1,0 +1,1 @@
+Empty file here to ensure the components folder is created


### PR DESCRIPTION
Workaround for #9948. Warn devs to delete component CSS file along with theme generated file in one run to avoid webpack compilation errors and application restart.

Related-to: #9948

(cherry picked from commit e33ec10fd591251fae6c26fcd05b358a1da053e4)