### PR TITLE
test: Explicitly register test servlet in OSGi (#11018)(CP: 2.7)

### DIFF
--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/osgi/Activator.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/osgi/Activator.java
@@ -37,6 +37,7 @@ import com.vaadin.flow.server.VaadinServletService;
 import com.vaadin.flow.uitest.servlet.Es6UrlViewTestServlet;
 import com.vaadin.flow.uitest.servlet.ProductionModeTimingDataViewTestServlet;
 import com.vaadin.flow.uitest.servlet.ProductionModeViewTestServlet;
+import com.vaadin.flow.uitest.servlet.RouterLayoutCustomScopeServlet;
 import com.vaadin.flow.uitest.servlet.RouterTestServlet;
 import com.vaadin.flow.uitest.servlet.ViewTestServlet;
 import com.vaadin.flow.uitest.ui.LogoutWithNotificationServlet;
@@ -143,6 +144,22 @@ public class Activator implements BundleActivator {
         }
     }
 
+    private static class FixedRouterLayoutCustomScopeServlet
+            extends RouterLayoutCustomScopeServlet {
+        @Override
+        public void init(ServletConfig servletConfig) throws ServletException {
+            super.init(servletConfig);
+
+            getService().setClassLoader(getClass().getClassLoader());
+        }
+
+        @Override
+        protected StaticFileHandler createStaticFileHandler(
+                VaadinServletService servletService) {
+            return new ItStaticFileServer(servletService);
+        }
+    }
+
     @VaadinServletConfiguration(productionMode = true)
     private static class FixedEs6UrlViewServlet extends Es6UrlViewTestServlet {
         @Override
@@ -206,6 +223,9 @@ public class Activator implements BundleActivator {
                             new FixedEs6UrlViewServlet(), dictionary, null);
                     httpService.registerServlet("/logout-with-notification/*",
                             new FixedLogoutWithNotificationServlet(),
+                            dictionary, null);
+                    httpService.registerServlet("/router-layout-custom-scope/*",
+                            new FixedRouterLayoutCustomScopeServlet(),
                             dictionary, null);
                 } catch (ServletException | NamespaceException exception) {
                     throw new RuntimeException(exception);


### PR DESCRIPTION
## Description

Explicitly registers RouterLayoutCustomScopeServlet in OSGi.

Related-to #10973

(cherry picked from commit 4a8dc42a874c62a5ed6a0b8729286f4550b1f61c)

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
