### PR TITLE
fix: Limit the requested pages to a given threshold (#12003)(CP: 2.7)

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -29,8 +29,6 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.slf4j.LoggerFactory;
-
 import com.vaadin.flow.data.provider.ArrayUpdater.Update;
 import com.vaadin.flow.data.provider.DataChangeEvent.DataRefreshEvent;
 import com.vaadin.flow.function.SerializableComparator;
@@ -165,11 +163,11 @@ public class DataCommunicator<T> implements Serializable {
      */
     public void setRequestedRange(int start, int length) {
         if (length > MAXIMUM_ALLOWED_ITEMS) {
-            getLogger().warn(String.format(
+            getLogger().warn(
                     "Attempted to fetch more items from server than allowed "
-                            + "in one go: number of items requested '%d', maximum "
-                            + "items allowed '%d'.",
-                    length, MAXIMUM_ALLOWED_ITEMS));
+                            + "in one go: number of items requested '{}', maximum "
+                            + "items allowed '{}'.",
+                    length, MAXIMUM_ALLOWED_ITEMS);
         }
         requestedRange = Range.withLength(start,
                 Math.min(length, MAXIMUM_ALLOWED_ITEMS));

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2020 Vaadin Ltd.
+ * Copyright 2000-2021 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
@@ -41,6 +41,9 @@ import com.vaadin.flow.internal.Range;
 import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.shared.Registration;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
@@ -57,6 +60,8 @@ import elemental.json.JsonValue;
  * @since 1.0
  */
 public class DataCommunicator<T> implements Serializable {
+    private static final int MAXIMUM_ALLOWED_ITEMS = 1000;
+
     private final DataGenerator<T> dataGenerator;
     private final ArrayUpdater arrayUpdater;
     private final SerializableConsumer<JsonArray> dataUpdater;
@@ -159,7 +164,15 @@ public class DataCommunicator<T> implements Serializable {
      *            the end of the requested range
      */
     public void setRequestedRange(int start, int length) {
-        requestedRange = Range.withLength(start, length);
+        if (length > MAXIMUM_ALLOWED_ITEMS) {
+            getLogger().warn(String.format(
+                    "Attempted to fetch more items from server than allowed "
+                            + "in one go: number of items requested '%d', maximum "
+                            + "items allowed '%d'.",
+                    length, MAXIMUM_ALLOWED_ITEMS));
+        }
+        requestedRange = Range.withLength(start,
+                Math.min(length, MAXIMUM_ALLOWED_ITEMS));
 
         requestFlush();
     }
@@ -276,7 +289,7 @@ public class DataCommunicator<T> implements Serializable {
      * Sets the {@link DataKeyMapper} used in this {@link DataCommunicator}. Key
      * mapper can be used to map keys sent to the client-side back to their
      * respective data objects.
-     * 
+     *
      * @param keyMapper
      *            the keyMapper
      */
@@ -361,10 +374,9 @@ public class DataCommunicator<T> implements Serializable {
                 inMemorySorting, filter);
         Stream<T> stream = getDataProvider().fetch(query);
         if (stream.isParallel()) {
-            LoggerFactory.getLogger(DataCommunicator.class)
-                    .debug("Data provider {} has returned "
-                            + "parallel stream on 'fetch' call",
-                            getDataProvider().getClass());
+            getLogger().debug(
+                    "Data provider {} has returned parallel stream on 'fetch' call",
+                    getDataProvider().getClass());
             stream = stream.collect(Collectors.toList()).stream();
             assert !stream.isParallel();
         }
@@ -383,10 +395,12 @@ public class DataCommunicator<T> implements Serializable {
     }
 
     private String getInvalidContractMessage(String method) {
-        return String.format("The data provider hasn't ever called %s() "
-                + "method on the provided query. "
-                + "It means that the the data provider breaks the contract "
-                + "and the returned stream contains unxpected data.", method);
+        return String.format(
+                "The data provider hasn't ever called %s() "
+                        + "method on the provided query. "
+                        + "It means that the the data provider breaks the contract "
+                        + "and the returned stream contains unxpected data.",
+                method);
     }
 
     private void handleAttach() {
@@ -408,7 +422,7 @@ public class DataCommunicator<T> implements Serializable {
     }
 
     protected void handleDataRefreshEvent(DataRefreshEvent<T> event) {
-        refresh (event.getItem());
+        refresh(event.getItem());
     }
 
     private void handleDetach() {
@@ -608,7 +622,7 @@ public class DataCommunicator<T> implements Serializable {
                 // If getStart is negative there is no data and empty Activation
                 // needs to be returned
                 return Activation.empty();
-            }          
+            }
             newActiveKeyOrder.addAll(activeKeyOrder.subList(overlap.getStart(),
                     overlap.getEnd()));
 
@@ -691,4 +705,9 @@ public class DataCommunicator<T> implements Serializable {
             return new Activation(Collections.emptyList(), false);
         }
     }
+
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(DataCommunicator.class);
+    }
+
 }


### PR DESCRIPTION
## Description

Limits the number of requested items from backend to a given threshold of 1000 items.

(cherry picked from commit 0ec90bf144c596214d34a2ef82ca9cf7bc8aa28b)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
