### PR TITLE
fix: Prevent deadlock in findOrCreateVaadinSession

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -763,13 +763,22 @@ public abstract class VaadinService implements Serializable {
     /**
      * Locks the given session for this service instance. Typically you want to
      * call {@link VaadinSession#lock()} instead of this method.
+     * <p>
+     * Note: The method and its signature has been changed to return lock 
+     * instance in Vaadin 8.14.0. If you have overriden this method, you need
+     * to update your implementation.
+     * <p>
+     * Note: Overriding this method is not recommended, for custom lock storage
+     * strategy override {@link #getSessionLock(WrappedSession)} and
+     * {@link #setSessionLock(WrappedSession,Lock)} instead.
      *
      * @param wrappedSession
      *            The session to lock
+     * @return Lock instance
      * @throws IllegalStateException
      *             if the session is invalidated before it can be locked
      */
-    protected void lockSession(WrappedSession wrappedSession) {
+    protected Lock lockSession(WrappedSession wrappedSession) {
         Lock lock = getSessionLock(wrappedSession);
         if (lock == null) {
             /*
@@ -799,21 +808,31 @@ public abstract class VaadinService implements Serializable {
             lock.unlock();
             throw e;
         }
+        return lock;
     }
 
     /**
      * Releases the lock for the given session for this service instance.
      * Typically you want to call {@link VaadinSession#unlock()} instead of this
      * method.
+     * <p>
+     * Note: The method and its signature has been changed to get lock instance
+     * as parameter in Vaadin X.X.0. If you have overriden this method, you need
+     * to update your implementation.
+     * <p>
+     * Note: Overriding this method is not recommended, for custom lock storage 
+     * strategy override {@link #getSessionLock(WrappedSession)} and
+     * {@link #setSessionLock(WrappedSession,Lock)} instead.
      *
      * @param wrappedSession
      *            The session to unlock
+     * @param lock
+     *            Lock instance to unlock
      */
     protected void unlockSession(WrappedSession wrappedSession) {
-        assert getSessionLock(wrappedSession) != null;
-        assert ((ReentrantLock) getSessionLock(wrappedSession))
+        assert ((ReentrantLock) lock)
                 .isHeldByCurrentThread() : "Trying to unlock the session but it has not been locked by this thread";
-        getSessionLock(wrappedSession).unlock();
+        lock.unlock();
     }
 
     private VaadinSession findOrCreateVaadinSession(VaadinRequest request)
@@ -822,8 +841,9 @@ public abstract class VaadinService implements Serializable {
         WrappedSession wrappedSession = getWrappedSession(request,
                 requestCanCreateSession);
 
+        final Lock lock;
         try {
-            lockSession(wrappedSession);
+            lock = lockSession(wrappedSession);
         } catch (IllegalStateException e) {
             throw new SessionExpiredException();
         }
@@ -832,7 +852,7 @@ public abstract class VaadinService implements Serializable {
             return doFindOrCreateVaadinSession(request,
                     requestCanCreateSession);
         } finally {
-            unlockSession(wrappedSession);
+            unlockSession(wrappedSession,lock);
         }
 
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -765,7 +765,7 @@ public abstract class VaadinService implements Serializable {
      * call {@link VaadinSession#lock()} instead of this method.
      * <p>
      * Note: The method and its signature has been changed to return lock 
-     * instance in Vaadin 8.14.0. If you have overriden this method, you need
+     * instance in Vaadin X.X.X. If you have overriden this method, you need
      * to update your implementation.
      * <p>
      * Note: Overriding this method is not recommended, for custom lock storage

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -764,9 +764,9 @@ public abstract class VaadinService implements Serializable {
      * Locks the given session for this service instance. Typically you want to
      * call {@link VaadinSession#lock()} instead of this method.
      * <p>
-     * Note: The method and its signature has been changed to return lock 
-     * instance in Vaadin X.X.X. If you have overriden this method, you need
-     * to update your implementation.
+     * Note: The method and its signature has been changed to return lock
+     * instance in Vaadin X.X.X. If you have overriden this method, you need to
+     * update your implementation.
      * <p>
      * Note: Overriding this method is not recommended, for custom lock storage
      * strategy override {@link #getSessionLock(WrappedSession)} and
@@ -820,7 +820,7 @@ public abstract class VaadinService implements Serializable {
      * as parameter in Vaadin X.X.0. If you have overriden this method, you need
      * to update your implementation.
      * <p>
-     * Note: Overriding this method is not recommended, for custom lock storage 
+     * Note: Overriding this method is not recommended, for custom lock storage
      * strategy override {@link #getSessionLock(WrappedSession)} and
      * {@link #setSessionLock(WrappedSession,Lock)} instead.
      *
@@ -852,7 +852,7 @@ public abstract class VaadinService implements Serializable {
             return doFindOrCreateVaadinSession(request,
                     requestCanCreateSession);
         } finally {
-            unlockSession(wrappedSession,lock);
+            unlockSession(wrappedSession, lock);
         }
 
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -829,7 +829,7 @@ public abstract class VaadinService implements Serializable {
      * @param lock
      *            Lock instance to unlock
      */
-    protected void unlockSession(WrappedSession wrappedSession) {
+    protected void unlockSession(WrappedSession wrappedSession, Lock lock) {
         assert ((ReentrantLock) lock)
                 .isHeldByCurrentThread() : "Trying to unlock the session but it has not been locked by this thread";
         lock.unlock();


### PR DESCRIPTION
It is possible findOrCreateVaadinSession leaves session locked if HTTP session is invalidated in an another thread between lockSession and unlockSession calls. This PR changes the implementation so that this can no longer happen.

This is a cherry pick from: https://github.com/vaadin/framework/pull/12355

See details: https://github.com/vaadin/framework/issues/12352

TODO: Update framework version in the comments when target release is known.