### PR TITLE
chore: Remove unused imports

### DIFF
--- a/flow-tests/test-application-theme/test-reusable-as-parent/src/test/java/com/vaadin/flow/uitest/ui/theme/ParentThemeIT.java
+++ b/flow-tests/test-application-theme/test-reusable-as-parent/src/test/java/com/vaadin/flow/uitest/ui/theme/ParentThemeIT.java
@@ -18,21 +18,15 @@ package com.vaadin.flow.uitest.ui.theme;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
-import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.flow.component.html.testbench.DivElement;
-import com.vaadin.flow.component.html.testbench.ImageElement;
 import com.vaadin.flow.component.html.testbench.SpanElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 
 import static com.vaadin.flow.uitest.ui.theme.ParentThemeView.BUTTERFLY_ID;
-import static com.vaadin.flow.uitest.ui.theme.ParentThemeView.FONTAWESOME_ID;
 import static com.vaadin.flow.uitest.ui.theme.ParentThemeView.MY_POLYMER_ID;
-import static com.vaadin.flow.uitest.ui.theme.ParentThemeView.SNOWFLAKE_ID;
 import static com.vaadin.flow.uitest.ui.theme.ParentThemeView.OCTOPUSS_ID;
-import static com.vaadin.flow.uitest.ui.theme.ParentThemeView.SUB_COMPONENT_ID;
 
 public class ParentThemeIT extends ChromeBrowserTest {
 

--- a/flow-tests/test-application-theme/test-theme-reusable/src/test/java/com/vaadin/flow/uitest/ui/theme/ReusableThemeIT.java
+++ b/flow-tests/test-application-theme/test-theme-reusable/src/test/java/com/vaadin/flow/uitest/ui/theme/ReusableThemeIT.java
@@ -21,7 +21,6 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.flow.component.html.testbench.DivElement;
 import com.vaadin.flow.component.html.testbench.ImageElement;
 import com.vaadin.flow.component.html.testbench.SpanElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;

--- a/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/ServerSideForwardView.java
+++ b/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/ServerSideForwardView.java
@@ -24,7 +24,6 @@ import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.BeforeEnterObserver;
 import com.vaadin.flow.router.BeforeEvent;
 import com.vaadin.flow.router.BeforeLeaveEvent;
-import com.vaadin.flow.router.BeforeLeaveObserver;
 import com.vaadin.flow.router.HasUrlParameter;
 import com.vaadin.flow.router.OptionalParameter;
 import com.vaadin.flow.router.Route;

--- a/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/ServerSidePostponeView.java
+++ b/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/ServerSidePostponeView.java
@@ -19,7 +19,6 @@ package com.vaadin.flow.ccdmtest;
 import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.BeforeLeaveEvent;
 import com.vaadin.flow.router.BeforeLeaveObserver;

--- a/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/IndexHtmlRequestHandlerIT.java
+++ b/flow-tests/test-ccdm/src/test/java/com/vaadin/flow/ccdmtest/IndexHtmlRequestHandlerIT.java
@@ -18,11 +18,9 @@ package com.vaadin.flow.ccdmtest;
 import java.util.Optional;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.JavascriptExecutor;
 
 public class IndexHtmlRequestHandlerIT extends CCDMTest {
 

--- a/flow-tests/test-common/src/main/java/com/vaadin/flow/uitest/servlet/ViewTestLayout.java
+++ b/flow-tests/test-common/src/main/java/com/vaadin/flow/uitest/servlet/ViewTestLayout.java
@@ -27,8 +27,6 @@ import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementFactory;
 import com.vaadin.flow.router.AfterNavigationEvent;
 import com.vaadin.flow.router.AfterNavigationObserver;
-import com.vaadin.flow.router.BeforeEnterEvent;
-import com.vaadin.flow.router.BeforeEnterObserver;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouterLayout;
 

--- a/flow-tests/test-dev-mode/src/main/java/com/vaadin/flow/uitest/ui/TestingServiceInitListener.java
+++ b/flow-tests/test-dev-mode/src/main/java/com/vaadin/flow/uitest/ui/TestingServiceInitListener.java
@@ -18,10 +18,7 @@ package com.vaadin.flow.uitest.ui;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.vaadin.flow.internal.BrowserLiveReload;
-import com.vaadin.flow.internal.BrowserLiveReloadAccess;
 import com.vaadin.flow.server.ServiceInitEvent;
-import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServiceInitListener;
 import com.vaadin.flow.shared.ui.Dependency;
 import com.vaadin.flow.shared.ui.LoadMode;

--- a/flow-tests/test-embedding/embedding-test-assets/src/main/java/com/vaadin/flow/webcomponent/PreserveOnRefreshExporter.java
+++ b/flow-tests/test-embedding/embedding-test-assets/src/main/java/com/vaadin/flow/webcomponent/PreserveOnRefreshExporter.java
@@ -17,11 +17,8 @@
 package com.vaadin.flow.webcomponent;
 
 import com.vaadin.flow.component.WebComponentExporter;
-import com.vaadin.flow.component.webcomponent.PropertyConfiguration;
 import com.vaadin.flow.component.webcomponent.WebComponent;
 import com.vaadin.flow.router.PreserveOnRefresh;
-
-import elemental.json.JsonValue;
 
 @PreserveOnRefresh
 public class PreserveOnRefreshExporter

--- a/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/WebComponentIT.java
+++ b/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/WebComponentIT.java
@@ -15,13 +15,10 @@
  */
 package com.vaadin.flow.webcomponent;
 
-import java.util.List;
-
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;

--- a/flow-tests/test-embedding/test-embedding-theme-variant/src/test/java/com/vaadin/flow/webcomponent/ThemedVariantComponentIT.java
+++ b/flow-tests/test-embedding/test-embedding-theme-variant/src/test/java/com/vaadin/flow/webcomponent/ThemedVariantComponentIT.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.webcomponent;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/flow-tests/test-frontend/vite-production/src/test/java/com/vaadin/viteapp/ProductionBasicsIT.java
+++ b/flow-tests/test-frontend/vite-production/src/test/java/com/vaadin/viteapp/ProductionBasicsIT.java
@@ -5,7 +5,6 @@ import com.vaadin.testbench.TestBenchElement;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import io.github.bonigarcia.wdm.WebDriverManager;

--- a/flow-tests/test-jetty-reload/src/main/java/com/vaadin/flow/uitest/ui/WebpackDevServerPortView.java
+++ b/flow-tests/test-jetty-reload/src/main/java/com/vaadin/flow/uitest/ui/WebpackDevServerPortView.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.UUID;
 
-import com.vaadin.base.devserver.DevModeHandlerManagerImpl;
 import com.vaadin.base.devserver.WebpackHandler;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;

--- a/flow-tests/test-misc/src/main/java/com/vaadin/flow/misc/ui/MiscelaneousView.java
+++ b/flow-tests/test-misc/src/main/java/com/vaadin/flow/misc/ui/MiscelaneousView.java
@@ -20,12 +20,8 @@ import java.util.List;
 
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.html.Div;
-import com.vaadin.flow.component.page.AppShellConfigurator;
-import com.vaadin.flow.misc.ui.MiscelaneousView.MyTheme;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.server.PWA;
 import com.vaadin.flow.theme.AbstractTheme;
-import com.vaadin.flow.theme.Theme;
 
 @Route(value = "")
 

--- a/flow-tests/test-misc/src/test/java/com/vaadin/flow/misc/ui/NpmThemedComponentIT.java
+++ b/flow-tests/test-misc/src/test/java/com/vaadin/flow/misc/ui/NpmThemedComponentIT.java
@@ -19,7 +19,6 @@ import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.openqa.selenium.By;
 
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;

--- a/flow-tests/test-multi-war/test-war1/src/main/java/com/vaadin/flow/multiwar/war1/MainView.java
+++ b/flow-tests/test-multi-war/test-war1/src/main/java/com/vaadin/flow/multiwar/war1/MainView.java
@@ -1,6 +1,5 @@
 package com.vaadin.flow.multiwar.war1;
 
-import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
 
 @Route("")

--- a/flow-tests/test-multi-war/test-war2/src/main/java/com/vaadin/flow/multiwar/war2/MainView.java
+++ b/flow-tests/test-multi-war/test-war2/src/main/java/com/vaadin/flow/multiwar/war2/MainView.java
@@ -1,6 +1,5 @@
 package com.vaadin.flow.multiwar.war2;
 
-import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
 
 @Route("")

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/RouterLinkView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/RouterLinkView.java
@@ -5,10 +5,8 @@ import com.vaadin.flow.component.html.Anchor;
 import com.vaadin.flow.component.html.Image;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementFactory;
-import com.vaadin.flow.router.Location;
 import com.vaadin.flow.router.Route;
 
-import elemental.json.Json;
 import elemental.json.JsonObject;
 
 @Route("com.vaadin.flow.uitest.ui.RouterLinkView")

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/littemplate/SimpleLitTemplateNoShadowRootView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/littemplate/SimpleLitTemplateNoShadowRootView.java
@@ -3,7 +3,6 @@ package com.vaadin.flow.uitest.ui.littemplate;
 import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
-import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.littemplate.LitTemplate;

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/littemplate/SimpleLitTemplateShadowRootView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/littemplate/SimpleLitTemplateShadowRootView.java
@@ -3,7 +3,6 @@ package com.vaadin.flow.uitest.ui.littemplate;
 import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.dependency.JsModule;
-import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.component.littemplate.LitTemplate;

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DirectionChangeIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DirectionChangeIT.java
@@ -16,17 +16,11 @@
 
 package com.vaadin.flow.uitest.ui;
 
-import java.util.function.Function;
-import java.util.function.Predicate;
-
 import com.vaadin.flow.component.Direction;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 import org.junit.Assert;
 import org.junit.Test;
-import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.support.ui.WebDriverWait;
 
 public class DirectionChangeIT extends ChromeBrowserTest {
 

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/IFrameIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/IFrameIT.java
@@ -7,8 +7,6 @@ import org.openqa.selenium.By;
 
 import net.jcip.annotations.NotThreadSafe;
 
-import static org.junit.Assert.assertTrue;
-
 @NotThreadSafe
 public class IFrameIT extends ChromeBrowserTest {
 

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/LogoutIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/LogoutIT.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.uitest.ui;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/NavigationTriggerIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/NavigationTriggerIT.java
@@ -18,11 +18,9 @@ package com.vaadin.flow.uitest.ui;
 import java.util.List;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import com.vaadin.flow.router.NavigationTrigger;
 import com.vaadin.flow.testutil.ChromeBrowserTest;

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PopStateHandlerIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PopStateHandlerIT.java
@@ -5,7 +5,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 
-import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.router.internal.PathUtil;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
 

--- a/flow-tests/test-router-custom-context/src/main/java/com/vaadin/flow/contexttest/ui/DependencyLayout.java
+++ b/flow-tests/test-router-custom-context/src/main/java/com/vaadin/flow/contexttest/ui/DependencyLayout.java
@@ -24,7 +24,6 @@ import com.vaadin.flow.dom.ElementFactory;
 import com.vaadin.flow.server.StreamRegistration;
 import com.vaadin.flow.server.StreamResource;
 import com.vaadin.flow.server.VaadinSession;
-import com.vaadin.flow.theme.NoTheme;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;

--- a/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
+++ b/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
@@ -24,7 +24,6 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.flow.component.html.testbench.DivElement;
 import com.vaadin.flow.component.html.testbench.ImageElement;
 import com.vaadin.flow.component.html.testbench.SpanElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;


### PR DESCRIPTION
Using `find . -name "*.java"|xargs java -jar google-java-format-1.12.0-all-deps.jar --fix-imports-only --skip-sorting-imports  -r`
