### PR TITLE
feat!: Add an option to enable access checker by default

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/ViewAccessChecker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/ViewAccessChecker.java
@@ -54,7 +54,9 @@ public class ViewAccessChecker implements BeforeEnterListener {
     /**
      * Creates an instance and enables access checker depending on the given
      * flag.
-     * @param enabled {@code false} for disabling the access checker, {@code
+     * 
+     * @param enabled
+     *            {@code false} for disabling the access checker, {@code
      * true} for enabling the access checker.
      */
     public ViewAccessChecker(boolean enabled) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/ViewAccessChecker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/ViewAccessChecker.java
@@ -41,10 +41,25 @@ public class ViewAccessChecker implements BeforeEnterListener {
     private boolean enabled = false;
 
     /**
-     * Create an instance.
+     * Creates an instance.
+     * <p>
+     * Note that the access checker is enabled by default. If this isn't
+     * desired, one can use {@link #ViewAccessChecker(boolean)} with {@code
+     * enabled=false} and call {@link #enable()} later on whenever appropriate.
      */
     public ViewAccessChecker() {
+        this(true);
+    }
+
+    /**
+     * Creates an instance and enables access checker depending on the given
+     * flag.
+     * @param enabled {@code false} for disabling the access checker, {@code
+     * true} for enabling the access checker.
+     */
+    public ViewAccessChecker(boolean enabled) {
         this(new AccessAnnotationChecker());
+        this.enabled = enabled;
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/server/auth/ViewAccessCheckerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/auth/ViewAccessCheckerTest.java
@@ -64,7 +64,6 @@ public class ViewAccessCheckerTest {
     @Before
     public void init() {
         this.viewAccessChecker = new ViewAccessChecker();
-        this.viewAccessChecker.enable();
         this.viewAccessChecker.setLoginView(TestLoginView.class);
     }
 
@@ -525,6 +524,15 @@ public class ViewAccessCheckerTest {
                 NoAnnotationPermitAllByGrandParentAsInterfacesIgnoredView.class,
                 User.USER_NO_ROLES);
         Assert.assertTrue(result.wasTargetViewRendered());
+    }
+
+    @Test
+    public void accessCheckerDisabled_beforeEnterReturns() {
+        BeforeEnterEvent beforeEnterEvent = Mockito.mock(BeforeEnterEvent.class);
+        viewAccessChecker = new ViewAccessChecker(false);
+        viewAccessChecker.beforeEnter(beforeEnterEvent);
+        Mockito.verify(beforeEnterEvent,
+                Mockito.times(0)).getNavigationTarget();
     }
 
     private void resetLoginView()

--- a/flow-server/src/test/java/com/vaadin/flow/server/auth/ViewAccessCheckerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/auth/ViewAccessCheckerTest.java
@@ -256,10 +256,19 @@ public class ViewAccessCheckerTest {
     }
 
     @Test
-    public void disabledAccessCheckerAlwaysPasses() throws Exception {
-        resetCheckerToDisabled();
-        Assert.assertTrue(checkAccess(RolesAllowedAdminView.class, null)
-                .wasTargetViewRendered());
+    public void disabledAccessCheckerAlwaysPasses_rejectsWhenEnabled() {
+        viewAccessChecker = new ViewAccessChecker(false);
+        Assert.assertTrue(
+                "Expected admin view to be accessible for non "
+                        + "authenticated users when access checker is disabled",
+                checkAccess(RolesAllowedAdminView.class, null)
+                        .wasTargetViewRendered());
+        viewAccessChecker.enable();
+        Assert.assertFalse(
+                "Expected admin view to be not accessible for non "
+                        + "authenticated users when access checker is enabled",
+                checkAccess(RolesAllowedAdminView.class, null)
+                        .wasTargetViewRendered());
     }
 
     @Test(expected = IllegalStateException.class)
@@ -526,27 +535,11 @@ public class ViewAccessCheckerTest {
         Assert.assertTrue(result.wasTargetViewRendered());
     }
 
-    @Test
-    public void accessCheckerDisabled_beforeEnterReturns() {
-        BeforeEnterEvent beforeEnterEvent = Mockito.mock(BeforeEnterEvent.class);
-        viewAccessChecker = new ViewAccessChecker(false);
-        viewAccessChecker.beforeEnter(beforeEnterEvent);
-        Mockito.verify(beforeEnterEvent,
-                Mockito.times(0)).getNavigationTarget();
-    }
-
     private void resetLoginView()
             throws NoSuchFieldException, IllegalAccessException {
         Field f = ViewAccessChecker.class.getDeclaredField("loginView");
         f.setAccessible(true);
         f.set(this.viewAccessChecker, null);
-    }
-
-    private void resetCheckerToDisabled()
-            throws NoSuchFieldException, IllegalAccessException {
-        Field f = ViewAccessChecker.class.getDeclaredField("enabled");
-        f.setAccessible(true);
-        f.set(this.viewAccessChecker, false);
     }
 
     private static class Result {


### PR DESCRIPTION
## Description

Makes default constructor of ViewAccessChecker enable security check by default.
Ands one more constructor to create a ViewAccessChecker with disabled security check.

Note that this is a breaking change, since `ViewAccessChecker()` CTOR changes it's semantics and brakes Spring based applications which use older versions of Spring add-on - even if Vaadin security helpers are not activated by extending the `VaadinWebSecurityConfigurerAdapter`, the access checker will be enabled anyway and the view access will be denied.

Latest Spring add-on version has a corresponding change. Consider review this change also https://github.com/vaadin/spring/pull/902.

Fixes #11231

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
