### PR TITLE
chore!: deprecate methods in AppShellSettings that require UI

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/AppShellSettings.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AppShellSettings.java
@@ -414,10 +414,11 @@ public class AppShellSettings {
      * @return An optional instance used for configuring the loading indicator
      *         or an empty optional if UI is not available.
      * 
-     * @Deprecated It only works when useDeprecatedV14Bootstrapping is enabled.
+     * @deprecated It only works when useDeprecatedV14Bootstrapping is enabled.
      *             Use a {@link UIInitListener} instead when there are
      *             server-side views.
      */
+    @Deprecated
     public Optional<LoadingIndicatorConfiguration> getLoadingIndicatorConfiguration() {
         return getUi().map(UI::getLoadingIndicatorConfiguration);
     }
@@ -428,10 +429,11 @@ public class AppShellSettings {
      * @return An optional instance used for reconnect dialog configuration or
      *         an empty optional if UI is not available.
      * 
-     * @Deprecated It only works when useDeprecatedV14Bootstrapping is enabled.
+     * @deprecated It only works when useDeprecatedV14Bootstrapping is enabled.
      *             Use a {@link UIInitListener} instead when there are
      *             server-side views.
      */
+    @Deprecated
     public Optional<ReconnectDialogConfiguration> getReconnectDialogConfiguration() {
         return getUi().map(UI::getReconnectDialogConfiguration);
     }
@@ -442,10 +444,11 @@ public class AppShellSettings {
      * @return An optional instance used for push channel configuration or an
      *         empty optional if UI is not available.
      * 
-     * @Deprecated It only works when useDeprecatedV14Bootstrapping is enabled.
+     * @deprecated It only works when useDeprecatedV14Bootstrapping is enabled.
      *             Use a {@link UIInitListener} instead when there are
      *             server-side views.
      */
+    @Deprecated
     public Optional<PushConfiguration> getPushConfiguration() {
         return getUi().map(UI::getPushConfiguration);
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/AppShellSettings.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AppShellSettings.java
@@ -411,7 +411,12 @@ public class AppShellSettings {
     /**
      * Returns the configuration object for loading indicator.
      *
-     * @return the instance used for configuring the loading indicator
+     * @return An optional instance used for configuring the loading 
+     * indicator or an empty optional if UI is not avaialbe.
+     * 
+     * @Deprecated It only works when useDeprecatedV14Bootstrapping 
+     * is enabled. Use a {@link UIInitListener} instead when
+     * there are server-side views.
      */
     public Optional<LoadingIndicatorConfiguration> getLoadingIndicatorConfiguration() {
         return getUi().map(UI::getLoadingIndicatorConfiguration);
@@ -420,7 +425,12 @@ public class AppShellSettings {
     /**
      * Returns the configuration object for reconnect dialog.
      *
-     * @return The instance used for reconnect dialog configuration
+     * @return An optional instance used for reconnect dialog configuration or
+     * an empty optional if UI is not avaialbe.
+     * 
+     * @Deprecated It only works when useDeprecatedV14Bootstrapping 
+     * is enabled. Use a {@link UIInitListener} instead when
+     * there are server-side views.
      */
     public Optional<ReconnectDialogConfiguration> getReconnectDialogConfiguration() {
         return getUi().map(UI::getReconnectDialogConfiguration);
@@ -429,7 +439,12 @@ public class AppShellSettings {
     /**
      * Returns the object used for configuring the push channel.
      *
-     * @return the instance used for push channel configuration
+     * @return An optional instance used for push channel configuration or 
+     * an empty optional if UI is not avaialbe.
+     * 
+     * @Deprecated It only works when useDeprecatedV14Bootstrapping 
+     * is enabled. Use a {@link UIInitListener} instead when
+     * there are server-side views.
      */
     public Optional<PushConfiguration> getPushConfiguration() {
         return getUi().map(UI::getPushConfiguration);

--- a/flow-server/src/main/java/com/vaadin/flow/server/AppShellSettings.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AppShellSettings.java
@@ -48,6 +48,10 @@ import com.vaadin.flow.component.page.Viewport;
  */
 public class AppShellSettings {
 
+    private static final String MSG_UNSUPPORTED_NO_UI = "It only works when "
+            + "useDeprecatedV14Bootstrapping is enabled. "
+            + "Use a UIInitListener instead if there are server-side views.";
+
     /**
      * A class representing an InlineElement.
      */
@@ -427,9 +431,7 @@ public class AppShellSettings {
         if (getUi().isPresent()) {
             return getUi().map(UI::getLoadingIndicatorConfiguration);
         } else {
-            throw new UnsupportedOperationException(
-                    "It only works when useDeprecatedV14Bootstrapping is enabled. "
-                            + "Use a UIInitListener instead if there are server-side views.");
+            throw new UnsupportedOperationException(MSG_UNSUPPORTED_NO_UI);
         }
     }
 
@@ -452,9 +454,7 @@ public class AppShellSettings {
         if (getUi().isPresent()) {
             return getUi().map(UI::getReconnectDialogConfiguration);
         } else {
-            throw new UnsupportedOperationException(
-                    "It only works when useDeprecatedV14Bootstrapping is enabled. "
-                            + "Use a UIInitListener instead if there are server-side views.");
+            throw new UnsupportedOperationException(MSG_UNSUPPORTED_NO_UI);
         }
     }
 
@@ -477,9 +477,7 @@ public class AppShellSettings {
         if (getUi().isPresent()) {
             return getUi().map(UI::getPushConfiguration);
         } else {
-            throw new UnsupportedOperationException(
-                    "It only works when useDeprecatedV14Bootstrapping is enabled. "
-                            + "Use a UIInitListener instead if there are server-side views.");
+            throw new UnsupportedOperationException(MSG_UNSUPPORTED_NO_UI);
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/AppShellSettings.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AppShellSettings.java
@@ -411,12 +411,12 @@ public class AppShellSettings {
     /**
      * Returns the configuration object for loading indicator.
      *
-     * @return An optional instance used for configuring the loading 
-     * indicator or an empty optional if UI is not available.
+     * @return An optional instance used for configuring the loading indicator
+     *         or an empty optional if UI is not available.
      * 
-     * @Deprecated It only works when useDeprecatedV14Bootstrapping 
-     * is enabled. Use a {@link UIInitListener} instead when
-     * there are server-side views.
+     * @Deprecated It only works when useDeprecatedV14Bootstrapping is enabled.
+     *             Use a {@link UIInitListener} instead when there are
+     *             server-side views.
      */
     public Optional<LoadingIndicatorConfiguration> getLoadingIndicatorConfiguration() {
         return getUi().map(UI::getLoadingIndicatorConfiguration);
@@ -426,11 +426,11 @@ public class AppShellSettings {
      * Returns the configuration object for reconnect dialog.
      *
      * @return An optional instance used for reconnect dialog configuration or
-     * an empty optional if UI is not available.
+     *         an empty optional if UI is not available.
      * 
-     * @Deprecated It only works when useDeprecatedV14Bootstrapping 
-     * is enabled. Use a {@link UIInitListener} instead when
-     * there are server-side views.
+     * @Deprecated It only works when useDeprecatedV14Bootstrapping is enabled.
+     *             Use a {@link UIInitListener} instead when there are
+     *             server-side views.
      */
     public Optional<ReconnectDialogConfiguration> getReconnectDialogConfiguration() {
         return getUi().map(UI::getReconnectDialogConfiguration);
@@ -439,12 +439,12 @@ public class AppShellSettings {
     /**
      * Returns the object used for configuring the push channel.
      *
-     * @return An optional instance used for push channel configuration or 
-     * an empty optional if UI is not available.
+     * @return An optional instance used for push channel configuration or an
+     *         empty optional if UI is not available.
      * 
-     * @Deprecated It only works when useDeprecatedV14Bootstrapping 
-     * is enabled. Use a {@link UIInitListener} instead when
-     * there are server-side views.
+     * @Deprecated It only works when useDeprecatedV14Bootstrapping is enabled.
+     *             Use a {@link UIInitListener} instead when there are
+     *             server-side views.
      */
     public Optional<PushConfiguration> getPushConfiguration() {
         return getUi().map(UI::getPushConfiguration);

--- a/flow-server/src/main/java/com/vaadin/flow/server/AppShellSettings.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AppShellSettings.java
@@ -412,7 +412,7 @@ public class AppShellSettings {
      * Returns the configuration object for loading indicator.
      *
      * @return An optional instance used for configuring the loading 
-     * indicator or an empty optional if UI is not avaialbe.
+     * indicator or an empty optional if UI is not available.
      * 
      * @Deprecated It only works when useDeprecatedV14Bootstrapping 
      * is enabled. Use a {@link UIInitListener} instead when
@@ -426,7 +426,7 @@ public class AppShellSettings {
      * Returns the configuration object for reconnect dialog.
      *
      * @return An optional instance used for reconnect dialog configuration or
-     * an empty optional if UI is not avaialbe.
+     * an empty optional if UI is not available.
      * 
      * @Deprecated It only works when useDeprecatedV14Bootstrapping 
      * is enabled. Use a {@link UIInitListener} instead when
@@ -440,7 +440,7 @@ public class AppShellSettings {
      * Returns the object used for configuring the push channel.
      *
      * @return An optional instance used for push channel configuration or 
-     * an empty optional if UI is not avaialbe.
+     * an empty optional if UI is not available.
      * 
      * @Deprecated It only works when useDeprecatedV14Bootstrapping 
      * is enabled. Use a {@link UIInitListener} instead when

--- a/flow-server/src/main/java/com/vaadin/flow/server/AppShellSettings.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AppShellSettings.java
@@ -414,13 +414,23 @@ public class AppShellSettings {
      * @return An optional instance used for configuring the loading indicator
      *         or an empty optional if UI is not available.
      * 
+     * @throws UnsupportedOperationException
+     *             If UI is not avaialble, for example, when using client-side
+     *             bootstrapping
+     * 
      * @deprecated It only works when useDeprecatedV14Bootstrapping is enabled.
-     *             Use a {@link UIInitListener} instead when there are
-     *             server-side views.
+     *             Use a {@link UIInitListener} instead if there are server-side
+     *             views.
      */
     @Deprecated
     public Optional<LoadingIndicatorConfiguration> getLoadingIndicatorConfiguration() {
-        return getUi().map(UI::getLoadingIndicatorConfiguration);
+        if (getUi().isPresent()) {
+            return getUi().map(UI::getLoadingIndicatorConfiguration);
+        } else {
+            throw new UnsupportedOperationException(
+                    "It only works when useDeprecatedV14Bootstrapping is enabled. "
+                            + "Use a UIInitListener instead if there are server-side views.");
+        }
     }
 
     /**
@@ -429,13 +439,23 @@ public class AppShellSettings {
      * @return An optional instance used for reconnect dialog configuration or
      *         an empty optional if UI is not available.
      * 
+     * @throws UnsupportedOperationException
+     *             If UI is not avaialble, for example, when using the
+     *             client-side bootstrapping
+     * 
      * @deprecated It only works when useDeprecatedV14Bootstrapping is enabled.
-     *             Use a {@link UIInitListener} instead when there are
-     *             server-side views.
+     *             Use a {@link UIInitListener} instead if there are server-side
+     *             views.
      */
     @Deprecated
     public Optional<ReconnectDialogConfiguration> getReconnectDialogConfiguration() {
-        return getUi().map(UI::getReconnectDialogConfiguration);
+        if (getUi().isPresent()) {
+            return getUi().map(UI::getReconnectDialogConfiguration);
+        } else {
+            throw new UnsupportedOperationException(
+                    "It only works when useDeprecatedV14Bootstrapping is enabled. "
+                            + "Use a UIInitListener instead if there are server-side views.");
+        }
     }
 
     /**
@@ -444,13 +464,23 @@ public class AppShellSettings {
      * @return An optional instance used for push channel configuration or an
      *         empty optional if UI is not available.
      * 
+     * @throws UnsupportedOperationException
+     *             If UI is not avaialble, for example, when using the
+     *             client-side bootstrapping
+     * 
      * @deprecated It only works when useDeprecatedV14Bootstrapping is enabled.
-     *             Use a {@link UIInitListener} instead when there are
-     *             server-side views.
+     *             Use a {@link UIInitListener} instead if there are server-side
+     *             views.
      */
     @Deprecated
     public Optional<PushConfiguration> getPushConfiguration() {
-        return getUi().map(UI::getPushConfiguration);
+        if (getUi().isPresent()) {
+            return getUi().map(UI::getPushConfiguration);
+        } else {
+            throw new UnsupportedOperationException(
+                    "It only works when useDeprecatedV14Bootstrapping is enabled. "
+                            + "Use a UIInitListener instead if there are server-side views.");
+        }
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
@@ -60,6 +60,9 @@ import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.startup.ApplicationConfiguration;
 import com.vaadin.flow.server.startup.VaadinAppShellInitializerTest.AppShellWithPWA;
 import com.vaadin.flow.server.startup.VaadinAppShellInitializerTest.MyAppShellWithConfigurator;
+import com.vaadin.flow.server.startup.VaadinAppShellInitializerTest.MyAppShellWithLoadingIndicatorConfig;
+import com.vaadin.flow.server.startup.VaadinAppShellInitializerTest.MyAppShellWithPushConfig;
+import com.vaadin.flow.server.startup.VaadinAppShellInitializerTest.MyAppShellWithReconnectionDialogConfig;
 import com.vaadin.flow.server.startup.VaadinInitializerException;
 import com.vaadin.tests.util.MockDeploymentConfiguration;
 
@@ -676,6 +679,42 @@ public class IndexHtmlRequestHandlerTest {
                 createVaadinRequest("/"), response);
         assertEquals("Flow Test CCDM",
                 UI.getCurrent().getInternals().getAppShellTitle());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void should_throwUnSupportedException_when_usingAppShellToConfigureLoadingIndicator()
+            throws Exception {
+        // Set class in context and do not call initializer
+        AppShellRegistry registry = AppShellRegistry.getInstance(context);
+        registry.setShell(MyAppShellWithLoadingIndicatorConfig.class);
+        mocks.setAppShellRegistry(registry);
+
+        indexHtmlRequestHandler.synchronizedHandleRequest(session,
+                createVaadinRequest("/"), response);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void should_throwUnSupportedException_when_usingAppShellToConfigureReconnectionDialog()
+            throws Exception {
+        // Set class in context and do not call initializer
+        AppShellRegistry registry = AppShellRegistry.getInstance(context);
+        registry.setShell(MyAppShellWithReconnectionDialogConfig.class);
+        mocks.setAppShellRegistry(registry);
+
+        indexHtmlRequestHandler.synchronizedHandleRequest(session,
+                createVaadinRequest("/"), response);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void should_throwUnSupportedException_when_usingAppShellToConfigurePushMode()
+            throws Exception {
+        // Set class in context and do not call initializer
+        AppShellRegistry registry = AppShellRegistry.getInstance(context);
+        registry.setShell(MyAppShellWithPushConfig.class);
+        mocks.setAppShellRegistry(registry);
+
+        indexHtmlRequestHandler.synchronizedHandleRequest(session,
+                createVaadinRequest("/"), response);
     }
 
     @After

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/VaadinAppShellInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/VaadinAppShellInitializerTest.java
@@ -183,6 +183,33 @@ public class VaadinAppShellInitializerTest {
     public static class AppShellWithPWA implements AppShellConfigurator {
     }
 
+    public static class MyAppShellWithLoadingIndicatorConfig
+            implements AppShellConfigurator {
+        @Override
+        public void configurePage(AppShellSettings settings) {
+             settings.getLoadingIndicatorConfiguration().ifPresent(
+                    indicator -> indicator.setApplyDefaultTheme(false));
+        }
+    }
+
+    public static class MyAppShellWithReconnectionDialogConfig
+            implements AppShellConfigurator {
+        @Override
+        public void configurePage(AppShellSettings settings) {
+             settings.getReconnectDialogConfiguration().ifPresent(
+                    dialog -> dialog.setDialogText("custom text"));
+        }
+    }
+
+    public static class MyAppShellWithPushConfig
+            implements AppShellConfigurator {
+        @Override
+        public void configurePage(AppShellSettings settings) {
+             settings.getPushConfiguration().ifPresent(
+                    push -> push.setPushMode(PushMode.MANUAL));
+        }
+    }
+
     @Rule
     public ExpectedException exception = ExpectedException.none();
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/VaadinAppShellInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/VaadinAppShellInitializerTest.java
@@ -187,7 +187,7 @@ public class VaadinAppShellInitializerTest {
             implements AppShellConfigurator {
         @Override
         public void configurePage(AppShellSettings settings) {
-             settings.getLoadingIndicatorConfiguration().ifPresent(
+            settings.getLoadingIndicatorConfiguration().ifPresent(
                     indicator -> indicator.setApplyDefaultTheme(false));
         }
     }
@@ -196,8 +196,8 @@ public class VaadinAppShellInitializerTest {
             implements AppShellConfigurator {
         @Override
         public void configurePage(AppShellSettings settings) {
-             settings.getReconnectDialogConfiguration().ifPresent(
-                    dialog -> dialog.setDialogText("custom text"));
+            settings.getReconnectDialogConfiguration()
+                    .ifPresent(dialog -> dialog.setDialogText("custom text"));
         }
     }
 
@@ -205,8 +205,8 @@ public class VaadinAppShellInitializerTest {
             implements AppShellConfigurator {
         @Override
         public void configurePage(AppShellSettings settings) {
-             settings.getPushConfiguration().ifPresent(
-                    push -> push.setPushMode(PushMode.MANUAL));
+            settings.getPushConfiguration()
+                    .ifPresent(push -> push.setPushMode(PushMode.MANUAL));
         }
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/VaadinAppShellInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/VaadinAppShellInitializerTest.java
@@ -158,13 +158,6 @@ public class VaadinAppShellInitializerTest {
 
             settings.addFavIcon("icon", "icons/icon-192.png", "192x192");
             settings.addFavIcon("icon", "icons/icon-200.png", "2");
-
-            settings.getLoadingIndicatorConfiguration().ifPresent(
-                    indicator -> indicator.setApplyDefaultTheme(false));
-            settings.getLoadingIndicatorConfiguration()
-                    .ifPresent(indicator -> indicator.setSecondDelay(700000));
-            settings.getPushConfiguration()
-                    .ifPresent(push -> push.setPushMode(PushMode.AUTOMATIC));
         }
     }
 


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

There are some methods on `AppShellSettings` that only work with legacy bootstrapping, marked those as deprecated, and throw unsupported exceptions to not confuse users.

Fixes https://github.com/vaadin/fusion/issues/60

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
