### PR TITLE
chore: disable lit/quoted-expressions rule in eslint

### DIFF
--- a/flow-client/.eslintrc.js
+++ b/flow-client/.eslintrc.js
@@ -57,6 +57,7 @@ module.exports = {
         "no-nested-ternary": 0,
         "no-restricted-globals": 0,
         "no-restricted-syntax": 0,
+        "lit/quoted-expressions": 0,
       },
     },
   ]


### PR DESCRIPTION
This should be reverted after #11181 is fixed