### PR TITLE
fix: Make webpack work with Node 17.1+

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -378,11 +378,12 @@ public class FrontendTools {
             return;
         }
         try {
-            List<String> nodeVersionCommand = new ArrayList<>();
-            nodeVersionCommand.add(doGetNodeExecutable());
-            nodeVersionCommand.add("--version"); // NOSONAR
-            FrontendVersion foundNodeVersion = FrontendUtils.getVersion("node",
-                    nodeVersionCommand);
+            FrontendVersion foundNodeVersion = getNodeVersion();
+            if (foundNodeVersion.getMajorVersion() == 17
+                    && foundNodeVersion.getMinorVersion() == 0) {
+                throw new IllegalStateException(
+                        "Node version 17.0 is incompatible with webpack 4. Please upgrade to Node 17.1 or newer, or downgrade to Node 16.");
+            }
             FrontendUtils.validateToolVersion("node", foundNodeVersion,
                     SUPPORTED_NODE_VERSION, SHOULD_WORK_NODE_VERSION);
         } catch (UnknownVersionException e) {
@@ -402,6 +403,16 @@ public class FrontendTools {
             getLogger().warn("Error checking if npm is new enough", e);
         }
 
+    }
+
+    /**
+     * Gets the version of the node executable.
+     */
+    public FrontendVersion getNodeVersion() throws UnknownVersionException {
+        List<String> nodeVersionCommand = new ArrayList<>();
+        nodeVersionCommand.add(doGetNodeExecutable());
+        nodeVersionCommand.add("--version"); // NOSONAR
+        return FrontendUtils.getVersion("node", nodeVersionCommand);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendVersion.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendVersion.java
@@ -284,6 +284,13 @@ public class FrontendVersion
     }
 
     @Override
+    public String toString() {
+        return "FrontendVersion [" + "majorVersion=" + majorVersion
+                + ", minorVersion=" + minorVersion + ", revision=" + revision
+                + ", buildIdentifier=" + buildIdentifier + "]";
+    }
+
+    @Override
     public int hashCode() {
         return (majorVersion + "." + minorVersion + "." + revision + "."
                 + buildIdentifier).hashCode();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -42,6 +42,7 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
 
 import com.vaadin.flow.server.frontend.installer.Platform;
 import com.vaadin.flow.server.frontend.installer.ProxyConfig;
@@ -78,7 +79,7 @@ public class FrontendToolsTest {
     public void setup() throws IOException {
         baseDir = tmpDir.newFolder().getAbsolutePath();
         vaadinHomeDir = tmpDir.newFolder().getAbsolutePath();
-        tools = new FrontendTools(baseDir, () -> vaadinHomeDir);
+        tools = Mockito.spy(new FrontendTools(baseDir, () -> vaadinHomeDir));
     }
 
     @Test
@@ -250,6 +251,15 @@ public class FrontendToolsTest {
         tools.validateNodeAndNpmVersion();
 
         Assert.assertTrue(file.exists());
+    }
+
+    @Test
+    public void validateNodeAndNpmVersion_brokenNode17() throws Exception {
+        Mockito.when(tools.getNodeVersion())
+                .thenReturn(new FrontendVersion(17, 0));
+        Assert.assertThrows(IllegalStateException.class, () -> {
+            tools.validateNodeAndNpmVersion();
+        });
     }
 
     @Test(expected = IllegalStateException.class)

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerImpl.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerImpl.java
@@ -59,6 +59,8 @@ import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.communication.StreamRequestHandler;
 import com.vaadin.flow.server.frontend.FrontendTools;
 import com.vaadin.flow.server.frontend.FrontendUtils;
+import com.vaadin.flow.server.frontend.FrontendVersion;
+import com.vaadin.flow.server.frontend.FrontendUtils.UnknownVersionException;
 import com.vaadin.flow.server.startup.ApplicationConfiguration;
 
 import static com.vaadin.flow.server.Constants.VAADIN_MAPPING;
@@ -655,6 +657,18 @@ public final class DevModeHandlerImpl
                 () -> FrontendUtils.getVaadinHomeDirectory().getAbsolutePath(),
                 useHomeNodeExec);
         tools.validateNodeAndNpmVersion();
+        FrontendVersion nodeVersion;
+        try {
+            nodeVersion = tools.getNodeVersion();
+        } catch (UnknownVersionException e) {
+            getLogger().error("Unable to determine node version", e);
+            // Need to assume something..
+            nodeVersion = new FrontendVersion(16, 0, 0);
+        }
+        if (!nodeVersion.isOlderThan(new FrontendVersion(17, 0, 0))) {
+            processBuilder.environment().put("NODE_OPTIONS",
+                    "--openssl-legacy-provider");
+        }
 
         String nodeExec = null;
         if (useHomeNodeExec) {


### PR DESCRIPTION
Disallows usage of Node 17.0.

Fixes #12246, #12285
