### PR TITLE
fix: pinned dependency only adds when modified

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -288,11 +288,18 @@ public class TaskUpdatePackages extends NodeUpdater {
         final JsonObject vaadinDeps = packageJson.getObject(VAADIN_DEP_KEY)
                 .getObject(DEPENDENCIES);
         final JsonObject packageJsonDeps = packageJson.getObject(DEPENDENCIES);
-        assert vaadinDeps != null; // exists at this point
-        assert packageJsonDeps != null;
-        packageJsonDeps.put(pkg, platformPinnedVersion.getFullVersion());
-        vaadinDeps.put(pkg, platformPinnedVersion.getFullVersion());
-        return true;
+        assert vaadinDeps != null :  "vaadin{ dependencies { } } should exist"; // exists at this point
+        assert packageJsonDeps != null : "dependencies { } should exist";
+        if (!packageJsonDeps.hasKey(pkg) || !vaadinDeps.hasKey(pkg)
+                || !platformPinnedVersion.equals(
+                        new FrontendVersion(packageJsonDeps.getString(pkg)))
+                || !platformPinnedVersion.equals(
+                        new FrontendVersion(vaadinDeps.getString(pkg)))) {
+            packageJsonDeps.put(pkg, platformPinnedVersion.getFullVersion());
+            vaadinDeps.put(pkg, platformPinnedVersion.getFullVersion());
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
@@ -464,6 +464,33 @@ public class TaskUpdatePackagesNpmTest {
                 vaadinDependencies.hasKey(VAADIN_CORE_NPM_PACKAGE));
     }
 
+    // #11888
+    @Test
+    public void npmIsInUse_versionsJsonContainsSameVersions_nothingIsModified()
+            throws IOException {
+        String versionJsonString = //@formatter:off
+                "{ \"core\": {"
+                        + "\"vaadin-element-mixin\": {\n"
+                        + "    \"jsVersion\": \"" + PLATFORM_DIALOG_VERSION + "\",\n"
+                        + "    \"npmName\": \"" + VAADIN_DIALOG
+                        + "\"\n"
+                        + "},\n"
+                + "}}},\n";//@formatter:on
+        FileUtils.write(versionJsonFile, versionJsonString,
+                StandardCharsets.UTF_8);
+
+        TaskUpdatePackages task = createTask(
+                createApplicationDependencies());
+        task.execute();
+        Assert.assertTrue("Creation of package.json should be marked with modified", task.modified);
+
+        // Rewriting with the same packages should not mark as modified
+        task = createTask(
+                createApplicationDependencies());
+        task.execute();
+        Assert.assertFalse("PackageJson modified without changes.", task.modified);
+    }
+
     private void createBasicVaadinVersionsJson() {
         createVaadinVersionsJson(PLATFORM_DIALOG_VERSION,
                 PLATFORM_ELEMENT_MIXIN_VERSION, PLATFORM_OVERLAY_VERSION);


### PR DESCRIPTION
Do not mark pin if no version is actually
added or changed.
With this npm install will not always be
executed on reload and the copied
modules will not disappear.

Fixes #11888
