### PR TITLE
fix: check that numeric value exists

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendVersion.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendVersion.java
@@ -338,6 +338,12 @@ public class FrontendVersion
                 return thisMatcher.group(1)
                         .compareToIgnoreCase(otherMatcher.group(1));
             }
+            // if one or both are missing numeric value do not parse int
+            if (thisMatcher.group(2).isEmpty()
+                    || otherMatcher.group(2).isEmpty()) {
+                return buildIdentifier
+                        .compareToIgnoreCase(other.buildIdentifier);
+            }
             return Integer.parseInt(thisMatcher.group(2))
                     - Integer.parseInt(otherMatcher.group(2));
         }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendVersionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendVersionTest.java
@@ -3,6 +3,7 @@ package com.vaadin.flow.server.frontend;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static com.helger.commons.mock.CommonsAssert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -75,6 +76,18 @@ public class FrontendVersionTest {
         fromConstructor = new FrontendVersion(12, 3, 5, "alpha12");
         assertTrue("Full version with build identifier didn't match",
                 fromString.isEqualTo(fromConstructor));
+    }
+
+    @Test // #12041
+    public void testSimilarBuildIdentifiers() {
+        FrontendVersion version = new FrontendVersion("1.1.1-SNAPSHOT");
+        FrontendVersion equals = new FrontendVersion("1.1.1-SNAPSHOT");
+
+        assertTrue("Versions be the same", version.isEqualTo(equals));
+        assertFalse("Version should not be older", version.isOlderThan(equals));
+        assertEquals("Versions should not have a difference", 0,
+                version.compareTo(equals));
+        assertFalse("Version should not be newer", version.isNewerThan(equals));
     }
 
     @Test(expected = NumberFormatException.class)


### PR DESCRIPTION
Check that a value exists for buildIdentifier
before parsing integer.

Fixes #12041
