### PR TITLE
test: add script for better control of module/test splitting 

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -3,6 +3,9 @@ on: [pull_request, workflow_dispatch]
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      matrix-unit: ${{ steps.set-matrix.outputs.matrix-unit }}
+      matrix-it: ${{ steps.set-matrix.outputs.matrix-it }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -12,60 +15,34 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
-      - name: Show Versions
+      - name: Set flow version to 999.99-SNAPSHOT
         run: |
-          uname -a
-          id
-          pwd
-          type java && java -version
-          type mvn && mvn -version
-          type node && node --version
-          type npm && npm --version
-      - name: Set flow version and Generate module lists
+          ./scripts/computeMatrix.js set-version --version=999.99-SNAPSHOT
+      - name: Generate matrices
+        id: set-matrix
         run: |
-          # run 3 maven process at the same time and wait for them, saves half minute
-          mvn -B -q -DnewVersion=999.99-SNAPSHOT versions:set -T 1C &
-          P1=$!
-          mvn help:evaluate -Dexpression=project.modules -DskipTests -Prun-tests \
-            | grep "<\/string>" \
-            | grep -v flow-tests \
-            | sed -e 's, *<string>\(.*\)</string>,\1,g' \
-            | sort > flow.modules &
-          P2=$!
-          mvn help:evaluate -B -Dexpression=project.modules -pl flow-tests -DskipTests -Prun-tests 2>/dev/null \
-            | grep "<\/string>" \
-            | sed -e 's, *<string>\(.*\)</string>,flow-tests/\1,g' \
-            | grep -v "test-ccdm$" \
-            | grep -v "test-pwa" \
-            | grep -v "test-root-context" \
-            | grep -v "test-root-ui-context" \
-            | grep -v "test-mixed/pom-pnpm-production" \
-            | grep -v "test-mixed/pom-npm-production" \
-            | sort > it.modules &
-          P3=$!
-          wait $P1 $P2 $P3
+          echo "::set-output name=matrix-unit::$(./scripts/computeMatrix.js unit-tests --parallel=2 current module args)"
+          echo "::set-output name=matrix-it::$(./scripts/computeMatrix.js it-tests --parallel=11 current module args)"
       - name: Compile and Install Flow
         run: |
-          # exclude gradle plugin not needed until gradle tests
           cmd="mvn install -B -DskipTests -pl \!flow-plugins/flow-gradle-plugin"
-          # run twice if fails, it might be multithread failure
+          # run twice if fails, it might be a multithread failure
           eval $cmd -T 2C -q || eval $cmd
       - name: Save workspace
         run: |
           mv ~/.m2/ .
-          tar cf workspace.tar .m2 *.modules `find . -name target -o -name "pom*.xml"`
+          tar cf workspace.tar .m2 `find . -name target -o -name "pom*.xml"`
       - uses: actions/upload-artifact@v2
         with:
           name: saved-workspace
           path: workspace.tar
   unit-tests:
     needs: build
+    outputs:
+      failure: ${{steps.set-failure.outputs.failure}}
     strategy:
       fail-fast: false
-      matrix:
-        modules:
-          - 'flow-client,fusion-endpoint,flow-jandex,flow-plugins/flow-plugin-base,flow-plugins/flow-maven-plugin,flow-plugins/flow-gradle-plugin'
-          - 'flow-server,flow-data,flow,flow-bom,vaadin-dev-server,flow-component-demo-helpers,flow-dnd,flow-html-components,flow-html-components-testbench,flow-lit-template,flow-polymer-template,flow-push,flow-server-production-mode,flow-test-generic,flow-test-util'
+      matrix: ${{fromJson(needs.build.outputs.matrix-unit)}}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -82,27 +59,29 @@ jobs:
           rm -rf ~/.m2 && mv -f .m2 ~/
       - name: Unit Test
         run: |
-          mvn -B verify -fae -T 1C \
-            -Dsurefire.rerunFailingTestsCount=2 \
-            -pl ${{ matrix.modules }}
+          echo Running TESTS: ${{ strategy.job-index }} ${{matrix.module}} ${{ matrix.args }}
+          [ -n "${{matrix.module}}" ] && \
+            ARGS="-pl ${{matrix.module}} -Dtest=${{matrix.args}}" || \
+            ARGS="-pl ${{matrix.args}}"
+          cmd="mvn -B -T 1C $ARGS"
+          set -x
+          $cmd -T 1C verify || $cmd -fae clean verify
+      - name: Set build status flag
+        id: set-failure
+        if: ${{ failure() }}
+        run: echo "::set-output name=failure::true"
       - uses: actions/upload-artifact@v2
-        if: always()
+        if: ${{ failure() || success() }}
         with:
           name: test-reports
           path: "**/target/*-reports/*"
   it-tests:
     needs: build
+    outputs:
+      failure: ${{steps.set-failure.outputs.failure}}
     strategy:
       fail-fast: false
-      matrix:
-        parallelism: [6]
-        current: [0, 1, 2, 3, 4, 5,
-        'test-ccdm,test-mixed/pom-pnpm-production.xml,test-pwa',
-        'test-root-ui-context,test-mixed/pom-npm-production.xml,test-pwa/pom-production.xml',
-        'test-root-context:0',
-        'test-root-context:1',
-        'test-root-context:2'
-        ]
+      matrix: ${{fromJson(needs.build.outputs.matrix-it)}}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -130,73 +109,34 @@ jobs:
           TB_LICENSE=${{secrets.TB_LICENSE}}
           mkdir -p ~/.vaadin/
           echo '{"username":"'`echo $TB_LICENSE | cut -d / -f1`'","proKey":"'`echo $TB_LICENSE | cut -d / -f2`'"}' > ~/.vaadin/proKey
-      - name: Compute Modules
-        run: |
-          case "${{matrix.current}}" in
-            *:*)
-              MAX=3
-              M="flow-tests/"`echo "${{matrix.current}}" | cut -d : -f1`
-              N=`echo "${{matrix.current}}" | cut -d : -f2`
-              H=`find $M/src/test -name "*IT.java" | xargs basename -s .java`
-              C=`echo "$H" | wc -l`
-              J=`echo "$C / $MAX" | bc`
-              I=`echo "$J * $N + 1" | bc`
-              T=`echo "$H" | tail +$I | head -$J`
-              A=`echo "$T" | grep ... | tr '\n' ',' | sed -e 's/,$//'`
-              A="-pl $M -Dit.test=$A -Dfailsafe.forkCount=4"
-              ;;
-            *test*)
-              M=`echo "flow-tests/${{matrix.current}}" | sed -e 's|,|,flow-tests/|g'`
-              A="-pl $M -Dfailsafe.forkCount=4"
-              ;;
-            *)
-              P="${{matrix.parallelism}}"
-              N="${{matrix.current}}"
-              H=`cat it.modules`
-              C=`echo "$H" | wc -l`
-              J=`echo "$C / $P" | bc`
-              I=`echo "$J * $N + 1" | bc`
-              M=`echo "$H" | tail +$I | head -$J`
-              A=`echo "$M" | grep ... | tr '\n' ',' | sed -e 's/,$//'`
-              [ -n "$A" ] && A="-pl $A"
-              ;;
-          esac
-          echo "MODULES:"
-          echo "$M"
-          echo "TESTS:"
-          echo "$T"
-          echo "ARGS:"
-          echo "$A"
-          echo "$A" > it.args
       - name: Install required modules
         run: |
