### PR TITLE
fix(Fusion): support PathPattern parsed mapping for endpoint prefix

### DIFF
--- a/fusion-endpoint/src/main/java/com/vaadin/fusion/FusionControllerConfiguration.java
+++ b/fusion-endpoint/src/main/java/com/vaadin/fusion/FusionControllerConfiguration.java
@@ -16,9 +16,8 @@
 
 package com.vaadin.fusion;
 
-import java.lang.reflect.Method;
-
 import javax.servlet.ServletContext;
+import java.lang.reflect.Method;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcRegistrations;
@@ -97,14 +96,9 @@ public class FusionControllerConfiguration {
      */
     private RequestMappingInfo prependEndpointPrefixUrl(
             RequestMappingInfo mapping) {
-        PatternsRequestCondition connectEndpointPattern = new PatternsRequestCondition(
-                fusionEndpointProperties.getVaadinEndpointPrefix())
-                        .combine(mapping.getPatternsCondition());
-
-        return new RequestMappingInfo(mapping.getName(), connectEndpointPattern,
-                mapping.getMethodsCondition(), mapping.getParamsCondition(),
-                mapping.getHeadersCondition(), mapping.getConsumesCondition(),
-                mapping.getProducesCondition(), mapping.getCustomCondition());
+        return mapping.mutate()
+                .paths(fusionEndpointProperties.getVaadinEndpointPrefix())
+                .build().combine(mapping);
     }
 
     /**

--- a/fusion-endpoint/src/main/java/com/vaadin/fusion/FusionControllerConfiguration.java
+++ b/fusion-endpoint/src/main/java/com/vaadin/fusion/FusionControllerConfiguration.java
@@ -23,7 +23,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcRegistrations;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.mvc.condition.PatternsRequestCondition;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 


### PR DESCRIPTION
Fixes compatibility with Spring Boot 2.6, which uses PathPattern matching.