### PR TITLE
fix: reset session field only when HTTP session is invalidated

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -2193,6 +2193,13 @@ public abstract class VaadinService implements Serializable {
      *            the underlying HTTP session
      */
     protected void removeFromHttpSession(WrappedSession wrappedSession) {
+        VaadinSession vaadinSession = readFromHttpSession(wrappedSession);
+        if (vaadinSession != null) {
+            // mark Vaadin session as closed explicitly (opposite to closing as
+            // a result of invalidated HTTP session)
+            vaadinSession.setAttribute(VaadinSession.CLOSE_SESSION_EXPLICITLY,
+                    true);
+        }
         wrappedSession.removeAttribute(getSessionAttributeName());
 
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
@@ -205,11 +205,11 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
             // it as soon as we acquire the lock.
             service.fireSessionDestroy(this);
         }
-        // Vaadin session attribut is removed from HTTP session in two cases:
+        // Vaadin session attribute is removed from HTTP session in two cases:
         // either Vaadin session is closed explicitly by VaadinService or HTTP
         // session is invalidated (and all attributes are removed from it). In
         // the latter case the session field should be set to {@code null}
-        // Immediately to avoid using HTTP session object which is invalid (its
+        // immediately to avoid using HTTP session object which is invalid (all
         // methods throw exceptions).
         try {
             lock();

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
@@ -78,6 +78,9 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
     @Deprecated
     public static final String UI_PARAMETER = InitParameters.UI_PARAMETER;
 
+    static final String CLOSE_SESSION_EXPLICITLY = "vaadin.close-session."
+            + UUID.randomUUID().toString();
+
     /**
      * Configuration for the session.
      */
@@ -202,7 +205,21 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
             // it as soon as we acquire the lock.
             service.fireSessionDestroy(this);
         }
-        session = null;
+        // Vaadin session attribut is removed from HTTP session in two cases:
+        // either Vaadin session is closed explicitly by VaadinService or HTTP
+        // session is invalidated (and all attributes are removed from it). In
+        // the latter case the session field should be set to {@code null}
+        // Immediately to avoid using HTTP session object which is invalid (its
+        // methods throw exceptions).
+        try {
+            lock();
+            if (getAttribute(CLOSE_SESSION_EXPLICITLY) == null) {
+                session = null;
+            }
+            setAttribute(CLOSE_SESSION_EXPLICITLY, null);
+        } finally {
+            unlock();
+        }
     }
 
     /**
@@ -887,6 +904,9 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
                 + this.state + "->" + state;
 
         this.state = state;
+        if (VaadinSessionState.CLOSED.equals(state)) {
+            session = null;
+        }
     }
 
     private boolean isValidChange(VaadinSessionState newState) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServiceTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServiceTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -414,6 +415,46 @@ public class VaadinServiceTest {
         Assert.assertTrue(set.contains(PwaHandler.class));
         Assert.assertTrue(set.contains(WebComponentProvider.class));
         Assert.assertTrue(set.contains(WebComponentBootstrapHandler.class));
+    }
+
+    @Test
+    public void fireSessionDestroy_sessionStateIsSetToClosed()
+            throws ServletException, ServiceException {
+        VaadinService service = createService();
+
+        AtomicReference<VaadinSessionState> stateRef = new AtomicReference<>();
+        MockVaadinSession vaadinSession = new MockVaadinSession(service) {
+            @Override
+            protected void setState(VaadinSessionState state) {
+                stateRef.set(state);
+            }
+        };
+
+        service.fireSessionDestroy(vaadinSession);
+
+        Assert.assertEquals(VaadinSessionState.CLOSED, stateRef.get());
+    }
+
+    @Test
+    public void removeFromHttpSession_setExplciitSessionCloseAttribute()
+            throws ServiceException {
+        WrappedSession httpSession = Mockito.mock(WrappedSession.class);
+        VaadinSession session = Mockito.mock(VaadinSession.class);
+        VaadinService service = new MockVaadinServletService() {
+
+            @Override
+            protected VaadinSession readFromHttpSession(
+                    WrappedSession wrappedSession) {
+                return session;
+            }
+        };
+
+        service.init();
+
+        service.removeFromHttpSession(httpSession);
+
+        Mockito.verify(session)
+                .setAttribute(VaadinSession.CLOSE_SESSION_EXPLICITLY, true);
     }
 
     private InstantiatorFactory createInstantiatorFactory(Lookup lookup) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServiceTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServiceTest.java
@@ -436,7 +436,7 @@ public class VaadinServiceTest {
     }
 
     @Test
-    public void removeFromHttpSession_setExplciitSessionCloseAttribute()
+    public void removeFromHttpSession_setExplicitSessionCloseAttribute()
             throws ServiceException {
         WrappedSession httpSession = Mockito.mock(WrappedSession.class);
         VaadinSession session = Mockito.mock(VaadinSession.class);

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinSessionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinSessionTest.java
@@ -376,4 +376,101 @@ public class VaadinSessionTest {
                 "getCsrfToken() should always return the same value for the same session",
                 token1, token2);
     }
+
+    @Test
+    public void valueUnbound_explicitVaadinSessionClose_wrappedSessionIsNotCleanedUp() {
+        ReentrantLock lock = Mockito.mock(ReentrantLock.class);
+        Mockito.when(lock.isHeldByCurrentThread()).thenReturn(true);
+        mockService = new MockVaadinServletService() {
+            @Override
+            protected Lock getSessionLock(WrappedSession wrappedSession) {
+                return lock;
+            }
+
+        };
+
+        VaadinSession vaadinSession = new VaadinSession(mockService) {
+            @Override
+            public boolean hasLock() {
+                return true;
+            }
+        };
+
+        vaadinSession.setAttribute(VaadinSession.CLOSE_SESSION_EXPLICITLY,
+                true);
+
+        WrappedSession httpSession = Mockito.mock(WrappedSession.class);
+        vaadinSession.refreshTransients(httpSession, mockService);
+
+        VaadinSession.setCurrent(vaadinSession);
+        mockService.setCurrentInstances(Mockito.mock(VaadinRequest.class),
+                Mockito.mock(VaadinResponse.class));
+
+        try {
+            vaadinSession
+                    .valueUnbound(Mockito.mock(HttpSessionBindingEvent.class));
+
+            Assert.assertNotNull(vaadinSession.getSession());
+        } finally {
+            CurrentInstance.clearAll();
+        }
+    }
+
+    @Test
+    public void valueUnbound_implicitVaadinSessionClose_wrappedSessionIsCleanedUp() {
+        ReentrantLock lock = Mockito.mock(ReentrantLock.class);
+        Mockito.when(lock.isHeldByCurrentThread()).thenReturn(true);
+        mockService = new MockVaadinServletService() {
+            @Override
+            protected Lock getSessionLock(WrappedSession wrappedSession) {
+                return lock;
+            }
+
+        };
+
+        VaadinSession vaadinSession = new VaadinSession(mockService) {
+            @Override
+            public boolean hasLock() {
+                return true;
+            }
+        };
+
+        WrappedSession httpSession = Mockito.mock(WrappedSession.class);
+        vaadinSession.refreshTransients(httpSession, mockService);
+
+        VaadinSession.setCurrent(vaadinSession);
+        mockService.setCurrentInstances(Mockito.mock(VaadinRequest.class),
+                Mockito.mock(VaadinResponse.class));
+
+        try {
+            vaadinSession
+                    .valueUnbound(Mockito.mock(HttpSessionBindingEvent.class));
+
+            Assert.assertNull(vaadinSession.getSession());
+        } finally {
+            CurrentInstance.clearAll();
+        }
+    }
+
+    @Test
+    public void setState_closedState_sessionFieldIsCleanedUp() {
+        ReentrantLock lock = Mockito.mock(ReentrantLock.class);
+        Mockito.when(lock.isHeldByCurrentThread()).thenReturn(true);
+        mockService = new MockVaadinServletService() {
+            @Override
+            protected Lock getSessionLock(WrappedSession wrappedSession) {
+                return lock;
+            }
+        };
+
+        VaadinSession vaadinSession = new VaadinSession(mockService);
+        WrappedSession httpSession = Mockito.mock(WrappedSession.class);
+        vaadinSession.refreshTransients(httpSession, mockService);
+
+        vaadinSession.setState(VaadinSessionState.CLOSING);
+        vaadinSession.setState(VaadinSessionState.CLOSED);
+
+        Assert.assertNull(vaadinSession.getSession());
+    }
+
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/InvalidateHttpSessionView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/InvalidateHttpSessionView.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.server.VaadinService;
+
+@Route("com.vaadin.flow.uitest.ui.InvalidateHttpSessionView")
+public class InvalidateHttpSessionView extends Div {
+
+    private static class SessionId {
+
+        private String id;
+
+        private SessionId(String id) {
+            this.id = id;
+        }
+    }
+
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        VaadinService service = attachEvent.getSession().getService();
+        String id = attachEvent.getSession().getSession().getId();
+
+        Div div = new Div();
+        div.setText(id);
+        div.setId("current-session-id");
+
+        add(div);
+
+        SessionId closedSessionId = attachEvent.getSession().getService()
+                .getContext().getAttribute(SessionId.class);
+        if (closedSessionId != null) {
+            div = new Div();
+            div.setText(closedSessionId.id);
+            div.setId("invalidated-session-id");
+            add(div);
+        }
+
+        service.addSessionDestroyListener(event -> {
+            SessionId sessionId = new SessionId(id);
+            service.getContext().setAttribute(SessionId.class, sessionId);
+        });
+        NativeButton button = new NativeButton("Invalidate HTTP session",
+                event -> attachEvent.getSession().getSession().invalidate());
+        add(button);
+        button.setId("invalidate-session");
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/InvalidateHttpSessionIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/InvalidateHttpSessionIT.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class InvalidateHttpSessionIT extends ChromeBrowserTest {
+
+    @Test
+    public void invalidateHttpSession_vaadinSessionIsClosed() {
+        open();
+
+        String sessionId = findElement(By.id("current-session-id")).getText();
+
+        findElement(By.id("invalidate-session")).click();
+
+        waitForElementPresent(By.id("invalidated-session-id"));
+
+        String invalidatedSessionId = findElement(
+                By.id("invalidated-session-id")).getText();
+
+        Assert.assertEquals(sessionId, invalidatedSessionId);
+
+        sessionId = findElement(By.id("current-session-id")).getText();
+        Assert.assertNotEquals(sessionId, invalidatedSessionId);
+    }
+
+}


### PR DESCRIPTION
fixes #6959

<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Please list all relevant dependencies in this section and provide summary of the change, motivation and context.

Fixes # (issue)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
