### PR TITLE
test: Fix most 'scanned from multiple locations' warnings

### DIFF
--- a/flow-tests/test-frontend/vite-basics/pom.xml
+++ b/flow-tests/test-frontend/vite-basics/pom.xml
@@ -58,9 +58,6 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <configuration>
-                    <webAppConfig>
-                        <containerIncludeJarPattern>.*</containerIncludeJarPattern>
-                    </webAppConfig>
                     <systemProperties>
                         <!-- Allow test clients not on localhost to connect to Vite-->
                         <systemProperty>


### PR DESCRIPTION
containerIncludeJarPattern is "A pattern to match against the urls of the jars on the container path to select those that should be examined for things like META-INF fragments, resources, tlds and class inheritance hierarchy" but the container path is not the class path but also includes all Maven dependencies like

 org.apache.maven:maven-core:jar:3.8.2:compile
    com.google.inject:guice:jar:no_aop:4.2.2:compile
       com.google.guava:guava:jar:25.1-android:compile
