### PR TITLE
test: Wait for the themed component to be present

### DIFF
--- a/flow-tests/test-application-theme/test-theme-component-live-reload/src/test/java/com/vaadin/flow/uitest/ui/ComponentThemeLiveReloadIT.java
+++ b/flow-tests/test-application-theme/test-theme-component-live-reload/src/test/java/com/vaadin/flow/uitest/ui/ComponentThemeLiveReloadIT.java
@@ -161,6 +161,7 @@ public class ComponentThemeLiveReloadIT extends ChromeBrowserTest {
 
     private boolean isComponentCustomStyle(String borderRadius) {
         try {
+            waitForElementPresent(By.id(THEMED_COMPONENT_ID));
             TestBenchElement themedTextField = $(TestBenchElement.class)
                     .id(THEMED_COMPONENT_ID);
             TestBenchElement input = themedTextField.$(DivElement.class)


### PR DESCRIPTION
## Description

Adds the waiting loop to the ComponentThemeLiveReloadIT to ensure the tested component is rendered.

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
