### PR TITLE
fix: transform null value in endpoint response to undefined

### DIFF
--- a/flow-client/src/main/frontend/Connect.ts
+++ b/flow-client/src/main/frontend/Connect.ts
@@ -340,7 +340,8 @@ export class ConnectClient {
     ): Promise<Response> => {
       const response = await next(context);
       await assertResponseIsOk(response);
-      return response.json();
+      const text = await response.text();
+      return JSON.parse(text, (_, value: any) => (value === null ? undefined : value));
     };
 
     // The actual fetch call itself is expressed as a middleware

--- a/flow-client/src/test/frontend/ConnectTests.ts
+++ b/flow-client/src/test/frontend/ConnectTests.ts
@@ -128,8 +128,10 @@ describe('ConnectClient', () => {
   });
 
   describe('call method', () => {
-    beforeEach(() => fetchMock
-      .post(base + '/connect/FooEndpoint/fooMethod', {fooData: 'foo'})
+    beforeEach(() => {
+        fetchMock.post(base + '/connect/FooEndpoint/fooMethod', {fooData: 'foo'});
+        fetchMock.post(base + '/connect/FooEndpoint/fooMethodWithNullValue', {fooData: 'foo', propWithNullValue: null})
+      }
     );
 
     afterEach(() => fetchMock.restore());
@@ -267,6 +269,12 @@ describe('ConnectClient', () => {
 
     it('should resolve to response JSON data', async() => {
       const data = await client.call('FooEndpoint', 'fooMethod');
+      expect(data).to.deep.equal({fooData: 'foo'});
+    });
+
+    it('should transform null value to undefined from response JSON data', async() => {
+      const data = await client.call('FooEndpoint', 'fooMethodWithNullValue');
+      expect(data['propWithNullValue']).to.be.undefined;
       expect(data).to.deep.equal({fooData: 'foo'});
     });
 


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Null value in and endpoint response should be transformed to undefined in TypeScript.

Fixes https://github.com/vaadin/fusion/issues/44

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
