### PR TITLE
fix: Ensure that side effects of readBean do not set hasChanges true (#12181)(CP: 2.7)

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -1875,7 +1875,6 @@ public class Binder<BEAN> implements Serializable {
         if (bean == null) {
             clearFields();
         } else {
-            changedBindings.clear();
             getBindings().forEach(binding -> {
                 /*
                  * Some bindings may have been removed from binder during
@@ -1887,6 +1886,7 @@ public class Binder<BEAN> implements Serializable {
                     binding.initFieldValue(bean, false);
                 }
             });
+            changedBindings.clear();
             getValidationStatusHandler().statusChange(
                     BinderValidationStatus.createUnresolvedStatus(this));
             fireStatusChangeEvent(false);

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -1734,6 +1734,29 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         Assert.assertSame(handler, binder.getValidationErrorHandler());
     }
 
+    // See: https://github.com/vaadin/framework/issues/9581
+    @Test
+    public void withConverter_hasChangesFalse() {
+        TestTextField nameField = new TestTextField();
+        nameField.setValue("");
+        TestTextField rentField = new TestTextField();
+        rentField.setValue("");
+        rentField.addValueChangeListener(event -> {
+            nameField.setValue("Name");
+        });
+        item.setRent(BigDecimal.valueOf(10));
+        binder.forField(nameField).bind(Person::getFirstName,
+                Person::setFirstName);
+        binder.forField(rentField).withConverter(new EuroConverter(""))
+                .withNullRepresentation(BigDecimal.valueOf(0d))
+                .bind(Person::getRent, Person::setRent);
+        binder.readBean(item);
+
+        assertFalse(binder.hasChanges());
+        assertEquals("€ 10.00", rentField.getValue());
+        assertEquals("Name", nameField.getValue());
+    }
+
     private TestTextField createNullRejectingFieldWithEmptyValue(
             String emptyValue) {
         return new TestTextField() {


### PR DESCRIPTION
JavaDoc of hasChanges says:

"Check whether any of the bound fields' have uncommitted changes
since last explicit call to readBean(Object), removeBean(), writeBean(Object)}
or writeBeanIfValid(Object)."

If readBean has converters, they will be run and field values updated accordingly.
Furthermore if fields have value change listeners that will produce further
changes in values, this should be considered according to above as part of
readBean procedure and thus hasChanges still should return false.

Cherry pick from: vaadin/framework#12455

(cherry picked from commit 4e36fd979ec4d592d08e8d1328eeb4149c8fa3ef)
