### PR TITLE
chore: Remove obsolete comment and assert in Binder

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -1324,8 +1324,7 @@ public class Binder<BEAN> implements Serializable {
 
         /**
          * Sets the field value by invoking the getter function on the given
-         * bean. The default listener attached to the field will be removed for
-         * the duration of this update.
+         * bean.
          *
          * @param bean
          *            the bean to fetch the property value from
@@ -1337,7 +1336,6 @@ public class Binder<BEAN> implements Serializable {
          */
         private void initFieldValue(BEAN bean, boolean writeBackChangedValues) {
             assert bean != null;
-            assert onValueChange != null;
             valueInit = true;
             try {
                 execute(() -> {


### PR DESCRIPTION
The original fix https://github.com/vaadin/flow/pull/4205 removed the temporary removal of the value change listener. Thus the comment is no longer valid and assert is no longer needed.