### PR TITLE
fix: fix client requests with windows.

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
@@ -56,9 +56,6 @@ public class UrlUtil {
      * <p>
      * Note that ? and # are not encoded so you should not pass a URL path that
      * includes a query string or a fragment
-     * <p>
-     * Note that : is not encoded as for windows environments file paths start
-     * with the drive e.g. C:
      * 
      * @param path
      *            the path to encode
@@ -66,8 +63,8 @@ public class UrlUtil {
     public static String encodeURI(String path) {
         try {
             return URLEncoder.encode(path, StandardCharsets.UTF_8.name())
-                    .replace("+", "%20").replace("%2F", "/").replace("%40", "@")
-                    .replace("%3A", ":");
+                    .replace("+", "%20").replace("%2F", "/")
+                    .replace("%40", "@");
         } catch (UnsupportedEncodingException e) {
             // Runtime exception as this doesn't really happen
             throw new RuntimeException("Encoding the URI failed", e); // NOSONAR

--- a/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
@@ -56,6 +56,9 @@ public class UrlUtil {
      * <p>
      * Note that ? and # are not encoded so you should not pass a URL path that
      * includes a query string or a fragment
+     * <p>
+     * Note that : is not encoded as for windows environments file paths start
+     * with the drive e.g. C:
      * 
      * @param path
      *            the path to encode
@@ -63,8 +66,8 @@ public class UrlUtil {
     public static String encodeURI(String path) {
         try {
             return URLEncoder.encode(path, StandardCharsets.UTF_8.name())
-                    .replace("+", "%20").replace("%2F", "/")
-                    .replace("%40", "@");
+                    .replace("+", "%20").replace("%2F", "/").replace("%40", "@")
+                    .replace("%3A", ":");
         } catch (UnsupportedEncodingException e) {
             // Runtime exception as this doesn't really happen
             throw new RuntimeException("Encoding the URI failed", e); // NOSONAR

--- a/flow-server/src/main/java/com/vaadin/flow/router/LocationUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/LocationUtil.java
@@ -16,15 +16,11 @@
 
 package com.vaadin.flow.router;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Utility class exposing reusable utility methods for location.
@@ -53,7 +49,7 @@ public class LocationUtil {
             // Ignore forbidden chars supported in route definitions
             String strippedPath = path.replaceAll("[{}*]", "");
 
-            URI uri = new URI(URLEncoder.encode(strippedPath, UTF_8.name()));
+            URI uri = new URI(null, null, strippedPath, null);
             if (uri.isAbsolute()) {
                 // "A URI is absolute if, and only if, it has a scheme
                 // component"
@@ -66,7 +62,7 @@ public class LocationUtil {
                 throw new InvalidLocationException(
                         "Relative path cannot contain .. segments");
             }
-        } catch (URISyntaxException | UnsupportedEncodingException e) {
+        } catch (URISyntaxException e) {
             throw new InvalidLocationException("Cannot parse path: " + path, e);
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/router/LocationUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/LocationUtil.java
@@ -16,13 +16,15 @@
 
 package com.vaadin.flow.router;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import com.vaadin.flow.internal.UrlUtil;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Utility class exposing reusable utility methods for location.
@@ -51,7 +53,7 @@ public class LocationUtil {
             // Ignore forbidden chars supported in route definitions
             String strippedPath = path.replaceAll("[{}*]", "");
 
-            URI uri = new URI(UrlUtil.encodeURI(strippedPath));
+            URI uri = new URI(URLEncoder.encode(strippedPath, UTF_8.name()));
             if (uri.isAbsolute()) {
                 // "A URI is absolute if, and only if, it has a scheme
                 // component"
@@ -64,7 +66,7 @@ public class LocationUtil {
                 throw new InvalidLocationException(
                         "Relative path cannot contain .. segments");
             }
-        } catch (URISyntaxException e) {
+        } catch (URISyntaxException | UnsupportedEncodingException e) {
             throw new InvalidLocationException("Cannot parse path: " + path, e);
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/router/LocationUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/LocationUtil.java
@@ -16,11 +16,15 @@
 
 package com.vaadin.flow.router;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Utility class exposing reusable utility methods for location.
@@ -49,7 +53,7 @@ public class LocationUtil {
             // Ignore forbidden chars supported in route definitions
             String strippedPath = path.replaceAll("[{}*]", "");
 
-            URI uri = new URI(null, null, strippedPath, null);
+            URI uri = new URI(URLEncoder.encode(strippedPath, UTF_8.name()));
             if (uri.isAbsolute()) {
                 // "A URI is absolute if, and only if, it has a scheme
                 // component"
@@ -62,7 +66,7 @@ public class LocationUtil {
                 throw new InvalidLocationException(
                         "Relative path cannot contain .. segments");
             }
-        } catch (URISyntaxException e) {
+        } catch (URISyntaxException | UnsupportedEncodingException e) {
             throw new InvalidLocationException("Cannot parse path: " + path, e);
         }
 

--- a/flow-server/src/test/java/com/vaadin/flow/internal/UrlUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/UrlUtilTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 
 public class UrlUtilTest {
 
-    private String shouldNotBeEscaped = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/_-.*@:";
+    private String shouldNotBeEscaped = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/_-.*@";
 
     @Test
     public void isExternal_URLStartsWithTwoSlashes_returnsTrue() {

--- a/flow-server/src/test/java/com/vaadin/flow/internal/UrlUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/UrlUtilTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 
 public class UrlUtilTest {
 
-    private String shouldNotBeEscaped = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/_-.*@";
+    private String shouldNotBeEscaped = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/_-.*@:";
 
     @Test
     public void isExternal_URLStartsWithTwoSlashes_returnsTrue() {

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
@@ -695,7 +695,10 @@ public abstract class AbstractDevServerRunner implements DevModeHandler {
             requestFilename = "/VAADIN/static" + requestFilename;
         }
 
-        String devServerRequestPath = UrlUtil.encodeURI(requestFilename);
+        // Dev server request can have an absolute system path making
+        // it required to not encode ':'
+        String devServerRequestPath = UrlUtil.encodeURI(requestFilename)
+                            .replace("%3A", ":");
         if (request.getQueryString() != null) {
             devServerRequestPath += "?" + request.getQueryString();
         }

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
@@ -695,10 +695,7 @@ public abstract class AbstractDevServerRunner implements DevModeHandler {
             requestFilename = "/VAADIN/static" + requestFilename;
         }
 
-        // Dev server request can have an absolute system path making
-        // it required to not encode ':'
-        String devServerRequestPath = UrlUtil.encodeURI(requestFilename)
-                            .replace("%3A", ":");
+        String devServerRequestPath = UrlUtil.encodeURI(requestFilename);
         if (request.getQueryString() != null) {
             devServerRequestPath += "?" + request.getQueryString();
         }


### PR DESCRIPTION
Windows vite requests will
contain the path with the drive
which contains `:` so it cannot be
encoded to `%3A` as then the
devServer returns a 404
