### PR TITLE
create javadocs for gradle plugin [skip-ci]

### DIFF
--- a/flow-plugins/flow-gradle-plugin/build.gradle
+++ b/flow-plugins/flow-gradle-plugin/build.gradle
@@ -10,7 +10,6 @@ plugins {
     id 'com.gradle.plugin-publish' version '0.11.0'
     id 'org.jetbrains.kotlin.jvm' version '1.4.31'
     id 'maven'
-    id 'org.jetbrains.dokka' version '1.4.32'
 }
 
 /***********************************************************************************************************************
@@ -44,11 +43,6 @@ sourceSets {
         compileClasspath += sourceSets.main.output + configurations.testRuntime
         runtimeClasspath += output + compileClasspath
     }
-}
-
-task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
 }
 
 /***********************************************************************************************************************

--- a/flow-plugins/flow-gradle-plugin/pom.xml
+++ b/flow-plugins/flow-gradle-plugin/pom.xml
@@ -70,7 +70,6 @@
                             <arguments>
                                 <argument>clean</argument>
                                 <argument>build</argument>
-                                <argument>javadocJar</argument>
                                 <argument>-x</argument>
                                 <argument>functionalTest</argument>
                                 <argument>-S</argument>

--- a/flow-plugins/flow-gradle-plugin/src/main/java/com/vaadin/ClassToGenerateJavadocs.java
+++ b/flow-plugins/flow-gradle-plugin/src/main/java/com/vaadin/ClassToGenerateJavadocs.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin;
+
+/**
+ * A dummy class to get javadocs generated for the flow gradle plugin, so that
+ * the plugin artifact release to central doesn't fail.
+ */
+public class ClassToGenerateJavadocs {
+
+}


### PR DESCRIPTION
Not to be squashed as this reverts the previous failed attempt to generate those.