### PR TITLE
fix: Use byte[] instead of String to store stats.json

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -628,7 +628,7 @@ public class FrontendUtils {
                         .getLastModified().orElse(LocalDateTime.MIN))) {
                     byte[] buffer = IOUtils
                             .toByteArray(connection.getInputStream());
-                    statistics = new Stats(buffer,lastModified);
+                    statistics = new Stats(buffer, lastModified);
                     context.setAttribute(statistics);
                 }
                 return new ByteArrayInputStream(statistics.statsJson);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -626,7 +626,8 @@ public class FrontendUtils {
                 Stats statistics = context.getAttribute(Stats.class);
                 if (statistics == null || modified.isAfter(statistics
                         .getLastModified().orElse(LocalDateTime.MIN))) {
-                    byte[] buffer = IOUtils.toByteArray(connection.getInputStream());
+                    byte[] buffer = IOUtils
+                            .toByteArray(connection.getInputStream());
                     statistics = new Stats(buffer,lastModified);
                     context.setAttribute(statistics);
                 }


### PR DESCRIPTION
This is made to avoid excessive memory usage when managing the data

fixes: #11515