### PR TITLE
fix: Using a custom RouteRegistry

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/Router.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/Router.java
@@ -16,18 +16,21 @@
 package com.vaadin.flow.router;
 
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
 import javax.servlet.http.HttpServletResponse;
 
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.router.internal.AbstractRouteRegistry;
 import com.vaadin.flow.router.internal.DefaultRouteResolver;
 import com.vaadin.flow.router.internal.ErrorStateRenderer;
 import com.vaadin.flow.router.internal.ErrorTargetEntry;
 import com.vaadin.flow.router.internal.InternalRedirectHandler;
 import com.vaadin.flow.router.internal.NavigationStateRenderer;
 import com.vaadin.flow.router.internal.ResolveRequest;
+import com.vaadin.flow.server.ErrorRouteRegistry;
 import com.vaadin.flow.server.RouteRegistry;
 import com.vaadin.flow.server.SessionRouteRegistry;
 import com.vaadin.flow.server.VaadinRequest;
@@ -313,8 +316,8 @@ public class Router implements Serializable {
      */
     public Optional<ErrorTargetEntry> getErrorNavigationTarget(
             Exception exception) {
-        if (registry instanceof ApplicationRouteRegistry) {
-            return ((ApplicationRouteRegistry) registry)
+        if (registry instanceof ErrorRouteRegistry) {
+            return ((ErrorRouteRegistry) registry)
                     .getErrorNavigationTarget(exception);
         }
         return Optional.empty();

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractRouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractRouteRegistry.java
@@ -357,6 +357,30 @@ public abstract class AbstractRouteRegistry implements RouteRegistry {
         });
     }
 
+    @Override
+    public NavigationRouteTarget getNavigationRouteTarget(String url) {
+        return getConfiguration().getNavigationRouteTarget(url);
+    }
+
+    @Override
+    public RouteTarget getRouteTarget(Class<? extends Component> target,
+            RouteParameters parameters) {
+        return getConfiguration().getRouteTarget(target, parameters);
+    }
+
+    @Override
+    public Optional<Class<? extends Component>> getNavigationTarget(
+            String url) {
+        Objects.requireNonNull(url, "url must not be null.");
+        return getConfiguration().getTarget(url);
+    }
+
+    @Override
+    public Optional<Class<? extends Component>> getNavigationTarget(String url,
+            List<String> segments) {
+        return getNavigationTarget(PathUtil.getPath(url, segments));
+    }
+
     /**
      * Add the given error target to the exceptionTargetMap. This will handle
      * existing overlapping exception types by assigning the correct error

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/NavigationRouteTarget.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/NavigationRouteTarget.java
@@ -33,15 +33,15 @@ import com.vaadin.flow.router.RouteParameters;
 public class NavigationRouteTarget implements Serializable {
 
     // Processed path.
-    private String path;
+    private final String path;
 
     // Target found for the specified path.
-    private RouteTarget routeTarget;
+    private final RouteTarget routeTarget;
 
     // Parameters found in the path.
-    private RouteParameters parameters;
+    private final RouteParameters parameters;
 
-    NavigationRouteTarget(String path, RouteTarget routeTarget,
+    public NavigationRouteTarget(String path, RouteTarget routeTarget,
             Map<String, String> parameters) {
         this.path = path;
         this.routeTarget = routeTarget;

--- a/flow-server/src/main/java/com/vaadin/flow/server/ErrorRouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/ErrorRouteRegistry.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.server;
+
+import java.io.Serializable;
+import java.util.Optional;
+
+import com.vaadin.flow.router.internal.ErrorTargetEntry;
+
+/**
+ * Interface class for RouteRegistries that can be used to request for error
+ * navigation views for Exceptions.
+ *
+ * @since
+ */
+public interface ErrorRouteRegistry extends Serializable {
+    /**
+     * Get a registered navigation target for given exception. First we will
+     * search for a matching cause for in the exception chain and if no match
+     * found search by extended type.
+     *
+     * @param exception
+     *            exception to search error view for
+     * @return optional error target entry corresponding to the given exception
+     */
+    Optional<ErrorTargetEntry> getErrorNavigationTarget(Exception exception);
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ApplicationRouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ApplicationRouteRegistry.java
@@ -42,6 +42,7 @@ import com.vaadin.flow.router.internal.ErrorTargetEntry;
 import com.vaadin.flow.router.internal.NavigationRouteTarget;
 import com.vaadin.flow.router.internal.PathUtil;
 import com.vaadin.flow.router.internal.RouteTarget;
+import com.vaadin.flow.server.ErrorRouteRegistry;
 import com.vaadin.flow.server.PWA;
 import com.vaadin.flow.server.VaadinContext;
 
@@ -51,7 +52,8 @@ import com.vaadin.flow.server.VaadinContext;
  *
  * @since 1.3
  */
-public class ApplicationRouteRegistry extends AbstractRouteRegistry {
+public class ApplicationRouteRegistry extends AbstractRouteRegistry
+        implements ErrorRouteRegistry {
 
     private AtomicReference<Class<?>> pwaConfigurationClass = new AtomicReference<>();
     private static final Set<Class<? extends Component>> defaultErrorHandlers = Stream
@@ -168,15 +170,7 @@ public class ApplicationRouteRegistry extends AbstractRouteRegistry {
                 .allMatch(filter -> filter.testErrorNavigationTarget(target));
     }
 
-    /**
-     * Get a registered navigation target for given exception. First we will
-     * search for a matching cause for in the exception chain and if no match
-     * found search by extended type.
-     *
-     * @param exception
-     *            exception to search error view for
-     * @return optional error target entry corresponding to the given exception
-     */
+    @Override
     public Optional<ErrorTargetEntry> getErrorNavigationTarget(
             Exception exception) {
         if (getConfiguration().getExceptionHandlers().isEmpty()) {
@@ -187,30 +181,6 @@ public class ApplicationRouteRegistry extends AbstractRouteRegistry {
             result = searchBySuperType(exception);
         }
         return result;
-    }
-
-    @Override
-    public NavigationRouteTarget getNavigationRouteTarget(String url) {
-        return getConfiguration().getNavigationRouteTarget(url);
-    }
-
-    @Override
-    public RouteTarget getRouteTarget(Class<? extends Component> target,
-            RouteParameters parameters) {
-        return getConfiguration().getRouteTarget(target, parameters);
-    }
-
-    @Override
-    public Optional<Class<? extends Component>> getNavigationTarget(
-            String url) {
-        Objects.requireNonNull(url, "url must not be null.");
-        return getConfiguration().getTarget(url);
-    }
-
-    @Override
-    public Optional<Class<? extends Component>> getNavigationTarget(String url,
-            List<String> segments) {
-        return getNavigationTarget(PathUtil.getPath(url, segments));
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/TestAbstractRouteRegistry.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/TestAbstractRouteRegistry.java
@@ -17,38 +17,6 @@
 
 package com.vaadin.flow.router.internal;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-
-import com.vaadin.flow.component.Component;
-import com.vaadin.flow.router.RouteParameters;
-
 public class TestAbstractRouteRegistry extends AbstractRouteRegistry {
-
-    @Override
-    public NavigationRouteTarget getNavigationRouteTarget(String url) {
-        return getConfiguration().getNavigationRouteTarget(url);
-    }
-
-    @Override
-    public RouteTarget getRouteTarget(Class<? extends Component> target,
-            RouteParameters parameters) {
-        return getConfiguration().getRouteTarget(target, parameters);
-    }
-
-    @Override
-    public Optional<Class<? extends Component>> getNavigationTarget(
-            String pathString) {
-        Objects.requireNonNull(pathString, "pathString must not be null.");
-        return getConfiguration().getTarget(pathString);
-    }
-
-    @Override
-    public Optional<Class<? extends Component>> getNavigationTarget(
-            String pathString, List<String> segments) {
-
-        return getNavigationTarget(PathUtil.getPath(pathString, segments));
-    }
 
 }

--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -353,6 +353,7 @@
                 <module>test-v14-bootstrap</module>
                 <module>test-v14-bootstrap/pom-production.xml</module>
 				
+                <module>test-custom-route-registry</module>
                 <!-- tests are disabled in this module, this reference is for maven version plugin -->
                 <module>test-no-theme</module>
                 <!-- move theme tests to the end, because theme switch live reload-->

--- a/flow-tests/test-custom-route-registry/pom.xml
+++ b/flow-tests/test-custom-route-registry/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>flow-tests</artifactId>
+        <groupId>com.vaadin</groupId>
+        <version>8.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>test-custom-route-registry</artifactId>
+    <name>Test using Flow with a custom RouteRegistry implementation</name>
+
+    <packaging>war</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-test-resources</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-html-components-testbench</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!--  Run flow plugin to build frontend -->
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>flow-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-frontend</goal>
+                            <goal>build-frontend</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <productionMode>true</productionMode>
+                </configuration>
+            </plugin>
+            <!-- Run jetty before integration tests, and stop after -->
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>local-run</id>
+            <activation>
+                <property>
+                    <name>!test.use.hub</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.lazerycode.selenium</groupId>
+                        <artifactId>driver-binary-downloader-maven-plugin</artifactId>
+                        <version>${driver.binary.downloader.maven.plugin.version}</version>
+                        <configuration>
+                            <onlyGetDriversForHostOperatingSystem>true</onlyGetDriversForHostOperatingSystem>
+                            <rootStandaloneServerDirectory>${project.rootdir}/driver</rootStandaloneServerDirectory>
+                            <downloadedZipFileDirectory>${project.rootdir}/driver_zips</downloadedZipFileDirectory>
+                            <customRepositoryMap>${project.rootdir}/drivers.xml</customRepositoryMap>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>selenium</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/flow-tests/test-custom-route-registry/src/main/java/com/vaadin/flow/custom/CustomErrorHandler.java
+++ b/flow-tests/test-custom-route-registry/src/main/java/com/vaadin/flow/custom/CustomErrorHandler.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.custom;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.ErrorParameter;
+import com.vaadin.flow.router.HasErrorParameter;
+
+/**
+ * Customized error handler for IllegalAccessException.
+ * <p>
+ * This should not be available through the CustomRouteRegistry.
+ */
+@Tag(Tag.DIV)
+public class CustomErrorHandler extends Component
+        implements HasErrorParameter<IllegalAccessException> {
+
+    @Override
+    public int setErrorParameter(BeforeEnterEvent event,
+            ErrorParameter<IllegalAccessException> parameter) {
+        getElement().appendChild(
+                new Span("This shouldn't be available").getElement());
+        return 0;
+    }
+}

--- a/flow-tests/test-custom-route-registry/src/main/java/com/vaadin/flow/custom/CustomInitListener.java
+++ b/flow-tests/test-custom-route-registry/src/main/java/com/vaadin/flow/custom/CustomInitListener.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.custom;
+
+import com.vaadin.flow.router.RouteConfiguration;
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinServiceInitListener;
+
+/**
+ * Customized VaadinServiceInitListener that registers the CustomRoute to
+ * CustomRouteRegistry.
+ */
+public class CustomInitListener implements VaadinServiceInitListener {
+
+    @Override
+    public void serviceInit(ServiceInitEvent event) {
+        final CustomRouteRegistry registry = CustomRouteRegistry
+                .getInstance(event.getSource().getContext());
+
+        RouteConfiguration configuration = RouteConfiguration
+                .forRegistry(registry);
+
+        configuration.setRoute("", CustomRoute.class);
+    }
+}

--- a/flow-tests/test-custom-route-registry/src/main/java/com/vaadin/flow/custom/CustomNotFoundView.java
+++ b/flow-tests/test-custom-route-registry/src/main/java/com/vaadin/flow/custom/CustomNotFoundView.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.custom;
+
+import javax.servlet.http.HttpServletResponse;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.ErrorParameter;
+import com.vaadin.flow.router.HasErrorParameter;
+import com.vaadin.flow.router.NotFoundException;
+
+/**
+ * Custom view for the NofFoundException to be used with the
+ * CustomRouteRegistry.
+ */
+@Tag("div")
+public class CustomNotFoundView extends Component
+        implements HasErrorParameter<NotFoundException> {
+
+    @Override
+    public int setErrorParameter(BeforeEnterEvent event,
+            ErrorParameter<NotFoundException> parameter) {
+        Span notFound = new Span("Requested route was simply not found!");
+        notFound.setId("error");
+        getElement().appendChild(notFound.getElement());
+
+        return HttpServletResponse.SC_NOT_FOUND;
+    }
+}

--- a/flow-tests/test-custom-route-registry/src/main/java/com/vaadin/flow/custom/CustomRoute.java
+++ b/flow-tests/test-custom-route-registry/src/main/java/com/vaadin/flow/custom/CustomRoute.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.custom;
+
+import java.util.Map;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.internal.AbstractRouteRegistry;
+import com.vaadin.flow.server.RouteRegistry;
+
+/**
+ * The root view for the test only registered to the CustomRouteRegistry.
+ */
+public class CustomRoute extends Div {
+
+    public CustomRoute() {
+        final RouteRegistry registry = ((CustomServletService) CustomServletService
+                .getCurrent()).getRouteRegistry();
+        final Span span = new Span(
+                "Used " + registry.getClass().getSimpleName());
+        span.setId("registry");
+
+        add(span);
+        add(new Div(), new Span("--"), new Div());
+
+        final Map<Class<? extends Exception>, Class<? extends Component>> exceptionHandlers = ((AbstractRouteRegistry) registry)
+                .getConfiguration().getExceptionHandlers();
+        add(new Span(
+                "Found " + exceptionHandlers.size() + " exception handlers"));
+        exceptionHandlers.forEach((exception, view) -> {
+            Span exceptionSpan = new Span(
+                    exception.getSimpleName() + " :: " + view.getSimpleName());
+            exceptionSpan.setId(exception.getSimpleName());
+            add(new Div(), exceptionSpan);
+        });
+
+    }
+}

--- a/flow-tests/test-custom-route-registry/src/main/java/com/vaadin/flow/custom/CustomRouteRegistry.java
+++ b/flow-tests/test-custom-route-registry/src/main/java/com/vaadin/flow/custom/CustomRouteRegistry.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.custom;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.router.NotFoundException;
+import com.vaadin.flow.router.RouterLayout;
+import com.vaadin.flow.router.internal.AbstractRouteRegistry;
+import com.vaadin.flow.router.internal.ErrorTargetEntry;
+import com.vaadin.flow.server.ErrorRouteRegistry;
+import com.vaadin.flow.server.VaadinContext;
+import com.vaadin.flow.server.startup.ApplicationRouteRegistry;
+
+/**
+ * Custom routeRegistry implementation for use instead of
+ * ApplicationRouteRegistry.
+ *
+ * Also implements ErrorRouteRegistry for showing error views if registered.
+ */
+public class CustomRouteRegistry extends AbstractRouteRegistry
+        implements ErrorRouteRegistry {
+
+    public static CustomRouteRegistry getInstance(VaadinContext context) {
+        assert context != null;
+
+        RegistryWrapper attribute;
+        synchronized (context) {
+            attribute = context.getAttribute(RegistryWrapper.class);
+
+            if (attribute == null) {
+                final CustomRouteRegistry registry = new CustomRouteRegistry();
+                attribute = new RegistryWrapper(registry);
+                context.setAttribute(attribute);
+
+                // Get collected application routes
+                final ApplicationRouteRegistry instance = ApplicationRouteRegistry
+                        .getInstance(context);
+                instance.getRegisteredRoutes().forEach(routeData -> {
+                    registry.setRoute(routeData.getTemplate(),
+                            routeData.getNavigationTarget(),
+                            routeData.getParentLayouts());
+                });
+
+                // Add only NotFoundException and Exception ignoring other error
+                // views collected
+                Map<Class<? extends Exception>, Class<? extends Component>> map = new HashMap<>();
+                map.put(NotFoundException.class, CustomNotFoundView.class);
+                registry.configure(configuration -> map
+                        .forEach(configuration::setErrorRoute));
+            }
+        }
+
+        return attribute.getRegistry();
+    }
+
+    @Override
+    public Optional<ErrorTargetEntry> getErrorNavigationTarget(
+            Exception exception) {
+        Optional<ErrorTargetEntry> result = searchByCause(exception);
+        if (!result.isPresent()) {
+            result = searchBySuperType(exception);
+        }
+        return result;
+    }
+
+    protected static class RegistryWrapper implements Serializable {
+        private final CustomRouteRegistry registry;
+
+        public RegistryWrapper(CustomRouteRegistry registry) {
+            this.registry = registry;
+        }
+
+        public CustomRouteRegistry getRegistry() {
+            return registry;
+        }
+    }
+
+    @Override
+    public void setRoute(String path,
+            Class<? extends Component> navigationTarget,
+            List<Class<? extends RouterLayout>> parentChain) {
+        getLogger().info("Added target '{}' for route '{}'",
+                navigationTarget.getSimpleName(), path);
+        super.setRoute(path, navigationTarget, parentChain);
+    }
+
+    private Logger getLogger() {
+        return LoggerFactory.getLogger(CustomRouteRegistry.class);
+    }
+}

--- a/flow-tests/test-custom-route-registry/src/main/java/com/vaadin/flow/custom/CustomServlet.java
+++ b/flow-tests/test-custom-route-registry/src/main/java/com/vaadin/flow/custom/CustomServlet.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.custom;
+
+import javax.servlet.annotation.WebServlet;
+
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.ServiceException;
+import com.vaadin.flow.server.VaadinServlet;
+import com.vaadin.flow.server.VaadinServletService;
+
+/**
+ * Servlet for creating CustomServletService instead of a VaadinServletService.
+ */
+@WebServlet(asyncSupported = true, urlPatterns = { "/*" })
+public class CustomServlet extends VaadinServlet {
+
+    @Override
+    protected VaadinServletService createServletService(
+            DeploymentConfiguration deploymentConfiguration)
+            throws ServiceException {
+        CustomServletService service = new CustomServletService(this,
+                deploymentConfiguration);
+        service.init();
+        return service;
+    }
+}

--- a/flow-tests/test-custom-route-registry/src/main/java/com/vaadin/flow/custom/CustomServletService.java
+++ b/flow-tests/test-custom-route-registry/src/main/java/com/vaadin/flow/custom/CustomServletService.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.custom;
+
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.RouteRegistry;
+import com.vaadin.flow.server.VaadinServlet;
+import com.vaadin.flow.server.VaadinServletService;
+
+/**
+ * ServletService that returns a CustomRouteRegistry for the RouteRegistry.
+ */
+public class CustomServletService extends VaadinServletService {
+
+    public CustomServletService(VaadinServlet servlet,
+            DeploymentConfiguration deploymentConfiguration) {
+        super(servlet, deploymentConfiguration);
+    }
+
+    @Override
+    protected RouteRegistry getRouteRegistry() {
+        return CustomRouteRegistry.getInstance(getContext());
+    }
+}

--- a/flow-tests/test-custom-route-registry/src/main/resources/META-INF/services/com.vaadin.flow.server.VaadinServiceInitListener
+++ b/flow-tests/test-custom-route-registry/src/main/resources/META-INF/services/com.vaadin.flow.server.VaadinServiceInitListener
@@ -1,0 +1,1 @@
+com.vaadin.flow.custom.CustomInitListener

--- a/flow-tests/test-custom-route-registry/src/test/java/com/vaadin/flow/custom/CustomRouteIT.java
+++ b/flow-tests/test-custom-route-registry/src/test/java/com/vaadin/flow/custom/CustomRouteIT.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.custom;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.NoSuchElementException;
+
+import com.vaadin.flow.component.html.testbench.SpanElement;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class CustomRouteIT extends ChromeBrowserTest {
+
+    @Test
+    public void CustomRegistry_hasExpectedErrorHandlers() {
+        getDriver().get(getRootURL());
+
+        final SpanElement notFoundException = $(SpanElement.class)
+                .id("NotFoundException");
+        Assert.assertEquals("Wrong error handler registered",
+                "NotFoundException :: CustomNotFoundView",
+                notFoundException.getText());
+
+        try {
+            $(SpanElement.class).id("IllegalAccessException");
+            Assert.fail(
+                    "Found IllegalAccessException error handler even though it should not be registered");
+        } catch (NoSuchElementException nsee) {
+            // NO-OP as this should throw element not found
+        }
+    }
+
+    @Test
+    public void testCustomErrorView() {
+        getDriver().get(getRootURL() + "/none");
+        final SpanElement error = $(SpanElement.class).id("error");
+        Assert.assertEquals("Requested route was simply not found!",
+                error.getText());
+    }
+}


### PR DESCRIPTION
## Description

Make it possible to create a custom
RouteRegistry and add test module for it.

Fixes #11022

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

