### PR TITLE
fix: Fail-fast if the path to npm cache contains whitespaces

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -521,9 +521,7 @@ public class FrontendTools {
             npmCacheCommand.add("cache");
             npmCacheCommand.add("--global");
             String output = FrontendUtils.executeCommand(npmCacheCommand);
-            getLogger().info("Command execution output: " + output);
             output = parseCommandOutput(output);
-            getLogger().info("Command execution output after parsing: " + output);
             if (output.isEmpty()) {
                 throw new IllegalStateException(
                         String.format("Command '%s' returned an empty path",

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -518,19 +518,14 @@ public class FrontendTools {
      * installed npm.
      *
      * @return the file object representing path to npm cache directory.
-     * @throws IOException
-     *             if an I/O occurs while getting npm cache directory.
-     * @throws InterruptedException
-     *             if the current thread is being interrupted while getting the
-     *             npm cache directory.
      * @throws CommandExecutionException
      *             if getting the npm cache directory completes exceptionally
      *             with non-zero code.
      * @throws IllegalStateException
      *             if npm cache command return an empty path.
      */
-    File getNpmCacheDir() throws IOException, InterruptedException,
-            CommandExecutionException, IllegalStateException {
+    File getNpmCacheDir()
+            throws CommandExecutionException, IllegalStateException {
         List<String> npmCacheCommand = new ArrayList<>(getNpmExecutable(false));
         npmCacheCommand.add("config");
         npmCacheCommand.add("get");

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -520,8 +520,9 @@ public class FrontendTools {
             npmCacheCommand.add("get");
             npmCacheCommand.add("cache");
             npmCacheCommand.add("--global");
-            String output = FrontendUtils.executeCommand(npmCacheCommand)
-                    .trim();
+            String output = FrontendUtils.executeCommand(npmCacheCommand);
+            output = output.replaceAll(System.getProperty("line.separator"),
+                    "");
             if (output.isEmpty()) {
                 throw new IllegalStateException(
                         String.format("Command '%s' returned an empty path",

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -473,38 +473,44 @@ public class FrontendTools {
      *             if <code>pnpm install</code> is blocked by whitespaces in
      *             user home
      */
-    boolean npmAcceptsWhitespaces(File dirToBeChecked) throws IllegalStateException {
+    boolean npmAcceptsWhitespaces(File dirToBeChecked)
+            throws IllegalStateException {
         Objects.requireNonNull(dirToBeChecked);
-        boolean hidden = dirToBeChecked.isHidden() || dirToBeChecked.getPath().contains(File.separator + ".");
-        if (!hidden && (!dirToBeChecked.exists() || !dirToBeChecked.isDirectory())) {
+        boolean hidden = dirToBeChecked.isHidden()
+                || dirToBeChecked.getPath().contains(File.separator + ".");
+        if (!hidden && (!dirToBeChecked.exists()
+                || !dirToBeChecked.isDirectory())) {
             getLogger().warn(
-                    "Failed to check whitespaces in '{}', because it doesn't exist or not a directory", dirToBeChecked);
+                    "Failed to check whitespaces in '{}', because it doesn't exist or not a directory",
+                    dirToBeChecked);
             return true;
         }
 
-        if (FrontendUtils.isWindows() && dirToBeChecked.getAbsolutePath().matches(".*[\\s+].*")) {
+        if (FrontendUtils.isWindows()
+                && dirToBeChecked.getAbsolutePath().matches(".*[\\s+].*")) {
             try {
                 FrontendVersion foundNpmVersion = getNpmVersion();
                 // npm < 7.0.0 doesn't accept whitespaces in user home
-                return FrontendUtils.isVersionAtLeast(
-                        foundNpmVersion, WHITESPACE_ACCEPTING_NPM_VERSION);
+                return FrontendUtils.isVersionAtLeast(foundNpmVersion,
+                        WHITESPACE_ACCEPTING_NPM_VERSION);
             } catch (UnknownVersionException e) {
                 getLogger().warn(
-                        "Error checking if npm supports whitespaces in path '{}'", dirToBeChecked,
-                        e);
+                        "Error checking if npm supports whitespaces in path '{}'",
+                        dirToBeChecked, e);
             }
         }
         return true;
     }
 
     /**
-     * Gives a file object representing path to the cache directory of
-     * currently installed npm.
+     * Gives a file object representing path to the cache directory of currently
+     * installed npm.
      *
      * @return the file object representing path to npm cache directory.
      *
-     * @throws IllegalStateException if the failure occurs during requesting
-     * the cache dir, or the returned path is empty.
+     * @throws IllegalStateException
+     *             if the failure occurs during requesting the cache dir, or the
+     *             returned path is empty.
      */
     File getNpmCacheDir() throws IllegalStateException {
         try {
@@ -514,14 +520,16 @@ public class FrontendTools {
             npmCacheCommand.add("get");
             npmCacheCommand.add("cache");
             npmCacheCommand.add("--global");
-            String output = FrontendUtils.executeCommand(npmCacheCommand).trim();
+            String output = FrontendUtils.executeCommand(npmCacheCommand)
+                    .trim();
             if (output.isEmpty()) {
-                throw new IllegalStateException(String.format(
-                        "Command '%s' returned an empty path",
-                        String.join(" ", npmCacheCommand)));
+                throw new IllegalStateException(
+                        String.format("Command '%s' returned an empty path",
+                                String.join(" ", npmCacheCommand)));
             }
             return new File(output);
-        } catch (InterruptedException | IOException | CommandExecutionException e) {
+        } catch (InterruptedException | IOException
+                | CommandExecutionException e) {
             throw new IllegalStateException("Failed to get npm cache dir", e);
         }
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -521,7 +521,9 @@ public class FrontendTools {
             npmCacheCommand.add("cache");
             npmCacheCommand.add("--global");
             String output = FrontendUtils.executeCommand(npmCacheCommand);
+            getLogger().info("Command execution output: " + output);
             output = parseCommandOutput(output);
+            getLogger().info("Command execution output after parsing: " + output);
             if (output.isEmpty()) {
                 throw new IllegalStateException(
                         String.format("Command '%s' returned an empty path",

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -520,6 +520,7 @@ public class FrontendTools {
             npmCacheCommand.add("get");
             npmCacheCommand.add("cache");
             npmCacheCommand.add("--global");
+            getLogger().info("Commands = " + npmCacheCommand);
             String output = FrontendUtils.executeCommand(npmCacheCommand);
             getLogger().info("Command execution output: " + output);
             output = parseCommandOutput(output);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -520,7 +520,6 @@ public class FrontendTools {
             npmCacheCommand.add("get");
             npmCacheCommand.add("cache");
             npmCacheCommand.add("--global");
-            getLogger().info("Commands = " + npmCacheCommand);
             String output = FrontendUtils.executeCommand(npmCacheCommand);
             getLogger().info("Command execution output: " + output);
             output = parseCommandOutput(output);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -521,8 +521,7 @@ public class FrontendTools {
             npmCacheCommand.add("cache");
             npmCacheCommand.add("--global");
             String output = FrontendUtils.executeCommand(npmCacheCommand);
-            output = output.replaceAll(System.getProperty("line.separator"),
-                    "");
+            output = parseCommandOutput(output);
             if (output.isEmpty()) {
                 throw new IllegalStateException(
                         String.format("Command '%s' returned an empty path",
@@ -799,5 +798,12 @@ public class FrontendTools {
         } else {
             return getNodeExecutable();
         }
+    }
+
+    private String parseCommandOutput(String output) {
+        if (output == null || output.isEmpty()) {
+            return output;
+        }
+        return String.join("", output.split(System.lineSeparator()));
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -528,8 +528,7 @@ public class FrontendTools {
                                 String.join(" ", npmCacheCommand)));
             }
             return new File(output);
-        } catch (InterruptedException | IOException
-                | CommandExecutionException e) {
+        } catch (CommandExecutionException e) {
             throw new IllegalStateException("Failed to get npm cache dir", e);
         }
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -508,19 +508,8 @@ public class FrontendTools {
      * installed npm.
      *
      * @return the file object representing path to npm cache directory.
-     *
-     * @throws IllegalStateException
-     *             if the failure occurs during requesting the cache dir, or the
-     *             returned path is empty.
-     */
-    /**
-     * Gives a file object representing path to the cache directory of currently
-     * installed npm.
-     *
-     * @return the file object representing path to npm cache directory.
      * @throws CommandExecutionException
-     *             if getting the npm cache directory completes exceptionally
-     *             with non-zero code.
+     *             if getting the npm cache directory completes exceptionally.
      * @throws IllegalStateException
      *             if npm cache command return an empty path.
      */

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -977,7 +977,8 @@ public class FrontendUtils {
          * Constructs an exception telling with which code the process was
          * exited.
          *
-         * @param processExitCode process exit code
+         * @param processExitCode
+         *            process exit code
          */
         public CommandExecutionException(int processExitCode) {
             super("Process execution failed with exit code " + processExitCode);
@@ -989,7 +990,8 @@ public class FrontendUtils {
         try {
             String output = executeCommand(versionCommand);
             return new FrontendVersion(parseVersionString(output));
-        } catch (InterruptedException | IOException | CommandExecutionException e) {
+        } catch (InterruptedException | IOException
+                | CommandExecutionException e) {
             throw new UnknownVersionException(tool,
                     "Using command " + String.join(" ", versionCommand), e);
         }
@@ -998,18 +1000,22 @@ public class FrontendUtils {
     /**
      * Executes a given command as a native process.
      *
-     * @param command the command to be executed and it's arguments.
+     * @param command
+     *            the command to be executed and it's arguments.
      *
      * @return process output string.
-     * @throws IOException if I/O error occurs during the execution.
-     * @throws InterruptedException when the current thread is being
-     * interrupted while waiting for a process to complete.
-     * @throws CommandExecutionException if the process completes with non-zero code.
+     * @throws IOException
+     *             if I/O error occurs during the execution.
+     * @throws InterruptedException
+     *             when the current thread is being interrupted while waiting
+     *             for a process to complete.
+     * @throws CommandExecutionException
+     *             if the process completes with non-zero code.
      */
     public static String executeCommand(List<String> command)
-            throws IOException, InterruptedException, CommandExecutionException {
-        Process process = FrontendUtils.createProcessBuilder(command)
-                .start();
+            throws IOException, InterruptedException,
+            CommandExecutionException {
+        Process process = FrontendUtils.createProcessBuilder(command).start();
         int exitCode = process.waitFor();
         if (exitCode != 0) {
             throw new CommandExecutionException(exitCode);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -998,7 +998,8 @@ public class FrontendUtils {
         try {
             String output = executeCommand(versionCommand);
             return new FrontendVersion(parseVersionString(output));
-        } catch (IOException | CommandExecutionException e) {
+        } catch (IOException | CommandExecutionException
+                | InterruptedException e) {
             throw new UnknownVersionException(tool,
                     "Using command " + String.join(" ", versionCommand), e);
         }
@@ -1014,19 +1015,29 @@ public class FrontendUtils {
      * @throws CommandExecutionException
      *             if the process completes exceptionally.
      */
+    /**
+     * Executes a given command as a native process.
+     *
+     * @param command
+     *            the command to be executed and it's arguments.
+     * @return process output string.
+     * @throws CommandExecutionException
+     *             if the process completes exceptionally with non-zero code.
+     * @throws IOException
+     *             if an I/O occurs during command execution.
+     * @throws InterruptedException
+     *             when the current thread is being interrupted while waiting
+     *             for command to complete.
+     */
     public static String executeCommand(List<String> command)
-            throws CommandExecutionException {
-        try {
-            Process process = FrontendUtils.createProcessBuilder(command)
-                    .start();
-            int exitCode = process.waitFor();
-            if (exitCode != 0) {
-                throw new CommandExecutionException(exitCode);
-            }
-            return streamToString(process.getInputStream());
-        } catch (Exception e) {
-            throw new CommandExecutionException(e);
+            throws CommandExecutionException, IOException,
+            InterruptedException {
+        Process process = FrontendUtils.createProcessBuilder(command).start();
+        int exitCode = process.waitFor();
+        if (exitCode != 0) {
+            throw new CommandExecutionException(exitCode);
         }
+        return streamToString(process.getInputStream());
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -967,12 +967,12 @@ public class FrontendUtils {
     }
 
     /**
-     * Thrown when the process execution fails.
+     * Thrown when the command execution fails.
      */
     public static class CommandExecutionException extends Exception {
         /**
-         * Constructs an exception telling what code the process was exited
-         * with.
+         * Constructs an exception telling what code the command execution
+         * process was exited with.
          *
          * @param processExitCode
          *            process exit code
@@ -983,7 +983,7 @@ public class FrontendUtils {
 
         /**
          * Constructs an exception telling what was the original exception the
-         * process failed with.
+         * command execution process failed with.
          *
          * @param cause
          *            the cause exception of process failure.
@@ -998,8 +998,7 @@ public class FrontendUtils {
         try {
             String output = executeCommand(versionCommand);
             return new FrontendVersion(parseVersionString(output));
-        } catch (IOException | CommandExecutionException
-                | InterruptedException e) {
+        } catch (IOException | CommandExecutionException e) {
             throw new UnknownVersionException(tool,
                     "Using command " + String.join(" ", versionCommand), e);
         }
@@ -1023,21 +1022,20 @@ public class FrontendUtils {
      * @return process output string.
      * @throws CommandExecutionException
      *             if the process completes exceptionally with non-zero code.
-     * @throws IOException
-     *             if an I/O occurs during command execution.
-     * @throws InterruptedException
-     *             when the current thread is being interrupted while waiting
-     *             for command to complete.
      */
     public static String executeCommand(List<String> command)
-            throws CommandExecutionException, IOException,
-            InterruptedException {
-        Process process = FrontendUtils.createProcessBuilder(command).start();
-        int exitCode = process.waitFor();
-        if (exitCode != 0) {
-            throw new CommandExecutionException(exitCode);
+            throws CommandExecutionException {
+        try {
+            Process process = FrontendUtils.createProcessBuilder(command)
+                    .start();
+            int exitCode = process.waitFor();
+            if (exitCode != 0) {
+                throw new CommandExecutionException(exitCode);
+            }
+            return streamToString(process.getInputStream());
+        } catch (IOException | InterruptedException e) {
+            throw new CommandExecutionException(e);
         }
-        return streamToString(process.getInputStream());
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -1009,19 +1009,9 @@ public class FrontendUtils {
      *
      * @param command
      *            the command to be executed and it's arguments.
-     *
      * @return process output string.
      * @throws CommandExecutionException
      *             if the process completes exceptionally.
-     */
-    /**
-     * Executes a given command as a native process.
-     *
-     * @param command
-     *            the command to be executed and it's arguments.
-     * @return process output string.
-     * @throws CommandExecutionException
-     *             if the process completes exceptionally with non-zero code.
      */
     public static String executeCommand(List<String> command)
             throws CommandExecutionException {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -335,7 +335,7 @@ public class TaskRunNpmInstall implements FallibleCommand {
                 File npmCacheDir = tools.getNpmCacheDir();
                 if (!tools.npmAcceptsWhitespaces(npmCacheDir)) {
                     throw new IllegalStateException(
-                            USER_HOME_CONTAINS_WHITESPACES);
+                            String.format(USER_HOME_CONTAINS_WHITESPACES));
                 }
                 executable = tools.getPnpmExecutable();
             } else {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -65,6 +65,24 @@ public class TaskRunNpmInstall implements FallibleCommand {
     // a new hash to the code repository.
     private static final String INSTALL_HASH = ".vaadin/vaadin.json";
 
+    private static final String USER_HOME_CONTAINS_WHITESPACES =
+            "\n\n======================================================================================================"
+            + "\nThe path to npm cache contains whitespaces, and the currently installed npm version doesn't accept this."
+            + "\nMost likely your Windows user home path contains whitespaces."
+            + "\nTo workaround it, please change the npm cache path by using the following command:"
+            + "\n    npm config set cache [path-to-npm-cache] --global"
+            + "\n(you may also want to exclude the whitespaces with 'dir /x' to use the same dir),"
+            + "\nor upgrade the npm version to 7 (or newer) by:"
+            + "\n 1) Running 'npm-windows-upgrade' tool with Windows PowerShell:"
+            + "\n        Set-ExecutionPolicy Unrestricted -Scope CurrentUser -Force"
+            + "\n        npm install -g npm-windows-upgrade"
+            + "\n        npm-windows-upgrade"
+            + "\n 2) Manually installing a newer version of npx: npm install -g npx"
+            + "\n 3) Manually installing a newer version of pnpm: npm install -g pnpm"
+            + "\n 4) Deleting the following files from your Vaadin project's folder (if present):"
+            + "\n        node_modules, package-lock.json, webpack.generated.js, pnpm-lock.yaml, pnpmfile.js"
+            + "\n======================================================================================================\n";
+
     private final NodeUpdater packageUpdater;
 
     private final List<String> ignoredNodeFolders = Arrays.asList(".bin",
@@ -315,7 +333,10 @@ public class TaskRunNpmInstall implements FallibleCommand {
                 tools.forceAlternativeNodeExecutable();
             }
             if (enablePnpm) {
-                tools.checkNpmAcceptsWhitespacesInUserHome();
+                File npmCacheDir = tools.getNpmCacheDir();
+                if (!tools.npmAcceptsWhitespaces(npmCacheDir)) {
+                    throw new IllegalStateException(USER_HOME_CONTAINS_WHITESPACES);
+                }
                 executable = tools.getPnpmExecutable();
             } else {
                 executable = tools.getNpmExecutable();

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -314,8 +314,12 @@ public class TaskRunNpmInstall implements FallibleCommand {
             if (requireHomeNodeExec) {
                 tools.forceAlternativeNodeExecutable();
             }
-            executable = enablePnpm ? tools.getPnpmExecutable()
-                    : tools.getNpmExecutable();
+            if (enablePnpm) {
+                tools.checkNpmAcceptsWhitespacesInUserHome();
+                executable = tools.getPnpmExecutable();
+            } else {
+                executable = tools.getNpmExecutable();
+            }
         } catch (IllegalStateException exception) {
             throw new ExecutionFailedException(exception.getMessage(),
                     exception);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -65,22 +65,22 @@ public class TaskRunNpmInstall implements FallibleCommand {
     // a new hash to the code repository.
     private static final String INSTALL_HASH = ".vaadin/vaadin.json";
 
-    private static final String USER_HOME_CONTAINS_WHITESPACES = "\n\n======================================================================================================"
-            + "\nThe path to npm cache contains whitespaces, and the currently installed npm version doesn't accept this."
-            + "\nMost likely your Windows user home path contains whitespaces."
-            + "\nTo workaround it, please change the npm cache path by using the following command:"
-            + "\n    npm config set cache [path-to-npm-cache] --global"
-            + "\n(you may also want to exclude the whitespaces with 'dir /x' to use the same dir),"
-            + "\nor upgrade the npm version to 7 (or newer) by:"
-            + "\n 1) Running 'npm-windows-upgrade' tool with Windows PowerShell:"
-            + "\n        Set-ExecutionPolicy Unrestricted -Scope CurrentUser -Force"
-            + "\n        npm install -g npm-windows-upgrade"
-            + "\n        npm-windows-upgrade"
-            + "\n 2) Manually installing a newer version of npx: npm install -g npx"
-            + "\n 3) Manually installing a newer version of pnpm: npm install -g pnpm"
-            + "\n 4) Deleting the following files from your Vaadin project's folder (if present):"
-            + "\n        node_modules, package-lock.json, webpack.generated.js, pnpm-lock.yaml, pnpmfile.js"
-            + "\n======================================================================================================\n";
+    private static final String USER_HOME_CONTAINS_WHITESPACES = "%n%n======================================================================================================"
+            + "%nThe path to npm cache contains whitespaces, and the currently installed npm version doesn't accept this."
+            + "%nMost likely your Windows user home path contains whitespaces."
+            + "%nTo workaround it, please change the npm cache path by using the following command:"
+            + "%n    npm config set cache [path-to-npm-cache] --global"
+            + "%n(you may also want to exclude the whitespaces with 'dir /x' to use the same dir),"
+            + "%nor upgrade the npm version to 7 (or newer) by:"
+            + "%n 1) Running 'npm-windows-upgrade' tool with Windows PowerShell:"
+            + "%n        Set-ExecutionPolicy Unrestricted -Scope CurrentUser -Force"
+            + "%n        npm install -g npm-windows-upgrade"
+            + "%n        npm-windows-upgrade"
+            + "%n 2) Manually installing a newer version of npx: npm install -g npx"
+            + "%n 3) Manually installing a newer version of pnpm: npm install -g pnpm"
+            + "%n 4) Deleting the following files from your Vaadin project's folder (if present):"
+            + "%n        node_modules, package-lock.json, webpack.generated.js, pnpm-lock.yaml, pnpmfile.js"
+            + "%n======================================================================================================%n";
 
     private final NodeUpdater packageUpdater;
 
@@ -335,7 +335,7 @@ public class TaskRunNpmInstall implements FallibleCommand {
                 File npmCacheDir = tools.getNpmCacheDir();
                 if (!tools.npmAcceptsWhitespaces(npmCacheDir)) {
                     throw new IllegalStateException(
-                            USER_HOME_CONTAINS_WHITESPACES);
+                            String.format(USER_HOME_CONTAINS_WHITESPACES));
                 }
                 executable = tools.getPnpmExecutable();
             } else {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -335,7 +335,7 @@ public class TaskRunNpmInstall implements FallibleCommand {
                 File npmCacheDir = tools.getNpmCacheDir();
                 if (!tools.npmAcceptsWhitespaces(npmCacheDir)) {
                     throw new IllegalStateException(
-                            String.format(USER_HOME_CONTAINS_WHITESPACES));
+                            USER_HOME_CONTAINS_WHITESPACES);
                 }
                 executable = tools.getPnpmExecutable();
             } else {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -528,8 +528,7 @@ public class TaskRunNpmInstall implements FallibleCommand {
         File npmCacheDir = null;
         try {
             npmCacheDir = tools.getNpmCacheDir();
-        } catch (InterruptedException | IOException
-                | FrontendUtils.CommandExecutionException
+        } catch (FrontendUtils.CommandExecutionException
                 | IllegalStateException e) {
             packageUpdater.log().warn("Failed to get npm cache directory", e);
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -65,8 +65,7 @@ public class TaskRunNpmInstall implements FallibleCommand {
     // a new hash to the code repository.
     private static final String INSTALL_HASH = ".vaadin/vaadin.json";
 
-    private static final String USER_HOME_CONTAINS_WHITESPACES =
-            "\n\n======================================================================================================"
+    private static final String USER_HOME_CONTAINS_WHITESPACES = "\n\n======================================================================================================"
             + "\nThe path to npm cache contains whitespaces, and the currently installed npm version doesn't accept this."
             + "\nMost likely your Windows user home path contains whitespaces."
             + "\nTo workaround it, please change the npm cache path by using the following command:"
@@ -335,7 +334,8 @@ public class TaskRunNpmInstall implements FallibleCommand {
             if (enablePnpm) {
                 File npmCacheDir = tools.getNpmCacheDir();
                 if (!tools.npmAcceptsWhitespaces(npmCacheDir)) {
-                    throw new IllegalStateException(USER_HOME_CONTAINS_WHITESPACES);
+                    throw new IllegalStateException(
+                            USER_HOME_CONTAINS_WHITESPACES);
                 }
                 executable = tools.getPnpmExecutable();
             } else {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -501,11 +501,9 @@ public class FrontendToolsTest {
     @Test
     public void npmAcceptsWhitespaces_npmCacheDirWithWhitespaces_falseForWindows()
             throws IOException {
-        Assume.assumeTrue(
-                "This test is only for Windows, since the issue with " +
-                "whitespaces in npm processed directories reproduces only on " +
-                "Windows",
-                FrontendUtils.isWindows());
+        Assume.assumeTrue("This test is only for Windows, since the issue with "
+                + "whitespaces in npm processed directories reproduces only on "
+                + "Windows", FrontendUtils.isWindows());
         // given
         // dir with whitespaces
         File npmCacheDir = tmpDir.newFolder("Foo Bar");
@@ -513,11 +511,11 @@ public class FrontendToolsTest {
         // this test uses node executable with npm-cli.js
         // thus, the node stub version parameter here (6.0.0) is actually
         // the returned version of stubbed npm
-        FrontendStubs.ToolStubInfo nodeStub =
-                FrontendStubs.ToolStubInfo.builder().forTool(FrontendStubs.BuildTool.NODE)
-                        .withVersion("6.0.0").build();
-        FrontendStubs.ToolStubInfo npmStub =
-                FrontendStubs.ToolStubInfo.builder().forTool(FrontendStubs.BuildTool.NPM).build();
+        FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo
+                .builder().forTool(FrontendStubs.BuildTool.NODE)
+                .withVersion("6.0.0").build();
+        FrontendStubs.ToolStubInfo npmStub = FrontendStubs.ToolStubInfo
+                .builder().forTool(FrontendStubs.BuildTool.NPM).build();
         createStubNode(nodeStub, npmStub, baseDir);
 
         // when
@@ -531,9 +529,9 @@ public class FrontendToolsTest {
     public void npmAcceptsWhitespaces_npmCacheDirWithWhitespaces_trueForNonWindows()
             throws IOException {
         Assume.assumeFalse(
-                "This test is for the rest of OS rather than Windows, since " +
-                "the issue with whitespaces in directories processed by npm, " +
-                "is not reproduced on them",
+                "This test is for the rest of OS rather than Windows, since "
+                        + "the issue with whitespaces in directories processed by npm, "
+                        + "is not reproduced on them",
                 FrontendUtils.isWindows());
 
         // given
@@ -543,11 +541,11 @@ public class FrontendToolsTest {
         // this test uses node executable with npm-cli.js
         // thus, the node stub version parameter here (6.0.0) is actually
         // the returned version of stubbed npm
-        FrontendStubs.ToolStubInfo nodeStub =
-                FrontendStubs.ToolStubInfo.builder().forTool(FrontendStubs.BuildTool.NODE)
-                        .withVersion("6.0.0").build();
-        FrontendStubs.ToolStubInfo npmStub =
-                FrontendStubs.ToolStubInfo.builder().forTool(FrontendStubs.BuildTool.NPM).build();
+        FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo
+                .builder().forTool(FrontendStubs.BuildTool.NODE)
+                .withVersion("6.0.0").build();
+        FrontendStubs.ToolStubInfo npmStub = FrontendStubs.ToolStubInfo
+                .builder().forTool(FrontendStubs.BuildTool.NPM).build();
         createStubNode(nodeStub, npmStub, baseDir);
 
         // when
@@ -560,11 +558,9 @@ public class FrontendToolsTest {
     @Test
     public void npmAcceptsWhitespaces_npmCacheNoWhitespaces_trueForWindows()
             throws IOException {
-        Assume.assumeTrue(
-                "This test is only for Windows, since the issue with " +
-                "whitespaces in npm processed directories reproduces only on " +
-                "Windows",
-                FrontendUtils.isWindows());
+        Assume.assumeTrue("This test is only for Windows, since the issue with "
+                + "whitespaces in npm processed directories reproduces only on "
+                + "Windows", FrontendUtils.isWindows());
 
         // given
         // dir with no whitespaces
@@ -573,11 +569,11 @@ public class FrontendToolsTest {
         // this test uses node executable with npm-cli.js
         // thus, the node stub version parameter here (6.0.0) is actually
         // the returned version of stubbed npm
-        FrontendStubs.ToolStubInfo nodeStub =
-                FrontendStubs.ToolStubInfo.builder().forTool(FrontendStubs.BuildTool.NODE)
-                        .withVersion("6.0.0").build();
-        FrontendStubs.ToolStubInfo npmStub =
-                FrontendStubs.ToolStubInfo.builder().forTool(FrontendStubs.BuildTool.NPM).build();
+        FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo
+                .builder().forTool(FrontendStubs.BuildTool.NODE)
+                .withVersion("6.0.0").build();
+        FrontendStubs.ToolStubInfo npmStub = FrontendStubs.ToolStubInfo
+                .builder().forTool(FrontendStubs.BuildTool.NPM).build();
         createStubNode(nodeStub, npmStub, baseDir);
 
         // when
@@ -588,13 +584,10 @@ public class FrontendToolsTest {
     }
 
     @Test
-    public void npmAcceptsWhitespaces_npm7_trueForWindows()
-            throws IOException {
-        Assume.assumeTrue(
-                "This test is only for Windows, since the issue with " +
-                "whitespaces in npm processed directories reproduces only on " +
-                "Windows",
-                FrontendUtils.isWindows());
+    public void npmAcceptsWhitespaces_npm7_trueForWindows() throws IOException {
+        Assume.assumeTrue("This test is only for Windows, since the issue with "
+                + "whitespaces in npm processed directories reproduces only on "
+                + "Windows", FrontendUtils.isWindows());
 
         // given
         // dir with whitespaces
@@ -603,11 +596,11 @@ public class FrontendToolsTest {
         // this test uses node executable with npm-cli.js
         // thus, the node stub version parameter here (6.0.0) is actually
         // the returned version of stubbed npm
-        FrontendStubs.ToolStubInfo nodeStub =
-                FrontendStubs.ToolStubInfo.builder().forTool(FrontendStubs.BuildTool.NODE)
-                        .withVersion("7.0.0").build();
-        FrontendStubs.ToolStubInfo npmStub =
-                FrontendStubs.ToolStubInfo.builder().forTool(FrontendStubs.BuildTool.NPM).build();
+        FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo
+                .builder().forTool(FrontendStubs.BuildTool.NODE)
+                .withVersion("7.0.0").build();
+        FrontendStubs.ToolStubInfo npmStub = FrontendStubs.ToolStubInfo
+                .builder().forTool(FrontendStubs.BuildTool.NPM).build();
         createStubNode(nodeStub, npmStub, baseDir);
 
         // when
@@ -619,11 +612,11 @@ public class FrontendToolsTest {
 
     @Test
     public void getNpmCacheDir_returnsCorrectPath() throws IOException {
-        FrontendStubs.ToolStubInfo nodeStub =
-                FrontendStubs.ToolStubInfo.builder().forTool(FrontendStubs.BuildTool.NODE)
-                        .withCacheDir("/foo/bar/").build();
-        FrontendStubs.ToolStubInfo npmStub =
-                FrontendStubs.ToolStubInfo.builder().forTool(FrontendStubs.BuildTool.NPM).build();
+        FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo
+                .builder().forTool(FrontendStubs.BuildTool.NODE)
+                .withCacheDir("/foo/bar/").build();
+        FrontendStubs.ToolStubInfo npmStub = FrontendStubs.ToolStubInfo
+                .builder().forTool(FrontendStubs.BuildTool.NPM).build();
         createStubNode(nodeStub, npmStub, baseDir);
 
         File npmCacheDir = tools.getNpmCacheDir();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -508,13 +508,10 @@ public class FrontendToolsTest {
         // dir with whitespaces
         File npmCacheDir = tmpDir.newFolder("Foo Bar");
 
-        // this test uses node executable with npm-cli.js
-        // thus, the node stub version parameter here (6.0.0) is actually
-        // the returned version of stubbed npm
-        FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo
-                .builder(FrontendStubs.Tool.NODE).withVersion("6.0.0").build();
+        FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo.none();
+        // Old npm version
         FrontendStubs.ToolStubInfo npmStub = FrontendStubs.ToolStubInfo
-                .builder(FrontendStubs.Tool.NPM).build();
+                .builder(FrontendStubs.Tool.NPM).withVersion("6.0.0").build();
         createStubNode(nodeStub, npmStub, baseDir);
 
         // when
@@ -537,13 +534,10 @@ public class FrontendToolsTest {
         // dir with whitespaces
         File npmCacheDir = tmpDir.newFolder("Foo Bar");
 
-        // this test uses node executable with npm-cli.js
-        // thus, the node stub version parameter here (6.0.0) is actually
-        // the returned version of stubbed npm
-        FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo
-                .builder(FrontendStubs.Tool.NODE).withVersion("6.0.0").build();
+        FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo.none();
+        // Old npm version
         FrontendStubs.ToolStubInfo npmStub = FrontendStubs.ToolStubInfo
-                .builder(FrontendStubs.Tool.NPM).build();
+                .builder(FrontendStubs.Tool.NPM).withVersion("6.0.0").build();
         createStubNode(nodeStub, npmStub, baseDir);
 
         // when
@@ -564,13 +558,10 @@ public class FrontendToolsTest {
         // dir with no whitespaces
         File npmCacheDir = tmpDir.newFolder("FooBar");
 
-        // this test uses node executable with npm-cli.js
-        // thus, the node stub version parameter here (6.0.0) is actually
-        // the returned version of stubbed npm
-        FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo
-                .builder(FrontendStubs.Tool.NODE).withVersion("6.0.0").build();
+        FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo.none();
+        // Old npm version
         FrontendStubs.ToolStubInfo npmStub = FrontendStubs.ToolStubInfo
-                .builder(FrontendStubs.Tool.NPM).build();
+                .builder(FrontendStubs.Tool.NPM).withVersion("6.0.0").build();
         createStubNode(nodeStub, npmStub, baseDir);
 
         // when
@@ -590,13 +581,10 @@ public class FrontendToolsTest {
         // dir with whitespaces
         File npmCacheDir = tmpDir.newFolder("Foo  Bar");
 
-        // this test uses node executable with npm-cli.js
-        // thus, the node stub version parameter here (6.0.0) is actually
-        // the returned version of stubbed npm
-        FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo
-                .builder(FrontendStubs.Tool.NODE).withVersion("7.0.0").build();
+        FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo.none();
+        // Acceptable npm version
         FrontendStubs.ToolStubInfo npmStub = FrontendStubs.ToolStubInfo
-                .builder(FrontendStubs.Tool.NPM).build();
+                .builder(FrontendStubs.Tool.NPM).withVersion("7.0.0").build();
         createStubNode(nodeStub, npmStub, baseDir);
 
         // when
@@ -608,11 +596,10 @@ public class FrontendToolsTest {
 
     @Test
     public void getNpmCacheDir_returnsCorrectPath() throws IOException {
-        FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo
-                .builder(FrontendStubs.Tool.NODE).withCacheDir("/foo/bar/")
-                .build();
+        FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo.none();
         FrontendStubs.ToolStubInfo npmStub = FrontendStubs.ToolStubInfo
-                .builder(FrontendStubs.Tool.NPM).build();
+                .builder(FrontendStubs.Tool.NPM).withCacheDir("/foo/bar")
+                .build();
         createStubNode(nodeStub, npmStub, baseDir);
 
         File npmCacheDir = tools.getNpmCacheDir();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -512,10 +512,9 @@ public class FrontendToolsTest {
         // thus, the node stub version parameter here (6.0.0) is actually
         // the returned version of stubbed npm
         FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo
-                .builder().forTool(FrontendStubs.BuildTool.NODE)
-                .withVersion("6.0.0").build();
+                .builder(FrontendStubs.Tool.NODE).withVersion("6.0.0").build();
         FrontendStubs.ToolStubInfo npmStub = FrontendStubs.ToolStubInfo
-                .builder().forTool(FrontendStubs.BuildTool.NPM).build();
+                .builder(FrontendStubs.Tool.NPM).build();
         createStubNode(nodeStub, npmStub, baseDir);
 
         // when
@@ -542,10 +541,9 @@ public class FrontendToolsTest {
         // thus, the node stub version parameter here (6.0.0) is actually
         // the returned version of stubbed npm
         FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo
-                .builder().forTool(FrontendStubs.BuildTool.NODE)
-                .withVersion("6.0.0").build();
+                .builder(FrontendStubs.Tool.NODE).withVersion("6.0.0").build();
         FrontendStubs.ToolStubInfo npmStub = FrontendStubs.ToolStubInfo
-                .builder().forTool(FrontendStubs.BuildTool.NPM).build();
+                .builder(FrontendStubs.Tool.NPM).build();
         createStubNode(nodeStub, npmStub, baseDir);
 
         // when
@@ -570,10 +568,9 @@ public class FrontendToolsTest {
         // thus, the node stub version parameter here (6.0.0) is actually
         // the returned version of stubbed npm
         FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo
-                .builder().forTool(FrontendStubs.BuildTool.NODE)
-                .withVersion("6.0.0").build();
+                .builder(FrontendStubs.Tool.NODE).withVersion("6.0.0").build();
         FrontendStubs.ToolStubInfo npmStub = FrontendStubs.ToolStubInfo
-                .builder().forTool(FrontendStubs.BuildTool.NPM).build();
+                .builder(FrontendStubs.Tool.NPM).build();
         createStubNode(nodeStub, npmStub, baseDir);
 
         // when
@@ -597,10 +594,9 @@ public class FrontendToolsTest {
         // thus, the node stub version parameter here (6.0.0) is actually
         // the returned version of stubbed npm
         FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo
-                .builder().forTool(FrontendStubs.BuildTool.NODE)
-                .withVersion("7.0.0").build();
+                .builder(FrontendStubs.Tool.NODE).withVersion("7.0.0").build();
         FrontendStubs.ToolStubInfo npmStub = FrontendStubs.ToolStubInfo
-                .builder().forTool(FrontendStubs.BuildTool.NPM).build();
+                .builder(FrontendStubs.Tool.NPM).build();
         createStubNode(nodeStub, npmStub, baseDir);
 
         // when
@@ -613,10 +609,10 @@ public class FrontendToolsTest {
     @Test
     public void getNpmCacheDir_returnsCorrectPath() throws IOException {
         FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo
-                .builder().forTool(FrontendStubs.BuildTool.NODE)
-                .withCacheDir("/foo/bar/").build();
+                .builder(FrontendStubs.Tool.NODE).withCacheDir("/foo/bar/")
+                .build();
         FrontendStubs.ToolStubInfo npmStub = FrontendStubs.ToolStubInfo
-                .builder().forTool(FrontendStubs.BuildTool.NPM).build();
+                .builder(FrontendStubs.Tool.NPM).build();
         createStubNode(nodeStub, npmStub, baseDir);
 
         File npmCacheDir = tools.getNpmCacheDir();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -35,6 +35,7 @@ import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
@@ -603,8 +604,14 @@ public class FrontendToolsTest {
         createStubNode(nodeStub, npmStub, baseDir);
 
         File npmCacheDir = tools.getNpmCacheDir();
+
         Assert.assertNotNull(npmCacheDir);
-        Assert.assertEquals("/foo/bar", npmCacheDir.getAbsolutePath());
+        String npmCachePath = npmCacheDir.getPath();
+
+        Assert.assertEquals("foo/bar",
+                npmCachePath
+                        .substring(FilenameUtils.getPrefixLength(npmCachePath))
+                        .replace("\\", "/"));
     }
 
     private void assertNpmCommand(Supplier<String> path) throws IOException {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -500,7 +500,7 @@ public class FrontendToolsTest {
     }
 
     @Test
-    public void npmAcceptsWhitespaces_npmCacheDirWithWhitespaces_falseForWindows()
+    public void folderIsAcceptableByNpm_npmCacheDirWithWhitespaces_falseForWindows()
             throws IOException {
         Assume.assumeTrue("This test is only for Windows, since the issue with "
                 + "whitespaces in npm processed directories reproduces only on "
@@ -516,14 +516,14 @@ public class FrontendToolsTest {
         createStubNode(nodeStub, npmStub, baseDir);
 
         // when
-        boolean accepted = tools.npmAcceptsWhitespaces(npmCacheDir);
+        boolean accepted = tools.folderIsAcceptableByNpm(npmCacheDir);
 
         // then
         Assert.assertFalse(accepted);
     }
 
     @Test
-    public void npmAcceptsWhitespaces_npmCacheDirWithWhitespaces_trueForNonWindows()
+    public void folderIsAcceptableByNpm_npmCacheDirWithWhitespaces_trueForNonWindows()
             throws IOException {
         Assume.assumeFalse(
                 "This test is for the rest of OS rather than Windows, since "
@@ -542,14 +542,14 @@ public class FrontendToolsTest {
         createStubNode(nodeStub, npmStub, baseDir);
 
         // when
-        boolean accepted = tools.npmAcceptsWhitespaces(npmCacheDir);
+        boolean accepted = tools.folderIsAcceptableByNpm(npmCacheDir);
 
         // then
         Assert.assertTrue(accepted);
     }
 
     @Test
-    public void npmAcceptsWhitespaces_npmCacheNoWhitespaces_trueForWindows()
+    public void folderIsAcceptableByNpm_npmCacheNoWhitespaces_trueForWindows()
             throws IOException {
         Assume.assumeTrue("This test is only for Windows, since the issue with "
                 + "whitespaces in npm processed directories reproduces only on "
@@ -566,14 +566,15 @@ public class FrontendToolsTest {
         createStubNode(nodeStub, npmStub, baseDir);
 
         // when
-        boolean accepted = tools.npmAcceptsWhitespaces(npmCacheDir);
+        boolean accepted = tools.folderIsAcceptableByNpm(npmCacheDir);
 
         // then
         Assert.assertTrue(accepted);
     }
 
     @Test
-    public void npmAcceptsWhitespaces_npm7_trueForWindows() throws IOException {
+    public void folderIsAcceptableByNpm_npm7_trueForWindows()
+            throws IOException {
         Assume.assumeTrue("This test is only for Windows, since the issue with "
                 + "whitespaces in npm processed directories reproduces only on "
                 + "Windows", FrontendUtils.isWindows());
@@ -589,14 +590,15 @@ public class FrontendToolsTest {
         createStubNode(nodeStub, npmStub, baseDir);
 
         // when
-        boolean accepted = tools.npmAcceptsWhitespaces(npmCacheDir);
+        boolean accepted = tools.folderIsAcceptableByNpm(npmCacheDir);
 
         // then
         Assert.assertTrue(accepted);
     }
 
     @Test
-    public void getNpmCacheDir_returnsCorrectPath() throws IOException {
+    public void getNpmCacheDir_returnsCorrectPath() throws IOException,
+            InterruptedException, FrontendUtils.CommandExecutionException {
         FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo.none();
         FrontendStubs.ToolStubInfo npmStub = FrontendStubs.ToolStubInfo
                 .builder(FrontendStubs.Tool.NPM).withCacheDir("/foo/bar")

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -611,38 +611,37 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
     @Test
     public void runPnpmInstall_checkNpmAcceptsWhitespaces_throwsOnWindows()
             throws ExecutionFailedException, IOException {
-        Assume.assumeTrue(
-                "This test is only for Windows, since the issue with " +
-                "whitespaces in npm processed directories reproduces only on " +
-                "Windows",
-                FrontendUtils.isWindows());
+        Assume.assumeTrue("This test is only for Windows, since the issue with "
+                + "whitespaces in npm processed directories reproduces only on "
+                + "Windows", FrontendUtils.isWindows());
 
         // given
-        FrontendStubs.ToolStubInfo nodeStub =
-                FrontendStubs.ToolStubInfo.builder().forTool(FrontendStubs.BuildTool.NODE)
-                        .withVersion("6.0.0").withCacheDir("/foo/bar/").build();
-        FrontendStubs.ToolStubInfo npmStub =
-                FrontendStubs.ToolStubInfo.builder().none();
-        createStubNode(nodeStub, npmStub, getNodeUpdater().npmFolder.getAbsolutePath());
+        FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo
+                .builder().forTool(FrontendStubs.BuildTool.NODE)
+                .withVersion("6.0.0").withCacheDir("/foo/bar/").build();
+        FrontendStubs.ToolStubInfo npmStub = FrontendStubs.ToolStubInfo
+                .builder().none();
+        createStubNode(nodeStub, npmStub,
+                getNodeUpdater().npmFolder.getAbsolutePath());
 
         exception.expect(ExecutionFailedException.class);
         exception.expectMessage(
-                "======================================================================================================\n" +
-                "The path to npm cache contains whitespaces, and the currently installed npm version doesn't accept this.\n" +
-                "Most likely your Windows user home path contains whitespaces.\n" +
-                "To workaround it, please change the npm cache path by using the following command:\n" +
-                "    npm config set cache [path-to-npm-cache] --global\n" +
-                "(you may also want to exclude the whitespaces with 'dir /x' to use the same dir),\n" +
-                "or upgrade npm version to 7 (or newer) by:\n" +
-                " 1) Running 'npm-windows-upgrade' tool with Windows PowerShell:\n" +
-                "        Set-ExecutionPolicy Unrestricted -Scope CurrentUser -Force\n" +
-                "        npm install -g npm-windows-upgrade\n" +
-                "        npm-windows-upgrade\n" +
-                " 2) Manually installing a newer version of npx: npm install -g npx\n" +
-                " 3) Manually installing a newer version of pnpm: npm install -g pnpm\n" +
-                " 4) Deleting the following files from your Vaadin project's folder (if present):\n" +
-                "        node_modules, package-lock.json, webpack.generated.js, pnpm-lock.yaml, pnpmfile.js\n" +
-                "======================================================================================================");
+                "======================================================================================================\n"
+                        + "The path to npm cache contains whitespaces, and the currently installed npm version doesn't accept this.\n"
+                        + "Most likely your Windows user home path contains whitespaces.\n"
+                        + "To workaround it, please change the npm cache path by using the following command:\n"
+                        + "    npm config set cache [path-to-npm-cache] --global\n"
+                        + "(you may also want to exclude the whitespaces with 'dir /x' to use the same dir),\n"
+                        + "or upgrade npm version to 7 (or newer) by:\n"
+                        + " 1) Running 'npm-windows-upgrade' tool with Windows PowerShell:\n"
+                        + "        Set-ExecutionPolicy Unrestricted -Scope CurrentUser -Force\n"
+                        + "        npm install -g npm-windows-upgrade\n"
+                        + "        npm-windows-upgrade\n"
+                        + " 2) Manually installing a newer version of npx: npm install -g npx\n"
+                        + " 3) Manually installing a newer version of pnpm: npm install -g pnpm\n"
+                        + " 4) Deleting the following files from your Vaadin project's folder (if present):\n"
+                        + "        node_modules, package-lock.json, webpack.generated.js, pnpm-lock.yaml, pnpmfile.js\n"
+                        + "======================================================================================================");
         TaskRunNpmInstall task = createTask();
         getNodeUpdater().modified = true;
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -27,6 +27,7 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.ExecutionFailedException;
@@ -617,6 +618,8 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
 
         // given
         File npmCacheFolder = temporaryFolder.newFolder("Foo Bar");
+        LoggerFactory.getLogger(TaskRunPnpmInstallTest.class).info(
+                "Npm cache folder = " + npmCacheFolder.getAbsolutePath());
         FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo.none();
         FrontendStubs.ToolStubInfo npmStub = FrontendStubs.ToolStubInfo
                 .builder(FrontendStubs.Tool.NPM).withVersion("6.0.0")

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -625,23 +625,9 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
                 getNodeUpdater().npmFolder.getAbsolutePath());
 
         exception.expect(ExecutionFailedException.class);
-        exception.expectMessage(
-                "%n%n======================================================================================================%n"
-                        + "The path to npm cache contains whitespaces, and the currently installed npm version doesn't accept this.%n"
-                        + "Most likely your Windows user home path contains whitespaces.%n"
-                        + "To workaround it, please change the npm cache path by using the following command:%n"
-                        + "    npm config set cache [path-to-npm-cache] --global%n"
-                        + "(you may also want to exclude the whitespaces with 'dir /x' to use the same dir),%n"
-                        + "or upgrade npm version to 7 (or newer) by:%n"
-                        + " 1) Running 'npm-windows-upgrade' tool with Windows PowerShell:%n"
-                        + "        Set-ExecutionPolicy Unrestricted -Scope CurrentUser -Force%n"
-                        + "        npm install -g npm-windows-upgrade%n"
-                        + "        npm-windows-upgrade%n"
-                        + " 2) Manually installing a newer version of npx: npm install -g npx%n"
-                        + " 3) Manually installing a newer version of pnpm: npm install -g pnpm%n"
-                        + " 4) Deleting the following files from your Vaadin project's folder (if present):%n"
-                        + "        node_modules, package-lock.json, webpack.generated.js, pnpm-lock.yaml, pnpmfile.js%n"
-                        + "======================================================================================================%n");
+        exception.expectMessage(CoreMatchers.containsString(
+                "The path to npm cache contains whitespaces, and the currently installed npm version doesn't accept this."));
+
         TaskRunNpmInstall task = createTask();
         getNodeUpdater().modified = true;
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -617,10 +617,9 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
 
         // given
         FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo
-                .builder().forTool(FrontendStubs.BuildTool.NODE)
-                .withVersion("6.0.0").withCacheDir("/foo/bar/").build();
-        FrontendStubs.ToolStubInfo npmStub = FrontendStubs.ToolStubInfo
-                .builder().none();
+                .builder(FrontendStubs.Tool.NODE).withVersion("6.0.0")
+                .withCacheDir("/foo/bar/").build();
+        FrontendStubs.ToolStubInfo npmStub = FrontendStubs.ToolStubInfo.none();
         createStubNode(nodeStub, npmStub,
                 getNodeUpdater().npmFolder.getAbsolutePath());
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -616,10 +616,11 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
                 + "Windows", FrontendUtils.isWindows());
 
         // given
-        FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo
-                .builder(FrontendStubs.Tool.NODE).withVersion("6.0.0")
-                .withCacheDir("/foo/bar/").build();
-        FrontendStubs.ToolStubInfo npmStub = FrontendStubs.ToolStubInfo.none();
+        File npmCacheFolder = temporaryFolder.newFolder("Foo Bar");
+        FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo.none();
+        FrontendStubs.ToolStubInfo npmStub = FrontendStubs.ToolStubInfo
+                .builder(FrontendStubs.Tool.NPM).withVersion("6.0.0")
+                .withCacheDir(npmCacheFolder.getAbsolutePath()).build();
         createStubNode(nodeStub, npmStub,
                 getNodeUpdater().npmFolder.getAbsolutePath());
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -628,7 +628,7 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
                 getNodeUpdater().npmFolder.getAbsolutePath());
 
         exception.expect(ExecutionFailedException.class);
-        exception.expectMessage(String.format(
+        exception.expectMessage(
                 "%n%n======================================================================================================%n"
                         + "The path to npm cache contains whitespaces, and the currently installed npm version doesn't accept this.%n"
                         + "Most likely your Windows user home path contains whitespaces.%n"
@@ -644,7 +644,7 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
                         + " 3) Manually installing a newer version of pnpm: npm install -g pnpm%n"
                         + " 4) Deleting the following files from your Vaadin project's folder (if present):%n"
                         + "        node_modules, package-lock.json, webpack.generated.js, pnpm-lock.yaml, pnpmfile.js%n"
-                        + "======================================================================================================%n"));
+                        + "======================================================================================================%n");
         TaskRunNpmInstall task = createTask();
         getNodeUpdater().modified = true;
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -44,8 +44,6 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
 
     private static final String PINNED_VERSION = "3.2.17";
 
-    private static final String USER_HOME = "user.home";
-
     @Override
     @Before
     public void setUp() throws IOException {
@@ -609,7 +607,7 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
     }
 
     @Test
-    public void runPnpmInstall_checkNpmAcceptsWhitespaces_throwsOnWindows()
+    public void runPnpmInstall_checkFolderIsAcceptableByNpm_throwsOnWindows()
             throws ExecutionFailedException, IOException {
         Assume.assumeTrue("This test is only for Windows, since the issue with "
                 + "whitespaces in npm processed directories reproduces only on "

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -27,7 +27,6 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.ExecutionFailedException;
@@ -618,8 +617,6 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
 
         // given
         File npmCacheFolder = temporaryFolder.newFolder("Foo Bar");
-        LoggerFactory.getLogger(TaskRunPnpmInstallTest.class).info(
-                "Npm cache folder = " + npmCacheFolder.getAbsolutePath());
         FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo.none();
         FrontendStubs.ToolStubInfo npmStub = FrontendStubs.ToolStubInfo
                 .builder(FrontendStubs.Tool.NPM).withVersion("6.0.0")

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -625,23 +625,23 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
                 getNodeUpdater().npmFolder.getAbsolutePath());
 
         exception.expect(ExecutionFailedException.class);
-        exception.expectMessage(
-                "======================================================================================================\n"
-                        + "The path to npm cache contains whitespaces, and the currently installed npm version doesn't accept this.\n"
-                        + "Most likely your Windows user home path contains whitespaces.\n"
-                        + "To workaround it, please change the npm cache path by using the following command:\n"
-                        + "    npm config set cache [path-to-npm-cache] --global\n"
-                        + "(you may also want to exclude the whitespaces with 'dir /x' to use the same dir),\n"
-                        + "or upgrade npm version to 7 (or newer) by:\n"
-                        + " 1) Running 'npm-windows-upgrade' tool with Windows PowerShell:\n"
-                        + "        Set-ExecutionPolicy Unrestricted -Scope CurrentUser -Force\n"
-                        + "        npm install -g npm-windows-upgrade\n"
-                        + "        npm-windows-upgrade\n"
-                        + " 2) Manually installing a newer version of npx: npm install -g npx\n"
-                        + " 3) Manually installing a newer version of pnpm: npm install -g pnpm\n"
-                        + " 4) Deleting the following files from your Vaadin project's folder (if present):\n"
-                        + "        node_modules, package-lock.json, webpack.generated.js, pnpm-lock.yaml, pnpmfile.js\n"
-                        + "======================================================================================================");
+        exception.expectMessage(String.format(
+                "%n%n======================================================================================================%n"
+                        + "The path to npm cache contains whitespaces, and the currently installed npm version doesn't accept this.%n"
+                        + "Most likely your Windows user home path contains whitespaces.%n"
+                        + "To workaround it, please change the npm cache path by using the following command:%n"
+                        + "    npm config set cache [path-to-npm-cache] --global%n"
+                        + "(you may also want to exclude the whitespaces with 'dir /x' to use the same dir),%n"
+                        + "or upgrade npm version to 7 (or newer) by:%n"
+                        + " 1) Running 'npm-windows-upgrade' tool with Windows PowerShell:%n"
+                        + "        Set-ExecutionPolicy Unrestricted -Scope CurrentUser -Force%n"
+                        + "        npm install -g npm-windows-upgrade%n"
+                        + "        npm-windows-upgrade%n"
+                        + " 2) Manually installing a newer version of npx: npm install -g npx%n"
+                        + " 3) Manually installing a newer version of pnpm: npm install -g pnpm%n"
+                        + " 4) Deleting the following files from your Vaadin project's folder (if present):%n"
+                        + "        node_modules, package-lock.json, webpack.generated.js, pnpm-lock.yaml, pnpmfile.js%n"
+                        + "======================================================================================================%n"));
         TaskRunNpmInstall task = createTask();
         getNodeUpdater().modified = true;
 

--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/FrontendStubs.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/FrontendStubs.java
@@ -88,15 +88,14 @@ public class FrontendStubs {
                 // ), node);
             } else {
                 // @formatter:off
-                FileUtils.write(node, String.format("#!/bin/sh\n"
-                        + "for arg in \"$@\"\n"
-                        + "do\n"
-                        + "  if [[ \"$arg\" == -v || \"$arg\" == --version ]]\n"
-                        + "  then\n"
-                        + "    echo %s\n"
-                        + "    break\n"
-                        + "  fi\n"
-                        + "done\n"
+                FileUtils.write(node, String.format("#!/bin/sh%n"
+                        + "for arg in \"$@\"%n"
+                        + "do%n"
+                        + "  if [ \"$arg\" = \"--version\" ] || [ \"$arg\" = \"-v\" ]; then%n"
+                        + "    echo %s%n"
+                        + "    break%n"
+                        + "  fi%n"
+                        + "done%n"
                         + "sleep 1",
                         stubNode.getVersion()), "UTF-8");
                 // @formatter:on
@@ -203,25 +202,50 @@ public class FrontendStubs {
         createStubWebpackServer(readyString, milliSecondsToRun, baseDir, false);
     }
 
+    /**
+     * Holds an information about build tool to be stubbed.
+     */
     public static final class ToolStubInfo {
         private final boolean stubbed;
         private final String version;
 
         private ToolStubInfo(boolean stubbed, String version) {
             this.stubbed = stubbed;
-            assert !stubbed || version != null && !version
-                    .isEmpty() : "Version may not be empty for stubbed tool";
+            assert !stubbed || (version != null && !version
+                    .isEmpty()) : "Version may not be empty for stubbed tool";
             this.version = version;
         }
 
+        /**
+         * Creates a tool stub info object denoting no stubbing.
+         *
+         * @return a tool stub info object denoting no stubbing.
+         */
         public static ToolStubInfo none() {
             return new ToolStubInfo(false, null);
         }
 
+        /**
+         * Creates a tool stub info object denoting generating a build tool's
+         * executable file outputting a given version number when executed with
+         * '-v' or '--version'.
+         *
+         * @param version
+         *            tool version for output.
+         * @return a tool stub info object denoting a given version to be
+         *         output.
+         */
         public static ToolStubInfo ofVersion(String version) {
             return new ToolStubInfo(true, version);
         }
 
+        /**
+         * Creates a tool stub info object denoting generating a build tool's
+         * executable with a non-sense version number, i.e. for those cases when
+         * result of calling '-v' or '--version' doesn't matter.
+         *
+         * @return a tool stub info object with non-used version output.
+         */
         public static ToolStubInfo ofAnyVersion() {
             return new ToolStubInfo(true, "0.0.0");
         }

--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/FrontendStubs.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/FrontendStubs.java
@@ -277,37 +277,33 @@ public class FrontendStubs {
             final StringBuilder scriptBuilder = new StringBuilder();
 
             switch (buildTool) {
-                case NPM:
-                    // default version used in tests
-                    version = version == null ? "6.14.10" : version;
+            case NPM:
+                // default version used in tests
+                version = version == null ? "6.14.10" : version;
+                scriptBuilder.append(
+                        "process.argv.includes('--version') && console.log(")
+                        .append(version).append(");\n");
+                if (cacheDir != null) {
+                    scriptBuilder.append(
+                            "process.argv.includes('cache') && console.log(")
+                            .append(cacheDir).append(");\n");
+                }
+                script = scriptBuilder.toString();
+                break;
+            case NODE:
+                // default version used in tests
+                version = version == null ? "8.0.0" : version;
+                scriptBuilder.append(
+                        "  if [ \"$arg\" = \"--version\" ] || [ \"$arg\" = \"-v\" ]; then\n")
+                        .append("    echo ").append(version).append("\n")
+                        .append("    break\n").append("  fi\n");
+                if (cacheDir != null) {
                     scriptBuilder
-                            .append("process.argv.includes('--version') && console.log(")
-                            .append(version)
-                            .append(");\n");
-                    if (cacheDir != null) {
-                        scriptBuilder
-                                .append("process.argv.includes('cache') && console.log(")
-                                .append(cacheDir)
-                                .append(");\n");
-                    }
-                    script = scriptBuilder.toString();
-                    break;
-                case NODE:
-                    // default version used in tests
-                    version = version == null ? "8.0.0" : version;
-                    scriptBuilder
-                            .append("  if [ \"$arg\" = \"--version\" ] || [ \"$arg\" = \"-v\" ]; then\n")
-                            .append("    echo ").append(version).append("\n")
-                            .append("    break\n")
-                            .append("  fi\n");
-                    if (cacheDir != null) {
-                        scriptBuilder
-                                .append("  if [ \"$arg\" = \"cache\" ]; then\n")
-                                .append("    echo ").append(cacheDir).append("\n")
-                                .append("    break\n")
-                                .append("  fi\n");
-                    }
-                    // @formatter:off
+                            .append("  if [ \"$arg\" = \"cache\" ]; then\n")
+                            .append("    echo ").append(cacheDir).append("\n")
+                            .append("    break\n").append("  fi\n");
+                }
+                // @formatter:off
                     script = String.format(
                             "#!/bin/sh%n"
                             + "for arg in \"$@\"%n"
@@ -316,9 +312,9 @@ public class FrontendStubs {
                             + "done%n"
                             + "sleep 1", scriptBuilder.toString());
                     // @formatter:on
-                    break;
-                default:
-                    throw new IllegalStateException("Unknown build tool");
+                break;
+            default:
+                throw new IllegalStateException("Unknown build tool");
             }
             return new ToolStubInfo(true, script);
         }

--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/FrontendStubs.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/FrontendStubs.java
@@ -87,7 +87,7 @@ public class FrontendStubs {
                 // getClassFinder().getClass().getClassLoader().getResource("test_node.exe").getFile()
                 // ), node);
             } else {
-                // @formatter::off
+                // @formatter:off
                 FileUtils.write(node, String.format("#!/bin/sh\n"
                         + "for arg in \"$@\"\n"
                         + "do\n"
@@ -99,7 +99,7 @@ public class FrontendStubs {
                         + "done\n"
                         + "sleep 1",
                         stubNode.getVersion()), "UTF-8");
-                // @formatter::on
+                // @formatter:on
             }
         }
     }

--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/FrontendStubs.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/FrontendStubs.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.testutil;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 
 import org.apache.commons.io.FileUtils;
 
@@ -29,10 +30,78 @@ public class FrontendStubs {
     public static final String WEBPACK_SERVER = "node_modules/webpack-dev-server/bin/webpack-dev-server.js";
     public static final String WEBPACK_TEST_OUT_FILE = "webpack-out.test";
 
+    private static final String DEFAULT_NODE_STUB_VERSION = "8.0.0";
+    private static final String DEFAULT_NPM_STUB_VERSION = "6.14.10";
+
     /**
      * Only static methods.
      */
     private FrontendStubs() {
+    }
+
+    /**
+     * Creates stub versions of `node` and `npm` in the ./node folder as
+     * frontend-maven-plugin does.
+     *
+     * @param stubNode
+     *            node stub information, including whether `node/node`
+     *            (`node/node.exe`) stub should be created, and what version
+     *            should it output if '-v' || '--version' flag are set.
+     * @param stubNpm
+     *            npm stub information, including whether
+     *            `node/node_modules/npm/bin/npm-cli` and `npx-cli` should be
+     *            created, and what version should it output if '-v' ||
+     *            '--version' flag are set.
+     * @param baseDir
+     *            parent to create `node` dir in
+     * @throws IOException
+     *             when a file operation fails
+     */
+    public static void createStubNode(ToolStubInfo stubNode,
+            ToolStubInfo stubNpm, String baseDir) throws IOException {
+
+        Objects.requireNonNull(stubNode);
+        Objects.requireNonNull(stubNpm);
+
+        if (stubNpm.isStubbed()) {
+            File binDir = new File(baseDir, "node/node_modules/npm/bin");
+            FileUtils.forceMkdir(binDir);
+            String stub = String.format("process.argv.includes('--version') && "
+                    + "console.log(%s);", stubNpm.getVersion());
+            FileUtils.writeStringToFile(new File(binDir, "npm-cli.js"), stub,
+                    StandardCharsets.UTF_8);
+            FileUtils.writeStringToFile(new File(binDir, "npx-cli.js"), stub,
+                    StandardCharsets.UTF_8);
+        }
+        boolean isWindows = System.getProperty("os.name").startsWith("Windows");
+
+        if (stubNode.isStubbed()) {
+            File node = new File(baseDir,
+                    isWindows ? "node/node.exe" : "node/node");
+            node.createNewFile();
+            node.setExecutable(true);
+            if (isWindows) {
+                // Commented out until a node.exe is created that is not flagged
+                // by Windows defender.
+                // FileUtils.copyFile(new File(
+                // getClassFinder().getClass().getClassLoader().getResource("test_node.exe").getFile()
+                // ), node);
+            } else {
+                // @formatter::off
+                FileUtils.write(node, String.format("#!/bin/sh\n"
+                        + "for arg in \"$@\"\n"
+                        + "do\n"
+                        + "  if [[ \"$arg\" == -v || \"$arg\" == --version ]]\n"
+                        + "  then\n"
+                        + "    echo %s\n"
+                        + "    break\n"
+                        + "  fi\n"
+                        + "done\n"
+                        + "sleep 1",
+                        stubNode.getVersion()), "UTF-8");
+                // @formatter::on
+            }
+        }
     }
 
     /**
@@ -51,35 +120,13 @@ public class FrontendStubs {
      */
     public static void createStubNode(boolean stubNode, boolean stubNpm,
             String baseDir) throws IOException {
-
-        if (stubNpm) {
-            File binDir = new File(baseDir, "node/node_modules/npm/bin");
-            FileUtils.forceMkdir(binDir);
-            String stub = "process.argv.includes('--version') && console.log('6.14.10');";
-            FileUtils.writeStringToFile(new File(binDir, "npm-cli.js"), stub,
-                    StandardCharsets.UTF_8);
-            FileUtils.writeStringToFile(new File(binDir, "npx-cli.js"), stub,
-                    StandardCharsets.UTF_8);
-        }
-        boolean isWindows = System.getProperty("os.name").startsWith("Windows");
-
-        if (stubNode) {
-            File node = new File(baseDir,
-                    isWindows ? "node/node.exe" : "node/node");
-            node.createNewFile();
-            node.setExecutable(true);
-            if (isWindows) {
-                // Commented out until a node.exe is created that is not flagged
-                // by Windows defender.
-                // FileUtils.copyFile(new File(
-                // getClassFinder().getClass().getClassLoader().getResource("test_node.exe").getFile()
-                // ), node);
-            } else {
-                FileUtils.write(node,
-                        "#!/bin/sh\n[ \"$1\" = -v ] && echo 8.0.0 || sleep 1\n",
-                        "UTF-8");
-            }
-        }
+        ToolStubInfo nodeStubInfo = stubNode
+                ? ToolStubInfo.ofVersion(DEFAULT_NODE_STUB_VERSION)
+                : ToolStubInfo.none();
+        ToolStubInfo npmStubInfo = stubNpm
+                ? ToolStubInfo.ofVersion(DEFAULT_NPM_STUB_VERSION)
+                : ToolStubInfo.none();
+        createStubNode(nodeStubInfo, npmStubInfo, baseDir);
     }
 
     /**
@@ -154,5 +201,37 @@ public class FrontendStubs {
     public static void createStubWebpackServer(String readyString,
             int milliSecondsToRun, String baseDir) throws IOException {
         createStubWebpackServer(readyString, milliSecondsToRun, baseDir, false);
+    }
+
+    public static final class ToolStubInfo {
+        private final boolean stubbed;
+        private final String version;
+
+        private ToolStubInfo(boolean stubbed, String version) {
+            this.stubbed = stubbed;
+            assert !stubbed || version != null && !version
+                    .isEmpty() : "Version may not be empty for stubbed tool";
+            this.version = version;
+        }
+
+        public static ToolStubInfo none() {
+            return new ToolStubInfo(false, null);
+        }
+
+        public static ToolStubInfo ofVersion(String version) {
+            return new ToolStubInfo(true, version);
+        }
+
+        public static ToolStubInfo ofAnyVersion() {
+            return new ToolStubInfo(true, "0.0.0");
+        }
+
+        public boolean isStubbed() {
+            return stubbed;
+        }
+
+        public String getVersion() {
+            return version;
+        }
     }
 }

--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/FrontendStubs.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/FrontendStubs.java
@@ -67,7 +67,7 @@ public class FrontendStubs {
         if (stubNpm.isStubbed()) {
             File binDir = new File(baseDir, NPM_BIN_PATH);
             FileUtils.forceMkdir(binDir);
-            String stub = stubNpm.getScript();
+            String stub = stubNpm.getScript().replace("\\", "\\\\");
             FileUtils.writeStringToFile(new File(binDir, "npm-cli.js"), stub,
                     StandardCharsets.UTF_8);
             FileUtils.writeStringToFile(new File(binDir, "npx-cli.js"), stub,

--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/FrontendStubs.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/FrontendStubs.java
@@ -21,6 +21,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 import org.apache.commons.io.FileUtils;
+import org.slf4j.LoggerFactory;
 
 /**
  * Utility class for stubbing Node.JS and Webpack scripts.
@@ -348,6 +349,8 @@ public class FrontendStubs {
                         .append(cacheDir).append("');\n");
             }
             script = scriptBuilder.toString();
+
+            LoggerFactory.getLogger(FrontendStubs.class).info("Script = " + script);
             return script;
         }
     }

--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/FrontendStubs.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/FrontendStubs.java
@@ -21,7 +21,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 import org.apache.commons.io.FileUtils;
-import org.slf4j.LoggerFactory;
 
 /**
  * Utility class for stubbing Node.JS and Webpack scripts.
@@ -349,8 +348,6 @@ public class FrontendStubs {
                         .append(cacheDir).append("');\n");
             }
             script = scriptBuilder.toString();
-
-            LoggerFactory.getLogger(FrontendStubs.class).info("Script = " + script);
             return script;
         }
     }


### PR DESCRIPTION
## Description

Checks that the npm version accepts whitespaces in user home path and explains how to fix that otherwise.

Fixes https://github.com/vaadin/flow/issues/10084

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
