### PR TITLE
test: Make more stable on CI

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/internal/StateNodeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/StateNodeTest.java
@@ -223,7 +223,7 @@ public class StateNodeTest {
     @Test
     public void recursiveTreeNavigation_resilienceInDepth() {
         TestStateNode childOfRoot = new TestStateNode();
-        TestStateNode node = createTree(childOfRoot, 5000);
+        TestStateNode node = createTree(childOfRoot, 3000);
         StateTree tree = createStateTree();
 
         setParent(childOfRoot, tree.getRootNode());


### PR DESCRIPTION
Testing a state tree with depth of 5000 seems excessive and has caused stackoverflow in the CI randomly.