### PR TITLE
fix: Render only one error page when trying to go to a view without access

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteNotFoundError.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteNotFoundError.java
@@ -77,7 +77,7 @@ public class RouteNotFoundError extends Component
         template = template.replace("{{additionalInfo}}", additionalInfo);
         template = template.replace("{{path}}", path);
 
-        getElement().appendChild(new Html(template).getElement());
+        getElement().setChild(0, new Html(template).getElement());
         return HttpServletResponse.SC_NOT_FOUND;
     }
 


### PR DESCRIPTION
The current behavior renders an additional error page below the current error page if an error occurs when navigating from the error page (which happens if you click on a view you do not have access to)