### PR TITLE
Revert "fix: make webpack respect path aliases in tsconfig (#11912)"

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -365,7 +365,6 @@ public abstract class NodeUpdater implements FallibleCommand {
         defaults.put("typescript", "4.4.3");
         defaults.put("esbuild-loader", "2.15.1");
         defaults.put("fork-ts-checker-webpack-plugin", "6.2.1");
-        defaults.put("tsconfig-paths-webpack-plugin", "3.5.1");
 
         defaults.put("webpack", "4.46.0");
         defaults.put("webpack-cli", "4.9.0");

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -12,7 +12,6 @@ const { DefinePlugin } = require('webpack');
 const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
 const ExtraWatchWebpackPlugin = require('extra-watch-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
-const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 
 // Flow plugins
 const StatsPlugin = require('@vaadin/stats-plugin');
@@ -368,10 +367,6 @@ module.exports = {
       typescript: {
         configFile: tsconfigJsonFile
       }
-    }),
-
-    enableTypeScript && new TsconfigPathsPlugin({
-      configFile: tsconfigJsonFile
     }),
 
     new BuildStatusPlugin()


### PR DESCRIPTION
This reverts commit ed1b2e93177f85af0bfa3b1db7a77d74c7c8bc6a.

Causing webpack errors during Spring addon build.