### PR TITLE
fix: ensure Flow client container is pre-attached on navigation

### DIFF
--- a/flow-client/src/main/frontend/Flow.ts
+++ b/flow-client/src/main/frontend/Flow.ts
@@ -275,16 +275,18 @@ export class Flow {
         const tag = `flow-container-${appId.toLowerCase()}`;
         this.container = flowRoot.$[appId] = document.createElement(tag);
         this.container.id = appId;
-
-        // It might be that components created from server expect that their content has been rendered.
-        // Appending eagerly the container we avoid these kind of errors.
-        // Note that the client router will move this container to the outlet if the navigation succeed
-        this.container.style.display = 'none';
-        document.body.appendChild(this.container);
       }
 
       // hide flow progress indicator
       this.loadingFinished();
+    }
+
+    // It might be that components created from server expect that their content has been rendered.
+    // Appending eagerly the container we avoid these kind of errors.
+    // Note that the client router will move this container to the outlet if the navigation succeed
+    if (this.container && !this.container.isConnected) {
+      this.container.style.display = 'none';
+      document.body.appendChild(this.container);
     }
     return this.response!;
   }

--- a/flow-tests/test-ccdm-flow-navigation/src/main/java/com/vaadin/flow/navigate/HelloWorldView.java
+++ b/flow-tests/test-ccdm-flow-navigation/src/main/java/com/vaadin/flow/navigate/HelloWorldView.java
@@ -16,16 +16,22 @@
 
 package com.vaadin.flow.navigate;
 
+import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.component.html.NativeButton;
 
 @Route(value = "hello")
 @PageTitle("Hello World")
 public class HelloWorldView extends Span {
-
     public static final String NAVIGATE_ABOUT = "navigate-about";
+    public static final String IS_CONNECTED_ON_INIT = "is-connected-on-init";
+    public static final String IS_CONNECTED_ON_ATTACH = "is-connected-on-attach";
+
+    private final Span isConnectedOnInit = new Span("");
+    private final Span isConnectedOnAttach = new Span("");
 
     public HelloWorldView() {
         setId("hello-world-view");
@@ -33,6 +39,20 @@ public class HelloWorldView extends Span {
                 e -> getUI().get().navigate("about"));
         toAbout.setId(NAVIGATE_ABOUT);
         add(toAbout);
+
+        isConnectedOnInit.setId(IS_CONNECTED_ON_INIT);
+        updateIsConnected(isConnectedOnInit);
+        add(new Paragraph(new Text("Connected on init: "), isConnectedOnInit));
+
+        isConnectedOnAttach.setId(IS_CONNECTED_ON_ATTACH);
+        isConnectedOnAttach.addAttachListener(
+                event -> updateIsConnected(isConnectedOnAttach));
+        add(new Paragraph(new Text("Connected on attach: "),
+                isConnectedOnAttach));
     }
 
+    private void updateIsConnected(Span output) {
+        output.getElement()
+                .executeJs("this.textContent=String(this.isConnected)");
+    }
 }


### PR DESCRIPTION
Fixes #12080

The client-side Vaadin Router does not attach components until the `onBeforeEnter` callback is run. However, when the Flow client initializes a server-side view, it assumes its container and the UI root are connected to the document. This concerns constructor timing as well as `AttachEvent` listeners.

This fixes the issue by pre-attaching the hidden container element created in the `Flow.ts` (the adapter for the client-side router) to the body.