### PR TITLE
fix: Remove old data provider listener on component attach (CP: 8.0)

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -1013,6 +1013,10 @@ public class DataCommunicator<T> implements Serializable {
     }
 
     private void handleAttach() {
+        if (dataProviderUpdateRegistration != null) {
+            dataProviderUpdateRegistration.remove();
+        }
+
         dataProviderUpdateRegistration = getDataProvider()
                 .addDataProviderListener(event -> {
                     if (event instanceof DataRefreshEvent) {


### PR DESCRIPTION
## Description

Re-applied after adding a fix on components side - https://github.com/vaadin/flow-components/pull/2005.
TO BE MERGED AFTER https://github.com/vaadin/flow-components/pull/2012.

Fixes: https://github.com/vaadin/flow-components/issues/1914

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
