### PR TITLE
fix: Do not use --ignore-existing which is only available in npm 6

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -935,7 +935,7 @@ public class FrontendTools {
             // see https://pnpm.io/installation#compatibility
             final String pnpmSpecifier = "pnpm@" + DEFAULT_PNPM_VERSION;
             pnpmCommand = getNpmCliToolExecutable(BuildTool.NPX, "--yes",
-                    "--quiet", "--ignore-existing", pnpmSpecifier);
+                    "--quiet", pnpmSpecifier);
         }
         getLogger().info("using '{}' for frontend package installation",
                 String.join(" ", pnpmCommand));

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -604,21 +604,6 @@ public class FrontendToolsTest {
     }
 
     @Test
-    public void getSuitablePnpm_useDefaultSupportedPnpmVersion_oldGlobalPnpmIgnored()
-            throws Exception {
-        createStubNode(false, true, baseDir);
-        createFakePnpm(OLD_PNPM_VERSION);
-        List<String> pnpmCommand = tools.getSuitablePnpm();
-        Assert.assertTrue(
-                "expected the default pnpm command to include '--ignore-existing' flag",
-                pnpmCommand.contains("--ignore-existing"));
-        Assert.assertEquals(
-                "expected old global pnpm version to be ignored and the default supported one is used",
-                "pnpm@" + FrontendTools.DEFAULT_PNPM_VERSION,
-                pnpmCommand.get(pnpmCommand.size() - 1));
-    }
-
-    @Test
     public void getSuitablePnpm_tooOldGlobalVersionInstalled_throws() {
         settings.setUseGlobalPnpm(true);
         tools = new FrontendTools(settings);


### PR DESCRIPTION
While this might break some pnpm case, it will still help more to have consistent behavior across npm versions. Also the cases it might break are already broken for many users (npm 7+)

Fixes #11963