-          if grep -q test-fusion-csrf-context it.args; then
+          if echo ${{matrix.args}} | grep -q test-fusion-csrf-context; then
             mvn -B -q install -DskipITs -pl flow-tests/test-fusion-csrf
           fi
       - name: Run ITs
         run: |
-          ARGS=`cat it.args`
-          echo "$ARGS"
-          if [ -n "$ARGS" ]; then
-            set -x
-            mvn verify -fae -V -B -e \
-              -Dcom.vaadin.testbench.Parameters.testsInParallel=5 \
-              -Dfailsafe.rerunFailingTestsCount=2 \
-              $ARGS
-          fi
+          echo TESTING: ${{ strategy.job-index }} ${{matrix.module}} ${{ matrix.args }}
+          [ -n "${{matrix.module}}" ] && \
+            ARGS="-Dfailsafe.forkCount=4 -pl ${{matrix.module}} -Dit.test=${{matrix.args}}" || \
+            ARGS="-pl ${{matrix.args}}"
+          cmd="mvn -V -B -e -Dcom.vaadin.testbench.Parameters.testsInParallel=5 $ARGS"
+          set -x
+          eval $cmd verify -fae -Dfailsafe.rerunFailingTestsCount=2 || eval $cmd clean verify
+      - name: Set build status flag
+        id: set-failure
+        if: ${{ failure() }}
+        run: echo "::set-output name=failure::true"
       - uses: actions/upload-artifact@v2
