### PR TITLE
chore: update slf4j to 1.7.32

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <!-- Dependencies -->
         <gwt.version>2.8.2</gwt.version>
         <hibernate.validator.version>6.0.1.Final</hibernate.validator.version>
-        <slf4j.version>1.7.30</slf4j.version>
+        <slf4j.version>1.7.32</slf4j.version>
         <polymer.version>2.6.1</polymer.version>
 
         <!-- Plugins -->


### PR DESCRIPTION
## Description

Align dependency management of slf4j with the latest version coming with spring boot 2.5.3 (https://github.com/vaadin/spring/pull/862)

See: https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/2.5.3/spring-boot-dependencies-2.5.3.pom
