### PR TITLE
test: try to make test more stable by letting the server choose the port

### DIFF
--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/WebpackHandlerTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/WebpackHandlerTest.java
@@ -46,8 +46,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.atomic.AtomicReference;
-
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletOutputStream;
@@ -56,8 +54,6 @@ import javax.servlet.http.HttpServletResponse;
 
 import com.sun.net.httpserver.HttpServer;
 import com.vaadin.base.devserver.startup.AbstractDevModeTest;
-import com.vaadin.flow.di.Lookup;
-import com.vaadin.flow.internal.DevModeHandlerManager;
 import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.VaadinRequest;
@@ -66,8 +62,6 @@ import com.vaadin.flow.server.VaadinServlet;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.communication.StreamRequestHandler;
 import com.vaadin.flow.server.frontend.FrontendUtils;
-import com.vaadin.flow.server.startup.ApplicationConfiguration;
-
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
@@ -719,11 +713,8 @@ public class WebpackHandlerTest extends AbstractDevModeTest {
 
     private int prepareHttpServer(int port, int status, String response)
             throws Exception {
-        if (port == 0) {
-            port = WebpackHandler.getFreePort();
-        }
         httpServer = createStubWebpackTcpListener(port, status, response);
-        return port;
+        return httpServer.getAddress().getPort();
     }
 
     public static HttpServer createStubWebpackTcpListener(int port, int status,


### PR DESCRIPTION
Tests currently fail randomly with something like

java.lang.IllegalArgumentException: Tried to create a server on port 46159 but it was already in use
	at com.vaadin.base.devserver.WebpackHandlerTest.createStubWebpackTcpListener(WebpackHandlerTest.java:742)
	at com.vaadin.base.devserver.WebpackHandlerTest.prepareHttpServer(WebpackHandlerTest.java:725)
	at com.vaadin.base.devserver.WebpackHandlerTest.shouldNot_Handle_IndexHtmlInManifestPaths(WebpackHandlerTest.java:326)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
...
Caused by: java.net.BindException: Address already in use
	at sun.nio.ch.Net.bind0(Native Method)
	at sun.nio.ch.Net.bind(Net.java:433)
	at sun.nio.ch.Net.bind(Net.java:425)
	at sun.nio.ch.ServerSocketChannelImpl.bind(ServerSocketChannelImpl.java:223)
	at sun.nio.ch.ServerSocketAdaptor.bind(ServerSocketAdaptor.java:74)
	at sun.net.httpserver.ServerImpl.<init>(ServerImpl.java:100)
	at sun.net.httpserver.HttpServerImpl.<init>(HttpServerImpl.java:50)
	at sun.net.httpserver.DefaultHttpServerProvider.createHttpServer(DefaultHttpServerProvider.java:35)
	at com.sun.net.httpserver.HttpServer.create(HttpServer.java:130)
