### PR TITLE
fix: NumberModel should read empty string as undefined

### DIFF
--- a/flow-client/src/main/frontend/form/Models.ts
+++ b/flow-client/src/main/frontend/form/Models.ts
@@ -76,7 +76,7 @@ export class BooleanModel extends PrimitiveModel<boolean> implements HasFromStri
   [_fromString] = Boolean;
 }
 
-export class NumberModel extends PrimitiveModel<number> implements HasFromString<number> {
+export class NumberModel extends PrimitiveModel<number> implements HasFromString<number | undefined> {
   static createEmptyValue = Number;
   constructor(
     parent: ModelParent<number>,
@@ -87,7 +87,10 @@ export class NumberModel extends PrimitiveModel<number> implements HasFromString
     // Prepend a built-in validator to indicate NaN input
     super(parent, key, optional, new IsNumber(optional), ...validators);
   }
-  [_fromString](str: string): number {
+  [_fromString](str: string): number | undefined {
+    // Returning undefined is needed to support passing the validation when the value of an optional number field is
+    // an empty string
+    if (str === '') return undefined;
     return isNumeric(str) ? Number.parseFloat(str) : NaN;
   }
 }

--- a/flow-client/src/test/frontend/form/FieldTests.ts
+++ b/flow-client/src/test/frontend/form/FieldTests.ts
@@ -272,11 +272,11 @@ suite('form/Field', () => {
       });
 
       test('should update binder value on typing', async () => {
-        const cases: Array<[string, number]> = [
+        const cases: Array<[string, number | undefined]> = [
           ['1', 1],
           ['1.', NaN], // not allowed format
           ['1.2', 1.2],
-          ['', NaN],
+          ['', undefined],
           ['not a number', NaN],
           ['.', NaN],
           ['.1', 0.1],
@@ -418,11 +418,11 @@ suite('form/Field', () => {
       });
 
       test('should update binder value on typing', async () => {
-        const cases: Array<[string, number]> = [
+        const cases: Array<[string, number | undefined]> = [
           ['1', 1],
           ['1.', NaN], // not allowed format
           ['1.2', 1.2],
-          ['', NaN],
+          ['', undefined],
           ['not a number', NaN],
           ['.', NaN],
           ['.1', 0.1],

--- a/flow-client/src/test/frontend/form/ModelTests.ts
+++ b/flow-client/src/test/frontend/form/ModelTests.ts
@@ -65,14 +65,14 @@ suite("form/Model", () => {
     });
 
     suite('_fromString', () => {
-      let fromString: (str: string) => number;
+      let fromString: (str: string) => number | undefined;
 
       beforeEach(() => {
         fromString = binder.model.fieldNumber[_fromString];
       });
 
       test('should disallow empty string', async () => {
-        expect(fromString('')).to.satisfy(Number.isNaN);
+        expect(fromString('')).to.equal(undefined);
       });
 
       test('should integer format', async () => {


### PR DESCRIPTION
## Description

NumberModel should read empty string as undefined so that the NumberValidator can pass the validation for an option number field when the input value is an empty string.

Fixes https://github.com/vaadin/fusion/issues/13

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
