### PR TITLE
chore: upgrade vaadin-parent version to 2.0.4 [skip ci]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-parent</artifactId>
-        <version>2.0.3</version>
+        <version>2.0.4</version>
     </parent>
 
     <modules>


### PR DESCRIPTION
2.0.4 uses maven-enforcer-plugin 3.0.0 aligned with flow project after `restrict-imports-enforcer-rule` updates.


