### PR TITLE
chore: Remove skipTests profile [skip ci] 

### DIFF
--- a/flow-plugins/flow-gradle-plugin/pom.xml
+++ b/flow-plugins/flow-gradle-plugin/pom.xml
@@ -148,43 +148,5 @@
                 <gradle.executable>gradlew.bat</gradle.executable>
             </properties>
         </profile>
-
-        <profile>
-            <id>skipTests</id>
-            <activation>
-                <property>
-                    <name>skipTests</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <!-- execute Gradle command -->
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <version>3.0.0</version>
-                        <executions>
-                            <execution>
-                                <id>gradle</id>
-                                <phase>prepare-package</phase>
-                                <configuration>
-                                    <executable>${gradle.executable}</executable>
-                                    <arguments>
-                                        <argument>clean</argument>
-                                        <argument>build</argument>
-                                        <argument>-x</argument>
-                                        <argument>functionalTest</argument>
-                                        <argument>-S</argument>
-                                    </arguments>
-                                </configuration>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Remove the skipTests profile as
by default we run the gradle tests in
another build.
