### PR TITLE
fix: Auto-update Node for alternative directory

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -504,7 +504,7 @@ public class FrontendTools {
                         String.format(LOCAL_NODE_NOT_FOUND, dir, dir,
                                 file.getAbsolutePath()));
             }
-            return file.getAbsolutePath();
+            return updateAlternateIfNeeded(file).getAbsolutePath();
         } else {
             getLogger().info("Node not found in {}. Installing node {}.", dir,
                     nodeVersion);


### PR DESCRIPTION
## Description

Auto-updates Node version when the Node is forced to be located in only alternative directory.

Fixes https://github.com/vaadin/flow/issues/12264

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
