### PR TITLE
chore: fix random failure on copying files when building flow-client

### DIFF
--- a/flow-client/scripts/client.js
+++ b/flow-client/scripts/client.js
@@ -15,7 +15,6 @@
  */
 
 const fs = require('fs');
-const mkdirp = require('mkdirp');
 
 const fromDir = "target/classes/META-INF/resources/VAADIN/static/client/";
 const fromFileRegex = /^client-.*\.cache\.js$/;
@@ -39,9 +38,9 @@ ${clientSource}
 fs.writeFileSync(sourceDir + toFile, clientSource, 'utf8');
 
 // Write to target (copy '.d.ts' and '.js' files from sourceDir)
-mkdirp(targetDir);
+fs.mkdirSync(targetDir, {recursive: true});
 fs.readdirSync(sourceDir)
-  .filter(s => s.endsWith('.d.ts') ||s.endsWith('.js'))
+  .filter(s => s.endsWith('.d.ts') || s.endsWith('.js'))
   .forEach(file => fs.copyFileSync(sourceDir + file, targetDir + file));
 
 // Check that chromedriver version matches in flow and intern


### PR DESCRIPTION
fixes: #11149

Note, I couldn't reproduce this in my local, but happens quite often in the build platform does for JDKs tests.
I added there an extra step for patching the file with this approach and couldn't see the failure any more.
There is no way for actually test this with an IT, or at least I do not see  any.