### PR TITLE
fix: Remove old router layouts content before navigation (#10973)(CP: 2.6)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -674,7 +675,7 @@ public class UIInternals implements Serializable {
 
         // Assemble previous parent-child relationships to enable detecting
         // changes
-        Map<RouterLayout, HasElement> oldChildren = new HashMap<>();
+        Map<RouterLayout, HasElement> oldChildren = new IdentityHashMap<>();
         for (int i = 0; i < routerTargetChain.size() - 1; i++) {
             HasElement child = routerTargetChain.get(i);
             RouterLayout parent = (RouterLayout) routerTargetChain.get(i + 1);
@@ -687,6 +688,17 @@ public class UIInternals implements Serializable {
 
         if (layouts != null) {
             routerTargetChain.addAll(layouts);
+        }
+
+        // If the old and the new router target chains are not intersect,
+        // meaning that the new chain doesn't contain the root router
+        // layout node of the old chain, this aims to recursively remove
+        // content of the all nested router layouts of the given old content
+        // to be detached. This is needed to let Dependency Injection
+        // frameworks to re-create managed components with no
+        // duplicates/leftovers.
+        if (oldRoot != null && !routerTargetChain.contains(oldRoot)) {
+            oldChildren.forEach(RouterLayout::removeRouterLayoutContent);
         }
 
         // Ensure the entire chain is connected
@@ -708,9 +720,7 @@ public class UIInternals implements Serializable {
 
                 if (oldContent != newContent) {
                     RouterLayout layout = (RouterLayout) current;
-                    if (oldContent != null) {
-                        layout.removeRouterLayoutContent(oldContent);
-                    }
+                    removeChildrenContentFromRouterLayout(layout, oldChildren);
                     layout.showRouterLayoutContent(newContent);
                 }
             }
@@ -1168,6 +1178,25 @@ public class UIInternals implements Serializable {
         pushConfiguration.setPushMode(pushMode);
         if (push.isPresent()) {
             pushConfiguration.setTransport(push.get().transport());
+        }
+    }
+
+    private void removeChildrenContentFromRouterLayout(
+            final RouterLayout targetRouterLayout,
+            final Map<RouterLayout, HasElement> oldChildren) {
+        HasElement oldContent = oldChildren.get(targetRouterLayout);
+        RouterLayout removeFrom = targetRouterLayout;
+        // Recursively remove content of the all nested router
+        // layouts of the given old content to be detached. This
+        // is needed to let Dependency Injection frameworks to
+        // re-create managed components with no
+        // duplicates/leftovers.
+        while (oldContent != null) {
+            removeFrom.removeRouterLayoutContent(oldContent);
+            if (oldContent instanceof RouterLayout) {
+                removeFrom = (RouterLayout) oldContent;
+            }
+            oldContent = oldChildren.get(oldContent);
         }
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/internal/UIInternalsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/internal/UIInternalsTest.java
@@ -2,6 +2,7 @@ package com.vaadin.flow.component.internal;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -16,6 +17,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.PushConfiguration;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.Text;
@@ -25,6 +27,7 @@ import com.vaadin.flow.di.DefaultInstantiator;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.router.Location;
+import com.vaadin.flow.router.ParentLayout;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.server.VaadinContext;
@@ -56,6 +59,54 @@ public class UIInternalsTest {
     @Tag(Tag.DIV)
     public static class RouteTarget1 extends Component {
 
+    }
+
+    @Tag(Tag.DIV)
+    static class MainLayout extends Component implements RouterLayout {
+        static String ID = "main-layout-id";
+
+        public MainLayout() {
+            setId(ID);
+        }
+    }
+
+    @Tag(Tag.DIV)
+    @ParentLayout(MainLayout.class)
+    static class SubLayout extends Component implements RouterLayout {
+        static String ID = "sub-layout-id";
+
+        public SubLayout() {
+            setId(ID);
+        }
+    }
+
+    @Tag(Tag.DIV)
+    @Route(value = "child", layout = SubLayout.class)
+    static class FirstView extends Component {
+        static String ID = "child-view-id";
+
+        public FirstView() {
+            setId(ID);
+        }
+    }
+
+    @Tag(Tag.DIV)
+    static class AnotherLayout extends Component implements RouterLayout {
+        static String ID = "another-layout-id";
+
+        public AnotherLayout() {
+            setId(ID);
+        }
+    }
+
+    @Tag(Tag.DIV)
+    @Route(value = "another", layout = MainLayout.class)
+    static class AnotherView extends Component {
+        static String ID = "another-view-id";
+
+        public AnotherView() {
+            setId(ID);
+        }
     }
 
     @Before
@@ -199,6 +250,106 @@ public class UIInternalsTest {
         Mockito.verify(pushConfig).setPushMode(PushMode.AUTOMATIC);
         Mockito.verify(pushConfig, Mockito.times(0))
                 .setTransport(Mockito.any());
+    }
+
+    @Test
+    public void showRouteTarget_navigateToAnotherViewWithinSameLayoutHierarchy_detachedRouterLayoutChildrenRemoved() {
+        MainLayout mainLayout = new MainLayout();
+        SubLayout subLayout = new SubLayout();
+        FirstView firstView = new FirstView();
+        AnotherView anotherView = new AnotherView();
+
+        List<RouterLayout> oldLayouts = Arrays.asList(subLayout, mainLayout);
+        List<RouterLayout> newLayouts = Collections.singletonList(mainLayout);
+
+        Location location = Mockito.mock(Location.class);
+        setUpInitialPush();
+
+        internals.showRouteTarget(location, "", firstView, oldLayouts);
+        List<HasElement> activeRouterTargetsChain = internals
+                .getActiveRouterTargetsChain();
+
+        // Initial router layouts hierarchy is checked here in order to be
+        // sure the sub layout and it's child view is in place BEFORE
+        // navigation and old content cleanup
+        Assert.assertArrayEquals("Unexpected initial router targets chain",
+                new HasElement[] { firstView, subLayout, mainLayout },
+                activeRouterTargetsChain.toArray());
+
+        Assert.assertEquals(
+                "Expected one child element for main layout before navigation",
+                1, mainLayout.getElement().getChildren().count());
+        @SuppressWarnings("OptionalGetWithoutIsPresent")
+        Element subLayoutElement = mainLayout.getElement().getChildren()
+                .findFirst().get();
+        Assert.assertEquals("Unexpected sub layout element", SubLayout.ID,
+                subLayoutElement.getAttribute("id"));
+        Assert.assertEquals(
+                "Expected one child element for sub layout before navigation",
+                1, subLayoutElement.getChildren().count());
+        @SuppressWarnings("OptionalGetWithoutIsPresent")
+        Element firstViewElement = subLayoutElement.getChildren().findFirst()
+                .get();
+        Assert.assertEquals("Unexpected first view element", FirstView.ID,
+                firstViewElement.getAttribute("id"));
+
+        // Trigger navigation
+        internals.showRouteTarget(location, "", anotherView, newLayouts);
+        activeRouterTargetsChain = internals.getActiveRouterTargetsChain();
+        Assert.assertArrayEquals(
+                "Unexpected router targets chain after navigation",
+                new HasElement[] { anotherView, mainLayout },
+                activeRouterTargetsChain.toArray());
+
+        // Check that the old content (sub layout) is detached and it's
+        // children are also detached
+        Assert.assertEquals(
+                "Expected one child element for main layout after navigation",
+                1, mainLayout.getElement().getChildren().count());
+        @SuppressWarnings("OptionalGetWithoutIsPresent")
+        Element anotherViewElement = mainLayout.getElement().getChildren()
+                .findFirst().get();
+        Assert.assertEquals("Unexpected another view element", AnotherView.ID,
+                anotherViewElement.getAttribute("id"));
+        Assert.assertEquals(
+                "Expected no child elements for sub layout after navigation", 0,
+                subLayout.getElement().getChildren().count());
+    }
+
+    @Test
+    public void showRouteTarget_navigateToAnotherLayoutHierarchy_detachedLayoutHierarchyChildrenRemoved() {
+        MainLayout mainLayout = new MainLayout();
+        SubLayout subLayout = new SubLayout();
+        FirstView firstView = new FirstView();
+        AnotherLayout anotherLayout = new AnotherLayout();
+        AnotherView anotherView = new AnotherView();
+
+        List<RouterLayout> oldLayouts = Arrays.asList(subLayout, mainLayout);
+        List<RouterLayout> newLayouts = Collections
+                .singletonList(anotherLayout);
+
+        Location location = Mockito.mock(Location.class);
+        setUpInitialPush();
+
+        // Initial navigation
+        internals.showRouteTarget(location, "", firstView, oldLayouts);
+        // Navigate to another view outside of the initial router hierarchy
+        internals.showRouteTarget(location, "", anotherView, newLayouts);
+        List<HasElement> activeRouterTargetsChain = internals
+                .getActiveRouterTargetsChain();
+        Assert.assertArrayEquals(
+                "Unexpected router targets chain after navigation",
+                new HasElement[] { anotherView, anotherLayout },
+                activeRouterTargetsChain.toArray());
+
+        // Check that both main layout, sub layout and it's child view are
+        // detached
+        Assert.assertEquals(
+                "Expected no child elements for main layout after navigation",
+                0, mainLayout.getElement().getChildren().count());
+        Assert.assertEquals(
+                "Expected no child elements for sub layout after navigation", 0,
+                subLayout.getElement().getChildren().count());
     }
 
     private PushConfiguration setUpInitialPush() {

--- a/flow-tests/test-common/src/main/java/com/vaadin/flow/uitest/servlet/RouterLayoutCustomScopeServlet.java
+++ b/flow-tests/test-common/src/main/java/com/vaadin/flow/uitest/servlet/RouterLayoutCustomScopeServlet.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.uitest.servlet;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.annotation.WebServlet;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.di.DefaultInstantiator;
+import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.function.SerializableFunction;
+import com.vaadin.flow.router.ParentLayout;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouterLayout;
+import com.vaadin.flow.server.ServiceException;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinServlet;
+import com.vaadin.flow.server.VaadinServletService;
+import com.vaadin.flow.server.VaadinSession;
+
+@WebServlet(asyncSupported = true, urlPatterns = {
+        "/router-layout-custom-scope/*" })
+public class RouterLayoutCustomScopeServlet extends VaadinServlet {
+
+    public static String NAVIGATE_TO_ANOTHER_ROUTE_INSIDE_MAIN_LAYOUT_BUTTON_ID = "navigate-to-another-route-inside-main-layout-button-id";
+    public static String NAVIGATE_TO_ANOTHER_ROUTE_OUTSIDE_MAIN_LAYOUT_BUTTON_ID = "navigate-to-another-layout-button-id";
+    public static String NAVIGATE_BACK_FROM_ANOTHER_ROUTE_INSIDE_MAIN_LAYOUT_BUTTON_ID = "navigate-back-from-another-route-inside-main-layout-button-id";
+    public static String NAVIGATE_BACK_FROM_ANOTHER_ROUTE_OUTSIDE_MAIN_LAYOUT_BUTTON_ID = "navigate-back-from-another-route-outside-main-layout-button-id";
+    public static String SUB_LAYOUT_ID = "sub-layout-id";
+
+    @Override
+    protected VaadinServletService createServletService(
+            DeploymentConfiguration deploymentConfiguration)
+            throws ServiceException {
+        RouterLayoutCustomScopeService routerLayoutCustomScopeService = new RouterLayoutCustomScopeService(
+                this, deploymentConfiguration);
+        routerLayoutCustomScopeService.init();
+        return routerLayoutCustomScopeService;
+    }
+
+    private static class CustomSessionScopeContext {
+        private static final String uiScopeContextKey = CustomSessionScopeContext.class
+                .getName();
+
+        static CustomUIScopeContext getUIScopeContext() {
+            VaadinSession current = VaadinSession.getCurrent();
+            CustomUIScopeContext uiScopeContext = (CustomUIScopeContext) current
+                    .getAttribute(uiScopeContextKey);
+            if (uiScopeContext == null) {
+                uiScopeContext = new CustomUIScopeContext();
+                current.setAttribute(uiScopeContextKey, uiScopeContext);
+            }
+            return uiScopeContext;
+        }
+    }
+
+    private static class CustomUIScopeContext {
+        // Modifying UI and layouts are supposed to be within a single
+        // test, so it's not necessary to use thread-safe collection or
+        // synchronization
+        private final Map<Integer, Map<Class<? extends RouterLayout>, RouterLayout>> routerLayouts = new HashMap<>();
+
+        void addUI(UI ui) {
+            routerLayouts.put(ui.getUIId(), new HashMap<>());
+            // Cleanup the layouts context upon detaching UI
+            ui.addDetachListener(event -> {
+                Map<Class<? extends RouterLayout>, RouterLayout> removed = routerLayouts
+                        .remove(event.getUI().getUIId());
+                removed.clear();
+            });
+        }
+
+        RouterLayout getRouterLayout(
+                Class<? extends RouterLayout> routerLayoutType,
+                SerializableFunction<Class<? extends RouterLayout>, RouterLayout> factory) {
+            UI current = UI.getCurrent();
+            assert current != null : "Current UI is supposed to be not empty "
+                    + "when a layout instance is being requested";
+            routerLayouts.get(current.getUIId())
+                    .computeIfAbsent(routerLayoutType, factory);
+            return routerLayouts.get(current.getUIId()).get(routerLayoutType);
+        }
+    }
+
+    private static class RouterLayoutCustomScopeService
+            extends VaadinServletService {
+
+        public RouterLayoutCustomScopeService(VaadinServlet servlet,
+                DeploymentConfiguration deploymentConfiguration) {
+            super(servlet, deploymentConfiguration);
+            // Create UIScope context upon entering a new UI (browser tab/new
+            // test)
+            addUIInitListener(event -> CustomSessionScopeContext
+                    .getUIScopeContext().addUI(event.getUI()));
+        }
+
+        @Override
+        protected Instantiator createInstantiator() {
+            RouterLayoutCustomScopeInstantiator routerLayoutCustomScopeInstantiator = new RouterLayoutCustomScopeInstantiator(
+                    this);
+            routerLayoutCustomScopeInstantiator.init(this);
+            return routerLayoutCustomScopeInstantiator;
+        }
+    }
+
+    private static class RouterLayoutCustomScopeInstantiator
+            extends DefaultInstantiator {
+
+        public RouterLayoutCustomScopeInstantiator(VaadinService service) {
+            super(service);
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public <T> T getOrCreate(Class<T> type) {
+            // All the RouterLayout objects handled by this servlet are
+            // always UI-scoped for the test purposes.
+            if (RouterLayout.class.isAssignableFrom(type)) {
+                return (T) CustomSessionScopeContext.getUIScopeContext()
+                        .getRouterLayout((Class<? extends RouterLayout>) type,
+                                super::getOrCreate);
+            }
+            return super.getOrCreate(type);
+        }
+    }
+
+    @Route("main")
+    public static class CustomUIScopeMainLayout extends Div
+            implements RouterLayout {
+
+        public CustomUIScopeMainLayout() {
+            add(new Span("This is a topmost parent router layout"));
+        }
+
+        @ParentLayout(CustomUIScopeMainLayout.class)
+        public static class SubLayout extends Div implements RouterLayout {
+            public SubLayout() {
+                setId(SUB_LAYOUT_ID);
+                add(new Span("This is a sub router layout"));
+            }
+        }
+
+        @Route(value = "first-child-route", layout = SubLayout.class)
+        public static class FirstView extends Div {
+
+            public FirstView() {
+                add(new Span("This is a child route inside main layout"));
+                NativeButton navigateToAnotherViewButton = new NativeButton(
+                        "Navigate to another route inside Main Layout",
+                        click -> UI.getCurrent().navigate(SecondView.class));
+                navigateToAnotherViewButton.setId(
+                        NAVIGATE_TO_ANOTHER_ROUTE_INSIDE_MAIN_LAYOUT_BUTTON_ID);
+                add(navigateToAnotherViewButton);
+                NativeButton navigateToAnotherLayoutButton = new NativeButton(
+                        "Navigate to another route outside Main Layout",
+                        click -> UI.getCurrent().navigate(
+                                CustomUIScopeAnotherLayout.ThirdView.class));
+                navigateToAnotherLayoutButton.setId(
+                        NAVIGATE_TO_ANOTHER_ROUTE_OUTSIDE_MAIN_LAYOUT_BUTTON_ID);
+                add(navigateToAnotherLayoutButton);
+            }
+        }
+
+        @Route(value = "second-child-route", layout = CustomUIScopeMainLayout.class)
+        public static class SecondView extends Div {
+
+            public SecondView() {
+                add(new Span("This is another route inside Main Layout"));
+                NativeButton navigateToChildView = new NativeButton(
+                        "Navigate to first route",
+                        click -> UI.getCurrent().navigate(FirstView.class));
+                navigateToChildView.setId(
+                        NAVIGATE_BACK_FROM_ANOTHER_ROUTE_OUTSIDE_MAIN_LAYOUT_BUTTON_ID);
+                add(navigateToChildView);
+            }
+        }
+    }
+
+    @Route("secondary")
+    public static class CustomUIScopeAnotherLayout extends Div
+            implements RouterLayout {
+
+        public CustomUIScopeAnotherLayout() {
+            add(new Span("This is an another topmost parent router layout"));
+        }
+
+        @Route(value = "third-child-route", layout = CustomUIScopeAnotherLayout.class)
+        public static class ThirdView extends Div {
+
+            public ThirdView() {
+                add(new Span("This is another route outside of Main Layout"));
+                NativeButton navigateToChildView = new NativeButton(
+                        "Navigate to first view",
+                        click -> UI.getCurrent().navigate(
+                                CustomUIScopeMainLayout.FirstView.class));
+                navigateToChildView.setId(
+                        NAVIGATE_BACK_FROM_ANOTHER_ROUTE_INSIDE_MAIN_LAYOUT_BUTTON_ID);
+                add(navigateToChildView);
+            }
+        }
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/RemoveRoutersLayoutContentIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/RemoveRoutersLayoutContentIT.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.uitest.ui;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+import com.vaadin.testbench.TestBenchElement;
+
+import static com.vaadin.flow.uitest.servlet.RouterLayoutCustomScopeServlet.NAVIGATE_TO_ANOTHER_ROUTE_OUTSIDE_MAIN_LAYOUT_BUTTON_ID;
+import static com.vaadin.flow.uitest.servlet.RouterLayoutCustomScopeServlet.NAVIGATE_TO_ANOTHER_ROUTE_INSIDE_MAIN_LAYOUT_BUTTON_ID;
+import static com.vaadin.flow.uitest.servlet.RouterLayoutCustomScopeServlet.NAVIGATE_BACK_FROM_ANOTHER_ROUTE_OUTSIDE_MAIN_LAYOUT_BUTTON_ID;
+import static com.vaadin.flow.uitest.servlet.RouterLayoutCustomScopeServlet.NAVIGATE_BACK_FROM_ANOTHER_ROUTE_INSIDE_MAIN_LAYOUT_BUTTON_ID;
+import static com.vaadin.flow.uitest.servlet.RouterLayoutCustomScopeServlet.SUB_LAYOUT_ID;
+
+public class RemoveRoutersLayoutContentIT extends ChromeBrowserTest {
+
+    @Override
+    protected String getTestPath() {
+        return "/router-layout-custom-scope/first-child-route";
+    }
+
+    @Test
+    public void removeUIScopedRouterLayoutContent_navigateToAnotherRouteInsideMainLayoutAndBack_subLayoutOldContentRemoved() {
+        open();
+        navigate(NAVIGATE_TO_ANOTHER_ROUTE_INSIDE_MAIN_LAYOUT_BUTTON_ID);
+        waitForElementPresent(By.id(
+                NAVIGATE_BACK_FROM_ANOTHER_ROUTE_OUTSIDE_MAIN_LAYOUT_BUTTON_ID));
+        navigate(
+                NAVIGATE_BACK_FROM_ANOTHER_ROUTE_OUTSIDE_MAIN_LAYOUT_BUTTON_ID);
+        waitForElementPresent(By.id(SUB_LAYOUT_ID));
+
+        assertSubLayoutHasNoOldContent();
+    }
+
+    @Test
+    public void removeUIScopedRouterLayoutContent_navigateToAnotherRouteOutsideMainLayoutAndBack_mainLayoutOldContentRemoved() {
+        open();
+        navigate(NAVIGATE_TO_ANOTHER_ROUTE_OUTSIDE_MAIN_LAYOUT_BUTTON_ID);
+        waitForElementPresent(By.id(
+                NAVIGATE_BACK_FROM_ANOTHER_ROUTE_INSIDE_MAIN_LAYOUT_BUTTON_ID));
+        navigate(NAVIGATE_BACK_FROM_ANOTHER_ROUTE_INSIDE_MAIN_LAYOUT_BUTTON_ID);
+        waitForElementPresent(By.id(SUB_LAYOUT_ID));
+
+        assertSubLayoutHasNoOldContent();
+    }
+
+    private void assertSubLayoutHasNoOldContent() {
+        TestBenchElement subLayout = $("div").id(SUB_LAYOUT_ID);
+        List<WebElement> subLayoutChildren = subLayout
+                .findElements(By.tagName("div"));
+        Assert.assertEquals(1, subLayoutChildren.size());
+    }
+
+    private void navigate(String navigateButtonId) {
+        $("button").id(navigateButtonId).click();
+    }
+}


### PR DESCRIPTION
## Description

Recursively removes content of the all nested router layouts of the given old content when the navigation occurs.
This is needed to let Dependency Injection frameworks (Spring and CDI add-ons) to re-create managed components with no duplicates/leftovers.

Fixes vaadin/cdi#345

Co-authored-by: @roeltje25

(cherry picked from commit 5f5fdcd1754bd283ba3f787d3d4dee0ca57955de)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
