### PR TITLE
chore: bump gradle wrapper and disable gradle daemon

### DIFF
--- a/flow-plugins/flow-gradle-plugin/gradle.properties
+++ b/flow-plugins/flow-gradle-plugin/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.daemon=false

--- a/flow-plugins/flow-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/flow-plugins/flow-gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Description

Updates gradle wrapper version to latest in order to fix issues in Flow CI like 

`java.lang.IllegalArgumentException: Supplied javaHome must be a valid directory.`

Related-to https://github.com/vaadin/platform/issues/2170
Fixes: https://github.com/vaadin/flow/issues/11159

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

