### PR TITLE
fix: Remove disused plugins from package.json

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -16,6 +16,7 @@
 package com.vaadin.flow.server.frontend;
 
 import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Set;
@@ -229,6 +230,16 @@ public class NodeUpdaterTest {
                 StringContains.containsString("Cannot parse package file "));
         MatcherAssert.assertThat(exception.getMessage(),
                 StringContains.containsString("broken-package.json"));
+    }
+
+    @Test public void removedDisusedPlugins() throws IOException {
+        File packageJson = new File(npmFolder, "package.json");
+        FileWriter packageJsonWriter = new FileWriter(packageJson);
+        packageJsonWriter.write(
+                "{\"devDependencies\": {\"@vaadin/some-old-plugin\": \"./target/plugins/some-old-plugin\"}}");
+        packageJsonWriter.close();
+        JsonObject actualDevDeps = nodeUpdater.getPackageJson();
+        Assert.assertFalse(actualDevDeps.hasKey("some-old-plugin"));
     }
 
     private String getPolymerVersion(JsonObject object) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -235,11 +235,16 @@ public class NodeUpdaterTest {
     @Test public void removedDisusedPlugins() throws IOException {
         File packageJson = new File(npmFolder, "package.json");
         FileWriter packageJsonWriter = new FileWriter(packageJson);
-        packageJsonWriter.write(
-                "{\"devDependencies\": {\"@vaadin/some-old-plugin\": \"./target/plugins/some-old-plugin\"}}");
+        packageJsonWriter.write("{\"devDependencies\": {"
+                + "\"@vaadin/some-old-plugin\": \"./target/plugins/some-old-plugin\","
+                + "\"@vaadin/application-theme-plugin\": \"./target/plugins/application-theme-plugin\"}"
+                + "}");
         packageJsonWriter.close();
-        JsonObject actualDevDeps = nodeUpdater.getPackageJson();
+        JsonObject actualDevDeps = nodeUpdater.getPackageJson()
+                .getObject(NodeUpdater.DEV_DEPENDENCIES);
         Assert.assertFalse(actualDevDeps.hasKey("some-old-plugin"));
+        Assert.assertTrue(
+                actualDevDeps.hasKey("@vaadin/application-theme-plugin"));
     }
 
     private String getPolymerVersion(JsonObject object) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -232,7 +232,8 @@ public class NodeUpdaterTest {
                 StringContains.containsString("broken-package.json"));
     }
 
-    @Test public void removedDisusedPlugins() throws IOException {
+    @Test
+    public void removedDisusedPlugins() throws IOException {
         File packageJson = new File(npmFolder, "package.json");
         FileWriter packageJsonWriter = new FileWriter(packageJson);
         packageJsonWriter.write("{\"devDependencies\": {"


### PR DESCRIPTION
It does not delete them from `target` as this will go away with the next clean.

Fixes #12335 