### PR TITLE
chore: Update bnd to latest in 3.x series

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <osgi.bundle.version>
             ${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}
         </osgi.bundle.version>
-        <bnd.version>3.3.0</bnd.version>
+        <bnd.version>3.5.0</bnd.version>
         <osgi.core.version>7.0.0</osgi.core.version>
         <osgi.compendium.version>7.0.0</osgi.compendium.version>
 


### PR DESCRIPTION
This allows using `-Dbnd.skip=true` and save time during testing
