### PR TITLE
feat: add support for @EventData of type Component

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/flow/StateTree.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/StateTree.java
@@ -22,6 +22,7 @@ import com.vaadin.client.flow.binding.ServerEventObject;
 import com.vaadin.client.flow.collection.JsArray;
 import com.vaadin.client.flow.collection.JsCollections;
 import com.vaadin.client.flow.collection.JsMap;
+import com.vaadin.client.flow.dom.DomNode;
 import com.vaadin.client.flow.nodefeature.MapProperty;
 import com.vaadin.client.flow.nodefeature.NodeList;
 import com.vaadin.client.flow.nodefeature.NodeMap;
@@ -151,6 +152,28 @@ public class StateTree {
                 node.setParent(null);
             }
         });
+    }
+
+    /**
+     * Returns the state node in the tree for the given dom node or {@code null}
+     * if none found.
+     * <p>
+     * Comparison is done with Node.isSameNode() method which is same as
+     * {@code ===} comparison.
+     *
+     * @param domNode
+     *            the dom node to find state node for
+     * @return the state node or null
+     */
+    public StateNode getStateNodeForDomNode(DomNode domNode) {
+        final JsArray<StateNode> stateNodes = idToNode.mapValues();
+        for (int i = 0; i < stateNodes.length(); i++) {
+            StateNode stateNode = stateNodes.get(i);
+            if (domNode.isSameNode(stateNode.getDomNode())) {
+                return stateNode;
+            }
+        }
+        return null;
     }
 
     private void clearLists(StateNode stateNode) {

--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
@@ -22,7 +22,6 @@ import jsinterop.annotations.JsFunction;
 
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.Scheduler;
-
 import com.vaadin.client.ApplicationConfiguration;
 import com.vaadin.client.Command;
 import com.vaadin.client.Console;
@@ -1256,27 +1255,41 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
             eventData = null;
         } else {
             eventData = Json.createObject();
+        }
+        for (String expressionString : expressions) {
+            if (expressionString
+                    .startsWith(JsonConstants.SYNCHRONIZE_PROPERTY_TOKEN)) {
+                String property = expressionString.substring(
+                        JsonConstants.SYNCHRONIZE_PROPERTY_TOKEN.length());
+                synchronizeProperties.add(property);
+            } else if (expressionString
+                    .equals(JsonConstants.MAP_STATE_NODE_EVENT_DATA)) {
+                // map event.target to the closest state node
+                int targetNodeId = getClosestStateNodeIdToTarget(node,
+                        event.getTarget(), "event.target");
+                eventData.put(JsonConstants.MAP_STATE_NODE_EVENT_DATA,
+                        targetNodeId);
+            } else if (expressionString
+                    .startsWith(JsonConstants.MAP_STATE_NODE_EVENT_DATA)) {
+                // map element returned by JS to the closest state node
+                String jsEvaluation = expressionString.substring(
+                        JsonConstants.MAP_STATE_NODE_EVENT_DATA.length());
+                EventExpression expression = getOrCreateExpression(
+                        jsEvaluation);
+                JsonValue expressionValue = expression.evaluate(event,
+                        (Element) element);
+                // find the closest state node matching the expression value
+                int targetNodeId = getClosestStateNodeIdToDomNode(
+                        node.getTree(), expressionValue, jsEvaluation);
+                eventData.put(expressionString, targetNodeId);
+            } else {
+                EventExpression expression = getOrCreateExpression(
+                        expressionString);
 
-            for (String expressionString : expressions) {
-                if (expressionString
-                        .startsWith(JsonConstants.SYNCHRONIZE_PROPERTY_TOKEN)) {
-                    String property = expressionString.substring(
-                            JsonConstants.SYNCHRONIZE_PROPERTY_TOKEN.length());
-                    synchronizeProperties.add(property);
-                } else if (expressionString
-                        .equals(JsonConstants.MAP_EVENT_TARGET)) {
-                    int targetNodeId = getClosestStateNodeToTarget(node,
-                            event.getTarget());
-                    eventData.put(JsonConstants.MAP_EVENT_TARGET, targetNodeId);
-                } else {
-                    EventExpression expression = getOrCreateExpression(
-                            expressionString);
+                JsonValue expressionValue = expression.evaluate(event,
+                        (Element) element);
 
-                    JsonValue expressionValue = expression.evaluate(event,
-                            (Element) element);
-
-                    eventData.put(expressionString, expressionValue);
-                }
+                eventData.put(expressionString, expressionValue);
             }
         }
 
@@ -1466,27 +1479,31 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
     }
 
     // This method could be moved somewhere to be reusable
