### PR TITLE
fix: add javadocs warning to avoid using ResponseWriter for dirs

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/ResponseWriter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/ResponseWriter.java
@@ -93,12 +93,12 @@ public class ResponseWriter implements Serializable {
      * Writes the contents and content type (if available) of the given
      * resourceUrl to the response.
      * <p>
-     * WARNING: note that this should not be used for {@code resourceUrl} which
-     * represents a directory! For security reasons the directory content should
-     * not be ever printed into the {@code response} and the implementation
-     * which is used for setting content length relies on
+     * WARNING: note that this should not be used for a {@code resourceUrl} that
+     * represents a directory! For security reasons, the directory contents should
+     * not be ever written into the {@code response}, and the implementation
+     * which is used for setting the content length relies on
      * {@link URLConnection#getContentLengthLong()} method which returns
-     * incorrect value for a directory.
+     * incorrect values for directories.
      *
      * @param filenameWithPath
      *            the name of the file being sent

--- a/flow-server/src/main/java/com/vaadin/flow/internal/ResponseWriter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/ResponseWriter.java
@@ -92,6 +92,13 @@ public class ResponseWriter implements Serializable {
     /**
      * Writes the contents and content type (if available) of the given
      * resourceUrl to the response.
+     * <p>
+     * WARNING: note that this should not be used for {@code resourceUrl} which
+     * represents a directory! For security reasons the directory content should
+     * not be ever printed into the {@code response} and the implementation
+     * which is used for setting content length relies on
+     * {@link URLConnection#getContentLengthLong()} method which returns
+     * incorrect value for a directory.
      *
      * @param filenameWithPath
      *            the name of the file being sent

--- a/flow-server/src/main/java/com/vaadin/flow/internal/ResponseWriter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/ResponseWriter.java
@@ -94,9 +94,9 @@ public class ResponseWriter implements Serializable {
      * resourceUrl to the response.
      * <p>
      * WARNING: note that this should not be used for a {@code resourceUrl} that
-     * represents a directory! For security reasons, the directory contents should
-     * not be ever written into the {@code response}, and the implementation
-     * which is used for setting the content length relies on
+     * represents a directory! For security reasons, the directory contents
+     * should not be ever written into the {@code response}, and the
+     * implementation which is used for setting the content length relies on
      * {@link URLConnection#getContentLengthLong()} method which returns
      * incorrect values for directories.
      *


### PR DESCRIPTION
fixes #11046

<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Please list all relevant dependencies in this section and provide summary of the change, motivation and context.

Fixes # (issue)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
