### PR TITLE
fix: remove the sw referer filter when adding csrf token

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
@@ -195,8 +195,7 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
             JsonObject springCsrfTokenJson = JsonUtils
                     .beanToJson(springCsrfToken);
             if (springCsrfTokenJson != null
-                    && springCsrfTokenJson
-                            .hasKey(SPRING_CSRF_TOKEN_PROPERTY)
+                    && springCsrfTokenJson.hasKey(SPRING_CSRF_TOKEN_PROPERTY)
                     && springCsrfTokenJson
                             .hasKey(SPRING_CSRF_HEADER_PROPERTY)) {
                 String springCsrfTokenString = springCsrfTokenJson

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
@@ -185,40 +185,35 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
 
     private void addInitialFlow(JsonObject initialJson, Document indexDocument,
             VaadinSession session, VaadinRequest request) {
-        // Do not add the CSRF token if the request comes from the service
-        // worker, to not have the token cached locally (#9537)
-        String referer = request.getHeader("referer");
-        if (referer == null || !referer.endsWith("/sw.js")) {
-            String csrfToken = session.getCsrfToken();
-            if (csrfToken != null) {
-                initialJson.put(CSRF_TOKEN, csrfToken);
-            }
-            Object springCsrfToken = request
-                    .getAttribute(SPRING_CSRF_TOKEN_ATTRIBUTE_IN_SESSION);
-            if (springCsrfToken != null) {
-                JsonObject springCsrfTokenJson = JsonUtils
-                        .beanToJson(springCsrfToken);
-                if (springCsrfTokenJson != null
-                        && springCsrfTokenJson
-                                .hasKey(SPRING_CSRF_TOKEN_PROPERTY)
-                        && springCsrfTokenJson
-                                .hasKey(SPRING_CSRF_HEADER_PROPERTY)) {
-                    String springCsrfTokenString = springCsrfTokenJson
-                            .getString(SPRING_CSRF_TOKEN_PROPERTY);
-                    String springCsrfTokenHeaderName = springCsrfTokenJson
-                            .getString(SPRING_CSRF_HEADER_PROPERTY);
-                    String springCsrfTokenParameterName = springCsrfTokenJson
-                            .getString(SPRING_CSRF_PARAMETER_PROPERTY);
+        String csrfToken = session.getCsrfToken();
+        if (csrfToken != null) {
+            initialJson.put(CSRF_TOKEN, csrfToken);
+        }
+        Object springCsrfToken = request
+                .getAttribute(SPRING_CSRF_TOKEN_ATTRIBUTE_IN_SESSION);
+        if (springCsrfToken != null) {
+            JsonObject springCsrfTokenJson = JsonUtils
+                    .beanToJson(springCsrfToken);
+            if (springCsrfTokenJson != null
+                    && springCsrfTokenJson
+                            .hasKey(SPRING_CSRF_TOKEN_PROPERTY)
+                    && springCsrfTokenJson
+                            .hasKey(SPRING_CSRF_HEADER_PROPERTY)) {
+                String springCsrfTokenString = springCsrfTokenJson
+                        .getString(SPRING_CSRF_TOKEN_PROPERTY);
+                String springCsrfTokenHeaderName = springCsrfTokenJson
+                        .getString(SPRING_CSRF_HEADER_PROPERTY);
+                String springCsrfTokenParameterName = springCsrfTokenJson
+                        .getString(SPRING_CSRF_PARAMETER_PROPERTY);
 
-                    addMetaTagToHead(indexDocument.head(),
-                            SPRING_CSRF_TOKEN_ATTRIBUTE, springCsrfTokenString);
-                    addMetaTagToHead(indexDocument.head(),
-                            SPRING_CSRF_HEADER_NAME_ATTRIBUTE,
-                            springCsrfTokenHeaderName);
-                    addMetaTagToHead(indexDocument.head(),
-                            SPRING_CSRF_PARAMETER_NAME_ATTRIBUTE,
-                            springCsrfTokenParameterName);
-                }
+                addMetaTagToHead(indexDocument.head(),
+                        SPRING_CSRF_TOKEN_ATTRIBUTE, springCsrfTokenString);
+                addMetaTagToHead(indexDocument.head(),
+                        SPRING_CSRF_HEADER_NAME_ATTRIBUTE,
+                        springCsrfTokenHeaderName);
+                addMetaTagToHead(indexDocument.head(),
+                        SPRING_CSRF_PARAMETER_NAME_ATTRIBUTE,
+                        springCsrfTokenParameterName);
             }
         }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
@@ -46,7 +46,6 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.internal.JavaScriptBootstrapUI;
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.internal.DevModeHandlerManager;
-import com.vaadin.flow.internal.JsonUtils;
 import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.internal.DevModeHandler;
 import com.vaadin.flow.server.AppShellRegistry;
@@ -89,6 +88,10 @@ public class IndexHtmlRequestHandlerTest {
     @Rule
     public ExpectedException exceptionRule = ExpectedException.none();
 
+    private String springTokenString;
+    private String springTokenHeaderName = "x-CSRF-TOKEN";
+    private String springTokenParamName = SPRING_CSRF_ATTRIBUTE_IN_SESSION;
+
     @Before
     public void setUp() throws Exception {
         mocks = new MockServletServiceSessionSetup();
@@ -102,6 +105,7 @@ public class IndexHtmlRequestHandlerTest {
         deploymentConfiguration.useDeprecatedV14Bootstrapping(false);
         indexHtmlRequestHandler = new IndexHtmlRequestHandler();
         context = Mockito.mock(VaadinContext.class);
+        springTokenString = UUID.randomUUID().toString();
     }
 
     @Test
@@ -404,40 +408,11 @@ public class IndexHtmlRequestHandlerTest {
     @Test
     public void should_include_spring_csrf_token_in_meta_tags_when_return_not_null_spring_csrf_in_request()
             throws IOException {
-        VaadinRequest request = Mockito.spy(createVaadinRequest("/"));
-        String springTokenString = UUID.randomUUID().toString();
-        String springTokenHeaderName = "x-CSRF-TOKEN";
-        String springTokenParamName = SPRING_CSRF_ATTRIBUTE_IN_SESSION;
-        Map<String, String> csrfJsonMap = new HashMap<>();
-        csrfJsonMap.put("token", springTokenString);
-        csrfJsonMap.put("headerName", springTokenHeaderName);
-        csrfJsonMap.put("parameterName", springTokenParamName);
-        Mockito.when(request.getAttribute(SPRING_CSRF_ATTRIBUTE_IN_SESSION))
-                .thenReturn(csrfJsonMap);
+        VaadinRequest request = createVaadinRequestWithSpringCsrfToken();
         indexHtmlRequestHandler.synchronizedHandleRequest(session, request,
                 response);
 
-        String indexHtml = responseOutput
-                .toString(StandardCharsets.UTF_8.name());
-        Document document = Jsoup.parse(indexHtml);
-
-        Elements csrfMetaEelement = document.head()
-                .getElementsByAttributeValue("name", SPRING_CSRF_ATTRIBUTE);
-        Assert.assertEquals(1, csrfMetaEelement.size());
-        Assert.assertEquals(springTokenString,
-                csrfMetaEelement.first().attr("content"));
-
-        Elements csrfHeaderMetaElement = document.head()
-                .getElementsByAttributeValue("name", "_csrf_header");
-        Assert.assertEquals(1, csrfHeaderMetaElement.size());
-        Assert.assertEquals(springTokenHeaderName,
-                csrfHeaderMetaElement.first().attr("content"));
-
-        Elements csrfParameterMetaElement = document.head()
-                .getElementsByAttributeValue("name", "_csrf_parameter");
-        Assert.assertEquals(1, csrfParameterMetaElement.size());
-        Assert.assertEquals(springTokenParamName,
-                csrfParameterMetaElement.first().attr("content"));
+        assertSpringCsrfTokenIsAvailableAsMetaTagsInDom();
     }
 
     @Test
@@ -475,7 +450,7 @@ public class IndexHtmlRequestHandlerTest {
     }
 
     @Test
-    public void should_not_include_token_in_dom_when_referer_is_service_worker()
+    public void should_include_token_in_dom_when_referer_is_service_worker()
             throws IOException {
         Mockito.when(session.getCsrfToken()).thenReturn("foo");
         VaadinServletRequest vaadinRequest = createVaadinRequest("/");
@@ -486,34 +461,18 @@ public class IndexHtmlRequestHandlerTest {
                 vaadinRequest, response);
         String indexHtml = responseOutput
                 .toString(StandardCharsets.UTF_8.name());
-        Assert.assertFalse(indexHtml.contains("csrfToken"));
+        Assert.assertTrue(indexHtml.contains("csrfToken"));
     }
 
     @Test
-    public void should_not_include_spring_token_in_dom_when_referer_is_service_worker()
+    public void should_include_spring_token_in_dom_when_referer_is_service_worker()
             throws IOException {
-        VaadinRequest request = Mockito.spy(createVaadinRequest("/"));
-        String springTokenString = UUID.randomUUID().toString();
-        String springTokenHeaderName = "x-CSRF-TOKEN";
-        Map<String, String> csrfJsonMap = new HashMap<>();
-        csrfJsonMap.put("token", springTokenString);
-        csrfJsonMap.put("headerName", springTokenHeaderName);
-        Object springCsrfToken = JsonUtils.mapToJson(csrfJsonMap);
-        Mockito.when(request.getAttribute(SPRING_CSRF_ATTRIBUTE_IN_SESSION))
-                .thenReturn(springCsrfToken);
-        VaadinServletRequest vaadinRequest = createVaadinRequest("/");
-        Mockito.when(((HttpServletRequest) vaadinRequest.getRequest())
-                .getHeader("referer"))
+        VaadinRequest request = createVaadinRequestWithSpringCsrfToken();
+        Mockito.when(request.getHeader("referer"))
                 .thenReturn("http://somewhere.test/sw.js");
-        indexHtmlRequestHandler.synchronizedHandleRequest(session,
-                vaadinRequest, response);
-        String indexHtml = responseOutput
-                .toString(StandardCharsets.UTF_8.name());
-        Document document = Jsoup.parse(indexHtml);
-        Assert.assertEquals(0, document.head()
-                .getElementsByAttribute(SPRING_CSRF_ATTRIBUTE).size());
-        Assert.assertEquals(0,
-                document.head().getElementsByAttribute("_csrf_header").size());
+        indexHtmlRequestHandler.synchronizedHandleRequest(session, request,
+                response);
+        assertSpringCsrfTokenIsAvailableAsMetaTagsInDom();
     }
 
     @Test
@@ -819,6 +778,38 @@ public class IndexHtmlRequestHandlerTest {
         Assert.assertEquals("Invalid message reported",
                 "Invalid location: Relative path cannot contain .. segments",
                 response.getErrorMessage());
+    }
+
+    private VaadinRequest createVaadinRequestWithSpringCsrfToken() {
+        VaadinRequest request = Mockito.spy(createVaadinRequest("/"));
+        Map<String, String> csrfJsonMap = new HashMap<>();
+        csrfJsonMap.put("token", springTokenString);
+        csrfJsonMap.put("headerName", springTokenHeaderName);
+        csrfJsonMap.put("parameterName", springTokenParamName);
+        Mockito.when(request.getAttribute(SPRING_CSRF_ATTRIBUTE_IN_SESSION))
+                .thenReturn(csrfJsonMap);
+        return request;
+    }
+
+    private void assertSpringCsrfTokenIsAvailableAsMetaTagsInDom() {
+        try {
+            String indexHtml = responseOutput.toString(StandardCharsets.UTF_8.name());
+            Document document = Jsoup.parse(indexHtml);
+
+            Elements csrfMetaEelement = document.head().getElementsByAttributeValue("name", SPRING_CSRF_ATTRIBUTE);
+            Assert.assertEquals(1, csrfMetaEelement.size());
+            Assert.assertEquals(springTokenString, csrfMetaEelement.first().attr("content"));
+
+            Elements csrfHeaderMetaElement = document.head().getElementsByAttributeValue("name", "_csrf_header");
+            Assert.assertEquals(1, csrfHeaderMetaElement.size());
+            Assert.assertEquals(springTokenHeaderName, csrfHeaderMetaElement.first().attr("content"));
+
+            Elements csrfParameterMetaElement = document.head().getElementsByAttributeValue("name", "_csrf_parameter");
+            Assert.assertEquals(1, csrfParameterMetaElement.size());
+            Assert.assertEquals(springTokenParamName, csrfParameterMetaElement.first().attr("content"));
+        } catch (Exception e) {
+            Assert.fail("Unable to parse the index html page");
+        }
     }
 
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
@@ -793,20 +793,27 @@ public class IndexHtmlRequestHandlerTest {
 
     private void assertSpringCsrfTokenIsAvailableAsMetaTagsInDom() {
         try {
-            String indexHtml = responseOutput.toString(StandardCharsets.UTF_8.name());
+            String indexHtml = responseOutput
+                    .toString(StandardCharsets.UTF_8.name());
             Document document = Jsoup.parse(indexHtml);
 
-            Elements csrfMetaEelement = document.head().getElementsByAttributeValue("name", SPRING_CSRF_ATTRIBUTE);
+            Elements csrfMetaEelement = document.head()
+                    .getElementsByAttributeValue("name", SPRING_CSRF_ATTRIBUTE);
             Assert.assertEquals(1, csrfMetaEelement.size());
-            Assert.assertEquals(springTokenString, csrfMetaEelement.first().attr("content"));
+            Assert.assertEquals(springTokenString,
+                    csrfMetaEelement.first().attr("content"));
 
-            Elements csrfHeaderMetaElement = document.head().getElementsByAttributeValue("name", "_csrf_header");
+            Elements csrfHeaderMetaElement = document.head()
+                    .getElementsByAttributeValue("name", "_csrf_header");
             Assert.assertEquals(1, csrfHeaderMetaElement.size());
-            Assert.assertEquals(springTokenHeaderName, csrfHeaderMetaElement.first().attr("content"));
+            Assert.assertEquals(springTokenHeaderName,
+                    csrfHeaderMetaElement.first().attr("content"));
 
-            Elements csrfParameterMetaElement = document.head().getElementsByAttributeValue("name", "_csrf_parameter");
+            Elements csrfParameterMetaElement = document.head()
+                    .getElementsByAttributeValue("name", "_csrf_parameter");
             Assert.assertEquals(1, csrfParameterMetaElement.size());
-            Assert.assertEquals(springTokenParamName, csrfParameterMetaElement.first().attr("content"));
+            Assert.assertEquals(springTokenParamName,
+                    csrfParameterMetaElement.first().attr("content"));
         } catch (Exception e) {
             Assert.fail("Unable to parse the index html page");
         }


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

The service worker referer filter for adding `CSRF` token to the index HTML page causes a problem that Endpoint doesn't work for Safari on refresh, since Safari never gets a CSRF token as it fetches the index page through the service worker once it has been installed.

Fixes # (issue)
https://github.com/vaadin/fusion/issues/84

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
