### PR TITLE
fix: Clear changed bindings after initing field values

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -2103,7 +2103,6 @@ public class Binder<BEAN> implements Serializable {
         if (bean == null) {
             clearFields();
         } else {
-            changedBindings.clear();
             getBindings().forEach(binding -> {
                 /*
                  * Some bindings may have been removed from binder during
@@ -2115,6 +2114,7 @@ public class Binder<BEAN> implements Serializable {
                     binding.initFieldValue(bean, false);
                 }
             });
+            changedBindings.clear();
             getValidationStatusHandler().statusChange(
                     BinderValidationStatus.createUnresolvedStatus(this));
             fireStatusChangeEvent(false);

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -1971,9 +1971,9 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
     // See: https://github.com/vaadin/framework/issues/9581
     @Test
     public void withConverter_hasChangesFalse() {
-        TextField nameField = new TextField();
+        TestTextField nameField = new TestTextField();
         nameField.setValue("");
-        TextField rentField = new TextField();
+        TestTextField rentField = new TestTextField();
         rentField.setValue("");
         rentField.addValueChangeListener(event -> {
             nameField.setValue("Name");

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -1968,6 +1968,28 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
                 (field, exception) -> Optional.of(bindingException));
     }
 
+    // See: https://github.com/vaadin/framework/issues/9581
+    @Test
+    public void withConverter_hasChangesFalse() {
+        TextField nameField = new TextField();
+        nameField.setValue("");
+        TextField rentField = new TextField();
+        rentField.setValue("");
+        rentField.addValueChangeListener(event -> {
+            nameField.setValue("Name");
+        });
+        item.setRent(BigDecimal.valueOf(10));
+        binder.forField(nameField).bind(Person::getFirstName, Person::setFirstName);
+        binder.forField(rentField).withConverter(new EuroConverter(""))
+                .withNullRepresentation(BigDecimal.valueOf(0d))
+                .bind(Person::getRent, Person::setRent);
+        binder.readBean(item);
+
+        assertFalse(binder.hasChanges());
+        assertEquals("€ 10.00", rentField.getValue());
+        assertEquals("Name", nameField.getValue());
+    }
+
     private TestTextField createNullRejectingFieldWithEmptyValue(
             String emptyValue) {
         return new TestTextField() {

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -1979,7 +1979,8 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
             nameField.setValue("Name");
         });
         item.setRent(BigDecimal.valueOf(10));
-        binder.forField(nameField).bind(Person::getFirstName, Person::setFirstName);
+        binder.forField(nameField).bind(Person::getFirstName,
+                Person::setFirstName);
         binder.forField(rentField).withConverter(new EuroConverter(""))
                 .withNullRepresentation(BigDecimal.valueOf(0d))
                 .bind(Person::getRent, Person::setRent);


### PR DESCRIPTION
JavaDoc of hasChanges says

"Check whether any of the bound fields' have uncommitted changes since last explicit call to {@link #readBean(Object)}, {@link #removeBean()}, * {@link #writeBean(Object)} or {@link #writeBeanIfValid(Object)}."

If readBean has converters, they will be run and field values updated accordingly. Furthermore if fields have value change listeners that will produce further changes in values, this should be considered according to above as part of readBean producedure and thus hasChanges still should return false.

Cherry pick from: https://github.com/vaadin/framework/pull/12455