### PR TITLE
fix: pin platform trans. deps with npm CP: #10864

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -1015,6 +1015,42 @@ public class FrontendUtils {
     }
 
     /**
+     * Tries to parse the given package's frontend version or if it doesn't
+     * exist, returns {@code null}. In case the value cannot be parsed, logs an
+     * error and returns {@code null}.
+     *
+     * @param sourceJson
+     *            json object that has the package
+     * @param pkg
+     *            the package name
+     * @param versionOrigin
+     *            origin of the version (like a file), used in error message
+     * @return the frontend version the package or {@code null}
+     */
+    public static FrontendVersion getPackageVersionFromJson(
+            JsonObject sourceJson, String pkg, String versionOrigin) {
+        if (!sourceJson.hasKey(pkg)) {
+            return null;
+        }
+        try {
+            final String versionString = sourceJson.getString(pkg);
+            return new FrontendVersion(pkg, versionString);
+        } catch (ClassCastException classCastException) {
+            LoggerFactory.getLogger(FrontendVersion.class).warn(
+                    "Ignoring error while parsing frontend dependency version for package '{}' in '{}'",
+                    pkg, versionOrigin);
+        } catch (NumberFormatException nfe) {
+            // intentionally not failing the build at this point
+            LoggerFactory.getLogger(FrontendVersion.class).warn(
+                    "Ignoring error while parsing frontend dependency version in {}: {}",
+                    versionOrigin, nfe.getMessage());
+        }
+        return null;
+    }
+
+    /**
+
+    /**
      * Intentionally send to console instead to log, useful when executing
      * external processes.
      *

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendVersion.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendVersion.java
@@ -125,9 +125,26 @@ public class FrontendVersion
      *            version string as "major.minor.revision[.build]"
      */
     public FrontendVersion(String version) {
+        this(null, version);
+    }
+
+    /**
+     * Parse version numbers from version string with the format
+     * "major.minor.revision[.build]". The build part is optional.
+     * <p>
+     * Versions are normalized and any caret or tildes will not be considered.
+     *
+     * @param name
+     *            the name of the artifact which version is to be parsed, used
+     *            in error message to help discover the issue
+     * @param version
+     *            version string as "major.minor.revision[.build]"
+     */
+    public FrontendVersion(String name, String version) {
         Objects.requireNonNull(version);
         if (version.isEmpty()) {
-            throw new NumberFormatException(getInvalidVersionMessage(version));
+            throw new NumberFormatException(
+                    getInvalidVersionMessage(name, version));
         }
         if (!Character.isDigit(version.charAt(0))) {
             this.version = version.substring(1).trim();
@@ -139,14 +156,15 @@ public class FrontendVersion
         try {
             majorVersion = Integer.parseInt(digits[0]);
         } catch (NumberFormatException nfe) {
-            throw new NumberFormatException(getInvalidVersionMessage(version));
+            throw new NumberFormatException(
+                    getInvalidVersionMessage(name, version));
         }
         if (digits.length >= 2) {
             try {
                 minorVersion = Integer.parseInt(digits[1]);
             } catch (NumberFormatException nfe) {
                 throw new NumberFormatException(
-                        getInvalidVersionMessage(version));
+                        getInvalidVersionMessage(name, version));
             }
         } else {
             minorVersion = 0;
@@ -326,8 +344,12 @@ public class FrontendVersion
         return buildIdentifier.compareToIgnoreCase(other.buildIdentifier);
     }
 
-    private String getInvalidVersionMessage(String version) {
-        return String.format("'%s' is not a valid version!", version);
+    private String getInvalidVersionMessage(String name, String version) {
+        if (name != null) {
+            return String.format("'%s' is not a valid version for '%s'!",
+                    version, name);
+        } else {
+            return String.format("'%s' is not a valid version!", version);
+        }
     }
-
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -228,7 +228,8 @@ public class NodeTasks implements FallibleCommand {
          *            <code>false</code>
          * @return this builder
          */
-        public Builder enableNpmFileCleaning(boolean forceClean) {
+        // This method is only used in tests ...
+        Builder enableNpmFileCleaning(boolean forceClean) {
             this.cleanNpmFiles = forceClean;
             return this;
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -17,7 +17,10 @@ package com.vaadin.flow.server.frontend;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -28,6 +31,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -128,6 +132,38 @@ public abstract class NodeUpdater implements FallibleCommand {
         return new File(npmFolder, PACKAGE_JSON);
     }
 
+    /**
+     * Gets the platform pinned versions that are not overridden by the user in
+     * package.json.
+     * 
+     * @return json object with the dependencies or {@code null}
+     * @throws IOException
+     *             when versions file could not be read
+     */
+    JsonObject getPlatformPinnedDependencies() throws IOException {
+        URL resource = finder.getResource(Constants.VAADIN_VERSIONS_JSON);
+        if (resource == null) {
+            log().info("Couldn't find {} file to pin dependency versions."
+                    + " Transitive dependencies won't be pinned for pnpm.",
+                    Constants.VAADIN_VERSIONS_JSON);
+        }
+
+        JsonObject versionsJson = null;
+        try (InputStream content = resource == null ? null
+                : resource.openStream()) {
+
+            if (content != null) {
+                VersionsJsonConverter convert = new VersionsJsonConverter(
+                        Json.parse(IOUtils.toString(content,
+                                StandardCharsets.UTF_8)));
+                versionsJson = convert.getConvertedJson();
+                versionsJson = new VersionsJsonFilter(getPackageJson(),
+                        DEPENDENCIES).getFilteredVersions(versionsJson);
+            }
+        }
+        return versionsJson;
+    }
+
     static Set<String> getGeneratedModules(File directory,
             Set<String> excludes) {
         if (!directory.exists()) {
@@ -197,6 +233,8 @@ public abstract class NodeUpdater implements FallibleCommand {
             packageJson = Json.createObject();
             packageJson.put(DEP_NAME_KEY, DEP_NAME_DEFAULT);
             packageJson.put(DEP_LICENSE_KEY, DEP_LICENSE_DEFAULT);
+            packageJson.put(DEPENDENCIES, Json.createObject());
+            packageJson.put(DEV_DEPENDENCIES, Json.createObject());
         }
 
         addDefaultObjects(packageJson);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -233,8 +233,6 @@ public abstract class NodeUpdater implements FallibleCommand {
             packageJson = Json.createObject();
             packageJson.put(DEP_NAME_KEY, DEP_NAME_DEFAULT);
             packageJson.put(DEP_LICENSE_KEY, DEP_LICENSE_DEFAULT);
-            packageJson.put(DEPENDENCIES, Json.createObject());
-            packageJson.put(DEV_DEPENDENCIES, Json.createObject());
         }
 
         addDefaultObjects(packageJson);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
@@ -92,7 +92,6 @@ public abstract class AbstractNodeUpdatePackagesTest
         mainNodeModules = new File(baseDir, FrontendUtils.NODE_MODULES);
         appNodeModules = new File(generatedDir, FrontendUtils.NODE_MODULES);
         packageLock = new File(baseDir, "package-lock.json");
-
     }
 
     protected abstract FrontendDependenciesScanner getScanner(
@@ -303,9 +302,6 @@ public abstract class AbstractNodeUpdatePackagesTest
         packageCreator.execute();
 
         json = packageUpdater.getPackageJson();
-        Assert.assertEquals("Vaadin dependency should be updated to latest DevDependency",
-                version, json.getObject(VAADIN_DEP_KEY).getObject(DEV_DEPENDENCIES)
-                        .getString(key));
         Assert.assertEquals(
                 "DevDependency should stay the same as it was", version,
                 json.getObject(DEV_DEPENDENCIES).getString(key));
@@ -360,7 +356,7 @@ public abstract class AbstractNodeUpdatePackagesTest
 
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
-        packageUpdater = new TaskUpdatePackages(null, frontendDependencies,
+        packageUpdater = new TaskUpdatePackages(classFinder, frontendDependencies,
                 baseDir, generatedDir, false, false);
 
         // Generate package json in a proper format first
@@ -411,7 +407,7 @@ public abstract class AbstractNodeUpdatePackagesTest
 
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
-        packageUpdater = new TaskUpdatePackages(null, frontendDependencies,
+        packageUpdater = new TaskUpdatePackages(classFinder, frontendDependencies,
                 baseDir, generatedDir, false, false);
 
         packageCreator.execute();
@@ -441,7 +437,7 @@ public abstract class AbstractNodeUpdatePackagesTest
 
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
-        packageUpdater = new TaskUpdatePackages(null, frontendDependencies,
+        packageUpdater = new TaskUpdatePackages(classFinder, frontendDependencies,
                 baseDir, generatedDir, false, false);
 
         packageCreator.execute();
@@ -486,7 +482,7 @@ public abstract class AbstractNodeUpdatePackagesTest
 
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
-        packageUpdater = new TaskUpdatePackages(null, frontendDependencies,
+        packageUpdater = new TaskUpdatePackages(classFinder, frontendDependencies,
                 baseDir, generatedDir, false, false);
 
         packageCreator.execute();
@@ -517,7 +513,7 @@ public abstract class AbstractNodeUpdatePackagesTest
 
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
-        packageUpdater = new TaskUpdatePackages(null, frontendDependencies,
+        packageUpdater = new TaskUpdatePackages(classFinder, frontendDependencies,
                 baseDir, generatedDir, false, false);
 
         packageCreator.execute();
@@ -540,7 +536,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         Map<String, String> packages = new HashMap<>();
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
-        packageUpdater = new TaskUpdatePackages(null, frontendDependencies,
+        packageUpdater = new TaskUpdatePackages(classFinder, frontendDependencies,
                 baseDir, generatedDir, false, false);
 
         packageCreator.execute();
@@ -566,7 +562,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         Map<String, String> packages = new HashMap<>();
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
-        packageUpdater = new TaskUpdatePackages(null, frontendDependencies,
+        packageUpdater = new TaskUpdatePackages(classFinder, frontendDependencies,
                 baseDir, generatedDir, false, false);
 
         packageCreator.execute();
@@ -594,7 +590,7 @@ public abstract class AbstractNodeUpdatePackagesTest
 
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
-        packageUpdater = new TaskUpdatePackages(null, frontendDependencies,
+        packageUpdater = new TaskUpdatePackages(classFinder, frontendDependencies,
                 baseDir, generatedDir, false, false);
 
         packageCreator.execute();
@@ -657,7 +653,7 @@ public abstract class AbstractNodeUpdatePackagesTest
 
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
-        packageUpdater = new TaskUpdatePackages(null, frontendDependencies,
+        packageUpdater = new TaskUpdatePackages(classFinder, frontendDependencies,
                 baseDir, generatedDir, false, false);
 
         packageCreator.execute();
@@ -703,7 +699,7 @@ public abstract class AbstractNodeUpdatePackagesTest
 
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
-        packageUpdater = new TaskUpdatePackages(null, frontendDependencies,
+        packageUpdater = new TaskUpdatePackages(classFinder, frontendDependencies,
                 baseDir, generatedDir, false, false);
 
         packageCreator.execute();
@@ -716,12 +712,23 @@ public abstract class AbstractNodeUpdatePackagesTest
         Assert.assertTrue("vaadin-checkbox is missing from the dependencies",
                 dependencies.hasKey("@vaadin/vaadin-checkbox"));
 
+        dependencies = getPackageJson(packageJson).getObject(VAADIN_DEP_KEY)
+                .getObject(DEPENDENCIES);
+        Assert.assertTrue("vaadin-checkbox is missing from vaadin.dependencies",
+                dependencies.hasKey("@vaadin/vaadin-checkbox"));
+
         // generate it one more time, this should remove the checkbox
         packageUpdater.execute();
 
         dependencies = getPackageJson(packageJson).getObject(DEPENDENCIES);
         Assert.assertFalse(
                 "vaadin-checkbox is still available in the dependencies",
+                dependencies.hasKey("@vaadin/vaadin-checkbox"));
+
+        dependencies = getPackageJson(packageJson).getObject(VAADIN_DEP_KEY)
+                .getObject(DEPENDENCIES);
+        Assert.assertFalse(
+                "vaadin-checkbox is still available in vaadin.dependencies",
                 dependencies.hasKey("@vaadin/vaadin-checkbox"));
 
     }
@@ -829,7 +836,7 @@ public abstract class AbstractNodeUpdatePackagesTest
 
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
-        packageUpdater = new TaskUpdatePackages(null, frontendDependencies,
+        packageUpdater = new TaskUpdatePackages(classFinder, frontendDependencies,
                 baseDir, generatedDir, false, isPnpm);
 
         // Generate package json in a proper format first

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -59,7 +59,7 @@ public class TaskRunNpmInstallTest {
 
     private File npmFolder;
 
-    private ClassFinder finder = Mockito.mock(ClassFinder.class);
+    private ClassFinder finder;
 
     private Logger logger = Mockito.mock(Logger.class);
 
@@ -74,7 +74,8 @@ public class TaskRunNpmInstallTest {
         npmFolder = temporaryFolder.newFolder();
         File generatedPath = new File(npmFolder, "generated");
         generatedPath.mkdir();
-        nodeUpdater = new NodeUpdater(getClassFinder(),
+        finder = Mockito.mock(ClassFinder.class);
+        nodeUpdater = new NodeUpdater(finder,
                 Mockito.mock(FrontendDependencies.class), npmFolder,
                 getGeneratedFolder()) {
             @Override

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
@@ -71,8 +71,6 @@ public class TaskUpdatePackagesNpmTest {
 
     private ClassFinder finder;
 
-    private Logger logger = Mockito
-            .spy(LoggerFactory.getLogger(NodeUpdater.class));
     private File generatedPath;
     private File versionJsonFile;
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/VersionsJsonFilterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/VersionsJsonFilterTest.java
@@ -56,7 +56,7 @@ public class VersionsJsonFilterTest {
     }
 
     @Test
-    public void missingVaadinDependencies_allDependenciesSholdBeUserHandled()
+    public void missingVaadinDependencies_allDependenciesShouldBeUserHandled()
             throws IOException {
         assertMissingVaadinDependencies_allDependenciesSholdBeUserHandled(
                 NodeUpdater.DEPENDENCIES);


### PR DESCRIPTION
Uses the same vaadin_versions.json file based pinning as with pnpm.
In case the application has @NpmPackage annotation with a certain version,
then that is used over the platform pinned version. When that is older,
a warning is logged (like with pnpm).
In case a dependency has been pinned directly in package.json, then that
is used over the platform pinned version. When that is older, a warning
is logged (like with pnpm).

Fixes #10572