### PR TITLE
Revert "chore: Exclude unused flow-plugin-base dependencies (#11224)"

### DIFF
--- a/flow-plugins/flow-plugin-base/pom.xml
+++ b/flow-plugins/flow-plugin-base/pom.xml
@@ -10,6 +10,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>flow-server</artifactId>
             <version>${project.version}</version>
@@ -22,17 +26,7 @@
         <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
-            <version>0.9.12</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.dom4j</groupId>
-                    <artifactId>dom4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.google.code.gson</groupId>
-                    <artifactId>gson</artifactId>
-                </exclusion>
-        </exclusions>
+            <version>0.9.11</version>
         </dependency>
         <dependency>
             <groupId>org.zeroturnaround</groupId>


### PR DESCRIPTION
This reverts commit bd084220e8a6409ae48f328f61987b67829f5d38.

Reverting commit as upstream projects have started failing with 
```
[16:07:02]	[Step 5/8] Caused by: java.lang.NoSuchMethodError: org.apache.commons.io.FileUtils.write(Ljava/io/File;Ljava/lang/CharSequence;Ljava/lang/String;)V
[16:07:02]	[Step 5/8]     at com.vaadin.flow.plugin.base.BuildFrontendUtil.propagateBuildInfo (BuildFrontendUtil.java:216)
[16:07:02]	[Step 5/8]     at com.vaadin.flow.plugin.maven.PrepareFrontendMojo.execute (PrepareFrontendMojo.java:48)
[16:07:02]	[Step 5/8]     at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:137)
```