### PR TITLE
chrore: Update byte-buddy for better Java 17 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,7 +240,7 @@
             <dependency>
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy</artifactId>
-                <version>1.11.6</version>
+                <version>1.11.22</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
## Description

Certain Java 17 bytecode is not compatible with the version of ASM that byte-buddy brings in. That needs to be updated.

fixes #12136

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

