### PR TITLE
fix: Downgrade Atmosphere client to the last in 2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <jsoup.version>1.14.2</jsoup.version>
         <!-- Note that this should be kept in sync with the class Constants -->
         <atmosphere.runtime.version>2.7.2.slf4jvaadin1</atmosphere.runtime.version>
-        <atmosphere.client.version>3.1.2</atmosphere.client.version>
+        <atmosphere.client.version>2.3.9</atmosphere.client.version>
 
         <!-- OSGi -->
         <!-- Note: the parserVersion value is set by build-helper-maven-plugin -->


### PR DESCRIPTION
## Description

Fixes https://github.com/vaadin/multiplatform-runtime-internal/issues/549

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
