### PR TITLE
Revert "chore(deps): bump formatter-maven-plugin from 2.16.0 to 2.17.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -304,7 +304,7 @@
             <plugin>
                 <groupId>net.revelc.code.formatter</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>
-                <version>2.17.0</version>
+                <version>2.16.0</version>
                 <configuration>
                     <configFile>eclipse/VaadinJavaConventions.xml
                     </configFile>


### PR DESCRIPTION
Reverts vaadin/flow#12244

The plugin is no longer Java 8 compatible since 2.17.0. See https://github.com/revelc/formatter-maven-plugin/pull/533