### PR TITLE
feat: Compress Vite output by default in production

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -374,6 +374,7 @@ public abstract class NodeUpdater implements FallibleCommand {
 
         if (featureFlags.isEnabled(FeatureFlags.VITE)) {
             defaults.put("vite", "v2.7.0-beta.3");
+            defaults.put("rollup-plugin-brotli", "3.1.0");
             defaults.put("mkdirp", "1.0.4"); // for application-theme-plugin
         } else {
             // Webpack plugins and helpers

--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -11,6 +11,8 @@ import { processThemeResources } from '@vaadin/application-theme-plugin/theme-ha
 import settings from '#settingsImport#';
 import { UserConfigFn, defineConfig, HtmlTagDescriptor, mergeConfig } from 'vite';
 
+import brotli from 'rollup-plugin-brotli';
+
 const frontendFolder = path.resolve(__dirname, settings.frontendFolder);
 const themeFolder = path.resolve(frontendFolder, settings.themeFolder);
 const buildFolder = path.resolve(__dirname, settings.frontendBundleOutput);
@@ -68,7 +70,9 @@ function runWatchDog(watchDogPort) {
 }
 
 export const vaadinConfig: UserConfigFn = (env) => {
-  if (env.mode === 'development' && process.env.watchDogPort) {
+  const devMode = env.mode === 'development';
+
+  if (devMode && process.env.watchDogPort) {
     // Open a connection with the Java dev-mode handler in order to finish
     // vite when it exits or crashes.
     runWatchDog(process.env.watchDogPort);
@@ -92,6 +96,7 @@ export const vaadinConfig: UserConfigFn = (env) => {
       }
     },
     plugins: [
+      !devMode && brotli(),
       {
         name: 'custom-theme',
         config() {

--- a/flow-tests/test-frontend/vite-production/pom.xml
+++ b/flow-tests/test-frontend/vite-production/pom.xml
@@ -43,6 +43,11 @@
             <classifier>tests</classifier>
             <type>test-jar</type>
         </dependency>
+        <dependency>
+            <groupId>org.brotli</groupId>
+            <artifactId>dec</artifactId>
+            <version>0.1.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/flow-tests/test-frontend/vite-production/src/test/java/com/vaadin/viteapp/CompressionIT.java
+++ b/flow-tests/test-frontend/vite-production/src/test/java/com/vaadin/viteapp/CompressionIT.java
@@ -1,0 +1,53 @@
+package com.vaadin.viteapp;
+
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.io.IOUtils;
+import org.brotli.dec.BrotliInputStream;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CompressionIT {
+
+    private String getRootURL() {
+        return "http://localhost:8888";
+    }
+
+    @Test
+    public void resourcesAvailableAsUncompressed() throws Exception {
+        String bundleName = getJsBundleName();
+
+        String file = IOUtils.toString(new URL(getRootURL() + bundleName),
+                StandardCharsets.UTF_8);
+        Assert.assertTrue(file.contains("generated-flow-imports"));
+    }
+
+    @Test
+    public void resourcesAvailableAsBrotli() throws Exception {
+        String bundleName = getJsBundleName();
+
+        URL compressedUrl = new URL(getRootURL() + bundleName + ".br");
+        BrotliInputStream stream = new BrotliInputStream(
+                compressedUrl.openStream());
+
+        String file = IOUtils.toString(stream, StandardCharsets.UTF_8);
+        Assert.assertTrue(file.contains("generated-flow-imports"));
+    }
+
+    private String getJsBundleName() throws Exception {
+        String indexHtml = IOUtils.toString(
+                new URL(getRootURL() + "/index.html"), StandardCharsets.UTF_8);
+        Pattern p = Pattern.compile(".* src=\"VAADIN/build/([^\"]*).*",
+                Pattern.DOTALL);
+
+        Matcher m = p.matcher(indexHtml);
+        if (!m.matches()) {
+            throw new IllegalStateException("No script found");
+        }
+        return "/VAADIN/build/" + m.group(1);
+    }
+
+}


### PR DESCRIPTION
As Brotli is disabled by default, you need to enable it to use this feature.
https://github.com/vaadin/flow/issues/4740 will enable Brotli by default once server issues are sorted out

Fixes #12055
