### PR TITLE
refactor: Move dev mode handler initialization to DevModeHandlerManager

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/DevModeHandlerManager.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/DevModeHandlerManager.java
@@ -16,10 +16,12 @@
 package com.vaadin.flow.internal;
 
 import java.util.Optional;
+import java.util.Set;
 
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.server.VaadinContext;
 import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.startup.VaadinInitializerException;
 
 /**
  * Provides API to access to the {@link DevModeHandler} instance by a
@@ -42,12 +44,18 @@ public interface DevModeHandlerManager {
     Class<?>[] getHandlesTypes();
 
     /**
-     * Defines the handler to use with this manager.
+     * Initialize the dev mode server if not in production mode.
      *
-     * @param devModeHandler
-     *            the dev mode handler to use
+     * @param classes
+     *            classes to check for npm and js modules
+     * @param context
+     *            VaadinContext we are running in
+     *
+     * @throws VaadinInitializerException
+     *             if the dev mode server cannot be initialized
      */
-    void setDevModeHandler(DevModeHandler devModeHandler);
+    void initDevModeHandler(Set<Class<?>> classes, VaadinContext context)
+            throws VaadinInitializerException;
 
     /**
      * Returns a {@link DevModeHandler} instance for the given {@code service}.

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
@@ -15,7 +15,10 @@
  */
 package com.vaadin.flow.server.communication;
 
-import javax.servlet.http.HttpServletRequest;
+import static com.vaadin.flow.component.internal.JavaScriptBootstrapUI.SERVER_ROUTING;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -24,22 +27,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import org.jsoup.Jsoup;
-import org.jsoup.internal.StringUtil;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
-import org.jsoup.select.Elements;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
+import javax.servlet.http.HttpServletRequest;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.internal.JavaScriptBootstrapUI;
@@ -62,15 +54,25 @@ import com.vaadin.flow.server.startup.VaadinAppShellInitializerTest.MyAppShellWi
 import com.vaadin.flow.server.startup.VaadinAppShellInitializerTest.MyAppShellWithLoadingIndicatorConfig;
 import com.vaadin.flow.server.startup.VaadinAppShellInitializerTest.MyAppShellWithPushConfig;
 import com.vaadin.flow.server.startup.VaadinAppShellInitializerTest.MyAppShellWithReconnectionDialogConfig;
+import com.vaadin.flow.server.startup.VaadinInitializerException;
 import com.vaadin.tests.util.MockDeploymentConfiguration;
+
+import org.jsoup.Jsoup;
+import org.jsoup.internal.StringUtil;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 
 import elemental.json.Json;
 import elemental.json.JsonObject;
