### PR TITLE
test: Explicitly register test servlet in OSGi

### DIFF
--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/osgi/Activator.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/osgi/Activator.java
@@ -36,6 +36,7 @@ import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
 import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.uitest.servlet.ProductionModeTimingDataViewTestServlet;
 import com.vaadin.flow.uitest.servlet.ProductionModeViewTestServlet;
+import com.vaadin.flow.uitest.servlet.RouterLayoutCustomScopeServlet;
 import com.vaadin.flow.uitest.servlet.RouterTestServlet;
 import com.vaadin.flow.uitest.servlet.ViewTestServlet;
 import com.vaadin.flow.uitest.ui.LogoutWithNotificationServlet;
@@ -43,7 +44,7 @@ import com.vaadin.flow.uitest.ui.LogoutWithNotificationServlet;
 @Component(immediate = true)
 public class Activator {
 
-    public static class OsgiResourceRgistration {
+    public static class OsgiResourceRegistration {
 
     }
 
@@ -132,6 +133,17 @@ public class Activator {
         }
     }
 
+    private static class FixedRouterLayoutCustomScopeServlet extends RouterLayoutCustomScopeServlet {
+        @Override
+        public void init(ServletConfig servletConfig) throws ServletException {
+            super.init(servletConfig);
+
+            if (getService() != null) {
+                getService().setClassLoader(getClass().getClassLoader());
+            }
+        }
+    }
+
     @Activate
     void activate() throws NamespaceException {
         BundleContext context = FrameworkUtil.getBundle(Activator.class)
@@ -158,6 +170,10 @@ public class Activator {
                 new FixedLogoutWithNotificationServlet(),
                 createProperties("/logout-with-notification/*", false));
 
+        context.registerService(Servlet.class,
+                new FixedRouterLayoutCustomScopeServlet(),
+                createProperties("/router-layout-custom-scope/*", false));
+
         registerPlainJsResource(context);
 
         String contextName = registerCustomContext(context);
@@ -170,8 +186,8 @@ public class Activator {
                 "/plain-script.js");
         properties.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_RESOURCE_PREFIX,
                 "/osgi-web-resources/plain-script.js");
-        context.registerService(OsgiResourceRgistration.class,
-                new OsgiResourceRgistration(), properties);
+        context.registerService(OsgiResourceRegistration.class,
+                new OsgiResourceRegistration(), properties);
     }
 
     private String registerCustomContext(BundleContext context) {

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/osgi/Activator.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/osgi/Activator.java
@@ -133,7 +133,8 @@ public class Activator {
         }
     }
 
-    private static class FixedRouterLayoutCustomScopeServlet extends RouterLayoutCustomScopeServlet {
+    private static class FixedRouterLayoutCustomScopeServlet
+            extends RouterLayoutCustomScopeServlet {
         @Override
         public void init(ServletConfig servletConfig) throws ServletException {
             super.init(servletConfig);


### PR DESCRIPTION
## Description

Explicitly registers RouterLayoutCustomScopeServlet in OSGi.

Related-to https://github.com/vaadin/flow/pull/10973

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
