### PR TITLE
Use simple space removing for CI

### DIFF
--- a/fusion-endpoint/src/test/java/com/vaadin/flow/server/connect/generator/IndentationUtils.java
+++ b/fusion-endpoint/src/test/java/com/vaadin/flow/server/connect/generator/IndentationUtils.java
@@ -6,6 +6,10 @@ import java.util.List;
 import java.util.Stack;
 
 final class IndentationUtils {
+    static String unifyIndentationCI(String code) {
+        return code.replaceAll("\\s+", " ");
+    }
+
     static String unifyIndentation(String code, int indentation)
             throws IndentationSyntaxException {
         Token[] tokens = Token.process(code);

--- a/fusion-endpoint/src/test/java/com/vaadin/flow/server/connect/generator/TestUtils.java
+++ b/fusion-endpoint/src/test/java/com/vaadin/flow/server/connect/generator/TestUtils.java
@@ -21,12 +21,14 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
 import org.junit.Assert;
 
 import static com.vaadin.flow.server.connect.generator.IndentationUtils.unifyIndentation;
+import static com.vaadin.flow.server.connect.generator.IndentationUtils.unifyIndentationCI;
 
 public final class TestUtils {
     private TestUtils() {
@@ -61,9 +63,15 @@ public final class TestUtils {
 
     public static void equalsIgnoreWhiteSpaces(String msg, String expected,
             String actual) {
+        boolean isCI = Optional.ofNullable(System.getenv("CI"))
+                .map(value -> value.equals("true")).orElse(false);
+
         try {
-            Assert.assertEquals(msg, unifyIndentation(expected, 2),
-                    unifyIndentation(actual, 2));
+            Assert.assertEquals(msg,
+                    isCI ? unifyIndentationCI(expected)
+                            : unifyIndentation(expected, 2),
+                    isCI ? unifyIndentationCI(actual)
+                            : unifyIndentation(actual, 2));
         } catch (IndentationUtils.IndentationSyntaxException e) {
             throw new AssertionError("Failed to unify indentation", e);
         }


### PR DESCRIPTION
Because of recent CI failures that are not reproducible on my Windows machine, let's run a previous version of code comparison where all spaces are simply removed. It will work only for CI, and the developer will get the human-readable output instead.