### PR TITLE
fix: fixes comparison of prerelease versions FE deps (#11353)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendVersion.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendVersion.java
@@ -17,6 +17,8 @@ package com.vaadin.flow.server.frontend;
 
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Version object for frontend versions comparison and handling.
@@ -27,6 +29,13 @@ import java.util.Objects;
  */
 public class FrontendVersion
         implements Serializable, Comparable<FrontendVersion> {
+
+    /**
+     * Parses the buildIdentifier to String + Integer. For instance beta1
+     * returns 'beta' and '1'
+     */
+    private final Pattern buildIdentifierParser = Pattern
+            .compile("(\\D*)(\\d*)");
 
     /**
      * The version number of this release. For example "6.2.0". Always in the
@@ -288,9 +297,33 @@ public class FrontendVersion
                     && other.buildIdentifier.isEmpty()) {
                 return -1;
             }
-            return buildIdentifier.compareToIgnoreCase(other.buildIdentifier);
+            return compareBuildIdentifier(other);
         }
         return 0;
+    }
+
+    private int compareBuildIdentifier(FrontendVersion other) {
+        final Matcher thisMatcher = buildIdentifierParser
+                .matcher(buildIdentifier);
+        final Matcher otherMatcher = buildIdentifierParser
+                .matcher(other.buildIdentifier);
+        if (thisMatcher.find() && otherMatcher.find()) {
+            if (thisMatcher.group(1)
+                    .compareToIgnoreCase(otherMatcher.group(1)) != 0) {
+                // If we do not have a text identifier assume newer
+                // If other doesn't have text identifier assume older
+                if (thisMatcher.group(1).isEmpty()) {
+                    return 1;
+                } else if (otherMatcher.group(1).isEmpty()) {
+                    return -1;
+                }
+                return thisMatcher.group(1)
+                        .compareToIgnoreCase(otherMatcher.group(1));
+            }
+            return Integer.parseInt(thisMatcher.group(2))
+                    - Integer.parseInt(otherMatcher.group(2));
+        }
+        return buildIdentifier.compareToIgnoreCase(other.buildIdentifier);
     }
 
     private String getInvalidVersionMessage(String version) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendVersionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendVersionTest.java
@@ -199,6 +199,56 @@ public class FrontendVersionTest {
                 test.isNewerThan(new FrontendVersion("2.0.0-RC1")));
     }
 
+    @Test
+    public void buildIdentifierNumbers_returnsAsExpected() {
+
+        FrontendVersion test = new FrontendVersion("2.0.0-alpha6");
+        assertTrue("2.0.0-alpha6 should be older than 2.0.0-alpha13",
+                test.isOlderThan(new FrontendVersion("2.0.0-alpha13")));
+
+        test = new FrontendVersion("2.0.0-alpha20");
+        assertTrue("2.0.0-alpha20 should be newer than 2.0.0-alpha13",
+                test.isNewerThan(new FrontendVersion("2.0.0-alpha13")));
+        assertFalse("2.0.0-alpha20 should be newer than 2.0.0-alpha13",
+                test.isOlderThan(new FrontendVersion("2.0.0-alpha13")));
+
+        assertTrue("2.0.0-alpha13 should not be older than 2.0.0-alpha20",
+                new FrontendVersion("2.0.0-alpha13").isOlderThan(test));
+        assertFalse("2.0.0-alpha13 should not be older than 2.0.0-alpha20",
+                new FrontendVersion("2.0.0-alpha13").isNewerThan(test));
+
+        assertTrue("same versions should equal",
+                test.isEqualTo(new FrontendVersion("2.0.0.alpha20")));
+    }
+
+    @Test
+    public void testAgainstVersionWithValueInBuildInfo() {
+        FrontendVersion alpha3 = new FrontendVersion("2.0.0-alpha3");
+        FrontendVersion five = new FrontendVersion("2.0.0.5");
+        FrontendVersion fifteen = new FrontendVersion("2.0.0.15");
+
+        assertTrue("2.0.0-alpha3 should be older than 2.0.0.5",
+                alpha3.isOlderThan(five));
+        assertFalse("2.0.0-alpha3 should be older than 2.0.0.5",
+                alpha3.isNewerThan(five));
+
+        assertTrue("2.0.0.5 should be newer than 2.0.0-alpha3",
+                five.isNewerThan(alpha3));
+        assertFalse("2.0.0.5 should be newer than 2.0.0-alpha3",
+                five.isOlderThan(alpha3));
+
+        assertTrue("2.0.0.5 should be older than 2.0.0.15",
+                five.isOlderThan(fifteen));
+        assertFalse("2.0.0.5 should be older than 2.0.0.15",
+                five.isNewerThan(fifteen));
+
+        assertTrue("2.0.0.15 should be newer than 2.0.0.5",
+                fifteen.isNewerThan(five));
+        assertFalse("2.0.0.15 should be newer than 2.0.0.5",
+                fifteen.isOlderThan(five));
+
+    }
+
     private void assertVersion(FrontendVersion version, int major, int minor,
             int revision, String build) {
         Assert.assertEquals(


### PR DESCRIPTION
Fix buildIdentifier comparison so values compare correctly.
The problem caused e.g. alphas greater than 10 to be considered older than 2-9.

fixes #11352

