### PR TITLE
fix: output version string when version parsing fails

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -975,20 +975,22 @@ public class FrontendUtils {
 
     protected static FrontendVersion getVersion(String tool,
             List<String> versionCommand) throws UnknownVersionException {
+        String output;
         try {
-            String output = executeCommand(versionCommand);
-            try {
-                return new FrontendVersion(parseVersionString(output));
-            } catch (IOException e) {
-                throw new UnknownVersionException(tool,
-                        "Expected a version number as output but got '" + output
-                                + "'" + " when using command "
-                                + String.join(" ", versionCommand),
-                        e);
-            }
+            output = executeCommand(versionCommand);
         } catch (CommandExecutionException e) {
             throw new UnknownVersionException(tool,
                     "Using command " + String.join(" ", versionCommand), e);
+        }
+
+        try {
+            return new FrontendVersion(parseVersionString(output));
+        } catch (IOException e) {
+            throw new UnknownVersionException(tool,
+                    "Expected a version number as output but got '" + output
+                            + "'" + " when using command "
+                            + String.join(" ", versionCommand),
+                    e);
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -977,8 +977,16 @@ public class FrontendUtils {
             List<String> versionCommand) throws UnknownVersionException {
         try {
             String output = executeCommand(versionCommand);
-            return new FrontendVersion(parseVersionString(output));
-        } catch (IOException | CommandExecutionException e) {
+            try {
+                return new FrontendVersion(parseVersionString(output));
+            } catch (IOException e) {
+                throw new UnknownVersionException(tool,
+                        "Expected a version number as output but got '" + output
+                                + "'" + " when using command "
+                                + String.join(" ", versionCommand),
+                        e);
+            }
+        } catch (CommandExecutionException e) {
             throw new UnknownVersionException(tool,
                     "Using command " + String.join(" ", versionCommand), e);
         }


### PR DESCRIPTION
This should ease debugging of problems like "UnknownVersionException: Unable to detect version of pnpm"
