### PR TITLE
Revert "fix: register data provider listener only if it has not been registered (#11471)" (#11555) (CP: 2.7)

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -390,10 +390,6 @@ public class DataCommunicator<T> implements Serializable {
     }
 
     private void handleAttach() {
-        if (dataProviderUpdateRegistration != null) {
-            dataProviderUpdateRegistration.remove();
-        }
-
         dataProviderUpdateRegistration = getDataProvider()
                 .addDataProviderListener(event -> {
                     if (event instanceof DataRefreshEvent) {

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.data.provider;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.IntStream;
@@ -33,8 +32,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.Range;
@@ -345,46 +342,6 @@ public class DataCommunicatorTest {
         Mockito.verify(dataProvider, Mockito.times(1)).fetch(Mockito.any());
     }
 
-    @Test
-    public void handleAttach_componentAttached_oldDataProviderListenerRemoved() {
-        // given
-        AtomicInteger listenerInvocationCounter = new AtomicInteger(0);
-
-        TestComponent componentWithDataProvider = new TestComponent();
-        dataCommunicator = new DataCommunicator<Item>(dataGenerator,
-                arrayUpdater, data -> {
-        }, componentWithDataProvider.getElement().getNode()) {
-            @Override
-            public void reset() {
-                listenerInvocationCounter.incrementAndGet();
-                super.reset();
-            }
-        };
-        dataCommunicator.setRequestedRange(0, 100);
-        AbstractDataProvider<Item, Object> dataProvider = createDataProvider();
-        dataCommunicator.setDataProvider(dataProvider, null);
-        // Add the component to a parent to trigger handle the attach event
-        ui.add(componentWithDataProvider);
-        fakeClientCommunication();
-
-        Assert.assertEquals(
-                "Expected two DataCommunicator::reset() invocations: upon "
-                + "setting the data provider and component attaching",
-                2, listenerInvocationCounter.get());
-
-        // when
-        // the data is being refreshed -> data provider's listeners are being
-        // invoked
-        dataProvider.refreshAll();
-        fakeClientCommunication();
-
-        // then
-        Assert.assertEquals(
-                "Expected only one reset() invocation, because the old "
-                + "listener was removed and then only one listener is stored",
-                3, listenerInvocationCounter.get());
-    }
-
     private void fakeClientCommunication() {
         ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
         ui.getInternals().getStateTree().collectChanges(ignore -> {
@@ -524,14 +481,6 @@ public class DataCommunicatorTest {
         private int closeCount;
 
         private ReentrantLock lock = new ReentrantLock();
-    }
-
-    @Tag("test-component")
-    private static class TestComponent extends Component {
-
-        public TestComponent() {
-            super(new Element("div"));
-        }
     }
 
 }


### PR DESCRIPTION
## Description

This reverts commit 067f63f7

(cherry picked from commit c1a75e6417d2979d39d872b1a9fece09d4a4900c)

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
