### PR TITLE
chore: enable ignored tests

### DIFF
--- a/flow-tests/test-embedding/test-embedding-application-theme/src/test/java/com/vaadin/flow/webcomponent/ApplicationThemeComponentIT.java
+++ b/flow-tests/test-embedding/test-embedding-application-theme/src/test/java/com/vaadin/flow/webcomponent/ApplicationThemeComponentIT.java
@@ -101,7 +101,6 @@ public class ApplicationThemeComponentIT extends ChromeBrowserTest {
     }
 
     @Test
-    @Ignore("Flaky test: #10331")
     public void componentThemeIsApplied_forPolymerAndLit() {
         open();
 

--- a/flow-tests/test-embedding/test-embedding-reusable-theme/src/test/java/com/vaadin/flow/webcomponent/ApplicationThemeComponentIT.java
+++ b/flow-tests/test-embedding/test-embedding-reusable-theme/src/test/java/com/vaadin/flow/webcomponent/ApplicationThemeComponentIT.java
@@ -97,7 +97,6 @@ public class ApplicationThemeComponentIT extends ChromeBrowserTest {
                 handElement.getCssValue("color"));
     }
 
-    @Ignore("Flaky test: #10331")
     @Test
     public void componentThemeIsApplied_forPolymerAndLit() {
         open();


### PR DESCRIPTION
No flakiness seen in 9 executions.
Re-enable tests for 2.8 and 2.7

Closes #10331