-
-import static com.vaadin.flow.component.internal.JavaScriptBootstrapUI.SERVER_ROUTING;
-import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.verify;
 
 public class IndexHtmlRequestHandlerTest {
     private static final String SPRING_CSRF_ATTRIBUTE_IN_SESSION = "org.springframework.security.web.csrf.CsrfToken";
@@ -489,9 +491,10 @@ public class IndexHtmlRequestHandlerTest {
             }
 
             @Override
-            public void setDevModeHandler(DevModeHandler devModeHandler) {
+            public void initDevModeHandler(Set<java.lang.Class<?>> classes,
+                    VaadinContext context) throws VaadinInitializerException {
 
-            }
+            };
 
             @Override
             public DevModeHandler getDevModeHandler() {

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerManagerImpl.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerManagerImpl.java
@@ -15,11 +15,78 @@
  */
 package com.vaadin.base.devserver;
 
+import static com.vaadin.flow.server.Constants.CONNECT_APPLICATION_PROPERTIES_TOKEN;
+import static com.vaadin.flow.server.Constants.CONNECT_JAVA_SOURCE_FOLDER_TOKEN;
+import static com.vaadin.flow.server.Constants.CONNECT_OPEN_API_FILE_TOKEN;
+import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
+import static com.vaadin.flow.server.Constants.PROJECT_FRONTEND_GENERATED_DIR_TOKEN;
+import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
+import static com.vaadin.flow.server.Constants.VAADIN_WEBAPP_RESOURCES;
+import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_CONNECT_APPLICATION_PROPERTIES;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_CONNECT_JAVA_SOURCE_FOLDER;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_CONNECT_OPENAPI_JSON_FILE;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
+import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_PROJECT_FRONTEND_GENERATED_DIR;
+import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_FRONTEND_DIR;
+import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_GENERATED_DIR;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.io.UncheckedIOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
 import javax.servlet.annotation.HandlesTypes;
 
 import com.vaadin.base.devserver.startup.DevModeInitializer;
+import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.internal.DevModeHandler;
 import com.vaadin.flow.internal.DevModeHandlerManager;
+import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.ExecutionFailedException;
+import com.vaadin.flow.server.InitParameters;
+import com.vaadin.flow.server.VaadinContext;
+import com.vaadin.flow.server.frontend.EndpointGeneratorTaskFactory;
+import com.vaadin.flow.server.frontend.FallbackChunk;
+import com.vaadin.flow.server.frontend.FrontendUtils;
+import com.vaadin.flow.server.frontend.NodeTasks;
+import com.vaadin.flow.server.frontend.NodeTasks.Builder;
+import com.vaadin.flow.server.frontend.scanner.ClassFinder;
+import com.vaadin.flow.server.frontend.scanner.ClassFinder.DefaultClassFinder;
+import com.vaadin.flow.server.startup.ApplicationConfiguration;
+import com.vaadin.flow.server.startup.VaadinInitializerException;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import elemental.json.Json;
+import elemental.json.JsonObject;
 
 /**
  * Provides API to access to the {@link DevModeHandler} instance.
@@ -31,6 +98,87 @@ import com.vaadin.flow.internal.DevModeHandlerManager;
  */
 public class DevModeHandlerManagerImpl implements DevModeHandlerManager {
 
+    static class DevModeClassFinder extends DefaultClassFinder {
+
+        private static final Set<String> APPLICABLE_CLASS_NAMES = Collections
+                .unmodifiableSet(calculateApplicableClassNames());
+
+        public DevModeClassFinder(Set<Class<?>> classes) {
+            super(classes);
+        }
+
+        @Override
+        public Set<Class<?>> getAnnotatedClasses(
+                Class<? extends Annotation> annotation) {
+            ensureImplementation(annotation);
+            return super.getAnnotatedClasses(annotation);
+        }
+
+        @Override
+        public <T> Set<Class<? extends T>> getSubTypesOf(Class<T> type) {
+            ensureImplementation(type);
+            return super.getSubTypesOf(type);
+        }
+
+        private void ensureImplementation(Class<?> clazz) {
+            if (!APPLICABLE_CLASS_NAMES.contains(clazz.getName())) {
+                throw new IllegalArgumentException("Unexpected class name "
+                        + clazz + ". Implementation error: the class finder "
+                        + "instance is not aware of this class. "
+                        + "Fix @HandlesTypes annotation value for "
+                        + DevModeInitializer.class.getName());
+            }
+        }
+
+        private static Set<String> calculateApplicableClassNames() {
+            HandlesTypes handlesTypes = DevModeInitializer.class
+                    .getAnnotation(HandlesTypes.class);
+            return Stream.of(handlesTypes.value()).map(Class::getName)
+                    .collect(Collectors.toSet());
+        }
+    }
+
+    // Attribute key for storing Dev Mode Handler startup flag.
+    // If presented in Servlet Context, shows the Dev Mode Handler already
+    // started / become starting.
+    // This attribute helps to avoid Dev Mode running twice.
+    //
+    // Addresses the issue https://github.com/vaadin/spring/issues/502
+    private static final class DevModeHandlerAlreadyStartedAttribute
+            implements Serializable {
+    }
+
+    private static final Pattern JAR_FILE_REGEX = Pattern
+            .compile(".*file:(.+\\.jar).*");
+
+    // Path of jar files in a URL with zip protocol doesn't start with
+    // "zip:"
+    // nor "file:". It contains only the path of the file.
+    // Weblogic uses zip protocol.
+    private static final Pattern ZIP_PROTOCOL_JAR_FILE_REGEX = Pattern
+            .compile("(.+\\.jar).*");
+
+    private static final Pattern VFS_FILE_REGEX = Pattern
+            .compile("(vfs:/.+\\.jar).*");
+
+    private static final Pattern VFS_DIRECTORY_REGEX = Pattern
+            .compile("vfs:/.+");
+
+    // allow trailing slash
+    private static final Pattern DIR_REGEX_FRONTEND_DEFAULT = Pattern.compile(
+            "^(?:file:0)?(.+)" + Constants.RESOURCES_FRONTEND_DEFAULT + "/?$");
+
+    // allow trailing slash
+    private static final Pattern DIR_REGEX_RESOURCES_JAR_DEFAULT = Pattern
+            .compile("^(?:file:0)?(.+)" + Constants.RESOURCES_THEME_JAR_DEFAULT
+                    + "/?$");
+
+    // allow trailing slash
+    private static final Pattern DIR_REGEX_COMPATIBILITY_FRONTEND_DEFAULT = Pattern
+            .compile("^(?:file:)?(.+)"
+                    + Constants.COMPATIBILITY_RESOURCES_FRONTEND_DEFAULT
+                    + "/?$");
+
     private DevModeHandler devModeHandler;
 
     @Override
@@ -40,18 +188,386 @@ public class DevModeHandlerManagerImpl implements DevModeHandlerManager {
     }
 
     @Override
-    public void setDevModeHandler(DevModeHandler devModeHandler) {
-        if (this.devModeHandler != null) {
-            throw new IllegalStateException(
-                    "Unable to initialize dev mode handler. A handler is already present: "
-                            + this.devModeHandler);
-        }
-        this.devModeHandler = devModeHandler;
+    public DevModeHandler getDevModeHandler() {
+        return devModeHandler;
     }
 
     @Override
-    public DevModeHandler getDevModeHandler() {
-        return devModeHandler;
+    public void initDevModeHandler(Set<Class<?>> classes, VaadinContext context)
+            throws VaadinInitializerException {
+
+        ApplicationConfiguration config = ApplicationConfiguration.get(context);
+        if (config.isProductionMode()) {
+            log().debug("Skipping DEV MODE because PRODUCTION MODE is set.");
+            return;
+        }
+        if (!config.enableDevServer()) {
+            log().debug(
+                    "Skipping DEV MODE because dev server shouldn't be enabled.");
+            return;
+        }
+
+        String baseDir = config.getStringProperty(FrontendUtils.PROJECT_BASEDIR,
+                null);
+        if (baseDir == null) {
+            baseDir = getBaseDirectoryFallback();
+        }
+
+        String generatedDir = System.getProperty(PARAM_GENERATED_DIR,
+                Paths.get(config.getBuildFolder(), DEFAULT_GENERATED_DIR)
+                        .toString());
+        String frontendFolder = config.getStringProperty(PARAM_FRONTEND_DIR,
+                System.getProperty(PARAM_FRONTEND_DIR, DEFAULT_FRONTEND_DIR));
+
+        File flowResourcesFolder = new File(baseDir,
+                config.getFlowResourcesFolder());
+
+        Lookup lookupFromContext = context.getAttribute(Lookup.class);
+        Lookup lookupForClassFinder = Lookup.of(new DevModeClassFinder(classes),
+                ClassFinder.class);
+        Lookup lookup = Lookup.compose(lookupForClassFinder, lookupFromContext);
+        Builder builder = new NodeTasks.Builder(lookup, new File(baseDir),
+                new File(generatedDir), new File(frontendFolder),
+                config.getBuildFolder());
+
+        log().info("Starting dev-mode updaters in {} folder.",
+                builder.getNpmFolder());
+
+        if (!builder.getGeneratedFolder().exists()) {
+            try {
+                FileUtils.forceMkdir(builder.getGeneratedFolder());
+            } catch (IOException e) {
+                throw new UncheckedIOException(
+                        String.format("Failed to create directory '%s'",
+                                builder.getGeneratedFolder()),
+                        e);
+            }
+        }
+
+        File generatedPackages = new File(builder.getGeneratedFolder(),
+                PACKAGE_JSON);
+
+        // Regenerate webpack configuration, as it may be necessary to
+        // update it
+        // TODO: make sure target directories are aligned with build
+        // config,
+        // see https://github.com/vaadin/flow/issues/9082
+        File target = new File(baseDir, config.getBuildFolder());
+        builder.withWebpack(new File(target, VAADIN_WEBAPP_RESOURCES),
+                new File(target, VAADIN_SERVLET_RESOURCES),
+                FrontendUtils.WEBPACK_CONFIG, FrontendUtils.WEBPACK_GENERATED);
+
+        builder.useV14Bootstrap(config.useV14Bootstrap());
+
+        if (!config.useV14Bootstrap() && isEndpointServiceAvailable(lookup)) {
+            String connectJavaSourceFolder = config.getStringProperty(
+                    CONNECT_JAVA_SOURCE_FOLDER_TOKEN,
+                    Paths.get(baseDir, DEFAULT_CONNECT_JAVA_SOURCE_FOLDER)
+                            .toString());
+            String connectApplicationProperties = config.getStringProperty(
+                    CONNECT_APPLICATION_PROPERTIES_TOKEN,
+                    Paths.get(baseDir, DEFAULT_CONNECT_APPLICATION_PROPERTIES)
+                            .toString());
+            String connectOpenApiJsonFile = config
+                    .getStringProperty(CONNECT_OPEN_API_FILE_TOKEN,
+                            Paths.get(baseDir, config.getBuildFolder(),
+                                    DEFAULT_CONNECT_OPENAPI_JSON_FILE)
+                                    .toString());
+
+            builder.withFusionJavaSourceFolder(
+                    new File(connectJavaSourceFolder))
+                    .withFusionApplicationProperties(
+                            new File(connectApplicationProperties))
+                    .withFusionGeneratedOpenAPIJson(
+                            new File(connectOpenApiJsonFile));
+        }
+
+        // If we are missing either the base or generated package json
+        // files
+        // generate those
+        if (!new File(builder.getNpmFolder(), PACKAGE_JSON).exists()
+                || !generatedPackages.exists()) {
+            builder.createMissingPackageJson(true);
+        }
+
+        Set<File> frontendLocations = getFrontendLocationsFromClassloader(
+                DevModeInitializer.class.getClassLoader());
+
+        boolean useByteCodeScanner = config.getBooleanProperty(
+                SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE,
+                Boolean.parseBoolean(System.getProperty(
+                        SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE,
+                        Boolean.FALSE.toString())));
+
+        boolean enablePnpm = config.isPnpmEnabled();
+
+        boolean useGlobalPnpm = config.isGlobalPnpm();
+
+        boolean useHomeNodeExec = config.getBooleanProperty(
+                InitParameters.REQUIRE_HOME_NODE_EXECUTABLE, false);
+
+        String fusionClientAPIFolder = config.getStringProperty(
+                PROJECT_FRONTEND_GENERATED_DIR_TOKEN,
+                Paths.get(baseDir, DEFAULT_PROJECT_FRONTEND_GENERATED_DIR)
+                        .toString());
+
+        JsonObject tokenFileData = Json.createObject();
+        NodeTasks tasks = builder.enablePackagesUpdate(true)
+                .useByteCodeScanner(useByteCodeScanner)
+                .withFlowResourcesFolder(flowResourcesFolder)
+                .withFusionClientAPIFolder(new File(fusionClientAPIFolder))
+                .copyResources(frontendLocations)
+                .copyLocalResources(new File(baseDir,
+                        Constants.LOCAL_FRONTEND_RESOURCES_PATH))
+                .enableImportsUpdate(true).runNpmInstall(true)
+                .populateTokenFileData(tokenFileData)
+                .withEmbeddableWebComponents(true).enablePnpm(enablePnpm)
+                .useGlobalPnpm(useGlobalPnpm)
+                .withHomeNodeExecRequired(useHomeNodeExec).build();
+
+        Runnable runnable = () -> runNodeTasks(context, tokenFileData, tasks);
+
+        CompletableFuture<Void> nodeTasksFuture = CompletableFuture
+                .runAsync(runnable);
+
+        this.devModeHandler = WebpackHandler.start(
+                Lookup.compose(lookup,
+                        Lookup.of(config, ApplicationConfiguration.class)),
+                builder.getNpmFolder(), nodeTasksFuture);
+
+        setDevModeStarted(context);
+
+    }
+
+    private void setDevModeStarted(VaadinContext context) {
+        context.setAttribute(DevModeHandlerAlreadyStartedAttribute.class,
+                new DevModeHandlerAlreadyStartedAttribute());
+    }
+
+    private static boolean isEndpointServiceAvailable(Lookup lookup) {
+        if (lookup == null) {
+            return false;
+        }
+        return lookup.lookup(EndpointGeneratorTaskFactory.class) != null;
+    }
+
+    /*
+     * Accept user.dir or cwd as a fallback only if the directory seems to be a
+     * Maven or Gradle project. Check to avoid cluttering server directories
+     * (see tickets #8249, #8403).
+     */
+    private static String getBaseDirectoryFallback() {
+        String baseDirCandidate = System.getProperty("user.dir", ".");
+        Path path = Paths.get(baseDirCandidate);
+        if (path.toFile().isDirectory()
+                && (path.resolve("pom.xml").toFile().exists()
+                        || path.resolve("build.gradle").toFile().exists())) {
+            return path.toString();
+        } else {
+            throw new IllegalStateException(String.format(
+                    "Failed to determine project directory for dev mode. "
+                            + "Directory '%s' does not look like a Maven or "
+                            + "Gradle project. Ensure that you have run the "
+                            + "prepare-frontend Maven goal, which generates "
+                            + "'flow-build-info.json', prior to deploying your "
+                            + "application",
+                    path.toString()));
+        }
+    }
+
+    /*
+     * This method returns all folders of jar files having files in the
+     * META-INF/resources/frontend and META-INF/resources/themes folder. We
+     * don't use URLClassLoader because will fail in Java 9+
+     */
+    static Set<File> getFrontendLocationsFromClassloader(
+            ClassLoader classLoader) throws VaadinInitializerException {
+        Set<File> frontendFiles = new HashSet<>();
+        frontendFiles.addAll(getFrontendLocationsFromClassloader(classLoader,
+                Constants.RESOURCES_FRONTEND_DEFAULT));
+        frontendFiles.addAll(getFrontendLocationsFromClassloader(classLoader,
+                Constants.COMPATIBILITY_RESOURCES_FRONTEND_DEFAULT));
+        frontendFiles.addAll(getFrontendLocationsFromClassloader(classLoader,
+                Constants.RESOURCES_THEME_JAR_DEFAULT));
+        return frontendFiles;
+    }
+
+    private static void runNodeTasks(VaadinContext vaadinContext,
+            JsonObject tokenFileData, NodeTasks tasks) {
+        try {
+            tasks.execute();
+
+            FallbackChunk chunk = FrontendUtils
+                    .readFallbackChunk(tokenFileData);
+            if (chunk != null) {
+                vaadinContext.setAttribute(chunk);
+            }
+        } catch (ExecutionFailedException exception) {
+            log().debug(
+                    "Could not initialize dev mode handler. One of the node tasks failed",
+                    exception);
+            throw new CompletionException(exception);
+        }
+    }
+
+    private static Set<File> getFrontendLocationsFromClassloader(
+            ClassLoader classLoader, String resourcesFolder)
+            throws VaadinInitializerException {
+        Set<File> frontendFiles = new HashSet<>();
+        try {
+            Enumeration<URL> en = classLoader.getResources(resourcesFolder);
+            if (en == null) {
+                return frontendFiles;
+            }
+            Set<String> vfsJars = new HashSet<>();
+            while (en.hasMoreElements()) {
+                URL url = en.nextElement();
+                String urlString = url.toString();
+
+                String path = URLDecoder.decode(url.getPath(),
+                        StandardCharsets.UTF_8.name());
+                Matcher jarMatcher = JAR_FILE_REGEX.matcher(path);
+                Matcher zipProtocolJarMatcher = ZIP_PROTOCOL_JAR_FILE_REGEX
+                        .matcher(path);
+                Matcher dirMatcher = DIR_REGEX_FRONTEND_DEFAULT.matcher(path);
+                Matcher dirResourcesMatcher = DIR_REGEX_RESOURCES_JAR_DEFAULT
+                        .matcher(path);
+                Matcher dirCompatibilityMatcher = DIR_REGEX_COMPATIBILITY_FRONTEND_DEFAULT
+                        .matcher(path);
+                Matcher jarVfsMatcher = VFS_FILE_REGEX.matcher(urlString);
+                Matcher dirVfsMatcher = VFS_DIRECTORY_REGEX.matcher(urlString);
+                if (jarVfsMatcher.find()) {
+                    String vfsJar = jarVfsMatcher.group(1);
+                    if (vfsJars.add(vfsJar)) { // NOSONAR
+                        frontendFiles.add(
+                                getPhysicalFileOfJBossVfsJar(new URL(vfsJar)));
+                    }
+                } else if (dirVfsMatcher.find()) {
+                    URL vfsDirUrl = new URL(urlString.substring(0,
+                            urlString.lastIndexOf(resourcesFolder)));
+                    frontendFiles
+                            .add(getPhysicalFileOfJBossVfsDirectory(vfsDirUrl));
+                } else if (jarMatcher.find()) {
+                    frontendFiles.add(new File(jarMatcher.group(1)));
+                } else if ("zip".equalsIgnoreCase(url.getProtocol())
+                        && zipProtocolJarMatcher.find()) {
+                    frontendFiles.add(new File(zipProtocolJarMatcher.group(1)));
+                } else if (dirMatcher.find()) {
+                    frontendFiles.add(new File(dirMatcher.group(1)));
+                } else if (dirResourcesMatcher.find()) {
+                    frontendFiles.add(new File(dirResourcesMatcher.group(1)));
+                } else if (dirCompatibilityMatcher.find()) {
+                    frontendFiles
+                            .add(new File(dirCompatibilityMatcher.group(1)));
+                } else {
+                    log().warn(
+                            "Resource {} not visited because does not meet supported formats.",
+                            url.getPath());
+                }
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        return frontendFiles;
+    }
+
+    private static File getPhysicalFileOfJBossVfsDirectory(URL url)
+            throws IOException, VaadinInitializerException {
+        try {
+            Object virtualFile = url.openConnection().getContent();
+            Class virtualFileClass = virtualFile.getClass();
+
+            // Reflection as we cannot afford a dependency to
+            // WildFly or JBoss
+            Method getChildrenRecursivelyMethod = virtualFileClass
+                    .getMethod("getChildrenRecursively");
+            Method getPhysicalFileMethod = virtualFileClass
+                    .getMethod("getPhysicalFile");
+
+            // By calling getPhysicalFile, we make sure that the
+            // corresponding
+            // physical files/directories of the root directory and
+            // its children
+            // are created. Later, these physical files are scanned
+            // to collect
+            // their resources.
+            List virtualFiles = (List) getChildrenRecursivelyMethod
+                    .invoke(virtualFile);
+            File rootDirectory = (File) getPhysicalFileMethod
+                    .invoke(virtualFile);
+            for (Object child : virtualFiles) {
+                // side effect: create real-world files
+                getPhysicalFileMethod.invoke(child);
+            }
+            return rootDirectory;
+        } catch (NoSuchMethodException | IllegalAccessException
+                | InvocationTargetException exc) {
+            throw new VaadinInitializerException(
+                    "Failed to invoke JBoss VFS API.", exc);
+        }
+    }
+
+    private static File getPhysicalFileOfJBossVfsJar(URL url)
+            throws IOException, VaadinInitializerException {
+        try {
+            Object jarVirtualFile = url.openConnection().getContent();
+
+            // Creating a temporary jar file out of the vfs files
+            String vfsJarPath = url.toString();
+            String fileNamePrefix = vfsJarPath.substring(
+                    vfsJarPath.lastIndexOf('/') + 1,
+                    vfsJarPath.lastIndexOf(".jar"));
+            Path tempJar = Files.createTempFile(fileNamePrefix, ".jar");
+
+            generateJarFromJBossVfsFolder(jarVirtualFile, tempJar);
+
+            File tempJarFile = tempJar.toFile();
+            tempJarFile.deleteOnExit();
+            return tempJarFile;
+        } catch (NoSuchMethodException | IllegalAccessException
+                | InvocationTargetException exc) {
+            throw new VaadinInitializerException(
+                    "Failed to invoke JBoss VFS API.", exc);
+        }
+    }
+
+    private static void generateJarFromJBossVfsFolder(Object jarVirtualFile,
+            Path tempJar) throws IOException, IllegalAccessException,
+            InvocationTargetException, NoSuchMethodException {
+        // We should use reflection to use JBoss VFS API as we cannot
+        // afford a
+        // dependency to WildFly or JBoss
+        Class virtualFileClass = jarVirtualFile.getClass();
+        Method getChildrenRecursivelyMethod = virtualFileClass
+                .getMethod("getChildrenRecursively");
+        Method openStreamMethod = virtualFileClass.getMethod("openStream");
+        Method isFileMethod = virtualFileClass.getMethod("isFile");
+        Method getPathNameRelativeToMethod = virtualFileClass
+                .getMethod("getPathNameRelativeTo", virtualFileClass);
+
+        List jarVirtualChildren = (List) getChildrenRecursivelyMethod
+                .invoke(jarVirtualFile);
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(
+                Files.newOutputStream(tempJar))) {
+            for (Object child : jarVirtualChildren) {
+                if (!(Boolean) isFileMethod.invoke(child))
+                    continue;
+
+                String relativePath = (String) getPathNameRelativeToMethod
+                        .invoke(child, jarVirtualFile);
+                InputStream inputStream = (InputStream) openStreamMethod
+                        .invoke(child);
+                ZipEntry zipEntry = new ZipEntry(relativePath);
+                zipOutputStream.putNextEntry(zipEntry);
+                IOUtils.copy(inputStream, zipOutputStream);
+                zipOutputStream.closeEntry();
+            }
+        }
+    }
+
+    private static Logger log() {
+        return LoggerFactory.getLogger(DevModeHandlerManagerImpl.class);
     }
 
 }

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
@@ -15,45 +15,14 @@
  */
 package com.vaadin.base.devserver.startup;
 
+import java.io.Serializable;
+import java.util.Set;
+
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
-import javax.servlet.ServletException;
 import javax.servlet.annotation.HandlesTypes;
 import javax.servlet.annotation.WebListener;
-
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.Serializable;
-import java.io.UncheckedIOException;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.net.URL;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Collections;
-import java.util.Enumeration;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
-
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.WebComponentExporter;
 import com.vaadin.flow.component.WebComponentExporterFactory;
@@ -62,52 +31,20 @@ import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.page.AppShellConfigurator;
-import com.vaadin.base.devserver.WebpackHandler;
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.internal.DevModeHandler;
 import com.vaadin.flow.internal.DevModeHandlerManager;
 import com.vaadin.flow.router.HasErrorParameter;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.server.Constants;
-import com.vaadin.flow.server.ExecutionFailedException;
-import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.PWA;
 import com.vaadin.flow.server.UIInitListener;
 import com.vaadin.flow.server.VaadinContext;
 import com.vaadin.flow.server.VaadinServiceInitListener;
 import com.vaadin.flow.server.VaadinServletContext;
-import com.vaadin.flow.server.frontend.EndpointGeneratorTaskFactory;
-import com.vaadin.flow.server.frontend.FallbackChunk;
-import com.vaadin.flow.server.frontend.FrontendUtils;
-import com.vaadin.flow.server.frontend.NodeTasks;
-import com.vaadin.flow.server.frontend.NodeTasks.Builder;
-import com.vaadin.flow.server.frontend.scanner.ClassFinder;
-import com.vaadin.flow.server.frontend.scanner.ClassFinder.DefaultClassFinder;
-import com.vaadin.flow.server.startup.ApplicationConfiguration;
 import com.vaadin.flow.server.startup.VaadinInitializerException;
 import com.vaadin.flow.server.startup.VaadinServletContextStartupInitializer;
 import com.vaadin.flow.theme.NoTheme;
 import com.vaadin.flow.theme.Theme;
-
-import elemental.json.Json;
-import elemental.json.JsonObject;
-
-import static com.vaadin.flow.server.Constants.CONNECT_APPLICATION_PROPERTIES_TOKEN;
-import static com.vaadin.flow.server.Constants.CONNECT_JAVA_SOURCE_FOLDER_TOKEN;
-import static com.vaadin.flow.server.Constants.CONNECT_OPEN_API_FILE_TOKEN;
-import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
-import static com.vaadin.flow.server.Constants.PROJECT_FRONTEND_GENERATED_DIR_TOKEN;
-import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
-import static com.vaadin.flow.server.Constants.VAADIN_WEBAPP_RESOURCES;
-import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE;
-import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_CONNECT_APPLICATION_PROPERTIES;
-import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_CONNECT_JAVA_SOURCE_FOLDER;
-import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_CONNECT_OPENAPI_JSON_FILE;
-import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR;
-import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
-import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_PROJECT_FRONTEND_GENERATED_DIR;
-import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_FRONTEND_DIR;
-import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_GENERATED_DIR;
 
 /**
  * Servlet initializer starting node updaters as well as the webpack-dev-mode
@@ -129,289 +66,16 @@ public class DevModeInitializer
         implements VaadinServletContextStartupInitializer, Serializable,
         ServletContextListener {
 
-    static class DevModeClassFinder extends DefaultClassFinder {
-
-        private static final Set<String> APPLICABLE_CLASS_NAMES = Collections
-                .unmodifiableSet(calculateApplicableClassNames());
-
-        public DevModeClassFinder(Set<Class<?>> classes) {
-            super(classes);
-        }
-
-        @Override
-        public Set<Class<?>> getAnnotatedClasses(
-                Class<? extends Annotation> annotation) {
-            ensureImplementation(annotation);
-            return super.getAnnotatedClasses(annotation);
-        }
-
-        @Override
-        public <T> Set<Class<? extends T>> getSubTypesOf(Class<T> type) {
-            ensureImplementation(type);
-            return super.getSubTypesOf(type);
-        }
-
-        private void ensureImplementation(Class<?> clazz) {
-            if (!APPLICABLE_CLASS_NAMES.contains(clazz.getName())) {
-                throw new IllegalArgumentException("Unexpected class name "
-                        + clazz + ". Implementation error: the class finder "
-                        + "instance is not aware of this class. "
-                        + "Fix @HandlesTypes annotation value for "
-                        + DevModeInitializer.class.getName());
-            }
-        }
-
-        private static Set<String> calculateApplicableClassNames() {
-            HandlesTypes handlesTypes = DevModeInitializer.class
-                    .getAnnotation(HandlesTypes.class);
-            return Stream.of(handlesTypes.value()).map(Class::getName)
-                    .collect(Collectors.toSet());
-        }
-    }
-
-    private static final Pattern JAR_FILE_REGEX = Pattern
-            .compile(".*file:(.+\\.jar).*");
-
-    // Path of jar files in a URL with zip protocol doesn't start with "zip:"
-    // nor "file:". It contains only the path of the file.
-    // Weblogic uses zip protocol.
-    private static final Pattern ZIP_PROTOCOL_JAR_FILE_REGEX = Pattern
-            .compile("(.+\\.jar).*");
-
-    private static final Pattern VFS_FILE_REGEX = Pattern
-            .compile("(vfs:/.+\\.jar).*");
-
-    private static final Pattern VFS_DIRECTORY_REGEX = Pattern
-            .compile("vfs:/.+");
-
-    // allow trailing slash
-    private static final Pattern DIR_REGEX_FRONTEND_DEFAULT = Pattern.compile(
-            "^(?:file:0)?(.+)" + Constants.RESOURCES_FRONTEND_DEFAULT + "/?$");
-
-    // allow trailing slash
-    private static final Pattern DIR_REGEX_RESOURCES_JAR_DEFAULT = Pattern
-            .compile("^(?:file:0)?(.+)" + Constants.RESOURCES_THEME_JAR_DEFAULT
-                    + "/?$");
-
-    // allow trailing slash
-    private static final Pattern DIR_REGEX_COMPATIBILITY_FRONTEND_DEFAULT = Pattern
-            .compile("^(?:file:)?(.+)"
-                    + Constants.COMPATIBILITY_RESOURCES_FRONTEND_DEFAULT
-                    + "/?$");
-
-    // Attribute key for storing Dev Mode Handler startup flag.
-    // If presented in Servlet Context, shows the Dev Mode Handler already
-    // started / become starting.
-    // This attribute helps to avoid Dev Mode running twice.
-    //
-    // Addresses the issue https://github.com/vaadin/spring/issues/502
-    private static final class DevModeHandlerAlreadyStartedAttribute
-            implements Serializable {
-    }
-
     @Override
     public void initialize(Set<Class<?>> classes, VaadinContext context)
             throws VaadinInitializerException {
-        DevModeHandler devModeHandler = initDevModeHandler(classes, context);
+        // DevModeHandler devModeHandler = initDevModeHandler(classes,
+        // context);
 
         Lookup lookup = context.getAttribute(Lookup.class);
         DevModeHandlerManager devModeHandlerManager = lookup
                 .lookup(DevModeHandlerManager.class);
-        devModeHandlerManager.setDevModeHandler(devModeHandler);
-
-        setDevModeStarted(context);
-    }
-
-    private void setDevModeStarted(VaadinContext context) {
-        context.setAttribute(DevModeHandlerAlreadyStartedAttribute.class,
-                new DevModeHandlerAlreadyStartedAttribute());
-    }
-
-    /**
-     * Initialize the devmode server if not in production mode or compatibility
-     * mode.
-     *
-     * @deprecated Use {@link #initDevModeHandler(Set, VaadinContext)} instead
-     *             by wrapping {@link ServletContext} with
-     *             {@link VaadinServletContext}.
-     *
-     * @param classes
-     *            classes to check for npm- and js modules
-     * @param context
-     *            servlet context we are running in
-     *
-     * @throws ServletException
-     *             if dev mode can't be initialized
-     */
-    @Deprecated
-    public static void initDevModeHandler(Set<Class<?>> classes,
-            ServletContext context) throws ServletException {
-        try {
-            initDevModeHandler(classes, new VaadinServletContext(context));
-        } catch (VaadinInitializerException e) {
-            throw new ServletException(e);
-        }
-    }
-
-    /**
-     * Initialize the devmode server if not in production mode or compatibility
-     * mode.
-     *
-     * @param classes
-     *            classes to check for npm- and js modules
-     * @param context
-     *            VaadinContext we are running in
-     * @return the initialized dev mode handler or {@code null} if none was
-     *         created
-     *
-     * @throws VaadinInitializerException
-     *             if dev mode can't be initialized
-     */
-    public static DevModeHandler initDevModeHandler(Set<Class<?>> classes,
-            VaadinContext context) throws VaadinInitializerException {
-
-        ApplicationConfiguration config = ApplicationConfiguration.get(context);
-        if (config.isProductionMode()) {
-            log().debug("Skipping DEV MODE because PRODUCTION MODE is set.");
-            return null;
-        }
-        if (!config.enableDevServer()) {
-            log().debug(
-                    "Skipping DEV MODE because dev server shouldn't be enabled.");
-            return null;
-        }
-
-        String baseDir = config.getStringProperty(FrontendUtils.PROJECT_BASEDIR,
-                null);
-        if (baseDir == null) {
-            baseDir = getBaseDirectoryFallback();
-        }
-
-        String generatedDir = System.getProperty(PARAM_GENERATED_DIR,
-                Paths.get(config.getBuildFolder(), DEFAULT_GENERATED_DIR)
-                        .toString());
-        String frontendFolder = config.getStringProperty(PARAM_FRONTEND_DIR,
-                System.getProperty(PARAM_FRONTEND_DIR, DEFAULT_FRONTEND_DIR));
-
-        File flowResourcesFolder = new File(baseDir,
-                config.getFlowResourcesFolder());
-
-        Lookup lookupFromContext = context.getAttribute(Lookup.class);
-        Lookup lookupForClassFinder = Lookup.of(new DevModeClassFinder(classes),
-                ClassFinder.class);
-        Lookup lookup = Lookup.compose(lookupForClassFinder, lookupFromContext);
-        Builder builder = new NodeTasks.Builder(lookup, new File(baseDir),
-                new File(generatedDir), new File(frontendFolder),
-                config.getBuildFolder());
-
-        log().info("Starting dev-mode updaters in {} folder.",
-                builder.getNpmFolder());
-
-        if (!builder.getGeneratedFolder().exists()) {
-            try {
-                FileUtils.forceMkdir(builder.getGeneratedFolder());
-            } catch (IOException e) {
-                throw new UncheckedIOException(
-                        String.format("Failed to create directory '%s'",
-                                builder.getGeneratedFolder()),
-                        e);
-            }
-        }
-
-        File generatedPackages = new File(builder.getGeneratedFolder(),
-                PACKAGE_JSON);
-
-        // Regenerate webpack configuration, as it may be necessary to update it
-        // TODO: make sure target directories are aligned with build config,
-        // see https://github.com/vaadin/flow/issues/9082
-        File target = new File(baseDir, config.getBuildFolder());
-        builder.withWebpack(new File(target, VAADIN_WEBAPP_RESOURCES),
-                new File(target, VAADIN_SERVLET_RESOURCES),
-                FrontendUtils.WEBPACK_CONFIG, FrontendUtils.WEBPACK_GENERATED);
-
-        builder.useV14Bootstrap(config.useV14Bootstrap());
-
-        if (!config.useV14Bootstrap() && isEndpointServiceAvailable(lookup)) {
-            String connectJavaSourceFolder = config.getStringProperty(
-                    CONNECT_JAVA_SOURCE_FOLDER_TOKEN,
-                    Paths.get(baseDir, DEFAULT_CONNECT_JAVA_SOURCE_FOLDER)
-                            .toString());
-            String connectApplicationProperties = config.getStringProperty(
-                    CONNECT_APPLICATION_PROPERTIES_TOKEN,
-                    Paths.get(baseDir, DEFAULT_CONNECT_APPLICATION_PROPERTIES)
-                            .toString());
-            String connectOpenApiJsonFile = config
-                    .getStringProperty(CONNECT_OPEN_API_FILE_TOKEN,
-                            Paths.get(baseDir, config.getBuildFolder(),
-                                    DEFAULT_CONNECT_OPENAPI_JSON_FILE)
-                                    .toString());
-
-            builder.withFusionJavaSourceFolder(
-                    new File(connectJavaSourceFolder))
-                    .withFusionApplicationProperties(
-                            new File(connectApplicationProperties))
-                    .withFusionGeneratedOpenAPIJson(
-                            new File(connectOpenApiJsonFile));
-        }
-
-        // If we are missing either the base or generated package json files
-        // generate those
-        if (!new File(builder.getNpmFolder(), PACKAGE_JSON).exists()
-                || !generatedPackages.exists()) {
-            builder.createMissingPackageJson(true);
-        }
-
-        Set<File> frontendLocations = getFrontendLocationsFromClassloader(
-                DevModeInitializer.class.getClassLoader());
-
-        boolean useByteCodeScanner = config.getBooleanProperty(
-                SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE,
-                Boolean.parseBoolean(System.getProperty(
-                        SERVLET_PARAMETER_DEVMODE_OPTIMIZE_BUNDLE,
-                        Boolean.FALSE.toString())));
-
-        boolean enablePnpm = config.isPnpmEnabled();
-
-        boolean useGlobalPnpm = config.isGlobalPnpm();
-
-        boolean useHomeNodeExec = config.getBooleanProperty(
-                InitParameters.REQUIRE_HOME_NODE_EXECUTABLE, false);
-
-        String fusionClientAPIFolder = config.getStringProperty(
-                PROJECT_FRONTEND_GENERATED_DIR_TOKEN,
-                Paths.get(baseDir, DEFAULT_PROJECT_FRONTEND_GENERATED_DIR)
-                        .toString());
-
-        JsonObject tokenFileData = Json.createObject();
-        NodeTasks tasks = builder.enablePackagesUpdate(true)
-                .useByteCodeScanner(useByteCodeScanner)
-                .withFlowResourcesFolder(flowResourcesFolder)
-                .withFusionClientAPIFolder(new File(fusionClientAPIFolder))
-                .copyResources(frontendLocations)
-                .copyLocalResources(new File(baseDir,
-                        Constants.LOCAL_FRONTEND_RESOURCES_PATH))
-                .enableImportsUpdate(true).runNpmInstall(true)
-                .populateTokenFileData(tokenFileData)
-                .withEmbeddableWebComponents(true).enablePnpm(enablePnpm)
-                .useGlobalPnpm(useGlobalPnpm)
-                .withHomeNodeExecRequired(useHomeNodeExec).build();
-
-        Runnable runnable = () -> runNodeTasks(context, tokenFileData, tasks);
-
-        CompletableFuture<Void> nodeTasksFuture = CompletableFuture
-                .runAsync(runnable);
-
-        return WebpackHandler.start(
-                Lookup.compose(lookup,
-                        Lookup.of(config, ApplicationConfiguration.class)),
-                builder.getNpmFolder(), nodeTasksFuture);
-    }
-
-    private static boolean isEndpointServiceAvailable(Lookup lookup) {
-        if (lookup == null) {
-            return false;
-        }
-        return lookup.lookup(EndpointGeneratorTaskFactory.class) != null;
+        devModeHandlerManager.initDevModeHandler(classes, context);
     }
 
     /**
@@ -440,15 +104,19 @@ public class DevModeInitializer
      *            The {@link VaadinContext}, not <code>null</code>
      * @return <code>true</code> if {@link DevModeHandler} has already been
      *         started, <code>false</code> - otherwise
+     * 
+     * @deprecated Check {@link DevModeHandlerManager#getDevModeHandler()} for
+     *             {@code null} instead.
+     * 
      */
+    @Deprecated
     public static boolean isDevModeAlreadyStarted(VaadinContext context) {
         assert context != null;
-        return context.getAttribute(
-                DevModeHandlerAlreadyStartedAttribute.class) != null;
-    }
+        Lookup lookup = context.getAttribute(Lookup.class);
+        DevModeHandlerManager devModeHandlerManager = lookup
+                .lookup(DevModeHandlerManager.class);
 
-    private static Logger log() {
-        return LoggerFactory.getLogger(DevModeInitializer.class);
+        return devModeHandlerManager.getDevModeHandler() != null;
     }
 
     @Override
@@ -464,213 +132,4 @@ public class DevModeInitializer
                 .ifPresent(DevModeHandler::stop);
     }
 
-    /*
-     * Accept user.dir or cwd as a fallback only if the directory seems to be a
-     * Maven or Gradle project. Check to avoid cluttering server directories
-     * (see tickets #8249, #8403).
-     */
-    private static String getBaseDirectoryFallback() {
-        String baseDirCandidate = System.getProperty("user.dir", ".");
-        Path path = Paths.get(baseDirCandidate);
-        if (path.toFile().isDirectory()
-                && (path.resolve("pom.xml").toFile().exists()
-                        || path.resolve("build.gradle").toFile().exists())) {
-            return path.toString();
-        } else {
-            throw new IllegalStateException(String.format(
-                    "Failed to determine project directory for dev mode. "
-                            + "Directory '%s' does not look like a Maven or "
-                            + "Gradle project. Ensure that you have run the "
-                            + "prepare-frontend Maven goal, which generates "
-                            + "'flow-build-info.json', prior to deploying your "
-                            + "application",
-                    path.toString()));
-        }
-    }
-
-    /*
-     * This method returns all folders of jar files having files in the
-     * META-INF/resources/frontend and META-INF/resources/themes folder. We
-     * don't use URLClassLoader because will fail in Java 9+
-     */
-    static Set<File> getFrontendLocationsFromClassloader(
-            ClassLoader classLoader) throws VaadinInitializerException {
-        Set<File> frontendFiles = new HashSet<>();
-        frontendFiles.addAll(getFrontendLocationsFromClassloader(classLoader,
-                Constants.RESOURCES_FRONTEND_DEFAULT));
-        frontendFiles.addAll(getFrontendLocationsFromClassloader(classLoader,
-                Constants.COMPATIBILITY_RESOURCES_FRONTEND_DEFAULT));
-        frontendFiles.addAll(getFrontendLocationsFromClassloader(classLoader,
-                Constants.RESOURCES_THEME_JAR_DEFAULT));
-        return frontendFiles;
-    }
-
-    private static void runNodeTasks(VaadinContext vaadinContext,
-            JsonObject tokenFileData, NodeTasks tasks) {
-        try {
-            tasks.execute();
-
-            FallbackChunk chunk = FrontendUtils
-                    .readFallbackChunk(tokenFileData);
-            if (chunk != null) {
-                vaadinContext.setAttribute(chunk);
-            }
-        } catch (ExecutionFailedException exception) {
-            log().debug(
-                    "Could not initialize dev mode handler. One of the node tasks failed",
-                    exception);
-            throw new CompletionException(exception);
-        }
-    }
-
-    private static Set<File> getFrontendLocationsFromClassloader(
-            ClassLoader classLoader, String resourcesFolder)
-            throws VaadinInitializerException {
-        Set<File> frontendFiles = new HashSet<>();
-        try {
-            Enumeration<URL> en = classLoader.getResources(resourcesFolder);
-            if (en == null) {
-                return frontendFiles;
-            }
-            Set<String> vfsJars = new HashSet<>();
-            while (en.hasMoreElements()) {
-                URL url = en.nextElement();
-                String urlString = url.toString();
-
-                String path = URLDecoder.decode(url.getPath(),
-                        StandardCharsets.UTF_8.name());
-                Matcher jarMatcher = JAR_FILE_REGEX.matcher(path);
-                Matcher zipProtocolJarMatcher = ZIP_PROTOCOL_JAR_FILE_REGEX
-                        .matcher(path);
-                Matcher dirMatcher = DIR_REGEX_FRONTEND_DEFAULT.matcher(path);
-                Matcher dirResourcesMatcher = DIR_REGEX_RESOURCES_JAR_DEFAULT
-                        .matcher(path);
-                Matcher dirCompatibilityMatcher = DIR_REGEX_COMPATIBILITY_FRONTEND_DEFAULT
-                        .matcher(path);
-                Matcher jarVfsMatcher = VFS_FILE_REGEX.matcher(urlString);
-                Matcher dirVfsMatcher = VFS_DIRECTORY_REGEX.matcher(urlString);
-                if (jarVfsMatcher.find()) {
-                    String vfsJar = jarVfsMatcher.group(1);
-                    if (vfsJars.add(vfsJar)) { // NOSONAR
-                        frontendFiles.add(
-                                getPhysicalFileOfJBossVfsJar(new URL(vfsJar)));
-                    }
-                } else if (dirVfsMatcher.find()) {
-                    URL vfsDirUrl = new URL(urlString.substring(0,
-                            urlString.lastIndexOf(resourcesFolder)));
-                    frontendFiles
-                            .add(getPhysicalFileOfJBossVfsDirectory(vfsDirUrl));
-                } else if (jarMatcher.find()) {
-                    frontendFiles.add(new File(jarMatcher.group(1)));
-                } else if ("zip".equalsIgnoreCase(url.getProtocol())
-                        && zipProtocolJarMatcher.find()) {
-                    frontendFiles.add(new File(zipProtocolJarMatcher.group(1)));
-                } else if (dirMatcher.find()) {
-                    frontendFiles.add(new File(dirMatcher.group(1)));
-                } else if (dirResourcesMatcher.find()) {
-                    frontendFiles.add(new File(dirResourcesMatcher.group(1)));
-                } else if (dirCompatibilityMatcher.find()) {
-                    frontendFiles
-                            .add(new File(dirCompatibilityMatcher.group(1)));
-                } else {
-                    log().warn(
-                            "Resource {} not visited because does not meet supported formats.",
-                            url.getPath());
-                }
-            }
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
-
-        return frontendFiles;
-    }
-
-    private static File getPhysicalFileOfJBossVfsDirectory(URL url)
-            throws IOException, VaadinInitializerException {
-        try {
-            Object virtualFile = url.openConnection().getContent();
-            Class virtualFileClass = virtualFile.getClass();
-
-            // Reflection as we cannot afford a dependency to WildFly or JBoss
-            Method getChildrenRecursivelyMethod = virtualFileClass
-                    .getMethod("getChildrenRecursively");
-            Method getPhysicalFileMethod = virtualFileClass
-                    .getMethod("getPhysicalFile");
-
-            // By calling getPhysicalFile, we make sure that the corresponding
-            // physical files/directories of the root directory and its children
-            // are created. Later, these physical files are scanned to collect
-            // their resources.
-            List virtualFiles = (List) getChildrenRecursivelyMethod
-                    .invoke(virtualFile);
-            File rootDirectory = (File) getPhysicalFileMethod
-                    .invoke(virtualFile);
-            for (Object child : virtualFiles) {
-                // side effect: create real-world files
-                getPhysicalFileMethod.invoke(child);
-            }
-            return rootDirectory;
-        } catch (NoSuchMethodException | IllegalAccessException
-                | InvocationTargetException exc) {
-            throw new VaadinInitializerException(
-                    "Failed to invoke JBoss VFS API.", exc);
-        }
-    }
-
-    private static File getPhysicalFileOfJBossVfsJar(URL url)
-            throws IOException, VaadinInitializerException {
-        try {
-            Object jarVirtualFile = url.openConnection().getContent();
-
-            // Creating a temporary jar file out of the vfs files
-            String vfsJarPath = url.toString();
-            String fileNamePrefix = vfsJarPath.substring(
-                    vfsJarPath.lastIndexOf('/') + 1,
-                    vfsJarPath.lastIndexOf(".jar"));
-            Path tempJar = Files.createTempFile(fileNamePrefix, ".jar");
-
-            generateJarFromJBossVfsFolder(jarVirtualFile, tempJar);
-
-            File tempJarFile = tempJar.toFile();
-            tempJarFile.deleteOnExit();
-            return tempJarFile;
-        } catch (NoSuchMethodException | IllegalAccessException
-                | InvocationTargetException exc) {
-            throw new VaadinInitializerException(
-                    "Failed to invoke JBoss VFS API.", exc);
-        }
-    }
-
-    private static void generateJarFromJBossVfsFolder(Object jarVirtualFile,
-            Path tempJar) throws IOException, IllegalAccessException,
-            InvocationTargetException, NoSuchMethodException {
-        // We should use reflection to use JBoss VFS API as we cannot afford a
-        // dependency to WildFly or JBoss
-        Class virtualFileClass = jarVirtualFile.getClass();
-        Method getChildrenRecursivelyMethod = virtualFileClass
-                .getMethod("getChildrenRecursively");
-        Method openStreamMethod = virtualFileClass.getMethod("openStream");
-        Method isFileMethod = virtualFileClass.getMethod("isFile");
-        Method getPathNameRelativeToMethod = virtualFileClass
-                .getMethod("getPathNameRelativeTo", virtualFileClass);
-
-        List jarVirtualChildren = (List) getChildrenRecursivelyMethod
-                .invoke(jarVirtualFile);
-        try (ZipOutputStream zipOutputStream = new ZipOutputStream(
-                Files.newOutputStream(tempJar))) {
-            for (Object child : jarVirtualChildren) {
-                if (!(Boolean) isFileMethod.invoke(child))
-                    continue;
-
-                String relativePath = (String) getPathNameRelativeToMethod
-                        .invoke(child, jarVirtualFile);
-                InputStream inputStream = (InputStream) openStreamMethod
-                        .invoke(child);
-                ZipEntry zipEntry = new ZipEntry(relativePath);
-                zipOutputStream.putNextEntry(zipEntry);
-                IOUtils.copy(inputStream, zipOutputStream);
-                zipOutputStream.closeEntry();
-            }
-        }
-    }
 }


### PR DESCRIPTION
This is needed so Spring can call it from its own init mechanism
