### PR TITLE
Revert "refactor(flow-server): bump construct-style-sheets-polyfill version (#11634)"

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -369,7 +369,7 @@ public abstract class NodeUpdater implements FallibleCommand {
 
         // Constructable style sheets is only implemented for chrome,
         // polyfill needed for FireFox et.al. at the moment
-        defaults.put("construct-style-sheets-polyfill", "3.0.0");
+        defaults.put("construct-style-sheets-polyfill", "2.4.16");
 
         return defaults;
     }


### PR DESCRIPTION
## Description

This reverts commit a345446cd524b1122c6d780eebcf084078878b05 because it breaks icon usage in Start in Safari, see https://github.com/vaadin/flow/pull/11634.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
