### PR TITLE
chore: Pin ESLint plugin Lit version

### DIFF
--- a/flow-client/package.json
+++ b/flow-client/package.json
@@ -32,6 +32,7 @@
     "chai": "4.2.0",
     "eslint": "7.21.0",
     "eslint-config-vaadin": "0.4.0",
+    "eslint-plugin-lit": "1.4.1",
     "fetch-mock": "7.3.0",
     "intern": "4.4.3",
     "mkdirp": "0.5.5",


### PR DESCRIPTION
## Description

Pins the ESLint plugin version because the newer one causes the build errors.

Fixes https://github.com/vaadin/flow/issues/11176

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
