### PR TITLE
Fix an inconsistency about the attribute name in HierarchicalFilterUtils.java

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalFilterUtils.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalFilterUtils.java
@@ -59,8 +59,8 @@ final class HierarchicalFilterUtils {
         }
 
         @Override
-        public int size(Query<T, Q> t) {
-            return HierarchicalConfigurableFilterDataProvider.super.size(t);
+        public int size(Query<T, Q> query) {
+            return HierarchicalConfigurableFilterDataProvider.super.size(query);
         }
 
         @Override


### PR DESCRIPTION
## Description

This is not an actual bug, but the attribute name should be consistent with others.
Other methods in the same file use "query" as an attribute name.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
