### PR TITLE
feat: add HeartbeatListener to UI

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/HeartbeatEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HeartbeatEvent.java
@@ -13,14 +13,12 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.flow.component.internal;
+package com.vaadin.flow.component;
 
 import java.util.EventObject;
 
-import com.vaadin.flow.component.UI;
-
 /**
- * Event created for a application heartbeat from the client.
+ * Event created for an application heartbeat from the client.
  *
  * @since 2.0
  */

--- a/flow-server/src/main/java/com/vaadin/flow/component/HeartbeatListener.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/HeartbeatListener.java
@@ -13,7 +13,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package com.vaadin.flow.component.internal;
+package com.vaadin.flow.component;
 
 import java.io.Serializable;
 

--- a/flow-server/src/main/java/com/vaadin/flow/component/UI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/UI.java
@@ -1178,6 +1178,26 @@ public class UI extends Component
     }
 
     /**
+     * Add a listener that will be informed when this UI received a heartbeat
+     * from the client-side.
+     * <p>
+     * Heartbeat requests are periodically sent by the client-side to inform the
+     * server that the UI sending the heartbeat is still alive (the browser
+     * window is open, the connection is up) even when there are no UIDL
+     * requests for a prolonged period of time. UIs that do not receive either
+     * heartbeat or UIDL requests are eventually removed from the session and
+     * garbage collected.
+     *
+     * @param listener
+     *            the heartbeat listener
+     * @return handler to remove the heartbeat listener
+     */
+    public Registration addHeartbeatListener(HeartbeatListener listener) {
+        Objects.requireNonNull(listener, NULL_LISTENER);
+        return internals.addHeartbeatListener(listener);
+    }
+
+    /**
      * Gets the drag source of an active HTML5 drag event.
      * <p>
      * <em>NOTE: the generic drag and drop feature for Flow is available in

--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -35,6 +35,8 @@ import org.slf4j.LoggerFactory;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.HasElement;
+import com.vaadin.flow.component.HeartbeatEvent;
+import com.vaadin.flow.component.HeartbeatListener;
 import com.vaadin.flow.component.PushConfiguration;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.CssImport;

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/HeartbeatHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/HeartbeatHandlerTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.communication;
+
+import java.io.IOException;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.internal.UIInternals;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinResponse;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+public class HeartbeatHandlerTest {
+
+    @Test
+    public void synchronizedHandleRequest_uiPresent_setLastHeartbeatTimestampIsCalledOnce()
+            throws IOException {
+        VaadinService service = mock(VaadinService.class);
+        VaadinSession session = mock(VaadinSession.class);
+        VaadinRequest request = mock(VaadinRequest.class);
+        VaadinResponse response = mock(VaadinResponse.class);
+        UI ui = mock(UI.class);
+        UIInternals uiInternals = mock(UIInternals.class);
+
+        when(ui.getInternals()).thenReturn(uiInternals);
+        when(session.getService()).thenReturn(service);
+        when(service.findUI(request)).thenReturn(ui);
+
+        HeartbeatHandler handler = new HeartbeatHandler();
+        handler.synchronizedHandleRequest(session, request, response);
+
+        Mockito.verify(ui.getInternals(), times(1))
+                .setLastHeartbeatTimestamp(anyLong());
+    }
+}


### PR DESCRIPTION
## Description

Moves `HeartbeatEvent` and `HeartbeatListener` from the internal package into the public packages.  
Creates a new method `UI::addHeartbeatListener` as public API to use instead of the internal API from `UIInternal`.

Fixes #12295 

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ x I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
