### PR TITLE
fix: Avoid processing value change event due writing back of converted value

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -1188,6 +1188,7 @@ public class Binder<BEAN> implements Serializable {
 
         private Registration onValueChange;
         private boolean valueInit = false;
+        private boolean convertedBack = false;
 
         /**
          * Contains all converters and validators chained together in the
@@ -1375,7 +1376,8 @@ public class Binder<BEAN> implements Serializable {
         private void handleFieldValueChange(
                 ValueChangeEvent<FIELDVALUE> event) {
             // Don't handle change events when setting initial value
-            if (valueInit) {
+            if (valueInit || convertedBack) {
+                convertedBackBack = false;
                 return;
             }
 
@@ -1404,6 +1406,7 @@ public class Binder<BEAN> implements Serializable {
                         if (convertBackToPresentation && value != null) {
                             FIELDVALUE converted = convertToFieldType(value);
                             if (!Objects.equals(field.getValue(), converted)) {
+                                convertedBack = true;
                                 getField().setValue(converted);
                             }
                         }

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -1377,7 +1377,7 @@ public class Binder<BEAN> implements Serializable {
                 ValueChangeEvent<FIELDVALUE> event) {
             // Don't handle change events when setting initial value
             if (valueInit || convertedBack) {
-                convertedBackBack = false;
+                convertedBack = false;
                 return;
             }
 

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -1745,7 +1745,7 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
 
     @Test
     public void validationShouldNotRunTwice() {
-        TextField salaryField = new TextField();
+        TestTextField  salaryField = new TestTextField ();
         AtomicInteger count = new AtomicInteger(0);
         item.setSalaryDouble(100d);
         binder.forField(salaryField)

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -1745,7 +1745,7 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
 
     @Test
     public void validationShouldNotRunTwice() {
-        TestTextField  salaryField = new TestTextField ();
+        TestTextField salaryField = new TestTextField ();
         AtomicInteger count = new AtomicInteger(0);
         item.setSalaryDouble(100d);
         binder.forField(salaryField)

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -70,7 +70,6 @@ import static org.junit.Assert.assertTrue;
 public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
 
     private Map<HasValue<?, ?>, String> componentErrors = new HashMap<>();
-    private int count;
 
     @Rule
     /*
@@ -1746,27 +1745,29 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
 
     @Test
     public void validationShouldNotRunTwice() {
-        TestTextField salaryField = new TestTextField();
-        count = 0;
+        TextField salaryField = new TextField();
+        AtomicInteger count = new AtomicInteger(0);
         item.setSalaryDouble(100d);
         binder.forField(salaryField)
                 .withConverter(new StringToDoubleConverter(""))
                 .bind(Person::getSalaryDouble, Person::setSalaryDouble);
         binder.setBean(item);
         binder.addValueChangeListener(event -> {
-            count++;
+            count.incrementAndGet();
         });
 
         salaryField.setValue("1000");
         assertTrue(binder.isValid());
+        assertEquals(1, count.get());
 
         salaryField.setValue("salary");
         assertFalse(binder.isValid());
+        assertEquals(2, count.get());
 
         salaryField.setValue("2000");
 
         // Without fix for #12356 count will be 5
-        assertEquals(3, count);
+        assertEquals(3, count.get());
 
         assertEquals(new Double(2000), item.getSalaryDouble());
     }

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -1745,7 +1745,7 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
 
     @Test
     public void validationShouldNotRunTwice() {
-        TestTextField salaryField = new TestTextField ();
+        TestTextField salaryField = new TestTextField();
         AtomicInteger count = new AtomicInteger(0);
         item.setSalaryDouble(100d);
         binder.forField(salaryField)

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -70,6 +70,7 @@ import static org.junit.Assert.assertTrue;
 public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
 
     private Map<HasValue<?, ?>, String> componentErrors = new HashMap<>();
+    private int count;
 
     @Rule
     /*
@@ -1749,11 +1750,11 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         count = 0;
         item.setSalaryDouble(100d);
         binder.forField(salaryField)
-            .withConverter(new StringToDoubleConverter(""))
-            .bind(Person::getSalaryDouble, Person::setSalaryDouble);
+                .withConverter(new StringToDoubleConverter(""))
+                .bind(Person::getSalaryDouble, Person::setSalaryDouble);
         binder.setBean(item);
         binder.addValueChangeListener(event -> {
-        	count++;
+            count++;
         });
 
         salaryField.setValue("1000");


### PR DESCRIPTION
This is both a optimization by skipping duplicate validation round and avoids ConcurrentModificationExpectation being thrown certain corner cases.

Cherry pick from: vaadin/framework#12360