### PR TITLE
feat: allow defining access control annotations on view super classes

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/AccessAnnotationChecker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/AccessAnnotationChecker.java
@@ -210,10 +210,12 @@ public class AccessAnnotationChecker implements Serializable {
      *         returned.
      *         <p>
      *         Access annotations that being checked are:
-     *         - <code>@AnonymousAllowed</code>
-     *         - <code>@PermitAll</code>
-     *         - <code>@RolesAllowed</code>
-     *         - <code>DenyAll</code>
+     *         <ul>
+     *         <li><code>@AnonymousAllowed</code>
+     *         <li><code>@PermitAll</code>
+     *         <li><code>@RolesAllowed</code>
+     *         <li><code>DenyAll</code>
+     *         </ul>
      *
      * @throws NullPointerException
      *             if the input <code>cls</code> is null

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/AccessAnnotationChecker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/AccessAnnotationChecker.java
@@ -201,8 +201,8 @@ public class AccessAnnotationChecker implements Serializable {
      * @param cls
      *            the class to check
      * @return the first annotated class in {@code cls}'s hierarchy that
-     *         annotated with one of the access annotations, starting from
-     *         the input {@code cls} class itself, going up in the hierarchy.
+     *         annotated with one of the access annotations, starting from the
+     *         input {@code cls} class itself, going up in the hierarchy.
      *         WARNING: Note that interfaces are ignored.
      *         <p>
      *         If no class in the hierarchy was annotated with any of the access

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/AccessAnnotationChecker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/AccessAnnotationChecker.java
@@ -201,19 +201,17 @@ public class AccessAnnotationChecker implements Serializable {
      * @param cls
      *            the class to check
      * @return the first annotated class in <code>cls</code>'s hierarchy with
-     *          that annotated with one of the access annotations,
-     *          starting from the input <code>cls</code> class itself, going up
-     *          in the hierarchy. Note that interfaces are ignored.
-     *          <p>
-     *          If no class in the hierarchy was annotated with any of the access
-     *          annotations, the <code>cls</code> input parameter itself would be
-     *          returned.
-     *          <p>
-     *          Access annotations that being checked against are:
-     *          <code>@AnonymousAllowed</code>
-     *          <code>@PermitAll</code>,
-     *          <code>@RolesAllowed</code>
-     *          <code>DenyAll</code>
+     *         that annotated with one of the access annotations, starting from
+     *         the input <code>cls</code> class itself, going up in the
+     *         hierarchy. Note that interfaces are ignored.
+     *         <p>
+     *         If no class in the hierarchy was annotated with any of the access
+     *         annotations, the <code>cls</code> input parameter itself would be
+     *         returned.
+     *         <p>
+     *         Access annotations that being checked against are:
+     *         <code>@AnonymousAllowed</code> <code>@PermitAll</code>
+     *         <code>@RolesAllowed</code> <code>DenyAll</code>
      *
      * @throws NullPointerException
      *             if the input <code>cls</code> is null

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/AccessAnnotationChecker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/AccessAnnotationChecker.java
@@ -200,25 +200,25 @@ public class AccessAnnotationChecker implements Serializable {
      *
      * @param cls
      *            the class to check
-     * @return the first annotated class in <code>cls</code>'s hierarchy with
-     *         that annotated with one of the access annotations, starting from
-     *         the input <code>cls</code> class itself, going up in the
-     *         hierarchy. Note that interfaces are ignored.
+     * @return the first annotated class in {@code cls}'s hierarchy that
+     *         annotated with one of the access annotations, starting from
+     *         the input {@code cls} class itself, going up in the hierarchy.
+     *         WARNING: Note that interfaces are ignored.
      *         <p>
      *         If no class in the hierarchy was annotated with any of the access
-     *         annotations, the <code>cls</code> input parameter itself would be
+     *         annotations, the {@code cls} input parameter itself would be
      *         returned.
      *         <p>
      *         Access annotations that being checked are:
      *         <ul>
-     *         <li><code>@AnonymousAllowed</code>
-     *         <li><code>@PermitAll</code>
-     *         <li><code>@RolesAllowed</code>
-     *         <li><code>DenyAll</code>
+     *         <li>{@code @AnonymousAllowed}
+     *         <li>{@code @PermitAll}
+     *         <li>{@code @RolesAllowed}
+     *         <li>{@code @DenyAll}
      *         </ul>
      *
      * @throws NullPointerException
-     *             if the input <code>cls</code> is null
+     *             if the input {@code cls} is null
      */
     public AnnotatedElement getSecurityTarget(Class<?> cls) {
         Objects.requireNonNull(cls, "The input Class must not be null.");

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/AccessAnnotationChecker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/AccessAnnotationChecker.java
@@ -209,9 +209,11 @@ public class AccessAnnotationChecker implements Serializable {
      *         annotations, the <code>cls</code> input parameter itself would be
      *         returned.
      *         <p>
-     *         Access annotations that being checked against are:
-     *         <code>@AnonymousAllowed</code> <code>@PermitAll</code>
-     *         <code>@RolesAllowed</code> <code>DenyAll</code>
+     *         Access annotations that being checked are:
+     *         - <code>@AnonymousAllowed</code>
+     *         - <code>@PermitAll</code>
+     *         - <code>@RolesAllowed</code>
+     *         - <code>DenyAll</code>
      *
      * @throws NullPointerException
      *             if the input <code>cls</code> is null

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/AccessAnnotationChecker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/AccessAnnotationChecker.java
@@ -203,7 +203,7 @@ public class AccessAnnotationChecker implements Serializable {
      * @return the first annotated class in {@code cls}'s hierarchy that
      *         annotated with one of the access annotations, starting from the
      *         input {@code cls} class itself, going up in the hierarchy.
-     *         WARNING: Note that interfaces are ignored.
+     *         <em>Note:</em> interfaces in the {@code cls}'s hierarchy are ignored.
      *         <p>
      *         If no class in the hierarchy was annotated with any of the access
      *         annotations, the {@code cls} input parameter itself would be

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/AccessAnnotationChecker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/AccessAnnotationChecker.java
@@ -203,7 +203,8 @@ public class AccessAnnotationChecker implements Serializable {
      * @return the first annotated class in {@code cls}'s hierarchy that
      *         annotated with one of the access annotations, starting from the
      *         input {@code cls} class itself, going up in the hierarchy.
-     *         <em>Note:</em> interfaces in the {@code cls}'s hierarchy are ignored.
+     *         <em>Note:</em> interfaces in the {@code cls}'s hierarchy are
+     *         ignored.
      *         <p>
      *         If no class in the hierarchy was annotated with any of the access
      *         annotations, the {@code cls} input parameter itself would be

--- a/flow-server/src/test/java/com/vaadin/flow/server/auth/AccessControlTestClasses.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/auth/AccessControlTestClasses.java
@@ -334,4 +334,18 @@ public class AccessControlTestClasses {
     public static class NoAnnotationDenyAllByGrandParentView
             extends DenyAllParentView {
     }
+
+    @AnonymousAllowed
+    public interface CustomComponent {
+    }
+
+    @Route("no-annotation-denyall-as-interfaces-ignored")
+    public static class NoAnnotationDenyAllAsInterfacesIgnoredView
+            implements CustomComponent {
+    }
+
+    @Route("no-annotation-permitall-from-parent-and-interfaces-ignored")
+    public static class NoAnnotationPermitAllByGrandParentAsInterfacesIgnoredView
+            extends PermitAllParentView implements CustomComponent {
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/auth/AccessControlTestClasses.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/auth/AccessControlTestClasses.java
@@ -282,15 +282,14 @@ public class AccessControlTestClasses {
 
     @Route("no-annotation-anonymous-by-grandparent")
     public static class NoAnnotationAnonymousAllowedByGrandParentView
-            extends NoAnnotationAnonymousAllowedByParentView{
+            extends NoAnnotationAnonymousAllowedByParentView {
     }
 
     @PermitAll
     public static class PermitAllGrandParentView {
     }
 
-    public static class PermitAllParentView
-            extends PermitAllGrandParentView {
+    public static class PermitAllParentView extends PermitAllGrandParentView {
     }
 
     @Route("no-annotation-permitall-by-grandparent")
@@ -303,7 +302,7 @@ public class AccessControlTestClasses {
     }
 
     public static class RolesAllowedUserParentView
-            extends RolesAllowedUserGrandParentView{
+            extends RolesAllowedUserGrandParentView {
     }
 
     @Route("no-annotation-roles-allowed-user-by-grandparent")
@@ -316,7 +315,7 @@ public class AccessControlTestClasses {
     }
 
     public static class RolesAllowedAdminParentView
-            extends RolesAllowedAdminGrandParentView{
+            extends RolesAllowedAdminGrandParentView {
     }
 
     @Route("no-annotation-roles-allowed-admin-by-grandparent")
@@ -328,8 +327,7 @@ public class AccessControlTestClasses {
     public static class DenyAllGrandParentView {
     }
 
-    public static class DenyAllParentView
-            extends DenyAllGrandParentView {
+    public static class DenyAllParentView extends DenyAllGrandParentView {
     }
 
     @Route("no-annotation-denyall-by-grandparent")

--- a/flow-server/src/test/java/com/vaadin/flow/server/auth/AccessControlTestClasses.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/auth/AccessControlTestClasses.java
@@ -270,4 +270,70 @@ public class AccessControlTestClasses {
     @Route("admin")
     public static class RolesAllowedAdminView extends Component {
     }
+
+    @AnonymousAllowed
+    public static class AnonymousAllowedParentView extends Component {
+    }
+
+    @Route("no-annotation-anonymous-by-parent")
+    public static class NoAnnotationAnonymousAllowedByParentView
+            extends AnonymousAllowedParentView {
+    }
+
+    @Route("no-annotation-anonymous-by-grandparent")
+    public static class NoAnnotationAnonymousAllowedByGrandParentView
+            extends NoAnnotationAnonymousAllowedByParentView{
+    }
+
+    @PermitAll
+    public static class PermitAllGrandParentView {
+    }
+
+    public static class PermitAllParentView
+            extends PermitAllGrandParentView {
+    }
+
+    @Route("no-annotation-permitall-by-grandparent")
+    public static class NoAnnotationPermitAllByGrandParentView
+            extends PermitAllParentView {
+    }
+
+    @RolesAllowed("user")
+    public static class RolesAllowedUserGrandParentView {
+    }
+
+    public static class RolesAllowedUserParentView
+            extends RolesAllowedUserGrandParentView{
+    }
+
+    @Route("no-annotation-roles-allowed-user-by-grandparent")
+    public static class NoAnnotationRolesAllowedUserByGrandParentView
+            extends RolesAllowedUserParentView {
+    }
+
+    @RolesAllowed("admin")
+    public static class RolesAllowedAdminGrandParentView {
+    }
+
+    public static class RolesAllowedAdminParentView
+            extends RolesAllowedAdminGrandParentView{
+    }
+
+    @Route("no-annotation-roles-allowed-admin-by-grandparent")
+    public static class NoAnnotationRolesAllowedAdminByGrandParentView
+            extends RolesAllowedAdminParentView {
+    }
+
+    @DenyAll
+    public static class DenyAllGrandParentView {
+    }
+
+    public static class DenyAllParentView
+            extends DenyAllGrandParentView {
+    }
+
+    @Route("no-annotation-denyall-by-grandparent")
+    public static class NoAnnotationDenyAllByGrandParentView
+            extends DenyAllParentView {
+    }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/auth/ViewAccessCheckerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/auth/ViewAccessCheckerTest.java
@@ -45,6 +45,8 @@ import com.vaadin.flow.server.auth.AccessControlTestClasses.NoAnnotationPermitAl
 import com.vaadin.flow.server.auth.AccessControlTestClasses.NoAnnotationDenyAllByGrandParentView;
 import com.vaadin.flow.server.auth.AccessControlTestClasses.NoAnnotationRolesAllowedUserByGrandParentView;
 import com.vaadin.flow.server.auth.AccessControlTestClasses.NoAnnotationRolesAllowedAdminByGrandParentView;
+import com.vaadin.flow.server.auth.AccessControlTestClasses.NoAnnotationDenyAllAsInterfacesIgnoredView;
+import com.vaadin.flow.server.auth.AccessControlTestClasses.NoAnnotationPermitAllByGrandParentAsInterfacesIgnoredView;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -55,7 +57,7 @@ public class ViewAccessCheckerTest {
 
     private enum User {
         USER_NO_ROLES, NORMAL_USER, ADMIN
-    };
+    }
 
     private ViewAccessChecker viewAccessChecker;
 
@@ -487,6 +489,41 @@ public class ViewAccessCheckerTest {
         Result result = checkAccess(
                 NoAnnotationRolesAllowedAdminByGrandParentView.class,
                 User.ADMIN);
+        Assert.assertTrue(result.wasTargetViewRendered());
+    }
+
+    @Test
+    public void anyAccess_to_noAnnotationDenyAllAsInterfacesIgnoredView_denied() {
+        Assert.assertFalse(
+                checkAccess(NoAnnotationDenyAllAsInterfacesIgnoredView.class,
+                        null).wasTargetViewRendered());
+
+        Assert.assertFalse(
+                checkAccess(NoAnnotationDenyAllAsInterfacesIgnoredView.class,
+                        User.USER_NO_ROLES).wasTargetViewRendered());
+
+        Assert.assertFalse(
+                checkAccess(NoAnnotationDenyAllAsInterfacesIgnoredView.class,
+                        User.NORMAL_USER).wasTargetViewRendered());
+
+        Assert.assertFalse(
+                checkAccess(NoAnnotationDenyAllAsInterfacesIgnoredView.class,
+                        User.ADMIN).wasTargetViewRendered());
+    }
+
+    @Test
+    public void anonymousAccess_to_noAnnotationPermitAllByGrandParentAsInterfacesIgnoredView_denied() {
+        Result result = checkAccess(
+                NoAnnotationPermitAllByGrandParentAsInterfacesIgnoredView.class,
+                null);
+        Assert.assertFalse(result.wasTargetViewRendered());
+    }
+
+    @Test
+    public void loggedInNoRolesAccess_to_noAnnotationPermitAllByGrandParentAsInterfacesIgnoredView_allowed() {
+        Result result = checkAccess(
+                NoAnnotationPermitAllByGrandParentAsInterfacesIgnoredView.class,
+                User.USER_NO_ROLES);
         Assert.assertTrue(result.wasTargetViewRendered());
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/auth/ViewAccessCheckerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/auth/ViewAccessCheckerTest.java
@@ -336,7 +336,7 @@ public class ViewAccessCheckerTest {
     @Test
     public void anonymousAccess_to_noAnnotationAnonymousAllowedByParent_allowed() {
         Result result = checkAccess(
-                NoAnnotationAnonymousAllowedByParentView.class,null);
+                NoAnnotationAnonymousAllowedByParentView.class, null);
         Assert.assertTrue(result.wasTargetViewRendered());
     }
 
@@ -356,8 +356,8 @@ public class ViewAccessCheckerTest {
 
     @Test
     public void anonymousAccess_to_noAnnotationDenyAllByGrandParentView_denied() {
-        Result result = checkAccess(
-                NoAnnotationDenyAllByGrandParentView.class, null);
+        Result result = checkAccess(NoAnnotationDenyAllByGrandParentView.class,
+                null);
         Assert.assertFalse(result.wasTargetViewRendered());
     }
 
@@ -393,8 +393,7 @@ public class ViewAccessCheckerTest {
 
     @Test
     public void loggedInNoRolesAccess_to_noAnnotationDenyAllByGrandParentView_denied() {
-        Result result = checkAccess(
-                NoAnnotationDenyAllByGrandParentView.class,
+        Result result = checkAccess(NoAnnotationDenyAllByGrandParentView.class,
                 User.USER_NO_ROLES);
         Assert.assertFalse(result.wasTargetViewRendered());
     }
@@ -426,15 +425,13 @@ public class ViewAccessCheckerTest {
     @Test
     public void loggedInUserRoleAccess_to_noAnnotationPermitAllByGrandParentView_allowed() {
         Result result = checkAccess(
-                NoAnnotationPermitAllByGrandParentView.class,
-                User.NORMAL_USER);
+                NoAnnotationPermitAllByGrandParentView.class, User.NORMAL_USER);
         Assert.assertTrue(result.wasTargetViewRendered());
     }
 
     @Test
     public void loggedInUserRoleAccess_to_noAnnotationDenyAllByGrandParentView_denied() {
-        Result result = checkAccess(
-                NoAnnotationDenyAllByGrandParentView.class,
+        Result result = checkAccess(NoAnnotationDenyAllByGrandParentView.class,
                 User.NORMAL_USER);
         Assert.assertFalse(result.wasTargetViewRendered());
     }
@@ -466,15 +463,13 @@ public class ViewAccessCheckerTest {
     @Test
     public void loggedInAdminRoleAccess_to_noAnnotationPermitAllByGrandParentView_allowed() {
         Result result = checkAccess(
-                NoAnnotationPermitAllByGrandParentView.class,
-                User.ADMIN);
+                NoAnnotationPermitAllByGrandParentView.class, User.ADMIN);
         Assert.assertTrue(result.wasTargetViewRendered());
     }
 
     @Test
     public void loggedInAdminRoleAccess_to_noAnnotationDenyAllByGrandParentView_denied() {
-        Result result = checkAccess(
-                NoAnnotationDenyAllByGrandParentView.class,
+        Result result = checkAccess(NoAnnotationDenyAllByGrandParentView.class,
                 User.ADMIN);
         Assert.assertFalse(result.wasTargetViewRendered());
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/auth/ViewAccessCheckerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/auth/ViewAccessCheckerTest.java
@@ -39,6 +39,12 @@ import com.vaadin.flow.server.auth.AccessControlTestClasses.PermitAllView;
 import com.vaadin.flow.server.auth.AccessControlTestClasses.RolesAllowedAdminView;
 import com.vaadin.flow.server.auth.AccessControlTestClasses.RolesAllowedUserView;
 import com.vaadin.flow.server.auth.AccessControlTestClasses.TestLoginView;
+import com.vaadin.flow.server.auth.AccessControlTestClasses.NoAnnotationAnonymousAllowedByParentView;
+import com.vaadin.flow.server.auth.AccessControlTestClasses.NoAnnotationAnonymousAllowedByGrandParentView;
+import com.vaadin.flow.server.auth.AccessControlTestClasses.NoAnnotationPermitAllByGrandParentView;
+import com.vaadin.flow.server.auth.AccessControlTestClasses.NoAnnotationDenyAllByGrandParentView;
+import com.vaadin.flow.server.auth.AccessControlTestClasses.NoAnnotationRolesAllowedUserByGrandParentView;
+import com.vaadin.flow.server.auth.AccessControlTestClasses.NoAnnotationRolesAllowedAdminByGrandParentView;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -81,7 +87,7 @@ public class ViewAccessCheckerTest {
     }
 
     @Test
-    public void anonymousAccessToPemitAllViewDenied() {
+    public void anonymousAccessToPermitAllViewDenied() {
         Result result = checkAccess(PermitAllView.class, null);
         Assert.assertFalse(result.wasTargetViewRendered());
     }
@@ -118,7 +124,7 @@ public class ViewAccessCheckerTest {
     }
 
     @Test
-    public void loggedInNoRolesAccessToPemitAllViewAllowed() {
+    public void loggedInNoRolesAccessToPermitAllViewAllowed() {
         Result result = checkAccess(PermitAllView.class, User.USER_NO_ROLES);
         Assert.assertTrue(result.wasTargetViewRendered());
     }
@@ -157,7 +163,7 @@ public class ViewAccessCheckerTest {
     }
 
     @Test
-    public void loggedInUserRoleAccessToPemitAllViewAllowed() {
+    public void loggedInUserRoleAccessToPermitAllViewAllowed() {
         Result result = checkAccess(PermitAllView.class, User.NORMAL_USER);
         Assert.assertTrue(result.wasTargetViewRendered());
     }
@@ -195,7 +201,7 @@ public class ViewAccessCheckerTest {
     }
 
     @Test
-    public void loggedInAdminRoleAccessToPemitAllViewAllowed() {
+    public void loggedInAdminRoleAccessToPermitAllViewAllowed() {
         Result result = checkAccess(PermitAllView.class, User.ADMIN);
         Assert.assertTrue(result.wasTargetViewRendered());
     }
@@ -325,6 +331,168 @@ public class ViewAccessCheckerTest {
         Result result = checkAccess(RolesAllowedAdminView.class, null);
         Assert.assertFalse(result.wasTargetViewRendered());
         Assert.assertEquals(NotFoundException.class, result.getRerouteError());
+    }
+
+    @Test
+    public void anonymousAccess_to_noAnnotationAnonymousAllowedByParent_allowed() {
+        Result result = checkAccess(
+                NoAnnotationAnonymousAllowedByParentView.class,null);
+        Assert.assertTrue(result.wasTargetViewRendered());
+    }
+
+    @Test
+    public void anonymousAccess_to_noAnnotationAnonymousAllowedByGrandParent_allowed() {
+        Result result = checkAccess(
+                NoAnnotationAnonymousAllowedByGrandParentView.class, null);
+        Assert.assertTrue(result.wasTargetViewRendered());
+    }
+
+    @Test
+    public void anonymousAccess_to_noAnnotationPermitAllByGrandParentView_denied() {
+        Result result = checkAccess(
+                NoAnnotationPermitAllByGrandParentView.class, null);
+        Assert.assertFalse(result.wasTargetViewRendered());
+    }
+
+    @Test
+    public void anonymousAccess_to_noAnnotationDenyAllByGrandParentView_denied() {
+        Result result = checkAccess(
+                NoAnnotationDenyAllByGrandParentView.class, null);
+        Assert.assertFalse(result.wasTargetViewRendered());
+    }
+
+    @Test
+    public void anonymousAccess_to_noAnnotationRolesAllowedUserByGrandParentView_denied() {
+        Result result = checkAccess(
+                NoAnnotationRolesAllowedUserByGrandParentView.class, null);
+        Assert.assertFalse(result.wasTargetViewRendered());
+    }
+
+    @Test
+    public void anonymousAccess_to_noAnnotationRolesAllowedAdminByGrandParentView_denied() {
+        Result result = checkAccess(
+                NoAnnotationRolesAllowedAdminByGrandParentView.class, null);
+        Assert.assertFalse(result.wasTargetViewRendered());
+    }
+
+    @Test
+    public void loggedInNoRolesAccess_to_noAnnotationAnonymousAllowedByGrandParentView_allowed() {
+        Result result = checkAccess(
+                NoAnnotationAnonymousAllowedByGrandParentView.class,
+                User.USER_NO_ROLES);
+        Assert.assertTrue(result.wasTargetViewRendered());
+    }
+
+    @Test
+    public void loggedInNoRolesAccess_to_noAnnotationPermitAllByGrandParentView_allowed() {
+        Result result = checkAccess(
+                NoAnnotationPermitAllByGrandParentView.class,
+                User.USER_NO_ROLES);
+        Assert.assertTrue(result.wasTargetViewRendered());
+    }
+
+    @Test
+    public void loggedInNoRolesAccess_to_noAnnotationDenyAllByGrandParentView_denied() {
+        Result result = checkAccess(
+                NoAnnotationDenyAllByGrandParentView.class,
+                User.USER_NO_ROLES);
+        Assert.assertFalse(result.wasTargetViewRendered());
+    }
+
+    @Test
+    public void loggedInNoRolesAccess_to_noAnnotationRolesAllowedUserByGrandParentView_denied() {
+        Result result = checkAccess(
+                NoAnnotationRolesAllowedUserByGrandParentView.class,
+                User.USER_NO_ROLES);
+        Assert.assertFalse(result.wasTargetViewRendered());
+    }
+
+    @Test
+    public void loggedInNoRolesAccess_to_noAnnotationRolesAllowedAdminByGrandParentView_denied() {
+        Result result = checkAccess(
+                NoAnnotationRolesAllowedAdminByGrandParentView.class,
+                User.USER_NO_ROLES);
+        Assert.assertFalse(result.wasTargetViewRendered());
+    }
+
+    @Test
+    public void loggedInUserRoleAccess_to_noAnnotationAnonymousAllowedByGrandParentView_allowed() {
+        Result result = checkAccess(
+                NoAnnotationAnonymousAllowedByGrandParentView.class,
+                User.NORMAL_USER);
+        Assert.assertTrue(result.wasTargetViewRendered());
+    }
+
+    @Test
+    public void loggedInUserRoleAccess_to_noAnnotationPermitAllByGrandParentView_allowed() {
+        Result result = checkAccess(
+                NoAnnotationPermitAllByGrandParentView.class,
+                User.NORMAL_USER);
+        Assert.assertTrue(result.wasTargetViewRendered());
+    }
+
+    @Test
+    public void loggedInUserRoleAccess_to_noAnnotationDenyAllByGrandParentView_denied() {
+        Result result = checkAccess(
+                NoAnnotationDenyAllByGrandParentView.class,
+                User.NORMAL_USER);
+        Assert.assertFalse(result.wasTargetViewRendered());
+    }
+
+    @Test
+    public void loggedInUserRoleAccess_to_noAnnotationRolesAllowedUserByGrandParentView_allowed() {
+        Result result = checkAccess(
+                NoAnnotationRolesAllowedUserByGrandParentView.class,
+                User.NORMAL_USER);
+        Assert.assertTrue(result.wasTargetViewRendered());
+    }
+
+    @Test
+    public void loggedInUserRoleAccess_to_noAnnotationRolesAllowedAdminByGrandParentView_denied() {
+        Result result = checkAccess(
+                NoAnnotationRolesAllowedAdminByGrandParentView.class,
+                User.NORMAL_USER);
+        Assert.assertFalse(result.wasTargetViewRendered());
+    }
+
+    @Test
+    public void loggedInAdminRoleAccess_to_noAnnotationAnonymousAllowedByGrandParentView_allowed() {
+        Result result = checkAccess(
+                NoAnnotationAnonymousAllowedByGrandParentView.class,
+                User.ADMIN);
+        Assert.assertTrue(result.wasTargetViewRendered());
+    }
+
+    @Test
+    public void loggedInAdminRoleAccess_to_noAnnotationPermitAllByGrandParentView_allowed() {
+        Result result = checkAccess(
+                NoAnnotationPermitAllByGrandParentView.class,
+                User.ADMIN);
+        Assert.assertTrue(result.wasTargetViewRendered());
+    }
+
+    @Test
+    public void loggedInAdminRoleAccess_to_noAnnotationDenyAllByGrandParentView_denied() {
+        Result result = checkAccess(
+                NoAnnotationDenyAllByGrandParentView.class,
+                User.ADMIN);
+        Assert.assertFalse(result.wasTargetViewRendered());
+    }
+
+    @Test
+    public void loggedInAdminRoleAccess_to_noAnnotationRolesAllowedUserByGrandParentView_denied() {
+        Result result = checkAccess(
+                NoAnnotationRolesAllowedUserByGrandParentView.class,
+                User.ADMIN);
+        Assert.assertFalse(result.wasTargetViewRendered());
+    }
+
+    @Test
+    public void loggedInAdminRoleAccess_To_noAnnotationRolesAllowedAdminByGrandParentView_allowed() {
+        Result result = checkAccess(
+                NoAnnotationRolesAllowedAdminByGrandParentView.class,
+                User.ADMIN);
+        Assert.assertTrue(result.wasTargetViewRendered());
     }
 
     private void resetLoginView()


### PR DESCRIPTION
## Description

This allows leaving child views unannotated 
(without any of the access annotations) and the 
access annotations to be defined on any of the 
view's superclasses. 

Fixes #10705

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
