### PR TITLE
refactor: Use maven vaadin plugin classloader as a parent for URLClas…

### DIFF
--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/server/scanner/ReflectionsClassFinder.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/server/scanner/ReflectionsClassFinder.java
@@ -46,7 +46,8 @@ public class ReflectionsClassFinder implements ClassFinder {
      *            the list of urls for finding classes.
      */
     public ReflectionsClassFinder(URL... urls) {
-        classLoader = new URLClassLoader(urls, null); // NOSONAR
+        classLoader = new URLClassLoader(urls,
+                ReflectionsClassFinder.class.getClassLoader()); // NOSONAR
         ConfigurationBuilder configurationBuilder = new ConfigurationBuilder()
                 .addClassLoader(classLoader).setExpandSuperTypes(false)
                 .addUrls(urls);

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/utils/LookupImpl.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/utils/LookupImpl.java
@@ -48,32 +48,19 @@ public class LookupImpl implements Lookup {
 
     @Override
     public <T> List<T> lookupAll(Class<T> serviceClass) {
-        Set<?> subTypes = classFinder
-                .getSubTypesOf(loadClassFromClassFindler(serviceClass));
+        // only services declared in flow-server may be used here
+        assert serviceClass.getClassLoader()
+                .equals(LookupImpl.class.getClassLoader());
+        Set<Class<? extends T>> subTypes = classFinder
+                .getSubTypesOf(serviceClass);
         List<T> result = new ArrayList<>(subTypes.size());
-        try {
-            for (Object clazz : subTypes) {
-                if (!ReflectTools.isInstantiableService((Class<?>) clazz)) {
-                    continue;
-                }
-                Class<?> serviceType = serviceClass.getClassLoader()
-                        .loadClass(((Class<?>) clazz).getName());
-                result.add(serviceClass
-                        .cast(ReflectTools.createInstance(serviceType)));
+        for (Class<? extends T> clazz : subTypes) {
+            if (!ReflectTools.isInstantiableService(clazz)) {
+                continue;
             }
-        } catch (ClassNotFoundException e) {
-            throw new IllegalStateException("Could not find service class", e);
+            result.add(serviceClass.cast(ReflectTools.createInstance(clazz)));
         }
         return result;
-    }
-
-    private Class<?> loadClassFromClassFindler(Class<?> clz) {
-        try {
-            return classFinder.loadClass(clz.getName());
-        } catch (ClassNotFoundException e) {
-            throw new IllegalStateException(
-                    "Could not load " + clz.getName() + " class", e);
-        }
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendWebComponentGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendWebComponentGenerator.java
@@ -82,24 +82,15 @@ public class FrontendWebComponentGenerator implements Serializable {
      */
     public Set<File> generateWebComponents(File outputDirectory,
             ThemeDefinition theme) {
-        try {
-            final Class<?> writerClass = finder
-                    .loadClass(WebComponentModulesWriter.class.getName());
-            Set<Class<?>> exporterRelatedClasses = new HashSet<>();
-            finder.getSubTypesOf(WebComponentExporter.class.getName())
-                    .forEach(exporterRelatedClasses::add);
-            finder.getSubTypesOf(WebComponentExporterFactory.class.getName())
-                    .forEach(exporterRelatedClasses::add);
-            final String themeName = theme == null ? "" : theme.getName();
-            return WebComponentModulesWriter.DirectoryWriter
-                    .generateWebComponentsToDirectory(writerClass,
-                            exporterRelatedClasses, outputDirectory, false,
-                            themeName);
-        } catch (ClassNotFoundException e) {
-            throw new IllegalStateException(
-                    "Unable to locate a required class using custom class "
-                            + "loader",
-                    e);
-        }
+        Set<Class<?>> exporterRelatedClasses = new HashSet<>();
+        finder.getSubTypesOf(WebComponentExporter.class)
+                .forEach(exporterRelatedClasses::add);
+        finder.getSubTypesOf(WebComponentExporterFactory.class)
+                .forEach(exporterRelatedClasses::add);
+        final String themeName = theme == null ? "" : theme.getName();
+        return WebComponentModulesWriter.DirectoryWriter
+                .generateWebComponentsToDirectory(
+                        WebComponentModulesWriter.class, exporterRelatedClasses,
+                        outputDirectory, false, themeName);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScanner.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScanner.java
@@ -58,8 +58,6 @@ import com.vaadin.flow.theme.ThemeDefinition;
  */
 class FullDependenciesScanner extends AbstractDependenciesScanner {
 
-    private static final String COULD_NOT_LOAD_ERROR_MSG = "Could not load annotation class ";
-
     private static final String VALUE = "value";
 
     private ThemeDefinition themeDefinition;
@@ -70,8 +68,6 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
     private Set<String> scripts = new LinkedHashSet<>();
     private Set<CssData> cssData;
     private List<String> modules;
-
-    private final Class<?> abstractTheme;
 
     private final SerializableBiFunction<Class<?>, Class<? extends Annotation>, List<? extends Annotation>> annotationFinder;
 
@@ -108,12 +104,6 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
 
         long start = System.currentTimeMillis();
         this.annotationFinder = annotationFinder;
-        try {
-            abstractTheme = finder.loadClass(AbstractTheme.class.getName());
-        } catch (ClassNotFoundException exception) {
-            throw new IllegalStateException("Could not load "
-                    + AbstractTheme.class.getName() + " class", exception);
-        }
 
         packages = discoverPackages();
 
@@ -201,77 +191,53 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
     }
 
     private Map<String, String> discoverPackages() {
-        try {
-            Class<? extends Annotation> loadedAnnotation = getFinder()
-                    .loadClass(NpmPackage.class.getName());
-            Set<Class<?>> annotatedClasses = getFinder()
-                    .getAnnotatedClasses(loadedAnnotation);
-            Map<String, String> result = new HashMap<>();
-            Set<String> logs = new HashSet<>();
-            for (Class<?> clazz : annotatedClasses) {
-                classes.add(clazz.getName());
-                List<? extends Annotation> packageAnnotations = annotationFinder
-                        .apply(clazz, loadedAnnotation);
-                packageAnnotations.forEach(pckg -> {
-                    String value = getAnnotationValueAsString(pckg, VALUE);
-                    String vers = getAnnotationValueAsString(pckg, "version");
-                    logs.add(value + " " + vers + " " + clazz.getName());
-                    result.put(value, vers);
-                });
-            }
-            debug("npm dependencies", logs);
-            return result;
-        } catch (ClassNotFoundException exception) {
-            throw new IllegalStateException(
-                    COULD_NOT_LOAD_ERROR_MSG + NpmPackage.class.getName(),
-                    exception);
+        Set<Class<?>> annotatedClasses = getFinder()
+                .getAnnotatedClasses(NpmPackage.class);
+        Map<String, String> result = new HashMap<>();
+        Set<String> logs = new HashSet<>();
+        for (Class<?> clazz : annotatedClasses) {
+            classes.add(clazz.getName());
+            List<? extends Annotation> packageAnnotations = annotationFinder
+                    .apply(clazz, NpmPackage.class);
+            packageAnnotations.forEach(pckg -> {
+                String value = getAnnotationValueAsString(pckg, VALUE);
+                String vers = getAnnotationValueAsString(pckg, "version");
+                logs.add(value + " " + vers + " " + clazz.getName());
+                result.put(value, vers);
+            });
         }
+        debug("npm dependencies", logs);
+        return result;
     }
 
     private Set<CssData> discoverCss() {
-        try {
-            Class<? extends Annotation> loadedAnnotation = getFinder()
-                    .loadClass(CssImport.class.getName());
-            Set<Class<?>> annotatedClasses = getFinder()
-                    .getAnnotatedClasses(loadedAnnotation);
-            Set<CssData> result = new LinkedHashSet<>();
-            for (Class<?> clazz : annotatedClasses) {
-                classes.add(clazz.getName());
-                List<? extends Annotation> imports = annotationFinder
-                        .apply(clazz, loadedAnnotation);
-                imports.stream().forEach(imp -> result.add(createCssData(imp)));
-            }
-            return result;
-        } catch (ClassNotFoundException exception) {
-            throw new IllegalStateException(
-                    COULD_NOT_LOAD_ERROR_MSG + CssData.class.getName(),
-                    exception);
+        Set<Class<?>> annotatedClasses = getFinder()
+                .getAnnotatedClasses(CssImport.class);
+        Set<CssData> result = new LinkedHashSet<>();
+        for (Class<?> clazz : annotatedClasses) {
+            classes.add(clazz.getName());
+            List<? extends Annotation> imports = annotationFinder.apply(clazz,
+                    CssImport.class);
+            imports.stream().forEach(imp -> result.add(createCssData(imp)));
         }
+        return result;
     }
 
     private <T extends Annotation> void collectAnnotationValues(
             BiConsumer<Class<?>, String> valueHandler, Class<T> annotationType,
             Function<Annotation, String> valueExtractor) {
-        try {
-            Set<String> logs = new HashSet<>();
-            Class<? extends Annotation> loadedAnnotation = getFinder()
-                    .loadClass(annotationType.getName());
-            Set<Class<?>> annotatedClasses = getFinder()
-                    .getAnnotatedClasses(loadedAnnotation);
+        Set<String> logs = new HashSet<>();
+        Set<Class<?>> annotatedClasses = getFinder()
+                .getAnnotatedClasses(annotationType);
 
-            annotatedClasses.stream().forEach(clazz -> annotationFinder
-                    .apply(clazz, loadedAnnotation).forEach(ann -> {
-                        String value = valueExtractor.apply(ann);
-                        valueHandler.accept(clazz, value);
-                        logs.add(value + " " + clazz);
-                    }));
+        annotatedClasses.stream().forEach(clazz -> annotationFinder
+                .apply(clazz, annotationType).forEach(ann -> {
+                    String value = valueExtractor.apply(ann);
+                    valueHandler.accept(clazz, value);
+                    logs.add(value + " " + clazz);
+                }));
 
-            debug("@" + annotationType.getSimpleName(), logs);
-        } catch (ClassNotFoundException exception) {
-            throw new IllegalStateException(
-                    COULD_NOT_LOAD_ERROR_MSG + annotationType.getName(),
-                    exception);
-        }
+        debug("@" + annotationType.getSimpleName(), logs);
     }
 
     private void debug(String label, Set<String> log) {
@@ -319,50 +285,37 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
     }
 
     private ThemeData verifyTheme() {
-        try {
-            Class<? extends Annotation> loadedThemeAnnotation = getFinder()
-                    .loadClass(Theme.class.getName());
+        Set<Class<?>> annotatedClasses = getFinder()
+                .getAnnotatedClasses(Theme.class);
+        Set<ThemeData> themes = annotatedClasses.stream().flatMap(
+                clazz -> annotationFinder.apply(clazz, Theme.class).stream())
+                .map(theme -> new ThemeData(
+                        ((Class<?>) getAnnotationValue(theme, "themeClass"))
+                                .getName(),
+                        getAnnotationValueAsString(theme, "variant"),
+                        getAnnotationValueAsString(theme, VALUE)))
+                .collect(Collectors.toSet());
 
-            Set<Class<?>> annotatedClasses = getFinder()
-                    .getAnnotatedClasses(loadedThemeAnnotation);
-            Set<ThemeData> themes = annotatedClasses.stream()
-                    .flatMap(clazz -> annotationFinder
-                            .apply(clazz, loadedThemeAnnotation).stream())
-                    .map(theme -> new ThemeData(
-                            ((Class<?>) getAnnotationValue(theme, "themeClass"))
-                                    .getName(),
-                            getAnnotationValueAsString(theme, "variant"),
-                            getAnnotationValueAsString(theme, VALUE)))
-                    .collect(Collectors.toSet());
-
-            Class<? extends Annotation> loadedNoThemeAnnotation = getFinder()
-                    .loadClass(NoTheme.class.getName());
-
-            Set<Class<?>> notThemeClasses = getFinder()
-                    .getAnnotatedClasses(loadedNoThemeAnnotation).stream()
-                    .collect(Collectors.toSet());
-            if (themes.size() > 1) {
-                throw new IllegalStateException(
-                        "Using multiple different Theme configurations is not "
-                                + "supported. The list of found themes:\n"
-                                + getThemesList(themes));
-            }
-            if (!themes.isEmpty() && !notThemeClasses.isEmpty()) {
-                throw new IllegalStateException(
-                        "@" + Theme.class.getSimpleName() + " ("
-                                + getThemesList(themes) + ") and @"
-                                + NoTheme.class.getSimpleName()
-                                + " annotations can't be used simultaneously.");
-            }
-            if (!notThemeClasses.isEmpty()) {
-                return ThemeData.createNoTheme();
-
-            }
-            return themes.isEmpty() ? null : themes.iterator().next();
-        } catch (ClassNotFoundException exception) {
+        Set<Class<?>> notThemeClasses = getFinder()
+                .getAnnotatedClasses(NoTheme.class).stream()
+                .collect(Collectors.toSet());
+        if (themes.size() > 1) {
             throw new IllegalStateException(
-                    "Could not load theme annotation class", exception);
+                    "Using multiple different Theme configurations is not "
+                            + "supported. The list of found themes:\n"
+                            + getThemesList(themes));
         }
+        if (!themes.isEmpty() && !notThemeClasses.isEmpty()) {
+            throw new IllegalStateException("@" + Theme.class.getSimpleName()
+                    + " (" + getThemesList(themes) + ") and @"
+                    + NoTheme.class.getSimpleName()
+                    + " annotations can't be used simultaneously.");
+        }
+        if (!notThemeClasses.isEmpty()) {
+            return ThemeData.createNoTheme();
+
+        }
+        return themes.isEmpty() ? null : themes.iterator().next();
     }
 
     private String getThemesList(Collection<ThemeData> themes) {
@@ -376,7 +329,7 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
     private void handleModule(Class<?> clazz, String module,
             Set<String> modules, Map<String, Set<String>> themeModules) {
 
-        if (abstractTheme.isAssignableFrom(clazz)) {
+        if (AbstractTheme.class.isAssignableFrom(clazz)) {
             Set<String> themingModules = themeModules.computeIfAbsent(
                     clazz.getName(), cl -> new LinkedHashSet<>());
             themingModules.add(module);
@@ -438,55 +391,45 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
     }
 
     private PwaConfiguration discoverPwa() {
-        try {
-            Class<? extends Annotation> loadedPWAAnnotation = getFinder()
-                    .loadClass(PWA.class.getName());
-
-            Set<Class<?>> annotatedClasses = getFinder()
-                    .getAnnotatedClasses(loadedPWAAnnotation);
-            if (annotatedClasses.isEmpty()) {
-                return new PwaConfiguration(useV14Bootstrap);
-            } else if (annotatedClasses.size() != 1) {
-                throw new IllegalStateException(ERROR_INVALID_PWA_ANNOTATION);
-            }
-
-            Class<?> hopefullyAppShellClass = annotatedClasses.iterator()
-                    .next();
-            if (!useV14Bootstrap
-                    && !Arrays.stream(hopefullyAppShellClass.getInterfaces())
-                            .map(Class::getName).collect(Collectors.toList())
-                            .contains(AppShellConfigurator.class.getName())) {
-                throw new IllegalStateException(ERROR_INVALID_PWA_ANNOTATION);
-            }
-
-            Annotation pwa = annotationFinder
-                    .apply(hopefullyAppShellClass, loadedPWAAnnotation).get(0);
-
-            String name = getAnnotationValueAsString(pwa, "name");
-            String shortName = getAnnotationValueAsString(pwa, "shortName");
-            String description = getAnnotationValueAsString(pwa, "description");
-            String backgroundColor = getAnnotationValueAsString(pwa,
-                    "backgroundColor");
-            String themeColor = getAnnotationValueAsString(pwa, "themeColor");
-            String iconPath = getAnnotationValueAsString(pwa, "iconPath");
-            String manifestPath = getAnnotationValueAsString(pwa,
-                    "manifestPath");
-            String offlinePath = getAnnotationValueAsString(pwa, "offlinePath");
-            String display = getAnnotationValueAsString(pwa, "display");
-            String startPath = getAnnotationValueAsString(pwa, "startPath");
-            String[] offlineResources = (String[]) getAnnotationValue(pwa,
-                    "offlineResources");
-
-            assert shortName != null; // required in @PWA annotation
-
-            return new PwaConfiguration(true, name, shortName, description,
-                    backgroundColor, themeColor, iconPath, manifestPath,
-                    offlinePath, display, startPath, offlineResources,
-                    useV14Bootstrap);
-        } catch (ClassNotFoundException exception) {
-            throw new IllegalStateException(
-                    "Could not load PWA annotation class", exception);
+        Set<Class<?>> annotatedClasses = getFinder()
+                .getAnnotatedClasses(PWA.class);
+        if (annotatedClasses.isEmpty()) {
+            return new PwaConfiguration(useV14Bootstrap);
+        } else if (annotatedClasses.size() != 1) {
+            throw new IllegalStateException(ERROR_INVALID_PWA_ANNOTATION);
         }
+
+        Class<?> hopefullyAppShellClass = annotatedClasses.iterator().next();
+        if (!useV14Bootstrap
+                && !Arrays.stream(hopefullyAppShellClass.getInterfaces())
+                        .map(Class::getName).collect(Collectors.toList())
+                        .contains(AppShellConfigurator.class.getName())) {
+            throw new IllegalStateException(ERROR_INVALID_PWA_ANNOTATION);
+        }
+
+        Annotation pwa = annotationFinder
+                .apply(hopefullyAppShellClass, PWA.class).get(0);
+
+        String name = getAnnotationValueAsString(pwa, "name");
+        String shortName = getAnnotationValueAsString(pwa, "shortName");
+        String description = getAnnotationValueAsString(pwa, "description");
+        String backgroundColor = getAnnotationValueAsString(pwa,
+                "backgroundColor");
+        String themeColor = getAnnotationValueAsString(pwa, "themeColor");
+        String iconPath = getAnnotationValueAsString(pwa, "iconPath");
+        String manifestPath = getAnnotationValueAsString(pwa, "manifestPath");
+        String offlinePath = getAnnotationValueAsString(pwa, "offlinePath");
+        String display = getAnnotationValueAsString(pwa, "display");
+        String startPath = getAnnotationValueAsString(pwa, "startPath");
+        String[] offlineResources = (String[]) getAnnotationValue(pwa,
+                "offlineResources");
+
+        assert shortName != null; // required in @PWA annotation
+
+        return new PwaConfiguration(true, name, shortName, description,
+                backgroundColor, themeColor, iconPath, manifestPath,
+                offlinePath, display, startPath, offlineResources,
+                useV14Bootstrap);
     }
 
     private Logger getLogger() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScannerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScannerTest.java
@@ -26,7 +26,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -88,20 +87,12 @@ public class FullDependenciesScannerTest {
 
     }
 
-    @Before
-    public void setUp() throws ClassNotFoundException {
-        Mockito.when(finder.loadClass(AbstractTheme.class.getName()))
-                .thenReturn((Class) AbstractTheme.class);
-    }
-
     @Test
     public void getTheme_noExplicitTheme_lumoThemeIsDiscovered()
             throws ClassNotFoundException {
         FrontendDependenciesScanner scanner = setUpThemeScanner(
                 Collections.emptySet(), Collections.emptySet(),
                 (type, annotationType) -> Collections.emptyList());
-
-        Mockito.verify(finder).loadClass(AbstractTheme.class.getName());
 
         Assert.assertNotNull(scanner.getTheme());
         Assert.assertEquals("foo", scanner.getTheme().getBaseUrl());
@@ -121,8 +112,6 @@ public class FullDependenciesScannerTest {
                         NoThemeComponent1.class)),
                 (type, annotationType) -> Collections.emptyList());
 
-        Mockito.verify(finder).loadClass(AbstractTheme.class.getName());
-
         Assert.assertNull(scanner.getTheme());
         Assert.assertNull(scanner.getThemeDefinition());
         Assert.assertEquals(0, scanner.getClasses().size());
@@ -137,8 +126,6 @@ public class FullDependenciesScannerTest {
         FrontendDependenciesScanner scanner = setUpThemeScanner(
                 getAnnotatedClasses(Theme.class), Collections.emptySet(),
                 (type, annotationType) -> findAnnotations(type, Theme.class));
-
-        Mockito.verify(finder).loadClass(AbstractTheme.class.getName());
 
         Assert.assertNotNull(scanner.getTheme());
         Assert.assertEquals("theme/lumo/", scanner.getTheme().getThemeUrl());
@@ -277,25 +264,12 @@ public class FullDependenciesScannerTest {
     @Test
     public void getModules_explcitTheme_returnAllModulesExcludingNotUsedTheme_getClassesReturnAllModuleAnnotatedComponents()
             throws ClassNotFoundException {
-        // use this fake/mock class for the loaded class to check that annotated
-        // classes are requested for the loaded class and not for the
-        // annotationType
-        Class clazz = Object.class;
-
-        Mockito.when(finder.loadClass(JsModule.class.getName()))
-                .thenReturn(clazz);
-
-        Mockito.when(finder.getAnnotatedClasses(clazz))
+        Mockito.when(finder.getAnnotatedClasses(JsModule.class))
                 .thenReturn(getAnnotatedClasses(JsModule.class));
-
-        Class themeClass = Throwable.class;
-
-        Mockito.when(finder.loadClass(Theme.class.getName()))
-                .thenReturn(themeClass);
 
         Set<Class<?>> themeClasses = getAnnotatedClasses(Theme.class);
         themeClasses.add(FakeLumoTheme.class);
-        Mockito.when(finder.getAnnotatedClasses(themeClass))
+        Mockito.when(finder.getAnnotatedClasses(Theme.class))
                 .thenReturn(themeClasses);
         Assert.assertTrue(themeClasses.size() >= 2);
 
@@ -305,18 +279,11 @@ public class FullDependenciesScannerTest {
                 .thenReturn((Class) FakeLumoTheme.class);
 
         FrontendDependenciesScanner scanner = new FullDependenciesScanner(
-                finder, (type, annotation) -> {
-                    if (annotation.equals(clazz)) {
-                        return findAnnotations(type, JsModule.class);
-                    } else if (annotation.equals(themeClass)) {
-                        return findAnnotations(type, Theme.class);
-                    }
-                    Assert.fail();
-                    return null;
-                }, false);
+                finder, this::findAnnotations, false);
 
         List<String> modules = scanner.getModules();
         Assert.assertEquals(23, modules.size());
+
         assertJsModules(modules);
 
         // Theme modules should be included now
@@ -374,15 +341,7 @@ public class FullDependenciesScannerTest {
     private FullDependenciesScanner setUpAnnotationScanner(
             Class<? extends Annotation> annotationType)
             throws ClassNotFoundException {
-        // use this fake/mock class for the loaded class to check that annotated
-        // classes are requested for the loaded class and not for the
-        // annotationType
-        Class clazz = Object.class;
-
-        Mockito.when(finder.loadClass(annotationType.getName()))
-                .thenReturn(clazz);
-
-        Mockito.when(finder.getAnnotatedClasses(clazz))
+        Mockito.when(finder.getAnnotatedClasses(annotationType))
                 .thenReturn(getAnnotatedClasses(annotationType));
 
         return new FullDependenciesScanner(finder,
@@ -394,17 +353,9 @@ public class FullDependenciesScannerTest {
             Set<Class<?>> themedClasses, Set<Class<?>> noThemeClasses,
             SerializableBiFunction<Class<?>, Class<? extends Annotation>, List<? extends Annotation>> annotationFinder)
             throws ClassNotFoundException {
-        Class fakeThemeClass = Object.class;
-        Class fakeNoThemeClass = Throwable.class;
-
-        Mockito.when(finder.loadClass(Theme.class.getName()))
-                .thenReturn(fakeThemeClass);
-        Mockito.when(finder.loadClass(NoTheme.class.getName()))
-                .thenReturn(fakeNoThemeClass);
-
-        Mockito.when(finder.getAnnotatedClasses(fakeThemeClass))
+        Mockito.when(finder.getAnnotatedClasses(Theme.class))
                 .thenReturn(themedClasses);
-        Mockito.when(finder.getAnnotatedClasses(fakeNoThemeClass))
+        Mockito.when(finder.getAnnotatedClasses(NoTheme.class))
                 .thenReturn(noThemeClasses);
 
         return new FullDependenciesScanner(finder, annotationFinder, false) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FullScannerPwaTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FullScannerPwaTest.java
@@ -6,33 +6,19 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.server.PWA;
 import com.vaadin.flow.server.PwaConfiguration;
-import com.vaadin.flow.server.frontend.scanner.samples.pwa.AnotherAppShellWithPwa;
-import com.vaadin.flow.server.frontend.scanner.samples.pwa.AppShellWithPwa;
-import com.vaadin.flow.server.frontend.scanner.samples.pwa.AppShellWithoutPwa;
-import com.vaadin.flow.server.frontend.scanner.samples.pwa.NonAppShellWithPwa;
-
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
 
 public class FullScannerPwaTest extends AbstractScannerPwaTest {
     private ClassFinder finder = Mockito.mock(ClassFinder.class);
 
+    @Override
     protected PwaConfiguration getPwaConfiguration(Class<?>... classes)
             throws Exception {
-        // use this fake/mock class for the loaded class to check that annotated
-        // classes are requested for the loaded class and not for the
-        // annotationType
-        Class clazz = Object.class;
-
-        Mockito.doReturn(clazz).when(finder).loadClass(PWA.class.getName());
-
         Mockito.doReturn(getPwaAnnotatedClasses(classes)).when(finder)
-                .getAnnotatedClasses(clazz);
+                .getAnnotatedClasses(PWA.class);
 
         FullDependenciesScanner fullDependenciesScanner = new FullDependenciesScanner(
                 finder, (type, annotation) -> findPwaAnnotations(type), false);


### PR DESCRIPTION
…sloader in ClassFinder (#12050)

Using maven vaadin plugin classloader as a parent for the classloader in ClassFinder allows to avoid extra loading class from flow-server (or its dependencies) since it's already available in the classloader. So it may be referred as is (e.g. Route.class) instead using loadClass(Route.class.getName()). That simplifies the code and allows to avoid unnecessary ClassNotFoundException catching in many places.

fixes #12077

<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Please list all relevant dependencies in this section and provide summary of the change, motivation and context.

Fixes # (issue)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
