### PR TITLE
fix: fix build issue with npm 7.20.3+

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -91,11 +91,7 @@ public class FrontendTools {
     private static final List<FrontendVersion> NPM_BLACKLISTED_VERSIONS = Arrays
             .asList(new FrontendVersion("6.11.0"),
                     new FrontendVersion("6.11.1"),
-                    new FrontendVersion("6.11.2"),
-                    new FrontendVersion("7.20.3"),
-                    new FrontendVersion("7.20.4"),
-                    new FrontendVersion("7.20.5"),
-                    new FrontendVersion("7.20.6"));
+                    new FrontendVersion("6.11.2"));
 
     private static final FrontendVersion WHITESPACE_ACCEPTING_NPM_VERSION = new FrontendVersion(
             7, 0);
@@ -136,7 +132,7 @@ public class FrontendTools {
             SUPPORTED_PNPM_MAJOR_VERSION, SUPPORTED_PNPM_MINOR_VERSION);
 
     // The current highest functional NPM version 'latest' if it works.
-    private static final String HIGHEST_FUNCTIONAL_NPM = "7.20.2";
+    private static final String HIGHEST_FUNCTIONAL_NPM = "latest";
 
     private enum NpmCliTool {
         NPM("npm", "npm-cli.js"), NPX("npx", "npx-cli.js");

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -273,6 +273,9 @@ public abstract class NodeUpdater implements FallibleCommand {
         defaults.put("webpack-cli", "3.3.11");
         defaults.put("webpack-dev-server", "3.11.0");
         defaults.put("webpack-babel-multi-target-plugin", "2.3.3");
+        // Defining loader until a resolution exists to issue
+        // https://github.com/DanielSchaffer/webpack-babel-multi-target-plugin/issues/94
+        defaults.put("babel-loader", "8.2.2");
         defaults.put("copy-webpack-plugin", "5.1.2");
         defaults.put("compression-webpack-plugin", "4.0.1");
         defaults.put("extra-watch-webpack-plugin", "1.0.3");


### PR DESCRIPTION
Add `babel-loader` to devDependencies
to fix issue happening after npm 7.20.3
where the loader gets only installed into
a sub node_modules folder and not to root.

Closes #11584

