### PR TITLE
test: Fix expectation on windows

### DIFF
--- a/flow-tests/test-dev-mode/src/test/java/com/vaadin/flow/uitest/ui/ClientSideExceptionHandlingIT.java
+++ b/flow-tests/test-dev-mode/src/test/java/com/vaadin/flow/uitest/ui/ClientSideExceptionHandlingIT.java
@@ -21,12 +21,15 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
 
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 
 public class ClientSideExceptionHandlingIT extends ChromeBrowserTest {
 
     private static final By ERROR_LOCATOR = By.className("v-system-error");
+    public static final String UNIX_PATTERN = ".*TypeError.* property 'foo' of.*null.*";
+    public static final String WINDOWS_PATTERN = ".*TypeError.* : Cannot read properties of null .*reading 'foo'.*";
 
     @Test
     public void developmentModeExceptions() {
@@ -35,9 +38,14 @@ public class ClientSideExceptionHandlingIT extends ChromeBrowserTest {
 
         String errorMessage = findElement(ERROR_LOCATOR).getText();
 
+        // Windows formats the error differently from unix
+        final boolean isWindows = (boolean) ((JavascriptExecutor) getDriver())
+                .executeScript(
+                        "return navigator.appVersion.indexOf(\"Win\")!=-1");
+        String testPattern = isWindows ? WINDOWS_PATTERN : UNIX_PATTERN;
+
         Assert.assertTrue("Unexpected error message: " + errorMessage,
-                Pattern.matches(".*TypeError.* property 'foo' of.*null.*",
-                        errorMessage));
+                Pattern.matches(testPattern, errorMessage));
     }
 
     @Test


### PR DESCRIPTION
Windows receives a different error string
so we need to check the target os when
running the test.

Fixes #11777
