### PR TITLE
fix: make TS validators accept null values

### DIFF
--- a/flow-client/src/main/frontend/form/Validators.ts
+++ b/flow-client/src/main/frontend/form/Validators.ts
@@ -79,7 +79,7 @@ export class IsNumber extends NumberValidator<number | null | undefined> {
   }
 
   validate(value: number | null | undefined) {
-    return (this.optional && (value === null || value === undefined)) || super.validate(value);
+    return (this.optional && value == null) || super.validate(value);
   }
 }
 

--- a/flow-client/src/main/frontend/form/Validators.ts
+++ b/flow-client/src/main/frontend/form/Validators.ts
@@ -71,15 +71,15 @@ abstract class NumberValidator<T> extends AbstractValidator<T> {
   }
 }
 
-export class IsNumber extends NumberValidator<number | undefined> {
+export class IsNumber extends NumberValidator<number | null | undefined> {
   optional: boolean;
   constructor(optional: boolean, attrs?: ValidatorAttributes) {
     super({ message: 'must be a number', ...attrs });
     this.optional = optional;
   }
 
-  validate(value: number | undefined) {
-    return (this.optional && value === undefined) || super.validate(value);
+  validate(value: number | null | undefined) {
+    return (this.optional && (value === null || value === undefined)) || super.validate(value);
   }
 }
 
@@ -97,8 +97,8 @@ export class Email extends AbstractValidator<string> {
   constructor(attrs?: ValidatorAttributes) {
     super({ message: 'must be a well-formed email address', ...attrs });
   }
-  validate(value: string | undefined) {
-    return value === undefined || isEmail(value);
+  validate(value: string | null | undefined) {
+    return !value || isEmail(value);
   }
 }
 export class Null extends AbstractValidator<any> {

--- a/flow-client/src/test/frontend/form/ValidatorsTests.ts
+++ b/flow-client/src/test/frontend/form/ValidatorsTests.ts
@@ -52,8 +52,9 @@ suite("form/Validators", () => {
     const validator = new Email();
     assert.isNotTrue(validator.impliesRequired);
     assert.isTrue(validator.validate(undefined));
+    assert.isTrue(validator.validate(null));
     assert.isTrue(validator.validate('foo@vaadin.com'));
-    assert.isFalse(validator.validate(''));
+    assert.isTrue(validator.validate(''));
     assert.isFalse(validator.validate('foo'));
     assert.isFalse(validator.validate('foo@vaadin.c'));
     assert.isFalse(validator.validate('ñññ@vaadin.c'));
@@ -136,6 +137,7 @@ suite("form/Validators", () => {
 
     validator = new IsNumber(true);
     assert.isTrue(validator.validate(undefined));
+    assert.isTrue(validator.validate(null));
   });
 
   test("Min", () => {


### PR DESCRIPTION
## Description
Fixes the bug that TypeScript form validators throw exceptions when validating null values. This could happen when loading an empty value from the backend. Related to https://github.com/vaadin/fusion/issues/44


Fixes # (issue)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
