### PR TITLE
fix: Remove old data provider listener on component attach

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -1013,6 +1013,10 @@ public class DataCommunicator<T> implements Serializable {
     }
 
     private void handleAttach() {
+        if (dataProviderUpdateRegistration != null) {
+            dataProviderUpdateRegistration.remove();
+        }
+
         dataProviderUpdateRegistration = getDataProvider()
                 .addDataProviderListener(event -> {
                     if (event instanceof DataRefreshEvent) {

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
@@ -1495,6 +1495,7 @@ public class DataCommunicatorTest {
                 super.reset();
             }
         };
+        
         dataCommunicator.setRequestedRange(0, 100);
         AbstractDataProvider<Item, Object> dataProvider = createDataProvider();
         dataCommunicator.setDataProvider(dataProvider, null);

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
@@ -1495,7 +1495,6 @@ public class DataCommunicatorTest {
                 super.reset();
             }
         };
-        
         dataCommunicator.setRequestedRange(0, 100);
         AbstractDataProvider<Item, Object> dataProvider = createDataProvider();
         dataCommunicator.setDataProvider(dataProvider, null);


### PR DESCRIPTION
## Description

Re-applied after adding a fix on components side - https://github.com/vaadin/flow-components/pull/2005.

Fixes: https://github.com/vaadin/flow-components/issues/1914

Note: to be merged to master only for now, to make sure it doesn't break the components again.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
