### PR TITLE
fix: trim class names value before splitting

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/dom/impl/ClassAttributeHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/impl/ClassAttributeHandler.java
@@ -50,11 +50,13 @@ public class ClassAttributeHandler extends CustomAttribute {
         Set<String> classList = element.getClassList();
         classList.clear();
 
-        if (value.isEmpty()) {
+        String classValue = value.trim();
+
+        if (classValue.isEmpty()) {
             return;
         }
 
-        String[] parts = value.split("\\s+");
+        String[] parts = classValue.split("\\s+");
         classList.addAll(Arrays.asList(parts));
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
@@ -783,7 +783,7 @@ public class ElementTest extends AbstractNodeTest {
         // Get instance right away to see that changes are live
         Set<String> classList = element.getClassList();
 
-        element.setAttribute("class", "foo bar");
+        element.setAttribute("class", "       foo bar ");
 
         Assert.assertEquals(2, classList.size());
         Assert.assertTrue(classList.contains("foo"));


### PR DESCRIPTION
fixes #11153

<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Please list all relevant dependencies in this section and provide summary of the change, motivation and context.

Fixes # (issue)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
