### PR TITLE
fix: Require Firefox 78 or later

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/shared/BrowserDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/BrowserDetails.java
@@ -617,8 +617,8 @@ public class BrowserDetails implements Serializable {
             }
             return true;
         }
-        // Firefox 65+ for now
-        if (isFirefox() && getBrowserMajorVersion() < 65) {
+        // Firefox 78+ for now
+        if (isFirefox() && getBrowserMajorVersion() < 78) {
             return true;
         }
         // Opera 58+ for now


### PR DESCRIPTION
## Description

Fixes #12442

Firefox 78 brings support for unicode property escapes, which
are used in Vaadin 22 and later since vaadin/web-components#2815.

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
