### PR TITLE
chore: Update exception pattern

### DIFF
--- a/flow-tests/test-dev-mode/src/test/java/com/vaadin/flow/uitest/ui/ClientSideExceptionHandlingIT.java
+++ b/flow-tests/test-dev-mode/src/test/java/com/vaadin/flow/uitest/ui/ClientSideExceptionHandlingIT.java
@@ -28,8 +28,8 @@ import com.vaadin.flow.testutil.ChromeBrowserTest;
 public class ClientSideExceptionHandlingIT extends ChromeBrowserTest {
 
     private static final By ERROR_LOCATOR = By.className("v-system-error");
-    public static final String UNIX_PATTERN = ".*TypeError.* property 'foo' of.*null.*";
-    public static final String WINDOWS_PATTERN = ".*TypeError.* : Cannot read properties of null .*reading 'foo'.*";
+
+    public static final String ERROR_PATTERN = ".*TypeError.* : Cannot read properties of null .*reading 'foo'.*";
 
     @Test
     public void developmentModeExceptions() {
@@ -38,14 +38,8 @@ public class ClientSideExceptionHandlingIT extends ChromeBrowserTest {
 
         String errorMessage = findElement(ERROR_LOCATOR).getText();
 
-        // Windows formats the error differently from unix
-        final boolean isWindows = (boolean) ((JavascriptExecutor) getDriver())
-                .executeScript(
-                        "return navigator.appVersion.indexOf(\"Win\")!=-1");
-        String testPattern = isWindows ? WINDOWS_PATTERN : UNIX_PATTERN;
-
         Assert.assertTrue("Unexpected error message: " + errorMessage,
-                Pattern.matches(testPattern, errorMessage));
+                Pattern.matches(ERROR_PATTERN, errorMessage));
     }
 
     @Test


### PR DESCRIPTION
It would seem like chrome changed
the exception after last update making
it the same as was gotten on the
windows agent.
