### PR TITLE
feat: Backport 'Inject Lumo CSS also into shadow roots' to 2.6

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -61,7 +61,7 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.IMPORTS_NAME;
 public class TaskUpdateImports extends NodeUpdater {
 
     private static final String THEME_PREPARE = "const div = document.createElement('div');";
-    private static final String THEME_LINE_TPL = "div.innerHTML = '%s';%n"
+    private static final String THEME_LINE_TPL = "%sdiv.innerHTML = '%s';%n"
             + "document.head.insertBefore(div.firstElementChild, document.head.firstChild);";
     private static final String THEME_VARIANT_TPL = "document.documentElement.setAttribute('%s', '%s');";
     // Trim and remove new lines.
@@ -138,19 +138,26 @@ public class TaskUpdateImports extends NodeUpdater {
             Collection<String> lines = new ArrayList<>();
             AbstractTheme theme = getTheme();
             ThemeDefinition themeDef = getThemeDefinition();
+            final boolean hasApplicationTheme =
+                    themeDef != null && !"".equals(themeDef.getName());
 
-            if (themeDef != null && !"".equals(themeDef.getName())) {
+            if (hasApplicationTheme) {
                 // If we define a theme name we need to import theme/theme-generated.js
                 lines.add("import {applyTheme} from 'themes/theme-generated.js';");
                 lines.add("applyTheme(document);");
             }
 
             if (theme != null) {
+                // There is no application theme in use, write theme includes here.
+                // Otherwise they are written by the theme
                 if (!theme.getHeaderInlineContents().isEmpty()) {
                     lines.add(THEME_PREPARE);
+                    if (hasApplicationTheme) {
+                        lines.add("// Handled in the application theme");
+                    }
                     theme.getHeaderInlineContents()
                             .forEach(html -> addLines(lines,
-                                    String.format(THEME_LINE_TPL, NEW_LINE_TRIM
+                                    String.format(THEME_LINE_TPL, hasApplicationTheme ? "// ":"", NEW_LINE_TRIM
                                             .matcher(html).replaceAll(""))));
                 }
                 if (themeDef != null) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -60,9 +60,9 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.IMPORTS_NAME;
  */
 public class TaskUpdateImports extends NodeUpdater {
 
-    private static final String THEME_PREPARE = "const div = document.createElement('div');";
+    private static final String THEME_PREPARE = "%sconst div = document.createElement('div');";
     private static final String THEME_LINE_TPL = "%sdiv.innerHTML = '%s';%n"
-            + "document.head.insertBefore(div.firstElementChild, document.head.firstChild);";
+            + "%sdocument.head.insertBefore(div.firstElementChild, document.head.firstChild);";
     private static final String THEME_VARIANT_TPL = "document.documentElement.setAttribute('%s', '%s');";
     // Trim and remove new lines.
     private static final Pattern NEW_LINE_TRIM = Pattern
@@ -151,14 +151,15 @@ public class TaskUpdateImports extends NodeUpdater {
                 // There is no application theme in use, write theme includes here.
                 // Otherwise they are written by the theme
                 if (!theme.getHeaderInlineContents().isEmpty()) {
-                    lines.add(THEME_PREPARE);
                     if (hasApplicationTheme) {
                         lines.add("// Handled in the application theme");
                     }
+                    String commentToken = hasApplicationTheme ? "// " : "";
+                    lines.add(String.format(THEME_PREPARE, commentToken));
                     theme.getHeaderInlineContents()
                             .forEach(html -> addLines(lines,
-                                    String.format(THEME_LINE_TPL, hasApplicationTheme ? "// ":"", NEW_LINE_TRIM
-                                            .matcher(html).replaceAll(""))));
+                                    String.format(THEME_LINE_TPL, commentToken, NEW_LINE_TRIM
+                                            .matcher(html).replaceAll(""), commentToken)));
                 }
                 if (themeDef != null) {
                     theme.getHtmlAttributes(themeDef.getVariant()).forEach(

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -60,9 +60,9 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.IMPORTS_NAME;
  */
 public class TaskUpdateImports extends NodeUpdater {
 
-    private static final String THEME_PREPARE = "%sconst div = document.createElement('div');";
-    private static final String THEME_LINE_TPL = "%sdiv.innerHTML = '%s';%n"
-            + "%sdocument.head.insertBefore(div.firstElementChild, document.head.firstChild);";
+    private static final String THEME_PREPARE = "const div = document.createElement('div');";
+    private static final String THEME_LINE_TPL = "div.innerHTML = '%s';%n"
+            + "document.head.insertBefore(div.firstElementChild, document.head.firstChild);";
     private static final String THEME_VARIANT_TPL = "document.documentElement.setAttribute('%s', '%s');";
     // Trim and remove new lines.
     private static final Pattern NEW_LINE_TRIM = Pattern
@@ -149,17 +149,13 @@ public class TaskUpdateImports extends NodeUpdater {
 
             if (theme != null) {
                 // There is no application theme in use, write theme includes here.
-                // Otherwise they are written by the theme
-                if (!theme.getHeaderInlineContents().isEmpty()) {
-                    if (hasApplicationTheme) {
-                        lines.add("// Handled in the application theme");
-                    }
-                    String commentToken = hasApplicationTheme ? "// " : "";
-                    lines.add(String.format(THEME_PREPARE, commentToken));
+                // Otherwise they are written by the application theme
+                if (!theme.getHeaderInlineContents().isEmpty() && !hasApplicationTheme) {
+                    lines.add(THEME_PREPARE);
                     theme.getHeaderInlineContents()
                             .forEach(html -> addLines(lines,
-                                    String.format(THEME_LINE_TPL, commentToken, NEW_LINE_TRIM
-                                            .matcher(html).replaceAll(""), commentToken)));
+                                    String.format(THEME_LINE_TPL, NEW_LINE_TRIM
+                                            .matcher(html).replaceAll(""))));
                 }
                 if (themeDef != null) {
                     theme.getHtmlAttributes(themeDef.getVariant()).forEach(

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
@@ -60,7 +60,6 @@ export const injectGlobalCss = (css, target, first) => {
 };
 `;
 
-// This is copied from flow-generated-import
 const addCssBlockMethod = `
 const addCssBlock = function (block, before = false) {
   const tpl = document.createElement("template");

--- a/flow-tests/test-application-theme/reusable-theme/src/main/resources/META-INF/resources/themes/reusable-theme/theme.json
+++ b/flow-tests/test-application-theme/reusable-theme/src/main/resources/META-INF/resources/themes/reusable-theme/theme.json
@@ -4,5 +4,6 @@
     "@fortawesome/fontawesome-free": {
       "svgs/regular/**": "fortawesome/icons"
     }
-  }
+  },
+  "lumoImports": ["color","typography","badge"]
 }

--- a/flow-tests/test-application-theme/test-theme-reusable/src/main/java/com/vaadin/flow/uitest/ui/theme/ReusableThemeView.java
+++ b/flow-tests/test-application-theme/test-theme-reusable/src/main/java/com/vaadin/flow/uitest/ui/theme/ReusableThemeView.java
@@ -66,5 +66,11 @@ public class ReusableThemeView extends Div {
 
         add(new Div());
         add(new MyLitField().withId(MY_LIT_ID));
+
+        Div badge = new Div();
+        badge.setText("This is a badge");
+        badge.getElement().setAttribute("theme", "badge");
+
+        add(badge);
     }
 }

--- a/flow-tests/test-application-theme/test-theme-reusable/src/test/java/com/vaadin/flow/uitest/ui/theme/ReusableThemeIT.java
+++ b/flow-tests/test-application-theme/test-theme-reusable/src/test/java/com/vaadin/flow/uitest/ui/theme/ReusableThemeIT.java
@@ -21,6 +21,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebElement;
 
+import com.vaadin.flow.component.html.testbench.DivElement;
 import com.vaadin.flow.component.html.testbench.ImageElement;
 import com.vaadin.flow.component.html.testbench.SpanElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
@@ -162,6 +163,16 @@ public class ReusableThemeIT extends ChromeBrowserTest {
         getDriver().get(getRootURL() + "/octopuss.jpg");
         Assert.assertFalse("root resource should be served",
             driver.getPageSource().contains("HTTP ERROR 404 Not Found"));
+    }
+
+    @Test
+    public void lumoBadgeIsRenderedCorrectly() {
+        open();
+        checkLogsForErrors();
+
+        DivElement badge = $(DivElement.class).attribute("theme", "badge").first();
+        String badgeBackgroundColor = badge.getCssValue("backgroundColor");
+        Assert.assertEquals("rgba(22, 118, 243, 0.1)", badgeBackgroundColor);
     }
 
     @Override


### PR DESCRIPTION
Adds support for
"lumoImports": ["color", "typography", "badge", ... ]
to theme.json to override the default ["color", "typography"]

If you do not have an application theme specified, Lumo imports are injected by generated-flow-imports.js like before.
If you have an application theme, Lumo imports are injected as part of applying the theme.

In both cases, Lumo imports are added to the beginning of <head> so they are considered before any other styles, such as @CssImport:ed stylesheets. This allows overriding Lumo CSS rules no matter how you add the CSS.

Related-to #9767 #9983