### PR TITLE
refactor: Use settings object for TaskRunNpmInstall

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -573,6 +573,25 @@ public class NodeTasks implements FallibleCommand {
         public File getGeneratedFolder() {
             return generatedFolder;
         }
+
+        /**
+         * Setup npm settings for given packageUpdater.
+         * 
+         * @param packageUpdater
+         *            package updater to use with npm
+         * @return npm settings
+         */
+        public TaskRunNpmInstall.NpmSettings getNpmSettings(
+                TaskUpdatePackages packageUpdater) {
+            TaskRunNpmInstall.NpmSettings settings = new TaskRunNpmInstall.NpmSettings(packageUpdater);
+            settings.setEnablePnpm(enablePnpm);
+            settings.setRequireHomeNodeExec(requireHomeNodeExec);
+            settings.setNodeVersion(nodeVersion);
+            settings.setNodeDownloadRoot(nodeDownloadRoot);
+            settings.setUseGlobalPnpm(useGlobalPnpm);
+            settings.setAutoUpdate(nodeAutoUpdate);
+            return settings;
+        }
     }
 
     // @formatter:off
@@ -637,10 +656,8 @@ public class NodeTasks implements FallibleCommand {
 
             }
             if (packageUpdater != null && builder.runNpmInstall) {
-                commands.add(new TaskRunNpmInstall(classFinder, packageUpdater,
-                        builder.enablePnpm, builder.requireHomeNodeExec,
-                        builder.nodeVersion, builder.nodeDownloadRoot,
-                        builder.useGlobalPnpm, builder.nodeAutoUpdate));
+                commands.add(new TaskRunNpmInstall(
+                        builder.getNpmSettings(packageUpdater)));
 
                 commands.add(new TaskInstallWebpackPlugins(
                         new File(builder.npmFolder, builder.buildDirectory)));

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.server.frontend;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URI;
 
 import net.jcip.annotations.NotThreadSafe;
 import org.apache.commons.io.FileUtils;
@@ -34,7 +33,6 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.ExecutionFailedException;
-import com.vaadin.flow.server.frontend.installer.NodeInstaller;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
 
@@ -69,6 +67,7 @@ public class TaskRunNpmInstallTest {
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
+    protected TaskRunNpmInstall.NpmSettings npmSettings;
 
     @Before
     public void setUp() throws IOException {
@@ -90,14 +89,13 @@ public class TaskRunNpmInstallTest {
             }
 
         };
+        npmSettings = new TaskRunNpmInstall.NpmSettings(getNodeUpdater());
         task = createTask();
     }
 
     protected TaskRunNpmInstall createTask() {
-        return new TaskRunNpmInstall(getClassFinder(), getNodeUpdater(), false,
-                false, FrontendTools.DEFAULT_NODE_VERSION,
-                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT), false,
-                false);
+        npmSettings.setEnablePnpm(false);
+        return new TaskRunNpmInstall(npmSettings);
     }
 
     @Test
@@ -261,11 +259,9 @@ public class TaskRunNpmInstallTest {
             throws IOException, ExecutionFailedException {
         exception.expectMessage(
                 "it's either not a file or not a 'node' executable.");
+        npmSettings.setRequireHomeNodeExec(true);
         assertRunNpmInstallThrows_vaadinHomeNodeIsAFolder(
-                new TaskRunNpmInstall(getClassFinder(), getNodeUpdater(), false,
-                        true, FrontendTools.DEFAULT_NODE_VERSION,
-                        URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT),
-                        false, false));
+                new TaskRunNpmInstall(npmSettings));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.server.frontend;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.FileUtils;
@@ -30,7 +29,6 @@ import org.mockito.Mockito;
 
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.ExecutionFailedException;
-import com.vaadin.flow.server.frontend.installer.NodeInstaller;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.testutil.FrontendStubs;
 
@@ -78,8 +76,7 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
                 "@vaadin/vaadin-overlay/package.json");
 
         // The resulting version should be the one specified via
-        // platform
-        // versions file
+        // platform versions file
         JsonObject overlayPackage = Json.parse(FileUtils
                 .readFileToString(overlayPackageJson, StandardCharsets.UTF_8));
         Assert.assertEquals(PINNED_VERSION,
@@ -138,11 +135,9 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
             throws IOException, ExecutionFailedException {
         exception.expectMessage(
                 "it's either not a file or not a 'node' executable.");
+        npmSettings.setRequireHomeNodeExec(true);
         assertRunNpmInstallThrows_vaadinHomeNodeIsAFolder(
-                new TaskRunNpmInstall(getClassFinder(), getNodeUpdater(), true,
-                        true, FrontendTools.DEFAULT_NODE_VERSION,
-                        URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT),
-                        false, false));
+                new TaskRunNpmInstall(npmSettings));
     }
 
     @Test
@@ -642,17 +637,11 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
 
     @Override
     protected TaskRunNpmInstall createTask() {
-        return new TaskRunNpmInstall(getClassFinder(), getNodeUpdater(), true,
-                false, FrontendTools.DEFAULT_NODE_VERSION,
-                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT), false,
-                false);
+        return new TaskRunNpmInstall(npmSettings);
     }
 
     protected TaskRunNpmInstall createTask(String versionsContent) {
-        return new TaskRunNpmInstall(getClassFinder(), getNodeUpdater(), true,
-                false, FrontendTools.DEFAULT_NODE_VERSION,
-                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT), false,
-                false) {
+        return new TaskRunNpmInstall(npmSettings) {
             @Override
             protected String generateVersionsJson() {
                 try {
@@ -674,11 +663,7 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         Mockito.when(classFinder.getResource(Constants.VAADIN_VERSIONS_JSON))
                 .thenReturn(versions.toURI().toURL());
 
-        TaskRunNpmInstall task = new TaskRunNpmInstall(getClassFinder(),
-                getNodeUpdater(), true, false,
-                FrontendTools.DEFAULT_NODE_VERSION,
-                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT), false,
-                false);
+        TaskRunNpmInstall task = new TaskRunNpmInstall(npmSettings);
 
         String path = task.generateVersionsJson();
 

--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
@@ -198,6 +198,7 @@ public abstract class ClassesSerializableTest extends ClassFinder {
                 "com\\.vaadin\\.flow\\.server\\.frontend\\.TaskCopyLocalFrontendFiles",
                 "com\\.vaadin\\.flow\\.server\\.frontend\\.TaskGeneratePackageJson",
                 "com\\.vaadin\\.flow\\.server\\.frontend\\.TaskRunNpmInstall",
+                "com\\.vaadin\\.flow\\.server\\.frontend\\.TaskRunNpmInstall\\$NpmSettings",
                 "com\\.vaadin\\.flow\\.server\\.frontend\\.TaskUpdateImports(\\$.*)?",
                 "com\\.vaadin\\.flow\\.server\\.frontend\\.TaskUpdatePackages",
                 "com\\.vaadin\\.flow\\.server\\.frontend\\.TaskUpdateWebpack",


### PR DESCRIPTION
Use a settings object with TaskRunNpmInstall
so it is easier to see and controll what settings
are used.

