### PR TITLE
fix: Use IOUtils toStream and toString

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -372,7 +372,8 @@ public class FrontendUtils {
     }
 
     /**
-     * Read a stream and copy the content in a String.
+     * Read a stream and copy the content into a String using system line
+     * separators for all 'carriage return' characters.
      *
      * @param inputStream
      *            the input stream
@@ -650,8 +651,8 @@ public class FrontendUtils {
         Stats statistics = service.getContext().getAttribute(Stats.class);
 
         if (statistics != null) {
-            return new ByteArrayInputStream(
-                    statistics.statsJson.getBytes(StandardCharsets.UTF_8));
+            return IOUtils.toInputStream(statistics.statsJson,
+                    StandardCharsets.UTF_8);
         }
 
         String stats = service.getDeploymentConfiguration()
@@ -666,10 +667,11 @@ public class FrontendUtils {
         try {
             stream = statsUrl == null ? null : statsUrl.openStream();
             if (stream != null) {
-                statistics = new Stats(streamToString(stream), null);
+                statistics = new Stats(
+                        IOUtils.toString(stream, StandardCharsets.UTF_8), null);
                 service.getContext().setAttribute(statistics);
-                stream = new ByteArrayInputStream(
-                        statistics.statsJson.getBytes(StandardCharsets.UTF_8));
+                stream = IOUtils.toInputStream(statistics.statsJson,
+                        StandardCharsets.UTF_8);
             }
         } catch (IOException exception) {
             getLogger().warn("Couldn't read content of stats file {}", stats,

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -46,6 +46,9 @@ import com.vaadin.flow.server.VaadinServlet;
 import com.vaadin.flow.server.VaadinServletService;
 import com.vaadin.tests.util.MockDeploymentConfiguration;
 
+import elemental.json.Json;
+import elemental.json.JsonException;
+import elemental.json.JsonObject;
 import static com.vaadin.flow.server.Constants.STATISTICS_JSON_DEFAULT;
 import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_STATISTICS_JSON;
@@ -346,6 +349,39 @@ public class FrontendUtilsTest {
 
         assertNotNull("Stats cache should be created",
                 service.getContext().getAttribute(CACHE_KEY));
+    }
+
+    @Test // #10893
+    public void newLineCharacterInJsonStats_readStreamIsJsonParsable()
+            throws IOException, ServiceException {
+        VaadinService service = setupStatsAssetMocks(
+                "specialCharacterValue.json");
+
+        assertNull("Stats cache should not be present",
+                service.getContext().getAttribute(CACHE_KEY));
+
+        // Load file from classpath and populate cache
+        String statsContent = FrontendUtils.getStatsContent(service);
+
+        try {
+            // Json parsing should not throw for loaded stats.
+            Json.parse(statsContent);
+        } catch (JsonException jsonException) {
+            Assert.fail("Json loaded from class path was not parsable json");
+        }
+
+        assertNotNull("Stats cache should be created",
+                service.getContext().getAttribute(CACHE_KEY));
+
+        // Load cached stats.
+        statsContent = FrontendUtils.getStatsContent(service);
+
+        try {
+            // Json parsing should not throw for cached stats.
+            Json.parse(statsContent);
+        } catch (JsonException jsonException) {
+            Assert.fail("Json loaded from cache was not parsable json");
+        }
     }
 
     @Test

--- a/flow-server/src/test/resources/specialCharacterValue.json
+++ b/flow-server/src/test/resources/specialCharacterValue.json
@@ -1,0 +1,3 @@
+{
+  "value": "function(e){return r(function(){return!!o[e]()||\"​᠎\"!=\"​᠎\"[e]()||o[e].name!==e;});};}",
+}


### PR DESCRIPTION
Use IOUtils toString and toInputStream
to not change any characters in the file content.
Using streamToString adds new lines for each usage,
but this can not be done for a json file that contains
in the string content new lines.

fixes #10893
