### PR TITLE
chore(deps): Override vulnerable dependencies

### DIFF
--- a/fusion-endpoint/pom.xml
+++ b/fusion-endpoint/pom.xml
@@ -109,6 +109,20 @@
             <artifactId>jackson-datatype-jsr310</artifactId>
             <version>${jackson.version}</version>
         </dependency>
+
+        <!-- Override snakeyaml via jackson-dataformat-yaml in swagger-codegen -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <!-- Override slf4j-ext in swagger-codegen -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-ext</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
         
         <!-- Needed for security annotations -->
         <dependency>


### PR DESCRIPTION
This overrides the following transitive dependencies of `swagger-codegen` with known vulnerabilities:
1. `slf4j-ext` 1.24.0 -> 1.32.0
2. `snakeyaml` 1.25.0 -> 1.26.0 (via `jackson-dataformat-yaml`)

This will silence SCA complaining about CVE-2017-18640 and CVE-2018-8088