### PR TITLE
fix: Show only single permanent notification (#11450)

### DIFF
--- a/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.ts
+++ b/flow-client/src/main/resources/META-INF/resources/frontend/VaadinDevmodeGizmo.ts
@@ -816,6 +816,13 @@ export class VaadinDevmodeGizmo extends LitElement {
 
   showNotification(type: MessageType, message: string, details?: string, link?: string, persistentId?: string) {
     if (persistentId === undefined || !VaadinDevmodeGizmo.notificationDismissed(persistentId!)) {
+      // Do not open persistent message if another is already visible with the same persistentId
+      const matchingVisibleNotifications = this.notifications
+          .filter((notification) => notification.persistentId === persistentId)
+          .filter((notification) => !notification.deleted);
+      if (matchingVisibleNotifications.length > 0) {
+        return;
+      }
       const id = this.nextMessageId++;
       this.notifications.push({
         id,


### PR DESCRIPTION
If a persistent message is open
do not open a new permanent message
for the same persistentId.

Closes #11074
