### PR TITLE
refactor: Move CSRF checking from AccessChecker to FusionController

### DIFF
--- a/fusion-endpoint/src/main/java/com/vaadin/fusion/FusionController.java
+++ b/fusion-endpoint/src/main/java/com/vaadin/fusion/FusionController.java
@@ -67,8 +67,8 @@ import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServletContext;
 import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.server.VaadinServletService;
-import com.vaadin.flow.server.startup.ApplicationConfiguration;
 import com.vaadin.fusion.EndpointRegistry.VaadinEndpointData;
+import com.vaadin.fusion.auth.CsrfChecker;
 import com.vaadin.fusion.auth.FusionAccessChecker;
 import com.vaadin.fusion.endpointransfermapper.EndpointTransferMapper;
 import com.vaadin.fusion.exception.EndpointException;
@@ -117,6 +117,8 @@ public class FusionController {
 
     private static EndpointTransferMapper endpointTransferMapper = new EndpointTransferMapper();
 
+    private CsrfChecker csrfChecker;
+
     /**
      * A constructor used to initialize the controller.
      *
@@ -134,12 +136,16 @@ public class FusionController {
      *            {@link Endpoint} from
      * @param endpointRegistry
      *            the registry used to store endpoint information
+     * @param csrfChecker
+     *            the csrf checker to use
      */
     public FusionController(
             @Autowired(required = false) @Qualifier(VAADIN_ENDPOINT_MAPPER_BEAN_QUALIFIER) ObjectMapper vaadinEndpointMapper,
             ExplicitNullableTypeChecker explicitNullableTypeChecker,
-            ApplicationContext context, EndpointRegistry endpointRegistry) {
+            ApplicationContext context, EndpointRegistry endpointRegistry,
+            CsrfChecker csrfChecker) {
         this.applicationContext = context;
+        this.csrfChecker = csrfChecker;
         this.vaadinEndpointMapper = vaadinEndpointMapper != null
                 ? vaadinEndpointMapper
                 : createVaadinConnectObjectMapper(context);
@@ -201,6 +207,12 @@ public class FusionController {
             HttpServletRequest request) {
         getLogger().debug("Endpoint: {}, method: {}, request body: {}",
                 endpointName, methodName, body);
+
+        if (!csrfChecker.validateCsrfTokenInRequest(request)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(createResponseErrorObject(
+                            FusionAccessChecker.ACCESS_DENIED_MSG));
+        }
 
         VaadinEndpointData vaadinEndpointData = endpointRegistry
                 .get(endpointName);
@@ -519,11 +531,6 @@ public class FusionController {
                 .getAttribute(VaadinConnectAccessCheckerWrapper.class, () -> {
                     FusionAccessChecker accessChecker = applicationContext
                             .getBean(FusionAccessChecker.class);
-                    ApplicationConfiguration cfg = ApplicationConfiguration
-                            .get(vaadinServletContext);
-                    if (cfg != null) {
-                        accessChecker.enableCsrf(cfg.isXsrfProtectionEnabled());
-                    }
                     return new VaadinConnectAccessCheckerWrapper(accessChecker);
                 });
         return wrapper.accessChecker;

--- a/fusion-endpoint/src/main/java/com/vaadin/fusion/FusionController.java
+++ b/fusion-endpoint/src/main/java/com/vaadin/fusion/FusionController.java
@@ -103,7 +103,7 @@ public class FusionController {
      * A qualifier to override the request and response default json mapper.
      *
      * @see #FusionController(ObjectMapper, ExplicitNullableTypeChecker,
-     *      ApplicationContext, EndpointRegistry)
+     *      ApplicationContext, EndpointRegistry, CsrfChecker)
      */
     public static final String VAADIN_ENDPOINT_MAPPER_BEAN_QUALIFIER = "vaadinEndpointMapper";
 

--- a/fusion-endpoint/src/main/java/com/vaadin/fusion/FusionControllerConfiguration.java
+++ b/fusion-endpoint/src/main/java/com/vaadin/fusion/FusionControllerConfiguration.java
@@ -18,6 +18,8 @@ package com.vaadin.fusion;
 
 import java.lang.reflect.Method;
 
+import javax.servlet.ServletContext;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcRegistrations;
 import org.springframework.context.annotation.Bean;
@@ -121,15 +123,12 @@ public class FusionControllerConfiguration {
      *
      * @param accessAnnotationChecker
      *            the access controlks checker to use
-     * @param csrfChecker
-     *            the CSRF checker to use
      * @return the default Vaadin endpoint access checker bean
      */
     @Bean
     public FusionAccessChecker accessChecker(
-            AccessAnnotationChecker accessAnnotationChecker,
-            CsrfChecker csrfChecker) {
-        return new FusionAccessChecker(accessAnnotationChecker, csrfChecker);
+            AccessAnnotationChecker accessAnnotationChecker) {
+        return new FusionAccessChecker(accessAnnotationChecker);
     }
 
     /**
@@ -146,11 +145,14 @@ public class FusionControllerConfiguration {
     /**
      * Registers a default {@link CsrfChecker} bean instance.
      *
+     * @param servletContext
+     *            the servlet context
+     *
      * @return the default bean
      */
     @Bean
-    public CsrfChecker csrfChecker() {
-        return new CsrfChecker();
+    public CsrfChecker csrfChecker(ServletContext servletContext) {
+        return new CsrfChecker(servletContext);
     }
 
     /**

--- a/fusion-endpoint/src/main/java/com/vaadin/fusion/auth/CsrfChecker.java
+++ b/fusion-endpoint/src/main/java/com/vaadin/fusion/auth/CsrfChecker.java
@@ -15,32 +15,49 @@
  */
 package com.vaadin.fusion.auth;
 
-import javax.servlet.ServletRequest;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-
-import com.vaadin.flow.internal.springcsrf.SpringCsrfTokenUtil;
-
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import javax.servlet.ServletContext;
+import javax.servlet.ServletRequest;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+
+import com.vaadin.flow.internal.springcsrf.SpringCsrfTokenUtil;
+import com.vaadin.flow.server.VaadinServletContext;
+import com.vaadin.flow.server.startup.ApplicationConfiguration;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
 /**
  * Handles checking of a CSRF token in endpoint requests.
  */
+@Component
 public class CsrfChecker {
+
     private static final String VAADIN_CSRF_TOKEN_HEADER_NAME = "X-CSRF-Token";
     private static final String VAADIN_CSRF_COOKIE_NAME = "csrfToken";
 
     private boolean csrfProtectionEnabled = true;
 
-    private static Logger getLogger() {
-        return LoggerFactory.getLogger(FusionAccessChecker.class);
+    /**
+     * Creates a new csrf checker for the given context.
+     * 
+     * @param servletContext
+     *            the servlet context
+     */
+    public CsrfChecker(ServletContext servletContext) {
+        ApplicationConfiguration cfg = ApplicationConfiguration
+                .get(new VaadinServletContext(servletContext));
+        if (cfg != null) {
+            setCsrfProtection(cfg.isXsrfProtectionEnabled());
+        }
+
     }
 
     /**
@@ -130,4 +147,9 @@ public class CsrfChecker {
     boolean isSpringCsrfTokenPresent(ServletRequest request) {
         return SpringCsrfTokenUtil.getSpringCsrfToken(request).isPresent();
     }
+
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(FusionAccessChecker.class);
+    }
+
 }

--- a/fusion-endpoint/src/main/java/com/vaadin/fusion/auth/FusionAccessChecker.java
+++ b/fusion-endpoint/src/main/java/com/vaadin/fusion/auth/FusionAccessChecker.java
@@ -74,22 +74,17 @@ public class FusionAccessChecker {
     public static final String ACCESS_DENIED_MSG_DEV_MODE = "Unauthorized access to Vaadin endpoint; "
             + "to enable endpoint access use one of the following annotations: @AnonymousAllowed, @PermitAll, @RolesAllowed";
 
-    private CsrfChecker csrfChecker;
-
     private AccessAnnotationChecker accessAnnotationChecker;
 
     /**
      * Creates a new instance.
      *
-     * @param csrfChecker
-     *            the csrf checker to use
      * @param accessAnnotationChecker
      *            the access checker to use
      */
-    public FusionAccessChecker(AccessAnnotationChecker accessAnnotationChecker,
-            CsrfChecker csrfChecker) {
+    public FusionAccessChecker(
+            AccessAnnotationChecker accessAnnotationChecker) {
         this.accessAnnotationChecker = accessAnnotationChecker;
-        this.csrfChecker = csrfChecker;
     }
 
     /**
@@ -103,10 +98,6 @@ public class FusionAccessChecker {
      *         issues occur, {@code null} otherwise
      */
     public String check(Method method, HttpServletRequest request) {
-        if (!csrfChecker.validateCsrfTokenInRequest(request)) {
-            return ACCESS_DENIED_MSG;
-        }
-
         if (accessAnnotationChecker.hasAccess(method, request)) {
             return null;
         }
@@ -123,16 +114,6 @@ public class FusionAccessChecker {
         VaadinService vaadinService = VaadinService.getCurrent();
         return (vaadinService != null && !vaadinService
                 .getDeploymentConfiguration().isProductionMode());
-    }
-
-    /**
-     * Enable or disable XSRF token checking in endpoints.
-     *
-     * @param xsrfProtectionEnabled
-     *            enable or disable protection.
-     */
-    public void enableCsrf(boolean xsrfProtectionEnabled) {
-        csrfChecker.setCsrfProtection(xsrfProtectionEnabled);
     }
 
     /**

--- a/fusion-endpoint/src/test/java/com/vaadin/fusion/EndpointUtilTest.java
+++ b/fusion-endpoint/src/test/java/com/vaadin/fusion/EndpointUtilTest.java
@@ -20,9 +20,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
-@SpringBootTest(classes = { EndpointUtil.class, FusionEndpointProperties.class,
-        EndpointRegistry.class, EndpointNameChecker.class,
-        FusionAccessChecker.class, CsrfChecker.class,
+@SpringBootTest(classes = { ServletContextTestSetup.class, EndpointUtil.class,
+        FusionEndpointProperties.class, EndpointRegistry.class,
+        EndpointNameChecker.class, FusionAccessChecker.class, CsrfChecker.class,
         AccessAnnotationChecker.class })
 @RunWith(SpringRunner.class)
 public class EndpointUtilTest {

--- a/fusion-endpoint/src/test/java/com/vaadin/fusion/FusionControllerConfigurationTest.java
+++ b/fusion-endpoint/src/test/java/com/vaadin/fusion/FusionControllerConfigurationTest.java
@@ -10,7 +10,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
-@SpringBootTest(classes = FusionEndpointProperties.class)
+@SpringBootTest(classes = { ServletContextTestSetup.class,
+        FusionEndpointProperties.class })
 @ContextConfiguration(classes = FusionControllerConfiguration.class)
 @RunWith(SpringRunner.class)
 public class FusionControllerConfigurationTest {

--- a/fusion-endpoint/src/test/java/com/vaadin/fusion/FusionControllerMockBuilder.java
+++ b/fusion-endpoint/src/test/java/com/vaadin/fusion/FusionControllerMockBuilder.java
@@ -2,14 +2,18 @@ package com.vaadin.fusion;
 
 import static org.mockito.Mockito.mock;
 
+import javax.servlet.ServletContext;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vaadin.flow.di.Lookup;
+import com.vaadin.fusion.auth.CsrfChecker;
 import com.vaadin.fusion.auth.FusionAccessChecker;
 
 import org.mockito.Mockito;
 import org.springframework.context.ApplicationContext;
 
 /**
- * A helper class to build a mocked VaadinConnectController.
+ * A helper class to build a mocked FusionController.
  */
 public class FusionControllerMockBuilder {
     private ApplicationContext applicationContext;
@@ -45,9 +49,12 @@ public class FusionControllerMockBuilder {
 
     public FusionController build() {
         EndpointRegistry registry = new EndpointRegistry(endpointNameChecker);
+        CsrfChecker csrfChecker = Mockito.mock(CsrfChecker.class);
+        Mockito.when(csrfChecker.validateCsrfTokenInRequest(Mockito.any()))
+                .thenReturn(true);
         FusionController controller = Mockito.spy(
                 new FusionController(objectMapper, explicitNullableTypeChecker,
-                        applicationContext, registry));
+                        applicationContext, registry, csrfChecker));
         Mockito.doReturn(mock(FusionAccessChecker.class)).when(controller)
                 .getAccessChecker(Mockito.any());
         return controller;

--- a/fusion-endpoint/src/test/java/com/vaadin/fusion/ServletContextTestSetup.java
+++ b/fusion-endpoint/src/test/java/com/vaadin/fusion/ServletContextTestSetup.java
@@ -1,0 +1,26 @@
+package com.vaadin.fusion;
+
+import javax.servlet.ServletContext;
+
+import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.server.startup.ApplicationConfiguration;
+
+import org.mockito.Mockito;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.ServletContextAware;
+
+@Component
+public class ServletContextTestSetup implements ServletContextAware {
+
+    @Override
+    public void setServletContext(ServletContext servletContext) {
+        Lookup lookup = Mockito.mock(Lookup.class);
+        servletContext.setAttribute(Lookup.class.getName(), lookup);
+        ApplicationConfiguration applicationConfiguration = Mockito
+                .mock(ApplicationConfiguration.class);
+        servletContext.setAttribute(ApplicationConfiguration.class.getName(),
+                applicationConfiguration);
+
+    }
+
+}

--- a/fusion-endpoint/src/test/java/com/vaadin/fusion/auth/FusionAccessCheckerTest.java
+++ b/fusion-endpoint/src/test/java/com/vaadin/fusion/auth/FusionAccessCheckerTest.java
@@ -9,6 +9,7 @@ import java.lang.reflect.Method;
 import java.security.Principal;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -35,8 +36,7 @@ public class FusionAccessCheckerTest {
 
     @Before
     public void before() {
-        checker = new FusionAccessChecker(new AccessAnnotationChecker(),
-                new CsrfChecker());
+        checker = new FusionAccessChecker(new AccessAnnotationChecker());
         requestMock = mock(HttpServletRequest.class);
         when(requestMock.getUserPrincipal()).thenReturn(mock(Principal.class));
         when(requestMock.getHeader("X-CSRF-Token")).thenReturn("Vaadin Fusion");
@@ -49,24 +49,6 @@ public class FusionAccessCheckerTest {
         when(requestMock.getUserPrincipal()).thenReturn(null);
     }
 
-    private void createDifferentCookieToken() {
-        when(requestMock.getCookies()).thenReturn(new Cookie[] {
-                new Cookie(ApplicationConstants.CSRF_TOKEN, "Fusion token") });
-    }
-
-    private void createNullTokenContextInHeaderRequest() {
-        when(requestMock.getHeader("X-CSRF-Token")).thenReturn(null);
-    }
-
-    private void createNullTokenCookies() {
-        when(requestMock.getCookies())
-                .thenReturn(new Cookie[] { new Cookie("JSESSIONID", "0") });
-    }
-
-    private void createNullCookies() {
-        when(requestMock.getCookies()).thenReturn(null);
-    }
-
     private void shouldPass(Class<?> test) throws Exception {
         Method method = test.getMethod("test");
         assertNull(checker.check(method, requestMock));
@@ -75,102 +57,6 @@ public class FusionAccessCheckerTest {
     private void shouldFail(Class<?> test) throws Exception {
         Method method = test.getMethod("test");
         assertNotNull(checker.check(method, requestMock));
-    }
-
-    @Test
-    public void should_fail_When_not_having_token_in_headerRequest()
-            throws Exception {
-        class Test {
-            public void test() {
-            }
-        }
-        createNullTokenContextInHeaderRequest();
-        shouldFail(Test.class);
-    }
-
-    @Test
-    public void should_fail_When_not_having_token_in_cookies_but_have_token_in_request_header()
-            throws Exception {
-        class Test {
-            public void test() {
-            }
-        }
-        createNullTokenCookies();
-        shouldFail(Test.class);
-    }
-
-    @Test
-    public void should_fail_When_not_having_token_in_cookies_but_have_token_in_request_header_And_AnonymousAllowed()
-            throws Exception {
-        @AnonymousAllowed
-        class Test {
-            public void test() {
-            }
-        }
-        createNullTokenCookies();
-        shouldFail(Test.class);
-    }
-
-    @Test
-    public void should_fail_When_not_having_cookies_And_not_having_token_in_request_header()
-            throws Exception {
-        @PermitAll
-        class Test {
-            public void test() {
-            }
-        }
-        createNullCookies();
-        createNullTokenContextInHeaderRequest();
-        shouldFail(Test.class);
-    }
-
-    @Test
-    public void should_fail_When_not_having_cookies_And_not_having_token_in_request_header_And_AnonymousAllowed()
-            throws Exception {
-        @AnonymousAllowed
-        class Test {
-            public void test() {
-            }
-        }
-        createNullCookies();
-        createNullTokenContextInHeaderRequest();
-        shouldFail(Test.class);
-    }
-
-    @Test
-    public void should_pass_When_csrf_disabled() throws Exception {
-        class Test {
-            @PermitAll
-            public void test() {
-            }
-        }
-        createNullTokenContextInHeaderRequest();
-        checker.enableCsrf(false);
-        shouldPass(Test.class);
-    }
-
-    @Test
-    public void should_fail_When_having_different_token_between_cookie_and_headerRequest()
-            throws Exception {
-        class Test {
-            public void test() {
-            }
-        }
-        createDifferentCookieToken();
-        shouldFail(Test.class);
-    }
-
-    @Test
-    public void should_fail_When_having_different_token_between_cookie_and_headerRequest_and_NoAuthentication_AnonymousAllowed()
-            throws Exception {
-        class Test {
-            @AnonymousAllowed
-            public void test() {
-            }
-        }
-        createAnonymousContext();
-        createDifferentCookieToken();
-        shouldFail(Test.class);
     }
 
     @Test

--- a/fusion-endpoint/src/test/java/com/vaadin/fusion/generator/endpoints/AbstractEndpointGenerationTest.java
+++ b/fusion-endpoint/src/test/java/com/vaadin/fusion/generator/endpoints/AbstractEndpointGenerationTest.java
@@ -80,7 +80,6 @@ import org.springframework.data.domain.Sort.NullHandling;
 import com.vaadin.flow.server.auth.AccessAnnotationChecker;
 import com.vaadin.fusion.Endpoint;
 import com.vaadin.fusion.EndpointExposed;
-import com.vaadin.fusion.auth.CsrfChecker;
 import com.vaadin.fusion.auth.FusionAccessChecker;
 import com.vaadin.fusion.endpointransfermapper.EndpointTransferMapper;
 import com.vaadin.fusion.generator.OpenAPIObjectGenerator;
@@ -111,7 +110,7 @@ public abstract class AbstractEndpointGenerationTest
     private static final List<Class> DENY_LIST_CHECKING_ABSOLUTE_PATH = Arrays
             .asList(Model.class, ParentModel.class, GrandParentModel.class);
     private static final FusionAccessChecker accessChecker = new FusionAccessChecker(
-            new AccessAnnotationChecker(), new CsrfChecker());
+            new AccessAnnotationChecker());
     private final Set<String> schemaReferences = new HashSet<>();
 
     public AbstractEndpointGenerationTest(List<Class<?>> testClasses) {


### PR DESCRIPTION
CSRF checking is related to the HTTP request and not at all related to the access checker. If you use the access checker in another context such as a websocket message, you cannot do the same CSRF check nor do you need any CSRF check.
