### PR TITLE
fix: use textContent instead of innerHTML for error elements (#11354)

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/SystemErrorHandler.java
+++ b/flow-client/src/main/java/com/vaadin/client/SystemErrorHandler.java
@@ -180,21 +180,21 @@ public class SystemErrorHandler {
         if (caption != null) {
             Element captionDiv = document.createDivElement();
             captionDiv.setClassName("caption");
-            captionDiv.setInnerHTML(caption);
+            captionDiv.setTextContent(caption);
             systemErrorContainer.appendChild(captionDiv);
             Console.error(caption);
         }
         if (message != null) {
             Element messageDiv = document.createDivElement();
             messageDiv.setClassName("message");
-            messageDiv.setInnerHTML(message);
+            messageDiv.setTextContent(message);
             systemErrorContainer.appendChild(messageDiv);
             Console.error(message);
         }
         if (details != null) {
             Element detailsDiv = document.createDivElement();
             detailsDiv.setClassName("details");
-            detailsDiv.setInnerHTML(details);
+            detailsDiv.setTextContent(details);
             systemErrorContainer.appendChild(detailsDiv);
             Console.error(details);
         }

--- a/flow-client/src/test-gwt/java/com/vaadin/client/GwtSuite.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/GwtSuite.java
@@ -6,8 +6,13 @@ import junit.framework.TestSuite;
 import com.google.gwt.junit.tools.GWTTestSuite;
 
 import com.vaadin.client.communication.GwtAtmoshperePushConnectionTest;
+<<<<<<< HEAD
 import com.vaadin.client.communication.GwtDefaultReconnectDialogTest;
+=======
+import com.vaadin.client.communication.GwtDefaultConnectionStateHandlerTest;
+>>>>>>> 3123cfd2ae... fix: use textContent instead of innerHTML for error elements (#11354)
 import com.vaadin.client.flow.GwtBasicElementBinderTest;
+import com.vaadin.client.flow.GwtErrotHandlerTest;
 import com.vaadin.client.flow.GwtEventHandlerTest;
 import com.vaadin.client.flow.GwtMultipleBindingTest;
 import com.vaadin.client.flow.GwtPolymerModelTest;
@@ -53,6 +58,7 @@ public class GwtSuite extends GWTTestSuite {
         suite.addTestSuite(GwtDependencyLoaderTest.class);
         suite.addTestSuite(GwtMessageHandlerTest.class);
         suite.addTestSuite(GwtMultipleBindingTest.class);
+        suite.addTestSuite(GwtErrotHandlerTest.class);
         return suite;
     }
 }

--- a/flow-client/src/test-gwt/java/com/vaadin/client/GwtSuite.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/GwtSuite.java
@@ -6,13 +6,8 @@ import junit.framework.TestSuite;
 import com.google.gwt.junit.tools.GWTTestSuite;
 
 import com.vaadin.client.communication.GwtAtmoshperePushConnectionTest;
-<<<<<<< HEAD
 import com.vaadin.client.communication.GwtDefaultReconnectDialogTest;
-=======
-import com.vaadin.client.communication.GwtDefaultConnectionStateHandlerTest;
->>>>>>> 3123cfd2ae... fix: use textContent instead of innerHTML for error elements (#11354)
 import com.vaadin.client.flow.GwtBasicElementBinderTest;
-import com.vaadin.client.flow.GwtErrotHandlerTest;
 import com.vaadin.client.flow.GwtEventHandlerTest;
 import com.vaadin.client.flow.GwtMultipleBindingTest;
 import com.vaadin.client.flow.GwtPolymerModelTest;

--- a/flow-client/src/test-gwt/java/com/vaadin/client/GwtSuite.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/GwtSuite.java
@@ -8,6 +8,7 @@ import com.google.gwt.junit.tools.GWTTestSuite;
 import com.vaadin.client.communication.GwtAtmoshperePushConnectionTest;
 import com.vaadin.client.communication.GwtDefaultReconnectDialogTest;
 import com.vaadin.client.flow.GwtBasicElementBinderTest;
+import com.vaadin.client.flow.GwtErrotHandlerTest;
 import com.vaadin.client.flow.GwtEventHandlerTest;
 import com.vaadin.client.flow.GwtMultipleBindingTest;
 import com.vaadin.client.flow.GwtPolymerModelTest;

--- a/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtErrotHandlerTest.java
+++ b/flow-client/src/test-gwt/java/com/vaadin/client/flow/GwtErrotHandlerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.client.flow;
+
+import com.vaadin.client.ApplicationConfiguration;
+import com.vaadin.client.ClientEngineTestBase;
+import com.vaadin.client.Registry;
+import com.vaadin.client.SystemErrorHandler;
+import com.vaadin.client.flow.reactive.Reactive;
+
+import elemental.client.Browser;
+import elemental.dom.Element;
+
+public class GwtErrotHandlerTest extends ClientEngineTestBase {
+
+    private Registry registry;
+
+    @Override
+    protected void gwtSetUp() throws Exception {
+        super.gwtSetUp();
+        Reactive.reset();
+
+        registry = new Registry() {
+            {
+                set(ApplicationConfiguration.class,
+                        new ApplicationConfiguration());
+                set(SystemErrorHandler.class, new SystemErrorHandler(this));
+            }
+        };
+
+    }
+
+    public void testhandleUnrecoverableError_textContentIsSetInDivsNotInnerHtml() {
+        registry.getSystemErrorHandler().handleUnrecoverableError("<foo></foo>",
+                "<bar></bar>", "<baz></baz>", null);
+        Element container = Browser.getDocument().getBody()
+                .querySelector(".v-system-error");
+        Element caption = container.querySelector(".caption");
+        Element message = container.querySelector(".message");
+        Element details = container.querySelector(".details");
+
+        assertEquals("&lt;foo&gt;&lt;/foo&gt;", caption.getInnerHTML());
+        assertEquals("<foo></foo>", caption.getTextContent());
+
+        assertEquals("&lt;bar&gt;&lt;/bar&gt;", message.getInnerHTML());
+        assertEquals("<bar></bar>", message.getTextContent());
+
+        assertEquals("&lt;baz&gt;&lt;/baz&gt;", details.getInnerHTML());
+        assertEquals("<baz></baz>", details.getTextContent());
+    }
+}


### PR DESCRIPTION
Fixes #11324

<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Please list all relevant dependencies in this section and provide summary of the change, motivation and context.

Fixes # (issue)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
