### PR TITLE
feat: support vite in v14 bootstrap

### DIFF
--- a/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
+++ b/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
@@ -126,6 +126,7 @@ public class FeatureFlags implements Serializable {
                         context.getAttribute(Lookup.class));
                 featureFlags.configuration = ApplicationConfiguration
                         .get(context);
+                featureFlags.loadProperties();
                 attribute = new FeatureFlagsWrapper(featureFlags);
                 context.setAttribute(attribute);
             }

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -881,6 +881,14 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                 BootstrapContext context) throws IOException {
             if (FeatureFlags.get(service.getContext())
                     .isEnabled(FeatureFlags.VITE)) {
+
+                if (!service.getDeploymentConfiguration().isProductionMode()) {
+                    Element script = createJavaScriptElement(
+                            "VAADIN/@vite/client", false);
+                    head.appendChild(script.attr("type", "module"));
+                    return;
+                }
+
                 // Get the index.html to get vite generated bundles
                 String index = FrontendUtils.getIndexHtmlContent(service);
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -894,7 +894,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
 
                 // Get and add all javascriptbundles
                 Matcher scriptMatcher = Pattern
-                        .compile("src=\\\"VAADIN\\/build\\/(.*.js)\\\"")
+                        .compile("src=\\\"VAADIN\\/build\\/(.*\\.js)\\\"")
                         .matcher(index);
                 while (scriptMatcher.find()) {
                     Element script = createJavaScriptElement(
@@ -907,7 +907,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
 
                 // Get and add all css bundle links
                 Matcher cssMatcher = Pattern
-                        .compile("href=\\\"VAADIN\\/build\\/(.*.css)\\\"")
+                        .compile("href=\\\"VAADIN\\/build\\/(.*\\.css)\\\"")
                         .matcher(index);
                 while (cssMatcher.find()) {
                     Element link = createStylesheetElement(

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -39,6 +39,8 @@ import java.util.Properties;
 import java.util.ServiceLoader;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -53,6 +55,7 @@ import org.jsoup.select.Elements;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.component.PushConfiguration;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.page.Inline;
@@ -876,6 +879,34 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
 
         private void appendNpmBundle(Element head, VaadinService service,
                 BootstrapContext context) throws IOException {
+            if (FeatureFlags.get(service.getContext())
+                    .isEnabled(FeatureFlags.VITE)) {
+                // Get the index.html to get vite generated bundles
+                String index = FrontendUtils.getIndexHtmlContent(service);
+
+                // Get and add all javascriptbundles
+                Matcher scriptMatcher = Pattern
+                        .compile("src=\\\"VAADIN\\/build\\/(.*.js)\\\"")
+                        .matcher(index);
+                while (scriptMatcher.find()) {
+                    Element script = createJavaScriptElement(
+                            "VAADIN/build/" + scriptMatcher.group(1), false);
+                    head.appendChild(
+                            script.attr("type", "module").attr("async", true)
+                                    // Fixes basic auth in Safari #6560
+                                    .attr("crossorigin", true));
+                }
+
+                // Get and add all css bundle links
+                Matcher cssMatcher = Pattern
+                        .compile("href=\\\"VAADIN\\/build\\/(.*.css)\\\"")
+                        .matcher(index);
+                while (cssMatcher.find()) {
+                    Element link = createStylesheetElement(cssMatcher.group(1));
+                    head.appendChild(link);
+                }
+                return;
+            }
             String content = FrontendUtils.getStatsAssetsByChunkName(service);
             if (content == null) {
                 StringBuilder message = new StringBuilder(

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -910,7 +910,8 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                         .compile("href=\\\"VAADIN\\/build\\/(.*.css)\\\"")
                         .matcher(index);
                 while (cssMatcher.find()) {
-                    Element link = createStylesheetElement(cssMatcher.group(1));
+                    Element link = createStylesheetElement(
+                            "VAADIN/build/" + cssMatcher.group(1));
                     head.appendChild(link);
                 }
                 return;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -540,13 +540,19 @@ public class FrontendUtils {
 
     private static InputStream getFileFromClassPath(VaadinService service,
             String filePath) {
-        InputStream stream = service.getClassLoader()
-                .getResourceAsStream(VAADIN_WEBAPP_RESOURCES + filePath);
-        if (stream == null) {
+        final URL resource = service.getContext().getAttribute(Lookup.class)
+                .lookup(ResourceProvider.class)
+                .getApplicationResource(VAADIN_WEBAPP_RESOURCES + filePath);
+        if (resource == null) {
             getLogger().error("Cannot get the '{}' from the classpath",
                     filePath);
+            return null;
         }
-        return stream;
+        try {
+            return resource.openStream();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
@@ -1698,7 +1698,13 @@ public class BootstrapHandlerTest {
                 bootstrapPage.head().toString()
                         .contains("VAADIN/@vite/client"));
         Assert.assertTrue(
-                bootstrapPage.head().toString().contains("VAADIN/build/"));
+                "Bundle should be gotten from index and added to bootstrap page",
+                bootstrapPage.head().toString()
+                        .contains("src=\"VAADIN/build/main.d253dd35.js\""));
+        Assert.assertTrue(
+                "Bundled css should be gotten from index and added to bootstrap page",
+                bootstrapPage.head().toString()
+                        .contains("href=\"VAADIN/build/main.688a5538.css\""));
     }
 
     private void enableViteFeature(boolean productionMode) throws IOException {
@@ -1728,7 +1734,8 @@ public class BootstrapHandlerTest {
         Mockito.when(configuration.getJavaResourceFolder())
                 .thenReturn(tmpDir.getRoot());
 
-        Mockito.when(lookup.lookup(ApplicationConfiguration.class)).thenReturn(configuration);
+        Mockito.when(lookup.lookup(ApplicationConfiguration.class))
+                .thenReturn(configuration);
         Mockito.when(vaadinContext.getAttribute(ApplicationConfiguration.class))
                 .thenReturn(configuration);
         Mockito.when(vaadinContext.getAttribute(


### PR DESCRIPTION
Support vite build in the v14 bootstrap
to have exported webcomponents working.

Closes #12057
