### PR TITLE
fix: x64 version for mac if node old

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
@@ -491,7 +491,8 @@ public class NodeInstaller {
                     .resolve(getNodeDownloadFilename(nodeVersion));
             tmpDirectory = getTempDirectory();
             archive = resolveArchive("node", nodeVersion,
-                    platform.getNodeClassifier(),
+                    platform.getNodeClassifier(
+                            new FrontendVersion(nodeVersion)),
                     platform.getArchiveExtension());
             nodeExecutable = platform.isWindows() ? "node.exe" : "node";
         }
@@ -536,7 +537,8 @@ public class NodeInstaller {
         }
 
         private String getLongNodeFilename(String nodeVersion) {
-            return "node-" + nodeVersion + "-" + platform.getNodeClassifier();
+            return "node-" + nodeVersion + "-" + platform
+                    .getNodeClassifier(new FrontendVersion(nodeVersion));
         }
 
         /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/Platform.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/Platform.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.server.frontend.installer;
 
+import com.vaadin.flow.server.frontend.FrontendVersion;
+
 /**
  * Platform contains information about system architecture and OS.
  * <p>
@@ -110,6 +112,9 @@ public class Platform {
     private final OS os;
     private final Architecture architecture;
 
+    // Node.js supports Apple silicon from v16.0.0
+    private static final int NODE_VERSION_THRESHOLD_MAC_ARM64 = 16;
+
     /**
      * Construct a new Platform.
      *
@@ -191,9 +196,23 @@ public class Platform {
     /**
      * Get the node classifier for current platform.
      *
+     * @param nodeVersion
+     *            node version to get classifier for
      * @return platform node classifier
      */
-    public String getNodeClassifier() {
-        return getCodename() + "-" + getArchitecture().getName();
+    public String getNodeClassifier(FrontendVersion nodeVersion) {
+        return getCodename() + "-" + resolveArchitecture(nodeVersion).getName();
+    }
+
+    private Architecture resolveArchitecture(FrontendVersion nodeVersion) {
+        if (isMac() && architecture == Architecture.ARM64) {
+            Integer nodeMajorVersion = nodeVersion.getMajorVersion();
+            if (nodeMajorVersion == null
+                    || nodeMajorVersion < NODE_VERSION_THRESHOLD_MAC_ARM64) {
+                return Architecture.X64;
+            }
+        }
+
+        return architecture;
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -94,7 +94,9 @@ public class FrontendToolsTest {
         nodeVersionCommand.add("--version");
         FrontendVersion node = FrontendUtils.getVersion("node",
                 nodeVersionCommand);
-        Assert.assertEquals(FrontendTools.DEFAULT_NODE_VERSION,
+        Assert.assertEquals(
+                new FrontendVersion(FrontendTools.DEFAULT_NODE_VERSION)
+                        .getFullVersion(),
                 node.getFullVersion());
 
         FrontendTools newTools = new FrontendTools(vaadinHomeDir, null);
@@ -103,7 +105,7 @@ public class FrontendToolsTest {
         npmVersionCommand.add("--version");
         FrontendVersion npm = FrontendUtils.getVersion("npm",
                 npmVersionCommand);
-        Assert.assertEquals("6.14.6", npm.getFullVersion());
+        Assert.assertEquals("7.10.0", npm.getFullVersion());
 
     }
 
@@ -111,7 +113,8 @@ public class FrontendToolsTest {
             throws IOException {
         Platform platform = Platform.guess();
         String nodeExec = platform.isWindows() ? "node.exe" : "node";
-        String prefix = "node-" + version + "-" + platform.getNodeClassifier();
+        String prefix = "node-" + version + "-"
+                + platform.getNodeClassifier(new FrontendVersion(version));
 
         File downloadDir = new File(baseDir, version);
         FileUtils.forceMkdir(downloadDir);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/installer/NodeInstallerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/installer/NodeInstallerTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import com.vaadin.flow.server.frontend.FrontendTools;
+import com.vaadin.flow.server.frontend.FrontendVersion;
 
 public class NodeInstallerTest {
 
@@ -39,7 +40,8 @@ public class NodeInstallerTest {
         String nodeExec = platform.isWindows() ? "node.exe" : "node";
         String prefix = String.format("node-%s-%s",
                 FrontendTools.DEFAULT_NODE_VERSION,
-                platform.getNodeClassifier());
+                platform.getNodeClassifier(new FrontendVersion(
+                        FrontendTools.DEFAULT_NODE_VERSION)));
 
         File targetDir = new File(baseDir + "/installation");
 


### PR DESCRIPTION
Use the x64 package for mac if the installed
node version is < 16.0.0 as ARM package
is not available before this.

Fixes #11060
