### PR TITLE
fix: Do not use Flow namespace for information not related to Flow

### DIFF
--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
@@ -85,10 +85,10 @@ const injectGlobalCssMethod = `
 export const injectGlobalCss = (css, target, first) => {
   if(target === document) {
     const hash = getHash(css);
-    if (window.Vaadin.Flow.injectedGlobalCss.indexOf(hash) !== -1) {
+    if (window.Vaadin.theme.injectedGlobalCss.indexOf(hash) !== -1) {
       return;
     }
-    window.Vaadin.Flow.injectedGlobalCss.push(hash);
+    window.Vaadin.theme.injectedGlobalCss.push(hash);
   }
   const sheet = new CSSStyleSheet();
   sheet.replaceSync(createLinkReferences(css,target));
@@ -260,8 +260,8 @@ function generateThemeFile(themeFolder, themeName, themeProperties, productionMo
   themeFile += imports.join('');
   themeFile += `
 window.Vaadin = window.Vaadin || {};
-window.Vaadin.Flow = window.Vaadin.Flow || {};
-window.Vaadin.Flow.injectedGlobalCss = [];
+window.Vaadin.theme = window.Vaadin.theme || {};
+window.Vaadin.theme.injectedGlobalCss = [];
 
 /**
  * Calculate a 32 bit FNV-1a hash

--- a/flow-tests/test-embedding/test-embedding-application-theme/src/test/java/com/vaadin/flow/webcomponent/ApplicationThemeComponentIT.java
+++ b/flow-tests/test-embedding/test-embedding-application-theme/src/test/java/com/vaadin/flow/webcomponent/ApplicationThemeComponentIT.java
@@ -233,6 +233,6 @@ public class ApplicationThemeComponentIT extends ChromeBrowserTest {
         Assert.assertEquals(
                 "Project contains 2 css injections to document and both should be hashed",
                 2l, getCommandExecutor().executeScript(
-                        "return window.Vaadin.Flow.injectedGlobalCss.length"));
+                        "return window.Vaadin.theme.injectedGlobalCss.length"));
     }
 }


### PR DESCRIPTION
Fixes #9905 again. It was re-introduced in #11669

