### PR TITLE
fix: Make webpack work with Node 17.1+

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -386,11 +386,12 @@ public class FrontendTools {
             return;
         }
         try {
-            List<String> nodeVersionCommand = new ArrayList<>();
-            nodeVersionCommand.add(doGetNodeExecutable());
-            nodeVersionCommand.add("--version"); // NOSONAR
-            FrontendVersion foundNodeVersion = FrontendUtils.getVersion("node",
-                    nodeVersionCommand);
+            FrontendVersion foundNodeVersion = getNodeVersion();
+            if (foundNodeVersion.getMajorVersion() == 17
+                    && foundNodeVersion.getMinorVersion() == 0) {
+                throw new IllegalStateException(
+                        "Node version 17.0 is incompatible with webpack 4. Please upgrade to Node 17.1 or newer, or downgrade to Node 16.");
+            }
             FrontendUtils.validateToolVersion("node", foundNodeVersion,
                     SUPPORTED_NODE_VERSION, SHOULD_WORK_NODE_VERSION);
         } catch (UnknownVersionException e) {
@@ -427,6 +428,16 @@ public class FrontendTools {
         return frontendToolsLocator.tryLocateTool(command).map(File::getPath)
                 .map(Collections::singletonList)
                 .orElse(Collections.emptyList());
+    }
+
+    /**
+     * Gets the version of the node executable.
+     */
+    public FrontendVersion getNodeVersion() throws UnknownVersionException {
+        List<String> nodeVersionCommand = new ArrayList<>();
+        nodeVersionCommand.add(doGetNodeExecutable());
+        nodeVersionCommand.add("--version"); // NOSONAR
+        return FrontendUtils.getVersion("node", nodeVersionCommand);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendVersion.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendVersion.java
@@ -284,6 +284,13 @@ public class FrontendVersion
     }
 
     @Override
+    public String toString() {
+        return "FrontendVersion [" + "majorVersion=" + majorVersion
+                + ", minorVersion=" + minorVersion + ", revision=" + revision
+                + ", buildIdentifier=" + buildIdentifier + "]";
+    }
+
+    @Override
     public int hashCode() {
         return (majorVersion + "." + minorVersion + "." + revision + "."
                 + buildIdentifier).hashCode();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -82,7 +82,7 @@ public class FrontendToolsTest {
     public void setup() throws IOException {
         baseDir = tmpDir.newFolder().getAbsolutePath();
         vaadinHomeDir = tmpDir.newFolder().getAbsolutePath();
-        tools = new FrontendTools(baseDir, () -> vaadinHomeDir);
+        tools = Mockito.spy(new FrontendTools(baseDir, () -> vaadinHomeDir));
     }
 
     @Test
@@ -257,9 +257,6 @@ public class FrontendToolsTest {
 
     @Test
     public void validateNodeAndNpmVersion_brokenNode17() throws Exception {
-        settings.setIgnoreVersionChecks(false);
-        tools = Mockito.spy(new FrontendTools(settings));
-
         Mockito.when(tools.getNodeVersion())
                 .thenReturn(new FrontendVersion(17, 0));
         Assert.assertThrows(IllegalStateException.class, () -> {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -43,6 +43,7 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
 
 import com.vaadin.flow.server.frontend.installer.Platform;
 import com.vaadin.flow.server.frontend.installer.ProxyConfig;
@@ -252,6 +253,18 @@ public class FrontendToolsTest {
         tools.validateNodeAndNpmVersion();
 
         Assert.assertTrue(file.exists());
+    }
+
+    @Test
+    public void validateNodeAndNpmVersion_brokenNode17() throws Exception {
+        settings.setIgnoreVersionChecks(false);
+        tools = Mockito.spy(new FrontendTools(settings));
+
+        Mockito.when(tools.getNodeVersion())
+                .thenReturn(new FrontendVersion(17, 0));
+        Assert.assertThrows(IllegalStateException.class, () -> {
+            tools.validateNodeAndNpmVersion();
+        });
     }
 
     @Test(expected = IllegalStateException.class)


### PR DESCRIPTION
Disallows usage of Node 17.0.

Fixes #12246, #12285
