### PR TITLE
chore: skip gradle plugin when compiling in jdk17 early access

### DIFF
--- a/flow-plugins/pom.xml
+++ b/flow-plugins/pom.xml
@@ -14,7 +14,6 @@
 	<modules>
 		<module>flow-plugin-base</module>
 		<module>flow-maven-plugin</module>
-		<module>flow-gradle-plugin</module>
 	</modules>
 	<build>
 		<plugins>
@@ -33,4 +32,15 @@
 			</plugin>
 		</plugins>
 	</build>
+        <profiles>
+                <profile>
+                        <id>gradle</id>
+                        <activation>
+                                <jdk>(,16]</jdk>
+                        </activation>
+                        <modules>
+                                <module>flow-gradle-plugin</module>
+                        </modules>
+               </profile>
+        </profiles>
 </project>


### PR DESCRIPTION
Running gradle plugin with JDK17 EA does not work see https://github.com/gradle/gradle/issues/16857
