### PR TITLE
fix: don't fire shortcut event if ancestor of component is not visible

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -554,19 +554,19 @@ public class ShortcutRegistration implements Registration, Serializable {
     }
 
     private void fireShortcutEvent(Component component) {
-        if (ancestorsAreVisible(lifecycleOwner)
+        if (ancestorsOrSelfAreVisible(lifecycleOwner)
                 && lifecycleOwner.getElement().isEnabled()) {
             invokeShortcutEventListener(component);
         }
     }
 
-    private boolean ancestorsAreVisible(Component component) {
+    private boolean ancestorsOrSelfAreVisible(Component component) {
         if (!component.isVisible()) {
             return false;
         }
         Optional<Component> parent = component.getParent();
         if (parent.isPresent()) {
-            return ancestorsAreVisible(parent.get());
+            return ancestorsOrSelfAreVisible(parent.get());
         }
         return true;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -536,13 +536,10 @@ public class ShortcutRegistration implements Registration, Serializable {
         if (shortcutListenerRegistrations[listenOnIndex] == null) {
             if (component.getUI().isPresent()) {
                 shortcutListenerRegistrations[listenOnIndex] = new CompoundRegistration();
-                Registration keyDownRegistration = ComponentUtil
-                        .addListener(component, KeyDownEvent.class, e -> {
-                            if (lifecycleOwner.isVisible() && lifecycleOwner
-                                    .getElement().isEnabled()) {
-                                invokeShortcutEventListener(component);
-                            }
-                        }, domRegistration -> {
+                Registration keyDownRegistration = ComponentUtil.addListener(
+                        component, KeyDownEvent.class,
+                        event -> fireShortcutEvent(component),
+                        domRegistration -> {
                             shortcutListenerRegistrations[listenOnIndex]
                                     .addRegistration(domRegistration);
                             configureHandlerListenerRegistration(listenOnIndex);
@@ -554,6 +551,24 @@ public class ShortcutRegistration implements Registration, Serializable {
         } else {
             configureHandlerListenerRegistration(listenOnIndex);
         }
+    }
+
+    private void fireShortcutEvent(Component component) {
+        if (ancestorsAreVisible(lifecycleOwner)
+                && lifecycleOwner.getElement().isEnabled()) {
+            invokeShortcutEventListener(component);
+        }
+    }
+
+    private boolean ancestorsAreVisible(Component component) {
+        if (!component.isVisible()) {
+            return false;
+        }
+        Optional<Component> parent = component.getParent();
+        if (parent.isPresent()) {
+            return ancestorsAreVisible(parent.get());
+        }
+        return true;
     }
 
     private void configureHandlerListenerRegistration(int listenOnIndex) {

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
@@ -19,6 +19,7 @@ package com.vaadin.flow.component;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -30,6 +31,7 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.dom.ElementFactory;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.ExecutionContext;
 import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
@@ -40,8 +42,8 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -417,6 +419,106 @@ public class ShortcutRegistrationTest {
                 "JS execution string should NOT have event.preventDefault() in it"
                         + expression,
                 expression.contains("event.preventDefault();"));
+    }
+
+    @Test
+    public void constructedRegistration_lifecycleIsVisibleAndEnabled_shorcutEventIsFired() {
+        AtomicReference<ShortcutEvent> event = new AtomicReference<>();
+
+        new ShortcutRegistration(lifecycleOwner, () -> listenOn, event::set,
+                Key.KEY_A);
+
+        mockLifecycle(true);
+
+        clientResponse();
+
+        listenOn[0].getEventBus()
+                .fireEvent(new KeyDownEvent(listenOn[0], Key.KEY_A.toString()));
+
+        Assert.assertNotNull(event.get());
+    }
+
+    @Test
+    public void constructedRegistration_lifecycleOnwerIsDisabled_shorcutEventIsNotFired() {
+        AtomicReference<ShortcutEvent> event = new AtomicReference<>();
+
+        new ShortcutRegistration(lifecycleOwner, () -> listenOn, event::set,
+                Key.KEY_A);
+
+        Element element = mockLifecycle(true);
+        element.setEnabled(false);
+
+        clientResponse();
+
+        listenOn[0].getEventBus()
+                .fireEvent(new KeyDownEvent(listenOn[0], Key.KEY_A.toString()));
+
+        Assert.assertNull(event.get());
+    }
+
+    @Test
+    public void constructedRegistration_lifecycleOnwerIsInvisible_shorcutEventIsNotFired() {
+        AtomicReference<ShortcutEvent> event = new AtomicReference<>();
+
+        new ShortcutRegistration(lifecycleOwner, () -> listenOn, event::set,
+                Key.KEY_A);
+
+        mockLifecycle(false);
+
+        clientResponse();
+
+        listenOn[0].getEventBus()
+                .fireEvent(new KeyDownEvent(listenOn[0], Key.KEY_A.toString()));
+
+        Assert.assertNull(event.get());
+    }
+
+    @Test
+    public void constructedRegistration_lifecycleOnwerAncestorsAreVisible_shorcutEventIsNotFired() {
+        AtomicReference<ShortcutEvent> event = new AtomicReference<>();
+
+        new ShortcutRegistration(lifecycleOwner, () -> listenOn, event::set,
+                Key.KEY_A);
+
+        mockLifecycle(true);
+        Mockito.when(lifecycleOwner.getParent())
+                .thenReturn(Optional.of(new FakeComponent()));
+
+        clientResponse();
+
+        listenOn[0].getEventBus()
+                .fireEvent(new KeyDownEvent(listenOn[0], Key.KEY_A.toString()));
+
+        Assert.assertNotNull(event.get());
+    }
+
+    @Test
+    public void constructedRegistration_lifecycleOnwerHasInvisibleParent_shorcutEventIsNotFired() {
+        AtomicReference<ShortcutEvent> event = new AtomicReference<>();
+
+        new ShortcutRegistration(lifecycleOwner, () -> listenOn, event::set,
+                Key.KEY_A);
+
+        mockLifecycle(true);
+
+        FakeComponent component = new FakeComponent();
+        component.setVisible(false);
+        Mockito.when(lifecycleOwner.getParent())
+                .thenReturn(Optional.of(component));
+
+        clientResponse();
+
+        listenOn[0].getEventBus()
+                .fireEvent(new KeyDownEvent(listenOn[0], Key.KEY_A.toString()));
+
+        Assert.assertNull(event.get());
+    }
+
+    private Element mockLifecycle(boolean visible) {
+        Mockito.when(lifecycleOwner.isVisible()).thenReturn(visible);
+        Element element = ElementFactory.createAnchor();
+        Mockito.when(lifecycleOwner.getElement()).thenReturn(element);
+        return element;
     }
 
     class ElementLocatorTestFixture {

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
@@ -474,7 +474,7 @@ public class ShortcutRegistrationTest {
     }
 
     @Test
-    public void constructedRegistration_lifecycleOnwerAncestorsAreVisible_shorcutEventIsNotFired() {
+    public void constructedRegistration_lifecycleOnwerAncestorsAreVisible_shorcutEventIsFired() {
         AtomicReference<ShortcutEvent> event = new AtomicReference<>();
 
         new ShortcutRegistration(lifecycleOwner, () -> listenOn, event::set,


### PR DESCRIPTION
fixes #7033

<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Please list all relevant dependencies in this section and provide summary of the change, motivation and context.

Fixes # (issue)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
