### PR TITLE
test: Move theme no polymer test to the end of list

### DIFF
--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -319,7 +319,6 @@
                 <module>test-memory-leaks</module>
                 <module>test-servlet</module>
                 <module>test-themes</module>
-                <module>test-theme-no-polymer</module>
                 <module>servlet-containers</module>
 
                 <!-- web component embedding -->
@@ -350,6 +349,7 @@
                 <!-- move theme tests to the end, because theme switch live reload-->
                 <!-- test impacts startup test-->
                 <module>test-application-theme</module>
+                <module>test-theme-no-polymer</module>
             </modules>
         </profile>
         <profile>


### PR DESCRIPTION
## Description

Moves theme-no-polymer test to the end of list, so it would be executed last.
Checks whether it impacts the theme live reload tests.

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
