### PR TITLE
chore: Remove unnecessary css wrapping

### DIFF
--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
@@ -105,7 +105,7 @@ function generateThemeFile(themeFolder, themeName, themeProperties, productionMo
   let themeFile = headerImport;
 
   if (componentsFiles.length > 0) {
-    themeFile += 'import { css, unsafeCSS, registerStyles } from \'@vaadin/vaadin-themable-mixin/register-styles\';\n';
+    themeFile += 'import { unsafeCSS, registerStyles } from \'@vaadin/vaadin-themable-mixin/register-styles\';\n';
   }
 
   if (themeProperties.parent) {
@@ -205,9 +205,7 @@ function generateThemeFile(themeFolder, themeName, themeProperties, productionMo
 // Don't format as the generated file formatting will get wonky!
     const componentString = `registerStyles(
       '${tag}',
-      css\`
-        \${unsafeCSS(${variable}.toString())}
-      \`
+      unsafeCSS(${variable}.toString())
     );
     `;
     componentCssCode.push(componentString);


### PR DESCRIPTION
## Description

`unsafeCSS` function already wraps a value into CSS tagged literal, so the extra wrapping is not needed.

Fixes # (issue)

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
