### PR TITLE
fix: show the accurate route class name in err msg

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteConfiguration.java
@@ -513,8 +513,7 @@ public class RouteConfiguration implements Serializable {
         if (!targetUrl.isPresent()) {
             throw new NotFoundException(String.format(
                     "No route found for the given navigation target '%s' and parameters '%s'",
-                    navigationTarget.getName(),
-                    parameters.toString()));
+                    navigationTarget.getName(), parameters.toString()));
         }
         return targetUrl.get();
     }


### PR DESCRIPTION
The `navigationTarget` is already a Class, should call `navigationTarget.getName()` directly, calling `navigationTarget.getClass().getName()` will always give `java.lang.Class` which is not helpful in the error message.