### PR TITLE
fix: Close only for click on Close

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -1541,11 +1541,10 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                 Element errorElement = document.createElement("div");
                 errorElement.setBaseUri("");
                 errorElement.attr("class", "v-system-error");
-                errorElement.attr("onclick",
-                        "this.parentElement.removeChild(this)");
                 errorElement
                         .html("<h3 style=\"display:inline;\">Webpack Error</h3>"
-                                + "<h6 style=\"display:inline; padding-left:10px;\">Click to close</h6>"
+                                + "<h6 style=\"display:inline; padding-left:10px;\" "
+                                + "onclick=\"this.parentElement.parentElement.removeChild(this.parentElement)\">Close</h6>"
                                 + "<pre>" + errorMsg + "</pre>");
                 document.body().appendChild(errorElement);
             }

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
@@ -513,8 +513,7 @@ public class IndexHtmlRequestHandlerTest {
         String indexHtml = responseOutput
                 .toString(StandardCharsets.UTF_8.name());
         Assert.assertTrue("Should have a system error dialog",
-                indexHtml.contains(
-                        "<div class=\"v-system-error\" onclick=\"this.parentElement.removeChild(this)\">"));
+                indexHtml.contains("<div class=\"v-system-error\">"));
         Assert.assertTrue("Should show webpack failure error",
                 indexHtml.contains("Failed to compile"));
     }


### PR DESCRIPTION
To enable copying of the exception
only clicking on `Close` closes the popup

Fixes #8964
