### PR TITLE
chore: Upgrade jaxb

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
         <jackson.version>2.13.0</jackson.version>
         <validation.api.version>2.0.1.Final</validation.api.version>
         <javax.annotation.api.version>1.3.2</javax.annotation.api.version>
+        <jaxb.version>2.3.0.1</jaxb.version>
 
         <!-- Plugins -->
         <driver.binary.downloader.maven.plugin.version>1.0.18</driver.binary.downloader.maven.plugin.version>
@@ -663,17 +664,17 @@
                                 <dependency>
                                     <groupId>javax.xml.bind</groupId>
                                     <artifactId>jaxb-api</artifactId>
-                                    <version>2.2.11</version>
+                                    <version>2.3.1</version>
                                 </dependency>
                                 <dependency>
                                     <groupId>com.sun.xml.bind</groupId>
                                     <artifactId>jaxb-core</artifactId>
-                                    <version>2.2.11</version>
+                                    <version>${jaxb.version}</version>
                                 </dependency>
                                 <dependency>
                                     <groupId>com.sun.xml.bind</groupId>
                                     <artifactId>jaxb-impl</artifactId>
-                                    <version>2.3.5</version>
+                                    <version>${jaxb.version}</version>
                                 </dependency>
                                 <dependency>
                                     <groupId>com.sun.activation</groupId>


### PR DESCRIPTION
Should remove the warning

The POM for com.sun.xml.bind:jaxb-core:jar:2.2.11 is invalid, transitive dependencies (if any) will not be available, enable debug logging for more details
