### PR TITLE
feat: Add async mode to flush operation and API to turn it on

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -108,7 +108,7 @@ public class DataCommunicator<T> implements Serializable {
     private SerializableConsumer<ExecutionContext> flushRequest;
     private SerializableConsumer<ExecutionContext> flushUpdatedDataRequest;
 
-    private ExecutorService executor = null;
+    private Executor executor = null;
     private CompletableFuture<Activation> future;
     private UI ui;
 
@@ -193,15 +193,14 @@ public class DataCommunicator<T> implements Serializable {
      * be enabled and set to PushMode.AUTOMATIC in order this to work.
      * 
      * @param executor
-     *            The ExecutorService used for async updates.
+     *            The Executor used for async updates.
      */
-    public void setExecutorForAsyncUpdates(ExecutorService executor) {
+    public void enablePushUpdates(Executor executor) {
         if (this.executor != null) {
             if (future != null) {
                 future.cancel(true);
                 future = null;
             }
-            this.executor.shutdown();
         }
         this.executor = executor;
     }

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -495,6 +495,7 @@ public class DataCommunicator<T> implements Serializable {
         }
     }
 
+    @SuppressWarnings("FutureReturnValueIgnored")
     private void flush() {
         Set<String> oldActive = new HashSet<>(activeKeyOrder);
 

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -41,6 +41,7 @@ import com.vaadin.flow.internal.JsonUtils;
 import com.vaadin.flow.internal.Range;
 import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.shared.Registration;
+import com.vaadin.flow.shared.communication.PushMode;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -24,11 +24,14 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.data.provider.ArrayUpdater.Update;
 import com.vaadin.flow.data.provider.DataChangeEvent.DataRefreshEvent;
 import com.vaadin.flow.function.SerializableComparator;
@@ -104,6 +107,10 @@ public class DataCommunicator<T> implements Serializable {
     private SerializableConsumer<ExecutionContext> flushRequest;
     private SerializableConsumer<ExecutionContext> flushUpdatedDataRequest;
 
+    private ExecutorService executor = null;
+    private CompletableFuture<Activation> future;
+    private UI ui;
+
     private static class SizeVerifier<T> implements Consumer<T>, Serializable {
 
         private int size;
@@ -174,6 +181,30 @@ public class DataCommunicator<T> implements Serializable {
 
         requestFlush();
     }
+
+    /**
+     * Control whether DataCommunicator should push data updates to the
+     * component asynchronously or not. By default the executor service is not
+     * defined and updates are done synchronously.
+     * <p>
+     * Note: This works only with Grid component. If set to true, Push needs to
+     * be enabled in order this to work.
+     * 
+     * @param executor
+     *            The ExecutorService used for async updates.
+     */
+    public void setExecutorForAsyncUpdates(ExecutorService executor) {
+        if (ui.getPushConfiguration().getPushMode() != PushMode.DISABLED) {
+            throw new IllegalStateException(
+                    "Asynchronous DataCommunicator updatres require Push to be enabled and PushMode.AUTOMATIC");
+        }
+        if (this.executor != null) {
+            future.cancel(true);
+            future = null;
+            this.executor.shutdown();
+        }
+        this.executor = executor;
+    }    
 
     /**
      * Resets all the data.
@@ -402,6 +433,7 @@ public class DataCommunicator<T> implements Serializable {
     }
 
     private void handleAttach() {
+        ui = UI.getCurrent();
         if (dataProviderUpdateRegistration != null) {
             dataProviderUpdateRegistration.remove();
         }
@@ -424,6 +456,11 @@ public class DataCommunicator<T> implements Serializable {
     }
 
     private void handleDetach() {
+        ui = null;
+        if (future != null) {
+            future.cancel(true);
+            future = null;
+        }
         dataGenerator.destroyAllData();
         if (dataProviderUpdateRegistration != null) {
             dataProviderUpdateRegistration.remove();
@@ -460,7 +497,6 @@ public class DataCommunicator<T> implements Serializable {
     private void flush() {
         Set<String> oldActive = new HashSet<>(activeKeyOrder);
 
-        Range effectiveRequested;
         final Range previousActive = Range.withLength(activeStart,
                 activeKeyOrder.size());
 
@@ -468,30 +504,58 @@ public class DataCommunicator<T> implements Serializable {
         if (resendEntireRange) {
             assumedSize = getDataProviderSize();
         }
-        effectiveRequested = requestedRange
+        final Range effectiveRequested = requestedRange
                 .restrictTo(Range.withLength(0, assumedSize));
 
         resendEntireRange |= !(previousActive.intersects(effectiveRequested)
                 || (previousActive.isEmpty() && effectiveRequested.isEmpty()));
 
-        Activation activation = collectKeysToFlush(previousActive,
-                effectiveRequested);
+        if (executor != null) {
+            if (future != null) {
+                future.cancel(true);
+            }
+            future = CompletableFuture
+                    .supplyAsync(() -> collectKeysToFlush(previousActive,
+                            effectiveRequested), executor);
+            future.thenAccept(activation -> {
+                if (ui == null) {
+                    return;
+                }
+                ui.access(() -> {
+                    performUpdate(oldActive, previousActive, effectiveRequested,
+                            activation);
+                });
+            });
+        } else {
+            Activation activation = collectKeysToFlush(previousActive,
+                    effectiveRequested);
 
-        // If the returned stream from the DataProvider is smaller than it
+            performUpdate(oldActive, previousActive, effectiveRequested,
+                    activation);
+        }
+    }
+
+    private void performUpdate(Set<String> oldActive,
+            final Range previousActive, final Range effectiveRequested,
+            Activation activation) {
+        Range effRequested = effectiveRequested;
+
+        // If the returned stream from the DataProvider is smaller
+        // than it
         // should, a new query for the actual size needs to be done
         if (activation.isSizeRecheckNeeded()) {
             assumedSize = getDataProviderSize();
-            effectiveRequested = requestedRange
+            effRequested = requestedRange
                     .restrictTo(Range.withLength(0, assumedSize));
         }
 
         activeKeyOrder = activation.getActiveKeys();
-        activeStart = effectiveRequested.getStart();
+        activeStart = effRequested.getStart();
 
         // Phase 2: Collect changes to send
         Update update = arrayUpdater.startUpdate(assumedSize);
-        boolean updated = collectChangesToSend(previousActive,
-                effectiveRequested, update);
+        boolean updated = collectChangesToSend(previousActive, effRequested,
+                update);
 
         resendEntireRange = false;
         assumeEmptyClient = false;

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -108,8 +108,8 @@ public class DataCommunicator<T> implements Serializable {
     private SerializableConsumer<ExecutionContext> flushRequest;
     private SerializableConsumer<ExecutionContext> flushUpdatedDataRequest;
 
-    private Executor executor = null;
-    private CompletableFuture<Activation> future;
+    private transient Executor executor = null;
+    private transient CompletableFuture<Activation> future;
     private UI ui;
 
     private static class SizeVerifier<T> implements Consumer<T>, Serializable {
@@ -196,11 +196,9 @@ public class DataCommunicator<T> implements Serializable {
      *            The Executor used for async updates.
      */
     public void enablePushUpdates(Executor executor) {
-        if (this.executor != null) {
-            if (future != null) {
-                future.cancel(true);
-                future = null;
-            }
+        if (this.executor != null && future != null) {
+            future.cancel(true);
+            future = null;
         }
         this.executor = executor;
     }

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorAsyncTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorAsyncTest.java
@@ -27,7 +27,7 @@ import com.vaadin.flow.shared.communication.PushMode;
 
 import elemental.json.JsonValue;
 
-public class DataCommunictorAsyncTest {
+public class DataCommunicatorAsyncTest {
 
     /**
      * Test item that uses id for identity.

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorAsyncTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorAsyncTest.java
@@ -2,7 +2,7 @@ package com.vaadin.flow.data.provider;
 
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -79,7 +79,7 @@ public class DataCommunicatorAsyncTest {
     private ArrayUpdater.Update update;
 
     private CountDownLatch latch;
-    private ExecutorService executor;
+    private Executor executor;
 
     public Range lastClear = null;
     public Range lastSet = null;
@@ -123,7 +123,7 @@ public class DataCommunicatorAsyncTest {
     public void asyncExcutorPushDisabledThrows() {
         ui.getPushConfiguration().setPushMode(PushMode.DISABLED);
         dataCommunicator.setDataProvider(createDataProvider(), null);
-        dataCommunicator.setExecutorForAsyncUpdates(executor);
+        dataCommunicator.enablePushUpdates(executor);
         dataCommunicator.setRequestedRange(0, 50);
         fakeClientCommunication();
     }    
@@ -133,7 +133,7 @@ public class DataCommunicatorAsyncTest {
         ui.getPushConfiguration().setPushMode(PushMode.AUTOMATIC);
         latch = new CountDownLatch(1);
         dataCommunicator.setDataProvider(createDataProvider(), null);
-        dataCommunicator.setExecutorForAsyncUpdates(executor);
+        dataCommunicator.enablePushUpdates(executor);
         dataCommunicator.setRequestedRange(0, 50);
         fakeClientCommunication();
 

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorAsyncTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorAsyncTest.java
@@ -1,0 +1,286 @@
+package com.vaadin.flow.data.provider;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.internal.Range;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinSession;
+
+import elemental.json.JsonValue;
+
+public class DataCommunicatorAsyncTest {
+
+    /**
+     * Test item that uses id for identity.
+     */
+    private static class Item {
+        private final int id;
+        private String value;
+
+        public Item(int id) {
+            this(id, "Item " + id);
+        }
+
+        public Item(int id, String value) {
+            this.id = id;
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return id + ": " + value;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj instanceof Item) {
+                Item that = (Item) obj;
+                return that.id == id;
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return id;
+        }
+    }
+
+    private DataCommunicator<Item> dataCommunicator;
+
+    @Mock
+    private DataGenerator<Item> dataGenerator;
+    @Mock
+    private ArrayUpdater arrayUpdater;
+
+    private Element element;
+    private MockUI ui;
+
+    private ArrayUpdater.Update update;
+
+    private CountDownLatch latch;
+    private ExecutorService executor;
+
+    public Range lastClear = null;
+    public Range lastSet = null;
+    public int lastUpdateId = -1;
+
+    @Before
+    public void init() {
+        MockitoAnnotations.initMocks(this);
+        ui = new MockUI();
+        element = new Element("div");
+        ui.getElement().appendChild(element);
+        lastClear = null;
+        lastSet = null;
+        lastUpdateId = -1;
+        executor = Executors.newCachedThreadPool();
+
+        update = new ArrayUpdater.Update() {
+
+            @Override
+            public void clear(int start, int length) {
+                lastClear = Range.withLength(start, length);
+            }
+
+            @Override
+            public void set(int start, List<JsonValue> items) {
+                lastSet = Range.withLength(start, items.size());
+            }
+
+            @Override
+            public void commit(int updateId) {
+                lastUpdateId = updateId;
+            }
+        };
+
+        Mockito.when(arrayUpdater.startUpdate(Mockito.anyInt()))
+                .thenReturn(update);
+
+        dataCommunicator = new DataCommunicator<>(dataGenerator, arrayUpdater,
+                data -> {
+                }, element.getNode());
+    }
+
+    @Test
+    public void asyncRequestedRangeHappensLater() {
+        latch = new CountDownLatch(1);
+        dataCommunicator.setDataProvider(createDataProvider(), null);
+        dataCommunicator.setExecutorForAsyncUpdates(executor);
+        dataCommunicator.setRequestedRange(0, 50);
+        fakeClientCommunication();
+
+        Assert.assertNotEquals("Expected initial reset not yet done.",
+                Range.withLength(0, 50), lastSet);
+
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        Assert.assertEquals("Expected initial full reset.",
+                Range.withLength(0, 50), lastSet);
+        lastSet = null;
+
+        element.removeFromParent();
+        fakeClientCommunication();
+
+        Assert.assertNull("Expected no during reattach.", lastSet);
+
+        ui.getElement().appendChild(element);
+        fakeClientCommunication();
+
+        latch = new CountDownLatch(1);
+
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        Assert.assertEquals("Expected initial full reset after reattach",
+                Range.withLength(0, 50), lastSet);
+    }
+
+    private AbstractDataProvider<Item, Object> createDataProvider() {
+        return createDataProvider(100);
+    }
+
+    private AbstractDataProvider<Item, Object> createDataProvider(int items) {
+        return new AbstractDataProvider<Item, Object>() {
+            @Override
+            public boolean isInMemory() {
+                return true;
+            }
+
+            @Override
+            public int size(Query<Item, Object> query) {
+                return items;
+            }
+
+            @Override
+            public Stream<Item> fetch(Query<Item, Object> query) {
+                try {
+                    Thread.sleep(500);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                // Note: Mockito is not able to mock background call, thus
+                // setting lastSet here
+                lastSet = Range.withLength(query.getOffset(), query.getLimit());
+                latch.countDown();
+                return IntStream
+                        .range(query.getOffset(),
+                                query.getLimit() + query.getOffset())
+                        .mapToObj(Item::new);
+            }
+        };
+    }
+
+    private void fakeClientCommunication() {
+        ui.getInternals().getStateTree().runExecutionsBeforeClientResponse();
+        ui.getInternals().getStateTree().collectChanges(ignore -> {
+        });
+    }
+
+    public static class MockUI extends UI {
+
+        public MockUI() {
+            this(findOrcreateSession());
+        }
+
+        public MockUI(VaadinSession session) {
+            getInternals().setSession(session);
+            setCurrent(this);
+        }
+
+        @Override
+        protected void init(VaadinRequest request) {
+            // Do nothing
+        }
+
+        private static VaadinSession findOrcreateSession() {
+            VaadinSession session = VaadinSession.getCurrent();
+            if (session == null) {
+                session = new AlwaysLockedVaadinSession(null);
+                VaadinSession.setCurrent(session);
+            }
+            return session;
+        }
+    }
+
+    public static class AlwaysLockedVaadinSession extends MockVaadinSession {
+
+        public AlwaysLockedVaadinSession(VaadinService service) {
+            super(service);
+            lock();
+        }
+
+    }
+
+    public static class MockVaadinSession extends VaadinSession {
+        /*
+         * Used to make sure there's at least one reference to the mock session
+         * while it's locked. This is used to prevent the session from being
+         * eaten by GC in tests where @Before creates a session and sets it as
+         * the current instance without keeping any direct reference to it. This
+         * pattern has a chance of leaking memory if the session is not unlocked
+         * in the right way, but it should be acceptable for testing use.
+         */
+        private static final ThreadLocal<MockVaadinSession> referenceKeeper = new ThreadLocal<>();
+
+        public MockVaadinSession(VaadinService service) {
+            super(service);
+        }
+
+        @Override
+        public void close() {
+            super.close();
+            closeCount++;
+        }
+
+        public int getCloseCount() {
+            return closeCount;
+        }
+
+        @Override
+        public Lock getLockInstance() {
+            return lock;
+        }
+
+        @Override
+        public void lock() {
+            super.lock();
+            referenceKeeper.set(this);
+        }
+
+        @Override
+        public void unlock() {
+            super.unlock();
+            referenceKeeper.remove();
+        }
+
+        private int closeCount;
+
+        private ReentrantLock lock = new ReentrantLock();
+    }
+}


### PR DESCRIPTION
In async mode data fetching is wrapped in the future

This version is for Vaadin 14.8

fixes: #1066
fixes: #10709
fixes: #12342