### PR TITLE
chore: remove non existent module from unused profile

### DIFF
--- a/flow-tests/servlet-containers/pom.xml
+++ b/flow-tests/servlet-containers/pom.xml
@@ -100,12 +100,6 @@
             </modules>
         </profile>
         <profile>
-            <id>felix-jetty</id>
-            <modules>
-                <module>felix-jetty</module>
-            </modules>
-        </profile>
-        <profile>
             <id>local-run</id>
             <activation>
                 <property>


### PR DESCRIPTION
The profile is never called, and the module does not exist