### PR TITLE
fix: do not open FileSystem for unknown schemes (#11235)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
@@ -151,7 +151,7 @@ public class StaticFileServer implements StaticFileHandler {
         if ("jar".equals(resource.getProtocol())) {
             // Get the file path in jar
             final String pathInJar = resource.getPath()
-                    .substring(resource.getPath().lastIndexOf("!") + 1);
+                    .substring(resource.getPath().indexOf('!') + 1);
             try {
                 FileSystem fileSystem = getFileSystem(resourceURI);
                 // Get the file path inside the jar.
@@ -159,7 +159,7 @@ public class StaticFileServer implements StaticFileHandler {
 
                 return Files.isDirectory(path);
             } catch (IOException e) {
-                getLogger().debug("failed to read zip file", e);
+                getLogger().debug("failed to read jar file contents", e);
             } finally {
                 closeFileSystem(resourceURI);
             }
@@ -208,6 +208,11 @@ public class StaticFileServer implements StaticFileHandler {
     FileSystem getFileSystem(URI resourceURI) throws IOException {
         synchronized (fileSystemLock) {
             URI fileURI = getFileURI(resourceURI);
+            if (!fileURI.getScheme().equals("file")) {
+                throw new IOException("Can not read scheme '"
+                        + fileURI.getScheme() + "' for resource " + resourceURI
+                        + " and will determine this as not a folder");
+            }
 
             if (openFileSystems.computeIfPresent(fileURI,
                     (key, value) -> value + 1) != null) {

--- a/flow-server/src/test/java/com/vaadin/flow/WarURLStreamHandlerFactory.java
+++ b/flow-server/src/test/java/com/vaadin/flow/WarURLStreamHandlerFactory.java
@@ -1,0 +1,188 @@
+package com.vaadin.flow;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.net.URLStreamHandlerFactory;
+import java.security.Permission;
+
+public class WarURLStreamHandlerFactory implements URLStreamHandlerFactory {
+
+    private static final String WAR_PROTOCOL = "war";
+
+    // Singleton instance
+    private static volatile WarURLStreamHandlerFactory instance = null;
+
+    private final boolean registered;
+
+    /**
+     * Obtain a reference to the singleton instance. It is recommended that
+     * callers check the value of {@link #isRegistered()} before using the
+     * returned instance.
+     *
+     * @return A reference to the singleton instance
+     */
+    public static WarURLStreamHandlerFactory getInstance() {
+        getInstanceInternal(true);
+        return instance;
+    }
+
+    private static WarURLStreamHandlerFactory getInstanceInternal(
+            boolean register) {
+        // Double checked locking. OK because instance is volatile.
+        if (instance == null) {
+            synchronized (WarURLStreamHandlerFactory.class) {
+                if (instance == null) {
+                    instance = new WarURLStreamHandlerFactory(register);
+                }
+            }
+        }
+        return instance;
+    }
+
+    private WarURLStreamHandlerFactory(boolean register) {
+        // Hide default constructor
+        // Singleton pattern to ensure there is only one instance of this
+        // factory
+        this.registered = register;
+        if (register) {
+            URL.setURLStreamHandlerFactory(this);
+        }
+    }
+
+    public boolean isRegistered() {
+        return registered;
+    }
+
+    /**
+     * Register this factory with the JVM. May be called more than once. The
+     * implementation ensures that registration only occurs once.
+     *
+     * @return <code>true</code> if the factory is already registered with the
+     *         JVM or was successfully registered as a result of this call.
+     *         <code>false</code> if the factory was disabled prior to this
+     *         call.
+     */
+    public static boolean register() {
+        return getInstanceInternal(true).isRegistered();
+    }
+
+    /**
+     * Prevent this this factory from registering with the JVM. May be called
+     * more than once.
+     *
+     * @return <code>true</code> if the factory is already disabled or was
+     *         successfully disabled as a result of this call.
+     *         <code>false</code> if the factory was already registered prior to
+     *         this call.
+     */
+    public static boolean disable() {
+        return !getInstanceInternal(false).isRegistered();
+    }
+
+    @Override
+    public URLStreamHandler createURLStreamHandler(String protocol) {
+
+        // Tomcat's handler always takes priority so applications can't override
+        // it.
+        if (WAR_PROTOCOL.equals(protocol)) {
+            return new WarHandler();
+        }
+
+        // Unknown protocol
+        return null;
+    }
+
+    public static class WarHandler extends URLStreamHandler {
+
+        @Override
+        protected URLConnection openConnection(URL u) throws IOException {
+            return new WarURLConnection(u);
+        }
+
+        @Override
+        protected void setURL(URL u, String protocol, String host, int port,
+                String authority, String userInfo, String path, String query,
+                String ref) {
+            if (path.startsWith("file:") && !path.startsWith("file:/")) {
+                // Work around a problem with the URLs in the security policy
+                // file.
+                // On Windows, the use of ${catalina.[home|base]} in the policy
+                // file
+                // results in codebase URLs of the form file:C:/... when they
+                // should
+                // be file:/C:/...
+                // For file: and jar: URLs, the JRE compensates for this. It
+                // does not
+                // compensate for this for war:file:... URLs. Therefore, we do
+                // that
+                // here
+                path = "file:/" + path.substring(5);
+            }
+            super.setURL(u, protocol, host, port, authority, userInfo, path,
+                    query, ref);
+        }
+
+    }
+
+    public static class WarURLConnection extends URLConnection {
+
+        private final URLConnection wrappedJarUrlConnection;
+        private boolean connected;
+
+        protected WarURLConnection(URL url) throws IOException {
+            super(url);
+            URL innerJarUrl = warToJar(url);
+            wrappedJarUrlConnection = innerJarUrl.openConnection();
+        }
+
+        @Override
+        public void connect() throws IOException {
+            if (!connected) {
+                wrappedJarUrlConnection.connect();
+                connected = true;
+            }
+        }
+
+        @Override
+        public InputStream getInputStream() throws IOException {
+            connect();
+            return wrappedJarUrlConnection.getInputStream();
+        }
+
+        @Override
+        public Permission getPermission() throws IOException {
+            return wrappedJarUrlConnection.getPermission();
+        }
+
+        @Override
+        public long getLastModified() {
+            return wrappedJarUrlConnection.getLastModified();
+        }
+
+        @Override
+        public int getContentLength() {
+            return wrappedJarUrlConnection.getContentLength();
+        }
+
+        @Override
+        public long getContentLengthLong() {
+            return wrappedJarUrlConnection.getContentLengthLong();
+        }
+
+        public static URL warToJar(URL warUrl) throws MalformedURLException {
+            // Assumes that the spec is absolute and starts war:file:/...
+            String file = warUrl.getFile();
+            if (file.contains("*/")) {
+                file = file.replaceFirst("\\*/", "!/");
+            } else if (file.contains("^/")) {
+                file = file.replaceFirst("\\^/", "!/");
+            }
+
+            return new URL("jar", warUrl.getHost(), warUrl.getPort(), file);
+        }
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
@@ -21,6 +21,7 @@ import javax.servlet.WriteListener;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -67,6 +68,7 @@ import org.junit.rules.TemporaryFolder;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
 
+import com.vaadin.flow.WarURLStreamHandlerFactory;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.CurrentInstance;
 
@@ -306,19 +308,8 @@ public class StaticFileServerTest implements Serializable {
                 "Fake should not check the file system nor be a static resource.",
                 fileServer.isStaticResourceRequest(request));
 
-        File archiveFile = new File(folder.getRoot(), "fake.jar");
-        archiveFile.createNewFile();
-        Path tempArchive = archiveFile.toPath();
+        Path tempArchive = generateZipArchive(folder);
 
-        try (ZipOutputStream zipOutputStream = new ZipOutputStream(
-                Files.newOutputStream(tempArchive))) {
-            // Create a file to the zip
-            zipOutputStream.putNextEntry(new ZipEntry("/file"));
-            zipOutputStream.closeEntry();
-            // Create a directory to the zip
-            zipOutputStream.putNextEntry(new ZipEntry("frontend/"));
-            zipOutputStream.closeEntry();
-        }
         setupRequestURI("", "", "/frontend/.");
         Mockito.when(servletService.getStaticResource("/frontend/."))
                 .thenReturn(new URL("jar:file:///"
@@ -340,14 +331,79 @@ public class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void openingJarFileSystemForDifferentFilesInSameJar_existingFileSystemIsUsed()
-            throws IOException, URISyntaxException {
+    public void isStaticResource_jarWarFileScheme_detectsAsStaticResources()
+            throws IOException {
         Assert.assertTrue("Can not run concurrently with other test",
                 StaticFileServer.openFileSystems.isEmpty());
 
         final TemporaryFolder folder = TemporaryFolder.builder().build();
         folder.create();
 
+        File archiveFile = new File(folder.getRoot(), "fake.jar");
+        archiveFile.createNewFile();
+        Path tempArchive = archiveFile.toPath();
+        File warFile = new File(folder.getRoot(), "war.jar");
+        warFile.createNewFile();
+        Path warArchive = warFile.toPath();
+
+        generateJarInJar(archiveFile, tempArchive, warArchive);
+
+        // Instantiate URL stream handler factory to be able to handle war:
+        WarURLStreamHandlerFactory.getInstance();
+
+        final URL folderResourceURL = new URL(
+                "jar:war:" + warFile.toURI().toURL() + "!/"
+                        + archiveFile.getName() + "!/frontend");
+
+        setupRequestURI("", "", "/frontend/.");
+        Mockito.when(servletService.getStaticResource("/frontend/."))
+                .thenReturn(folderResourceURL);
+
+        Assert.assertTrue(
+                "Request should return as static request as we can not determine non file resources in jar files.",
+                fileServer.isStaticResourceRequest(request));
+
+        folder.delete();
+    }
+
+    @Test
+    public void isStaticResource_jarInAJar_detectsAsStaticResources()
+            throws IOException {
+        Assert.assertTrue("Can not run concurrently with other test",
+                StaticFileServer.openFileSystems.isEmpty());
+
+        final TemporaryFolder folder = TemporaryFolder.builder().build();
+        folder.create();
+
+        File archiveFile = new File(folder.getRoot(), "fake.jar");
+        archiveFile.createNewFile();
+        Path tempArchive = archiveFile.toPath();
+
+        File warFile = new File(folder.getRoot(), "war.jar");
+        warFile.createNewFile();
+        Path warArchive = warFile.toPath();
+
+        generateJarInJar(archiveFile, tempArchive, warArchive);
+
+        setupRequestURI("", "", "/frontend/.");
+        Mockito.when(servletService.getStaticResource("/frontend/."))
+                .thenReturn(new URL("jar:" + warFile.toURI().toURL() + "!/"
+                        + archiveFile.getName() + "!/frontend"));
+        Assert.assertTrue(
+                "Request should return as static request as we can not determine non file resources in jar files.",
+                fileServer.isStaticResourceRequest(request));
+        setupRequestURI("", "", "/file.txt");
+        Mockito.when(servletService.getStaticResource("/file.txt"))
+                .thenReturn(new URL("jar:" + warFile.toURI().toURL() + "!/"
+                        + archiveFile.getName() + "!/file.txt"));
+        Assert.assertTrue(
+                "Request should return as static request as we can not determine non file resources in jar files.",
+                fileServer.isStaticResourceRequest(request));
+
+        folder.delete();
+    }
+
+    private Path generateZipArchive(TemporaryFolder folder) throws IOException {
         File archiveFile = new File(folder.getRoot(), "fake.jar");
         archiveFile.createNewFile();
         Path tempArchive = archiveFile.toPath();
@@ -361,6 +417,41 @@ public class StaticFileServerTest implements Serializable {
             zipOutputStream.putNextEntry(new ZipEntry("frontend/"));
             zipOutputStream.closeEntry();
         }
+        return tempArchive;
+    }
+
+    private void generateJarInJar(File archiveFile, Path tempArchive,
+            Path warArchive) throws IOException {
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(
+                Files.newOutputStream(tempArchive))) {
+            // Create a file to the zip
+            zipOutputStream.putNextEntry(new ZipEntry("/file"));
+            zipOutputStream.closeEntry();
+            // Create a directory to the zip
+            zipOutputStream.putNextEntry(new ZipEntry("frontend/"));
+            zipOutputStream.closeEntry();
+        }
+
+        try (ZipOutputStream warOutputStream = new ZipOutputStream(
+                Files.newOutputStream(warArchive))) {
+            // Create a file to the zip
+            warOutputStream.putNextEntry(new ZipEntry(archiveFile.getName()));
+            warOutputStream.write(Files.readAllBytes(tempArchive));
+
+            warOutputStream.closeEntry();
+        }
+    }
+
+    @Test
+    public void openingJarFileSystemForDifferentFilesInSameJar_existingFileSystemIsUsed()
+            throws IOException, URISyntaxException {
+        Assert.assertTrue("Can not run concurrently with other test",
+                StaticFileServer.openFileSystems.isEmpty());
+
+        final TemporaryFolder folder = TemporaryFolder.builder().build();
+        folder.create();
+
+        Path tempArchive = generateZipArchive(folder);
 
         final URL folderResourceURL = new URL(
                 "jar:file:///" + tempArchive.toString().replaceAll("\\\\", "/")
@@ -402,19 +493,8 @@ public class StaticFileServerTest implements Serializable {
         final TemporaryFolder folder = TemporaryFolder.builder().build();
         folder.create();
 
-        File archiveFile = new File(folder.getRoot(), "fake.jar");
-        archiveFile.createNewFile();
-        Path tempArchive = archiveFile.toPath();
+        Path tempArchive = generateZipArchive(folder);
 
-        try (ZipOutputStream zipOutputStream = new ZipOutputStream(
-                Files.newOutputStream(tempArchive))) {
-            // Create a file to the zip
-            zipOutputStream.putNextEntry(new ZipEntry("/file"));
-            zipOutputStream.closeEntry();
-            // Create a directory to the zip
-            zipOutputStream.putNextEntry(new ZipEntry("frontend/"));
-            zipOutputStream.closeEntry();
-        }
         setupRequestURI("", "", "/frontend/.");
         final URL folderResourceURL = new URL(
                 "jar:file:///" + tempArchive.toString().replaceAll("\\\\", "/")


### PR DESCRIPTION
Don't open a filesystem for unknown schemes
that are probably custom for container and
have no FileSystem Provider implementation added.

Fixes #11230
