### PR TITLE
feat: Add async mode to flush operation and API to turn it on

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -196,7 +196,7 @@ public class DataCommunicator<T> implements Serializable {
      */
     public void setAsyncDataUpdates(boolean async) {
         this.asyncDataUpdates = async;
-    }    
+    }
 
     /**
      * Resets all the data.

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -26,7 +26,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorAsyncTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorAsyncTest.java
@@ -1,0 +1,286 @@
+package com.vaadin.flow.data.provider;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.internal.Range;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
+
+import elemental.json.JsonValue;
+
+public class DataCommunictorAsyncTest {
+
+    /**
+     * Test item that uses id for identity.
+     */
+    private static class Item {
+        private final int id;
+        private String value;
+
+        public Item(int id) {
+            this(id, "Item " + id);
+        }
+
+        public Item(int id, String value) {
+            this.id = id;
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return id + ": " + value;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj instanceof Item) {
+                Item that = (Item) obj;
+                return that.id == id;
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return id;
+        }
+    }
+
+    private DataCommunicator<Item> dataCommunicator;
+
+    @Mock
+    private DataGenerator<Item> dataGenerator;
+    @Mock
+    private ArrayUpdater arrayUpdater;
+
+    private Element element;
+    private MockUI ui;
+
+    private ArrayUpdater.Update update;
+
+    private CountDownLatch latch;
+    private ExecutorService executor;
+
+    public Range lastClear = null;
+    public Range lastSet = null;
+    public int lastUpdateId = -1;
+
+    @Before
+    public void init() {
+        MockitoAnnotations.initMocks(this);
+        ui = new MockUI();
+        element = new Element("div");
+        ui.getElement().appendChild(element);
+        lastClear = null;
+        lastSet = null;
+        lastUpdateId = -1;
+        executor = Executors.newCachedThreadPool();
+
+        update = new ArrayUpdater.Update() {
+
+            @Override
+            public void clear(int start, int length) {
+                lastClear = Range.withLength(start, length);
+            }
+
+            @Override
+            public void set(int start, List<JsonValue> items) {
+                lastSet = Range.withLength(start, items.size());
+            }
+
+            @Override
+            public void commit(int updateId) {
+                lastUpdateId = updateId;
+            }
+        };
+
+        Mockito.when(arrayUpdater.startUpdate(Mockito.anyInt()))
+                .thenReturn(update);
+
+        dataCommunicator = new DataCommunicator<>(dataGenerator, arrayUpdater,
+                data -> {
+                }, element.getNode());
+    }
+
+    @Test
+    public void asyncRequestedRangeHappensLater() {
+        latch = new CountDownLatch(1);
+        dataCommunicator.setDataProvider(createDataProvider(), null);
+        dataCommunicator.setAsyncDataUpdates(executor);
+        dataCommunicator.setRequestedRange(0, 50);
+        fakeClientCommunication();
+
+        Assert.assertNotEquals("Expected initial reset not yet done.",
+                Range.withLength(0, 50), lastSet);
+
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        Assert.assertEquals("Expected initial full reset.",
+                Range.withLength(0, 50), lastSet);
+        lastSet = null;
+
+        element.removeFromParent();
+        fakeClientCommunication();
+
+        Assert.assertNull("Expected no during reattach.", lastSet);
+
+        ui.getElement().appendChild(element);
+        fakeClientCommunication();
+
+        latch = new CountDownLatch(1);
+
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        Assert.assertEquals("Expected initial full reset after reattach",
+                Range.withLength(0, 50), lastSet);
+    }
+
+    private AbstractDataProvider<Item, Object> createDataProvider() {
+        return createDataProvider(100);
+    }
+
+    private AbstractDataProvider<Item, Object> createDataProvider(int items) {
+        return new AbstractDataProvider<Item, Object>() {
+            @Override
+            public boolean isInMemory() {
+                return true;
+            }
+
+            @Override
+            public int size(Query<Item, Object> query) {
+                return items;
+            }
+
+            @Override
+            public Stream<Item> fetch(Query<Item, Object> query) {
+                try {
+                    Thread.sleep(500);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                // Note: Mockito is not able to mock background call, thus
+                // setting lastSet here
+                lastSet = Range.withLength(query.getOffset(), query.getLimit());
+                latch.countDown();
+                return IntStream
+                        .range(query.getOffset(),
+                                query.getLimit() + query.getOffset())
+                        .mapToObj(Item::new);
+            }
+        };
+    }
+
+    private void fakeClientCommunication() {
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+        ui.getInternals().getStateTree().collectChanges(ignore -> {
+        });
+    }
+
+    public static class MockUI extends UI {
+
+        public MockUI() {
+            this(findOrcreateSession());
+        }
+
+        public MockUI(VaadinSession session) {
+            getInternals().setSession(session);
+            setCurrent(this);
+        }
+
+        @Override
+        protected void init(VaadinRequest request) {
+            // Do nothing
+        }
+
+        private static VaadinSession findOrcreateSession() {
+            VaadinSession session = VaadinSession.getCurrent();
+            if (session == null) {
+                session = new AlwaysLockedVaadinSession(null);
+                VaadinSession.setCurrent(session);
+            }
+            return session;
+        }
+    }
+
+    public static class AlwaysLockedVaadinSession extends MockVaadinSession {
+
+        public AlwaysLockedVaadinSession(VaadinService service) {
+            super(service);
+            lock();
+        }
+
+    }
+
+    public static class MockVaadinSession extends VaadinSession {
+        /*
+         * Used to make sure there's at least one reference to the mock session
+         * while it's locked. This is used to prevent the session from being
+         * eaten by GC in tests where @Before creates a session and sets it as
+         * the current instance without keeping any direct reference to it. This
+         * pattern has a chance of leaking memory if the session is not unlocked
+         * in the right way, but it should be acceptable for testing use.
+         */
+        private static final ThreadLocal<MockVaadinSession> referenceKeeper = new ThreadLocal<>();
+
+        public MockVaadinSession(VaadinService service) {
+            super(service);
+        }
+
+        @Override
+        public void close() {
+            super.close();
+            closeCount++;
+        }
+
+        public int getCloseCount() {
+            return closeCount;
+        }
+
+        @Override
+        public Lock getLockInstance() {
+            return lock;
+        }
+
+        @Override
+        public void lock() {
+            super.lock();
+            referenceKeeper.set(this);
+        }
+
+        @Override
+        public void unlock() {
+            super.unlock();
+            referenceKeeper.remove();
+        }
+
+        private int closeCount;
+
+        private ReentrantLock lock = new ReentrantLock();
+    }
+}

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorAsyncTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorAsyncTest.java
@@ -25,7 +25,7 @@ import com.vaadin.flow.server.VaadinSession;
 
 import elemental.json.JsonValue;
 
-public class DataCommunictorAsyncTest {
+public class DataCommunicatorAsyncTest {
 
     /**
      * Test item that uses id for identity.

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorAsyncTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorAsyncTest.java
@@ -124,7 +124,7 @@ public class DataCommunictorAsyncTest {
     public void asyncRequestedRangeHappensLater() {
         latch = new CountDownLatch(1);
         dataCommunicator.setDataProvider(createDataProvider(), null);
-        dataCommunicator.setAsyncDataUpdates(executor);
+        dataCommunicator.setExecutorForAsyncUpdates(executor);
         dataCommunicator.setRequestedRange(0, 50);
         fakeClientCommunication();
 


### PR DESCRIPTION
In async mode data fetching is wrapped in the future

This version is for Vaadin 14

fixes: [#1066](https://github.com/vaadin/flow-components/issues/1066)
fixes: #10709
fixes: #12342

Draft for comments