### PR TITLE
fix: bump webpack version in client package.json

### DIFF
--- a/flow-client/package.json
+++ b/flow-client/package.json
@@ -42,8 +42,8 @@
     "sinon": "7.5.0",
     "sinon-chai": "3.6.0",
     "typescript": "4.0.3",
-    "webpack": "4.39.1",
-    "webpack-cli": "3.3.6",
+    "webpack": "4.46.0",
+    "webpack-cli": "3.3.12",
     "workbox-core": "5.1.4",
     "workbox-precaching": "5.1.4",
     "xhr-mock": "2.5.0"


### PR DESCRIPTION
## Description

It turns out that esbuild-loader supports webpack 4.40.0 and later which is an issue with strict peer dependencies mechanism in Node 16.

Fixes #11668

## Type of change

- Bugfix