### PR TITLE
Do not copy transfer encoding from the webpack dev server

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerImpl.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerImpl.java
@@ -363,6 +363,9 @@ public final class DevModeHandlerImpl
         // Copies response headers
         connection.getHeaderFields().forEach((header, values) -> {
             if (header != null) {
+                if ("Transfer-Encoding".equals(header)) {
+                    return;
+                }
                 response.addHeader(header, values.get(0));
             }
         });


### PR DESCRIPTION
The transfer encoding used between Vaadin and the webpack dev server might be different than the encoding used between the user and Vaadin. The latter is determined by the server.

When the encoding is included, loading chunks in dev mode with webpack 5 fails with ERR_INVALID_CHUNKED_ENCODING