### PR TITLE
fix: Always use  unix convention for the path (#11326)

### DIFF
--- a/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/BundleLitParser.java
+++ b/flow-lit-template/src/main/java/com/vaadin/flow/component/littemplate/BundleLitParser.java
@@ -199,7 +199,8 @@ public final class BundleLitParser {
             // "node_modules/@vaadin/flow-frontend/" instead of "./"
             // "target/flow-frontend/" instead of "./"
             if (name.contains(FLOW_NPM_PACKAGE_NAME) || name.contains(service
-                    .getDeploymentConfiguration().getFlowResourcesFolder())) {
+                    .getDeploymentConfiguration().getFlowResourcesFolder()
+                    .replaceAll("\\\\", "/"))) {
                 alternativeFileName = alternativeFileName.replaceFirst("\\./",
                         "");
             }

--- a/flow-lit-template/src/test/java/com/vaadin/flow/component/littemplate/internal/LitTemplateParserImplTest.java
+++ b/flow-lit-template/src/test/java/com/vaadin/flow/component/littemplate/internal/LitTemplateParserImplTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component.littemplate.internal;
 
+import java.nio.file.Paths;
 import java.util.Properties;
 import java.util.stream.Stream;
 
@@ -58,7 +59,8 @@ public class LitTemplateParserImplTest {
         Properties properties = new Properties();
         Mockito.when(configuration.getInitParameters()).thenReturn(properties);
         Mockito.when(configuration.getFlowResourcesFolder()).thenReturn(
-                "target/" + FrontendUtils.DEFAULT_FLOW_RESOURCES_FOLDER);
+                Paths.get("target", FrontendUtils.DEFAULT_FLOW_RESOURCES_FOLDER)
+                        .toString());
 
         Instantiator instantiator = Mockito.mock(Instantiator.class);
         Mockito.when(instantiator.getServiceInitListeners())
@@ -220,6 +222,23 @@ public class LitTemplateParserImplTest {
     }
 
     @Test
+    public void getTemplateContent_nonLocalTemplateInTargetFolder_rootElementParsed() {
+        Mockito.when(configuration.getStringProperty(Mockito.anyString(),
+                Mockito.anyString()))
+                .thenReturn(VAADIN_SERVLET_RESOURCES + "config/stats.json");
+        LitTemplateParser.TemplateData templateContent = LitTemplateParserImpl
+                .getInstance().getTemplateContent(HelloWorld2.class,
+                        HelloWorld2.class.getAnnotation(Tag.class).value(),
+                        service);
+
+        Assert.assertEquals("Template should contain one child", 2,
+                templateContent.getTemplateElement().childNodeSize());
+
+        Assert.assertEquals("Template should have 3 divs", 3, templateContent
+                .getTemplateElement().getElementsByTag("div").size());
+    }
+
+    @Test
     public void severalJsModuleAnnotations_theFirstFileDoesNotExist_fileWithContentIsChosen() {
         Mockito.when(configuration.getStringProperty(Mockito.anyString(),
                 Mockito.anyString()))
@@ -293,6 +312,11 @@ public class LitTemplateParserImplTest {
     @Tag("hello-world")
     @JsModule("./src/hello-world-lit.js")
     public class HelloWorld extends LitTemplate {
+    }
+
+    @Tag("hello-world")
+    @JsModule("./src/hello-world2.js")
+    public class HelloWorld2 extends LitTemplate {
     }
 
     @Tag("my-lit-element-view")

--- a/flow-lit-template/src/test/resources/META-INF/VAADIN/config/stats.json
+++ b/flow-lit-template/src/test/resources/META-INF/VAADIN/config/stats.json
@@ -6,8 +6,12 @@
   },
   "modules": [
         {
-        "name": "../node_modules/@vaadin/flow-frontend/src/hello-world-lit.js",
-        "source": "// Import an element\nimport { LitElement, html } from 'lit-element';\n\n// Define an element class\n export class HelloWorld extends LitElement {\n\n  // Define the element's template\n  render() {\n    return html`\n      <style>\n        :host{ \n          margin: 5px; \n        }\n      \n        .response { margin-top: 10px; } \n      </style>\n   <div>Tag name doesn't match the JS module name<div>inner</div></div>   <div id='test'  class='response'>Web components like you, too.</div>\n    `;\n  }\n}\n\n// Register the element with the browser\ncustomElements.define('hello-world-lit', HelloWorld);"
+          "name": "../node_modules/@vaadin/flow-frontend/src/hello-world-lit.js",
+          "source": "// Import an element\nimport { LitElement, html } from 'lit';\n\n// Define an element class\n export class HelloWorld extends LitElement {\n\n  // Define the element's template\n  render() {\n    return html`\n      <style>\n        :host{ \n          margin: 5px; \n        }\n      \n        .response { margin-top: 10px; } \n      </style>\n   <div>Tag name doesn't match the JS module name<div>inner</div></div>   <div id='test'  class='response'>Web components like you, too.</div>\n    `;\n  }\n}\n\n// Register the element with the browser\ncustomElements.define('hello-world-lit', HelloWorld);"
+        },
+        {
+          "name": "../target/flow-frontend/src/hello-world2.js",
+          "source": "// Import an element\nimport { LitElement, html } from 'lit';\n\n// Define an element class\n export class HelloWorld extends LitElement {\n\n  // Define the element's template\n  render() {\n    return html`\n      <style>\n        :host{ \n          margin: 5px; \n        }\n      \n        .response { margin-top: 10px; } \n      </style>\n   <div>Tag name doesn't match the JS module name<div>inner</div></div>   <div id='test'  class='response'>Web components like you, too.</div>\n    `;\n  }\n}\n\n// Register the element with the browser\ncustomElements.define('hello-world-lit', HelloWorld);"
         },
         {
             "name": "./frontend/MyElementFaultyMethods.js",

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/BundleParser.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/BundleParser.java
@@ -267,7 +267,8 @@ public final class BundleParser {
             // "node_modules/@vaadin/flow-frontend/" instead of "./"
             // "target/flow-frontend/" instead of "./"
             if (name.contains(FLOW_NPM_PACKAGE_NAME) || name.contains(service
-                    .getDeploymentConfiguration().getFlowResourcesFolder())) {
+                    .getDeploymentConfiguration().getFlowResourcesFolder()
+                    .replaceAll("\\\\", "/"))) {
                 alternativeFileName = alternativeFileName.replaceFirst("\\./",
                         "");
             }

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/BundleParserTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/BundleParserTest.java
@@ -3,6 +3,7 @@ package com.vaadin.flow.component.polymertemplate;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.Properties;
 import java.util.stream.Stream;
 
@@ -32,6 +33,7 @@ public class BundleParserTest {
     private static JsonObject stats;
 
     private MockVaadinServletService service;
+    private DeploymentConfiguration configuration;
 
     @BeforeClass
     public static void initClass() throws IOException {
@@ -44,13 +46,13 @@ public class BundleParserTest {
 
     @Before
     public void init() {
-        DeploymentConfiguration configuration = Mockito
-                .mock(DeploymentConfiguration.class);
+        configuration = Mockito.mock(DeploymentConfiguration.class);
         Mockito.when(configuration.getStringProperty(Mockito.anyString(),
                 Mockito.anyString()))
                 .thenAnswer(invocation -> invocation.getArgument(1));
         Mockito.when(configuration.getFlowResourcesFolder()).thenReturn(
-                "target/" + FrontendUtils.DEFAULT_FLOW_RESOURCES_FOLDER);
+                Paths.get("target", FrontendUtils.DEFAULT_FLOW_RESOURCES_FOLDER)
+                        .toString());
 
         Properties properties = new Properties();
         Mockito.when(configuration.getInitParameters()).thenReturn(properties);
@@ -77,6 +79,15 @@ public class BundleParserTest {
 
     @Test
     public void nonLocalTemplate_sourcesShouldBeFoundInTargetFolder() {
+        final String source = BundleParser.getSourceFromStatistics(
+                "./src/hello-world2.js", stats, service);
+        Assert.assertNotNull("Source expected in stats.json", source);
+    }
+
+    @Test
+    public void nonLocalTemplate_windowsPath_sourcesShouldBeFoundInTargetFolder() {
+        Mockito.when(configuration.getFlowResourcesFolder()).thenReturn(
+                "target\\" + FrontendUtils.DEFAULT_FLOW_RESOURCES_FOLDER);
         final String source = BundleParser.getSourceFromStatistics(
                 "./src/hello-world2.js", stats, service);
         Assert.assertNotNull("Source expected in stats.json", source);

--- a/flow-server/src/main/java/com/vaadin/flow/server/AbstractConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AbstractConfiguration.java
@@ -120,10 +120,29 @@ public interface AbstractConfiguration extends Serializable {
                 false);
     }
 
+    /**
+     * Return the defined build folder for the used build system.
+     * <p>
+     * Default value is <code>target</code> used by maven and the gradle plugin
+     * will set it to <code>build</code>.
+     *
+     * @return build folder name, default {@code target}
+     */
     default String getBuildFolder() {
         return getStringProperty(InitParameters.BUILD_FOLDER, Constants.TARGET);
     }
 
+    /**
+     * Get the location for flow resources inside the build folder.
+     * <p>
+     * Default will be <code>target/flow-frontend</code> where target is the
+     * defined buildFolder see {@link #getBuildFolder()}.
+     * <p>
+     * Note! The path is made using Paths.get which will use File.separator that
+     * is OS dependent.
+     *
+     * @return flow resources folder, default {@code target/flow-frontend}
+     */
     default String getFlowResourcesFolder() {
         return Paths.get(getBuildFolder(),
                 FrontendUtils.DEFAULT_FLOW_RESOURCES_FOLDER).toString();


### PR DESCRIPTION
Fixes a regression in Vaadin 20 with templates (.js, .ts) from add-ons which didn't resolve correclty on Windows due to an issue in the path to flow-frontend getting `\` instead of `/`.

Fixes #11220
Fixes #11325
