### PR TITLE
fix: allow empty segments at start

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/BeforeEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/BeforeEvent.java
@@ -30,6 +30,7 @@ import com.vaadin.flow.router.internal.ErrorStateRenderer;
 import com.vaadin.flow.router.internal.ErrorTargetEntry;
 import com.vaadin.flow.router.internal.HasUrlParameterFormat;
 import com.vaadin.flow.router.internal.NavigationStateRenderer;
+import com.vaadin.flow.router.internal.PathUtil;
 
 /**
  * Abstract before event class that has the common functionalities for
@@ -360,7 +361,7 @@ public abstract class BeforeEvent extends EventObject {
                     location));
         } else {
             // Inform that forward target location is not known.
-            forwardToUrl = trimPath(location);
+            forwardToUrl = PathUtil.trimPath(location);
         }
     }
 
@@ -504,7 +505,7 @@ public abstract class BeforeEvent extends EventObject {
                     route));
         } else {
             // Inform that reroute target location is not known.
-            rerouteToUrl = trimPath(route);
+            rerouteToUrl = PathUtil.trimPath(route);
         }
     }
 
@@ -820,22 +821,6 @@ public abstract class BeforeEvent extends EventObject {
      */
     public UI getUI() {
         return ui;
-    }
-
-    private static String trimPath(String path) {
-        if (path == null) {
-            return "";
-        }
-
-        path = path.trim();
-
-        if (path.startsWith("/")) {
-            path = path.substring(1);
-        }
-        if (path.endsWith("/")) {
-            path = path.substring(0, path.length() - 1);
-        }
-        return path;
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/PathUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/PathUtil.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Utility class which contains various methods for parsing a route url into
@@ -39,7 +40,7 @@ public class PathUtil implements Serializable {
      * @return a List containing the segments of the path.
      */
     public static List<String> getSegmentsList(String path) {
-        path = trimPathEnding(path);
+        path = path == null ? "" : trimSegmentsString(path);
 
         final String[] segments = path.split("/");
         if (segments.length == 1 && segments[0].isEmpty()) {
@@ -59,7 +60,7 @@ public class PathUtil implements Serializable {
      * @return path form from input segments.
      */
     public static String getPath(List<String> segments) {
-        return trimPathEnding(
+        return trimSegmentsString(
                 segments == null ? "" : String.join("/", segments));
     }
 
@@ -106,18 +107,16 @@ public class PathUtil implements Serializable {
     }
 
     /**
-     * Trim the path by removing any leading whitespaces and trailing slashes
-     * and whitespaces.
+     * Trim the path by removing any leading and trailing whitespaces and
+     * trailing slashes.
      *
      * @param path
-     *            url path to trim.
+     *            url path to trim, not null
      * @return a String representing the input path without any leading and
-     *         trailing whitespaces and trailing slash.
+     *         trailing whitespaces or trailing slash.
      */
-    public static String trimPathEnding(String path) {
-        if (path == null) {
-            return "";
-        }
+    public static String trimSegmentsString(String path) {
+        Objects.requireNonNull(path);
 
         path = path.trim();
 

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/PathUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/PathUtil.java
@@ -39,7 +39,7 @@ public class PathUtil implements Serializable {
      * @return a List containing the segments of the path.
      */
     public static List<String> getSegmentsList(String path) {
-        path = trimPath(path);
+        path = trimPathEnding(path);
 
         final String[] segments = path.split("/");
         if (segments.length == 1 && segments[0].isEmpty()) {
@@ -59,8 +59,8 @@ public class PathUtil implements Serializable {
      * @return path form from input segments.
      */
     public static String getPath(List<String> segments) {
-        return trimPath((segments == null || segments.isEmpty()) ? ""
-                : String.join("/", segments));
+        return trimPathEnding(
+                segments == null ? "" : String.join("/", segments));
     }
 
     /**
@@ -99,6 +99,28 @@ public class PathUtil implements Serializable {
         if (path.startsWith("/")) {
             path = path.substring(1);
         }
+        if (path.endsWith("/")) {
+            path = path.substring(0, path.length() - 1);
+        }
+        return path;
+    }
+
+    /**
+     * Trim the path by removing any leading whitespaces and trailing slashes
+     * and whitespaces.
+     *
+     * @param path
+     *            url path to trim.
+     * @return a String representing the input path without any leading and
+     *         trailing whitespaces and trailing slash.
+     */
+    public static String trimPathEnding(String path) {
+        if (path == null) {
+            return "";
+        }
+
+        path = path.trim();
+
         if (path.endsWith("/")) {
             path = path.substring(0, path.length() - 1);
         }

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterConfigurationUrlResolvingTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterConfigurationUrlResolvingTest.java
@@ -147,6 +147,28 @@ public class RouterConfigurationUrlResolvingTest extends RoutingTestBase {
     }
 
     @Test
+    public void wildcardPathWithEmptyParameter_emptyParameterIsAvailable() {
+        WildParameter.events.clear();
+        WildParameter.param = null;
+        setNavigationTargets(WildParameter.class);
+
+        router.navigate(ui, new Location("wild//two/three"),
+                NavigationTrigger.PROGRAMMATIC);
+
+        Assert.assertEquals("/two/three", WildParameter.param);
+
+        router.navigate(ui, new Location("wild////four/five"),
+                NavigationTrigger.PROGRAMMATIC);
+
+        Assert.assertEquals("///four/five", WildParameter.param);
+
+        router.navigate(ui, new Location("wild//two//four"),
+                NavigationTrigger.PROGRAMMATIC);
+
+        Assert.assertEquals("/two//four", WildParameter.param);
+    }
+
+    @Test
     public void root_navigation_target_with_wildcard_parameter()
             throws InvalidRouteConfigurationException {
         WildRootParameter.events.clear();

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/PathUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/PathUtilTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.router.internal;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -45,10 +46,14 @@ public class PathUtilTest {
         Assert.assertEquals("Unexpected result", segments,
                 PathUtil.getSegmentsList(path));
         Assert.assertEquals("Unexpected result", segments,
-                PathUtil.getSegmentsList("/" + path));
-        Assert.assertEquals("Unexpected result", segments,
                 PathUtil.getSegmentsList(path + "/"));
-        Assert.assertEquals("Unexpected result", segments,
+
+        List<String> emptyStartSegment = new ArrayList<>();
+        emptyStartSegment.add("");
+        emptyStartSegment.addAll(segments);
+        Assert.assertEquals("Unexpected result", emptyStartSegment,
+                PathUtil.getSegmentsList("/" + path));
+        Assert.assertEquals("Unexpected result", emptyStartSegment,
                 PathUtil.getSegmentsList("/" + path + "/"));
 
         Assert.assertEquals("Unexpected result", path, PathUtil.trimPath(path));


### PR DESCRIPTION
Allow having empty segment as first segment
for parameters.

fixes #10729

