### PR TITLE
Revert "chore(deps-dev): bump org.eclipse.core.contenttype from 3.7.1000 to 3.8.100"

### DIFF
--- a/flow-client/pom.xml
+++ b/flow-client/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>org.eclipse.platform</groupId>
             <artifactId>org.eclipse.core.contenttype</artifactId>
-            <version>3.8.100</version>
+            <version>3.7.1000</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Reverts vaadin/flow#12540

Needs [bump of java](https://github.com/vaadin/flow/pull/12440) previous to this .