### PR TITLE
feat: Automatic update of node version

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
@@ -121,6 +121,8 @@ internal class GradlePluginAdapter(val project: Project, private val isBeforePro
     override fun nodeDownloadRoot(): URI =
         URI.create(extension.nodeDownloadRoot)
 
+    override fun nodeAutoUpdate(): Boolean = extension.nodeAutoUpdate
+
     override fun nodeVersion(): String = extension.nodeVersion
 
     override fun npmFolder(): File = extension.npmFolder

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
@@ -169,6 +169,11 @@ public open class VaadinFlowPluginExtension(project: Project) {
     public var nodeDownloadRoot: String = NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT
 
     /**
+     * Allow automatic update of node installed to alternate location. Default `false`
+     */
+    public var nodeAutoUpdate: Boolean = false
+
+    /**
      * Defines the output directory for generated non-served resources, such as
      * the token file. Defaults to `build/vaadin-generated` folder.
      *
@@ -250,6 +255,7 @@ public open class VaadinFlowPluginExtension(project: Project) {
             "generatedTsFolder=$generatedTsFolder, " +
             "nodeVersion=$nodeVersion, " +
             "nodeDownloadRoot=$nodeDownloadRoot, " +
+            "nodeAutoUpdate=$nodeAutoUpdate" +
             "resourceOutputDirectory=$resourceOutputDirectory" +
             ")"
 }

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinUtils.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinUtils.kt
@@ -15,12 +15,13 @@
  */
 package com.vaadin.gradle
 
+import com.vaadin.flow.function.SerializableSupplier
 import com.vaadin.flow.server.frontend.FrontendTools
+import com.vaadin.flow.server.frontend.FrontendToolsSettings
 import com.vaadin.flow.server.frontend.FrontendUtils
 import org.gradle.api.Project
 import java.io.File
 import java.net.URI
-import java.util.function.Supplier
 
 /**
  * Finds the value of a boolean property. It searches in gradle and system properties.
@@ -62,9 +63,10 @@ public fun Project.vaadin(block: VaadinFlowPluginExtension.() -> Unit) {
 
 internal fun Collection<File>.toPrettyFormat(): String = joinToString(prefix = "[", postfix = "]") { if (it.isFile) it.name else it.absolutePath }
 
-internal fun VaadinFlowPluginExtension.createFrontendTools(): FrontendTools =
-    FrontendTools(npmFolder.absolutePath,
-        Supplier { FrontendUtils.getVaadinHomeDirectory().absolutePath },
-        nodeVersion,
-        URI(nodeDownloadRoot)
-    )
+internal fun VaadinFlowPluginExtension.createFrontendTools(): FrontendTools {
+    var settings = FrontendToolsSettings(npmFolder.absolutePath, SerializableSupplier { FrontendUtils.getVaadinHomeDirectory().absolutePath })
+    settings.setNodeVersion(nodeVersion)
+    settings.setNodeDownloadRoot(URI(nodeDownloadRoot))
+    return FrontendTools(settings)
+}
+

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -115,6 +115,13 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
     private String nodeVersion;
 
     /**
+     * Setting defining if the automatically installed node version may be
+     * updated to the default Vaadin node version.
+     */
+    @Parameter(property = InitParameters.NODE_AUTO_UPDATE, defaultValue = Constants.DEFAULT_NODE_AUTO_UPDATE)
+    private boolean nodeAutoUpdate;
+
+    /**
      * The folder where `package.json` file is located. Default is project root
      * dir.
      */
@@ -162,7 +169,7 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
      * absent. Then it will be used instead of globally 'node' or locally
      * installed installed 'node'.
      */
-    @Parameter(property = Constants.REQUIRE_HOME_NODE_EXECUTABLE, defaultValue = "false")
+    @Parameter(property = Constants.REQUIRE_HOME_NODE_EXECUTABLE, defaultValue = Constants.DEFAULT_REQUIRE_HOME_NODE_EXECUTABLE)
     private boolean requireHomeNodeExec;
 
     /**
@@ -327,6 +334,11 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
             throw new URISyntaxException(nodeDownloadRoot,
                     "Failed to parse nodeDownloadRoot uri");
         }
+    }
+
+    @Override
+    public boolean nodeAutoUpdate() {
+        return nodeAutoUpdate;
     }
 
     @Override

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBase.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/PluginAdapterBase.java
@@ -206,6 +206,13 @@ public interface PluginAdapterBase {
     URI nodeDownloadRoot() throws URISyntaxException;
 
     /**
+     * Whether the alternative node may be autoupdated or not.
+     *
+     * @return {@code true} to update node if older than default
+     */
+    boolean nodeAutoUpdate();
+
+    /**
      * The node.js version to be used when node.js is installed automatically by
      * Vaadin, for example `"v12.18.3"`. Defaults to null which uses the
      * Vaadin-default node version - see {@link FrontendTools} for details.

--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -324,6 +324,16 @@ public final class Constants implements Serializable {
     public static final String GLOBAL_PNPM_DEFAULT_STRING = "false";
 
     /**
+     * The default value for {@link InitParameters#NODE_AUTO_UPDATE}.
+     */
+    public static final String DEFAULT_NODE_AUTO_UPDATE = "false";
+
+    /**
+     * The default value for {@link #REQUIRE_HOME_NODE_EXECUTABLE}.
+     */
+    public static final String DEFAULT_REQUIRE_HOME_NODE_EXECUTABLE = "false";
+
+    /**
      * @deprecated Use {@link InitParameters#REQUIRE_HOME_NODE_EXECUTABLE}
      *             instead.
      */

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -165,6 +165,14 @@ public class InitParameters implements Serializable {
     public static final String REQUIRE_HOME_NODE_EXECUTABLE = "require.home.node";
 
     /**
+     * Configuration parameter name for requiring node executable installed in
+     * home directory.
+     *
+     * @since
+     */
+    public static final String NODE_AUTO_UPDATE = "node.auto.update";
+
+    /**
      * Configuration name for the parameter that sets the compiled web
      * components path. The path should be the same as
      * {@code webComponentOutputDirectoryName} in the maven plugin that

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -30,6 +30,7 @@ import java.util.Properties;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+import org.apache.commons.compress.utils.Lists;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -165,9 +166,9 @@ public class FrontendTools {
     private final URI nodeDownloadRoot;
 
     private final boolean ignoreVersionChecks;
-
     private final boolean forceAlternativeNode;
     private final boolean useGlobalPnpm;
+    private final boolean autoUpdate;
 
     /**
      * Creates an instance of the class using the {@code baseDir} as a base
@@ -176,128 +177,23 @@ public class FrontendTools {
      * not found and use it as an alternative tools location.
      * <p>
      * If {@code alternativeDir} is {@code null} tools won't be installed.
-     *
-     *
-     * @param baseDir
-     *            the base directory to locate the tools, not {@code null}
-     * @param alternativeDirGetter
-     *            the getter for a directory where tools will be installed if
-     *            they are not found globally or in the {@code baseDir}, may be
-     *            {@code null}
-     * @param forceAlternativeNode
-     *            force usage of node executable from alternative directory
-     */
-    public FrontendTools(String baseDir, Supplier<String> alternativeDirGetter,
-            boolean forceAlternativeNode) {
-        this(baseDir, alternativeDirGetter, DEFAULT_NODE_VERSION,
-                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT),
-                forceAlternativeNode, false);
-    }
-
-    /**
-     * Creates an instance of the class using the {@code baseDir} as a base
-     * directory to locate the tools and the directory returned by the
-     * {@code alternativeDirGetter} as a directory to install tools if they are
-     * not found and use it as an alternative tools location.
      * <p>
-     * If {@code alternativeDir} is {@code null} tools won't be installed.
+     * Note: settings for this object can not be changed through the settings
+     * object after creation.
      *
-     *
-     * @param baseDir
-     *            the base directory to locate the tools, not {@code null}
-     * @param alternativeDirGetter
-     *            the getter for a directory where tools will be installed if
-     *            they are not found globally or in the {@code baseDir}, may be
-     *            {@code null}
+     * @param settings
+     *            tooling settings to use
      */
-    public FrontendTools(String baseDir,
-            Supplier<String> alternativeDirGetter) {
-        this(baseDir, alternativeDirGetter, DEFAULT_NODE_VERSION,
-                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT), false,
-                false);
-    }
-
-    /**
-     * Creates an instance of the class using the {@code baseDir} as a base
-     * directory to locate the tools and the directory returned by the
-     * {@code alternativeDirGetter} as a directory to install tools if they are
-     * not found and use it as an alternative tools location.
-     * <p>
-     * If {@code alternativeDir} is {@code null} tools won't be installed.
-     *
-     *
-     * @param baseDir
-     *            the base directory to locate the tools, not {@code null}
-     * @param alternativeDirGetter
-     *            the getter for a directory where tools will be installed if
-     *            they are not found globally or in the {@code baseDir}, may be
-     *            {@code null}
-     * @param nodeVersion
-     *            The node.js version to be used when node.js is installed
-     *            automatically by Vaadin, for example <code>"v16.0.0"</code>.
-     *            Use {@value #DEFAULT_NODE_VERSION} by default.
-     * @param nodeDownloadRoot
-     *            Download node.js from this URL. Handy in heavily firewalled
-     *            corporate environments where the node.js download can be
-     *            provided from an intranet mirror. Use
-     *            {@link NodeInstaller#DEFAULT_NODEJS_DOWNLOAD_ROOT} by default.
-     * @param forceAlternativeNode
-     *            force usage of node executable from alternative directory
-     * @param useGlobalPnpm
-     *            use globally installed pnpm instead of the default one (see
-     *            {@link #DEFAULT_PNPM_VERSION})
-     */
-    public FrontendTools(String baseDir, Supplier<String> alternativeDirGetter,
-            String nodeVersion, URI nodeDownloadRoot,
-            boolean forceAlternativeNode, boolean useGlobalPnpm) {
-        this(baseDir, alternativeDirGetter, nodeVersion, nodeDownloadRoot,
-                "true".equalsIgnoreCase(System.getProperty(
-                        FrontendUtils.PARAM_IGNORE_VERSION_CHECKS)),
-                forceAlternativeNode, useGlobalPnpm);
-    }
-
-    /**
-     * Creates an instance of the class using the {@code baseDir} as a base
-     * directory to locate the tools and the directory returned by the
-     * {@code alternativeDirGetter} as a directory to install tools if they are
-     * not found and use it as an alternative tools location.
-     * <p>
-     * If {@code alternativeDir} is {@code null} tools won't be installed.
-     *
-     *
-     * @param baseDir
-     *            the base directory to locate the tools, not {@code null}
-     * @param alternativeDirGetter
-     *            the getter for a directory where tools will be installed if
-     *            they are not found globally or in the {@code baseDir}, may be
-     *            {@code null}
-     * @param nodeVersion
-     *            The node.js version to be used when node.js is installed
-     *            automatically by Vaadin, for example <code>"v16.0.0"</code>.
-     *            Use {@value #DEFAULT_NODE_VERSION} by default.
-     * @param nodeDownloadRoot
-     *            Download node.js from this URL. Handy in heavily firewalled
-     *            corporate environments where the node.js download can be
-     *            provided from an intranet mirror. Use
-     *            {@link NodeInstaller#DEFAULT_NODEJS_DOWNLOAD_ROOT} by default.
-     */
-    public FrontendTools(String baseDir, Supplier<String> alternativeDirGetter,
-            String nodeVersion, URI nodeDownloadRoot) {
-        this(baseDir, alternativeDirGetter, nodeVersion, nodeDownloadRoot,
-                false, false);
-    }
-
-    FrontendTools(String baseDir, Supplier<String> alternativeDirGetter,
-            String nodeVersion, URI nodeDownloadRoot,
-            boolean ignoreVersionChecks, boolean forceAlternativeNode,
-            boolean useGlobalPnpm) {
-        this.baseDir = Objects.requireNonNull(baseDir);
-        this.alternativeDirGetter = alternativeDirGetter;
-        this.nodeVersion = Objects.requireNonNull(nodeVersion);
-        this.nodeDownloadRoot = Objects.requireNonNull(nodeDownloadRoot);
-        this.ignoreVersionChecks = ignoreVersionChecks;
-        this.forceAlternativeNode = forceAlternativeNode;
-        this.useGlobalPnpm = useGlobalPnpm;
+    public FrontendTools(FrontendToolsSettings settings) {
+        this.baseDir = Objects.requireNonNull(settings.getBaseDir());
+        this.alternativeDirGetter = settings.getAlternativeDirGetter();
+        this.nodeVersion = Objects.requireNonNull(settings.getNodeVersion());
+        this.nodeDownloadRoot = Objects
+                .requireNonNull(settings.getNodeDownloadRoot());
+        this.ignoreVersionChecks = settings.isIgnoreVersionChecks();
+        this.forceAlternativeNode = settings.isForceAlternativeNode();
+        this.useGlobalPnpm = settings.isUseGlobalPnpm();
+        this.autoUpdate = settings.isAutoUpdate();
     }
 
     /**
@@ -308,12 +204,13 @@ public class FrontendTools {
     public String getNodeExecutable() {
         Pair<String, String> nodeCommands = getNodeCommands();
         File file = getExecutable(baseDir, nodeCommands.getSecond());
-        if (file == null) {
+        if (file == null && !forceAlternativeNode) {
             file = frontendToolsLocator.tryLocateTool(nodeCommands.getFirst())
                     .orElse(null);
         }
         if (file == null) {
-            file = getExecutable(getAlternativeDir(), nodeCommands.getSecond());
+            file = updateAlternateIfNeeded(getExecutable(getAlternativeDir(),
+                    nodeCommands.getSecond()));
         }
         if (file == null && alternativeDirGetter != null) {
             getLogger().info("Couldn't find {}. Installing Node and NPM to {}.",
@@ -324,6 +221,54 @@ public class FrontendTools {
             throw new IllegalStateException(String.format(NODE_NOT_FOUND));
         }
         return file.getAbsolutePath();
+    }
+
+    /**
+     * Update installed node version if installed version is not supported.
+     * <p>
+     * Also update is {@code auto.update} flag set and installed version is
+     * older than the current default version.
+     *
+     * @param file
+     *            node executable
+     * @return node executable after possible installation of new version
+     */
+    private File updateAlternateIfNeeded(File file) {
+        if (file == null) {
+            return null;
+        }
+        // If auto-update flag set or installed node older than minimum
+        // supported
+        try {
+            List<String> versionCommand = Lists.newArrayList();
+            versionCommand.add(file.getAbsolutePath());
+            versionCommand.add("--version"); // NOSONAR
+            final FrontendVersion installedNodeVersion = FrontendUtils
+                    .getVersion("node", versionCommand);
+
+            boolean installDefault = false;
+            final FrontendVersion defaultVersion = new FrontendVersion(
+                    nodeVersion);
+            if (installedNodeVersion.isOlderThan(SHOULD_WORK_NODE_VERSION)) {
+                getLogger().info("Updating unsupported node version {} to {}",
+                        installedNodeVersion.getFullVersion(),
+                        defaultVersion.getFullVersion());
+                installDefault = true;
+            } else if (autoUpdate
+                    && installedNodeVersion.isOlderThan(defaultVersion)) {
+                getLogger().info(
+                        "Updating current installed node version from {} to {}",
+                        installedNodeVersion.getFullVersion(),
+                        defaultVersion.getFullVersion());
+                installDefault = true;
+            }
+            if (installDefault) {
+                file = new File(installNode(nodeVersion, nodeDownloadRoot));
+            }
+        } catch (UnknownVersionException e) {
+            getLogger().error("Failed to get version for installed node.", e);
+        }
+        return file;
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsSettings.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsSettings.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.frontend;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import com.vaadin.flow.function.SerializableSupplier;
+import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.frontend.installer.NodeInstaller;
+
+import static com.vaadin.flow.server.frontend.FrontendTools.DEFAULT_NODE_VERSION;
+
+/**
+ * Configuration object for controlling the {@link FrontendTools} features.
+ * <p>
+ * This can be modified, but the choices will be locked in {@link FrontendTools}
+ * when it is initialized. Until then any settings can be changed.
+ */
+public class FrontendToolsSettings implements Serializable {
+
+    private String baseDir;
+    private SerializableSupplier<String> alternativeDirGetter;
+
+    private String nodeVersion = DEFAULT_NODE_VERSION;
+    private URI nodeDownloadRoot = URI
+            .create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT);
+
+    private boolean ignoreVersionChecks;
+    private boolean forceAlternativeNode = Boolean
+            .parseBoolean(Constants.DEFAULT_REQUIRE_HOME_NODE_EXECUTABLE);
+    private boolean useGlobalPnpm = Boolean
+            .parseBoolean(Constants.GLOBAL_PNPM_DEFAULT_STRING);
+    private boolean autoUpdate = Boolean
+            .parseBoolean(Constants.DEFAULT_NODE_AUTO_UPDATE);
+
+    /**
+     * Create a tools configuration object.
+     * <p>
+     * The {@code baseDir} is used as a base directory to locate the tools and
+     * {@code alternativeDirGetter} is the directory to install tools if they
+     * are not found.
+     * <p>
+     * Note that if {@code alternativeDir} is {@code null} tools won't be
+     * installed.
+     *
+     * @param baseDir
+     *            the base directory to locate the tools, not {@code null}
+     * @param alternativeDirGetter
+     *            the getter for a directory where tools will be installed if
+     *            they are not found globally or in the {@code baseDir}, may be
+     *            {@code null}
+     */
+    public FrontendToolsSettings(String baseDir,
+            SerializableSupplier<String> alternativeDirGetter) {
+        this.baseDir = Objects.requireNonNull(baseDir);
+        this.alternativeDirGetter = alternativeDirGetter;
+        ignoreVersionChecks = "true".equalsIgnoreCase(
+                System.getProperty(FrontendUtils.PARAM_IGNORE_VERSION_CHECKS));
+    }
+
+    /**
+     * Set the base directory for locating tools.
+     *
+     * @param baseDir
+     *            the base directory to locate the tools, not {@code null}
+     */
+    public void setBaseDir(String baseDir) {
+        this.baseDir = Objects.requireNonNull(baseDir);
+    }
+
+    /**
+     * Set the installation directory if no tools are found.
+     *
+     * @param alternativeDirGetter
+     *            the getter for a directory where tools will be installed if
+     *            they are not found globally or in the {@code baseDir}, may be
+     *            {@code null}
+     */
+    public void setAlternativeDirGetter(
+            SerializableSupplier<String> alternativeDirGetter) {
+        this.alternativeDirGetter = alternativeDirGetter;
+    }
+
+    /**
+     * Set the root URI for downloading node.
+     *
+     * @param nodeDownloadRoot
+     *            node download root uri, default is
+     *            {@value NodeInstaller#DEFAULT_NODEJS_DOWNLOAD_ROOT}
+     */
+    public void setNodeDownloadRoot(URI nodeDownloadRoot) {
+        this.nodeDownloadRoot = nodeDownloadRoot;
+    }
+
+    /**
+     * Set the node version to install when installation is required.
+     *
+     * @param nodeVersion
+     *            The node.js version to be used when node.js is installed
+     *            automatically, default is
+     *            {@value FrontendTools#DEFAULT_NODE_VERSION}
+     */
+    public void setNodeVersion(String nodeVersion) {
+        this.nodeVersion = nodeVersion;
+    }
+
+    /**
+     * Set if node and npm versions should be checked or not.
+     *
+     * @param ignoreVersionChecks
+     *            set if versions should be validated, default is system
+     *            property for
+     *            {@value FrontendUtils#PARAM_IGNORE_VERSION_CHECKS}
+     */
+    public void setIgnoreVersionChecks(boolean ignoreVersionChecks) {
+        this.ignoreVersionChecks = ignoreVersionChecks;
+    }
+
+    /**
+     * Set if the alternative folder should always be used even if a global
+     * installation exists.
+     * <p>
+     * This will force the installation if a version doesn't exist in the folder
+     * defined in {@link #alternativeDirGetter}.
+     *
+     * @param forceAlternativeNode
+     *            if {@code true} force usage of node executable from
+     *            alternative directory
+     */
+    public void setForceAlternativeNode(boolean forceAlternativeNode) {
+        this.forceAlternativeNode = forceAlternativeNode;
+    }
+
+    /**
+     * Force usage of global pnpm.
+     *
+     * @param useGlobalPnpm
+     *            use globally installed pnpm instead of the default version
+     *            {@value FrontendTools#DEFAULT_PNPM_VERSION}
+     */
+    public void setUseGlobalPnpm(boolean useGlobalPnpm) {
+        this.useGlobalPnpm = useGlobalPnpm;
+    }
+
+    /**
+     * When set to true the alternative version is updated to the latest default
+     * node version as defined for the framework.
+     *
+     * @param autoUpdate
+     *            update node in {@link #alternativeDirGetter} if version older
+     *            than the current default
+     *            {@value FrontendTools#DEFAULT_NODE_VERSION}
+     */
+    public void setAutoUpdate(boolean autoUpdate) {
+        this.autoUpdate = autoUpdate;
+    }
+
+    /**
+     * Get the defined base dir.
+     *
+     * @return defined base dir
+     */
+    public String getBaseDir() {
+        return baseDir;
+    }
+
+    /**
+     * Get the alternative directory getter.
+     *
+     * @return alternative directory getter
+     */
+    public Supplier<String> getAlternativeDirGetter() {
+        return alternativeDirGetter;
+    }
+
+    /**
+     * Get the defined node version.
+     *
+     * @return node version
+     */
+    public String getNodeVersion() {
+        return nodeVersion;
+    }
+
+    /**
+     * Get the node download root to be used for downloading node.
+     *
+     * @return node download root
+     */
+    public URI getNodeDownloadRoot() {
+        return nodeDownloadRoot;
+    }
+
+    /**
+     * Check if version checks should be ignored.
+     *
+     * @return ignore version checks
+     */
+    public boolean isIgnoreVersionChecks() {
+        return ignoreVersionChecks;
+    }
+
+    /**
+     * Check if alternative node usage should be forced.
+     *
+     * @return force alternative node usage
+     */
+    public boolean isForceAlternativeNode() {
+        return forceAlternativeNode;
+    }
+
+    /**
+     * Check if global pnpm should be used.
+     *
+     * @return use global pnpm
+     */
+    public boolean isUseGlobalPnpm() {
+        return useGlobalPnpm;
+    }
+
+    /**
+     * Check if automatic updates are enabled.
+     *
+     * @return automatic update
+     */
+    public boolean isAutoUpdate() {
+        return autoUpdate;
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -140,6 +140,8 @@ public class NodeTasks implements FallibleCommand {
         private URI nodeDownloadRoot = URI
                 .create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT);
 
+        private boolean nodeAutoUpdate = false;
+
         private Lookup lookup;
 
         /**
@@ -542,6 +544,19 @@ public class NodeTasks implements FallibleCommand {
         }
 
         /**
+         * Sets whether it is fine to automatically update the alternate node
+         * installation if installed version is older than the current default.
+         *
+         * @param update
+         *            true to update alternate node when used
+         * @return the builder
+         */
+        public Builder setNodeAutoUpdate(boolean update) {
+            this.nodeAutoUpdate = update;
+            return this;
+        }
+
+        /**
          * Get the npm folder used for this build.
          *
          * @return npmFolder
@@ -625,7 +640,7 @@ public class NodeTasks implements FallibleCommand {
                 commands.add(new TaskRunNpmInstall(classFinder, packageUpdater,
                         builder.enablePnpm, builder.requireHomeNodeExec,
                         builder.nodeVersion, builder.nodeDownloadRoot,
-                        builder.useGlobalPnpm));
+                        builder.useGlobalPnpm, builder.nodeAutoUpdate));
 
                 commands.add(new TaskInstallWebpackPlugins(
                         new File(builder.npmFolder, builder.buildDirectory)));

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -89,6 +89,7 @@ public class TaskRunNpmInstall implements FallibleCommand {
             MODULES_YAML);
     private final boolean enablePnpm;
     private final boolean requireHomeNodeExec;
+    private final boolean autoUpdate;
     private final ClassFinder classFinder;
 
     private final String nodeVersion;
@@ -119,11 +120,12 @@ public class TaskRunNpmInstall implements FallibleCommand {
      * @param useGlobalPnpm
      *            use globally installed pnpm instead of the default one (see
      *            {@link FrontendTools#DEFAULT_PNPM_VERSION})
-     *
+     * @param autoUpdate
+     *            {@code true} to automatically update to a new node version
      */
     TaskRunNpmInstall(ClassFinder classFinder, NodeUpdater packageUpdater,
             boolean enablePnpm, boolean requireHomeNodeExec, String nodeVersion,
-            URI nodeDownloadRoot, boolean useGlobalPnpm) {
+            URI nodeDownloadRoot, boolean useGlobalPnpm, boolean autoUpdate) {
         this.classFinder = classFinder;
         this.packageUpdater = packageUpdater;
         this.enablePnpm = enablePnpm;
@@ -131,6 +133,7 @@ public class TaskRunNpmInstall implements FallibleCommand {
         this.nodeVersion = Objects.requireNonNull(nodeVersion);
         this.nodeDownloadRoot = Objects.requireNonNull(nodeDownloadRoot);
         this.useGlobalPnpm = useGlobalPnpm;
+        this.autoUpdate = autoUpdate;
     }
 
     @Override
@@ -330,10 +333,14 @@ public class TaskRunNpmInstall implements FallibleCommand {
         List<String> executable;
         String baseDir = packageUpdater.npmFolder.getAbsolutePath();
 
-        FrontendTools tools = new FrontendTools(baseDir,
-                () -> FrontendUtils.getVaadinHomeDirectory().getAbsolutePath(),
-                nodeVersion, nodeDownloadRoot, requireHomeNodeExec,
-                useGlobalPnpm);
+        FrontendToolsSettings settings = new FrontendToolsSettings(baseDir,
+                () -> FrontendUtils.getVaadinHomeDirectory().getAbsolutePath());
+        settings.setNodeDownloadRoot(nodeDownloadRoot);
+        settings.setForceAlternativeNode(requireHomeNodeExec);
+        settings.setUseGlobalPnpm(useGlobalPnpm);
+        settings.setAutoUpdate(autoUpdate);
+        settings.setNodeVersion(nodeVersion);
+        FrontendTools tools = new FrontendTools(settings);
         try {
             if (requireHomeNodeExec) {
                 tools.forceAlternativeNodeExecutable();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -97,7 +97,6 @@ public class FrontendToolsTest {
     }
 
     @Test
-    @Ignore("Ignored to lessen PRs hitting the server too often")
     public void installNode_NodeIsInstalledToTargetDirectory()
             throws FrontendUtils.UnknownVersionException {
         String nodeExecutable = tools
@@ -127,7 +126,6 @@ public class FrontendToolsTest {
     }
 
     @Test
-    // @Ignore("Ignored to lessen PRs hitting the server too often")
     public void updateTooOldNode_NodeInstalledToTargetDirectoryIsUpdated()
             throws FrontendUtils.UnknownVersionException {
         settings.setForceAlternativeNode(true);
@@ -156,7 +154,6 @@ public class FrontendToolsTest {
     }
 
     @Test
-    // @Ignore("Ignored to lessen PRs hitting the server too often")
     public void supportedNodeInstalled_autoUpdateFalse_NodeNotUpdated()
             throws FrontendUtils.UnknownVersionException {
         settings.setForceAlternativeNode(true);
@@ -183,7 +180,6 @@ public class FrontendToolsTest {
     }
 
     @Test
-    // @Ignore("Ignored to lessen PRs hitting the server too often")
     public void supportedNodeInstalled_autoUpdateTrue_NodeUpdated()
             throws FrontendUtils.UnknownVersionException {
         settings.setForceAlternativeNode(true);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -96,7 +96,8 @@ public class TaskRunNpmInstallTest {
     protected TaskRunNpmInstall createTask() {
         return new TaskRunNpmInstall(getClassFinder(), getNodeUpdater(), false,
                 false, FrontendTools.DEFAULT_NODE_VERSION,
-                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT), false);
+                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT), false,
+                false);
     }
 
     @Test
@@ -260,10 +261,11 @@ public class TaskRunNpmInstallTest {
             throws IOException, ExecutionFailedException {
         exception.expectMessage(
                 "it's either not a file or not a 'node' executable.");
-        assertRunNpmInstallThrows_vaadinHomeNodeIsAFolder(new TaskRunNpmInstall(
-                getClassFinder(), getNodeUpdater(), false, true,
-                FrontendTools.DEFAULT_NODE_VERSION,
-                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT), false));
+        assertRunNpmInstallThrows_vaadinHomeNodeIsAFolder(
+                new TaskRunNpmInstall(getClassFinder(), getNodeUpdater(), false,
+                        true, FrontendTools.DEFAULT_NODE_VERSION,
+                        URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT),
+                        false, false));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -138,10 +138,11 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
             throws IOException, ExecutionFailedException {
         exception.expectMessage(
                 "it's either not a file or not a 'node' executable.");
-        assertRunNpmInstallThrows_vaadinHomeNodeIsAFolder(new TaskRunNpmInstall(
-                getClassFinder(), getNodeUpdater(), true, true,
-                FrontendTools.DEFAULT_NODE_VERSION,
-                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT), false));
+        assertRunNpmInstallThrows_vaadinHomeNodeIsAFolder(
+                new TaskRunNpmInstall(getClassFinder(), getNodeUpdater(), true,
+                        true, FrontendTools.DEFAULT_NODE_VERSION,
+                        URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT),
+                        false, false));
     }
 
     @Test
@@ -643,13 +644,15 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
     protected TaskRunNpmInstall createTask() {
         return new TaskRunNpmInstall(getClassFinder(), getNodeUpdater(), true,
                 false, FrontendTools.DEFAULT_NODE_VERSION,
-                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT), false);
+                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT), false,
+                false);
     }
 
     protected TaskRunNpmInstall createTask(String versionsContent) {
         return new TaskRunNpmInstall(getClassFinder(), getNodeUpdater(), true,
                 false, FrontendTools.DEFAULT_NODE_VERSION,
-                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT), false) {
+                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT), false,
+                false) {
             @Override
             protected String generateVersionsJson() {
                 try {
@@ -674,7 +677,8 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         TaskRunNpmInstall task = new TaskRunNpmInstall(getClassFinder(),
                 getNodeUpdater(), true, false,
                 FrontendTools.DEFAULT_NODE_VERSION,
-                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT), false);
+                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT), false,
+                false);
 
         String path = task.generateVersionsJson();
 

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerImpl.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerImpl.java
@@ -58,6 +58,7 @@ import com.vaadin.flow.server.VaadinResponse;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.communication.StreamRequestHandler;
 import com.vaadin.flow.server.frontend.FrontendTools;
+import com.vaadin.flow.server.frontend.FrontendToolsSettings;
 import com.vaadin.flow.server.frontend.FrontendUtils;
 import com.vaadin.flow.server.startup.ApplicationConfiguration;
 
@@ -655,9 +656,19 @@ public final class DevModeHandlerImpl
 
         boolean useHomeNodeExec = config.getBooleanProperty(
                 InitParameters.REQUIRE_HOME_NODE_EXECUTABLE, false);
-        FrontendTools tools = new FrontendTools(npmFolder.getAbsolutePath(),
-                () -> FrontendUtils.getVaadinHomeDirectory().getAbsolutePath(),
-                useHomeNodeExec);
+        boolean nodeAutoUpdate = config
+                .getBooleanProperty(InitParameters.NODE_AUTO_UPDATE, false);
+        boolean useGlobalPnpm = config.getBooleanProperty(
+                InitParameters.SERVLET_PARAMETER_GLOBAL_PNPM, false);
+
+        FrontendToolsSettings settings = new FrontendToolsSettings(
+                npmFolder.getAbsolutePath(),
+                () -> FrontendUtils.getVaadinHomeDirectory().getAbsolutePath());
+        settings.setForceAlternativeNode(useHomeNodeExec);
+        settings.setAutoUpdate(nodeAutoUpdate);
+        settings.setUseGlobalPnpm(useGlobalPnpm);
+
+        FrontendTools tools = new FrontendTools(settings);
         tools.validateNodeAndNpmVersion();
 
         String nodeExec = null;


### PR DESCRIPTION
Enable automatic update of the node version
installed by the framework. Auto update is opt in,
but for a version that is older than what should
work it is updated automatically.

Closes #9864
