### PR TITLE
refactor!: Remove StaticFileHandler.isStaticResourceRequest

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/StaticFileHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StaticFileHandler.java
@@ -33,16 +33,6 @@ import java.io.Serializable;
 public interface StaticFileHandler extends Serializable {
 
     /**
-     * Checks if a static resource can be found for the requested path.
-     *
-     * @param request
-     *            the request to check
-     * @return <code>true</code> if a static resource exists and can be sent as
-     *         a response to this request, <code>false</code> otherwise
-     */
-    boolean isStaticResourceRequest(HttpServletRequest request);
-
-    /**
      * Serves a static resource for the requested path if a resource can be
      * found.
      *

--- a/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
@@ -239,8 +239,8 @@ public class StaticFileServer implements StaticFileHandler {
             return true;
         }
 
-        if (devModeHandler != null && devModeHandler
-                .serveDevModeRequest(request, response)) {
+        if (devModeHandler != null
+                && devModeHandler.serveDevModeRequest(request, response)) {
             // We don't know what the dev server can serve, but if it served
             // something we are happy.
             return true;

--- a/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
@@ -235,7 +235,7 @@ public class StaticFileServer implements StaticFileHandler {
         if (HandlerHelper.isPathUnsafe(filenameWithPath)) {
             getLogger().info(HandlerHelper.UNSAFE_PATH_ERROR_MESSAGE_PATTERN,
                     filenameWithPath);
-            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             return true;
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
@@ -232,6 +232,13 @@ public class StaticFileServer implements StaticFileHandler {
             HttpServletResponse response) throws IOException {
 
         String filenameWithPath = getRequestFilename(request);
+        if (filenameWithPath.endsWith("/")) {
+            // Directories are not static resources although
+            // servletContext.getResource will return a URL for them, at
+            // least with Jetty
+            return false;
+        }
+
         if (HandlerHelper.isPathUnsafe(filenameWithPath)) {
             getLogger().info(HandlerHelper.UNSAFE_PATH_ERROR_MESSAGE_PATTERN,
                     filenameWithPath);

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
@@ -328,8 +328,7 @@ public class VaadinServlet extends HttpServlet {
     protected boolean serveStaticOrWebJarRequest(HttpServletRequest request,
             HttpServletResponse response) throws IOException {
 
-        if (staticFileHandler.isStaticResourceRequest(request)) {
-            staticFileHandler.serveStaticResource(request, response);
+        if (staticFileHandler.serveStaticResource(request, response)) {
             return true;
         }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
@@ -950,61 +950,61 @@ public class StaticFileServerTest implements Serializable {
 
         Assert.assertTrue(fileServer.serveStaticResource(request, response));
         Assert.assertEquals(0, out.getOutput().length);
-        Assert.assertEquals(HttpServletResponse.SC_FORBIDDEN,
+        Assert.assertEquals(HttpServletResponse.SC_BAD_REQUEST,
                 responseCode.get());
     }
 
     @Test
-    public void serveStaticResource_uriWithDirectoryChangeWithSlash_returnsImmediatelyAndSetsForbiddenStatus()
+    public void serveStaticResource_uriWithDirectoryChangeWithSlash_returnsImmediatelyAndSetsBadRequestStatus()
             throws IOException {
         staticBuildResourceWithDirectoryChange_nothingServed(
                 "/VAADIN/build/../vaadin-bundle-1234.cache.js");
     }
 
     @Test
-    public void serveStaticResource_uriWithDirectoryChangeWithBackslash_returnsImmediatelyAndSetsForbiddenStatus()
+    public void serveStaticResource_uriWithDirectoryChangeWithBackslash_returnsImmediatelyAndSetsBadRequestStatus()
             throws IOException {
         staticBuildResourceWithDirectoryChange_nothingServed(
                 "/VAADIN/build/something\\..\\vaadin-bundle-1234.cache.js");
     }
 
     @Test
-    public void serveStaticResource_uriWithDirectoryChangeWithEncodedBackslashUpperCase_returnsImmediatelyAndSetsForbiddenStatus()
+    public void serveStaticResource_uriWithDirectoryChangeWithEncodedBackslashUpperCase_returnsImmediatelyAndSetsBadRequestStatus()
             throws IOException {
         staticBuildResourceWithDirectoryChange_nothingServed(
                 "/VAADIN/build/something%5C..%5Cvaadin-bundle-1234.cache.js");
     }
 
     @Test
-    public void serveStaticResource_uriWithDirectoryChangeWithEncodedBackslashLowerCase_returnsImmediatelyAndSetsForbiddenStatus()
+    public void serveStaticResource_uriWithDirectoryChangeWithEncodedBackslashLowerCase_returnsImmediatelyAndSetsBadRequestStatus()
             throws IOException {
         staticBuildResourceWithDirectoryChange_nothingServed(
                 "/VAADIN/build/something%5c..%5cvaadin-bundle-1234.cache.js");
     }
 
     @Test
-    public void serveStaticResource_uriWithDirectoryChangeInTheEndWithSlash_returnsImmediatelyAndSetsForbiddenStatus()
+    public void serveStaticResource_uriWithDirectoryChangeInTheEndWithSlash_returnsImmediatelyAndSetsBadRequestStatus()
             throws IOException {
         staticBuildResourceWithDirectoryChange_nothingServed(
                 "/VAADIN/build/..");
     }
 
     @Test
-    public void serveStaticResource_uriWithDirectoryChangeInTheEndWithBackslash_returnsImmediatelyAndSetsForbiddenStatus()
+    public void serveStaticResource_uriWithDirectoryChangeInTheEndWithBackslash_returnsImmediatelyAndSetsBadRequestStatus()
             throws IOException {
         staticBuildResourceWithDirectoryChange_nothingServed(
                 "/VAADIN/build/something\\..");
     }
 
     @Test
-    public void serveStaticResource_uriWithDirectoryChangeInTheEndWithEncodedBackslashUpperCase_returnsImmediatelyAndSetsForbiddenStatus()
+    public void serveStaticResource_uriWithDirectoryChangeInTheEndWithEncodedBackslashUpperCase_returnsImmediatelyAndSetsBadRequestStatus()
             throws IOException {
         staticBuildResourceWithDirectoryChange_nothingServed(
                 "/VAADIN/build/something%5C..");
     }
 
     @Test
-    public void serveStaticResource_uriWithDirectoryChangeInTheEndWithEncodedBackslashLowerCase_returnsImmediatelyAndSetsForbiddenStatus()
+    public void serveStaticResource_uriWithDirectoryChangeInTheEndWithEncodedBackslashLowerCase_returnsImmediatelyAndSetsBadRequestStatus()
             throws IOException {
         staticBuildResourceWithDirectoryChange_nothingServed(
                 "/VAADIN/build/something%5c..");

--- a/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
@@ -26,6 +26,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
+import java.lang.reflect.Field;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -70,6 +71,7 @@ import org.mockito.Mockito;
 import com.vaadin.flow.WarURLStreamHandlerFactory;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.CurrentInstance;
+import com.vaadin.flow.internal.ResponseWriter;
 
 import static com.vaadin.flow.server.Constants.POLYFILLS_DEFAULT_VALUE;
 import static com.vaadin.flow.server.Constants.STATISTICS_JSON_DEFAULT;
@@ -173,7 +175,8 @@ public class StaticFileServerTest implements Serializable {
                 invocationOnMock -> servletService.getClass().getClassLoader())
                 .when(servletService).getClassLoader();
 
-        fileServer = new OverrideableStaticFileServer(servletService);
+        fileServer = new OverrideableStaticFileServer(servletService,
+                configuration);
 
         // Required by the ResponseWriter
         servletContext = Mockito.mock(ServletContext.class);
@@ -257,29 +260,32 @@ public class StaticFileServerTest implements Serializable {
 
     @Test
     public void isResourceRequest() throws Exception {
+        fileServer.writeResponse = false;
         setupRequestURI("", "/static", "/file.png");
         Mockito.when(servletService.getStaticResource("/static/file.png"))
                 .thenReturn(new URL("file:///static/file.png"));
-        Assert.assertTrue(fileServer.isStaticResourceRequest(request));
+        Assert.assertTrue(fileServer.serveStaticResource(request, response));
     }
 
     @Test
     public void isResourceRequestWithContextPath() throws Exception {
+        fileServer.writeResponse = false;
         setupRequestURI("/foo", "/static", "/file.png");
         Mockito.when(servletService.getStaticResource("/static/file.png"))
                 .thenReturn(new URL("file:///static/file.png"));
-        Assert.assertTrue(fileServer.isStaticResourceRequest(request));
+        Assert.assertTrue(fileServer.serveStaticResource(request, response));
     }
 
     @Test
     public void isNotResourceRequest() throws Exception {
         setupRequestURI("", "", null);
         Mockito.when(servletContext.getResource("/")).thenReturn(null);
-        Assert.assertFalse(fileServer.isStaticResourceRequest(request));
+        Assert.assertFalse(fileServer.serveStaticResource(request, response));
     }
 
     @Test
     public void directoryIsNotResourceRequest() throws Exception {
+        fileServer.writeResponse = false;
         final TemporaryFolder folder = TemporaryFolder.builder().build();
         folder.create();
 
@@ -297,7 +303,7 @@ public class StaticFileServerTest implements Serializable {
         Mockito.when(servletService.getStaticResource("/frontend"))
                 .thenReturn(folderPath);
         Assert.assertFalse("Folder on disk should not be a static resource.",
-                fileServer.isStaticResourceRequest(request));
+                fileServer.serveStaticResource(request, response));
 
         // Test any path ending with / to be seen as a directory
         setupRequestURI("", "", "/fake");
@@ -305,7 +311,7 @@ public class StaticFileServerTest implements Serializable {
                 .thenReturn(new URL("file:///fake/"));
         Assert.assertFalse(
                 "Fake should not check the file system nor be a static resource.",
-                fileServer.isStaticResourceRequest(request));
+                fileServer.serveStaticResource(request, response));
 
         Path tempArchive = generateZipArchive(folder);
 
@@ -316,7 +322,7 @@ public class StaticFileServerTest implements Serializable {
                         + "!/frontend"));
         Assert.assertFalse(
                 "Folder 'frontend' in jar should not be a static resource.",
-                fileServer.isStaticResourceRequest(request));
+                fileServer.serveStaticResource(request, response));
         setupRequestURI("", "", "/file.txt");
         Mockito.when(servletService.getStaticResource("/file.txt"))
                 .thenReturn(new URL("jar:file:///"
@@ -324,7 +330,7 @@ public class StaticFileServerTest implements Serializable {
                         + "!/file.txt"));
         Assert.assertTrue(
                 "File 'file.txt' inside jar should be a static resource.",
-                fileServer.isStaticResourceRequest(request));
+                fileServer.serveStaticResource(request, response));
 
         folder.delete();
     }
@@ -332,6 +338,7 @@ public class StaticFileServerTest implements Serializable {
     @Test
     public void isStaticResource_jarWarFileScheme_detectsAsStaticResources()
             throws IOException {
+        fileServer.writeResponse = false;
         Assert.assertTrue("Can not run concurrently with other test",
                 StaticFileServer.openFileSystems.isEmpty());
 
@@ -360,7 +367,7 @@ public class StaticFileServerTest implements Serializable {
 
         Assert.assertTrue(
                 "Request should return as static request as we can not determine non file resources in jar files.",
-                fileServer.isStaticResourceRequest(request));
+                fileServer.serveStaticResource(request, response));
 
         folder.delete();
     }
@@ -368,6 +375,7 @@ public class StaticFileServerTest implements Serializable {
     @Test
     public void isStaticResource_jarInAJar_detectsAsStaticResources()
             throws IOException {
+        fileServer.writeResponse = false;
         Assert.assertTrue("Can not run concurrently with other test",
                 StaticFileServer.openFileSystems.isEmpty());
 
@@ -390,14 +398,14 @@ public class StaticFileServerTest implements Serializable {
                         + archiveFile.getName() + "!/frontend"));
         Assert.assertTrue(
                 "Request should return as static request as we can not determine non file resources in jar files.",
-                fileServer.isStaticResourceRequest(request));
+                fileServer.serveStaticResource(request, response));
         setupRequestURI("", "", "/file.txt");
         Mockito.when(servletService.getStaticResource("/file.txt"))
                 .thenReturn(new URL("jar:" + warFile.toURI().toURL() + "!/"
                         + archiveFile.getName() + "!/file.txt"));
         Assert.assertTrue(
                 "Request should return as static request as we can not determine non file resources in jar files.",
-                fileServer.isStaticResourceRequest(request));
+                fileServer.serveStaticResource(request, response));
 
         folder.delete();
     }
@@ -516,6 +524,7 @@ public class StaticFileServerTest implements Serializable {
     public void concurrentRequestsToJarResources_checksAreCorrect()
             throws IOException, InterruptedException, ExecutionException,
             URISyntaxException {
+        fileServer.writeResponse = false;
         Assert.assertTrue("Can not run concurrently with other test",
                 StaticFileServer.openFileSystems.isEmpty());
 
@@ -537,7 +546,8 @@ public class StaticFileServerTest implements Serializable {
                 .mapToObj(i -> {
                     Callable<Result> callable = () -> {
                         try {
-                            if (fileServer.isStaticResourceRequest(request)) {
+                            if (fileServer.serveStaticResource(request,
+                                    response)) {
                                 throw new IllegalArgumentException(
                                         "Folder 'frontend' in jar should not be a static resource.");
                             }
@@ -586,7 +596,8 @@ public class StaticFileServerTest implements Serializable {
                 .mapToObj(i -> {
                     Callable<Result> callable = () -> {
                         try {
-                            if (!fileServer.isStaticResourceRequest(request)) {
+                            if (!fileServer.serveStaticResource(request,
+                                    response)) {
                                 throw new IllegalArgumentException(
                                         "File 'file.txt' inside jar should be a static resource.");
                             }
@@ -651,39 +662,42 @@ public class StaticFileServerTest implements Serializable {
                     }
                 }));
 
-        Assert.assertFalse(fileServer.isStaticResourceRequest(request));
+        Assert.assertFalse(fileServer.serveStaticResource(request, response));
     }
 
     @Test
-    public void manifestPath_isResourceRequest() {
+    public void manifestPath_isResourceRequest() throws IOException {
         setupRequestURI("", "", "/sw.js");
         Mockito.when(servletService.getStaticResource("/sw.js"))
                 .thenReturn(null);
-        Assert.assertTrue(fileServer.isStaticResourceRequest(request));
+        Assert.assertTrue(fileServer.serveStaticResource(request, response));
     }
 
     @Test
-    public void manifestPath_isResourceRequest_withContextPath() {
+    public void manifestPath_isResourceRequest_withContextPath()
+            throws IOException {
         setupRequestURI("/foo", "", "/sw.js");
         Mockito.when(servletService.getStaticResource("/sw.js"))
                 .thenReturn(null);
-        Assert.assertTrue(fileServer.isStaticResourceRequest(request));
+        Assert.assertTrue(fileServer.serveStaticResource(request, response));
     }
 
     @Test
-    public void manifestPath_indexHtml_isNotResourceRequest() {
+    public void manifestPath_indexHtml_isNotResourceRequest()
+            throws IOException {
         setupRequestURI("", "", "/index.html");
         Mockito.when(servletService.getStaticResource("/index.html"))
                 .thenReturn(null);
-        Assert.assertFalse(fileServer.isStaticResourceRequest(request));
+        Assert.assertFalse(fileServer.serveStaticResource(request, response));
     }
 
     @Test
-    public void manifestPath_indexHtml_isNotResourceRequest_withContextPath() {
+    public void manifestPath_indexHtml_isNotResourceRequest_withContextPath()
+            throws IOException {
         setupRequestURI("/foo", "", "/index.html");
         Mockito.when(servletService.getStaticResource("/index.html"))
                 .thenReturn(null);
-        Assert.assertFalse(fileServer.isStaticResourceRequest(request));
+        Assert.assertFalse(fileServer.serveStaticResource(request, response));
     }
 
     @Test
@@ -819,9 +833,7 @@ public class StaticFileServerTest implements Serializable {
     public void serveNonExistingStaticResource() throws IOException {
         setupRequestURI("", "", "/nonexisting/file.js");
 
-        fileServer.serveStaticResource(request, response);
-        Assert.assertEquals(HttpServletResponse.SC_NOT_FOUND,
-                responseCode.get());
+        Assert.assertFalse(fileServer.serveStaticResource(request, response));
     }
 
     @Test
@@ -1018,8 +1030,7 @@ public class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void nonexistingStaticBuildResource_returnsNotFound()
-            throws IOException {
+    public void nonexistingStaticBuildResource_notServed() throws IOException {
         String pathInfo = "/VAADIN/build/my-text.txt";
         setupRequestURI("", "", pathInfo);
         ClassLoader mockLoader = Mockito.mock(ClassLoader.class);
@@ -1028,9 +1039,7 @@ public class StaticFileServerTest implements Serializable {
         mockStatsBundles(mockLoader);
         mockConfigurationPolyfills();
 
-        Assert.assertTrue(fileServer.serveStaticResource(request, response));
-        Assert.assertEquals(HttpServletResponse.SC_NOT_FOUND,
-                responseCode.get());
+        Assert.assertFalse(fileServer.serveStaticResource(request, response));
     }
 
     @Test
@@ -1050,7 +1059,7 @@ public class StaticFileServerTest implements Serializable {
     }
 
     @Test
-    public void staticManifestPathIndexHtmlResource_returnsNotFound()
+    public void staticManifestPathIndexHtmlResource_notServed()
             throws IOException {
         String pathInfo = "/index.html";
         setupRequestURI("", "", pathInfo);
@@ -1062,9 +1071,7 @@ public class StaticFileServerTest implements Serializable {
                 .thenReturn(createFileURLWithDataAndLength(
                         "/" + WEBAPP_RESOURCE_PREFIX + pathInfo, fileData));
 
-        Assert.assertTrue(fileServer.serveStaticResource(request, response));
-        Assert.assertEquals(HttpServletResponse.SC_NOT_FOUND,
-                responseCode.get());
+        Assert.assertFalse(fileServer.serveStaticResource(request, response));
     }
 
     @Test
@@ -1144,7 +1151,6 @@ public class StaticFileServerTest implements Serializable {
 
         setupRequestURI("", "", "/frontend/src/webjars/foo/bar.js");
 
-        Assert.assertTrue(fileServer.isStaticResourceRequest(request));
         Assert.assertTrue(fileServer.serveStaticResource(request, response));
         Assert.assertEquals(fileData, out.getOutputString());
     }
@@ -1162,10 +1168,7 @@ public class StaticFileServerTest implements Serializable {
 
         setupRequestURI("", "", "/frontend/src/webjars/foo/bar.js");
 
-        Assert.assertFalse(fileServer.isStaticResourceRequest(request));
-        Assert.assertTrue(fileServer.serveStaticResource(request, response));
-        Assert.assertEquals(HttpServletResponse.SC_NOT_FOUND,
-                responseCode.get());
+        Assert.assertFalse(fileServer.serveStaticResource(request, response));
     }
 
     @Test
@@ -1207,11 +1210,15 @@ public class StaticFileServerTest implements Serializable {
     }
 
     private static class OverrideableStaticFileServer extends StaticFileServer {
+        public boolean writeResponse = true;
         private Boolean overrideBrowserHasNewestVersion;
         private Integer overrideCacheTime;
+        private DeploymentConfiguration configuration;
 
-        OverrideableStaticFileServer(VaadinServletService servletService) {
+        OverrideableStaticFileServer(VaadinServletService servletService,
+                DeploymentConfiguration configuration) {
             super(servletService);
+            this.configuration = configuration;
         }
 
         @Override
@@ -1232,5 +1239,35 @@ public class StaticFileServerTest implements Serializable {
             }
             return super.getCacheTime(filenameWithPath);
         }
+
+        @Override
+        public boolean serveStaticResource(HttpServletRequest request,
+                HttpServletResponse response) throws IOException {
+            if (!writeResponse)
+                try {
+                    {
+                        ResponseWriter fakeWriter = new ResponseWriter(
+                                configuration) {
+                            @Override
+                            public void writeResponseContents(
+                                    String filenameWithPath, URL resourceUrl,
+                                    HttpServletRequest request,
+                                    HttpServletResponse response)
+                                    throws IOException {
+                                return;
+                            }
+                        };
+                        Field f = StaticFileServer.class
+                                .getDeclaredField("responseWriter");
+                        f.setAccessible(true);
+                        f.set(this, fakeWriter);
+                    }
+                } catch (IllegalArgumentException | IllegalAccessException
+                        | NoSuchFieldException | SecurityException e) {
+                    throw new RuntimeException(e);
+                }
+            return super.serveStaticResource(request, response);
+        }
+
     }
 }

--- a/flow-tests/test-application-theme/test-theme-reusable/src/test/java/com/vaadin/flow/uitest/ui/theme/ReusableThemeIT.java
+++ b/flow-tests/test-application-theme/test-theme-reusable/src/test/java/com/vaadin/flow/uitest/ui/theme/ReusableThemeIT.java
@@ -33,6 +33,9 @@ import static com.vaadin.flow.uitest.ui.theme.ReusableThemeView.SNOWFLAKE_ID;
 import static com.vaadin.flow.uitest.ui.theme.ReusableThemeView.OCTOPUSS_ID;
 import static com.vaadin.flow.uitest.ui.theme.ReusableThemeView.SUB_COMPONENT_ID;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class ReusableThemeIT extends ChromeBrowserTest {
 
     @Test

--- a/flow-tests/test-application-theme/test-theme-reusable/src/test/java/com/vaadin/flow/uitest/ui/theme/ReusableThemeIT.java
+++ b/flow-tests/test-application-theme/test-theme-reusable/src/test/java/com/vaadin/flow/uitest/ui/theme/ReusableThemeIT.java
@@ -42,9 +42,11 @@ public class ReusableThemeIT extends ChromeBrowserTest {
         Assert.assertFalse("reusable-theme static files should be copied",
                 driver.getPageSource().contains("HTTP ERROR 404 Not Found"));
 
-        getDriver().get(getRootURL() + "/path/themes/no-copy/no-copy.txt");
-        Assert.assertTrue("no-copy theme should not be handled",
-                driver.getPageSource().contains("HTTP ERROR 404 Not Found"));
+        String source = driver.getPageSource();
+        Matcher m = Pattern.compile(
+                ".*Could not navigate to.*themes/no-copy/no-copy.txt.*",
+                Pattern.DOTALL).matcher(source);
+        Assert.assertTrue("no-copy theme should not be handled", m.matches());
     }
 
     @Test

--- a/flow-tests/test-application-theme/test-theme-reusable/src/test/java/com/vaadin/flow/uitest/ui/theme/ReusableThemeIT.java
+++ b/flow-tests/test-application-theme/test-theme-reusable/src/test/java/com/vaadin/flow/uitest/ui/theme/ReusableThemeIT.java
@@ -45,6 +45,7 @@ public class ReusableThemeIT extends ChromeBrowserTest {
         Assert.assertFalse("reusable-theme static files should be copied",
                 driver.getPageSource().contains("HTTP ERROR 404 Not Found"));
 
+        getDriver().get(getRootURL() + "/path/themes/no-copy/no-copy.txt");
         String source = driver.getPageSource();
         Matcher m = Pattern.compile(
                 ".*Could not navigate to.*themes/no-copy/no-copy.txt.*",

--- a/flow-tests/test-dev-mode/src/test/java/com/vaadin/flow/uitest/ui/UrlValidationIT.java
+++ b/flow-tests/test-dev-mode/src/test/java/com/vaadin/flow/uitest/ui/UrlValidationIT.java
@@ -38,7 +38,7 @@ public class UrlValidationIT extends ChromeBrowserTest {
         open();
         waitUntil(input -> $(LabelElement.class).id("elementId").isDisplayed());
         // check the forbidden url
-        sendRequestAndValidateResponseStatusForbidden(
+        sendRequestAndValidateResponseStatusBadRequest(
                 "/VAADIN/build/%252E%252E");
     }
 
@@ -49,11 +49,11 @@ public class UrlValidationIT extends ChromeBrowserTest {
         open();
         waitUntil(input -> $(LabelElement.class).id("elementId").isDisplayed());
         // check the forbidden url
-        sendRequestAndValidateResponseStatusForbidden(
+        sendRequestAndValidateResponseStatusBadRequest(
                 "/VAADIN/build/%252E%252E/some-resource.css");
     }
 
-    private void sendRequestAndValidateResponseStatusForbidden(
+    private void sendRequestAndValidateResponseStatusBadRequest(
             String pathToResource) throws Exception {
         final String urlString = getRootURL() + "/view" + pathToResource;
         URL url = new URL(urlString);
@@ -62,8 +62,8 @@ public class UrlValidationIT extends ChromeBrowserTest {
         connection.setRequestMethod("GET");
         int responseCode = connection.getResponseCode();
         Assert.assertEquals(
-                "HTTP 403 Forbidden expected for urls with "
+                "HTTP 400 Bad request expected for urls with "
                         + "directory change",
-                HttpURLConnection.HTTP_FORBIDDEN, responseCode);
+                HttpURLConnection.HTTP_BAD_REQUEST, responseCode);
     }
 }

--- a/flow-tests/test-pwa/src/test/java/com/vaadin/flow/pwatest/ui/PwaTestIT.java
+++ b/flow-tests/test-pwa/src/test/java/com/vaadin/flow/pwatest/ui/PwaTestIT.java
@@ -250,14 +250,14 @@ public class PwaTestIT extends ChromeDeviceTest {
         // with the actual served file
         String expectedMimeType = URLConnection.guessContentTypeFromName(url);
         String script = "const mimeType = arguments[0];"
-                + "const resolve = arguments[1];" + "fetch('" + url
-                + "', {method: 'GET'})"
-                + ".then(response => resolve(response.status===200"
-                + "      && !response.redirected"
-                + "      && (mimeType===null || response.headers.get('Content-Type')===mimeType)))"
+                + "const resolve = arguments[2];" //
+                + "fetch(arguments[1], {method: 'GET'})" //
+                + ".then(response => resolve(response.status===200" //
+                + "      && !response.redirected" //
+                + "      && (mimeType===null || response.headers.get('Content-Type').replace(';charset=utf-8','')===mimeType)))" //
                 + ".catch(err => resolve(false));";
         return (boolean) ((JavascriptExecutor) getDriver())
-                .executeAsyncScript(script, expectedMimeType);
+                .executeAsyncScript(script, expectedMimeType, url);
     }
 
     private static String readStringFromUrl(String url) throws IOException {

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/InvalidLocationIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/InvalidLocationIT.java
@@ -16,10 +16,9 @@
 
 package com.vaadin.flow;
 
-import org.junit.Assert;
-import org.junit.Test;
-
 import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+import org.junit.Test;
 
 public class InvalidLocationIT extends ChromeBrowserTest {
 
@@ -28,8 +27,8 @@ public class InvalidLocationIT extends ChromeBrowserTest {
     public void invalidCharactersOnPath_UiNotServed() {
         open();
 
-        Assert.assertTrue("Faulty URL didn't return 400 error page.",
-                getDriver().getPageSource().contains("400"));
+        checkLogsForErrors(msg -> msg
+                .contains("the server responded with a status of 400"));
     }
 
     @Override

--- a/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
+++ b/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
@@ -16,6 +16,8 @@
 package com.vaadin.flow.uitest.ui.theme;
 
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.junit.Assert;
@@ -94,9 +96,10 @@ public class ThemeIT extends ChromeBrowserTest {
                 driver.getPageSource().contains("HTTP ERROR 404 Not Found"));
 
         getDriver().get(getRootURL() + "/path/themes/no-copy/no-copy.txt");
+        String source = driver.getPageSource();
+Matcher m =Pattern.compile(".*Could not navigate to.*themes/no-copy/no-copy.txt.*", Pattern.DOTALL).matcher(source);
         Assert.assertTrue("no-copy theme should not be handled",
-                driver.getPageSource().matches(
-                        "Could not navigate to.*themes/no-copy/no-copy.txt"));
+                m.matches());
     }
 
     @Test

--- a/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
+++ b/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
@@ -97,9 +97,10 @@ public class ThemeIT extends ChromeBrowserTest {
 
         getDriver().get(getRootURL() + "/path/themes/no-copy/no-copy.txt");
         String source = driver.getPageSource();
-Matcher m =Pattern.compile(".*Could not navigate to.*themes/no-copy/no-copy.txt.*", Pattern.DOTALL).matcher(source);
-        Assert.assertTrue("no-copy theme should not be handled",
-                m.matches());
+        Matcher m = Pattern.compile(
+                ".*Could not navigate to.*themes/no-copy/no-copy.txt.*",
+                Pattern.DOTALL).matcher(source);
+        Assert.assertTrue("no-copy theme should not be handled", m.matches());
     }
 
     @Test

--- a/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
+++ b/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
@@ -95,7 +95,7 @@ public class ThemeIT extends ChromeBrowserTest {
 
         getDriver().get(getRootURL() + "/path/themes/no-copy/no-copy.txt");
         Assert.assertTrue("no-copy theme should not be handled",
-                driver.getPageSource().contains("HTTP ERROR 404 Not Found"));
+                driver.getPageSource().contains("Could not navigate to 'themes/no-copy/no-copy.txt'"));
     }
 
     @Test

--- a/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
+++ b/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
@@ -95,7 +95,8 @@ public class ThemeIT extends ChromeBrowserTest {
 
         getDriver().get(getRootURL() + "/path/themes/no-copy/no-copy.txt");
         Assert.assertTrue("no-copy theme should not be handled",
-                driver.getPageSource().contains("Could not navigate to 'themes/no-copy/no-copy.txt'"));
+                driver.getPageSource().contains(
+                        "Could not navigate to 'themes/no-copy/no-copy.txt'"));
     }
 
     @Test

--- a/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
+++ b/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
@@ -95,8 +95,8 @@ public class ThemeIT extends ChromeBrowserTest {
 
         getDriver().get(getRootURL() + "/path/themes/no-copy/no-copy.txt");
         Assert.assertTrue("no-copy theme should not be handled",
-                driver.getPageSource().contains(
-                        "Could not navigate to 'themes/no-copy/no-copy.txt'"));
+                driver.getPageSource().matches(
+                        "Could not navigate to.*themes/no-copy/no-copy.txt"));
     }
 
     @Test

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
@@ -695,6 +695,10 @@ public abstract class AbstractDevServerRunner implements DevModeHandler {
             requestFilename = "/VAADIN/static" + requestFilename;
         }
 
+        if (requestFilename.equals("") || requestFilename.equals("/")) {
+            // Index file must be handled by IndexHtmlRequestHandler
+            return false;
+        }
         String devServerRequestPath = UrlUtil.encodeURI(requestFilename);
         if (request.getQueryString() != null) {
             devServerRequestPath += "?" + request.getQueryString();


### PR DESCRIPTION
This simplifies static file handling so the same logic is not duplicate in two places. It also makes it possible to always query the dev server for files instead of knowing upfront what the dev server can serve.

The method is removed instead of retained as there are two ways it could have been used:
1. Called to check if a given request is a static resource request
2. Overridden in a custom StaticFileHandler

To keep the method we would need to do the following for the cases:
1. Make isStaticResourceRequest return serveStaticResource() != null
2. Make serveStaticResource() call isStaticResourceRequest() as the first thing

We cannot do both so it is safer to remove the method to force code to be updated
