### PR TITLE
test: UnixFileSystem.getPath introduces null assertion in new JDKs

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/CustomUIClassLoaderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/CustomUIClassLoaderTest.java
@@ -66,6 +66,7 @@ public class CustomUIClassLoaderTest extends TestCase {
                 .mock(ApplicationConfiguration.class);
         Mockito.when(config.getPropertyNames())
                 .thenReturn(Collections.emptyEnumeration());
+        Mockito.when(config.getBuildFolder()).thenReturn(".");
         return new DefaultDeploymentConfiguration(config,
                 CustomUIClassLoaderTest.class, properties);
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/DefaultDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DefaultDeploymentConfigurationTest.java
@@ -283,6 +283,7 @@ public class DefaultDeploymentConfigurationTest {
             ApplicationConfiguration appConfig, Properties initParameters) {
         Mockito.when(appConfig.getPropertyNames())
                 .thenReturn(Collections.emptyEnumeration());
+        Mockito.when(appConfig.getBuildFolder()).thenReturn(".");
         return new DefaultDeploymentConfiguration(appConfig,
                 DefaultDeploymentConfigurationTest.class, initParameters);
     }


### PR DESCRIPTION
Running tests in JDK16 fails if appConfig.getBuildFolder returns null, because a new assertion introduced in UnixFileSystem.getPath