### PR TITLE
fix: use JS to get DOM element value instead Selenium getAttribute

### DIFF
--- a/flow-tests/test-live-reload/src/test/java/com/vaadin/flow/uitest/ui/FrontendLiveReloadIT.java
+++ b/flow-tests/test-live-reload/src/test/java/com/vaadin/flow/uitest/ui/FrontendLiveReloadIT.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.uitest.ui;
 import net.jcip.annotations.NotThreadSafe;
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -31,7 +30,6 @@ public class FrontendLiveReloadIT extends AbstractLiveReloadIT {
         executeScript("fetch('/context/view/reset_frontend')");
     }
 
-    @Ignore("https://github.com/vaadin/flow/issues/11210")
     @Test
     public void liveReloadOnTouchedFrontendFile() {
         open();
@@ -39,7 +37,7 @@ public class FrontendLiveReloadIT extends AbstractLiveReloadIT {
         // when: the frontend code is updated
         WebElement codeField = findElement(
                 By.id(FrontendLiveReloadView.FRONTEND_CODE_TEXT));
-        String oldCode = codeField.getAttribute("value");
+        String oldCode = getValue(codeField);
         String newCode = oldCode.replace("Custom component contents",
                 "Updated component contents");
         codeField.clear();
@@ -70,7 +68,7 @@ public class FrontendLiveReloadIT extends AbstractLiveReloadIT {
         // when: a webpack error occurs during frontend file edit
         WebElement codeField = findElement(
                 By.id(FrontendLiveReloadView.FRONTEND_CODE_TEXT));
-        String oldCode = codeField.getAttribute("value");
+        String oldCode = getValue(codeField);
         String erroneousCode = "{" + oldCode;
         codeField.clear();
         codeField.sendKeys(erroneousCode); // illegal TS
@@ -86,5 +84,11 @@ public class FrontendLiveReloadIT extends AbstractLiveReloadIT {
 
         // then: the error box is not shown and the view is reloaded
         waitForElementNotPresent(By.className("v-system-error"));
+    }
+
+    private String getValue(WebElement element) {
+        Object result = getCommandExecutor()
+                .executeScript("return arguments[0].value;", element);
+        return result == null ? "" : result.toString();
     }
 }


### PR DESCRIPTION
fixes #11210

<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Please list all relevant dependencies in this section and provide summary of the change, motivation and context.

Fixes # (issue)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
