### PR TITLE
Revert "chore(deps): bump commons-fileupload from 1.3.3 to 1.4 (#11742)"

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.4</version>
+            <version>1.3.3</version>
             <!-- commons-fileupload:1.3.3 depends on commons-io:2.2, override 
                 it with Flow declaration -->
             <exclusions>


### PR DESCRIPTION
This reverts commit be77bbee86b94d343f8f028dac4902a8a737a50a.

## Description

This reverts version bump of `commons-fileupload` 1.3.3 -> 1.4

Fixes # (issue)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
