### PR TITLE
feat: bump lit-css-loader for Lit 2

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -385,7 +385,7 @@ public abstract class NodeUpdater implements FallibleCommand {
         defaults.put("webpack-merge", "4.2.2");
         defaults.put("css-loader", "4.2.1");
         defaults.put("extract-loader", "5.1.0");
-        defaults.put("lit-css-loader", "0.0.4");
+        defaults.put("lit-css-loader", "0.1.0");
         defaults.put("file-loader", "6.2.0");
         defaults.put("loader-utils", "2.0.0");
         final String WORKBOX_VERSION = "6.1.0";

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -266,7 +266,10 @@ module.exports = {
         test: /\.css$/i,
         use: [
           {
-            loader: "lit-css-loader"
+            loader: 'lit-css-loader',
+            options: {
+              import: 'lit'
+            }
           },
           {
             loader: "extract-loader"


### PR DESCRIPTION
## Description

This change updates the import for CSS files processed with `lit-css-loader` to get rid of the warning:

```
"The main 'lit-element' module entrypoint is deprecated. Please update your imports to use the 'lit' package: 'lit' and 'lit/decorators.ts' or import from 'lit-element/lit-element.ts'.""
```

See https://github.com/vaadin/flow-components/pull/928#issuecomment-833478933

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.