### PR TITLE
fix: include flow-dnd module to flow-bom

### DIFF
--- a/flow-bom/pom.xml
+++ b/flow-bom/pom.xml
@@ -63,6 +63,11 @@
                 <artifactId>flow-html-components-testbench</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.vaadin</groupId>
+                <artifactId>flow-dnd</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>


### PR DESCRIPTION
Left out as a mistake.