### PR TITLE
chore: Remove non-supported teletype text tag from javadoc

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/BindingException.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/BindingException.java
@@ -22,7 +22,7 @@ import com.vaadin.flow.data.binder.Binder.Binding;
  * A subclass of {@link RuntimeException} which may be thrown inside
  * {@link Binding} logic to wrap an exception caused by {@link HasValue},
  * validator, converter, etc. behavior.
- * 
+ *
  * @author Vaadin Ltd
  * @since
  *
@@ -48,7 +48,7 @@ public class BindingException extends RuntimeException {
      *            the detail message
      * @param cause
      *            the cause (which is saved for later retrieval by the
-     *            {@link #getCause()} method). (A <tt>null</tt> value is
+     *            {@link #getCause()} method). (A <code>null</code> value is
      *            permitted, and indicates that the cause is nonexistent or
      *            unknown.)
      */
@@ -58,12 +58,12 @@ public class BindingException extends RuntimeException {
 
     /**
      * Constructs a new binding exception with the specified cause and a detail
-     * message of <tt>(cause==null ? null : cause.toString())</tt> (which
-     * typically contains the class and detail message of <tt>cause</tt>).
+     * message of <code>(cause==null ? null : cause.toString())</code> (which
+     * typically contains the class and detail message of <code>cause</code>).
      *
      * @param cause
      *            the cause (which is saved for later retrieval by the
-     *            {@link #getCause()} method). (A <tt>null</tt> value is
+     *            {@link #getCause()} method). (A <code>null</code> value is
      *            permitted, and indicates that the cause is nonexistent or
      *            unknown.)
      */

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ModelList.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ModelList.java
@@ -76,11 +76,11 @@ public class ModelList extends StateNodeNodeList {
     }
 
     /**
-     * Returns <tt>true</tt> if this list contains the specified node. More
+     * Returns <code>true</code> if this list contains the specified node. More
      *
      * @param node
      *            node whose presence in this list is to be tested
-     * @return <tt>true</tt> if this list contains the specified node
+     * @return <code>true</code> if this list contains the specified node
      */
     public boolean contains(StateNode node) {
         return indexOf(node) != -1;

--- a/flow-server/src/main/java/com/vaadin/flow/router/InvalidLocationException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/InvalidLocationException.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.router;
 
 /**
  * Thrown to indicate that a {@link Location} instance is invalid.
- * 
+ *
  * @author Vaadin Ltd
  * @since
  *
@@ -39,13 +39,13 @@ public class InvalidLocationException extends RuntimeException {
     /**
      * Constructs a new runtime exception with the specified detail message and
      * cause.
-     * 
+     *
      * @param message
      *            the detail message (which is saved for later retrieval by the
      *            {@link #getMessage()} method).
      * @param cause
      *            the cause (which is saved for later retrieval by the
-     *            {@link #getCause()} method). (A <tt>null</tt> value is
+     *            {@link #getCause()} method). (A <code>null</code> value is
      *            permitted, and indicates that the cause is nonexistent or
      *            unknown.)
      */

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapException.java
@@ -49,7 +49,7 @@ public class BootstrapException extends RuntimeException {
      *            {@link #getMessage()} method).
      * @param cause
      *            the cause (which is saved for later retrieval by the
-     *            {@link #getCause()} method). (A <tt>null</tt> value is
+     *            {@link #getCause()} method). (A <code>null</code> value is
      *            permitted, and indicates that the cause is nonexistent or
      *            unknown.)
      */

--- a/flow-server/src/main/java/com/vaadin/flow/server/InvalidI18NConfigurationException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InvalidI18NConfigurationException.java
@@ -44,7 +44,7 @@ public class InvalidI18NConfigurationException extends RuntimeException {
      *            retrieval by the {@link #getMessage()} method.
      * @param cause
      *            the cause (which is saved for later retrieval by the
-     *            {@link #getCause()} method). (A <tt>null</tt> value is
+     *            {@link #getCause()} method). (A <code>null</code> value is
      *            permitted, and indicates that the cause is nonexistent or
      *            unknown.)
      */

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ClassLoaderAwareServletContainerInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ClassLoaderAwareServletContainerInitializer.java
@@ -124,7 +124,7 @@ public interface ClassLoaderAwareServletContainerInitializer
 
     /**
      * Whether this initializer requires lookup or not.
-     * 
+     *
      * @return whether this initializer requires lookup
      */
     default boolean requiresLookup() {
@@ -139,14 +139,14 @@ public interface ClassLoaderAwareServletContainerInitializer
      *            the Set of application classes that extend, implement, or have
      *            been annotated with the class types specified by the
      *            {@link javax.servlet.annotation.HandlesTypes HandlesTypes}
-     *            annotation, or <tt>null</tt> if there are no matches, or this
-     *            <tt>ServletContainerInitializer</tt> has not been annotated
-     *            with <tt>HandlesTypes</tt>
+     *            annotation, or <code>null</code> if there are no matches, or
+     *            this <code>ServletContainerInitializer</code> has not been
+     *            annotated with <code>HandlesTypes</code>
      *
      * @param context
-     *            the <tt>ServletContext</tt> of the web application that is
+     *            the <code>ServletContext</code> of the web application that is
      *            being started and in which the classes contained in
-     *            <tt>classSet</tt> were found
+     *            <code>classSet</code> were found
      *
      * @throws ServletException
      *             if an error has occurred

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinInitializerException.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinInitializerException.java
@@ -41,7 +41,7 @@ public class VaadinInitializerException extends Exception {
      *            {@link #getMessage()} method).
      * @param cause
      *            the cause (which is saved for later retrieval by the
-     *            {@link #getCause()} method). (A <tt>null</tt> value is
+     *            {@link #getCause()} method). (A <code>null</code> value is
      *            permitted, and indicates that the cause is nonexistent or
      *            unknown.)
      */


### PR DESCRIPTION
## Description

The `<tt>` tag is not supported in HTML5 anymore, thus replaced by another one in javadoc.

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
