### PR TITLE
fix: Move generated theme files to frontend/generated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ flow-tests/**/types.d.ts
 package.json
 package-lock.json
 /flow-tests/**/*.generated.js
+/flow-tests/**/frontend/generated/

--- a/drivers.xml
+++ b/drivers.xml
@@ -2,10 +2,10 @@
 <root>
     <windows>
         <driver id="googlechrome">
-            <version id="89.0.4389.23">
+            <version id="91.0.4472.19">
                 <bitrate thirtytwobit="true" sixtyfourbit="true">
-                    <filelocation>https://chromedriver.storage.googleapis.com/89.0.4389.23/chromedriver_win32.zip</filelocation>
-                    <hash>9ac62a6bcdb49627a2839e5cbb312d8fe7c340e3</hash>
+                    <filelocation>https://chromedriver.storage.googleapis.com/91.0.4472.19/chromedriver_win32.zip</filelocation>
+                    <hash>ff66f571ffc16745badf0de3fd5474a54ba126ad</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
             </version>
@@ -13,10 +13,10 @@
     </windows>
     <linux>
         <driver id="googlechrome">
-            <version id="89.0.4389.23">
+            <version id="91.0.4472.19">
                 <bitrate sixtyfourbit="true">
-                    <filelocation>https://chromedriver.storage.googleapis.com/89.0.4389.23/chromedriver_linux64.zip</filelocation>
-                    <hash>b6db711b7ceb4655dc61df3ff7bd89b4b1647f81</hash>
+                    <filelocation>https://chromedriver.storage.googleapis.com/91.0.4472.19/chromedriver_linux64.zip</filelocation>
+                    <hash>ef30bc45922ccaefba075cec2b71bd96e61415c7</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
             </version>
@@ -24,10 +24,10 @@
     </linux>
     <osx>
         <driver id="googlechrome">
-            <version id="89.0.4389.23">
+            <version id="91.0.4472.19">
                 <bitrate sixtyfourbit="true">
-                    <filelocation>https://chromedriver.storage.googleapis.com/89.0.4389.23/chromedriver_mac64.zip</filelocation>
-                    <hash>b0857b123b956317ed5a858bac400a6d9ad01f8c</hash>
+                    <filelocation>https://chromedriver.storage.googleapis.com/91.0.4472.19/chromedriver_mac64.zip</filelocation>
+                    <hash>7cb6549ff48a04bfb4e64a512ffdbf22e59fdc87</hash>
                     <hashtype>sha1</hashtype>
                 </bitrate>
             </version>

