### PR TITLE
fix: remove 'target/' prefix for fusion form version check

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -67,7 +67,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  */
 public abstract class NodeUpdater implements FallibleCommand {
 
-    private static final String VAADIN_FORM_PKG_LEGACY_VERSION = "target/flow-frontend/form";
+    private static final String VAADIN_FORM_PKG_LEGACY_VERSION = "flow-frontend/form";
 
     private static final String VAADIN_FORM_PKG = "@vaadin/form";
 


### PR DESCRIPTION
Remove the `target/` prefix for checking the legacy version of fusion form so that it also works with `Gradle` which uses `build` instead `target` for the output folder.