### PR TITLE
fix: stop sorting package.json keys

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -543,6 +543,18 @@ public class NodeTasks implements FallibleCommand {
         public File getGeneratedFolder() {
             return generatedFolder;
         }
+
+        /**
+         * Tells if the project is Fusion-based.
+         *
+         * @return isFusionProject
+         */
+        public boolean isFusionProject() {
+            return fusionJavaSourceFolder != null
+                    && fusionJavaSourceFolder.exists()
+                    && fusionGeneratedOpenAPIFile != null
+                    && fusionGeneratedOpenAPIFile.exists();
+        }
     }
 
     // @formatter:off
@@ -560,8 +572,8 @@ public class NodeTasks implements FallibleCommand {
             TaskGenerateFusion.class,
             TaskGenerateBootstrap.class,
             TaskInstallWebpackPlugins.class,
-            TaskUpdatePackages.class,
             TaskUseFusionPackage.class,
+            TaskUpdatePackages.class,
             TaskRunNpmInstall.class,
             TaskCopyFrontendFiles.class,
             TaskCopyLocalFrontendFiles.class,
@@ -634,9 +646,7 @@ public class NodeTasks implements FallibleCommand {
         if (!builder.useDeprecatedV14Bootstrapping) {
             addBootstrapTasks(builder);
 
-            if (builder.fusionJavaSourceFolder != null
-                    && builder.fusionJavaSourceFolder.exists()
-                    && builder.fusionGeneratedOpenAPIFile != null) {
+            if (builder.isFusionProject()) {
                 addFusionServicesTasks(builder);
             }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksTest.java
@@ -217,8 +217,10 @@ public class NodeTasksTest {
         List<Class<? extends FallibleCommand>> list = (List<Class<? extends FallibleCommand>>) commandOrder
                 .get(NodeTasks.class);
 
-        Assert.assertTrue("TaskUseFusionPackage should go before TaskUpdatePackages",
-                list.indexOf(TaskUseFusionPackage.class) < list.indexOf(TaskUpdatePackages.class));
+        Assert.assertTrue(
+                "TaskUseFusionPackage should go before TaskUpdatePackages",
+                list.indexOf(TaskUseFusionPackage.class) < list
+                        .indexOf(TaskUpdatePackages.class));
     }
 
     private static void setPropertyIfPresent(String key, String value) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTasksTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.AfterClass;
@@ -201,11 +202,23 @@ public class NodeTasksTest {
         Builder builder = new Builder(mockedLookup, new File(userDir), TARGET)
                 .enablePackagesUpdate(false).useV14Bootstrap(true)
                 .enableImportsUpdate(true).runNpmInstall(false)
-                .withEmbeddableWebComponents(false).useV14Bootstrap(false);
+                .withEmbeddableWebComponents(false);
         builder.build().execute();
 
         Assert.assertTrue(new File(userDir, "tsconfig.json").exists());
         Assert.assertTrue(new File(userDir, "types.d.ts").exists());
+    }
+
+    @Test
+    public void should_HaveTaskUseFusionPackageBeforeTaskUpdatePackages()
+            throws NoSuchFieldException, IllegalAccessException {
+        Field commandOrder = NodeTasks.class.getDeclaredField("commandOrder");
+        commandOrder.setAccessible(true);
+        List<Class<? extends FallibleCommand>> list = (List<Class<? extends FallibleCommand>>) commandOrder
+                .get(NodeTasks.class);
+
+        Assert.assertTrue("TaskUseFusionPackage should go before TaskUpdatePackages",
+                list.indexOf(TaskUseFusionPackage.class) < list.indexOf(TaskUpdatePackages.class));
     }
 
     private static void setPropertyIfPresent(String key, String value) {

--- a/fusion-endpoint/src/main/java/com/vaadin/fusion/frontend/TaskUseFusionPackageImpl.java
+++ b/fusion-endpoint/src/main/java/com/vaadin/fusion/frontend/TaskUseFusionPackageImpl.java
@@ -60,7 +60,7 @@ public class TaskUseFusionPackageImpl extends NodeUpdater
             getDependencies().forEach((key, value) -> addDependency(packageJson,
                     DEPENDENCIES, key, value));
 
-            writePackageFile(sort(packageJson));
+            writePackageFile(packageJson);
         } catch (IOException e) {
             throw new ExecutionFailedException("PackageJson update is failed",
                     e);
@@ -74,19 +74,5 @@ public class TaskUseFusionPackageImpl extends NodeUpdater
         dependencies.put("mobx", "^6.1.5");
 
         return dependencies;
-    }
-
-    private JsonObject sort(JsonObject object) {
-        String[] keys = object.keys();
-        Arrays.sort(keys);
-        JsonObject result = Json.createObject();
-        for (String key : keys) {
-            JsonValue value = object.get(key);
-            if (value instanceof JsonObject) {
-                value = sort((JsonObject) value);
-            }
-            result.put(key, value);
-        }
-        return result;
     }
 }

--- a/fusion-endpoint/src/test/java/com/vaadin/fusion/frontend/NodeTasksEndpointTest.java
+++ b/fusion-endpoint/src/test/java/com/vaadin/fusion/frontend/NodeTasksEndpointTest.java
@@ -10,6 +10,7 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.fusion.Endpoint;
@@ -99,5 +100,21 @@ public class NodeTasksEndpointTest {
 
         assertTrue(dependencies.hasKey("@adobe/lit-mobx"));
         assertTrue(dependencies.hasKey("mobx"));
+    }
+
+    @Test
+    public void should_NotSortPackageJson() throws Exception {
+        builder.createMissingPackageJson(true);
+
+        builder.build().execute();
+
+        File packageJson = new File(dir, "package.json");
+
+        JsonObject content = Json
+                .parse(FileUtils.readFileToString(packageJson, UTF_8));
+
+        List<String> keys = Arrays.asList(content.keys());
+        assertTrue("The 'name' key in package.json should come before the 'licence' key", keys.indexOf("name") < keys.indexOf("license"));
+        assertTrue("The 'name' key in package.json should come before the 'dependencies' key",keys.indexOf("name") < keys.indexOf("dependencies"));
     }
 }

--- a/fusion-endpoint/src/test/java/com/vaadin/fusion/frontend/NodeTasksEndpointTest.java
+++ b/fusion-endpoint/src/test/java/com/vaadin/fusion/frontend/NodeTasksEndpointTest.java
@@ -114,7 +114,11 @@ public class NodeTasksEndpointTest {
                 .parse(FileUtils.readFileToString(packageJson, UTF_8));
 
         List<String> keys = Arrays.asList(content.keys());
-        assertTrue("The 'name' key in package.json should come before the 'licence' key", keys.indexOf("name") < keys.indexOf("license"));
-        assertTrue("The 'name' key in package.json should come before the 'dependencies' key",keys.indexOf("name") < keys.indexOf("dependencies"));
+        assertTrue(
+                "The 'name' key in package.json should come before the 'licence' key",
+                keys.indexOf("name") < keys.indexOf("license"));
+        assertTrue(
+                "The 'name' key in package.json should come before the 'dependencies' key",
+                keys.indexOf("name") < keys.indexOf("dependencies"));
     }
 }


### PR DESCRIPTION
Fixes #11622

Also prevents adding Fusion-only packages to the `package.json` when Flow is used.