### PR TITLE
fix: prevent passing bad character to dev-server

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/DevModeHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/DevModeHandler.java
@@ -35,7 +35,7 @@ public interface DevModeHandler extends RequestHandler {
      * Prepare a HTTP connection against webpack-dev-server.
      *
      * @param path
-     *            the file to request
+     *            the file to request, needs to be safe
      * @param method
      *            the http method to use
      * @return the connection

--- a/flow-server/src/main/java/com/vaadin/flow/server/HandlerHelper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/HandlerHelper.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.server;
 
+import javax.servlet.http.HttpServletRequest;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -27,8 +28,6 @@ import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
-import javax.servlet.http.HttpServletRequest;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.server.communication.PwaHandler;

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/DevModeHandlerImplTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/DevModeHandlerImplTest.java
@@ -643,7 +643,8 @@ public class DevModeHandlerImplTest {
     @Test
     public void serveDevModeRequest_uriForDevmodeGizmo_goesToWebpack()
             throws Exception {
-        HttpServletRequest request = prepareRequest("/VAADIN/build/vaadin-devmodeGizmo-f679dbf313191ec3d018.cache.js");
+        HttpServletRequest request = prepareRequest(
+                "/VAADIN/build/vaadin-devmodeGizmo-f679dbf313191ec3d018.cache.js");
         HttpServletResponse response = prepareResponse();
 
         final String manifestJsonResponse = "{ \"sw.js\": "
@@ -662,7 +663,8 @@ public class DevModeHandlerImplTest {
     @Test
     public void serveDevModeRequest_uriWithScriptInjected_returnsImmediatelyAndSetsForbiddenStatus()
             throws Exception {
-        HttpServletRequest request = prepareRequest("/VAADIN/build/vaadin-devmodeGizmo-f679dbf313191ec3d018.cache%3f%22onload=%22alert(1)");
+        HttpServletRequest request = prepareRequest(
+                "/VAADIN/build/vaadin-devmodeGizmo-f679dbf313191ec3d018.cache%3f%22onload=%22alert(1)");
         HttpServletResponse response = prepareResponse();
 
         final String manifestJsonResponse = "{ \"sw.js\": "

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/DevModeHandlerImplTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/DevModeHandlerImplTest.java
@@ -21,12 +21,12 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.ConnectException;
+import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -638,6 +638,44 @@ public class DevModeHandlerImplTest {
         Assert.assertTrue("expected a body child",
                 document.body().children().size() > 0);
         Mockito.verify(response).setContentType("text/html;charset=utf-8");
+    }
+
+    @Test
+    public void serveDevModeRequest_uriForDevmodeGizmo_goesToWebpack()
+            throws Exception {
+        HttpServletRequest request = prepareRequest("/VAADIN/build/vaadin-devmodeGizmo-f679dbf313191ec3d018.cache.js");
+        HttpServletResponse response = prepareResponse();
+
+        final String manifestJsonResponse = "{ \"sw.js\": "
+                + "\"sw.js\", \"index.html\": \"index.html\" }";
+        int port = prepareHttpServer(0, HTTP_OK, manifestJsonResponse);
+
+        DevModeHandlerImpl devModeHandler = DevModeHandlerImpl.start(port,
+                createDevModeLookup(), npmFolder,
+                CompletableFuture.completedFuture(null));
+        devModeHandler.join();
+
+        assertTrue(devModeHandler.serveDevModeRequest(request, response));
+        assertEquals(HTTP_OK, responseStatus);
+    }
+
+    @Test
+    public void serveDevModeRequest_uriWithScriptInjected_returnsImmediatelyAndSetsForbiddenStatus()
+            throws Exception {
+        HttpServletRequest request = prepareRequest("/VAADIN/build/vaadin-devmodeGizmo-f679dbf313191ec3d018.cache%3f%22onload=%22alert(1)");
+        HttpServletResponse response = prepareResponse();
+
+        final String manifestJsonResponse = "{ \"sw.js\": "
+                + "\"sw.js\", \"index.html\": \"index.html\" }";
+        int port = prepareHttpServer(0, HTTP_OK, manifestJsonResponse);
+
+        DevModeHandlerImpl devModeHandler = DevModeHandlerImpl.start(port,
+                createDevModeLookup(), npmFolder,
+                CompletableFuture.completedFuture(null));
+        devModeHandler.join();
+
+        assertTrue(devModeHandler.serveDevModeRequest(request, response));
+        assertEquals(HTTP_FORBIDDEN, responseStatus);
     }
 
     @Test


### PR DESCRIPTION
The webpack dev-server does not escape " character, as it is not valid
URL. This limitation was not checked when passing request to it via
DevModeHandlerImpl.
