### PR TITLE
fix: Clean Vite production output folder on build

### DIFF
--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -388,7 +388,8 @@ public class BuildFrontendUtil {
      */
     public static void runVite(PluginAdapterBase adapter)
             throws TimeoutException, URISyntaxException {
-        runFrontendBuildTool(adapter, "Vite", "vite/bin/vite.js", "build");
+        runFrontendBuildTool(adapter, "Vite", "vite/bin/vite.js", "build",
+                "--emptyOutDir");
     }
 
     private static void runFrontendBuildTool(PluginAdapterBase adapter,


### PR DESCRIPTION
Without this you get

```
(!) outDir /.../project/target/classes/META-INF/VAADIN/webapp is not inside project root and will not be emptied.
Use --emptyOutDir to override.
```