### PR TITLE
fix: Change construct-style-sheets-polyfill to be a runtime dependency (#10991)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -254,6 +254,10 @@ public abstract class NodeUpdater implements FallibleCommand {
         defaults.put("lit-element", "2.5.1");
         defaults.put("lit-html", "1.4.1");
 
+        // Constructable style sheets is only implemented for chrome,
+        // polyfill needed for FireFox et.al. at the moment
+        defaults.put("construct-style-sheets-polyfill", "2.4.16");
+
         return defaults;
     }
 
@@ -276,9 +280,6 @@ public abstract class NodeUpdater implements FallibleCommand {
         defaults.put("file-loader", "6.1.0");
         defaults.put("extract-loader", "5.1.0");
         defaults.put("lit-css-loader", "0.0.4");
-        // Constructable style sheets is only implemented for chrome,
-        // polyfill needed for FireFox et.al. at the moment
-        defaults.put("construct-style-sheets-polyfill", "2.4.6");
 
         // Forcing chokidar version for now until new babel version is available
         // check out https://github.com/babel/babel/issues/11488


### PR DESCRIPTION
Fixes #10988

