### PR TITLE
chore: warn about missing DevModeHandlerManager

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.internal.DevModeHandler;
 import com.vaadin.flow.internal.DevModeHandlerManager;
 import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.server.communication.FaviconHandler;
@@ -98,8 +99,17 @@ public class VaadinServletService extends VaadinService {
         }
 
         if (getDeploymentConfiguration().enableDevServer()) {
-            DevModeHandlerManager.getDevModeHandler(this)
-                    .ifPresent(handlers::add);
+            Optional<DevModeHandler> handlerManager = DevModeHandlerManager
+                    .getDevModeHandler(this);
+            if (handlerManager.isPresent()) {
+                handlers.add(handlerManager.get());
+            } else {
+                getLogger()
+                        .warn("no DevModeHandlerManager implementation found "
+                                + "but dev server enabled. Include the "
+                                + "com.vaadin.vaadin-dev-server maven "
+                                + "dependency.");
+            }
         }
 
         addBootstrapHandler(handlers);

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
@@ -107,8 +107,7 @@ public class VaadinServletService extends VaadinService {
                 getLogger()
                         .warn("no DevModeHandlerManager implementation found "
                                 + "but dev server enabled. Include the "
-                                + "com.vaadin.vaadin-dev-server maven "
-                                + "dependency.");
+                                + "com.vaadin.vaadin-dev-server dependency.");
             }
         }
 


### PR DESCRIPTION
Gives a clue in case the vaadin-dev-server module is accidentally excluded in dev mode.