### PR TITLE
fix: Fail-fast if the path to npm cache contains whitespaces (CP: 2.7)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -810,21 +810,65 @@ public class FrontendUtils {
         }
     }
 
+    /**
+     * Thrown when the command execution fails.
+     */
+    public static class CommandExecutionException extends Exception {
+        /**
+         * Constructs an exception telling what code the command execution
+         * process was exited with.
+         *
+         * @param processExitCode
+         *            process exit code
+         */
+        public CommandExecutionException(int processExitCode) {
+            super("Process execution failed with exit code " + processExitCode);
+        }
+
+        /**
+         * Constructs an exception telling what was the original exception the
+         * command execution process failed with.
+         *
+         * @param cause
+         *            the cause exception of process failure.
+         */
+        public CommandExecutionException(Throwable cause) {
+            super("Process execution failed", cause);
+        }
+    }
+
     protected static FrontendVersion getVersion(String tool,
             List<String> versionCommand) throws UnknownVersionException {
         try {
-            Process process = FrontendUtils.createProcessBuilder(versionCommand)
+            String output = executeCommand(versionCommand);
+            return new FrontendVersion(parseVersionString(output));
+        } catch (IOException | CommandExecutionException e) {
+            throw new UnknownVersionException(tool,
+                    "Using command " + String.join(" ", versionCommand), e);
+        }
+    }
+
+    /**
+     * Executes a given command as a native process.
+     *
+     * @param command
+     *            the command to be executed and it's arguments.
+     * @return process output string.
+     * @throws CommandExecutionException
+     *             if the process completes exceptionally.
+     */
+    public static String executeCommand(List<String> command)
+            throws CommandExecutionException {
+        try {
+            Process process = FrontendUtils.createProcessBuilder(command)
                     .start();
             int exitCode = process.waitFor();
             if (exitCode != 0) {
-                throw new UnknownVersionException(tool,
-                        "Using command " + String.join(" ", versionCommand));
+                throw new CommandExecutionException(exitCode);
             }
-            String output = streamToString(process.getInputStream());
-            return new FrontendVersion(parseVersionString(output));
-        } catch (InterruptedException | IOException e) {
-            throw new UnknownVersionException(tool,
-                    "Using command " + String.join(" ", versionCommand), e);
+            return streamToString(process.getInputStream());
+        } catch (IOException | InterruptedException e) {
+            throw new CommandExecutionException(e);
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2020 Vaadin Ltd.
+ * Copyright 2000-2021 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -66,6 +66,23 @@ public class TaskRunNpmInstall implements FallibleCommand {
     // This will hep us know to execute even when another developer has pushed
     // a new hash to the code repository.
     private static final String INSTALL_HASH = ".vaadin/vaadin.json";
+
+    private static final String NPM_VALIDATION_FAIL_MESSAGE = "%n%n======================================================================================================"
+            + "%nThe path to npm cache contains whitespaces, and the currently installed npm version doesn't accept this."
+            + "%nMost likely your Windows user home path contains whitespaces."
+            + "%nTo workaround it, please change the npm cache path by using the following command:"
+            + "%n    npm config set cache [path-to-npm-cache] --global"
+            + "%n(you may also want to exclude the whitespaces with 'dir /x' to use the same dir),"
+            + "%nor upgrade the npm version to 7 (or newer) by:"
+            + "%n 1) Running 'npm-windows-upgrade' tool with Windows PowerShell:"
+            + "%n        Set-ExecutionPolicy Unrestricted -Scope CurrentUser -Force"
+            + "%n        npm install -g npm-windows-upgrade"
+            + "%n        npm-windows-upgrade"
+            + "%n 2) Manually installing a newer version of npx: npm install -g npx"
+            + "%n 3) Manually installing a newer version of pnpm: npm install -g pnpm"
+            + "%n 4) Deleting the following files from your Vaadin project's folder (if present):"
+            + "%n        node_modules, package-lock.json, webpack.generated.js, pnpm-lock.yaml, pnpmfile.js"
+            + "%n======================================================================================================%n";
 
     private final NodeUpdater packageUpdater;
 
@@ -329,8 +346,12 @@ public class TaskRunNpmInstall implements FallibleCommand {
             if (requireHomeNodeExec) {
                 tools.forceAlternativeNodeExecutable();
             }
-            executable = enablePnpm ? tools.getPnpmExecutable()
-                    : tools.getNpmExecutable();
+            if (enablePnpm) {
+                validateInstalledNpm(tools);
+                executable = tools.getPnpmExecutable();
+            } else {
+                executable = tools.getNpmExecutable();
+            }
         } catch (IllegalStateException exception) {
             throw new ExecutionFailedException(exception.getMessage(),
                     exception);
@@ -472,6 +493,23 @@ public class TaskRunNpmInstall implements FallibleCommand {
                     (dir, name) -> name.startsWith("pnpm-")).length == 0) {
                 FileUtils.forceDelete(packageUpdater.nodeModulesFolder);
             }
+        }
+    }
+
+    private void validateInstalledNpm(FrontendTools tools)
+            throws IllegalStateException {
+        File npmCacheDir = null;
+        try {
+            npmCacheDir = tools.getNpmCacheDir();
+        } catch (FrontendUtils.CommandExecutionException
+                | IllegalStateException e) {
+            packageUpdater.log().warn("Failed to get npm cache directory", e);
+        }
+
+        if (npmCacheDir != null
+                && !tools.folderIsAcceptableByNpm(npmCacheDir)) {
+            throw new IllegalStateException(
+                    String.format(NPM_VALIDATION_FAIL_MESSAGE));
         }
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateTestUtil.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateTestUtil.java
@@ -25,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
@@ -39,6 +40,9 @@ import static org.junit.Assert.assertNotNull;
 public class NodeUpdateTestUtil {
 
     public static final String WEBPACK_TEST_OUT_FILE = "webpack-out.test";
+
+    private static final String NPM_BIN_PATH = "node/node_modules/npm/bin";
+    private static final String NPM_CACHE_PATH_STUB = "cache";
 
     static ClassFinder getClassFinder() throws MalformedURLException {
         return new DefaultClassFinder(new URLClassLoader(getClassPath()),
@@ -70,38 +74,88 @@ public class NodeUpdateTestUtil {
         return classPaths.toArray(new URL[0]);
     }
 
-    // Creates stub versions of `node` and `npm` in the ./node folder as
-    // frontend-maven-plugin does
-    // Also creates a stub version of webpack-devmode-server
-    public static void createStubNode(boolean stubNode, boolean stubNpm,
-            String baseDir) throws IOException {
+    /**
+     * Creates stub versions of `node` and `npm` in the ./node folder as
+     * frontend-maven-plugin does.
+     *
+     * @param stubNode
+     *            node stub information, including whether `node/node`
+     *            (`node/node.exe`) stub should be created, and what version
+     *            should it output if '-v' || '--version' flag are set.
+     * @param stubNpm
+     *            npm stub information, including whether
+     *            `node/node_modules/npm/bin/npm-cli` and `npx-cli` should be
+     *            created, and what version should it output if '-v' ||
+     *            '--version' flag are set.
+     * @param baseDir
+     *            parent to create `node` dir in
+     * @throws IOException
+     *             when a file operation fails
+     */
+    public static void createStubNode(ToolStubInfo stubNode,
+                                      ToolStubInfo stubNpm, String baseDir) throws IOException {
 
-        if (stubNpm) {
-            File binDir = new File(baseDir, "node/node_modules/npm/bin");
+        Objects.requireNonNull(stubNode);
+        Objects.requireNonNull(stubNpm);
+
+        if (stubNpm.isStubbed()) {
+            File binDir = new File(baseDir, NPM_BIN_PATH);
             FileUtils.forceMkdir(binDir);
-            String stub = "process.argv.includes('--version') && console.log('6.14.10');";
+            String stub = stubNpm.getScript().replace("\\", "\\\\");
             FileUtils.writeStringToFile(new File(binDir, "npm-cli.js"), stub,
                     StandardCharsets.UTF_8);
             FileUtils.writeStringToFile(new File(binDir, "npx-cli.js"), stub,
                     StandardCharsets.UTF_8);
         }
-        if (stubNode) {
+        boolean isWindows = System.getProperty("os.name").startsWith("Windows");
+
+        if (stubNode.isStubbed()) {
+            File nodeDir = new File(baseDir, "node");
+            FileUtils.forceMkdir(nodeDir);
             File node = new File(baseDir,
-                    FrontendUtils.isWindows() ? "node/node.exe" : "node/node");
+                    isWindows ? "node/node.exe" : "node/node");
             node.createNewFile();
             node.setExecutable(true);
-            if (FrontendUtils.isWindows()) {
+            if (isWindows) {
                 // Commented out until a node.exe is created that is not flagged
                 // by Windows defender.
                 // FileUtils.copyFile(new File(
                 // getClassFinder().getClass().getClassLoader().getResource("test_node.exe").getFile()
                 // ), node);
             } else {
-                FileUtils.write(node,
-                        "#!/bin/sh\n[ \"$1\" = -v ] && echo 8.0.0 || sleep 1\n",
-                        "UTF-8");
+                FileUtils.write(node, stubNode.getScript(), "UTF-8");
             }
         }
+    }
+
+    /**
+     * Creates stub versions of `node` and `npm` in the ./node folder as
+     * frontend-maven-plugin does. This method creates a default stubs for
+     * tool's versions.
+     *
+     * @param stubNode
+     *            whether `node/node` (`node/node.exe`) stub should be created
+     * @param stubNpm
+     *            whether `node/node_modules/npm/bin/npm-cli` and `npx-cli`
+     *            should be created
+     * @param baseDir
+     *            parent to create `node` dir in
+     * @throws IOException
+     *             when a file operation fails
+     */
+    public static void createStubNode(boolean stubNode, boolean stubNpm,
+                                      String baseDir) throws IOException {
+        final File defaultNpmCacheDirStub = new File(
+                new File(baseDir, NPM_BIN_PATH), NPM_CACHE_PATH_STUB);
+        FileUtils.forceMkdir(defaultNpmCacheDirStub);
+
+        ToolStubInfo nodeStubInfo = stubNode ? ToolStubInfo.builder(Tool.NODE)
+                .withCacheDir(defaultNpmCacheDirStub.getAbsolutePath()).build()
+                : ToolStubInfo.none();
+        ToolStubInfo npmStubInfo = stubNpm ? ToolStubInfo.builder(Tool.NPM)
+                .withCacheDir(defaultNpmCacheDirStub.getAbsolutePath()).build()
+                : ToolStubInfo.none();
+        createStubNode(nodeStubInfo, npmStubInfo, baseDir);
     }
 
     // Creates a stub webpack-dev-server able to output a ready string, sleep
@@ -191,6 +245,168 @@ public class NodeUpdateTestUtil {
             return WEBPACK_PREFIX_ALIAS + s.substring(2);
         }
         return s;
+    }
+
+    /**
+     * Holds an information about build tool to be stubbed.
+     */
+    public static final class ToolStubInfo {
+        private final boolean stubbed;
+        private final String script;
+
+        private ToolStubInfo(boolean stubbed, String script) {
+            this.stubbed = stubbed;
+            assert !stubbed || (script != null && !script
+                    .isEmpty()) : "Script may not be empty for stubbed tool";
+            this.script = script;
+        }
+
+        /**
+         * Creates a new builder for constructing a new instance of tool stub
+         * info.
+         *
+         * @param tool
+         *            the build tool to create a stub for.
+         *
+         * @return a new tool stub info builder.
+         */
+        public static ToolStubBuilder builder(Tool tool) {
+            Objects.requireNonNull(tool, "Build tool may not be empty");
+            return new ToolStubBuilder(tool);
+        }
+
+        /**
+         * Returns a dummy tool stub info, which denotes no stub is used.
+         *
+         * @return a tool stub info for non-used stub.
+         */
+        public static ToolStubInfo none() {
+            return new ToolStubInfo(false, "");
+        }
+
+        public boolean isStubbed() {
+            return stubbed;
+        }
+
+        public String getScript() {
+            return script;
+        }
+    }
+
+    /**
+     * Builds a new instance of {@link ToolStubInfo}.
+     */
+    public static class ToolStubBuilder {
+
+        private static final String DEFAULT_NPM_VERSION = "6.14.10";
+        private static final String DEFAULT_NODE_VERSION = "8.0.0";
+
+        private String version;
+        private String cacheDir;
+        private final Tool tool;
+
+        private ToolStubBuilder(Tool tool) {
+            this.tool = tool;
+        }
+
+        /**
+         * Adds a stub for tool version. The version will be returned if a tool
+         * executable is called with '-v' or '--version' argument. If no value
+         * is set, the default one is used.
+         *
+         * @param version
+         *            a tool version to stub.
+         * @return a tool stub info builder.
+         */
+        public ToolStubBuilder withVersion(String version) {
+            this.version = version;
+            return this;
+        }
+
+        /**
+         * Adds a stub for npm cache directory. The path to cache will be
+         * returned if a tool executable is called with 'cache' argument. If no
+         * value is set, the default one is used.
+         *
+         * @param cacheDir
+         *            a npm cache dir to stub.
+         *
+         * @return a tool stub info builder.
+         */
+        public ToolStubBuilder withCacheDir(String cacheDir) {
+            this.cacheDir = cacheDir;
+            return this;
+        }
+
+        /**
+         * Builds a new instance of tool stub info.
+         *
+         * @return a new tool stub info instance.
+         */
+        public ToolStubInfo build() {
+            String script;
+            final StringBuilder scriptBuilder = new StringBuilder();
+
+            switch (tool) {
+                case NPM:
+                    script = generateNpmScript(scriptBuilder);
+                    break;
+                case NODE:
+                    script = generateNodeScript(scriptBuilder);
+                    break;
+                default:
+                    throw new IllegalStateException("Unknown build tool");
+            }
+            return new ToolStubInfo(true, script);
+        }
+
+        private String generateNodeScript(StringBuilder scriptBuilder) {
+            String script;
+            // default version used in tests
+            version = version == null ? DEFAULT_NODE_VERSION : version;
+            scriptBuilder.append(
+                    "  if [ \"$arg\" = \"--version\" ] || [ \"$arg\" = \"-v\" ]; then\n")
+                    .append("    echo ").append(version).append("\n")
+                    .append("    break\n").append("  fi\n");
+            if (cacheDir != null) {
+                scriptBuilder.append("  if [ \"$arg\" = \"cache\" ]; then\n")
+                        .append("    echo ").append(cacheDir).append("\n")
+                        .append("    break\n").append("  fi\n");
+            }
+            // @formatter:off
+            script = String.format(
+                    "#!/bin/sh%n"
+                    + "for arg in \"$@\"%n"
+                    + "do%n"
+                    + "%s"
+                    + "done%n"
+                    + "sleep 1", scriptBuilder.toString());
+            // @formatter:on
+            return script;
+        }
+
+        private String generateNpmScript(StringBuilder scriptBuilder) {
+            String script;
+            // default version used in tests
+            version = version == null ? DEFAULT_NPM_VERSION : version;
+            scriptBuilder.append(
+                    "process.argv.includes('--version') && console.log('")
+                    .append(version).append("');\n");
+            if (cacheDir != null) {
+                scriptBuilder.append(
+                        "process.argv.includes('cache') && console.log('")
+                        .append(cacheDir).append("');\n");
+            }
+            script = scriptBuilder.toString();
+            return script;
+        }
+    }
+
+    /**
+     * Types of build tools.
+     */
+    public enum Tool {
+        NODE, NPM
     }
 
 }


### PR DESCRIPTION
## Description

Checks that the npm version accepts whitespaces in user home path and explains how to fix that otherwise.

Fixes https://github.com/vaadin/flow/issues/10084

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