-    private int getClosestStateNodeToTarget(StateNode topNode,
-            EventTarget target) {
+    private int getClosestStateNodeIdToTarget(StateNode topNode,
+            EventTarget target, String eventDataExpression) {
+        if (target == null) {
+            return -1;
+        }
         try {
             DomNode targetNode = DomApi.wrap(WidgetUtil.crazyJsCast(target));
-
-            // collect children and test eagerly for direct match
             JsArray<StateNode> stack = JsCollections.array();
             stack.push(topNode);
+
+            // collect children and test eagerly for direct match
             for (int i = 0; i < stack.length(); i++) {
                 final StateNode stateNode = stack.get(i);
                 if (targetNode.isSameNode(stateNode.getDomNode())) {
                     return stateNode.getId();
                 }
+                // NOTE: for now not looking at virtual children on purpose.
+                // If needed (?), those can be included here to the search stack
                 stateNode.getList(NodeFeatures.ELEMENT_CHILDREN)
                         .forEach(child -> stack.push((StateNode) child));
             }
             // no direct match, all child element state nodes collected.
             // bottom-up search elements until matching state node found
             targetNode = DomApi.wrap(targetNode.getParentNode());
-            while (targetNode != null
-                    && !targetNode.isSameNode(topNode.getDomNode())) {
+            while (targetNode != null) {
                 for (int i = stack.length() - 1; i > -1; i--) {
                     final StateNode stateNode = stack.get(i);
                     if (targetNode.isSameNode(stateNode.getDomNode())) {
@@ -1495,13 +1512,47 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
                 }
                 targetNode = DomApi.wrap(targetNode.getParentNode());
             }
+            //
         } catch (Exception e) {
             // not going to let event handling fail; just report nothing found
             Console.debug(
-                    "Flow could not detect state node matching event.target");
+                    "An error occurred when Flow tried to find a state node matching the element "
+                            + target + ", returned by an event data expression "
+                            + eventDataExpression + ". Error: "
+                            + e.getMessage());
         }
-        // no match / error; not considering topNode as it is reported as
-        // event.currentTarget
+        // no match / error;
         return -1;
     }
+
+    private int getClosestStateNodeIdToDomNode(StateTree stateTree,
+            Object domNodeReference, String eventDataExpression) {
+        if (domNodeReference == null) {
+            return -1;
+        }
+        try {
+            DomNode targetNode = DomApi
+                    .wrap(WidgetUtil.crazyJsCast(domNodeReference));
+            StateNode stateNodeForDomNode = null;
+            do {
+                stateNodeForDomNode = stateTree
+                        .getStateNodeForDomNode(targetNode);
+                targetNode = DomApi.wrap(targetNode.getParentNode());
+            } while (stateNodeForDomNode == null && targetNode != null);
+            if (stateNodeForDomNode != null) {
+                return stateNodeForDomNode.getId();
+            }
+        } catch (Exception e) {
+            // not going to let event handling fail; just report nothing found
+            Console.debug(
+                    "An error occurred when Flow tried to find a state node matching the element "
+                            + domNodeReference
+                            + ", returned by an event data expression "
+                            + eventDataExpression + ". Error: "
+                            + e.getMessage());
+        }
+        // no match / error;
+        return -1;
+    }
+
 }

--- a/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/binding/SimpleElementBindingStrategy.java
@@ -1480,7 +1480,7 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
 
     // This method could be moved somewhere to be reusable
     private int getClosestStateNodeIdToEventTarget(StateNode topNode,
-                                                   EventTarget target) {
+            EventTarget target) {
         if (target == null) {
             return -1;
         }
@@ -1514,7 +1514,8 @@ public class SimpleElementBindingStrategy implements BindingStrategy<Element> {
         return -1; // no match / error;
     }
 
-    private static int getStateNodeForElement(JsArray<StateNode> searchStack, DomNode targetNode) {
+    private static int getStateNodeForElement(JsArray<StateNode> searchStack,
+            DomNode targetNode) {
         while (targetNode != null) {
             for (int i = searchStack.length() - 1; i > -1; i--) {
                 final StateNode stateNode = searchStack.get(i);

--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentEventBus.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentEventBus.java
@@ -33,7 +33,6 @@ import com.vaadin.flow.dom.DomListenerRegistration;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.AnnotationReader;
 import com.vaadin.flow.internal.JsonCodec;
-import com.vaadin.flow.shared.JsonConstants;
 import com.vaadin.flow.shared.Registration;
 
 import elemental.json.Json;
@@ -359,7 +358,7 @@ public class ComponentEventBus implements Serializable {
                                     + " was mapped to an element with tag '%s' and "
                                     + "node-id '%s', but it is mapped to a "
                                     + "component of type '%s' instead of the "
-                                    + "expected type of %s.\n"
+                                    + "expected type of %s.%n"
                                     + "Either the event data expression returns the"
                                     + " wrong element, or the type for the "
                                     + "'@EventType(\"%s\")' should be changed from "
@@ -380,7 +379,7 @@ public class ComponentEventBus implements Serializable {
                                 + "in component %s from browser: the event data expression '%s'"
                                 + " was mapped to an element with tag '%s' and "
                                 + "node-id '%s', but it doesn't have a "
-                                + "component instance mapped to it.\n"
+                                + "component instance mapped to it.%n"
                                 + "Either the event data expression returns the"
                                 + " wrong element, or the type for the "
                                 + "'@EventType(\"%s\")' should be changed from "

--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentEventBus.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentEventBus.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import com.vaadin.flow.dom.DebouncePhase;
@@ -32,6 +33,7 @@ import com.vaadin.flow.dom.DomListenerRegistration;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.AnnotationReader;
 import com.vaadin.flow.internal.JsonCodec;
+import com.vaadin.flow.shared.JsonConstants;
 import com.vaadin.flow.shared.Registration;
 
 import elemental.json.Json;
@@ -269,7 +271,15 @@ public class ComponentEventBus implements Serializable {
 
         LinkedHashMap<String, Class<?>> eventDataExpressions = ComponentEventBusUtil
                 .getEventDataExpressions(eventType);
-        eventDataExpressions.keySet().forEach(registration::addEventData);
+
+        eventDataExpressions.forEach((expression, type) -> {
+            if (Component.class.isAssignableFrom(type)
+                    || type == Element.class) {
+                registration.addEventDataElement(expression);
+            } else {
+                registration.addEventData(expression);
+            }
+        });
 
         if (!"".equals(filter)) {
             registration.setFilter(filter);
@@ -291,7 +301,8 @@ public class ComponentEventBus implements Serializable {
 
     /**
      * Creates a list of data objects which can be passed to the constructor
-     * returned by {@link #getEventConstructor(Class)} as parameters 3+.
+     * returned by {@link ComponentEventBusUtil#getEventConstructor(Class)} as
+     * parameters 3+.
      *
      * @param domEvent
      *            the DOM event containing the data
@@ -307,14 +318,79 @@ public class ComponentEventBus implements Serializable {
         LinkedHashMap<String, Class<?>> expressions = ComponentEventBusUtil
                 .getEventDataExpressions(eventType);
         expressions.forEach((expression, type) -> {
-            JsonValue jsonValue = domEvent.getEventData().get(expression);
-            if (jsonValue == null) {
-                jsonValue = Json.createNull();
+            if (Component.class.isAssignableFrom(type)
+                    || type == Element.class) {
+                eventDataObjects.add(parseStateNodeIdToComponentReference(
+                        domEvent, type, expression));
+            } else {
+                JsonValue jsonValue = domEvent.getEventData().get(expression);
+                if (jsonValue == null) {
+                    jsonValue = Json.createNull();
+                }
+                Object value = JsonCodec.decodeAs(jsonValue, type);
+                eventDataObjects.add(value);
             }
-            Object value = JsonCodec.decodeAs(jsonValue, type);
-            eventDataObjects.add(value);
         });
         return eventDataObjects;
+    }
+
+    private Object parseStateNodeIdToComponentReference(DomEvent event,
+            Class<?> expectedEventDataType, String eventDataExpression) {
+        assert Component.class.isAssignableFrom(expectedEventDataType)
+                || Element.class == expectedEventDataType;
+
+        final Element mappedElement = event
+                .getEventDataElement(eventDataExpression).orElse(null);
+
+        if (expectedEventDataType == Element.class || mappedElement == null) {
+            return mappedElement;
+        } else {
+            final Optional<Component> componentMaybe = mappedElement
+                    .getComponent();
+            if (componentMaybe.isPresent()) {
+                final Component mappedComponent = componentMaybe.get();
+                if (expectedEventDataType
+                        .isAssignableFrom(mappedComponent.getClass())) {
+                    return mappedComponent;
+                } else {
+                    throw new IllegalStateException(String.format(
+                            "Error when trying to map event data for event '%s' "
+                                    + "in component %s from browser: the event data expression '%s'"
+                                    + " was mapped to an element with tag '%s' and "
+                                    + "node-id '%s', but it is mapped to a "
+                                    + "component of type '%s' instead of the "
+                                    + "expected type of %s.\n"
+                                    + "Either the event data expression returns the"
+                                    + " wrong element, or the type for the "
+                                    + "'@EventType(\"%s\")' should be changed from "
+                                    + "%s to %s",
+                            event.getType(),
+                            component.getClass().getSimpleName(),
+                            eventDataExpression, mappedElement.getTag(),
+                            mappedElement.getNode().getId(),
+                            mappedComponent.getClass().getSimpleName(),
+                            expectedEventDataType.getSimpleName(),
+                            eventDataExpression,
+                            mappedComponent.getClass().getSimpleName(),
+                            expectedEventDataType.getSimpleName()));
+                }
+            } else {
+                throw new IllegalStateException(String.format(
+                        "Error when trying to map event data for event '%s' "
+                                + "in component %s from browser: the event data expression '%s'"
+                                + " was mapped to an element with tag '%s' and "
+                                + "node-id '%s', but it doesn't have a "
+                                + "component instance mapped to it.\n"
+                                + "Either the event data expression returns the"
+                                + " wrong element, or the type for the "
+                                + "'@EventType(\"%s\")' should be changed from "
+                                + "%s to Element",
+                        event.getType(), component.getClass().getSimpleName(),
+                        eventDataExpression, mappedElement.getTag(),
+                        mappedElement.getNode().getId(), eventDataExpression,
+                        expectedEventDataType));
+            }
+        }
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentEventBusUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentEventBusUtil.java
@@ -170,10 +170,12 @@ public class ComponentEventBusUtil {
                     eventDataConstructor = c;
                 } else {
                     throw new IllegalArgumentException(
-                            "Multiple DOM event constructors annotated with @"
+                            "More than one DOM event constructors annotated with @"
                                     + EventData.class.getSimpleName()
-                                    + " found for " + eventType.getName() + ". "
-                                    + EVENT_CONSTRUCTOR_DEFINITION);
+                                    + " found for " + eventType.getName()
+                                    + ". There can be only one constructor with @"
+                                    + EventData.class.getSimpleName()
+                                    + " annotations present.");
                 }
             }
         }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/DomEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/DomEvent.java
@@ -16,9 +16,15 @@
 package com.vaadin.flow.dom;
 
 import java.util.EventObject;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.internal.NodeOwner;
+import com.vaadin.flow.internal.StateNode;
+import com.vaadin.flow.internal.StateTree;
 import com.vaadin.flow.shared.JsonConstants;
 
 import elemental.json.JsonObject;
@@ -78,22 +84,45 @@ public class DomEvent extends EventObject {
 
     private static Element extractEventTarget(JsonObject eventData,
             Element currentTarget) {
-        JsonValue jsonValue = eventData.get(JsonConstants.MAP_EVENT_TARGET);
-        if (jsonValue == null) {
+        return extractElement(eventData, currentTarget,
+                JsonConstants.MAP_STATE_NODE_EVENT_DATA, false);
+    }
+
+    static Element extractElement(JsonObject eventData, Element source,
+            String key, boolean lookUnderUI) {
+        assert key.startsWith(JsonConstants.MAP_STATE_NODE_EVENT_DATA);
+        if (!eventData.hasKey(key)) {
             return null;
-        } else {
-            int id = (int) jsonValue.asNumber();
-            if (id == -1) {
-                return null;
-            }
-            AtomicReference<Element> matchingNode = new AtomicReference<>();
-            currentTarget.getNode().visitNodeTree(node -> {
-                if (node.getId() == id) {
-                    matchingNode.set(Element.get(node));
-                }
-            });
-            return matchingNode.get();
         }
+        final JsonValue reportedStateNodeId = eventData.get(key);
+        if (reportedStateNodeId == null) {
+            return null;
+        }
+        int id = (int) reportedStateNodeId.asNumber();
+        if (id == -1) {
+            return null;
+        }
+        AtomicReference<Element> matchingNode = new AtomicReference<>();
+        final Consumer<StateNode> visitor = node -> {
+            if (node.getId() == id) {
+                matchingNode.set(Element.get(node));
+            }
+        };
+        // first look under event source
+        source.getNode().visitNodeTree(visitor);
+        if (lookUnderUI && matchingNode.get() == null) {
+            // widen search to look under UI too
+            final NodeOwner owner = source.getNode().getOwner();
+            if (owner instanceof StateTree) {
+                ((StateTree) owner).getRootNode().visitNodeTree(visitor);
+            }
+        }
+        final Element mappedElementOrNull = matchingNode.get();
+        // prevent spoofing invisible elements by sending bad state node ids
+        if (mappedElementOrNull != null && !mappedElementOrNull.isVisible()) {
+            return null;
+        }
+        return mappedElementOrNull;
     }
 
     /**
@@ -161,5 +190,31 @@ public class DomEvent extends EventObject {
      */
     public Optional<Element> getEventTarget() {
         return Optional.ofNullable(eventTarget);
+    }
+
+    /**
+     * Gets the closest {@link Element} corresponding to the given event data
+     * expression. <em>NOTE:</em> this only works if you have added the
+     * expression using
+     * {@link DomListenerRegistration#addEventDataElement(String)}.
+     * <p>
+     * If the evaluated JS expression returned an element that is not created or
+     * controlled by the server side, the closest parent element that is
+     * controlled is returned instead. Invisible elements are not reported.
+     * <p>
+     * In case you want the {@code event.target} element, use
+     * {@link #getEventTarget()} instead.
+     * 
+     * @param expression
+     *            the expression that was executed on the client to retrieve the
+     *            element, not <code>null</code>
+     * @return the element that corresponds to the given expression or an empty
+     *         optional
+     * @since 9.0
+     */
+    public Optional<Element> getEventDataElement(String expression) {
+        Objects.requireNonNull(expression);
+        return Optional.ofNullable(extractElement(eventData, getSource(),
+                JsonConstants.MAP_STATE_NODE_EVENT_DATA + expression, true));
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/DomEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/DomEvent.java
@@ -21,7 +21,6 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
-import com.vaadin.flow.component.UI;
 import com.vaadin.flow.internal.NodeOwner;
 import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.internal.StateTree;
@@ -205,16 +204,22 @@ public class DomEvent extends EventObject {
      * In case you want the {@code event.target} element, use
      * {@link #getEventTarget()} instead.
      * 
-     * @param expression
+     * @param eventDataExpression
      *            the expression that was executed on the client to retrieve the
      *            element, not <code>null</code>
      * @return the element that corresponds to the given expression or an empty
      *         optional
      * @since 9.0
      */
-    public Optional<Element> getEventDataElement(String expression) {
-        Objects.requireNonNull(expression);
-        return Optional.ofNullable(extractElement(eventData, getSource(),
-                JsonConstants.MAP_STATE_NODE_EVENT_DATA + expression, true));
+    public Optional<Element> getEventDataElement(String eventDataExpression) {
+        Objects.requireNonNull(eventDataExpression);
+        if (Objects.equals(eventDataExpression, "event.target")) {
+            return getEventTarget();
+        } else {
+            return Optional.ofNullable(extractElement(eventData, getSource(),
+                    JsonConstants.MAP_STATE_NODE_EVENT_DATA
+                            + eventDataExpression,
+                    true));
+        }
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/DomListenerRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/DomListenerRegistration.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.dom;
 
+import java.util.Objects;
 import java.util.Set;
 
 import com.vaadin.flow.function.SerializableRunnable;
@@ -54,6 +55,9 @@ public interface DomListenerRegistration extends Registration {
      *            definition for data that should be passed back to the server
      *            together with the event, not <code>null</code>
      * @return this registration, for chaining
+     * @see #addEventDataElement(String) for mapping an element
+     * @see #mapEventTargetElement() to map the {@code event.target} to an
+     *      element
      */
     DomListenerRegistration addEventData(String eventData);
 
@@ -295,9 +299,17 @@ public interface DomListenerRegistration extends Registration {
      *            server together with the event, not <code>null</code>
      * @return this registration, for chaining
      * @since 9.0
+     * @see #mapEventTargetElement() to map the {@code event.target} to an
+     *      element
      */
     default DomListenerRegistration addEventDataElement(String eventData) {
-        return addEventData(
-                JsonConstants.MAP_STATE_NODE_EVENT_DATA + eventData);
+        Objects.requireNonNull(eventData);
+        // optimizing this case as it is quite trivial
+        if (Objects.equals(eventData, "event.target")) {
+            return mapEventTargetElement();
+        } else {
+            return addEventData(
+                    JsonConstants.MAP_STATE_NODE_EVENT_DATA + eventData);
+        }
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/DomListenerRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/DomListenerRegistration.java
@@ -270,6 +270,34 @@ public interface DomListenerRegistration extends Registration {
      * @since 9.0
      */
     default DomListenerRegistration mapEventTargetElement() {
-        return addEventData(JsonConstants.MAP_EVENT_TARGET);
+        return addEventData(JsonConstants.MAP_STATE_NODE_EVENT_DATA);
+    }
+
+    /**
+     * Add a JavaScript expression for extracting an element as event data. When
+     * an event is fired in the browser, the expression is evaluated and if it
+     * returns an element from DOM, the server side element or closest parent
+     * element is sent to server side. The expression is evaluated in a context
+     * where <code>element</code> refers to this element and <code>event</code>
+     * refers to the fired event. If multiple expressions are defined for the
+     * same event, their order of execution is undefined.
+     * <p>
+     * The result of the evaluation is available in
+     * {@link DomEvent#getEventDataElement(String)} with the expression as the
+     * key in the JSON object.
+     * <p>
+     * In case you want to get the {@code event.target} element to the server
+     * side, use the {@link #mapEventTargetElement()} method to get it mapped
+     * and the {@link DomEvent#getEventTarget()} to fetch the element.
+     *
+     * @param eventData
+     *            definition for element that should be passed back to the
+     *            server together with the event, not <code>null</code>
+     * @return this registration, for chaining
+     * @since 9.0
+     */
+    default DomListenerRegistration addEventDataElement(String eventData) {
+        return addEventData(
+                JsonConstants.MAP_STATE_NODE_EVENT_DATA + eventData);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/shared/JsonConstants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/JsonConstants.java
@@ -316,15 +316,18 @@ public class JsonConstants implements Serializable {
     public static final String SYNCHRONIZE_PROPERTY_TOKEN = "}";
 
     /**
-     * Token used as an event data expression to represent that the state node
-     * ID should be fetched for the element, or its closest parent, that
-     * corresponds to {@code event.target}. The token is chosen to avoid
-     * collisions with regular event data expressions by using a character that
-     * cannot be the start of a valid JS expression.
+     * Token used as an event data expression or prefix to an event data
+     * expression to represent that the state node ID should be fetched for the
+     * element, or its closest parent, that corresponds to {@code event.target}
+     * or the element returned by the evaluated expression.
+     * <p>
+     * The token is chosen to avoid collisions with regular event data
+     * expressions by using a character that cannot be the start of a valid JS
+     * expression.
      * 
      * @since 9.0
      */
-    public static final String MAP_EVENT_TARGET = "]";
+    public static final String MAP_STATE_NODE_EVENT_DATA = "]";
 
     /**
      * RPC type value used for return channel messages.

--- a/flow-server/src/test/java/com/vaadin/flow/component/MappedDomEventWithComponentData.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/MappedDomEventWithComponentData.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.component;
+
+import com.vaadin.flow.router.RouterLink;
+
+@DomEvent("dom-event")
+public class MappedDomEventWithComponentData extends ComponentEvent<Component> {
+
+    private final Component component;
+
+    public MappedDomEventWithComponentData(Component source, boolean fromClient,
+            @EventData("component") Component component) {
+        super(source, fromClient);
+        this.component = component;
+    }
+
+    public Component getComponent() {
+        return component;
+    }
+
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/MappedDomEventWithRouterLinkData.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/MappedDomEventWithRouterLinkData.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.component;
+
+import com.vaadin.flow.router.RouterLink;
+
+public class MappedDomEventWithRouterLinkData
+        extends MappedDomEventWithComponentData {
+
+    private final RouterLink routerLink;
+
+    public MappedDomEventWithRouterLinkData(Component source,
+            boolean fromClient, @EventData("component") Component component,
+            @EventData("router.link") RouterLink routerLink) {
+        super(source, fromClient, component);
+        this.routerLink = routerLink;
+    }
+
+    public RouterLink getRouterLink() {
+        return routerLink;
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/component/MappedToDomEventWithElementData.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/MappedToDomEventWithElementData.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.component;
+
+import com.vaadin.flow.dom.Element;
+
+@DomEvent("dom-event")
+public class MappedToDomEventWithElementData extends ComponentEvent<Component> {
+
+    private final Element element;
+
+    /**
+     * Creates a new event using the given source and indicator whether the
+     * event originated from the client side or the server side.
+     *
+     * @param source
+     *            the source component
+     * @param fromClient
+     *            <code>true</code> if the event originated from the client
+     */
+    public MappedToDomEventWithElementData(Component source, boolean fromClient,
+            @EventData("element") Element element) {
+        super(source, fromClient);
+        this.element = element;
+    }
+
+    public Element getElement() {
+        return element;
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/ElementListenersTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/ElementListenersTest.java
@@ -353,47 +353,95 @@ public class ElementListenersTest
         parent.appendChild(child.appendChild(grandChild));
         new StateTree(new UI().getInternals(), ElementChildrenList.class)
                 .getUI().getElement().appendChild(parent);
+        final String eventType = "click";
 
         AtomicReference<Element> capturedTarget = new AtomicReference<>();
         final DomListenerRegistration registration = parent
-                .addEventListener("click", e -> {
+                .addEventListener(eventType, e -> {
                     capturedTarget.set(e.getEventTarget().orElse(null));
                 });
         final ElementListenerMap listenerMap = parent.getNode()
                 .getFeature(ElementListenerMap.class);
-        Set<String> expressions = getExpressions(listenerMap, "click");
+        Set<String> expressions = getExpressions(listenerMap, eventType);
         Assert.assertEquals(0, expressions.size());
 
         registration.mapEventTargetElement();
-        expressions = getExpressions(listenerMap, "click");
+        expressions = getExpressions(listenerMap, eventType);
 
         Assert.assertEquals(1, expressions.size());
-        Assert.assertEquals(JsonConstants.MAP_EVENT_TARGET,
+        Assert.assertEquals(JsonConstants.MAP_STATE_NODE_EVENT_DATA,
                 expressions.iterator().next());
 
         // child
         final JsonObject eventData = Json.createObject();
-        eventData.put(JsonConstants.MAP_EVENT_TARGET, child.getNode().getId());
-        listenerMap.fireEvent(new DomEvent(parent, "click", eventData));
+        eventData.put(JsonConstants.MAP_STATE_NODE_EVENT_DATA,
+                child.getNode().getId());
+        listenerMap.fireEvent(new DomEvent(parent, eventType, eventData));
         Assert.assertEquals(child, capturedTarget.get());
 
         // nothing reported -> empty optional
-        listenerMap
-                .fireEvent(new DomEvent(parent, "click", Json.createObject()));
+        listenerMap.fireEvent(
+                new DomEvent(parent, eventType, Json.createObject()));
         Assert.assertNull("no element should be reported",
                 capturedTarget.get());
 
         // grandchild
-        eventData.put(JsonConstants.MAP_EVENT_TARGET,
+        eventData.put(JsonConstants.MAP_STATE_NODE_EVENT_DATA,
                 grandChild.getNode().getId());
-        listenerMap.fireEvent(new DomEvent(parent, "click", eventData));
+        listenerMap.fireEvent(new DomEvent(parent, eventType, eventData));
         Assert.assertEquals(grandChild, capturedTarget.get());
 
         // -1 -> empty optional
-        eventData.put(JsonConstants.MAP_EVENT_TARGET, -1);
-        listenerMap.fireEvent(new DomEvent(parent, "click", eventData));
+        eventData.put(JsonConstants.MAP_STATE_NODE_EVENT_DATA, -1);
+        listenerMap.fireEvent(new DomEvent(parent, eventType, eventData));
         Assert.assertNull("no element should be reported",
                 capturedTarget.get());
+    }
+
+    @Test
+    public void addEventDataElement_targetNodeInJsonData_elementMapped() {
+        Element parent = new Element("parent");
+        Element child = new Element("child");
+        Element sibling = new Element("sibling");
+        parent.appendChild(child);
+        new StateTree(new UI().getInternals(), ElementChildrenList.class)
+                .getUI().getElement().appendChild(parent, sibling);
+        final String eventType = "click";
+        final String expression = "expression";
+        final String key = JsonConstants.MAP_STATE_NODE_EVENT_DATA + expression;
+
+        AtomicReference<DomEvent> capturedTarget = new AtomicReference<>();
+        final DomListenerRegistration registration = parent
+                .addEventListener(eventType, capturedTarget::set);
+        final ElementListenerMap listenerMap = parent.getNode()
+                .getFeature(ElementListenerMap.class);
+
+        Set<String> expressions = getExpressions(listenerMap, eventType);
+        Assert.assertEquals(0, expressions.size());
+
+        registration.addEventDataElement(expression);
+        expressions = getExpressions(listenerMap, eventType);
+
+        Assert.assertEquals(1, expressions.size());
+        Assert.assertEquals(key, expressions.iterator().next());
+
+        final JsonObject eventData = Json.createObject();
+        eventData.put(key, child.getNode().getId());
+        listenerMap.fireEvent(new DomEvent(parent, eventType, eventData));
+        Assert.assertEquals(child,
+                capturedTarget.get().getEventDataElement(expression).get());
+
+        // nothing reported -> empty optional
+        listenerMap.fireEvent(
+                new DomEvent(parent, eventType, Json.createObject()));
+        Assert.assertFalse("no element should be reported", capturedTarget.get()
+                .getEventDataElement(expression).isPresent());
+
+        // sibling
+        eventData.put(key, sibling.getNode().getId());
+        listenerMap.fireEvent(new DomEvent(parent, eventType, eventData));
+        Assert.assertEquals(sibling,
+                capturedTarget.get().getEventDataElement(expression).get());
     }
 
     // Helper for accessing package private API from other tests

--- a/flow-tests/test-root-context/pom.xml
+++ b/flow-tests/test-root-context/pom.xml
@@ -80,7 +80,6 @@
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
                 <!-- This is because we run multiple modes on the same module -->
-                    <!--
                 <executions>
                     <execution>
                         <id>auto-clean</id>
@@ -90,7 +89,6 @@
                         </goals>
                     </execution>
                 </executions>
-                -->
             </plugin>
             <!-- Clean lib before running jetty -->
             <plugin>

--- a/flow-tests/test-root-context/pom.xml
+++ b/flow-tests/test-root-context/pom.xml
@@ -80,6 +80,7 @@
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
                 <!-- This is because we run multiple modes on the same module -->
+                    <!--
                 <executions>
                     <execution>
                         <id>auto-clean</id>
@@ -89,6 +90,7 @@
                         </goals>
                     </execution>
                 </executions>
+                -->
             </plugin>
             <!-- Clean lib before running jetty -->
             <plugin>

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/AbstractEventDataView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/AbstractEventDataView.java
@@ -22,11 +22,14 @@ import com.vaadin.flow.component.html.H3;
 
 public class AbstractEventDataView extends AbstractDivView {
 
+    public static final String EMPTY_VALUE = "EMPTY";
     public static final String TARGET_ID = "target";
+    public static final String VIEW_CONTAINER = "View-container";
+    public static final String HEADER = "Header";
 
     public AbstractEventDataView() {
-        add(new Text("View container"), new H3("Header"));
-        setId("container");
+        add(new Text(VIEW_CONTAINER), new H3(HEADER));
+        setId(VIEW_CONTAINER);
     }
 
     protected void createComponents() {

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/AbstractEventDataView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/AbstractEventDataView.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H3;
+
+public class AbstractEventDataView extends AbstractDivView {
+
+    public static final String TARGET_ID = "target";
+
+    public AbstractEventDataView() {
+        add(new Text("View container"), new H3("Header"));
+        setId("container");
+    }
+
+    protected void createComponents() {
+        for (int i = 0; i < 10; i++) {
+            final Div container = createContainer("Child-" + i);
+            for (int j = 0; j < 10; j++) {
+                final Div child = createContainer("Grandchild-" + i + j);
+                child.getStyle().set("display", "inline-block");
+                container.add(child);
+            }
+            add(container);
+        }
+    }
+
+    private Div createContainer(String identifier) {
+        final Div div = new Div();
+        div.add(new Text(identifier));
+        div.setId(identifier);
+        div.getStyle().set("border", "1px solid orange").set("padding", "5px");
+        return div;
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ComponentEventDataView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ComponentEventDataView.java
@@ -56,14 +56,14 @@ public class ComponentEventDataView extends AbstractEventDataView {
 
         addListener(LayoutClickEvent.class, event -> {
             childComponent.setText(event.getChildComponent()
-                    .flatMap(Component::getId).orElse("EMPTY"));
+                    .flatMap(Component::getId).orElse(EMPTY_VALUE));
             clickedComponent.setText(event.getClickedComponent()
-                    .flatMap(Component::getId).orElse("EMPTY"));
+                    .flatMap(Component::getId).orElse(EMPTY_VALUE));
             firstChild.setText(event.getFirstChild()
                     .map(element -> element.getAttribute("id"))
-                    .orElse("EMPTY"));
-            headerClicked.setText(
-                    event.header == null ? "EMPTY" : event.header.getText());
+                    .orElse(EMPTY_VALUE));
+            headerClicked.setText(event.header == null ? EMPTY_VALUE
+                    : event.header.getText());
         });
 
         createComponents();

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ComponentEventDataView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ComponentEventDataView.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.uitest.ui;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import com.vaadin.flow.component.ClickEvent;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.EventData;
+import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H3;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.uitest.servlet.ViewTestLayout;
+
+@Route(value = "com.vaadin.flow.uitest.ui.ComponentEventDataView", layout = ViewTestLayout.class)
+public class ComponentEventDataView extends AbstractEventDataView {
+
+    public static final String CHILD_COMPONENT = "child-component";
+    public static final String FIRST_CHILD = "first-child";
+    public static final String HEADER_CLICKED = "header-clicked";
+
+    public ComponentEventDataView() {
+        Div childComponent = new Div();
+        childComponent.getStyle().set("display", "list-item");
+        childComponent.setId(CHILD_COMPONENT);
+        Div clickedComponent = new Div();
+        clickedComponent.getStyle().set("display", "list-item");
+        clickedComponent.setId(TARGET_ID);
+        Div firstChild = new Div();
+        firstChild.getStyle().set("display", "list-item");
+        firstChild.setId(FIRST_CHILD);
+        Div headerClicked = new Div();
+        headerClicked.getStyle().set("display", "list-item");
+        headerClicked.setId(HEADER_CLICKED);
+        add(new Text("direct of listener child based on event.target"),
+                childComponent, new Text("event.target"), clickedComponent,
+                new Text("event.currentTarget.children[0]"), firstChild,
+                new Text("H3 if clicked"), headerClicked);
+
+        addListener(LayoutClickEvent.class, event -> {
+            childComponent.setText(event.getChildComponent()
+                    .flatMap(Component::getId).orElse("EMPTY"));
+            clickedComponent.setText(event.getClickedComponent()
+                    .flatMap(Component::getId).orElse("EMPTY"));
+            firstChild.setText(event.getFirstChild()
+                    .map(element -> element.getAttribute("id"))
+                    .orElse("EMPTY"));
+            headerClicked.setText(
+                    event.header == null ? "EMPTY" : event.header.getText());
+        });
+
+        createComponents();
+    }
+
+    public static class LayoutClickEvent extends ClickEvent<Component> {
+
+        private final Component clickedComponent;
+        private final Component childComponent;
+        private final Element firstChild;
+        private final H3 header;
+
+        public LayoutClickEvent(Component source, boolean fromClient,
+                @EventData("event.screenX") int screenX,
+                @EventData("event.screenY") int screenY,
+                @EventData("event.clientX") int clientX,
+                @EventData("event.clientY") int clientY,
+                @EventData("event.detail") int clickCount,
+                @EventData("event.button") int button,
+                @EventData("event.ctrlKey") boolean ctrlKey,
+                @EventData("event.shiftKey") boolean shiftKey,
+                @EventData("event.altKey") boolean altKey,
+                @EventData("event.metaKey") boolean metaKey,
+                @EventData("event.target") Component clickedComponent,
+                // this is just to test that element references work too
+                @EventData("event.target.children[0]") Element firstChild,
+                // testing that subtypes and null element works
+                @EventData("event.target.tagName === 'H3' ? event.target : undefined") H3 header) {
+            super(source, fromClient, screenX, screenY, clientX, clientY,
+                    clickCount, button, ctrlKey, shiftKey, altKey, metaKey);
+
+            this.clickedComponent = clickedComponent;
+            this.firstChild = firstChild;
+            this.header = header;
+            // just to showcase that this is possible
+            childComponent = getSourcesDirectChildWith(clickedComponent)
+                    .orElse(null);
+        }
+
+        private Optional<Component> getSourcesDirectChildWith(
+                Component component) {
+            if (component == source) {
+                return Optional.empty();
+            }
+            Optional<Component> potentialDirectChild = Optional
+                    .ofNullable(component);
+            while (potentialDirectChild.flatMap(Component::getParent)
+                    .filter(that -> !Objects.equals(that, source))
+                    .isPresent()) {
+                potentialDirectChild = potentialDirectChild.get().getParent();
+            }
+            return potentialDirectChild;
+        }
+
+        public Optional<Component> getClickedComponent() {
+            return Optional.ofNullable(clickedComponent);
+        }
+
+        public Optional<Component> getChildComponent() {
+            return Optional.ofNullable(childComponent);
+        }
+
+        public Optional<Element> getFirstChild() {
+            return Optional.ofNullable(firstChild);
+        }
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/EventTargetView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/EventTargetView.java
@@ -16,44 +16,28 @@
 
 package com.vaadin.flow.uitest.ui;
 
-import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H3;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.uitest.servlet.ViewTestLayout;
 
 @Route(value = "com.vaadin.flow.uitest.ui.EventTargetView", layout = ViewTestLayout.class)
-public class EventTargetView extends AbstractDivView {
+public class EventTargetView extends AbstractEventDataView {
 
     public static final String TARGET_ID = "target";
 
     public EventTargetView() {
-        add(new Text("container"));
-        setId("container");
         final Div eventTarget = new Div();
         eventTarget.setId(TARGET_ID);
-        add(new H3("Event.target reported for any child."), eventTarget);
-        for (int i = 0; i < 10; i++) {
-            final Div container = createContainer("Child-" + i);
-            for (int j = 0; j < 10; j++) {
-                final Div child = createContainer("Grandchild-" + i + j);
-                child.getStyle().set("display", "inline-block");
-                container.add(child);
-            }
-            add(container);
-        }
+        addComponentAtIndex(1, new H3("Event.target reported for any child."));
+        addComponentAtIndex(2, eventTarget);
+
         getElement().addEventListener("click", event -> {
             eventTarget.setText(event.getEventTarget()
                     .map(element -> element.getText()).orElse("No target"));
         }).mapEventTargetElement();
-    }
 
-    private Div createContainer(String identifier) {
-        final Div div = new Div();
-        div.add(new Text(identifier));
-        div.setId(identifier);
-        div.getStyle().set("border", "1px solid orange").set("padding", "5px");
-        return div;
+        createComponents();
     }
 
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/EventTargetView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/EventTargetView.java
@@ -34,7 +34,7 @@ public class EventTargetView extends AbstractEventDataView {
 
         getElement().addEventListener("click", event -> {
             eventTarget.setText(event.getEventTarget()
-                    .map(element -> element.getText()).orElse("No target"));
+                    .map(element -> element.getText()).orElse(EMPTY_VALUE));
         }).mapEventTargetElement();
 
         createComponents();

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/AbstractEventDataIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/AbstractEventDataIT.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.uitest.ui;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public abstract class AbstractEventDataIT extends ChromeBrowserTest {
+
+    protected void clickAndVerifyTarget(String id) {
+        final WebElement element = findElement(By.id(id));
+        element.click();
+
+        verifyEventTargetString(id);
+    }
+
+    protected abstract void verifyEventTargetString(String text);
+
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ComponentEventDataIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ComponentEventDataIT.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.component.html.testbench.DivElement;
+
+public class ComponentEventDataIT extends AbstractEventDataIT {
+
+    @Test
+    public void clickElement_reportsComponentAndElementEventData() {
+        open();
+
+        clickAndVerifyTarget("Child-0");
+        verifyDirectChild("Child-0");
+        verifyTargetFirstChild("Grandchild-00");
+        verifyHeader("EMPTY");
+
+        clickAndVerifyTarget("Grandchild-00");
+        verifyDirectChild("Child-0");
+        verifyTargetFirstChild("EMPTY");
+        verifyHeader("EMPTY");
+
+        clickAndVerifyTarget("Grandchild-99");
+        verifyDirectChild("Child-9");
+        verifyTargetFirstChild("EMPTY");
+        verifyHeader("EMPTY");
+
+        clickAndVerifyTarget("Child-9");
+        verifyDirectChild("Child-9");
+        verifyTargetFirstChild("Grandchild-90");
+        verifyHeader("EMPTY");
+    }
+
+    @Test
+    public void clickConcreteComponent_mapsToCorrectComponentType() {
+        open();
+
+        final WebElement h3 = findElement(By.tagName("h3"));
+        h3.click();
+        verifyEventTargetString(h3.getText());
+        verifyDirectChild("EMPTY"); // this is how the test code works
+        verifyTargetFirstChild("EMPTY");
+        verifyHeader("Header");
+    }
+
+    private void verifyHeader(String text) {
+        Assert.assertEquals("Invalid header reported", text, $(DivElement.class)
+                .id(ComponentEventDataView.HEADER_CLICKED).getText());
+    }
+
+    private void verifyTargetFirstChild(String text) {
+        Assert.assertEquals("Invalid event.target.children[0] element reported",
+                text, $(DivElement.class).id(ComponentEventDataView.FIRST_CHILD)
+                        .getText());
+    }
+
+    private void verifyDirectChild(String text) {
+        // this is just for making sure it is possible to do this
+        Assert.assertEquals("Invalid direct target component reported", text,
+                $(DivElement.class).id(ComponentEventDataView.CHILD_COMPONENT)
+                        .getText());
+    }
+
+    @Override
+    protected void verifyEventTargetString(String text) {
+
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ComponentEventDataIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ComponentEventDataIT.java
@@ -23,6 +23,8 @@ import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.html.testbench.DivElement;
 
+import static com.vaadin.flow.uitest.ui.AbstractEventDataView.EMPTY_VALUE;
+
 public class ComponentEventDataIT extends AbstractEventDataIT {
 
     @Test
@@ -32,22 +34,22 @@ public class ComponentEventDataIT extends AbstractEventDataIT {
         clickAndVerifyTarget("Child-0");
         verifyDirectChild("Child-0");
         verifyTargetFirstChild("Grandchild-00");
-        verifyHeader("EMPTY");
+        verifyHeader(EMPTY_VALUE);
 
         clickAndVerifyTarget("Grandchild-00");
         verifyDirectChild("Child-0");
-        verifyTargetFirstChild("EMPTY");
-        verifyHeader("EMPTY");
+        verifyTargetFirstChild(EMPTY_VALUE);
+        verifyHeader(EMPTY_VALUE);
 
         clickAndVerifyTarget("Grandchild-99");
         verifyDirectChild("Child-9");
-        verifyTargetFirstChild("EMPTY");
-        verifyHeader("EMPTY");
+        verifyTargetFirstChild(EMPTY_VALUE);
+        verifyHeader(EMPTY_VALUE);
 
         clickAndVerifyTarget("Child-9");
         verifyDirectChild("Child-9");
         verifyTargetFirstChild("Grandchild-90");
-        verifyHeader("EMPTY");
+        verifyHeader(EMPTY_VALUE);
     }
 
     @Test
@@ -57,9 +59,9 @@ public class ComponentEventDataIT extends AbstractEventDataIT {
         final WebElement h3 = findElement(By.tagName("h3"));
         h3.click();
         verifyEventTargetString(h3.getText());
-        verifyDirectChild("EMPTY"); // this is how the test code works
-        verifyTargetFirstChild("EMPTY");
-        verifyHeader("Header");
+        verifyDirectChild(EMPTY_VALUE); // this is how the test code works
+        verifyTargetFirstChild(EMPTY_VALUE);
+        verifyHeader(AbstractEventDataView.HEADER);
     }
 
     private void verifyHeader(String text) {

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/EventTargetIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/EventTargetIT.java
@@ -22,44 +22,36 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 import com.vaadin.flow.component.html.testbench.DivElement;
-import com.vaadin.flow.testutil.ChromeBrowserTest;
 
-public class EventTargetIT extends ChromeBrowserTest {
+public class EventTargetIT extends AbstractEventDataIT {
 
     @Test
     public void clickOnChildElement_reportsChildAsEventTarget() {
         open();
-        clickAndVerify("Child-0");
-        clickAndVerify("Grandchild-00");
-        clickAndVerify("Grandchild-09");
-        clickAndVerify("Child-1");
-        clickAndVerify("Grandchild-19");
-        clickAndVerify("Grandchild-15");
-        clickAndVerify("Grandchild-55");
-        clickAndVerify("Child-5");
+        clickAndVerifyTarget("Child-0");
+        clickAndVerifyTarget("Grandchild-00");
+        clickAndVerifyTarget("Grandchild-09");
+        clickAndVerifyTarget("Child-1");
+        clickAndVerifyTarget("Grandchild-19");
+        clickAndVerifyTarget("Grandchild-15");
+        clickAndVerifyTarget("Grandchild-55");
+        clickAndVerifyTarget("Child-5");
         final WebElement h3 = findElement(By.tagName("h3"));
         h3.click();
         verifyEventTargetString(h3.getText());
 
-        clickAndVerify("Child-6");
-        clickAndVerify("Child-5");
-        clickAndVerify("Grandchild-99");
-        clickAndVerify("Grandchild-98");
-        clickAndVerify("Grandchild-98");
-        clickAndVerify("Child-9");
+        clickAndVerifyTarget("Child-6");
+        clickAndVerifyTarget("Child-5");
+        clickAndVerifyTarget("Grandchild-99");
+        clickAndVerifyTarget("Grandchild-98");
+        clickAndVerifyTarget("Grandchild-98");
+        clickAndVerifyTarget("Child-9");
 
         // click on source of the listener reports itself too
-        clickAndVerify("container");
+        clickAndVerifyTarget("container");
     }
 
-    private void clickAndVerify(String id) {
-        final WebElement element = findElement(By.id(id));
-        element.click();
-
-        verifyEventTargetString(id);
-    }
-
-    private void verifyEventTargetString(String text) {
+    protected void verifyEventTargetString(String text) {
         Assert.assertEquals("Invalid event.target element reported", text,
                 $(DivElement.class).id(EventTargetView.TARGET_ID).getText());
     }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/EventTargetIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/EventTargetIT.java
@@ -48,7 +48,7 @@ public class EventTargetIT extends AbstractEventDataIT {
         clickAndVerifyTarget("Child-9");
 
         // click on source of the listener reports itself too
-        clickAndVerifyTarget("container");
+        clickAndVerifyTarget(AbstractEventDataView.VIEW_CONTAINER);
     }
 
     protected void verifyEventTargetString(String text) {


### PR DESCRIPTION
Makes it possible to use event data expressions that map to any Component / Element from server side state tree.
For example it will be possible to use:
- `@EventData("event.target") Component eventTarget` for `@DomEvent`
- `@EventData("event.target") Element eventTarget` for `@DomEvent`
- `DomEventRegistration::addEventDataElement(String expression)` to get any element mapped,
- and fetch it with `DomEvent::getEventDataElement(String expression)`

Follow up for #11992, #3356