### PR TITLE
Revert "refactor: Use maven vaadin plugin classloader as a parent for URLClassloader in ClassFinder (#12050)  (#12171)"

### DIFF
--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/common/AnnotationValuesExtractorTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/common/AnnotationValuesExtractorTest.java
@@ -65,6 +65,14 @@ public class AnnotationValuesExtractorTest {
                 Collections.singletonMap(HtmlImport.class, "doomed to fail"));
     }
 
+    @Test
+    public void extractAnnotationValues_annotationNotInClassLoader() {
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("");
+
+        extractor.extractAnnotationValues(
+                Collections.singletonMap(Mojo.class, "whatever"));
+    }
 
     @Test
     public void extractAnnotationValues_missingAnnotation() {

--- a/flow-migration/src/main/java/com/vaadin/flow/server/scanner/ReflectionsClassFinder.java
+++ b/flow-migration/src/main/java/com/vaadin/flow/server/scanner/ReflectionsClassFinder.java
@@ -46,8 +46,7 @@ public class ReflectionsClassFinder implements ClassFinder {
      *            the list of urls for finding classes.
      */
     public ReflectionsClassFinder(URL... urls) {
-        classLoader = new URLClassLoader(urls,
-                ReflectionsClassFinder.class.getClassLoader()); // NOSONAR
+        classLoader = new URLClassLoader(urls, null); // NOSONAR
         ConfigurationBuilder configurationBuilder = new ConfigurationBuilder()
                 .addClassLoader(classLoader).setExpandSuperTypes(false)
                 .addUrls(urls);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendWebComponentGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendWebComponentGenerator.java
@@ -82,15 +82,23 @@ public class FrontendWebComponentGenerator implements Serializable {
      */
     public Set<File> generateWebComponents(File outputDirectory,
             ThemeDefinition theme) {
-        Set<Class<?>> exporterRelatedClasses = new HashSet<>();
-        finder.getSubTypesOf(WebComponentExporter.class)
-                .forEach(exporterRelatedClasses::add);
-        finder.getSubTypesOf(WebComponentExporterFactory.class)
-                .forEach(exporterRelatedClasses::add);
-        final String themeName = theme == null ? "" : theme.getName();
-        return WebComponentModulesWriter.DirectoryWriter
-                .generateWebComponentsToDirectory(
-                        WebComponentModulesWriter.class, exporterRelatedClasses,
-                        outputDirectory, false, themeName);
+        try {
+            final Class<?> writerClass = finder
+                    .loadClass(WebComponentModulesWriter.class.getName());
+            Set<Class<?>> exporterRelatedClasses = new HashSet<>();
+            finder.getSubTypesOf(WebComponentExporter.class.getName())
+                    .forEach(exporterRelatedClasses::add);
+            finder.getSubTypesOf(WebComponentExporterFactory.class.getName())
+                    .forEach(exporterRelatedClasses::add);
+            final String themeName = theme == null ? "" : theme.getName();
+            return WebComponentModulesWriter.DirectoryWriter
+                .generateWebComponentsToDirectory(writerClass,
+                    exporterRelatedClasses, outputDirectory, false, themeName);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException(
+                    "Unable to locate a required class using custom class "
+                            + "loader",
+                    e);
+        }
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScanner.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScanner.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.server.frontend.scanner;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -53,6 +54,10 @@ import com.vaadin.flow.theme.ThemeDefinition;
  */
 class FullDependenciesScanner extends AbstractDependenciesScanner {
 
+    private static final String COULD_NOT_LOAD_ERROR_MSG = "Could not load annotation class ";
+
+    private static final String VALUE = "value";
+
     private ThemeDefinition themeDefinition;
     private AbstractTheme themeInstance;
     private Set<String> classes = new HashSet<>();
@@ -60,6 +65,8 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
     private Set<String> scripts = new LinkedHashSet<>();
     private Set<CssData> cssData;
     private List<String> modules;
+
+    private final Class<?> abstractTheme;
 
     private final SerializableBiFunction<Class<?>, Class<? extends Annotation>, List<? extends Annotation>> annotationFinder;
 
@@ -88,6 +95,12 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
         super(finder);
         long start = System.currentTimeMillis();
         this.annotationFinder = annotationFinder;
+        try {
+            abstractTheme = finder.loadClass(AbstractTheme.class.getName());
+        } catch (ClassNotFoundException exception) {
+            throw new IllegalStateException("Could not load "
+                    + AbstractTheme.class.getName() + " class", exception);
+        }
 
         packages = discoverPackages();
 
@@ -97,12 +110,14 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
         collectAnnotationValues(
                 (clazz, module) -> handleModule(clazz, module, regularModules,
                         themeModules),
-                JsModule.class, module -> ((JsModule) module).value());
+                JsModule.class,
+                module -> invokeAnnotationMethodAsString(module, VALUE));
 
         collectAnnotationValues((clazz, script) -> {
             classes.add(clazz.getName());
             scripts.add(script);
-        }, JavaScript.class, module -> ((JavaScript) module).value());
+        }, JavaScript.class,
+                module -> invokeAnnotationMethodAsString(module, VALUE));
         cssData = discoverCss();
 
         discoverTheme();
@@ -147,16 +162,17 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
         return Collections.unmodifiableSet(classes);
     }
 
-    private CssData createCssData(CssImport cssImport) {
+    private CssData createCssData(Annotation cssImport) {
         CssData data = new CssData();
-        data.id = adaptCssValue(cssImport.id());
-        data.include = adaptCssValue(cssImport.include());
-        data.themefor = adaptCssValue(cssImport.themeFor());
-        data.value = adaptCssValue(cssImport.value());
+        data.id = adaptCssValue(cssImport, "id");
+        data.include = adaptCssValue(cssImport, "include");
+        data.themefor = adaptCssValue(cssImport, "themeFor");
+        data.value = adaptCssValue(cssImport, VALUE);
         return data;
     }
 
-    private String adaptCssValue(String value) {
+    private String adaptCssValue(Annotation cssImport, String method) {
+        String value = invokeAnnotationMethodAsString(cssImport, method);
         if (value == null) {
             return value;
         }
@@ -164,55 +180,78 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
     }
 
     private Map<String, String> discoverPackages() {
-        Set<Class<?>> annotatedClasses = getFinder()
-                .getAnnotatedClasses(NpmPackage.class);
-        Map<String, String> result = new HashMap<>();
-        Set<String> logs = new HashSet<>();
-        for (Class<?> clazz : annotatedClasses) {
-            classes.add(clazz.getName());
-            List<? extends Annotation> packageAnnotations = annotationFinder
-                    .apply(clazz, NpmPackage.class);
-            packageAnnotations.forEach(pckg -> {
-                NpmPackage npmPckg = (NpmPackage) pckg;
-                String value = npmPckg.value();
-                String vers = npmPckg.version();
-                logs.add(value + " " + vers + " " + clazz.getName());
-                result.put(value, vers);
-            });
+        try {
+            Class<? extends Annotation> loadedAnnotation = getFinder()
+                    .loadClass(NpmPackage.class.getName());
+            Set<Class<?>> annotatedClasses = getFinder()
+                    .getAnnotatedClasses(loadedAnnotation);
+            Map<String, String> result = new HashMap<>();
+            Set<String> logs = new HashSet<>();
+            for (Class<?> clazz : annotatedClasses) {
+                classes.add(clazz.getName());
+                List<? extends Annotation> packageAnnotations = annotationFinder
+                        .apply(clazz, loadedAnnotation);
+                packageAnnotations.forEach(pckg -> {
+                    String value = invokeAnnotationMethodAsString(pckg, VALUE);
+                    String vers = invokeAnnotationMethodAsString(pckg,
+                            "version");
+                    logs.add(value + " " + vers + " " + clazz.getName());
+                    result.put(value, vers);
+                });
+            }
+            debug("npm dependencies", logs);
+            return result;
+        } catch (ClassNotFoundException exception) {
+            throw new IllegalStateException(
+                    COULD_NOT_LOAD_ERROR_MSG + NpmPackage.class.getName(),
+                    exception);
         }
-        debug("npm dependencies", logs);
-        return result;
     }
 
     private Set<CssData> discoverCss() {
-        Set<Class<?>> annotatedClasses = getFinder()
-                .getAnnotatedClasses(CssImport.class);
-        Set<CssData> result = new LinkedHashSet<>();
-        for (Class<?> clazz : annotatedClasses) {
-            classes.add(clazz.getName());
-            List<? extends Annotation> imports = annotationFinder.apply(clazz,
-                    CssImport.class);
-            imports.stream()
-                    .forEach(imp -> result.add(createCssData((CssImport) imp)));
+        try {
+            Class<? extends Annotation> loadedAnnotation = getFinder()
+                    .loadClass(CssImport.class.getName());
+            Set<Class<?>> annotatedClasses = getFinder()
+                    .getAnnotatedClasses(loadedAnnotation);
+            Set<CssData> result = new LinkedHashSet<>();
+            for (Class<?> clazz : annotatedClasses) {
+                classes.add(clazz.getName());
+                List<? extends Annotation> imports = annotationFinder
+                        .apply(clazz, loadedAnnotation);
+                imports.stream().forEach(imp -> result.add(createCssData(imp)));
+            }
+            return result;
+        } catch (ClassNotFoundException exception) {
+            throw new IllegalStateException(
+                    COULD_NOT_LOAD_ERROR_MSG + CssData.class.getName(),
+                    exception);
         }
-        return result;
     }
 
     private <T extends Annotation> void collectAnnotationValues(
             BiConsumer<Class<?>, String> valueHandler, Class<T> annotationType,
             Function<Annotation, String> valueExtractor) {
-        Set<String> logs = new HashSet<>();
-        Set<Class<?>> annotatedClasses = getFinder()
-                .getAnnotatedClasses(annotationType);
+        try {
+            Set<String> logs = new HashSet<>();
+            Class<? extends Annotation> loadedAnnotation = getFinder()
+                    .loadClass(annotationType.getName());
+            Set<Class<?>> annotatedClasses = getFinder()
+                    .getAnnotatedClasses(loadedAnnotation);
 
-        annotatedClasses.stream().forEach(clazz -> annotationFinder
-                .apply(clazz, annotationType).forEach(ann -> {
-                    String value = valueExtractor.apply(ann);
-                    valueHandler.accept(clazz, value);
-                    logs.add(value + " " + clazz);
-                }));
+            annotatedClasses.stream().forEach(clazz -> annotationFinder
+                    .apply(clazz, loadedAnnotation).forEach(ann -> {
+                        String value = valueExtractor.apply(ann);
+                        valueHandler.accept(clazz, value);
+                        logs.add(value + " " + clazz);
+                    }));
 
-        debug("@" + annotationType.getSimpleName(), logs);
+            debug("@" + annotationType.getSimpleName(), logs);
+        } catch (ClassNotFoundException exception) {
+            throw new IllegalStateException(
+                    COULD_NOT_LOAD_ERROR_MSG + annotationType.getName(),
+                    exception);
+        }
     }
 
     private void debug(String label, Set<String> log) {
@@ -241,8 +280,8 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
             setupTheme(theme, data.getVariant(), data.getThemeName());
         } catch (ClassNotFoundException exception) {
             throw new IllegalStateException(
-                    "Could not load theme class " + data.getThemeClass(),
-                    exception);
+                "Could not load theme class " + data.getThemeClass(),
+                exception);
         }
     }
 
@@ -260,36 +299,50 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
     }
 
     private ThemeData verifyTheme() {
-        Set<Class<?>> annotatedClasses = getFinder()
-                .getAnnotatedClasses(Theme.class);
-        Set<ThemeData> themes = annotatedClasses.stream()
-                .flatMap(clazz -> annotationFinder
-                        .apply(clazz, Theme.class).stream())
-                .map(theme -> (Theme) theme)
-                .map(theme -> new ThemeData(theme.value().getName(),
-                        theme.variant(), theme.themeFolder()))
-                .collect(Collectors.toSet());
+        try {
+            Class<? extends Annotation> loadedThemeAnnotation = getFinder()
+                    .loadClass(Theme.class.getName());
 
-        Set<Class<?>> notThemeClasses = getFinder()
-                .getAnnotatedClasses(NoTheme.class).stream()
-                .collect(Collectors.toSet());
-        if (themes.size() > 1) {
+            Set<Class<?>> annotatedClasses = getFinder()
+                    .getAnnotatedClasses(loadedThemeAnnotation);
+            Set<ThemeData> themes = annotatedClasses.stream()
+                    .flatMap(clazz -> annotationFinder
+                            .apply(clazz, loadedThemeAnnotation).stream())
+                    .map(theme -> new ThemeData(
+                            ((Class<?>) invokeAnnotationMethod(theme, VALUE))
+                                    .getName(),
+                            invokeAnnotationMethodAsString(theme, "variant"),
+                            invokeAnnotationMethodAsString(theme, "themeFolder")))
+                    .collect(Collectors.toSet());
+
+            Class<? extends Annotation> loadedNoThemeAnnotation = getFinder()
+                    .loadClass(NoTheme.class.getName());
+
+            Set<Class<?>> notThemeClasses = getFinder()
+                    .getAnnotatedClasses(loadedNoThemeAnnotation).stream()
+                    .collect(Collectors.toSet());
+            if (themes.size() > 1) {
+                throw new IllegalStateException(
+                        "Using multiple different Theme configurations is not "
+                                + "supported. The list of found themes:\n"
+                                + getThemesList(themes));
+            }
+            if (!themes.isEmpty() && !notThemeClasses.isEmpty()) {
+                throw new IllegalStateException("@"
+                        + Theme.class.getSimpleName() + " ("
+                        + getThemesList(themes) + ") and @"
+                        + NoTheme.class.getSimpleName()
+                        + " annotations can't be used simultaneously.");
+            }
+            if (!notThemeClasses.isEmpty()) {
+                return ThemeData.createNoTheme();
+
+            }
+            return themes.isEmpty() ? null : themes.iterator().next();
+        } catch (ClassNotFoundException exception) {
             throw new IllegalStateException(
-                    "Using multiple different Theme configurations is not "
-                            + "supported. The list of found themes:\n"
-                            + getThemesList(themes));
+                    "Could not load theme annotation class", exception);
         }
-        if (!themes.isEmpty() && !notThemeClasses.isEmpty()) {
-            throw new IllegalStateException("@" + Theme.class.getSimpleName()
-                    + " (" + getThemesList(themes) + ") and @"
-                    + NoTheme.class.getSimpleName()
-                    + " annotations can't be used simultaneously.");
-        }
-        if (!notThemeClasses.isEmpty()) {
-            return ThemeData.createNoTheme();
-
-        }
-        return themes.isEmpty() ? null : themes.iterator().next();
     }
 
     private String getThemesList(Collection<ThemeData> themes) {
@@ -303,7 +356,7 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
     private void handleModule(Class<?> clazz, String module,
             Set<String> modules, Map<String, Set<String>> themeModules) {
 
-        if (AbstractTheme.class.isAssignableFrom(clazz)) {
+        if (abstractTheme.isAssignableFrom(clazz)) {
             Set<String> themingModules = themeModules.computeIfAbsent(
                     clazz.getName(), cl -> new LinkedHashSet<>());
             themingModules.add(module);
@@ -330,6 +383,33 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
         result.addAll(themingModules);
         result.addAll(modules);
         return result;
+    }
+
+    private String invokeAnnotationMethodAsString(Annotation target,
+            String methodName) {
+        Object result = invokeAnnotationMethod(target, methodName);
+        return result == null ? null : result.toString();
+    }
+
+    private Object invokeAnnotationMethod(Annotation target,
+            String methodName) {
+        try {
+            return target.getClass().getDeclaredMethod(methodName)
+                    .invoke(target);
+        } catch (IllegalAccessException e) {
+            throw new UnsupportedOperationException(String.format(
+                    "Failed to access method '%s' in annotation interface '%s', should not be happening due to JLS definition of annotation interface",
+                    methodName, target), e);
+        } catch (InvocationTargetException e) {
+            throw new IllegalStateException(String.format(
+                    "Got an exception by invoking method '%s' from annotation '%s'",
+                    methodName, target), e);
+        } catch (NoSuchMethodException e) {
+            throw new IllegalArgumentException(
+                    String.format("Annotation '%s' has no method named `%s",
+                            target, methodName),
+                    e);
+        }
     }
 
     private Logger getLogger() {


### PR DESCRIPTION
## Description

This reverts commit 929b7207.
Reverted because this change causes class loading errors for Flow 2.7 Portlet integration.

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
