### PR TITLE
fix: show the accurate route class name in err msg (#12045)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteConfiguration.java
@@ -511,8 +511,7 @@ public class RouteConfiguration implements Serializable {
         if (!targetUrl.isPresent()) {
             throw new NotFoundException(String.format(
                     "No route found for the given navigation target '%s' and parameters '%s'",
-                    navigationTarget.getClass().getName(),
-                    parameters.toString()));
+                    navigationTarget.getName(), parameters.toString()));
         }
         return targetUrl.get();
     }


### PR DESCRIPTION
closes #12145
