### PR TITLE
Organize dependency versions and update vulnerable jackson-databind version for fusion-endpoint

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -11,17 +11,6 @@
     <name>Flow Server</name>
     <packaging>jar</packaging>
 
-    <properties>
-        <validation.api.version>2.0.1.Final</validation.api.version>
-        <jackson.version>2.11.2</jackson.version>
-        <spring.version>5.2.0.RELEASE</spring.version>
-        <spring.autoconfigure.version>2.2.0.RELEASE</spring.autoconfigure.version>
-        <javax.annotation.api.version>1.3.2</javax.annotation.api.version>
-        <javaparser.version>3.15.1</javaparser.version>
-        <swagger.codegen.version>3.0.2</swagger.codegen.version>
-        <swagger.codegen.generators.version>1.0.2</swagger.codegen.generators.version>
-    </properties>
-
     <dependencies>
 
         <!-- Project dependencies -->

--- a/fusion-endpoint/pom.xml
+++ b/fusion-endpoint/pom.xml
@@ -103,6 +103,7 @@
             <artifactId>jackson-datatype-jsr310</artifactId>
             <version>${jackson.version}</version>
         </dependency>
+        
         <!-- Needed for security annotations -->
         <dependency>
             <groupId>javax.annotation</groupId>

--- a/fusion-endpoint/pom.xml
+++ b/fusion-endpoint/pom.xml
@@ -12,11 +12,8 @@
     <packaging>jar</packaging>
 
     <properties>
-        <validation.api.version>2.0.1.Final</validation.api.version>
-        <jackson.version>2.10.2</jackson.version>
         <spring.version>5.3.0</spring.version>
         <spring.autoconfigure.version>2.2.0.RELEASE</spring.autoconfigure.version>
-        <javax.annotation.api.version>1.3.2</javax.annotation.api.version>
         <javaparser.version>3.15.1</javaparser.version>
         <swagger.codegen.version>3.0.2</swagger.codegen.version>
         <swagger.codegen.generators.version>1.0.2</swagger.codegen.generators.version>

--- a/fusion-endpoint/src/test/java/com/vaadin/fusion/typeconversion/DateTimeConversionTest.java
+++ b/fusion-endpoint/src/test/java/com/vaadin/fusion/typeconversion/DateTimeConversionTest.java
@@ -23,7 +23,7 @@ public class DateTimeConversionTest extends BaseTypeConversionTest {
     @Test
     public void should_ConvertToDate_When_ReceiveATimeStampAsNumber() {
         String timeStamp = "1546300800000"; // 01-01-2019 00:00:00
-        String expectedValue = "\"2019-01-02T00:00:00.000+0000\"";
+        String expectedValue = "\"2019-01-02T00:00:00.000+00:00\"";
         assertEqualExpectedValueWhenCallingMethod("addOneDayToDate", timeStamp,
                 expectedValue);
     }
@@ -31,7 +31,7 @@ public class DateTimeConversionTest extends BaseTypeConversionTest {
     @Test
     public void should_ConvertToDate_When_ReceiveATimeStampAsString() {
         String timeStamp = "\"1546300800000\""; // 01-01-2019 00:00:00
-        String expected = "\"2019-01-02T00:00:00.000+0000\"";
+        String expected = "\"2019-01-02T00:00:00.000+00:00\"";
         assertEqualExpectedValueWhenCallingMethod("addOneDayToDate", timeStamp,
                 expected);
     }
@@ -39,7 +39,7 @@ public class DateTimeConversionTest extends BaseTypeConversionTest {
     @Test
     public void should_ConvertToDate_When_ReceiveADate() {
         String inputDate = "\"2019-01-01\"";
-        String expectedTimestamp = "\"2019-01-02T00:00:00.000+0000\"";
+        String expectedTimestamp = "\"2019-01-02T00:00:00.000+00:00\"";
         assertEqualExpectedValueWhenCallingMethod("addOneDayToDate", inputDate,
                 expectedTimestamp);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,9 @@
         <hibernate.validator.version>6.0.1.Final</hibernate.validator.version>
         <slf4j.version>1.7.32</slf4j.version>
         <polymer.version>2.6.1</polymer.version>
+        <jackson.version>2.11.2</jackson.version>
+        <validation.api.version>2.0.1.Final</validation.api.version>
+        <javax.annotation.api.version>1.3.2</javax.annotation.api.version>
 
         <!-- Plugins -->
         <driver.binary.downloader.maven.plugin.version>1.0.17


### PR DESCRIPTION
## Description

This fix rearranges version properties in `pom.xml` files: common versions are moved from `flow-server` and `fusion-endpoint` up to the root `pom.xml`; unused properties are cleared

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
