### PR TITLE
fix: Skip session unbound event when session deserialised as empty

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
@@ -169,10 +169,12 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
      */
     @Override
     public void valueUnbound(HttpSessionBindingEvent event) {
-        // If we are going to be unbound from the session, the session must be
-        // closing
-        // Notify the service
-        if (service == null) {
+        if (deserializedAsEmpty) {
+            // The session is being unbound from http session, but was
+            // deserialized previously without content, so return immediately
+            // without further handling of session unbound event.
+            return;
+        } else if (service == null) {
             getLogger().warn(
                     "A VaadinSession instance not associated to any service is getting unbound. "
                             + "Session destroy events will not be fired and UIs in the session will not get detached. "


### PR DESCRIPTION
## Description

If the session wasn't serialised, then its unbound event is skipped and not handled.

Fixes #11620

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
