### PR TITLE
fix: explain deprecation of PageConfigurator [skip-ci]

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/InitialPageSettings.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitialPageSettings.java
@@ -41,7 +41,10 @@ import elemental.json.JsonObject;
  *
  * @since 1.0
  * @deprecated Use {@link BootstrapPageResponse} instance passed via
- *             {@link BootstrapListener} instead
+ * {@link BootstrapListener} instead, or acquire the {@link UI} via
+ * {@link BootstrapListener} for certain modifications and configuration. For
+ * more details, see {@link PageConfigurator} deprecation message. To be removed
+ * after the next long term support release (targeted Vaadin 23).
  */
 @Deprecated
 public class InitialPageSettings implements Serializable {

--- a/flow-server/src/main/java/com/vaadin/flow/server/PageConfigurator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PageConfigurator.java
@@ -17,12 +17,22 @@ package com.vaadin.flow.server;
 
 import java.io.Serializable;
 
+import com.vaadin.flow.component.UI;
+
 /**
  * Configures the initial page contents.
  *
  * @since 1.0
- * 
- * @deprecated Use {@link BootstrapListener} instead
+ * @deprecated Deprecated due to multiple issues on feature design, like this
+ * won't work together with the {@link com.vaadin.flow.router.PreserveOnRefresh}
+ * annotation. Will not be removed until <em>after the next long term support
+ * version</em> (targeted Vaadin 23).
+ * <p>
+ * For Vaadin 14, use {@link BootstrapListener} instead, which provides API for
+ * modifying the bootstrap page and access to the {@link UI}, which provides
+ * further replacement API like {@link UI#getLoadingIndicatorConfiguration()}.
+ * <p>
+ * For Vaadin 15+, use {@code AppShellConfigurator} instead.
  */
 @Deprecated
 @FunctionalInterface


### PR DESCRIPTION
The previous deprecation message was totally lacking any details to the
users.