### PR TITLE
Bump TypeScript to 4.5.3

### DIFF
--- a/flow-client/package.json
+++ b/flow-client/package.json
@@ -44,7 +44,7 @@
     "prettier": "2.2.1",
     "sinon": "7.5.0",
     "sinon-chai": "3.6.0",
-    "typescript": "4.0.3",
+    "typescript": "4.5.3",
     "webpack": "4.46.0",
     "webpack-cli": "3.3.12",
     "workbox-core": "5.1.4",

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -383,7 +383,7 @@ public abstract class NodeUpdater implements FallibleCommand {
     Map<String, String> getDefaultDevDependencies() {
         Map<String, String> defaults = new HashMap<>();
 
-        defaults.put("typescript", "4.4.3");
+        defaults.put("typescript", "4.5.3");
 
         final String WORKBOX_VERSION = "6.4.2";
 


### PR DESCRIPTION
A customer has been using `this.shadowRoot?.elementFromPoint` method which got broken in TS 4.4 (Vaadin 21) due to lib DOM type definition changes. In V22 with TS 4.4 it requires additional casting workaround to be able to call that method. This should be resolved by upgrading to TS 4.5 ([change in TS](https://github.com/microsoft/TypeScript-DOM-lib-generator/pull/1123)). Related: https://github.com/WICG/webcomponents/issues/661#issuecomment-992262771