### PR TITLE
chore: Remove non-supported summary attribute from javadoc

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -2907,6 +2907,7 @@ public class Binder<BEAN> implements Serializable {
      *
      * Return values for each case are compiled into the following table:
      * <table>
+     * <caption>Return values</caption>
      * <tr>
      * <td></td>
      * <td>After readBean, setBean or removeBean</td>


### PR DESCRIPTION
## Description

Using JDK17 fails when `summary` attribute of `table` is used + HTML5 doesn't support it.

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
