### PR TITLE
feat!: use regular string enum instead of a const enum

### DIFF
--- a/fusion-endpoint/src/main/resources/com/vaadin/flow/server/connect/generator/EntityTemplate.mustache
+++ b/fusion-endpoint/src/main/resources/com/vaadin/flow/server/connect/generator/EntityTemplate.mustache
@@ -17,7 +17,7 @@ import {{~#importAs}} {{importAs}}{{/importAs}}{{~^importAs}} {{className}}{{/im
  }}{{/vendorExtensions.x-vaadin-file-path}}
  */
 {{#if vendorExtensions.x-is-enum}}
-const enum {{{getClassNameFromImports classname ../../imports}}} {
+enum {{{getClassNameFromImports classname ../../imports}}} {
 {{#allowableValues.enumVars}}
   {{name}} = {{{value}}},
 {{/allowableValues.enumVars}}

--- a/fusion-endpoint/src/test/resources/com/vaadin/flow/server/connect/generator/endpoints/enumtype/expected-model-enumtype.EnumEndpoint.MyEnum.ts
+++ b/fusion-endpoint/src/test/resources/com/vaadin/flow/server/connect/generator/endpoints/enumtype/expected-model-enumtype.EnumEndpoint.MyEnum.ts
@@ -2,7 +2,7 @@
  * This module is generated from com.vaadin.flow.server.connect.generator.endpoints.enumtype.EnumEndpoint.MyEnum.
  * All changes to this file are overridden. Please consider to make changes in the corresponding Java file if necessary.
  */
-const enum MyEnum {
+enum MyEnum {
   ENUM1 = 'ENUM1',
   ENUM2 = 'ENUM2',
   ENUM_2 = 'ENUM_2',


### PR DESCRIPTION
Given a Java enum as
```java
pubic enum Environment {
  DEV, TEST, PROD
}
```
the generated Typescript source will be
```typescript
enum Environment {
  DEV = "DEV",
  TEST = "TEST",
  PROD = "PROD"
}
```
which translates to JavaScript in a following way:
```javascript
var Environment;

(function (Environment) {
  Environment["DEV"] = "DEV";
  Environment["TEST"] = "TEST";
  Environment["PROD"] = "PROD";
})(Environment || (Environment = {}));
```
So now it is possible to do any object action with the final `Environment` enum:
```javascript
Object.keys(Environment).forEach(enumValue => console.log(enumValue));
```

Resolves #8963