### PR TITLE
Revert "fix: register data provider listener only if it has not been registered (#11471)"

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -1013,10 +1013,6 @@ public class DataCommunicator<T> implements Serializable {
     }
 
     private void handleAttach() {
-        if (dataProviderUpdateRegistration != null) {
-            dataProviderUpdateRegistration.remove();
-        }
-
         dataProviderUpdateRegistration = getDataProvider()
                 .addDataProviderListener(event -> {
                     if (event instanceof DataRefreshEvent) {

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
@@ -16,9 +16,9 @@
 package com.vaadin.flow.data.provider;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -1477,47 +1477,6 @@ public class DataCommunicatorTest {
                 dataCommunicator.getItemCount());
         Assert.assertEquals("Expected the item with value 42", filter.get(),
                 dataCommunicator.getItem(0));
-    }
-
-    @Test
-    public void handleAttach_componentAttached_oldDataProviderListenerRemoved() {
-        // given
-        AtomicInteger listenerInvocationCounter = new AtomicInteger(0);
-
-        TestComponent componentWithDataProvider = new TestComponent(
-                new Element("div"));
-        dataCommunicator = new DataCommunicator<Item>(dataGenerator,
-                arrayUpdater, data -> {
-                }, componentWithDataProvider.getElement().getNode()) {
-            @Override
-            public void reset() {
-                listenerInvocationCounter.incrementAndGet();
-                super.reset();
-            }
-        };
-        dataCommunicator.setRequestedRange(0, 100);
-        AbstractDataProvider<Item, Object> dataProvider = createDataProvider();
-        dataCommunicator.setDataProvider(dataProvider, null);
-        // Add the component to a parent to trigger handle the attach event
-        ui.add(componentWithDataProvider);
-        fakeClientCommunication();
-
-        Assert.assertEquals(
-                "Expected two DataCommunicator::reset() invocations: upon "
-                        + "setting the data provider and component attaching",
-                2, listenerInvocationCounter.get());
-
-        // when
-        // the data is being refreshed -> data provider's listeners are being
-        // invoked
-        dataProvider.refreshAll();
-        fakeClientCommunication();
-
-        // then
-        Assert.assertEquals(
-                "Expected only one reset() invocation, because the old "
-                        + "listener was removed and then only one listener is stored",
-                3, listenerInvocationCounter.get());
     }
 
     @Tag("test-component")


### PR DESCRIPTION
## Description

This reverts https://github.com/vaadin/flow/pull/11471, because it breaks ComboBox filtering tests, and it needs time to investigate.

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
