### PR TITLE
fix: Prevent Vite from reloading if live reload has been turned off

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/vite-devmode.ts
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/vite-devmode.ts
@@ -2,17 +2,30 @@
 if (import.meta.hot) {
   // @ts-ignore
   const hot = import.meta.hot;
+
+  const isLiveReloadDisabled = () => {
+    // Checks if live reload is disabled in the debug window
+    return sessionStorage.getItem('vaadin.live-reload.active') === 'false';
+  };
+
+  const preventViteReload = (payload: any) => {
+    // Changing the path prevents Vite from reloading
+    payload.path = '/_fake/path.html';
+  };
+
   let pendingNavigationTo: string | undefined = undefined;
 
   window.addEventListener('vaadin-router-go', (routerEvent: any) => {
     pendingNavigationTo = routerEvent.detail.pathname + routerEvent.detail.search;
   });
   hot.on('vite:beforeFullReload', (payload: any) => {
+    if (isLiveReloadDisabled()) {
+      preventViteReload(payload);
+    }
     if (pendingNavigationTo) {
       // Force reload with the new URL
       location.href = pendingNavigationTo;
-      // Prevent Vite from reloading
-      payload.path = '/_fake/path.html';
+      preventViteReload(payload);
     }
   });
 }


### PR DESCRIPTION
Fixes #12133
