### PR TITLE
fix: Use jdk8 compatible package (CP:1.0)

### DIFF
--- a/flow-client/pom.xml
+++ b/flow-client/pom.xml
@@ -78,6 +78,21 @@
             <version>3.12.0</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- Force Java8 compatible package -->
+        <dependency>
+            <groupId>org.eclipse.platform</groupId>
+            <artifactId>org.eclipse.core.jobs</artifactId>
+            <version>3.11.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.platform</groupId>
+            <artifactId>org.eclipse.core.contenttype</artifactId>
+            <version>3.7.1000</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/flow-tests/test-dev-mode/src/test/java/com/vaadin/flow/uitest/ui/ClientSideExceptionHandlingIT.java
+++ b/flow-tests/test-dev-mode/src/test/java/com/vaadin/flow/uitest/ui/ClientSideExceptionHandlingIT.java
@@ -27,6 +27,8 @@ public class ClientSideExceptionHandlingIT extends ChromeBrowserTest {
 
     private static final By ERROR_LOCATOR = By.className("v-system-error");
 
+    public static final String ERROR_PATTERN = ".*TypeError.* : Cannot read properties of null .*reading 'foo'.*";
+
     @Test
     public void developmentModeExceptions() {
         open();
@@ -35,8 +37,7 @@ public class ClientSideExceptionHandlingIT extends ChromeBrowserTest {
         String errorMessage = findElement(ERROR_LOCATOR).getText();
 
         Assert.assertTrue("Unexpected error message: " + errorMessage,
-                Pattern.matches(".*TypeError.* property 'foo' of.*null.*",
-                        errorMessage));
+                Pattern.matches(ERROR_PATTERN, errorMessage));
     }
 
     @Test


### PR DESCRIPTION
## Description

Some transitive packages that were
in a defined range got released built
on JDK11 instead of JDK8

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
