### PR TITLE
chore: Upgrade webpack-dev-server to 4.0.0+

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -384,7 +384,7 @@ public abstract class NodeUpdater implements FallibleCommand {
 
         defaults.put("webpack", "4.46.0");
         defaults.put("webpack-cli", "3.3.12");
-        defaults.put("webpack-dev-server", "4.10.0");
+        defaults.put("webpack-dev-server", "4.1.0");
         defaults.put("compression-webpack-plugin", "4.0.1");
         defaults.put("extra-watch-webpack-plugin", "1.0.3");
         defaults.put("webpack-merge", "4.2.2");

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -383,7 +383,7 @@ public abstract class NodeUpdater implements FallibleCommand {
         defaults.put("fork-ts-checker-webpack-plugin", "6.2.1");
 
         defaults.put("webpack", "4.46.0");
-        defaults.put("webpack-cli", "3.3.12");
+        defaults.put("webpack-cli", "4.8.0");
         defaults.put("webpack-dev-server", "4.1.1");
         defaults.put("compression-webpack-plugin", "4.0.1");
         defaults.put("extra-watch-webpack-plugin", "1.0.3");

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -384,7 +384,7 @@ public abstract class NodeUpdater implements FallibleCommand {
 
         defaults.put("webpack", "4.46.0");
         defaults.put("webpack-cli", "3.3.12");
-        defaults.put("webpack-dev-server", "3.11.0");
+        defaults.put("webpack-dev-server", "4.10.0");
         defaults.put("compression-webpack-plugin", "4.0.1");
         defaults.put("extra-watch-webpack-plugin", "1.0.3");
         defaults.put("webpack-merge", "4.2.2");

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -384,7 +384,7 @@ public abstract class NodeUpdater implements FallibleCommand {
 
         defaults.put("webpack", "4.46.0");
         defaults.put("webpack-cli", "3.3.12");
-        defaults.put("webpack-dev-server", "4.1.0");
+        defaults.put("webpack-dev-server", "4.1.1");
         defaults.put("compression-webpack-plugin", "4.0.1");
         defaults.put("extra-watch-webpack-plugin", "1.0.3");
         defaults.put("webpack-merge", "4.2.2");

--- a/flow-server/src/main/resources/plugins/build-status-plugin/build-status-plugin.js
+++ b/flow-server/src/main/resources/plugins/build-status-plugin/build-status-plugin.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2000-2020 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * This plugin handles communicates to Java dev-mode handler status of compilation
+ */
+class BuildStatusPlugin {
+
+  constructor(options = {}) {
+    this.options = options;
+  }
+
+  apply(compiler) {
+    const logger = compiler.getInfrastructureLogger("build-status");
+
+    compiler.hooks.done.tap("done", (stats) => {
+      // Defer notification and let the webpack-dev-server finish
+      setTimeout(() => {
+        const errors = stats.compilation.errors;
+        const warnings = stats.compilation.warnings;
+        if (errors.length > 0) {
+          logger.info(`${humanReadable(errors.length, "error")} and ${humanReadable(warnings.length, "warning")} were reported.`);
+          logger.info(": Failed to compile.")
+        } else {
+          if (warnings.length > 0) {
+            logger.info(`${humanReadable(warnings.length, "warning")} were reported.`);
+          }
+          logger.info(": Compiled.");
+        }
+      }, 0);
+    });
+  }
+}
+
+function humanReadable(count, label) {
+  if (count % 10 == 1) {
+    return `${count} ${label}`;
+  } else {
+    return `${count} ${label}s`;
+  }
+}
+
+module.exports = BuildStatusPlugin;

--- a/flow-server/src/main/resources/plugins/build-status-plugin/build-status-plugin.js
+++ b/flow-server/src/main/resources/plugins/build-status-plugin/build-status-plugin.js
@@ -33,7 +33,7 @@ class BuildStatusPlugin {
         const warnings = stats.compilation.warnings;
         if (errors.length > 0) {
           logger.info(`${humanReadable(errors.length, "error")} and ${humanReadable(warnings.length, "warning")} were reported.`);
-          logger.info(": Failed to compile.")
+          logger.info(": Failed to compile.");
         } else {
           if (warnings.length > 0) {
             logger.info(`${humanReadable(warnings.length, "warning")} were reported.`);

--- a/flow-server/src/main/resources/plugins/build-status-plugin/package.json
+++ b/flow-server/src/main/resources/plugins/build-status-plugin/package.json
@@ -1,0 +1,18 @@
+{
+  "description": "build-status-plugin",
+  "keywords": [
+    "plugin"
+  ],
+  "repository": "vaadin/flow",
+  "name": "@vaadin/build-status-plugin",
+  "version": "1.0.0",
+  "main": "build-status-plugin.js",
+  "author": "Vaadin Ltd",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/vaadin/flow/issues"
+  },
+  "files": [
+    "build-status-plugin.js"
+  ]
+}

--- a/flow-server/src/main/resources/plugins/webpack-plugins.json
+++ b/flow-server/src/main/resources/plugins/webpack-plugins.json
@@ -1,6 +1,7 @@
 {
   "plugins": [
     "stats-plugin",
+    "build-status-plugin",
     "application-theme-plugin",
     "theme-loader",
     "theme-live-reload-plugin"

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -233,8 +233,9 @@ module.exports = {
   },
 
   devServer: {
+    hot: false,
     // webpack-dev-server serves ./ ,  webpack-generated,  and java webapp
-    static: [outputFolder, 'src/main/webapp'],
+    static: [ outputFolder, path.resolve(__dirname, 'src', 'main', 'webapp') ],
     onAfterSetupMiddleware: function(devServer) {
       devServer.app.get(`/stats.json`, function(req, res) {
         res.json(stats);

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -15,6 +15,7 @@ const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 
 // Flow plugins
 const StatsPlugin = require('@vaadin/stats-plugin');
+const BuildStatusPlugin = require('@vaadin/build-status-plugin');
 const ThemeLiveReloadPlugin = require('@vaadin/theme-live-reload-plugin');
 const { ApplicationThemePlugin, processThemeResources, extractThemeName, findParentThemes } = require('@vaadin/application-theme-plugin');
 
@@ -74,6 +75,7 @@ const enableTypeScript = fs.existsSync(tsconfigJsonFile);
 // Target flow-fronted auto generated to be the actual target folder
 const flowFrontendFolder = '[to-be-generated-by-flow]';
 
+const statsSetViaCLI = process.argv.find(v => v.indexOf('--stats') >= 0);
 const devMode = process.argv.find(v => v.indexOf('webpack-dev-server') >= 0);
 if (!devMode) {
   // make sure that build folder exists before outputting anything
@@ -232,8 +234,11 @@ module.exports = {
     }
   },
 
+  stats: devMode && !statsSetViaCLI ? 'errors-warnings' : 'normal', // Unclutter output in dev mode
+
   devServer: {
-    hot: false,
+    hot: false,     // disable HMR
+    client: false,  // disable wds client as we handle reloads and errors better
     // webpack-dev-server serves ./ ,  webpack-generated,  and java webapp
     static: [ outputFolder, path.resolve(__dirname, 'src', 'main', 'webapp') ],
     onAfterSetupMiddleware: function(devServer) {
@@ -363,5 +368,7 @@ module.exports = {
         configFile: tsconfigJsonFile
       }
     }),
+
+    new BuildStatusPlugin()
   ].filter(Boolean)
 };

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -234,18 +234,18 @@ module.exports = {
 
   devServer: {
     // webpack-dev-server serves ./ ,  webpack-generated,  and java webapp
-    contentBase: [outputFolder, 'src/main/webapp'],
-    after: function(app, server) {
-      app.get(`/stats.json`, function(req, res) {
+    static: [outputFolder, 'src/main/webapp'],
+    onAfterSetupMiddleware: function(devServer) {
+      devServer.app.get(`/stats.json`, function(req, res) {
         res.json(stats);
       });
-      app.get(`/stats.hash`, function(req, res) {
+      devServer.app.get(`/stats.hash`, function(req, res) {
         res.json(stats.hash.toString());
       });
-      app.get(`/assetsByChunkName`, function(req, res) {
+      devServer.app.get(`/assetsByChunkName`, function(req, res) {
         res.json(stats.assetsByChunkName);
       });
-      app.get(`/stop`, function(req, res) {
+      devServer.app.get(`/stop`, function(req, res) {
         // eslint-disable-next-line no-console
         console.log("Stopped 'webpack-dev-server'");
         process.exit(0);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskInstallWebpackPluginsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskInstallWebpackPluginsTest.java
@@ -65,7 +65,7 @@ public class TaskInstallWebpackPluginsTest {
     public void getPluginsReturnsExpectedList() {
         String[] expectedPlugins = new String[] { "stats-plugin",
                 "application-theme-plugin", "theme-loader",
-                "theme-live-reload-plugin" };
+                "theme-live-reload-plugin", "build-status-plugin" };
         final List<String> plugins = WebpackPluginsUtil.getPlugins();
         Assert.assertEquals(
                 "Unexpected amount of plugins in 'webpack-plugins.json'",

--- a/flow-tests/test-mixed/pom.xml
+++ b/flow-tests/test-mixed/pom.xml
@@ -72,7 +72,7 @@
                             <!-- this avoids an issue in chrome not loading
                                 the components randomly when webpack dev server is not in debug mode -->
                             <name>vaadin.devmode.webpack.options</name>
-                            <value>--debug</value>
+                            <value>--mode=development</value>
                         </systemProperty>
                         <systemProperty>
                             <!-- make sure we do not leave webpack-dev-server

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerImpl.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerImpl.java
@@ -752,7 +752,7 @@ public final class DevModeHandlerImpl
         command.add("watchDogPort=" + watchDog.get().getWatchDogPort());
         command.addAll(Arrays.asList(config
                 .getStringProperty(SERVLET_PARAMETER_DEVMODE_WEBPACK_OPTIONS,
-                        "--devtool=eval")
+                        "--devtool=eval-source-map")
                 .split(" +")));
         return command;
     }

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerImpl.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerImpl.java
@@ -469,11 +469,15 @@ public final class DevModeHandlerImpl
         // remove color escape codes for console
         String cleanLine = line.replaceAll("(\u001b\\[[;\\d]*m|[\b\r]+)", "");
 
-        // save output so as it can be used to alert user in browser.
-        cumulativeOutput.append(cleanLine);
-
         boolean succeed = success.matcher(line).find();
         boolean failed = failure.matcher(line).find();
+
+        // save output so as it can be used to alert user in browser, unless
+        // it's `: Failed to compile.`
+        if (!failed) {
+            cumulativeOutput.append(cleanLine);
+        }
+
         // We found the success or failure pattern in stream
         if (succeed || failed) {
             if (succeed) {
@@ -742,11 +746,13 @@ public final class DevModeHandlerImpl
         command.add(webpackConfig.getAbsolutePath());
         command.add("--port");
         command.add(String.valueOf(port));
+        command.add("--watch-options-stdin"); // Tell wds to stop even if
+                                              // watchDog fail
         command.add("--env");
         command.add("watchDogPort=" + watchDog.get().getWatchDogPort());
         command.addAll(Arrays.asList(config
                 .getStringProperty(SERVLET_PARAMETER_DEVMODE_WEBPACK_OPTIONS,
-                        "-d eval")
+                        "--devtool=eval")
                 .split(" +")));
         return command;
     }

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerImpl.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerImpl.java
@@ -746,7 +746,7 @@ public final class DevModeHandlerImpl
         command.add("watchDogPort=" + watchDog.get().getWatchDogPort());
         command.addAll(Arrays.asList(config
                 .getStringProperty(SERVLET_PARAMETER_DEVMODE_WEBPACK_OPTIONS,
-                        "-d --inline=false")
+                        "-d eval")
                 .split(" +")));
         return command;
     }


### PR DESCRIPTION
## Description

Flow/Fusion currently uses webpack-dev-server 3.11.0, which depends on chokidar 2.x. According to sources, chokidar 2.x breaks/doesn't work properly on node 14+. Besides, this version of chokidar brings glob-parent with known vulnerability (https://nvd.nist.gov/vuln/detail/CVE-2020-28469), which is getting reported by Software Composition Analysis tools.
Fixes #11762

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
