### PR TITLE
fix: reset HTTP session on CLOSED state, not immidiately

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
@@ -202,7 +202,6 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
             // it as soon as we acquire the lock.
             service.fireSessionDestroy(this);
         }
-        session = null;
     }
 
     /**
@@ -887,6 +886,10 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
                 + this.state + "->" + state;
 
         this.state = state;
+
+        if (VaadinSessionState.CLOSED.equals(state)) {
+            session = null;
+        }
     }
 
     private boolean isValidChange(VaadinSessionState newState) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServiceTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServiceTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -160,6 +161,24 @@ public class VaadinServiceTest {
 
         Assert.assertEquals("SessionDestroyListeners not called exactly once",
                 1, listener.callCount);
+    }
+
+    @Test
+    public void fireSessionDestroy_sessionStateIsSetToClosed()
+            throws ServletException, ServiceException {
+        VaadinService service = createService();
+
+        AtomicReference<VaadinSessionState> stateRef = new AtomicReference<>();
+        MockVaadinSession vaadinSession = new MockVaadinSession(service) {
+            @Override
+            protected void setState(VaadinSessionState state) {
+                stateRef.set(state);
+            }
+        };
+
+        service.fireSessionDestroy(vaadinSession);
+
+        Assert.assertEquals(VaadinSessionState.CLOSED, stateRef.get());
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinSessionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinSessionTest.java
@@ -376,4 +376,55 @@ public class VaadinSessionTest {
                 "getCsrfToken() should always return the same value for the same session",
                 token1, token2);
     }
+
+    @Test
+    public void valueUnbound_wrappedSessionIsNotCleanedUp() {
+        ReentrantLock lock = Mockito.mock(ReentrantLock.class);
+        Mockito.when(lock.isHeldByCurrentThread()).thenReturn(true);
+        mockService = new MockVaadinServletService() {
+            @Override
+            protected Lock getSessionLock(WrappedSession wrappedSession) {
+                return lock;
+            }
+        };
+
+        VaadinSession vaadinSession = new VaadinSession(mockService);
+
+        WrappedSession httpSession = Mockito.mock(WrappedSession.class);
+        vaadinSession.refreshTransients(httpSession, mockService);
+
+        VaadinSession.setCurrent(vaadinSession);
+        mockService.setCurrentInstances(Mockito.mock(VaadinRequest.class),
+                Mockito.mock(VaadinResponse.class));
+
+        try {
+            vaadinSession
+                    .valueUnbound(Mockito.mock(HttpSessionBindingEvent.class));
+
+            Assert.assertNotNull(vaadinSession.getSession());
+        } finally {
+            CurrentInstance.clearAll();
+        }
+    }
+
+    @Test
+    public void setState_closedState_sessionAttributeIsCleanedUp() {
+        ReentrantLock lock = Mockito.mock(ReentrantLock.class);
+        Mockito.when(lock.isHeldByCurrentThread()).thenReturn(true);
+        mockService = new MockVaadinServletService() {
+            @Override
+            protected Lock getSessionLock(WrappedSession wrappedSession) {
+                return lock;
+            }
+        };
+
+        VaadinSession vaadinSession = new VaadinSession(mockService);
+        WrappedSession httpSession = Mockito.mock(WrappedSession.class);
+        vaadinSession.refreshTransients(httpSession, mockService);
+
+        vaadinSession.setState(VaadinSessionState.CLOSING);
+        vaadinSession.setState(VaadinSessionState.CLOSED);
+
+        Assert.assertNull(vaadinSession.getSession());
+    }
 }


### PR DESCRIPTION
fixes #6959

<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Please list all relevant dependencies in this section and provide summary of the change, motivation and context.

Fixes # (issue)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
