### PR TITLE
fix: don't bootstrap UI for invalid location

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
@@ -77,6 +77,10 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
     @Override
     public boolean synchronizedHandleRequest(VaadinSession session,
             VaadinRequest request, VaadinResponse response) throws IOException {
+        if (writeErrorCodeIfRequestLocationIsInvalid(request, response)) {
+            return true;
+        }
+
         DeploymentConfiguration config = session.getConfiguration();
         IndexHtmlResponse indexHtmlResponse;
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/MockServletServiceSessionSetup.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/MockServletServiceSessionSetup.java
@@ -55,7 +55,7 @@ public class MockServletServiceSessionSetup {
         private VaadinContext context;
 
         public TestVaadinServletService(TestVaadinServlet testVaadinServlet,
-                                        DeploymentConfiguration deploymentConfiguration) {
+                DeploymentConfiguration deploymentConfiguration) {
             super(testVaadinServlet, deploymentConfiguration);
         }
 
@@ -219,7 +219,7 @@ public class MockServletServiceSessionSetup {
         private String type;
 
         private TestVaadinServletResponse(HttpServletResponse response,
-                                          VaadinServletService vaadinService) {
+                VaadinServletService vaadinService) {
             super(response, vaadinService);
         }
 
@@ -303,7 +303,7 @@ public class MockServletServiceSessionSetup {
 
         deploymentConfiguration.setXsrfProtectionEnabled(false);
         Mockito.doAnswer(
-                        invocation -> servletContext.getClass().getClassLoader())
+                invocation -> servletContext.getClass().getClassLoader())
                 .when(servletContext).getClassLoader();
         Mockito.when(servletConfig.getServletContext())
                 .thenReturn(servletContext);
@@ -317,13 +317,13 @@ public class MockServletServiceSessionSetup {
                 .thenReturn(staticFileHandlerFactory);
 
         Mockito.when(resourceProvider.getClientResourceAsStream(
-                        "META-INF/resources/" + ApplicationConstants.CLIENT_ENGINE_PATH
-                                + "/compile.properties"))
+                "META-INF/resources/" + ApplicationConstants.CLIENT_ENGINE_PATH
+                        + "/compile.properties"))
                 .thenAnswer(invocation -> new ByteArrayInputStream(
                         "jsFile=foo".getBytes(StandardCharsets.UTF_8)));
 
         Mockito.when(
-                        resourceProvider.getApplicationResource(Mockito.anyString()))
+                resourceProvider.getApplicationResource(Mockito.anyString()))
                 .thenAnswer(invocation -> {
                     return MockServletServiceSessionSetup.class
                             .getResource("/" + invocation.getArgument(0));
@@ -411,7 +411,7 @@ public class MockServletServiceSessionSetup {
 
     public void setAppShellRegistry(AppShellRegistry appShellRegistry) {
         Mockito.when(servletContext
-                        .getAttribute(AppShellRegistryWrapper.class.getName()))
+                .getAttribute(AppShellRegistryWrapper.class.getName()))
                 .thenReturn(new AppShellRegistryWrapper(appShellRegistry));
     }
 
@@ -425,7 +425,7 @@ public class MockServletServiceSessionSetup {
     }
 
     public VaadinRequest createRequest(MockServletServiceSessionSetup mocks,
-                                       String path, String queryString) {
+            String path, String queryString) {
         QueryParameters queryParams = QueryParameters.fromString(queryString);
         Map<String, List<String>> params = queryParams.getParameters();
         HttpServletRequest httpServletRequest = Mockito

--- a/flow-server/src/test/java/com/vaadin/flow/server/MockServletServiceSessionSetup.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/MockServletServiceSessionSetup.java
@@ -55,7 +55,7 @@ public class MockServletServiceSessionSetup {
         private VaadinContext context;
 
         public TestVaadinServletService(TestVaadinServlet testVaadinServlet,
-                DeploymentConfiguration deploymentConfiguration) {
+                                        DeploymentConfiguration deploymentConfiguration) {
             super(testVaadinServlet, deploymentConfiguration);
         }
 
@@ -219,7 +219,7 @@ public class MockServletServiceSessionSetup {
         private String type;
 
         private TestVaadinServletResponse(HttpServletResponse response,
-                VaadinServletService vaadinService) {
+                                          VaadinServletService vaadinService) {
             super(response, vaadinService);
         }
 
@@ -303,7 +303,7 @@ public class MockServletServiceSessionSetup {
 
         deploymentConfiguration.setXsrfProtectionEnabled(false);
         Mockito.doAnswer(
-                invocation -> servletContext.getClass().getClassLoader())
+                        invocation -> servletContext.getClass().getClassLoader())
                 .when(servletContext).getClassLoader();
         Mockito.when(servletConfig.getServletContext())
                 .thenReturn(servletContext);
@@ -317,13 +317,13 @@ public class MockServletServiceSessionSetup {
                 .thenReturn(staticFileHandlerFactory);
 
         Mockito.when(resourceProvider.getClientResourceAsStream(
-                "META-INF/resources/" + ApplicationConstants.CLIENT_ENGINE_PATH
-                        + "/compile.properties"))
+                        "META-INF/resources/" + ApplicationConstants.CLIENT_ENGINE_PATH
+                                + "/compile.properties"))
                 .thenAnswer(invocation -> new ByteArrayInputStream(
                         "jsFile=foo".getBytes(StandardCharsets.UTF_8)));
 
         Mockito.when(
-                resourceProvider.getApplicationResource(Mockito.anyString()))
+                        resourceProvider.getApplicationResource(Mockito.anyString()))
                 .thenAnswer(invocation -> {
                     return MockServletServiceSessionSetup.class
                             .getResource("/" + invocation.getArgument(0));
@@ -411,7 +411,7 @@ public class MockServletServiceSessionSetup {
 
     public void setAppShellRegistry(AppShellRegistry appShellRegistry) {
         Mockito.when(servletContext
-                .getAttribute(AppShellRegistryWrapper.class.getName()))
+                        .getAttribute(AppShellRegistryWrapper.class.getName()))
                 .thenReturn(new AppShellRegistryWrapper(appShellRegistry));
     }
 
@@ -425,7 +425,7 @@ public class MockServletServiceSessionSetup {
     }
 
     public VaadinRequest createRequest(MockServletServiceSessionSetup mocks,
-            String path, String queryString) {
+                                       String path, String queryString) {
         QueryParameters queryParams = QueryParameters.fromString(queryString);
         Map<String, List<String>> params = queryParams.getParameters();
         HttpServletRequest httpServletRequest = Mockito

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
@@ -766,4 +766,28 @@ public class IndexHtmlRequestHandlerTest {
         Assert.assertFalse(indexHtmlRequestHandler.canHandleRequest(request));
     }
 
+    @Test
+    public void synchronizedHandleRequest_badLocation_noUiCreated()
+            throws IOException {
+        final IndexHtmlRequestHandler bootstrapHandler = new IndexHtmlRequestHandler();
+
+        final VaadinServletRequest request = Mockito
+                .mock(VaadinServletRequest.class);
+        Mockito.doAnswer(invocation -> "..**").when(request).getPathInfo();
+
+        final MockServletServiceSessionSetup.TestVaadinServletResponse response = mocks
+                .createResponse();
+
+        final boolean value = bootstrapHandler.synchronizedHandleRequest(
+                mocks.getSession(), request, response);
+        Assert.assertTrue("No further request handlers should be called",
+                value);
+
+        Assert.assertEquals("Invalid status code reported", 400,
+                response.getErrorCode());
+        Assert.assertEquals("Invalid message reported",
+                "Invalid location: Relative path cannot contain .. segments",
+                response.getErrorMessage());
+    }
+
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandlerTest.java
@@ -15,6 +15,9 @@
  */
 package com.vaadin.flow.server.communication;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import net.jcip.annotations.NotThreadSafe;
@@ -37,6 +40,7 @@ import com.vaadin.flow.server.MockServletServiceSessionSetup;
 import com.vaadin.flow.server.MockServletServiceSessionSetup.TestVaadinServletResponse;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinServletContext;
+import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.shared.communication.PushMode;
 
@@ -93,7 +97,7 @@ public class JavaScriptBootstrapHandlerTest {
 
     @Test
     public void should_produceValidJsonResponse() throws Exception {
-        VaadinRequest request = mocks.createRequest(mocks, "/", "v-r=init&foo");
+        VaadinRequest request = mocks.createRequest(mocks, "/", "v-r=init&foo&location");
         jsInitHandler.handleRequest(session, request, response);
 
         Assert.assertEquals(200, response.getErrorCode());
@@ -125,7 +129,7 @@ public class JavaScriptBootstrapHandlerTest {
 
     @Test
     public void should_initialize_UI() throws Exception {
-        VaadinRequest request = mocks.createRequest(mocks, "/", "v-r=init&foo");
+        VaadinRequest request = mocks.createRequest(mocks, "/", "v-r=init&foo&location=");
         jsInitHandler.handleRequest(session, request, response);
 
         Assert.assertNotNull(UI.getCurrent());
@@ -139,7 +143,7 @@ public class JavaScriptBootstrapHandlerTest {
 
     @Test
     public void should_attachViewTo_UiContainer() throws Exception {
-        VaadinRequest request = mocks.createRequest(mocks, "/", "v-r=init&foo");
+        VaadinRequest request = mocks.createRequest(mocks, "/", "v-r=init&foo&location=");
         jsInitHandler.handleRequest(session, request, response);
 
         JavaScriptBootstrapUI ui = (JavaScriptBootstrapUI) UI.getCurrent();
@@ -188,7 +192,7 @@ public class JavaScriptBootstrapHandlerTest {
             throws Exception {
         mocks.getDeploymentConfiguration().setPushMode(PushMode.AUTOMATIC);
 
-        VaadinRequest request = mocks.createRequest(mocks, "/", "v-r=init&foo");
+        VaadinRequest request = mocks.createRequest(mocks, "/", "v-r=init&foo&location=");
         jsInitHandler.handleRequest(session, request, response);
 
         Assert.assertEquals(200, response.getErrorCode());
@@ -205,7 +209,7 @@ public class JavaScriptBootstrapHandlerTest {
         AppShellRegistry registry = Mockito.mock(AppShellRegistry.class);
         mocks.setAppShellRegistry(registry);
 
-        VaadinRequest request = mocks.createRequest(mocks, "/", "v-r=init&foo");
+        VaadinRequest request = mocks.createRequest(mocks, "/", "v-r=init&foo&location=");
         jsInitHandler.handleRequest(session, request, response);
 
         Mockito.verify(registry)
@@ -221,7 +225,7 @@ public class JavaScriptBootstrapHandlerTest {
         registry.setShell(PushAppShell.class);
         mocks.setAppShellRegistry(registry);
 
-        VaadinRequest request = mocks.createRequest(mocks, "/", "v-r=init&foo");
+        VaadinRequest request = mocks.createRequest(mocks, "/", "v-r=init&foo&location");
         jsInitHandler.handleRequest(session, request, response);
 
         Assert.assertEquals(200, response.getErrorCode());
@@ -231,6 +235,49 @@ public class JavaScriptBootstrapHandlerTest {
         // Using regex, because version depends on the build
         Assert.assertTrue(json.getString("pushScript").matches(
                 "^\\./VAADIN/static/push/vaadinPush\\.js\\?v=[\\w\\.\\-]+$"));
+    }
+
+    @Test
+    public void synchronizedHandleRequest_badLocation_noUiCreated()
+            throws IOException {
+        final JavaScriptBootstrapHandler bootstrapHandler = new JavaScriptBootstrapHandler();
+
+        VaadinRequest request = mocks.createRequest(mocks, "/", "v-r=init&location=..**");
+
+        final MockServletServiceSessionSetup.TestVaadinServletResponse response = mocks
+                .createResponse();
+
+        final boolean value = bootstrapHandler.synchronizedHandleRequest(
+                mocks.getSession(), request, response);
+        Assert.assertTrue("No further request handlers should be called",
+                value);
+
+        Assert.assertEquals("Invalid status code reported", 400,
+                response.getErrorCode());
+        Assert.assertEquals("Invalid message reported",
+                "Invalid location: Relative path cannot contain .. segments",
+                response.getErrorMessage());
+    }
+
+    @Test
+    public void synchronizedHandleRequest_noLocationParameter_noUiCreated() throws IOException {
+        final JavaScriptBootstrapHandler bootstrapHandler = new JavaScriptBootstrapHandler();
+
+        VaadinRequest request = mocks.createRequest(mocks, "/", "v-r=ini&foobar");
+
+        final MockServletServiceSessionSetup.TestVaadinServletResponse response = mocks
+                .createResponse();
+
+        final boolean value = bootstrapHandler.synchronizedHandleRequest(
+                mocks.getSession(), request, response);
+        Assert.assertTrue("No further request handlers should be called",
+                value);
+
+        Assert.assertEquals("Invalid status code reported", 400,
+                response.getErrorCode());
+        Assert.assertEquals("Invalid message reported",
+                "Invalid location: Location parameter missing from bootstrap request to server.",
+                response.getErrorMessage());
     }
 
     private boolean hasNodeTag(TestNodeVisitor visitor, String htmContent,

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandlerTest.java
@@ -97,7 +97,8 @@ public class JavaScriptBootstrapHandlerTest {
 
     @Test
     public void should_produceValidJsonResponse() throws Exception {
-        VaadinRequest request = mocks.createRequest(mocks, "/", "v-r=init&foo&location");
+        VaadinRequest request = mocks.createRequest(mocks, "/",
+                "v-r=init&foo&location");
         jsInitHandler.handleRequest(session, request, response);
 
         Assert.assertEquals(200, response.getErrorCode());
@@ -129,7 +130,8 @@ public class JavaScriptBootstrapHandlerTest {
 
     @Test
     public void should_initialize_UI() throws Exception {
-        VaadinRequest request = mocks.createRequest(mocks, "/", "v-r=init&foo&location=");
+        VaadinRequest request = mocks.createRequest(mocks, "/",
+                "v-r=init&foo&location=");
         jsInitHandler.handleRequest(session, request, response);
 
         Assert.assertNotNull(UI.getCurrent());
@@ -143,7 +145,8 @@ public class JavaScriptBootstrapHandlerTest {
 
     @Test
     public void should_attachViewTo_UiContainer() throws Exception {
-        VaadinRequest request = mocks.createRequest(mocks, "/", "v-r=init&foo&location=");
+        VaadinRequest request = mocks.createRequest(mocks, "/",
+                "v-r=init&foo&location=");
         jsInitHandler.handleRequest(session, request, response);
 
         JavaScriptBootstrapUI ui = (JavaScriptBootstrapUI) UI.getCurrent();
@@ -192,7 +195,8 @@ public class JavaScriptBootstrapHandlerTest {
             throws Exception {
         mocks.getDeploymentConfiguration().setPushMode(PushMode.AUTOMATIC);
 
-        VaadinRequest request = mocks.createRequest(mocks, "/", "v-r=init&foo&location=");
+        VaadinRequest request = mocks.createRequest(mocks, "/",
+                "v-r=init&foo&location=");
         jsInitHandler.handleRequest(session, request, response);
 
         Assert.assertEquals(200, response.getErrorCode());
@@ -209,7 +213,8 @@ public class JavaScriptBootstrapHandlerTest {
         AppShellRegistry registry = Mockito.mock(AppShellRegistry.class);
         mocks.setAppShellRegistry(registry);
 
-        VaadinRequest request = mocks.createRequest(mocks, "/", "v-r=init&foo&location=");
+        VaadinRequest request = mocks.createRequest(mocks, "/",
+                "v-r=init&foo&location=");
         jsInitHandler.handleRequest(session, request, response);
 
         Mockito.verify(registry)
@@ -225,7 +230,8 @@ public class JavaScriptBootstrapHandlerTest {
         registry.setShell(PushAppShell.class);
         mocks.setAppShellRegistry(registry);
 
-        VaadinRequest request = mocks.createRequest(mocks, "/", "v-r=init&foo&location");
+        VaadinRequest request = mocks.createRequest(mocks, "/",
+                "v-r=init&foo&location");
         jsInitHandler.handleRequest(session, request, response);
 
         Assert.assertEquals(200, response.getErrorCode());
@@ -242,7 +248,8 @@ public class JavaScriptBootstrapHandlerTest {
             throws IOException {
         final JavaScriptBootstrapHandler bootstrapHandler = new JavaScriptBootstrapHandler();
 
-        VaadinRequest request = mocks.createRequest(mocks, "/", "v-r=init&location=..**");
+        VaadinRequest request = mocks.createRequest(mocks, "/",
+                "v-r=init&location=..**");
 
         final MockServletServiceSessionSetup.TestVaadinServletResponse response = mocks
                 .createResponse();
@@ -260,10 +267,12 @@ public class JavaScriptBootstrapHandlerTest {
     }
 
     @Test
-    public void synchronizedHandleRequest_noLocationParameter_noUiCreated() throws IOException {
+    public void synchronizedHandleRequest_noLocationParameter_noUiCreated()
+            throws IOException {
         final JavaScriptBootstrapHandler bootstrapHandler = new JavaScriptBootstrapHandler();
 
-        VaadinRequest request = mocks.createRequest(mocks, "/", "v-r=ini&foobar");
+        VaadinRequest request = mocks.createRequest(mocks, "/",
+                "v-r=ini&foobar");
 
         final MockServletServiceSessionSetup.TestVaadinServletResponse response = mocks
                 .createResponse();

--- a/flow-tests/test-pwa/src/test/java/com/vaadin/flow/pwatest/ui/PwaTestIT.java
+++ b/flow-tests/test-pwa/src/test/java/com/vaadin/flow/pwatest/ui/PwaTestIT.java
@@ -288,7 +288,8 @@ public class PwaTestIT extends ChromeDeviceTest {
     }
 
     private boolean isProductionMode() throws IOException {
-        JsonObject stats = readJsonFromUrl(getRootURL() + "?v-r=init");
+        JsonObject stats = readJsonFromUrl(
+                getRootURL() + "?v-r=init&location=");
         return stats.getObject("appConfig").getBoolean("productionMode");
     }
 

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/InvalidLocationIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/InvalidLocationIT.java
@@ -26,7 +26,7 @@ public class InvalidLocationIT extends ChromeBrowserTest {
     // #9443
     @Test
     public void invalidCharactersOnPath_UiNotServed() {
-        open("..**");
+        open();
 
         Assert.assertTrue("Faulty URL didn't return 400 error page.",
                 getDriver().getPageSource().contains("400"));

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/InvalidLocationIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/InvalidLocationIT.java
@@ -28,8 +28,8 @@ public class InvalidLocationIT extends ChromeBrowserTest {
     public void invalidCharactersOnPath_UiNotServed() {
         open("..**");
 
-        Assert.assertTrue("Faulty URL didn't return 400 error page.", getDriver()
-                .getPageSource().contains("400"));
+        Assert.assertTrue("Faulty URL didn't return 400 error page.",
+                getDriver().getPageSource().contains("400"));
     }
 
     @Override

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/InvalidLocationIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/InvalidLocationIT.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class InvalidLocationIT extends ChromeBrowserTest {
+
+    // #9443
+    @Test
+    public void invalidCharactersOnPath_UiNotServed() {
+        open("..**");
+
+        Assert.assertTrue("Faulty URL didn't return 400 error page.", getDriver()
+                .getPageSource().contains("400"));
+    }
+
+    @Override
+    protected String getTestPath() {
+        return "/view/..**";
+    }
+}


### PR DESCRIPTION
Based on #11552 and to be rebased on top of it.

Fixes #9443 for Flow 3+ bootstrapping.