### PR TITLE
fix: Reuse existing filesystem

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
@@ -26,6 +26,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.file.FileSystem;
+import java.nio.file.FileSystemAlreadyExistsException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -220,10 +221,22 @@ public class StaticFileServer implements StaticFileHandler {
                 return FileSystems.getFileSystem(resourceURI);
             }
             // Opened filesystem is for the file to get the correct provider
-            FileSystem fileSystem = FileSystems.newFileSystem(resourceURI,
-                    Collections.emptyMap());
+            FileSystem fileSystem = getNewOrExistingFileSystem(resourceURI);
             openFileSystems.put(fileURI, 1);
             return fileSystem;
+        }
+    }
+
+    private FileSystem getNewOrExistingFileSystem(URI resourceURI)
+            throws IOException {
+        try {
+            return FileSystems.newFileSystem(resourceURI,
+                    Collections.emptyMap());
+        } catch (FileSystemAlreadyExistsException fsaee) {
+            getLogger().trace(
+                    "Tried to get new filesystem, but it already existed for target uri.",
+                    fsaee);
+            return FileSystems.getFileSystem(resourceURI);
         }
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
@@ -443,6 +443,36 @@ public class StaticFileServerTest implements Serializable {
     }
 
     @Test
+    public void openFileServerExistsForZip_openingNewDoesNotFail()
+            throws IOException, URISyntaxException {
+        Assert.assertTrue("Can not run concurrently with other test",
+                StaticFileServer.openFileSystems.isEmpty());
+
+        final TemporaryFolder folder = TemporaryFolder.builder().build();
+        folder.create();
+
+        Path tempArchive = generateZipArchive(folder);
+
+        final FileSystem fileSystem = FileSystems
+                .newFileSystem(new URL("jar:file:///"
+                        + tempArchive.toString().replaceAll("\\\\", "/") + "!/")
+                                .toURI(),
+                        Collections.emptyMap());
+
+        final URL folderResourceURL = new URL(
+                "jar:file:///" + tempArchive.toString().replaceAll("\\\\", "/")
+                        + "!/frontend");
+
+        try {
+            fileServer.getFileSystem(folderResourceURL.toURI());
+        } finally {
+            fileServer.closeFileSystem(folderResourceURL.toURI());
+            fileSystem.close();
+        }
+
+    }
+
+    @Test
     public void openingJarFileSystemForDifferentFilesInSameJar_existingFileSystemIsUsed()
             throws IOException, URISyntaxException {
         Assert.assertTrue("Can not run concurrently with other test",


### PR DESCRIPTION
When getting a for Flow new FileSystem
there is the possibility that a filesystem
has been created elsewhere. Reuse the
existing FileSystem if it exists.

Fixes #11378

