### PR TITLE
Revert use maven plugin classloader as parent

### DIFF
--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/server/scanner/ReflectionsClassFinder.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/server/scanner/ReflectionsClassFinder.java
@@ -46,8 +46,7 @@ public class ReflectionsClassFinder implements ClassFinder {
      *            the list of urls for finding classes.
      */
     public ReflectionsClassFinder(URL... urls) {
-        classLoader = new URLClassLoader(urls,
-                ReflectionsClassFinder.class.getClassLoader()); // NOSONAR
+        classLoader = new URLClassLoader(urls, null); // NOSONAR
         ConfigurationBuilder configurationBuilder = new ConfigurationBuilder()
                 .addClassLoaders(classLoader).setExpandSuperTypes(false)
                 .addUrls(urls);

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/utils/LookupImpl.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/utils/LookupImpl.java
@@ -52,19 +52,32 @@ public class LookupImpl implements Lookup {
 
     @Override
     public <T> List<T> lookupAll(Class<T> serviceClass) {
-        // only services declared in flow-server may be used here
-        assert serviceClass.getClassLoader()
-                .equals(LookupImpl.class.getClassLoader());
-        Set<Class<? extends T>> subTypes = classFinder
-                .getSubTypesOf(serviceClass);
+        Set<?> subTypes = classFinder
+                .getSubTypesOf(loadClassFromClassFindler(serviceClass));
         List<T> result = new ArrayList<>(subTypes.size());
-        for (Class<? extends T> clazz : subTypes) {
-            if (!ReflectTools.isInstantiableService(clazz)) {
-                continue;
+        try {
+            for (Object clazz : subTypes) {
+                if (!ReflectTools.isInstantiableService((Class<?>) clazz)) {
+                    continue;
+                }
+                Class<?> serviceType = serviceClass.getClassLoader()
+                        .loadClass(((Class<?>) clazz).getName());
+                result.add(serviceClass
+                        .cast(ReflectTools.createInstance(serviceType)));
             }
-            result.add(serviceClass.cast(ReflectTools.createInstance(clazz)));
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException("Could not find service class", e);
         }
         return result;
+    }
+
+    private Class<?> loadClassFromClassFindler(Class<?> clz) {
+        try {
+            return classFinder.loadClass(clz.getName());
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException(
+                    "Could not load " + clz.getName() + " class", e);
+        }
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendWebComponentGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendWebComponentGenerator.java
@@ -82,14 +82,21 @@ public class FrontendWebComponentGenerator implements Serializable {
      */
     public Set<File> generateWebComponents(File outputDirectory,
             ThemeDefinition theme) {
-        Set<Class<?>> exporterRelatedClasses = new HashSet<>();
-        finder.getSubTypesOf(WebComponentExporter.class)
-                .forEach(exporterRelatedClasses::add);
-        finder.getSubTypesOf(WebComponentExporterFactory.class)
-                .forEach(exporterRelatedClasses::add);
-        final String themeName = theme == null ? "" : theme.getName();
-        return WebComponentModulesWriter.DirectoryWriter
-                .generateWebComponentsToDirectory(exporterRelatedClasses,
-                        outputDirectory, false, themeName);
+        try {
+            Set<Class<?>> exporterRelatedClasses = new HashSet<>();
+            finder.getSubTypesOf(WebComponentExporter.class.getName())
+                    .forEach(exporterRelatedClasses::add);
+            finder.getSubTypesOf(WebComponentExporterFactory.class.getName())
+                    .forEach(exporterRelatedClasses::add);
+            final String themeName = theme == null ? "" : theme.getName();
+            return WebComponentModulesWriter.DirectoryWriter
+                    .generateWebComponentsToDirectory(exporterRelatedClasses,
+                            outputDirectory, false, themeName);
+        } catch (ClassNotFoundException e) {
+            throw new IllegalStateException(
+                    "Unable to locate a required class using custom class "
+                            + "loader",
+                    e);
+        }
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendWebComponentGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendWebComponentGenerator.java
@@ -83,6 +83,8 @@ public class FrontendWebComponentGenerator implements Serializable {
     public Set<File> generateWebComponents(File outputDirectory,
             ThemeDefinition theme) {
         try {
+            final Class<?> writerClass = finder
+                    .loadClass(WebComponentModulesWriter.class.getName());
             Set<Class<?>> exporterRelatedClasses = new HashSet<>();
             finder.getSubTypesOf(WebComponentExporter.class.getName())
                     .forEach(exporterRelatedClasses::add);
@@ -90,8 +92,9 @@ public class FrontendWebComponentGenerator implements Serializable {
                     .forEach(exporterRelatedClasses::add);
             final String themeName = theme == null ? "" : theme.getName();
             return WebComponentModulesWriter.DirectoryWriter
-                    .generateWebComponentsToDirectory(exporterRelatedClasses,
-                            outputDirectory, false, themeName);
+                    .generateWebComponentsToDirectory(writerClass,
+                            exporterRelatedClasses, outputDirectory, false,
+                            themeName);
         } catch (ClassNotFoundException e) {
             throw new IllegalStateException(
                     "Unable to locate a required class using custom class "

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
@@ -254,31 +254,35 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
      * At the same time when the root level view is visited, compute the theme
      * to use and create its instance.
      *
+     * @throws ClassNotFoundException
+     * @throws IOException
      */
-    private void computeEndpoints() throws IOException {
+    private void computeEndpoints() throws ClassNotFoundException, IOException {
         // Because of different classLoaders we need compare against class
         // references loaded by the specific class finder loader
-        for (Class<?> route : getFinder().getAnnotatedClasses(Route.class)) {
+        Class<? extends Annotation> routeClass = getFinder()
+                .loadClass(Route.class.getName());
+        for (Class<?> route : getFinder().getAnnotatedClasses(routeClass)) {
             collectEndpoints(route);
         }
 
-        for (Class<?> initListener : getFinder()
-                .getSubTypesOf(UIInitListener.class)) {
+        for (Class<?> initListener : getFinder().getSubTypesOf(
+                getFinder().loadClass(UIInitListener.class.getName()))) {
             collectEndpoints(initListener);
         }
 
-        for (Class<?> initListener : getFinder()
-                .getSubTypesOf(VaadinServiceInitListener.class)) {
+        for (Class<?> initListener : getFinder().getSubTypesOf(getFinder()
+                .loadClass(VaadinServiceInitListener.class.getName()))) {
             collectEndpoints(initListener);
         }
 
-        for (Class<?> appShell : getFinder()
-                .getSubTypesOf(AppShellConfigurator.class)) {
+        for (Class<?> appShell : getFinder().getSubTypesOf(
+                getFinder().loadClass(AppShellConfigurator.class.getName()))) {
             collectEndpoints(appShell);
         }
 
-        for (Class<?> errorParameters : getFinder()
-                .getSubTypesOf(HasErrorParameter.class)) {
+        for (Class<?> errorParameters : getFinder().getSubTypesOf(
+                getFinder().loadClass(HasErrorParameter.class.getName()))) {
             collectEndpoints(errorParameters);
         }
 
@@ -410,13 +414,16 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
     /**
      * Visit all classes annotated with {@link NpmPackage} and update the list
      * of dependencies and their versions.
+     *
+     * @throws ClassNotFoundException
+     * @throws IOException
      */
-    private void computePackages() {
+    private void computePackages() throws ClassNotFoundException, IOException {
         FrontendAnnotatedClassVisitor npmPackageVisitor = new FrontendAnnotatedClassVisitor(
                 getFinder(), NpmPackage.class.getName());
 
         for (Class<?> component : getFinder()
-                .getAnnotatedClasses(NpmPackage.class)) {
+                .getAnnotatedClasses(NpmPackage.class.getName())) {
             npmPackageVisitor.visitClass(component.getName());
         }
 
@@ -439,15 +446,18 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
      * Find the class with a {@link com.vaadin.flow.server.PWA} annotation and
      * read it into a {@link com.vaadin.flow.server.PwaConfiguration} object.
      *
+     * @throws ClassNotFoundException
      */
-    private void computePwaConfiguration() {
+    private void computePwaConfiguration() throws ClassNotFoundException {
         FrontendAnnotatedClassVisitor pwaVisitor = new FrontendAnnotatedClassVisitor(
                 getFinder(), PWA.class.getName());
+        Class<?> appShellConfiguratorClass = getFinder()
+                .loadClass(AppShellConfigurator.class.getName());
 
         for (Class<?> hopefullyAppShellClass : getFinder()
-                .getAnnotatedClasses(PWA.class)) {
+                .getAnnotatedClasses(PWA.class.getName())) {
             if (!Arrays.asList(hopefullyAppShellClass.getInterfaces())
-                    .contains(AppShellConfigurator.class)) {
+                    .contains(appShellConfiguratorClass)) {
                 throw new IllegalStateException(ERROR_INVALID_PWA_ANNOTATION);
             }
             pwaVisitor.visitClass(hopefullyAppShellClass.getName());
@@ -500,14 +510,21 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
      *
      * @param clazz
      *            the exporter endpoint class
+     * @throws ClassNotFoundException
+     *             if unable to load a class by class name
      * @throws IOException
      *             if unable to scan the class byte code
      */
-    private void computeExporterEndpoints(Class<?> clazz) throws IOException {
+    @SuppressWarnings("unchecked")
+    private void computeExporterEndpoints(Class<?> clazz)
+            throws ClassNotFoundException, IOException {
         // Because of different classLoaders we need compare against class
         // references loaded by the specific class finder loader
+        Class<? extends Annotation> routeClass = getFinder()
+                .loadClass(Route.class.getName());
+        Class<?> exporterClass = getFinder().loadClass(clazz.getName());
         Set<? extends Class<?>> exporterClasses = getFinder()
-                .getSubTypesOf(clazz);
+                .getSubTypesOf(exporterClass);
 
         // if no exporters in the project, return
         if (exporterClasses.isEmpty()) {
@@ -525,7 +542,7 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
             }
 
             if (!Modifier.isAbstract(exporter.getModifiers())) {
-                visitComponenClass(Route.class, clazz, exportedPoints,
+                visitComponenClass(routeClass, exporterClass, exportedPoints,
                         exporter);
             }
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentModulesWriter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/webcomponent/WebComponentModulesWriter.java
@@ -19,13 +19,17 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.UncheckedIOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
 
@@ -150,6 +154,7 @@ public final class WebComponentModulesWriter implements Serializable {
      * by a different class loader than the code using the writer.
      */
     public static final class DirectoryWriter implements Serializable {
+        private static final String WRITE_MODULES_METHOD = "writeWebComponentsToDirectory";
 
         /**
          * Calls
@@ -157,6 +162,8 @@ public final class WebComponentModulesWriter implements Serializable {
          * via reflection on the supplied {@code writer}. The {@code writer} and
          * {@code exporterClasses} must be loaded with the same class loader.
          *
+         * @param writerClass
+         *            {@code WebComponentModulesWriter} class
          * @param exporterClasses
          *            set of
          *            {@link WebComponentExporter}/{@link WebComponentExporterFactory}
@@ -173,17 +180,30 @@ public final class WebComponentModulesWriter implements Serializable {
          *            not defined
          * @return generated files
          * @throws java.lang.NullPointerException
-         *             if {@code exporterClassSupplier}, or {@code
+         *             if {@code writerClassSupplier},
+         *             {@code exporterClassSupplier}, or {@code
          *             outputDirectory} is {@code null}
          * @throws java.lang.IllegalArgumentException
-         *             if {@link WebComponentModulesWriter} and
-         *             {@code exporterClasses} do not share a class loader
+         *             if {@code writer} is not
+         *             {@code WebComponentModulesWriter} class
+         * @throws java.lang.IllegalArgumentException
+         *             if {@code writerClass} and {@code exporterClasses} do not
+         *             share a class loader
+         * @throws java.lang.IllegalStateException
+         *             if the received {@code writer} does not have method
+         *             {@link #writeWebComponentsToDirectory(java.util.Set, java.io.File, boolean, java.lang.String)}
+         * @throws java.lang.RuntimeException
+         *             if reflective method invocation fails
          * @see #writeWebComponentsToDirectory(java.util.Set, java.io.File,
          *      boolean, java.lang.String)
          */
+        @SuppressWarnings("unchecked")
         public static Set<File> generateWebComponentsToDirectory(
-                Set<Class<?>> exporterClasses, File outputDirectory,
-                boolean compatibilityMode, String themeName) {
+                Class<?> writerClass, Set<Class<?>> exporterClasses,
+                File outputDirectory, boolean compatibilityMode,
+                String themeName) {
+            Objects.requireNonNull(writerClass,
+                    "Parameter 'writerClassSupplier' must not null");
             Objects.requireNonNull(exporterClasses,
                     "Parameter 'exporterClasses' must not be null");
             Objects.requireNonNull(outputDirectory,
@@ -194,37 +214,62 @@ public final class WebComponentModulesWriter implements Serializable {
              * bootstrap classloader - otherwise we'd have no way of ensuring
              * that the class loaders share parentage.
              */
-            ClassLoader writerClassLoader = WebComponentModulesWriter.class
-                    .getClassLoader();
             for (Class<?> exporterClass : exporterClasses) {
-                ClassLoader exporterClassLoader = exporterClass
-                        .getClassLoader();
                 if (!ReflectTools.findClosestCommonClassLoaderAncestor(
-                        writerClassLoader, exporterClassLoader).isPresent()) {
-                    String writerClassLoaderName = writerClassLoader == null
-                            ? "null"
-                            : writerClassLoader.getClass().getName();
-
-                    String exporterClassLoaderName = exporterClassLoader == null
-                            ? "null"
-                            : exporterClassLoader.getClass().getName();
-
+                        writerClass.getClassLoader(),
+                        exporterClass.getClassLoader()).isPresent()) {
                     throw new IllegalArgumentException(String.format(
                             "Supplied writer '%s' and "
                                     + "supplied exporter '%s' have different "
                                     + "class loaders, '%s' and '%s', "
                                     + "respectively. Writer and exporters "
                                     + "must share a class loader.",
-                            WebComponentModulesWriter.class.getName(),
-                            exporterClass.getName(), writerClassLoaderName,
-                            exporterClassLoaderName));
+                            writerClass.getName(), exporterClass.getName(),
+                            writerClass.getClassLoader().getClass().getName(),
+                            exporterClass.getClassLoader().getClass()
+                                    .getName()));
                 }
             }
 
-            return WebComponentModulesWriter.writeWebComponentsToDirectory(
-                    exporterClasses, outputDirectory, compatibilityMode,
-                    themeName);
+            if (!WebComponentModulesWriter.class.getName()
+                    .equals(writerClass.getName())) { // NOSONAR
+                throw new IllegalArgumentException(
+                        "Argument 'writer' should be a class of '"
+                                + WebComponentModulesWriter.class.getName()
+                                + "' but it is '" + writerClass.getName()
+                                + "'");
+            }
+            Method writeMethod = getMethod(writerClass, WRITE_MODULES_METHOD)
+                    .orElseThrow(() -> new IllegalStateException(String.format(
+                            "Could not locate locate method '%s' on the "
+                                    + "received writer '%s'.",
+                            WRITE_MODULES_METHOD, writerClass.getName())));
+            try {
+                final boolean accessible = writeMethod.isAccessible();
+                writeMethod.setAccessible(true);
+                Set<File> files = ((Set<File>) writeMethod.invoke(null,
+                        exporterClasses, outputDirectory, compatibilityMode,
+                        themeName));
+                writeMethod.setAccessible(accessible);
+                return files;
+            } catch (IllegalAccessException exception) {
+                throw new RuntimeException("Failed to call '"
+                        + WRITE_MODULES_METHOD
+                        + "' via reflection because Java language access control doesn't allow to call it",
+                        exception);
+            } catch (InvocationTargetException exception) {
+                throw new RuntimeException(
+                        "Could not write exported web component module because of exception: "
+                                + exception.getCause().getMessage(),
+                        exception.getCause());
+            }
         }
 
+        private static Optional<Method> getMethod(Class<?> writerClass,
+                String methodName) {
+            return Stream.of(writerClass.getDeclaredMethods())
+                    .filter(method -> method.getName().equals(methodName))
+                    .findFirst();
+        }
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScannerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScannerTest.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -87,12 +88,20 @@ public class FullDependenciesScannerTest {
 
     }
 
+    @Before
+    public void setUp() throws ClassNotFoundException {
+        Mockito.when(finder.loadClass(AbstractTheme.class.getName()))
+                .thenReturn((Class) AbstractTheme.class);
+    }
+
     @Test
     public void getTheme_noExplicitTheme_lumoThemeIsDiscovered()
             throws ClassNotFoundException {
         FrontendDependenciesScanner scanner = setUpThemeScanner(
                 Collections.emptySet(), Collections.emptySet(),
                 (type, annotationType) -> Collections.emptyList());
+
+        Mockito.verify(finder).loadClass(AbstractTheme.class.getName());
 
         Assert.assertNotNull(scanner.getTheme());
         Assert.assertEquals("foo", scanner.getTheme().getBaseUrl());
@@ -112,6 +121,8 @@ public class FullDependenciesScannerTest {
                         NoThemeComponent1.class)),
                 (type, annotationType) -> Collections.emptyList());
 
+        Mockito.verify(finder).loadClass(AbstractTheme.class.getName());
+
         Assert.assertNull(scanner.getTheme());
         Assert.assertNull(scanner.getThemeDefinition());
         Assert.assertEquals(0, scanner.getClasses().size());
@@ -126,6 +137,8 @@ public class FullDependenciesScannerTest {
         FrontendDependenciesScanner scanner = setUpThemeScanner(
                 getAnnotatedClasses(Theme.class), Collections.emptySet(),
                 (type, annotationType) -> findAnnotations(type, Theme.class));
+
+        Mockito.verify(finder).loadClass(AbstractTheme.class.getName());
 
         Assert.assertNotNull(scanner.getTheme());
         Assert.assertEquals("theme/lumo/", scanner.getTheme().getThemeUrl());
@@ -264,12 +277,25 @@ public class FullDependenciesScannerTest {
     @Test
     public void getModules_explcitTheme_returnAllModulesExcludingNotUsedTheme_getClassesReturnAllModuleAnnotatedComponents()
             throws ClassNotFoundException {
-        Mockito.when(finder.getAnnotatedClasses(JsModule.class))
+        // use this fake/mock class for the loaded class to check that annotated
+        // classes are requested for the loaded class and not for the
+        // annotationType
+        Class clazz = Object.class;
+
+        Mockito.when(finder.loadClass(JsModule.class.getName()))
+                .thenReturn(clazz);
+
+        Mockito.when(finder.getAnnotatedClasses(clazz))
                 .thenReturn(getAnnotatedClasses(JsModule.class));
+
+        Class themeClass = Throwable.class;
+
+        Mockito.when(finder.loadClass(Theme.class.getName()))
+                .thenReturn(themeClass);
 
         Set<Class<?>> themeClasses = getAnnotatedClasses(Theme.class);
         themeClasses.add(FakeLumoTheme.class);
-        Mockito.when(finder.getAnnotatedClasses(Theme.class))
+        Mockito.when(finder.getAnnotatedClasses(themeClass))
                 .thenReturn(themeClasses);
         Assert.assertTrue(themeClasses.size() >= 2);
 
@@ -279,11 +305,18 @@ public class FullDependenciesScannerTest {
                 .thenReturn((Class) FakeLumoTheme.class);
 
         FrontendDependenciesScanner scanner = new FullDependenciesScanner(
-                finder, this::findAnnotations, false);
+                finder, (type, annotation) -> {
+                    if (annotation.equals(clazz)) {
+                        return findAnnotations(type, JsModule.class);
+                    } else if (annotation.equals(themeClass)) {
+                        return findAnnotations(type, Theme.class);
+                    }
+                    Assert.fail();
+                    return null;
+                }, false);
 
         List<String> modules = scanner.getModules();
         Assert.assertEquals(23, modules.size());
-
         assertJsModules(modules);
 
         // Theme modules should be included now
@@ -341,7 +374,15 @@ public class FullDependenciesScannerTest {
     private FullDependenciesScanner setUpAnnotationScanner(
             Class<? extends Annotation> annotationType)
             throws ClassNotFoundException {
-        Mockito.when(finder.getAnnotatedClasses(annotationType))
+        // use this fake/mock class for the loaded class to check that annotated
+        // classes are requested for the loaded class and not for the
+        // annotationType
+        Class clazz = Object.class;
+
+        Mockito.when(finder.loadClass(annotationType.getName()))
+                .thenReturn(clazz);
+
+        Mockito.when(finder.getAnnotatedClasses(clazz))
                 .thenReturn(getAnnotatedClasses(annotationType));
 
         return new FullDependenciesScanner(finder,
@@ -353,9 +394,17 @@ public class FullDependenciesScannerTest {
             Set<Class<?>> themedClasses, Set<Class<?>> noThemeClasses,
             SerializableBiFunction<Class<?>, Class<? extends Annotation>, List<? extends Annotation>> annotationFinder)
             throws ClassNotFoundException {
-        Mockito.when(finder.getAnnotatedClasses(Theme.class))
+        Class fakeThemeClass = Object.class;
+        Class fakeNoThemeClass = Throwable.class;
+
+        Mockito.when(finder.loadClass(Theme.class.getName()))
+                .thenReturn(fakeThemeClass);
+        Mockito.when(finder.loadClass(NoTheme.class.getName()))
+                .thenReturn(fakeNoThemeClass);
+
+        Mockito.when(finder.getAnnotatedClasses(fakeThemeClass))
                 .thenReturn(themedClasses);
-        Mockito.when(finder.getAnnotatedClasses(NoTheme.class))
+        Mockito.when(finder.getAnnotatedClasses(fakeNoThemeClass))
                 .thenReturn(noThemeClasses);
 
         return new FullDependenciesScanner(finder, annotationFinder, false) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FullScannerPwaTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FullScannerPwaTest.java
@@ -6,19 +6,33 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.junit.Test;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.server.PWA;
 import com.vaadin.flow.server.PwaConfiguration;
+import com.vaadin.flow.server.frontend.scanner.samples.pwa.AnotherAppShellWithPwa;
+import com.vaadin.flow.server.frontend.scanner.samples.pwa.AppShellWithPwa;
+import com.vaadin.flow.server.frontend.scanner.samples.pwa.AppShellWithoutPwa;
+import com.vaadin.flow.server.frontend.scanner.samples.pwa.NonAppShellWithPwa;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 public class FullScannerPwaTest extends AbstractScannerPwaTest {
     private ClassFinder finder = Mockito.mock(ClassFinder.class);
 
-    @Override
     protected PwaConfiguration getPwaConfiguration(Class<?>... classes)
             throws Exception {
+        // use this fake/mock class for the loaded class to check that annotated
+        // classes are requested for the loaded class and not for the
+        // annotationType
+        Class clazz = Object.class;
+
+        Mockito.doReturn(clazz).when(finder).loadClass(PWA.class.getName());
+
         Mockito.doReturn(getPwaAnnotatedClasses(classes)).when(finder)
-                .getAnnotatedClasses(PWA.class);
+                .getAnnotatedClasses(clazz);
 
         FullDependenciesScanner fullDependenciesScanner = new FullDependenciesScanner(
                 finder, (type, annotation) -> findPwaAnnotations(type), false);

--- a/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/WebComponentModulesWriterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/webcomponent/WebComponentModulesWriterTest.java
@@ -50,6 +50,7 @@ public class WebComponentModulesWriterTest {
     public void directoryWriter_generateWebComponentsToDirectory_canCallMethodReflectively_js() {
         Set<File> files = WebComponentModulesWriter.DirectoryWriter
                 .generateWebComponentsToDirectory(
+                        WebComponentModulesWriter.class,
                         Collections.singleton(MyExporter.class),
                         outputDirectory, false, null);
 
@@ -62,6 +63,7 @@ public class WebComponentModulesWriterTest {
     public void directoryWriter_generateWebComponentsToDirectoryUsingFactory_canCallMethodReflectively_js() {
         Set<File> files = WebComponentModulesWriter.DirectoryWriter
                 .generateWebComponentsToDirectory(
+                        WebComponentModulesWriter.class,
                         Collections.singleton(ExporterFactory.class),
                         outputDirectory, false, null);
 
@@ -74,6 +76,7 @@ public class WebComponentModulesWriterTest {
     public void directoryWriter_generateWebComponentsToDirectory_canCallMethodReflectively_html() {
         Set<File> files = WebComponentModulesWriter.DirectoryWriter
                 .generateWebComponentsToDirectory(
+                        WebComponentModulesWriter.class,
                         Collections.singleton(MyExporter.class),
                         outputDirectory, true, null);
 
@@ -86,6 +89,7 @@ public class WebComponentModulesWriterTest {
     public void directoryWriter_generateWebComponentsToDirectoryUsingFactory_canCallMethodReflectively_html() {
         Set<File> files = WebComponentModulesWriter.DirectoryWriter
                 .generateWebComponentsToDirectory(
+                        WebComponentModulesWriter.class,
                         Collections.singleton(ExporterFactory.class),
                         outputDirectory, true, null);
 
@@ -97,24 +101,45 @@ public class WebComponentModulesWriterTest {
     @Test
     public void directoryWriter_generateWebComponentsToDirectory_zeroExportersCreatesZeroFiles() {
         Set<File> files = WebComponentModulesWriter.DirectoryWriter
-                .generateWebComponentsToDirectory(new HashSet<>(),
+                .generateWebComponentsToDirectory(
+                        WebComponentModulesWriter.class, new HashSet<>(),
                         outputDirectory, false, null);
 
         Assert.assertEquals("No files were created", 0, files.size());
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void directoryWriter_generateWebComponentsToDirectory_nonWriterClassThrows() {
+        exception.expect(IllegalArgumentException.class);
+        // end of the exception
+        exception.expectMessage(
+                "but it is '" + MyComponent.class.getName() + "'");
+        Set<File> files = WebComponentModulesWriter.DirectoryWriter
+                .generateWebComponentsToDirectory(MyComponent.class,
+                        new HashSet<>(), outputDirectory, false, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void directoryWriter_generateWebComponentsToDirectory_nullWriterThrows() {
+        Set<File> files = WebComponentModulesWriter.DirectoryWriter
+                .generateWebComponentsToDirectory(null, new HashSet<>(),
+                        outputDirectory, false, null);
+    }
+
     @Test(expected = NullPointerException.class)
     public void directoryWriter_generateWebComponentsToDirectory_nullExporterSetThrows() {
         Set<File> files = WebComponentModulesWriter.DirectoryWriter
-                .generateWebComponentsToDirectory(null, outputDirectory, false,
-                        null);
+                .generateWebComponentsToDirectory(
+                        WebComponentModulesWriter.class, null, outputDirectory,
+                        false, null);
     }
 
     @Test(expected = NullPointerException.class)
     public void directoryWriter_generateWebComponentsToDirectory_nullOutputDirectoryThrows() {
         Set<File> files = WebComponentModulesWriter.DirectoryWriter
-                .generateWebComponentsToDirectory(new HashSet<>(), null, false,
-                        null);
+                .generateWebComponentsToDirectory(
+                        WebComponentModulesWriter.class, new HashSet<>(), null,
+                        false, null);
     }
 
     /*


### PR DESCRIPTION
Do not squash!

This reverts commit 51837be415104765231ae072e725a024f1ea658d and fd22ee99cba158ba8e261e33f8e8f554904706c2  due to Maven plugin classloader throwing ClassNotFoundException for Spring classes during class scanning.