### PR TITLE
chore: run webpack in dev mode by default

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerImpl.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerImpl.java
@@ -752,7 +752,7 @@ public final class DevModeHandlerImpl
         command.add("watchDogPort=" + watchDog.get().getWatchDogPort());
         command.addAll(Arrays.asList(config
                 .getStringProperty(SERVLET_PARAMETER_DEVMODE_WEBPACK_OPTIONS,
-                        "--devtool=eval-source-map")
+                        "--devtool=eval-source-map --mode=development")
                 .split(" +")));
         return command;
     }


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

https://github.com/vaadin/flow/pull/11783 introduced a bug that webpack is NOT running in development by default, which results in the `index.html` and `manifest.json` not emitted, which is the root cause of https://github.com/vaadin/fusion/issues/117.

This PR is not marked as a fix, since it's a continuation of https://github.com/vaadin/flow/pull/11783 which is not released yet.

Fixes https://github.com/vaadin/fusion/issues/117

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
