### PR TITLE
chore: change usage of deprecated TextNote constructor

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/dom/ElementUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/ElementUtil.java
@@ -213,7 +213,7 @@ public class ElementUtil {
      */
     public static Node toJsoup(Document document, Element element) {
         if (element.isTextNode()) {
-            return new TextNode(element.getText(), document.baseUri());
+            return new TextNode(element.getText());
         }
 
         org.jsoup.nodes.Element target = document


### PR DESCRIPTION
## Description

Removes usage of the deprecated TextNode constructor (String, String) in favour of the (String) constructor available in 1.11.x and 1.14.x allowing projects to upgrade the transitive jsoup depenency without waiting for an official release of vaadin at the user's own risk.

Relates #11609 

Targets 2.7 -> Should be ported to 2.6, 1.0(?), 7(?), 8(?)

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
