### PR TITLE
fix: error reading value of nested property from optional parent

### DIFF
--- a/flow-client/src/main/frontend/form/BinderNode.ts
+++ b/flow-client/src/main/frontend/form/BinderNode.ts
@@ -88,6 +88,9 @@ export class BinderNode<T, M extends AbstractModel<T>> {
    * The current value related to the model
    */
   get value(): T | undefined {
+    if (this.parent!.value === undefined) {
+      this.parent!.initializeValue(true);
+    }
     return this.parent!.value[this.model[_key]];
   }
 

--- a/flow-client/src/test/frontend/form/BinderTests.ts
+++ b/flow-client/src/test/frontend/form/BinderTests.ts
@@ -362,5 +362,21 @@ suite("form/Binder", () => {
       await binder.validate();
       assert.isFalse(binder.invalid);
     });
+
+    // https://github.com/vaadin/fusion/issues/43
+    test('should be able to bind to a nested property of an optional parent', async () => {
+      const superNameNode = binder.for(binder.model.supervisor.fullName);
+      binder.read({
+        ...expectedEmptyEmployee
+      });
+      assert.equal('', superNameNode.value);
+    });
+
+    // https://github.com/vaadin/fusion/issues/43
+    test('should be able to read a nested property of an optional parent after clear', async () => {
+      const superNameNode = binder.for(binder.model.supervisor.fullName);
+      binder.clear()
+      assert.equal('', superNameNode.value);
+    });
   });
 });


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Fixes a bug that Fusion form throws exceptions when reading the value of a nested property from an optional parent.
Fixes https://github.com/vaadin/fusion/issues/43.

Fixes # (issue)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
