### PR TITLE
chore: Pin org.eclipse.equinox.common version [skip-ci]

### DIFF
--- a/flow-client/pom.xml
+++ b/flow-client/pom.xml
@@ -17,6 +17,8 @@
         <gwt.module.output>${project.build.outputDirectory}/META-INF/resources/VAADIN/static/</gwt.module.output>
         <gwt.module.style>OBF</gwt.module.style>
         <gwt.sdm.bindAddress>0.0.0.0</gwt.sdm.bindAddress>
+        <org.eclipse.equinox.common.version>3.14.100</org.eclipse.equinox.common.version>
+        <org.eclipse.core.runtime.version>3.20.100</org.eclipse.core.runtime.version>
     </properties>
 
     <dependencyManagement>
@@ -27,6 +29,18 @@
                 <version>${gwt.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.platform</groupId>
+                <artifactId>org.eclipse.equinox.common</artifactId>
+                <version>${org.eclipse.equinox.common.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.platform</groupId>
+                <artifactId>org.eclipse.core.runtime</artifactId>
+                <version>${org.eclipse.core.runtime.version}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Description

Pins org.eclipse.equinox.common dependency version with 3.14.100, because 3.15.0 causes compilation errors.

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
