### PR TITLE
feat: add vite watchdog

### DIFF
--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -55,11 +55,10 @@ function updateTheme(contextPath: string) {
 }
 
 function runWatchDog(watchDogPort) {
-  console.log("Starting on port:", watchDogPort);
   const client = net.Socket();
   client.setEncoding('utf8');
   client.on('error', function () {
-    console.log("Watchdog connection error. Terminating webpack process...");
+    console.log("Watchdog connection error. Terminating vite process...");
     client.destroy();
     process.exit(0);
   });
@@ -72,9 +71,9 @@ function runWatchDog(watchDogPort) {
 }
 
 export const vaadinConfig:UserConfigFn = (env) => {
-  console.log("Executing in", env.mode);
-  console.log("watchdogport", process.env.watchDogPort);
   if (env.mode === 'development' && process.env.watchDogPort) {
+    // Open a connection with the Java dev-mode handler in order to finish
+    // vite when it exits or crashes.
     runWatchDog(process.env.watchDogPort);
   }
   return ({

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
@@ -342,6 +342,8 @@ public abstract class AbstractDevServerRunner implements DevModeHandler {
         }
 
         processBuilder.command(command);
+        processBuilder.environment().put("watchDogPort",
+                Integer.toString(getWatchDog().getWatchDogPort()));
 
         try {
             Process process = processBuilder.redirectErrorStream(true).start();

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/WebpackHandler.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/WebpackHandler.java
@@ -205,8 +205,7 @@ public final class WebpackHandler extends AbstractDevServerRunner {
         command.add(String.valueOf(getPort()));
         command.add("--watch-options-stdin"); // Tell wds to stop even if
                                               // watchDog fail
-        command.add("--env");
-        command.add("watchDogPort=" + getWatchDog().getWatchDogPort());
+
         String customParameters = getApplicationConfiguration()
                 .getStringProperty(
                         InitParameters.SERVLET_PARAMETER_DEVMODE_WEBPACK_OPTIONS,

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/AbstractDevModeTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/AbstractDevModeTest.java
@@ -11,7 +11,6 @@ import javax.servlet.ServletContext;
 import com.vaadin.base.devserver.AbstractDevServerRunner;
 import com.vaadin.base.devserver.DevModeHandlerManagerImpl;
 import com.vaadin.base.devserver.MockDeploymentConfiguration;
-import com.vaadin.base.devserver.WebpackHandler;
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.di.ResourceProvider;
 import com.vaadin.flow.function.DeploymentConfiguration;
@@ -136,7 +135,7 @@ public abstract class AbstractDevModeTest {
     }
 
     protected int getDevServerPort() {
-        return ((WebpackHandler) handler).getPort();
+        return ((AbstractDevServerRunner) handler).getPort();
     }
 
     protected void waitForDevServer() {
@@ -145,7 +144,7 @@ public abstract class AbstractDevModeTest {
 
     protected static void waitForDevServer(DevModeHandler devModeHandler) {
         Assert.assertNotNull(devModeHandler);
-        ((WebpackHandler) (devModeHandler)).waitForDevServer();
+        ((AbstractDevServerRunner) (devModeHandler)).waitForDevServer();
     }
 
     protected static boolean hasDevServerProcess(


### PR DESCRIPTION
## Description

Add watchdog to stop vite
when java handler exits or crashes.

Fixes #12060

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
