### PR TITLE
fix: Throw exception in dev mode if dependency missing

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -463,7 +463,11 @@ public class FrontendUtils {
             if (!config.isProductionMode() && config.enableDevServer()) {
                 Optional<DevModeHandler> devModeHandler = DevModeHandlerManager
                         .getDevModeHandler(service);
-                assert devModeHandler.isPresent();
+                if (!devModeHandler.isPresent()) {
+                    throw new WebpackConnectionException(
+                            "DevModeHandlerManager implementation missing. Include the "
+                                    + "com.vaadin:vaadin-dev-server dependency.");
+                }
                 content = getStatsFromWebpack(devModeHandler.get());
             }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -29,7 +29,6 @@ import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 
@@ -69,9 +68,6 @@ public class FrontendUtilsTest {
             Assert.fail("Could not access cache key for stats.json!");
         }
     }
-
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
 
     @Rule
     public final TemporaryFolder tmpDir = new TemporaryFolder();
@@ -305,6 +301,28 @@ public class FrontendUtilsTest {
         VaadinServlet servlet = service.getServlet();
 
         Mockito.verify(provider).getApplicationResource("foo");
+    }
+
+    @Test
+    public void getStatsContent_getStatsFromDevServerWithNoImplementation_throwsException() {
+        VaadinServletService service = mockServletService();
+
+        DeploymentConfiguration config = Mockito
+                .mock(DeploymentConfiguration.class);
+
+        Mockito.when(service.getDeploymentConfiguration()).thenReturn(config);
+
+        Mockito.when(config.isProductionMode()).thenReturn(false);
+        Mockito.when(config.enableDevServer()).thenReturn(true);
+
+        WebpackConnectionException exception = Assert.assertThrows(
+                WebpackConnectionException.class,
+                () -> FrontendUtils.getStatsContent(service));
+
+        Assert.assertEquals(
+                "DevModeHandlerManager implementation missing. Include "
+                        + "the com.vaadin:vaadin-dev-server dependency.",
+                exception.getMessage());
     }
 
     @Test


### PR DESCRIPTION
When running the application in
devMode and the vaadin-dev-server
dependency is missing, instead of an
assert when getting stats from dev derver
throw exception on missing dependency.
