### PR TITLE
Do not return  a null buildFolder to avoid NPE in latest JDK

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/UidlRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/UidlRequestHandlerTest.java
@@ -74,6 +74,7 @@ public class UidlRequestHandlerTest {
                 .mock(ApplicationConfiguration.class);
         Mockito.when(config.getPropertyNames())
                 .thenReturn(Collections.emptyEnumeration());
+        Mockito.when(config.getBuildFolder()).thenReturn(".");
         VaadinService service = new VaadinServletService(null,
                 new DefaultDeploymentConfiguration(config, getClass(),
                         new Properties()));


### PR DESCRIPTION
`UnixFileSystem.getPath` has a null assertion that breaks tests that pass null as the first argument (base folder) in `Paths.get` 

This fixes flow-server tests when running them in the nightly JDKs build