### PR TITLE
chore: fix a locale-dependent Binder unit test

### DIFF
--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -19,6 +19,7 @@ package com.vaadin.flow.data.binder;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.util.HashMap;
 import java.util.Locale;
@@ -583,8 +584,12 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         rentField.setValue("10");
 
         // € 10.00
-        assertEquals("€ " + new DecimalFormat("0.00").format(10),
-                rentField.getValue());
+        DecimalFormat formatter = new DecimalFormat("0.00",
+                // Needed for the environments where Locale.getDefault()
+                // differs from Locale.getDefault(Locale.Category.FORMAT).
+                // For example, these could be en_US and en_FI.
+                DecimalFormatSymbols.getInstance(Locale.getDefault()));
+        assertEquals("€ " + formatter.format(10), rentField.getValue());
     }
 
     @Test


### PR DESCRIPTION
## Description

The `withConverter_writeBackValue` test was passing on systems where `Locale.getDefault()` is the same as `Locale.getDefault(Locale.Category.FORMAT)`, and failing on systems where these locales differ (e.g. Corretto 11 on Windows with country Finland and language English).

## Type of change

- [x] Internal change