### PR TITLE
fixes #11730

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -735,7 +735,7 @@ public class FrontendTools {
         // install pnpm version < 6.0.0, later requires ensuring
         // NodeJS >= 12.17
         final String pnpmSpecifier = ignoreVersionChecks ? "pnpm"
-                : "pnpm@" + DEFAULT_PNPM_VERSION;
+                : "pnpm@" + DEFAULT_PNPM_VERSION + "+";
         List<String> pnpmCommand = Stream.of(pnpmSpecifier)
                 // do NOT modify the order of the --yes and --quiet flags, as it
                 // changes the behavior of npx


### PR DESCRIPTION
The command line used for checking pnpm version fails when only a newer version is available on the system. Adding a `+` after a required version number also checks for newer ones, which fixes issue #11730.

Fixes #11730 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

