### PR TITLE
fix: prevent passing bad character to wp (#11099)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/HandlerHelper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/HandlerHelper.java
@@ -16,6 +16,7 @@
 
 package com.vaadin.flow.server;
 
+import javax.servlet.http.HttpServletRequest;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;

--- a/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
@@ -26,7 +26,6 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.ConnectException;
-import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;

--- a/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
@@ -557,8 +557,8 @@ public class DevModeHandlerTest {
                 + "\"sw.js\", \"index.html\": \"index.html\" }";
         int port = prepareHttpServer(0, HTTP_OK, manifestJsonResponse);
 
-        DevModeHandlerImpl devModeHandler = DevModeHandlerImpl.start(port,
-                createDevModeLookup(), npmFolder,
+        DevModeHandler devModeHandler = DevModeHandler.start(port,
+                configuration, npmFolder,
                 CompletableFuture.completedFuture(null));
         devModeHandler.join();
 
@@ -577,8 +577,8 @@ public class DevModeHandlerTest {
                 + "\"sw.js\", \"index.html\": \"index.html\" }";
         int port = prepareHttpServer(0, HTTP_OK, manifestJsonResponse);
 
-        DevModeHandlerImpl devModeHandler = DevModeHandlerImpl.start(port,
-                createDevModeLookup(), npmFolder,
+        DevModeHandler devModeHandler = DevModeHandler.start(port,
+                configuration, npmFolder,
                 CompletableFuture.completedFuture(null));
         devModeHandler.join();
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DevModeHandlerTest.java
@@ -21,12 +21,12 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.ConnectException;
+import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -544,6 +544,46 @@ public class DevModeHandlerTest {
         DevModeHandler handler = DevModeHandler.start(port, configuration,
                 npmFolder, CompletableFuture.completedFuture(null));
         handler.join();
+    }
+
+    @Test
+    public void serveDevModeRequest_uriForDevmodeGizmo_goesToWebpack()
+            throws Exception {
+        HttpServletRequest request = prepareRequest(
+                "/VAADIN/build/vaadin-devmodeGizmo-f679dbf313191ec3d018.cache.js");
+        HttpServletResponse response = prepareResponse();
+
+        final String manifestJsonResponse = "{ \"sw.js\": "
+                + "\"sw.js\", \"index.html\": \"index.html\" }";
+        int port = prepareHttpServer(0, HTTP_OK, manifestJsonResponse);
+
+        DevModeHandlerImpl devModeHandler = DevModeHandlerImpl.start(port,
+                createDevModeLookup(), npmFolder,
+                CompletableFuture.completedFuture(null));
+        devModeHandler.join();
+
+        assertTrue(devModeHandler.serveDevModeRequest(request, response));
+        assertEquals(HTTP_OK, responseStatus);
+    }
+
+    @Test
+    public void serveDevModeRequest_uriWithScriptInjected_returnsImmediatelyAndSetsForbiddenStatus()
+            throws Exception {
+        HttpServletRequest request = prepareRequest(
+                "/VAADIN/build/vaadin-devmodeGizmo-f679dbf313191ec3d018.cache%3f%22onload=%22alert(1)");
+        HttpServletResponse response = prepareResponse();
+
+        final String manifestJsonResponse = "{ \"sw.js\": "
+                + "\"sw.js\", \"index.html\": \"index.html\" }";
+        int port = prepareHttpServer(0, HTTP_OK, manifestJsonResponse);
+
+        DevModeHandlerImpl devModeHandler = DevModeHandlerImpl.start(port,
+                createDevModeLookup(), npmFolder,
+                CompletableFuture.completedFuture(null));
+        devModeHandler.join();
+
+        assertTrue(devModeHandler.serveDevModeRequest(request, response));
+        assertEquals(HTTP_FORBIDDEN, responseStatus);
     }
 
     @Test


### PR DESCRIPTION
The webpack dev-server does not escape " character, as it is not valid
URL. This limitation was not checked when passing request to it via
DevModeHandlerImpl.