### PR TITLE
fix: Use byte[] instead of String to store stats.json

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -486,13 +486,12 @@ public class FrontendUtils {
                 Stats statistics = context.getAttribute(Stats.class);
                 if (statistics == null
                   || modified.isAfter(statistics.getLastModified().orElse(LocalDateTime.MIN))) {
-                    statistics = new Stats(
-                            streamToString(connection.getInputStream()),
-                            lastModified);
+                    byte[] buffer = IOUtils
+                            .toByteArray(connection.getInputStream());
+                    statistics = new Stats(buffer, lastModified);
                     context.setAttribute(statistics);
                 }
-                return new ByteArrayInputStream(
-                        statistics.statsJson.getBytes(StandardCharsets.UTF_8));
+                return new ByteArrayInputStream(statistics.statsJson);
             }
             return connection.getInputStream();
         } catch (IOException e) {
@@ -547,11 +546,10 @@ public class FrontendUtils {
                     "Cannot get the 'stats.json' from the classpath '{}'",
                     stats);
         } else {
-            statistics = new Stats(
-                    IOUtils.toString(stream, StandardCharsets.UTF_8), null);
+            byte[] buffer = IOUtils.toByteArray(stream);
+            statistics = new Stats(buffer, null);
             service.getContext().setAttribute(statistics);
-            stream = IOUtils.toInputStream(statistics.statsJson,
-                    StandardCharsets.UTF_8);
+            stream = new ByteArrayInputStream(buffer);
         }
         return stream;
     }
@@ -913,7 +911,7 @@ public class FrontendUtils {
      */
     private static class Stats implements Serializable {
         private final String lastModified;
-        protected final String statsJson;
+        protected final byte[] statsJson;
 
         /**
          * Create a new container for stats.json caching.
@@ -924,7 +922,7 @@ public class FrontendUtils {
          *            last modification timestamp for stats.json in RFC-1123
          *            date-time format, such as 'Tue, 3 Jun 2008 11:05:30 GMT'
          */
-        public Stats(String statsJson, String lastModified) {
+        public Stats(byte[] statsJson, String lastModified) {
             this.statsJson = statsJson;
             this.lastModified = lastModified;
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -520,8 +520,7 @@ public class FrontendUtils {
         Stats statistics = service.getContext().getAttribute(Stats.class);
 
         if (statistics != null) {
-            return IOUtils.toInputStream(statistics.statsJson,
-                    StandardCharsets.UTF_8);
+            return new ByteArrayInputStream(statistics.statsJson);
         }
 
         String stats = service.getDeploymentConfiguration()


### PR DESCRIPTION
Cherry pick for Flow 2.7: https://github.com/vaadin/flow/commit/841244967cc662619370e4ab6e689https://github.com/vaadin/flow/commit/841244967cc662619370e4ab6e6890e704bf7f610e704bf7f61
