### PR TITLE
fix: remove duplicates when collecting BeforeEnterObservers

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/EventUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/EventUtil.java
@@ -132,7 +132,7 @@ public final class EventUtil {
         return chain.stream()
                 .flatMap(chainRoot -> collectBeforeEnterObserversStream(
                         chainRoot.getElement(), childrenExclusionElements))
-                .collect(Collectors.toList());
+                .distinct().collect(Collectors.toList());
     }
 
     /**

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PreserveOnRefreshNestedBeforeEnterCounter.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PreserveOnRefreshNestedBeforeEnterCounter.java
@@ -1,0 +1,22 @@
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.BeforeEnterObserver;
+
+public class PreserveOnRefreshNestedBeforeEnterCounter extends Div
+        implements BeforeEnterObserver {
+    private int beforeEnterCount = 0;
+    private final Span count = new Span();
+
+    public PreserveOnRefreshNestedBeforeEnterCounter() {
+        count.setId(getClass().getSimpleName() + "-before-enter-count");
+        add(count);
+    }
+
+    @Override
+    public void beforeEnter(BeforeEnterEvent event) {
+        count.setText(Integer.toString(++beforeEnterCount));
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PreserveOnRefreshNestedBeforeEnterView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PreserveOnRefreshNestedBeforeEnterView.java
@@ -1,0 +1,21 @@
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.router.ParentLayout;
+import com.vaadin.flow.router.PreserveOnRefresh;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouterLayout;
+
+@Route(value = "com.vaadin.flow.uitest.ui.PreserveOnRefreshNestedBeforeEnterView", layout = PreserveOnRefreshNestedBeforeEnterView.NestedLayout.class)
+public class PreserveOnRefreshNestedBeforeEnterView
+        extends PreserveOnRefreshNestedBeforeEnterCounter {
+
+    @PreserveOnRefresh
+    public static class RootLayout extends
+            PreserveOnRefreshNestedBeforeEnterCounter implements RouterLayout {
+    }
+
+    @ParentLayout(RootLayout.class)
+    public static class NestedLayout extends
+            PreserveOnRefreshNestedBeforeEnterCounter implements RouterLayout {
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PreserveOnRefreshNestedBeforeEnterIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PreserveOnRefreshNestedBeforeEnterIT.java
@@ -1,0 +1,33 @@
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+import com.vaadin.flow.component.html.testbench.SpanElement;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+// IT for https://github.com/vaadin/flow/issues/12356
+public class PreserveOnRefreshNestedBeforeEnterIT extends ChromeBrowserTest {
+
+    @Test
+    public void refreshViewWithNestedLayouts_eachBeforeEnterIsCalledOnlyOnce() {
+        open();
+
+        Assert.assertEquals("1", $(SpanElement.class)
+                .id("RootLayout-before-enter-count").getText());
+        Assert.assertEquals("1", $(SpanElement.class)
+                .id("NestedLayout-before-enter-count").getText());
+        Assert.assertEquals("1", $(SpanElement.class)
+                .id("PreserveOnRefreshNestedBeforeEnterView-before-enter-count")
+                .getText());
+
+        open();
+
+        Assert.assertEquals("2", $(SpanElement.class)
+                .id("RootLayout-before-enter-count").getText());
+        Assert.assertEquals("2", $(SpanElement.class)
+                .id("NestedLayout-before-enter-count").getText());
+        Assert.assertEquals("2", $(SpanElement.class)
+                .id("PreserveOnRefreshNestedBeforeEnterView-before-enter-count")
+                .getText());
+    }
+}


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Fixes a bug where the stream of `BeforeEnterObserver`s could contain duplicates, causing extraneous calls to `BeforeEnterObserver::beforeEnter` for non-root components.

Fixes #12356

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
