### PR TITLE
fix: Use jdk8 compatible package.

### DIFF
--- a/flow-client/pom.xml
+++ b/flow-client/pom.xml
@@ -79,6 +79,19 @@
             <version>3.12.0</version>
             <scope>test</scope>
         </dependency>
+        <!-- Force Java8 compatible package -->
+        <dependency>
+            <groupId>org.eclipse.platform</groupId>
+            <artifactId>org.eclipse.core.jobs</artifactId>
+            <version>3.11.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.platform</groupId>
+            <artifactId>org.eclipse.core.contenttype</artifactId>
+            <version>3.7.1000</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.osgi</groupId>


### PR DESCRIPTION
Some transitive packages that were
in a defined range got released built
on JDK11 instead of JDK8