-        if: always()
+        if: ${{ failure() || success() }}
         with:
           name: test-reports
           path: |
             **/target/*-reports/*
             **/error-screenshots/*.png
-            **/target/site/*-report.html
   test-results:
-    if: always()
-    needs:
-      - unit-tests
-      - it-tests
+    if: ${{ failure() || success() }}
+    needs: [unit-tests, it-tests]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v2
@@ -209,9 +149,7 @@ jobs:
       - uses: geekyeggo/delete-artifact@v1
         with:
           name: saved-workspace
-      - name: The Build has Failed
-        if: ${{ failure() || cancelled() }}
-        run: exit 1
-      - name: The Build has Succeeded
-        if: ${{ success() }}
-        run: exit 0
+      - name: Check Failure Status
+        run: |
+          fail="${{ needs.unit-tests.outputs.failure }}${{ needs.it-tests.outputs.failure }}"
+          [ -n "$fail" ] && echo "!! THERE ARE TEST MODULES WITH FAILURES !!" >&2 && exit 1 || exit 0

--- a/scripts/computeMatrix.js
+++ b/scripts/computeMatrix.js
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+const exec = require('util').promisify(require('child_process').exec);
+const fs = require("fs");
+
+/****************** START CONFIG */
+const globalExclusions = ['flow-tests'];
+// Set modules or tests weights and fixed slice position for better distribution
+//  weight: can be time in minutes, default 1
+//  pos:    from 1 to parallel (default fastest based in weigth)
+const moduleWeights = {
+  'flow-client': {weight: 9},
+  'flow-server': {weight: 4},
+  'vaadin-dev-server': {weight: 3},
+  'fusion-end-point': {weight: 3},
+  'flow-tests/test-ccdm': {pos: 1},
+  'flow-tests/test-mixed/pom-pnpm-production.xml': {pos: 1},
+  'flow-tests/test-pwa' : {pos: 1},
+  'flow-tests/test-root-ui-context': {pos: 2},
+  'flow-tests/test-mixed/pom-npm-production.xml': {pos: 2},
+  'flow-tests/test-pwa/pom-production.xml': {pos: 2},
+  'flow-tests/test-ccdm-flow-navigation': {pos: 2},
+  'flow-tests/test-fusion-csrf-context': {pos: 3},
+  'flow-tests/test-v14-bootstrap': {pos: 4},
+  'flow-tests/test-fusion-csrf': {pos: 5, weight: 20}
+}
+// Set split number for modules with several tests
+const moduleSplits = {
+  'flow-tests/test-root-context': 3
+}
+/****************** END CONFIG */
+
+// Using regex to avoid having to run `npm install` for xml libs.
+const regexComment = /<!--[\s\S]+?-->/gm;
+const regexModule = /([\s\S]*?)<module>([\s\S]*?)<\/module>([\s\S]*)/;
+const regexVersion = '(<version>)(VERSION)(</version>)';
+
+/**
+ * 10 seconds faster than `mvn help:evaluate -Dexpression=project.modules`
+ */
+function getModules(pomFile, prefix) {
+  prefix = prefix || '';
+  const modules = [];
+  
+  const content = fs.readFileSync(prefix + pomFile).toString().replace(regexComment, '');
+  let res = regexModule.exec(content);
+  while(res) {
+    modules.push(prefix + res[2]);
+    res = regexModule.exec(res[3]);
+  }
+  return modules;
+}
+
+/**
+ * Returns a list of files in a folder matching a pattern
+ */
+function getFiles(files, folder, pattern) {
+  fs.readdirSync(folder).forEach(file => {
+    file = folder + '/' + file;
+    if (fs.lstatSync(file).isDirectory()) {
+      files.concat(getFiles(files, file, pattern))
+    } else if (pattern.test(file)) {
+      files.push(file);
+    }
+  });
+  return files;
+}
+
+/**
+ * 30 seconds faster than `mvn versions:set -DnewVersion=...`
+ */
+function setVersion(newVersion) {
+  const pomContent = fs.readFileSync('pom.xml').toString();
+  const current = RegExp(regexVersion.replace('VERSION', '\\d+\\.\\d+\\-SNAPSHOT')).exec(pomContent)[2];
+  if (current && current != newVersion) {
+    const regexChangeVersion = RegExp(regexVersion.replace('VERSION', current), 'g');
+    const files = getFiles([], '.', /.*\/pom.*\.xml$/);
+    files.forEach(file => {
+      console.log(`Replacing ${current} to ${newVersion} in ${file}`);
+      const content = fs.readFileSync(file).toString();
+      const newContent = content.replace(regexChangeVersion, '$1' + newVersion + '$3');
+      fs.writeFileSync(file, newContent)
+    });
+  }
+}
+
+/**
+ * return a list of file names removing path and extension
+ */
+function getTestFiles(folder, pattern) {
+  return getFiles([], folder, pattern)
+    .map(f => f.replace(/^.*\//, '').replace(/\..*?$/, '')).sort();
+}
+
+/**
+ * remove excluded elements from array
+ */
+function grep(array, exclude) {
+  return array.filter(item => !exclude.includes(item));
+}
+
+function sumWeights(items, slowMap) {
+  return items.reduce((prev, curr) => prev + (slowMap[curr] && slowMap[curr].weight || 1), 0);
+}
+
+/**
+ * return the slice with lower sum of weights
+ */
+function getFasterSlice(item, parts, slowMap) {
+  return slowMap[item] && slowMap[item].pos && parts[slowMap[item].pos - 1]
+    ? parts[slowMap[item].pos - 1]
+    : parts.reduce((previous, current) =>
+      sumWeights(previous, slowMap) < sumWeights(current, slowMap) ? previous : current,
+      parts[0]);
+}
+
+/**
+ * splits an array of modules in the desired slices based on weights defined in a map
+ */
+function splitArray(array, slices, slowMap) {
+  const items = [...array];
+  const nItems = items.length;
+  slices = Math.min(slices, nItems);
+
+  const parts = [...new Array(slices)].map(_ => []);
+
+  const slows = Object.keys(slowMap)
+    .sort((a,b) => slowMap[b].weight - slowMap[a].weight)
+    .filter(e => items.includes(e));
+
+  for (i = 0; i < slows.length; i++) {
+    const item = slows[i];
+    getFasterSlice(item, parts, slowMap).push(item);
+    items.splice(items.indexOf(item), 1)
+  }
+
+  for (i = 0; i < items.length; i++) {
+    const item = items[i];
+    getFasterSlice(item, parts, slowMap).push(item);
+  }
+  return parts;
+}
+
+/**
+ * convert the sliced data to a JS object
+ */
+function toObject(parts, suite, module, prevIdx) {
+  const object = [];
+  parts.forEach((items, idx, arr) => {
+    const current = prevIdx + idx + 1;
+    const total = arr.length;
+    const name = `${suite} (${total}, ${current})`;
+    const args = items.join(',');
+    const weight = sumWeights(items, moduleWeights);
+    const matrix = [arr.length, prevIdx + idx + 1]
+    object.push({total, current, weight, suite, module, name, args, items, matrix});
+  });
+  return object;
+}
+
+/**
+ * The main function to visit pom files and tests based on configuration and produce
+ * the object json for actions
+ */
+function getParts(suite, prefix, slices) {
+  let modules = getModules('pom.xml', prefix);
+  const exclusions = Object.keys(moduleSplits).filter(module => modules.includes(module));
+  modules = grep(modules, exclusions);
+
+  const excSlices = exclusions.reduce((prev, module) => prev + moduleSplits[module], 0);
+  const parts = splitArray(modules, slices - excSlices, moduleWeights);
+
+  let object = toObject(parts, suite, '', 0);
+
+  const testRegex = RegExp(`.*${suite == 'it-tests' ? 'IT' : 'Test'}.java`);
+
+  exclusions.forEach(module => {
+    const tests = getTestFiles(module + '/src/test/java', testRegex);
+    const parts = splitArray(tests, moduleSplits[module], moduleWeights);
+    object = [...object, ...toObject(parts, suite, module, object.length)];
+  });
+  return object;
+}
+
+/**
+ * Produces a JSON string that works with GH actions
+ */
+function objectToString(object, keys) {
+  if (keys && keys.length) {
+    object.forEach(o => {
+      Object.keys(o).forEach(k => {
+        if (!keys.includes(k)) {
+          delete o[k];
+        }
+      });
+    });
+  }
+  return JSON.stringify({
+    include: object
+  }, null, 0)
+}
+
+function printStrategy(object) {
+  const json = [];
+  const o = object.map(o => {
+    return {
+      matrix: [o.suite, ...o.matrix, o.weight],
+      module: o.module,
+      items: o.module ? o.args : o.items
+    }
+  });
+  console.error(o);
+}
+
+/*
+ * The script entry-point
+ */
+async function main() {
+  const versionRegx= /--version=(.*)/;
+  const parallelRegx= /--parallel=(\d+)/;
+  const program = process.argv[1].replace(/.*\//, ''); 
+  const action = process.argv[2];
+  const parameter = process.argv[3];
+  const keys = process.argv.slice(4);
+
+  if (action == 'set-version' && versionRegx.test(parameter)) {
+    setVersion(parameter.replace(versionRegx, '$1'));
+  } else if (action == 'unit-tests' && parallelRegx.test(parameter)) {
+    const object = getParts(action, '', parameter.replace(parallelRegx, '$1'));
+    printStrategy(object);
+    const json = objectToString(object, keys);
+    console.log(json);
+  } else if (action == 'it-tests' && parallelRegx.test(parameter)) {
+    const object = getParts(action, 'flow-tests/', parameter.replace(parallelRegx, '$1'));
+    printStrategy(object);
+    const json = objectToString(object, keys);
+    console.log(json);
+  } else {
+    console.log(`
+Usage:
+  ${program} action parameters [keys]
+
+Actions
+  set-version        replace versions in all pom files of the project
+  unit-tests         outputs the JSON matrix for unit-tests
+  it-tests           outpurs the JSON matrix for it-tests
+
+Parameters
+  --version=xxx      the version to set
+  --parallel=N       number of items for the matrix
+
+Keys
+  A comma separated list of keys for the matrix object.
+  Valid keys are: current, suite, module, total, weight, name, args, items, matrix
+   `);
+    process.exit(1);
+  }
+}
+
+main();
+
+

--- a/scripts/computeMatrix.js
+++ b/scripts/computeMatrix.js
@@ -12,16 +12,28 @@ const moduleWeights = {
   'flow-server': {weight: 4},
   'vaadin-dev-server': {weight: 3},
   'fusion-end-point': {weight: 3},
-  'flow-tests/test-ccdm': {pos: 1},
   'flow-tests/test-mixed/pom-pnpm-production.xml': {pos: 1},
-  'flow-tests/test-pwa' : {pos: 1},
   'flow-tests/test-root-ui-context': {pos: 2},
   'flow-tests/test-mixed/pom-npm-production.xml': {pos: 2},
   'flow-tests/test-pwa/pom-production.xml': {pos: 2},
   'flow-tests/test-ccdm-flow-navigation': {pos: 2},
   'flow-tests/test-fusion-csrf-context': {pos: 3},
   'flow-tests/test-v14-bootstrap': {pos: 4},
-  'flow-tests/test-fusion-csrf': {pos: 5, weight: 20}
+  'flow-tests/test-fusion-csrf': {pos: 5, weight: 20},
+  'flow-tests/test-ccdm': {pos: 5},
+  'flow-tests/test-pwa' : {pos: 5},
+  'flow-tests/test-ccdm/pom-production.xml': {pos: 6},
+  
+  'RemoveRoutersLayoutContentIT': {weight: 2},
+  'BrowserWindowResizeIT': {weight: 2},
+  'FragmentLinkIT': {weight: 2},
+  'AttachListenerIT': {weight: 2},
+  'template.ChildOrderIT': {weight: 2},
+  'WaitForVaadinIT': {weight: 2},
+  'ErrorPageIT': {weight: 2},
+  'DomEventFilterIT': {weight: 2},
+  'ShortcutsIT': {weight: 2},
+  'JavaScriptReturnValueIT': {weight: 8},
 }
 // Set split number for modules with several tests
 const moduleSplits = {


### PR DESCRIPTION
This build implementation:
 - introduces a script which makes easier configure slices of modules and tests
 - improve performance by reducing times in 30-60 secs
 - latest job is red when any of the parallel jobs fails, which makes easier configure branch checks for PRs