--- a/flow-server/README.md
+++ b/flow-server/README.md
@@ -86,3 +86,38 @@ then add the plugin with required options to `plugins` in the generated file
     }),
  ]
 ```
+
+### Logs from plugins and loaders
+
+To set logging for the plugins one can add to the `webpack.config.js`
+file:
+```js
+  {
+    stats: {
+      logging: 'log'
+    }
+  }
+```
+
+where the accepted logging levels are:
+- 'none', false - disable logging
+- 'error' - errors only
+- 'warn' - errors and warnings only
+- 'info' - errors, warnings, and info messages
+- 'log', true - errors, warnings, info messages, log messages, groups, clears. Collapsed groups are displayed in a collapsed state.
+- 'verbose' - log everything except debug and trace. Collapsed groups are displayed in expanded state.
+
+For debug level logs one should have the settings as:
+
+```js
+  {
+    stats: {
+      logging: 'log',
+      loggingDebug: [
+        'theme-loader',
+        'ApplicationThemePlugin',
+        'FlowIdPlugin'
+      ]
+    }
+  }
+```

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -146,9 +146,9 @@ public class TaskUpdateImports extends NodeUpdater {
 
             if (hasApplicationTheme) {
                 // If we define a theme name we need to import
-                // theme/theme-generated.js
+                // theme/theme.js
                 lines.add(
-                        "import {applyTheme} from 'generated/theme-generated.js';");
+                        "import {applyTheme} from 'generated/theme.js';");
                 lines.add("applyTheme(document);");
             }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -148,7 +148,7 @@ public class TaskUpdateImports extends NodeUpdater {
                 // If we define a theme name we need to import
                 // theme/theme-generated.js
                 lines.add(
-                        "import {applyTheme} from 'themes/theme-generated.js';");
+                        "import {applyTheme} from 'generated/theme-generated.js';");
                 lines.add("applyTheme(document);");
             }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateThemeImport.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateThemeImport.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.server.frontend;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -29,12 +30,16 @@ import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.theme.ThemeDefinition;
 
 import static com.vaadin.flow.server.Constants.APPLICATION_THEME_ROOT;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
+import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_FRONTEND_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_GENERATED_DIR;
 
 /**
  * Task for generating the theme-generated.js file for importing application
  * theme.
+ * <p>
+ * Generated file is generated into <code>./frontend/generated</code>
  *
  * @since
  */
@@ -50,11 +55,10 @@ public class TaskUpdateThemeImport implements FallibleCommand {
 
     TaskUpdateThemeImport(File npmFolder, ThemeDefinition theme,
             File frontendDirectory) {
-        File generatedDir = new File(npmFolder,
-                System.getProperty(PARAM_GENERATED_DIR, DEFAULT_GENERATED_DIR));
-        this.themeImportFile = new File(
-                new File(generatedDir, APPLICATION_THEME_ROOT),
-                "theme-generated.js");
+        File generatedDir = new File(new File(npmFolder.getAbsolutePath(),
+                System.getProperty(PARAM_FRONTEND_DIR, DEFAULT_FRONTEND_DIR)),
+                "generated");
+        this.themeImportFile = new File(generatedDir, "theme-generated.js");
         this.theme = theme;
         this.frontendDirectory = frontendDirectory;
         this.npmFolder = npmFolder;
@@ -80,9 +84,9 @@ public class TaskUpdateThemeImport implements FallibleCommand {
 
         try {
             FileUtils.write(themeImportFile, String.format(
-                    "import {applyTheme as _applyTheme} from 'themes/%s/%s.generated.js';%n"
+                    "import {applyTheme as _applyTheme} from 'generated/%s.generated.js';%n"
                             + "export const applyTheme = _applyTheme;%n",
-                    theme.getName(), theme.getName()), StandardCharsets.UTF_8);
+                    theme.getName()), StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new ExecutionFailedException(
                     "Unable to write theme import file", e);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateThemeImport.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateThemeImport.java
@@ -36,7 +36,7 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_FRONTEND_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_GENERATED_DIR;
 
 /**
- * Task for generating the theme-generated.js file for importing application
+ * Task for generating the theme.js file for importing application
  * theme.
  * <p>
  * Generated file is generated into <code>./frontend/generated</code>
@@ -58,7 +58,7 @@ public class TaskUpdateThemeImport implements FallibleCommand {
         File generatedDir = new File(new File(npmFolder.getAbsolutePath(),
                 System.getProperty(PARAM_FRONTEND_DIR, DEFAULT_FRONTEND_DIR)),
                 "generated");
-        this.themeImportFile = new File(generatedDir, "theme-generated.js");
+        this.themeImportFile = new File(generatedDir, "theme.js");
         this.theme = theme;
         this.frontendDirectory = frontendDirectory;
         this.npmFolder = npmFolder;
@@ -84,7 +84,7 @@ public class TaskUpdateThemeImport implements FallibleCommand {
 
         try {
             FileUtils.write(themeImportFile, String.format(
-                    "import {applyTheme as _applyTheme} from 'generated/%s.generated.js';%n"
+                    "import {applyTheme as _applyTheme} from 'generated/theme-%s.generated.js';%n"
                             + "export const applyTheme = _applyTheme;%n",
                     theme.getName()), StandardCharsets.UTF_8);
         } catch (IOException e) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentGenerator.java
@@ -161,7 +161,7 @@ public class WebComponentGenerator {
 
         if (themeName != null && !themeName.isEmpty()) {
             replacements.put("ThemeImport",
-                "import {applyTheme} from 'themes/theme-generated.js';\n\n");
+                "import {applyTheme} from 'generated/theme-generated.js';\n\n");
             replacements.put("ApplyTheme", "applyTheme(shadow);\n    ");
         } else {
             replacements.put("ThemeImport", "");

--- a/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentGenerator.java
@@ -161,7 +161,7 @@ public class WebComponentGenerator {
 
         if (themeName != null && !themeName.isEmpty()) {
             replacements.put("ThemeImport",
-                "import {applyTheme} from 'generated/theme-generated.js';\n\n");
+                "import {applyTheme} from 'generated/theme.js';\n\n");
             replacements.put("ApplyTheme", "applyTheme(shadow);\n    ");
         } else {
             replacements.put("ThemeImport", "");

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/application-theme-plugin.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/application-theme-plugin.js
@@ -40,6 +40,9 @@ class ApplicationThemePlugin {
     if (!this.options.themeProjectFolders) {
       throw new Error("Missing themeProjectFolders path array");
     }
+    if (!this.options.frontendGeneratedFolder) {
+      throw new Error("Missing frontendGeneratedFolder path");
+    }
   }
 
   apply(compiler) {

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/package.json
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/package.json
@@ -6,7 +6,7 @@
   ],
   "repository": "vaadin/flow",
   "name": "@vaadin/application-theme-plugin",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "application-theme-plugin.js",
   "author": "Vaadin Ltd",
   "license": "Apache-2.0",

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
@@ -134,7 +134,7 @@ function generateThemeFile(themeFolder, themeName, themeProperties, productionMo
   }
 
   if (themeProperties.parent) {
-    themeFile += `import {applyTheme as applyBaseTheme} from 'themes/${themeProperties.parent}/${themeProperties.parent}.generated.js';`;
+    themeFile += `import {applyTheme as applyBaseTheme} from 'generated/${themeProperties.parent}.generated.js';`;
   }
 
   themeFile += createLinkReferences;
@@ -164,7 +164,7 @@ function generateThemeFile(themeFolder, themeName, themeProperties, productionMo
   // styles.css will always be available as we write one if it doesn't exist.
   let filename = path.basename(styles);
   let variable = camelCase(filename);
-  imports.push(`import ${variable} from './${filename}';\n`);
+  imports.push(`import ${variable} from 'themes/${themeName}/${filename}';\n`);
 
   /* Lumo must be first so that custom styles override Lumo styles */
   const lumoImports = themeProperties.lumoImports || ["color", "typography"];
@@ -193,7 +193,7 @@ function generateThemeFile(themeFolder, themeName, themeProperties, productionMo
   if (fs.existsSync(document)) {
     filename = path.basename(document);
     variable = camelCase(filename);
-    imports.push(`import ${variable} from './${filename}';\n`);
+    imports.push(`import ${variable} from 'themes/${themeName}/${filename}';\n`);
     globalCssCode.push(`injectGlobalCss(${variable}.toString(), document);\n    `);
   }
 
@@ -237,7 +237,7 @@ function generateThemeFile(themeFolder, themeName, themeProperties, productionMo
     const tag = filename.replace('.css', '');
     const variable = camelCase(filename);
     imports.push(
-      `import ${variable} from './${themeComponentsFolder}/${filename}';\n`
+      `import ${variable} from 'themes/${themeName}/${themeComponentsFolder}/${filename}';\n`
     );
 // Don't format as the generated file formatting will get wonky!
     const componentString = `registerStyles(

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
@@ -134,7 +134,7 @@ function generateThemeFile(themeFolder, themeName, themeProperties, productionMo
   }
 
   if (themeProperties.parent) {
-    themeFile += `import {applyTheme as applyBaseTheme} from 'generated/${themeProperties.parent}.generated.js';`;
+    themeFile += `import {applyTheme as applyBaseTheme} from './theme-${themeProperties.parent}.generated.js';`;
   }
 
   themeFile += createLinkReferences;

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-handle.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-handle.js
@@ -23,7 +23,7 @@ const path = require('path');
 const generateThemeFile = require('./theme-generator');
 const {copyStaticAssets, copyThemeResources} = require('./theme-copy');
 
-// matches theme folder name in 'themes/my-theme/my-theme.generated.js'
+// matches theme name 'my-theme' in 'generated/my-theme.generated.js'
 const nameRegex = /generated\/(.*).generated.js/;
 
 let prevThemeName = undefined;

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-handle.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-handle.js
@@ -24,7 +24,7 @@ const generateThemeFile = require('./theme-generator');
 const {copyStaticAssets, copyThemeResources} = require('./theme-copy');
 
 // matches theme folder name in 'themes/my-theme/my-theme.generated.js'
-const nameRegex = /themes\/(.*)\/\1.generated.js/;
+const nameRegex = /generated\/(.*).generated.js/;
 
 let prevThemeName = undefined;
 let firstThemeName = undefined;
@@ -40,7 +40,7 @@ let firstThemeName = undefined;
  * @param logger application theme plugin logger
  */
 function processThemeResources(options, logger) {
-  const themeName = extractThemeName(options.themeResourceFolder);
+  const themeName = extractThemeName(options.frontendGeneratedFolder);
   if (themeName) {
     if (!prevThemeName && !firstThemeName) {
       firstThemeName = themeName;
@@ -152,7 +152,7 @@ function handleThemes(themeName, themesFolder, options, logger) {
     copyThemeResources(themeFolder, options.projectStaticAssetsOutputFolder, logger);
     const themeFile = generateThemeFile(themeFolder, themeName, themeProperties, !options.devMode);
 
-    fs.writeFileSync(path.resolve(themeFolder, themeName + '.generated.js'), themeFile);
+    fs.writeFileSync(path.resolve(options.frontendGeneratedFolder, themeName + '.generated.js'), themeFile);
     return true;
   }
   return false;
@@ -173,18 +173,18 @@ function getThemeProperties(themeFolder) {
 /**
  * Extracts current theme name from 'theme-generated.js' file located on a
  * given folder.
- * @param themeFolder theme folder where flow generates 'theme-generated.js'
+ * @param frontendGeneratedFolder theme folder where flow generates 'theme-generated.js'
  * file and copies local and jar resource frontend files
  * @returns {string} current theme name
  */
-function extractThemeName(themeFolder) {
-  if (!themeFolder) {
+function extractThemeName(frontendGeneratedFolder) {
+  if (!frontendGeneratedFolder) {
     throw new Error("Couldn't extract theme name from 'theme-generated.js'," +
       " because the path to folder containing this file is empty. Please set" +
       " the a correct folder path in ApplicationThemePlugin constructor" +
       " parameters.");
   }
-  const generatedThemeFile = path.resolve(themeFolder, "theme-generated.js");
+  const generatedThemeFile = path.resolve(frontendGeneratedFolder, "theme-generated.js");
   if (fs.existsSync(generatedThemeFile)) {
     // read theme name from the theme-generated.js as there we always mark the used theme for webpack to handle.
     const themeName = nameRegex.exec(fs.readFileSync(generatedThemeFile, {encoding: 'utf8'}))[1];

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-handle.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-handle.js
@@ -23,8 +23,8 @@ const path = require('path');
 const generateThemeFile = require('./theme-generator');
 const {copyStaticAssets, copyThemeResources} = require('./theme-copy');
 
-// matches theme name 'my-theme' in 'generated/my-theme.generated.js'
-const nameRegex = /generated\/(.*).generated.js/;
+// matches theme name 'my-theme' in 'generated/theme-my-theme.generated.js'
+const nameRegex = /theme-(.*).generated.js/;
 
 let prevThemeName = undefined;
 let firstThemeName = undefined;
@@ -152,7 +152,7 @@ function handleThemes(themeName, themesFolder, options, logger) {
     copyThemeResources(themeFolder, options.projectStaticAssetsOutputFolder, logger);
     const themeFile = generateThemeFile(themeFolder, themeName, themeProperties, !options.devMode);
 
-    fs.writeFileSync(path.resolve(options.frontendGeneratedFolder, themeName + '.generated.js'), themeFile);
+    fs.writeFileSync(path.resolve(options.frontendGeneratedFolder, 'theme-' + themeName + '.generated.js'), themeFile);
     return true;
   }
   return false;
@@ -171,22 +171,22 @@ function getThemeProperties(themeFolder) {
 }
 
 /**
- * Extracts current theme name from 'theme-generated.js' file located on a
+ * Extracts current theme name from 'theme.js' file located on a
  * given folder.
- * @param frontendGeneratedFolder theme folder where flow generates 'theme-generated.js'
+ * @param frontendGeneratedFolder theme folder where flow generates 'theme.js'
  * file and copies local and jar resource frontend files
  * @returns {string} current theme name
  */
 function extractThemeName(frontendGeneratedFolder) {
   if (!frontendGeneratedFolder) {
-    throw new Error("Couldn't extract theme name from 'theme-generated.js'," +
+    throw new Error("Couldn't extract theme name from 'theme.js'," +
       " because the path to folder containing this file is empty. Please set" +
       " the a correct folder path in ApplicationThemePlugin constructor" +
       " parameters.");
   }
-  const generatedThemeFile = path.resolve(frontendGeneratedFolder, "theme-generated.js");
+  const generatedThemeFile = path.resolve(frontendGeneratedFolder, "theme.js");
   if (fs.existsSync(generatedThemeFile)) {
-    // read theme name from the theme-generated.js as there we always mark the used theme for webpack to handle.
+    // read theme name from the theme.js as there we always mark the used theme for webpack to handle.
     const themeName = nameRegex.exec(fs.readFileSync(generatedThemeFile, {encoding: 'utf8'}))[1];
     if (!themeName) {
       throw new Error("Couldn't parse theme name from '" + generatedThemeFile + "'.");

--- a/flow-server/src/main/resources/plugins/theme-live-reload-plugin/theme-live-reload-plugin.js
+++ b/flow-server/src/main/resources/plugins/theme-live-reload-plugin/theme-live-reload-plugin.js
@@ -80,7 +80,7 @@ class ThemeLiveReloadPlugin {
           // styles and theme generated file in one run to not have webpack
           // compile error
           if (deletedComponentStyleFile && !themeGeneratedFileDeleted) {
-            const themeGeneratedPath = "./frontend/themes/" + themeName + "/" + themeName + ".generated.js";
+            const themeGeneratedPath = "./frontend/generated/theme-" + themeName + ".generated.js";
 
             logger.warn("Custom theme component style sheet '" + deletedComponentStyleFile + "' has been deleted.\n\n" +
               "You should also delete '" + themeGeneratedPath + "' (simultaneously) with the component stylesheet'.\n" +

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -95,6 +95,7 @@ if (watchDogPort) {
 }
 
 const flowFrontendThemesFolder = path.resolve(flowFrontendFolder, 'themes');
+const frontendGeneratedFolder = path.resolve(frontendFolder, "generated");
 const themeOptions = {
   devMode: devMode,
   // The following matches ./frontend/generated/theme-generated.js
@@ -102,14 +103,14 @@ const themeOptions = {
   themeResourceFolder: flowFrontendThemesFolder,
   themeProjectFolders: themeProjectFolders,
   projectStaticAssetsOutputFolder: projectStaticAssetsOutputFolder,
-  frontendGeneratedFolder: path.resolve(frontendFolder, "generated"),
+  frontendGeneratedFolder: frontendGeneratedFolder
 };
 let themeName = undefined;
 let themeWatchFolders = undefined;
 if (devMode) {
   // Current theme name is being extracted from theme-generated.js located in
-  // target/frontend/themes folder
-  themeName = extractThemeName(flowFrontendThemesFolder);
+  // frontend/generated folder
+  themeName = extractThemeName(frontendGeneratedFolder);
   const parentThemePaths = findParentThemes(themeName, themeOptions);
   const currentThemeFolders = [...projectStaticAssetsFolders
     .map((folder) => path.resolve(folder, "themes", themeName)),

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -97,11 +97,12 @@ if (watchDogPort) {
 const flowFrontendThemesFolder = path.resolve(flowFrontendFolder, 'themes');
 const themeOptions = {
   devMode: devMode,
-  // The following matches target/frontend/themes/theme-generated.js
+  // The following matches ./frontend/generated/theme-generated.js
   // and for theme in JAR that is copied to target/frontend/themes/
   themeResourceFolder: flowFrontendThemesFolder,
   themeProjectFolders: themeProjectFolders,
   projectStaticAssetsOutputFolder: projectStaticAssetsOutputFolder,
+  frontendGeneratedFolder: path.resolve(frontendFolder, "generated"),
 };
 let themeName = undefined;
 let themeWatchFolders = undefined;

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -98,7 +98,7 @@ const flowFrontendThemesFolder = path.resolve(flowFrontendFolder, 'themes');
 const frontendGeneratedFolder = path.resolve(frontendFolder, "generated");
 const themeOptions = {
   devMode: devMode,
-  // The following matches ./frontend/generated/theme-generated.js
+  // The following matches ./frontend/generated/theme.js
   // and for theme in JAR that is copied to target/frontend/themes/
   themeResourceFolder: flowFrontendThemesFolder,
   themeProjectFolders: themeProjectFolders,
@@ -108,7 +108,7 @@ const themeOptions = {
 let themeName = undefined;
 let themeWatchFolders = undefined;
 if (devMode) {
-  // Current theme name is being extracted from theme-generated.js located in
+  // Current theme name is being extracted from theme.js located in
   // frontend/generated folder
   themeName = extractThemeName(frontendGeneratedFolder);
   const parentThemePaths = findParentThemes(themeName, themeOptions);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateThemeImportTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateThemeImportTest.java
@@ -64,7 +64,7 @@ public class TaskUpdateThemeImportTest {
         frontendDirectory = new File(projectRoot, DEFAULT_FRONTEND_DIR);
 
         File generated = new File(frontendDirectory, "generated");
-        themeImportFile = new File(generated, "theme-generated.js");
+        themeImportFile = new File(generated, "theme.js");
 
         dummyThemeClass = Mockito.mock(AbstractTheme.class).getClass();
         customTheme = new ThemeDefinition(dummyThemeClass, CUSTOM_VARIANT_NAME,
@@ -109,14 +109,14 @@ public class TaskUpdateThemeImportTest {
                 CUSTOM_THEME_NAME), customThemeDirCreatedSuccessfully);
 
         Assert.assertFalse(
-                "\"theme-generated.js\" should not exist before"
+                "\"theme.js\" should not exist before"
                         + " executing TaskUpdateThemeImport.",
                 themeImportFile.exists());
 
         taskUpdateThemeImport.execute();
 
         Assert.assertTrue(
-                "\"theme-generated.js\" should be created as the "
+                "\"theme.js\" should be created as the "
                         + "result of executing TaskUpdateThemeImport.",
                 themeImportFile.exists());
     }
@@ -140,14 +140,14 @@ public class TaskUpdateThemeImportTest {
                 customThemeDirCreatedSuccessfully);
 
         Assert.assertFalse(
-                "\"theme-generated.js\" should not exist before"
+                "\"theme.js\" should not exist before"
                         + " executing TaskUpdateThemeImport.",
                 themeImportFile.exists());
 
         taskUpdateThemeImport.execute();
 
         Assert.assertTrue(
-                "\"theme-generated.js\" should be created as the "
+                "\"theme.js\" should be created as the "
                         + "result of executing TaskUpdateThemeImport.",
                 themeImportFile.exists());
     }
@@ -171,14 +171,14 @@ public class TaskUpdateThemeImportTest {
                 customThemeDirCreatedSuccessfully);
 
         Assert.assertFalse(
-                "\"theme-generated.js\" should not exist before"
+                "\"theme.js\" should not exist before"
                         + " executing TaskUpdateThemeImport.",
                 themeImportFile.exists());
 
         taskUpdateThemeImport.execute();
 
         Assert.assertTrue(
-                "\"theme-generated.js\" should be created as the "
+                "\"theme.js\" should be created as the "
                         + "result of executing TaskUpdateThemeImport.",
                 themeImportFile.exists());
     }
@@ -200,14 +200,14 @@ public class TaskUpdateThemeImportTest {
                 customThemeDirCreatedSuccessfully);
 
         Assert.assertFalse(
-                "\"theme-generated.js\" should not exist before"
+                "\"theme.js\" should not exist before"
                         + " executing TaskUpdateThemeImport.",
                 themeImportFile.exists());
 
         taskUpdateThemeImport.execute();
 
         Assert.assertTrue(
-                "\"theme-generated.js\" should be created as the "
+                "\"theme.js\" should be created as the "
                         + "result of executing TaskUpdateThemeImport.",
                 themeImportFile.exists());
     }
@@ -226,12 +226,12 @@ public class TaskUpdateThemeImportTest {
                 CUSTOM_THEME_NAME, DEFAULT_FRONTEND_DIR, APPLICATION_THEME_ROOT,
                 CUSTOM_THEME_NAME), customThemeDirCreatedSuccessfully);
 
-        Assert.assertFalse("\"theme-generated.js\" should not exist before"
+        Assert.assertFalse("\"theme.js\" should not exist before"
             + " executing TaskUpdateThemeImport.", themeImportFile.exists());
 
         taskUpdateThemeImport.execute();
 
-        Assert.assertTrue("\"theme-generated.js\" should be created as the "
+        Assert.assertTrue("\"theme.js\" should be created as the "
                 + "result of executing TaskUpdateThemeImport.",
             themeImportFile.exists());
 
@@ -240,7 +240,7 @@ public class TaskUpdateThemeImportTest {
 
         taskUpdateThemeImport.execute();
 
-        Assert.assertFalse("\"theme-generated.js\" should not exist before"
+        Assert.assertFalse("\"theme.js\" should not exist before"
             + " executing TaskUpdateThemeImport.", themeImportFile.exists());
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateThemeImportTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdateThemeImportTest.java
@@ -63,10 +63,8 @@ public class TaskUpdateThemeImportTest {
         npmFolder = temporaryFolder.getRoot();
         frontendDirectory = new File(projectRoot, DEFAULT_FRONTEND_DIR);
 
-        File generated = new File(npmFolder, DEFAULT_GENERATED_DIR);
-        themeImportFile = new File(
-                new File(generated, APPLICATION_THEME_ROOT),
-                "theme-generated.js");
+        File generated = new File(frontendDirectory, "generated");
+        themeImportFile = new File(generated, "theme-generated.js");
 
         dummyThemeClass = Mockito.mock(AbstractTheme.class).getClass();
         customTheme = new ThemeDefinition(dummyThemeClass, CUSTOM_VARIANT_NAME,

--- a/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/WebComponentGeneratorTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/WebComponentGeneratorTest.java
@@ -181,7 +181,7 @@ public class WebComponentGeneratorTest {
         // make sure that the test works on windows machines:
         module = module.replace("\r", "");
         MatcherAssert.assertThat(module,
-                startsWith("import {applyTheme} from 'generated/theme-generated.js';\n\nclass Tag extends HTMLElement {"));
+                startsWith("import {applyTheme} from 'generated/theme.js';\n\nclass Tag extends HTMLElement {"));
         MatcherAssert
             .assertThat(module, containsString("style.innerHTML = `\n" //
                 + "      :host {\n" //

--- a/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/WebComponentGeneratorTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/WebComponentGeneratorTest.java
@@ -181,7 +181,7 @@ public class WebComponentGeneratorTest {
         // make sure that the test works on windows machines:
         module = module.replace("\r", "");
         MatcherAssert.assertThat(module,
-                startsWith("import {applyTheme} from 'themes/theme-generated.js';\n\nclass Tag extends HTMLElement {"));
+                startsWith("import {applyTheme} from 'generated/theme-generated.js';\n\nclass Tag extends HTMLElement {"));
         MatcherAssert
             .assertThat(module, containsString("style.innerHTML = `\n" //
                 + "      :host {\n" //

--- a/flow-tests/test-application-theme/test-theme-component-live-reload/src/test/java/com/vaadin/flow/uitest/ui/ComponentThemeLiveReloadIT.java
+++ b/flow-tests/test-application-theme/test-theme-component-live-reload/src/test/java/com/vaadin/flow/uitest/ui/ComponentThemeLiveReloadIT.java
@@ -55,7 +55,7 @@ public class ComponentThemeLiveReloadIT extends ChromeBrowserTest {
             + CURRENT_THEME + "/";
     private static final String PARENT_THEME_FOLDER = THEMES_FOLDER
             + PARENT_THEME + "/";
-    private static final String THEME_GENERATED_PATTERN = "%s.generated.js";
+    private static final String THEME_GENERATED_PATTERN = "frontend/generated/%s.generated.js";
     private static final String COMPONENT_STYLE_SHEET = "components/vaadin-text-field.css";
 
     private File currentThemeComponentCSSFile;
@@ -71,13 +71,13 @@ public class ComponentThemeLiveReloadIT extends ChromeBrowserTest {
         final File currentThemeFolder = new File(baseDir, CURRENT_THEME_FOLDER);
         currentThemeComponentCSSFile = new File(currentThemeFolder,
                 COMPONENT_STYLE_SHEET);
-        currentThemeGeneratedFile = new File(currentThemeFolder,
+        currentThemeGeneratedFile = new File(baseDir,
                 String.format(THEME_GENERATED_PATTERN, CURRENT_THEME));
 
         final File parentThemeFolder = new File(baseDir, PARENT_THEME_FOLDER);
         parentThemeComponentCSSFile = new File(parentThemeFolder,
                 COMPONENT_STYLE_SHEET);
-        parentThemeGeneratedFile = new File(parentThemeFolder,
+        parentThemeGeneratedFile = new File(baseDir,
                 String.format(THEME_GENERATED_PATTERN, PARENT_THEME));
     }
 

--- a/flow-tests/test-application-theme/test-theme-component-live-reload/src/test/java/com/vaadin/flow/uitest/ui/ComponentThemeLiveReloadIT.java
+++ b/flow-tests/test-application-theme/test-theme-component-live-reload/src/test/java/com/vaadin/flow/uitest/ui/ComponentThemeLiveReloadIT.java
@@ -55,7 +55,7 @@ public class ComponentThemeLiveReloadIT extends ChromeBrowserTest {
             + CURRENT_THEME + "/";
     private static final String PARENT_THEME_FOLDER = THEMES_FOLDER
             + PARENT_THEME + "/";
-    private static final String THEME_GENERATED_PATTERN = "frontend/generated/%s.generated.js";
+    private static final String THEME_GENERATED_PATTERN = "frontend/generated/theme-%s.generated.js";
     private static final String COMPONENT_STYLE_SHEET = "components/vaadin-text-field.css";
 
     private File currentThemeComponentCSSFile;


### PR DESCRIPTION
Any theme file that is generated is
now generated into `frontend/generated`

Fixes #11180
