### PR TITLE
chore: use correct line endings for Windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -304,6 +304,7 @@
                     <!-- Provide a dummy JS config file to avoid errors -->
                     <configJsFile>eclipse/VaadinJavaConventions.xml
                     </configJsFile>
+                    <lineEnding>LF</lineEnding>
                 </configuration>
                 <dependencies>
                     <dependency>


### PR DESCRIPTION
This PR forces `formatter` to use `LF` endings on Windows machine to avoid broken line endings each time the formatter runs.

#### NOTE
When I setup the repo, I have the following command run:
```
git config --global core.autocrlf input
```

Since it is a recommended settings, I guess it should be used on any Windows machine by default.