### PR TITLE
fix: only copy javascript files.

### DIFF
--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -308,7 +308,8 @@ module.exports = {
     // have its own loader based on browser quirks.
     new CopyWebpackPlugin([{
       from: `${baseDir}/node_modules/@webcomponents/webcomponentsjs`,
-      to: `${build}/webcomponentsjs/`
+      to: `${build}/webcomponentsjs/`,
+      ignore: ['*.md', '*.json']
     }]),
   ]
 };


### PR DESCRIPTION
When copygin the webcomponentsjs
polyfill do not copy in package.json
or the md files.

closes #11560
