### PR TITLE
Revert "fix: Clean Vite production output folder on build"

### DIFF
--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -385,8 +385,7 @@ public class BuildFrontendUtil {
      */
     public static void runVite(PluginAdapterBase adapter)
             throws TimeoutException, URISyntaxException {
-        runFrontendBuildTool(adapter, "Vite", "vite/bin/vite.js", "build",
-                "--emptyOutDir");
+        runFrontendBuildTool(adapter, "Vite", "vite/bin/vite.js", "build");
     }
 
     private static void runFrontendBuildTool(PluginAdapterBase adapter,


### PR DESCRIPTION
Reverts vaadin/flow#12304

This causes #12312
Should be added back after that is fixed but preferrably in the `vite.generated.js` instead