### PR TITLE
test: fix gradle tests so as they can be run with gradle-7.0 and jdk16

### DIFF
--- a/flow-plugins/flow-gradle-plugin/build.gradle
+++ b/flow-plugins/flow-gradle-plugin/build.gradle
@@ -33,15 +33,13 @@ targetCompatibility = 1.8
 
 sourceSets {
     functionalTest {
-        kotlin {
-            srcDir file('src/functionalTest/kotlin')
-        }
-        resources {
-            srcDir file('src/functionalTest/resources')
-        }
-        compileClasspath += sourceSets.main.output + configurations.testRuntime
-        runtimeClasspath += output + compileClasspath
+        compileClasspath += sourceSets.main.output
+        runtimeClasspath += sourceSets.main.output
     }
+}
+
+configurations {
+    functionalTestImplementation.extendsFrom testImplementation
 }
 
 /***********************************************************************************************************************
@@ -59,12 +57,12 @@ repositories {
 }
 
 dependencies {
-    compile("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.31")
+    compile("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.32")
 
     compile("com.vaadin:flow-plugin-base:${pom.parent.version}")
 
-    testCompile("junit:junit:4.12")
-    testCompile("org.jetbrains.kotlin:kotlin-test:1.4.31")
+    testImplementation("junit:junit:4.12")
+    testImplementation("org.jetbrains.kotlin:kotlin-test:1.4.32")
 }
 
 idea {


### PR DESCRIPTION
Applied the same fix than in 
https://github.com/vaadin/vaadin-gradle-plugin/commit/aee343d58383c82859b0983f02f6e79fc73c8c8b from @mvysny

This fix avoid having to revert https://github.com/vaadin/flow/pull/11119 