### PR TITLE
fix: log limitation of adding new styles while switching themes

### DIFF
--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-handle.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-handle.js
@@ -43,7 +43,6 @@ function processThemeResources(options, logger) {
   const themeName = extractThemeName(options.frontendGeneratedFolder);
   if (themeName) {
     if (!prevThemeName && !firstThemeName) {
-      prevThemeName = themeName;
       firstThemeName = themeName;
     } else if ((prevThemeName && prevThemeName !== themeName && firstThemeName !== themeName)
         || (!prevThemeName && firstThemeName !== themeName)) {

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-handle.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-handle.js
@@ -49,7 +49,7 @@ function processThemeResources(options, logger) {
       const warning = `Attention: Active theme is switched to '${themeName}'.`
       const description = `
       Note that adding new style sheet files to '/themes/${themeName}/components', 
-      may not be taken into effect until the next application is restart.
+      may not be taken into effect until the next application restart.
       Changes to existing style sheet files are being reloaded as before.`;
       logger.warn("*******************************************************************");
       logger.warn(warning);

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-handle.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-handle.js
@@ -46,6 +46,13 @@ function processThemeResources(options, logger) {
       firstThemeName = themeName;
     } else if ((prevThemeName && prevThemeName !== themeName && firstThemeName !== themeName)
         || (!prevThemeName && firstThemeName !== themeName)) {
+      // Warning message is shown to the developer when:
+      // 1. He is switching to any theme, which is differ from one being set up
+      // on application startup, by changing theme name in `@Theme()`
+      // 2. He removes or comments out `@Theme()` to see how the app
+      // looks like without theming, and then again brings `@Theme()` back
+      // with a themeName which is differ from one being set up on application
+      // startup.
       const warning = `Attention: Active theme is switched to '${themeName}'.`
       const description = `
       Note that adding new style sheet files to '/themes/${themeName}/components', 
@@ -60,6 +67,10 @@ function processThemeResources(options, logger) {
 
     findThemeFolderAndHandleTheme(themeName, options, logger);
   } else {
+    // This is needed in the situation that the user decides to comment or
+    // remove the @Theme(...) completely to see how the application looks
+    // without any theme. Then when the user brings back one of the themes,
+    // the previous theme should be undefined to enable us to detect the change.
     prevThemeName = undefined;
     logger.debug("Skipping Vaadin application theme handling.");
     logger.trace("Most likely no @Theme annotation for application or only themeClass used.");

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-handle.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-handle.js
@@ -50,7 +50,7 @@ function processThemeResources(options, logger) {
       const description = `
       Note that adding new style sheet files to '/themes/${themeName}/components', 
       may not be taken into effect until the next application restart.
-      Changes to existing style sheet files are being reloaded as before.`;
+      Changes to already existing style sheet files are being reloaded as before.`;
       logger.warn("*******************************************************************");
       logger.warn(warning);
       logger.warn(description);


### PR DESCRIPTION
## Description

If there are more than one theme available in
themes folder, user can switch between them in
development mode by changing the name of the
theme in `@Theme`. As having a watch for adding
new styles in component folder is 'static' and could
not be changed to another theme folder dynamically, 
at least a log about this limitation can help the users.

Fixes #10680 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

This PR does not change any existing behavior, just adds some logs that can help users to find out when a restart is needed to see the effect of their changes in the available themes.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
