### PR TITLE
fix: make ts email validator accept undefined value

### DIFF
--- a/flow-client/src/main/frontend/form/Validators.ts
+++ b/flow-client/src/main/frontend/form/Validators.ts
@@ -66,8 +66,8 @@ abstract class NumberValidator<T> extends AbstractValidator<T> {
   constructor(attrs?: ValidatorAttributes) {
     super(attrs);
   }
-  validate(value: T) {
-    return isNumeric(String(value));
+  validate(value: T | undefined) {
+    return value === undefined || isNumeric(String(value));
   }
 }
 
@@ -97,8 +97,8 @@ export class Email extends AbstractValidator<string> {
   constructor(attrs?: ValidatorAttributes) {
     super({ message: 'must be a well-formed email address', ...attrs });
   }
-  validate(value: string) {
-    return isEmail(value);
+  validate(value: string | undefined) {
+    return value === undefined || isEmail(value);
   }
 }
 export class Null extends AbstractValidator<any> {

--- a/flow-client/src/main/frontend/form/Validators.ts
+++ b/flow-client/src/main/frontend/form/Validators.ts
@@ -66,7 +66,7 @@ abstract class NumberValidator<T> extends AbstractValidator<T> {
   constructor(attrs?: ValidatorAttributes) {
     super(attrs);
   }
-  validate(value: T | undefined) {
+  validate(value: T | undefined) {
     return value === undefined || isNumeric(String(value));
   }
 }

--- a/flow-client/src/main/frontend/form/Validators.ts
+++ b/flow-client/src/main/frontend/form/Validators.ts
@@ -66,8 +66,8 @@ abstract class NumberValidator<T> extends AbstractValidator<T> {
   constructor(attrs?: ValidatorAttributes) {
     super(attrs);
   }
-  validate(value: T | undefined) {
-    return value === undefined || isNumeric(String(value));
+  validate(value: T) {
+    return isNumeric(String(value));
   }
 }
 

--- a/flow-client/src/test/frontend/form/ValidatorsTests.ts
+++ b/flow-client/src/test/frontend/form/ValidatorsTests.ts
@@ -51,6 +51,7 @@ suite("form/Validators", () => {
   test("Email", () => {
     const validator = new Email();
     assert.isNotTrue(validator.impliesRequired);
+    assert.isTrue(validator.validate(undefined));
     assert.isTrue(validator.validate('foo@vaadin.com'));
     assert.isFalse(validator.validate(''));
     assert.isFalse(validator.validate('foo'));


### PR DESCRIPTION
This change makes the TypeScript email validator accept undefined values. It fixes the runtime error when validating an empty email field on the UI, since the field is now undefined by default.
Added IT tests in https://github.com/vaadin/spring/pull/799