### PR TITLE
fix: prevent passing bad character to wp (#11099)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.server;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -89,6 +88,10 @@ public final class DevModeHandler implements RequestHandler {
 
     private static final AtomicReference<DevModeHandler> atomicHandler = new AtomicReference<>();
 
+    // webpack dev-server allows " character if passed through, need to
+    // explicitly check requests for it
+    private static final Pattern WEBPACK_ILLEGAL_CHAR_PATTERN = Pattern
+            .compile("\"|%22");
     // It's not possible to know whether webpack is ready unless reading output
     // messages. When webpack finishes, it writes either a `Compiled` or a
     // `Failed` in the last line
@@ -324,8 +327,10 @@ public final class DevModeHandler implements RequestHandler {
         // a valid request for webpack-dev-server should start with '/VAADIN/'
         String requestFilename = request.getPathInfo();
 
-        if (HandlerHelper.isPathUnsafe(requestFilename)) {
-            getLogger().info(HandlerHelper.UNSAFE_PATH_ERROR_MESSAGE_PATTERN,
+        if (HandlerHelper.isPathUnsafe(requestFilename)
+                || WEBPACK_ILLEGAL_CHAR_PATTERN.matcher(requestFilename)
+                        .find()) {
+            getLogger().info("Blocked attempt to access file: {}",
                     requestFilename);
             response.setStatus(HttpServletResponse.SC_FORBIDDEN);
             return true;
@@ -411,6 +416,7 @@ public final class DevModeHandler implements RequestHandler {
      */
     public HttpURLConnection prepareConnection(String path, String method)
             throws IOException {
+        // path should have been checked at this point for any outside requests
         URL uri = new URL(WEBPACK_HOST + ":" + getPort() + path);
         HttpURLConnection connection = (HttpURLConnection) uri.openConnection();
         connection.setRequestMethod(method);

--- a/flow-server/src/main/java/com/vaadin/flow/server/HandlerHelper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/HandlerHelper.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.server;
 
+import javax.servlet.http.HttpServletRequest;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;

--- a/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
@@ -26,7 +26,6 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.ConnectException;
-import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;

--- a/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
@@ -21,12 +21,12 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.ConnectException;
+import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -607,6 +607,46 @@ public class DevModeHandlerTest {
         Assert.assertTrue("expected a body child",
                 document.body().children().size() > 0);
         Mockito.verify(response).setContentType("text/html;charset=utf-8");
+    }
+
+    @Test
+    public void serveDevModeRequest_uriForDevmodeGizmo_goesToWebpack()
+            throws Exception {
+        HttpServletRequest request = prepareRequest(
+                "/VAADIN/build/vaadin-devmodeGizmo-f679dbf313191ec3d018.cache.js");
+        HttpServletResponse response = prepareResponse();
+
+        final String manifestJsonResponse = "{ \"sw.js\": "
+                + "\"sw.js\", \"index.html\": \"index.html\" }";
+        int port = prepareHttpServer(0, HTTP_OK, manifestJsonResponse);
+
+        DevModeHandler devModeHandler = DevModeHandler.start(port,
+                createDevModeLookup(), npmFolder,
+                CompletableFuture.completedFuture(null));
+        devModeHandler.join();
+
+        assertTrue(devModeHandler.serveDevModeRequest(request, response));
+        assertEquals(HTTP_OK, responseStatus);
+    }
+
+    @Test
+    public void serveDevModeRequest_uriWithScriptInjected_returnsImmediatelyAndSetsForbiddenStatus()
+            throws Exception {
+        HttpServletRequest request = prepareRequest(
+                "/VAADIN/build/vaadin-devmodeGizmo-f679dbf313191ec3d018.cache%3f%22onload=%22alert(1)");
+        HttpServletResponse response = prepareResponse();
+
+        final String manifestJsonResponse = "{ \"sw.js\": "
+                + "\"sw.js\", \"index.html\": \"index.html\" }";
+        int port = prepareHttpServer(0, HTTP_OK, manifestJsonResponse);
+
+        DevModeHandler devModeHandler = DevModeHandler.start(port,
+                createDevModeLookup(), npmFolder,
+                CompletableFuture.completedFuture(null));
+        devModeHandler.join();
+
+        assertTrue(devModeHandler.serveDevModeRequest(request, response));
+        assertEquals(HTTP_FORBIDDEN, responseStatus);
     }
 
     @Test


### PR DESCRIPTION
The webpack dev-server does not escape " character, as it is not valid
URL. This limitation was not checked when passing request to it via
DevModeHandlerImpl.