### PR TITLE
refactor(flow-server): bump construct-style-sheets-polyfill version

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -369,7 +369,7 @@ public abstract class NodeUpdater implements FallibleCommand {
 
         // Constructable style sheets is only implemented for chrome,
         // polyfill needed for FireFox et.al. at the moment
-        defaults.put("construct-style-sheets-polyfill", "2.4.16");
+        defaults.put("construct-style-sheets-polyfill", "3.0.0");
 
         return defaults;
     }


### PR DESCRIPTION
The `3.0.0` version of the [construct-style-sheets-polyfill](https://github.com/calebdwilliams/construct-style-sheets) package is released as `latest` recently. This PR bumps the dependency version accordingly.