### PR TITLE
test: run tests in sub-sub-modules

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,8 +1,7 @@
 name: Flow Validation push
 on:
   push:
-    branches:
-      - master
+    branches: [master, '9.0']
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
@@ -13,6 +12,10 @@ jobs:
       matrix-unit: ${{ steps.set-matrix.outputs.matrix-unit }}
       matrix-it: ${{ steps.set-matrix.outputs.matrix-it }}
     steps:
+      - name: Check Secrets
+        run: |
+          TB_LICENSE="${{secrets.TB_LICENSE}}"
+          [ -z "TB_LICENSE" ] && echo "::error::!! ERROR NO TB_LICENSE: Check if the PR is from an external contributor !!" && exit 1 || exit 0
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
@@ -133,7 +136,6 @@ jobs:
       - name: Set TB License
         run: |
           TB_LICENSE=${{secrets.TB_LICENSE}}
-          [ -z "$TB_LICENSE" ] && echo "::debug::ERROR NO TB_LICENSE: Check if the PR is from an external contributor" && exit 1
           mkdir -p ~/.vaadin/
           echo '{"username":"'`echo $TB_LICENSE | cut -d / -f1`'","proKey":"'`echo $TB_LICENSE | cut -d / -f2`'"}' > ~/.vaadin/proKey
       - name: Compile Shared modules
@@ -150,7 +152,7 @@ jobs:
             ARGS="-pl ${{matrix.args}}"
           cmd="mvn -V -B -e -fae -Dcom.vaadin.testbench.Parameters.testsInParallel=5 -Dfailsafe.rerunFailingTestsCount=2 $ARGS"
           set -x -e -o pipefail
-          eval $cmd verify | tee -a mvn-it-tests-${{matrix.current}}.out
+          timeout -v -s KILL 540 $cmd verify | tee -a mvn-it-tests-${{matrix.current}}.out
       - name: Set build status flag
         id: set-failure
         if: ${{ failure() }}
@@ -172,14 +174,16 @@ jobs:
         with:
           name: test-reports
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action/composite@v1
+        uses: EnricoMi/publish-unit-test-result-action@v1
         with:
           files: "**/target/*-reports/TEST*.xml"
-          check_run_annotations: true
+          check_run_annotations: all tests, skipped tests
+          check_run_annotations_branch: master, 9.0
       - uses: geekyeggo/delete-artifact@v1
         with:
           name: saved-workspace
       - name: Check Failure Status
         run: |
           fail="${{ needs.unit-tests.outputs.failure }}${{ needs.it-tests.outputs.failure }}"
-          [ -n "$fail" ] && echo "!! THERE ARE TEST MODULES WITH FAILURES !!" >&2 && exit 1 || exit 0
+          [ -n "$fail" ] && echo "::error::!! THERE ARE TEST MODULES WITH FAILURES !!" && exit 1 || exit 0
+

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -87,7 +87,7 @@ jobs:
           ($cmd -T 1C verify || $cmd -fae clean verify) | tee mvn-unit-tests-${{matrix.current}}.out
       - name: Set build status flag
         id: set-failure
-        if: ${{ failure() }}
+        if: ${{ failure() || cancelled() }}
         run: echo "::set-output name=failure::true"
       - uses: actions/upload-artifact@v2
         if: ${{ failure() || success() }}
@@ -155,7 +155,7 @@ jobs:
           timeout -v -s KILL 540 $cmd verify | tee -a mvn-it-tests-${{matrix.current}}.out
       - name: Set build status flag
         id: set-failure
-        if: ${{ failure() }}
+        if: ${{ failure() || cancelled() }}
         run: echo "::set-output name=failure::true"
       - uses: actions/upload-artifact@v2
         if: ${{ failure() || success() }}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,5 +1,11 @@
-name: Flow Validation
-on: [pull_request, workflow_dispatch]
+name: Flow Validation push
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -15,23 +21,27 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
       - name: Set flow version to 999.99-SNAPSHOT
         run: |
           ./scripts/computeMatrix.js set-version --version=999.99-SNAPSHOT
       - name: Generate matrices
         id: set-matrix
         run: |
-          echo "::set-output name=matrix-unit::$(./scripts/computeMatrix.js unit-tests --parallel=2 current module args)"
           echo "::set-output name=matrix-it::$(./scripts/computeMatrix.js it-tests --parallel=11 current module args)"
+          echo "::set-output name=matrix-unit::$(./scripts/computeMatrix.js unit-tests --parallel=2 current module args)"
       - name: Compile and Install Flow
         run: |
-          cmd="mvn install -B -DskipTests -pl \!flow-plugins/flow-gradle-plugin"
-          # run twice if fails, it might be a multithread failure
+          cmd="mvn install -B -DskipTests  -pl \!flow-plugins/flow-gradle-plugin"
           eval $cmd -T 2C -q || eval $cmd
       - name: Save workspace
         run: |
-          mv ~/.m2/ .
-          tar cf workspace.tar .m2 `find . -name target -o -name "pom*.xml"`
+          tar cf workspace.tar -C ~/ .m2
+          tar rf workspace.tar `find . -name target -o -name "pom*xml"`
       - uses: actions/upload-artifact@v2
         with:
           name: saved-workspace
@@ -50,11 +60,17 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
       - uses: actions/download-artifact@v2
         with:
           name: saved-workspace
       - name: Restore Workspace
         run: |
+          set -x
           tar xf workspace.tar
           rm -rf ~/.m2 && mv -f .m2 ~/
       - name: Unit Test
@@ -64,8 +80,8 @@ jobs:
             ARGS="-pl ${{matrix.module}} -Dtest=${{matrix.args}}" || \
             ARGS="-pl ${{matrix.args}}"
           cmd="mvn -B -T 1C $ARGS"
-          set -x
-          $cmd -T 1C verify || $cmd -fae clean verify
+          set -x -e -o pipefail
+          ($cmd -T 1C verify || $cmd -fae clean verify) | tee mvn-unit-tests-${{matrix.current}}.out
       - name: Set build status flag
         id: set-failure
         if: ${{ failure() }}
@@ -74,7 +90,9 @@ jobs:
         if: ${{ failure() || success() }}
         with:
           name: test-reports
-          path: "**/target/*-reports/*"
+          path: |
+            **/target/*-reports/*
+            mvn-*.out
   it-tests:
     needs: build
     outputs:
@@ -88,11 +106,19 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '16'
+      - uses: pnpm/action-setup@v2.0.1
+        with:
+          version: '5.15.0'
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
           java-version: '11'
           distribution: 'adopt'
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven-
       - uses: browser-actions/setup-chrome@latest
         with:
           chrome-version: stable
@@ -107,12 +133,14 @@ jobs:
       - name: Set TB License
         run: |
           TB_LICENSE=${{secrets.TB_LICENSE}}
+          [ -z "$TB_LICENSE" ] && echo "::debug::ERROR NO TB_LICENSE: Check if the PR is from an external contributor" && exit 1
           mkdir -p ~/.vaadin/
           echo '{"username":"'`echo $TB_LICENSE | cut -d / -f1`'","proKey":"'`echo $TB_LICENSE | cut -d / -f2`'"}' > ~/.vaadin/proKey
-      - name: Install required modules
+      - name: Compile Shared modules
         run: |
-          if echo ${{matrix.args}} | grep -q test-fusion-csrf-context; then
-            mvn -B -q install -DskipITs -pl flow-tests/test-fusion-csrf
+          if [ ${{matrix.current}} -eq 2 -o ${{matrix.current}} -eq 3 ]; then
+            cmd="mvn install -B -DskipTests -Pit-shared-modules -amd -pl flow-tests"
+            $cmd -T 1C || $cmd
           fi
       - name: Run ITs
         run: |
@@ -120,9 +148,9 @@ jobs:
           [ -n "${{matrix.module}}" ] && \
             ARGS="-Dfailsafe.forkCount=4 -pl ${{matrix.module}} -Dit.test=${{matrix.args}}" || \
             ARGS="-pl ${{matrix.args}}"
-          cmd="mvn -V -B -e -Dcom.vaadin.testbench.Parameters.testsInParallel=5 $ARGS"
-          set -x
-          eval $cmd verify -fae -Dfailsafe.rerunFailingTestsCount=2 || eval $cmd clean verify
+          cmd="mvn -V -B -e -fae -Dcom.vaadin.testbench.Parameters.testsInParallel=5 -Dfailsafe.rerunFailingTestsCount=2 $ARGS"
+          set -x -e -o pipefail
+          eval $cmd verify | tee -a mvn-it-tests-${{matrix.current}}.out
       - name: Set build status flag
         id: set-failure
         if: ${{ failure() }}
@@ -134,6 +162,7 @@ jobs:
           path: |
             **/target/*-reports/*
             **/error-screenshots/*.png
+            mvn-*.out
   test-results:
     if: ${{ failure() || success() }}
     needs: [unit-tests, it-tests]
@@ -146,6 +175,7 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action/composite@v1
         with:
           files: "**/target/*-reports/TEST*.xml"
+          check_run_annotations: true
       - uses: geekyeggo/delete-artifact@v1
         with:
           name: saved-workspace

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -152,7 +152,7 @@ jobs:
             ARGS="-pl ${{matrix.args}}"
           cmd="mvn -V -B -e -fae -Dcom.vaadin.testbench.Parameters.testsInParallel=5 -Dfailsafe.rerunFailingTestsCount=2 $ARGS"
           set -x -e -o pipefail
-          timeout -v -s KILL 540 $cmd verify | tee -a mvn-it-tests-${{matrix.current}}.out
+          $cmd verify | tee -a mvn-it-tests-${{matrix.current}}.out
       - name: Set build status flag
         id: set-failure
         if: ${{ failure() || cancelled() }}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,4 +1,4 @@
-name: Flow Validation push
+name: Flow Validation
 on:
   push:
     branches: [master, '9.0']

--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -296,13 +296,30 @@
 
     <profiles>
         <profile>
-            <id>run-tests</id>
+            <!-- Modules that have shared stuff used in other modules -->
+            <id>it-shared-modules</id>
+            <activation>
+                <property>
+                    <!-- usind -DsharedModules -DskipTests we can install these modules and run tests later (GH actions) -->
+                    <name>sharedModules</name>
+                </property>
+            </activation>
+            <modules>
+                <module>test-fusion-csrf</module>
+                <module>test-root-context</module>
+                <module>test-embedding</module>
+                <module>test-frontend</module>
+                <module>test-application-theme</module>
+                <module>test-multi-war</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>it-test-modules</id>
             <activation>
                 <property>
                     <name>!skipTests</name>
                 </property>
             </activation>
-
             <modules>
                 <module>test-dev-mode</module>
                 <module>test-pwa</module>

--- a/flow-tests/test-application-theme/pom.xml
+++ b/flow-tests/test-application-theme/pom.xml
@@ -15,11 +15,22 @@
 
     <modules>
         <module>reusable-theme</module>
-        <module>test-theme-reusable</module>
-        <module>test-reusable-as-parent</module>
-        <module>test-theme-live-reload</module>
-        <module>test-theme-component-live-reload</module>
-        <module>test-theme-switch-live-reload</module>
     </modules>
-
+    <profiles>
+        <profile>
+            <id>run-tests</id>
+            <activation>
+                <property>
+                    <name>!skipTests</name>
+                </property>
+            </activation>
+            <modules>
+                <module>test-theme-reusable</module>
+                <module>test-reusable-as-parent</module>
+                <module>test-theme-live-reload</module>
+                <module>test-theme-component-live-reload</module>
+                <module>test-theme-switch-live-reload</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>

--- a/flow-tests/test-embedding/pom.xml
+++ b/flow-tests/test-embedding/pom.xml
@@ -37,15 +37,28 @@
     <modules>
         <!-- shared assets -->
         <module>embedding-test-assets</module>
-
-        <!-- npm -->
-        <module>test-embedding-generic</module>
-        <module>test-embedding-theme-variant</module>
-        <module>test-embedding-production-mode</module>
-
-        <!-- Custom theme tests -->
-        <module>test-embedding-application-theme</module>
+        <!-- shared theme -->
         <module>embedding-reusable-custom-theme</module>
-        <module>test-embedding-reusable-theme</module>
     </modules>
+
+    <profiles>
+        <profile>
+            <id>run-tests</id>
+            <activation>
+                <property>
+                    <name>!skipTests</name>
+                </property>
+            </activation>
+            <modules>
+                <!-- npm -->
+                <module>test-embedding-generic</module>
+                <module>test-embedding-theme-variant</module>
+                <module>test-embedding-production-mode</module>
+
+                <!-- Custom theme tests -->
+                <module>test-embedding-application-theme</module>
+                <module>test-embedding-reusable-theme</module>
+            </modules>
+        </profile>
+    </profiles>
 </project>

--- a/flow-tests/test-frontend/pom.xml
+++ b/flow-tests/test-frontend/pom.xml
@@ -15,17 +15,6 @@
         <!-- shared assets -->
         <module>addon-with-templates</module>
         <module>vite-test-assets</module>
-
-        <!-- test modules -->
-        <module>vite-basics</module>
-        <module>vite-production</module>
-
-        <!-- npm and pnpm dev mode and prod mode -->
-        <module>test-npm</module>
-        <module>test-npm/pom-production.xml</module>
-        <module>test-pnpm</module>
-        <module>test-pnpm/pom-production.xml</module>
-
     </modules>
 
     <dependencies>
@@ -36,4 +25,26 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>run-tests</id>
+            <activation>
+                <property>
+                    <name>!skipTests</name>
+                </property>
+            </activation>
+            <modules>
+                <!-- test modules -->
+                <module>vite-basics</module>
+                <module>vite-production</module>
+                <!-- npm and pnpm dev mode and prod mode -->
+                <module>test-npm</module>
+                <module>test-npm/pom-production.xml</module>
+                <module>test-pnpm</module>
+                <module>test-pnpm/pom-production.xml</module>
+            </modules>
+        </profile>
+    </profiles>
+
 </project>

--- a/flow-tests/test-fusion-csrf/pom.xml
+++ b/flow-tests/test-fusion-csrf/pom.xml
@@ -64,30 +64,25 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- This module is mapped to default web context -->
-            <plugin>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>com.vaadin</groupId>
-                <artifactId>flow-maven-plugin</artifactId>
-                <configuration>
-                    <productionMode>false</productionMode>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
     <profiles>
         <profile>
-            <id>local-run</id>
+            <id>run-tests</id>
             <activation>
                 <property>
-                    <name>!test.use.hub</name>
+                    <name>!skipTests</name>
                 </property>
             </activation>
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>com.vaadin</groupId>
+                        <artifactId>flow-maven-plugin</artifactId>
+                        <configuration>
+                            <productionMode>false</productionMode>
+                        </configuration>
+                    </plugin>
                     <plugin>
                         <groupId>com.lazerycode.selenium</groupId>
                         <artifactId>driver-binary-downloader-maven-plugin
@@ -117,6 +112,20 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <!-- This module is mapped to default web context -->
+                    <plugin>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-maven-plugin</artifactId>
+                        <configuration>
+                            <systemProperties>
+                                <systemProperty>
+                                    <!-- make sure we do not leave webpack-dev-server running after IT -->
+                                    <name>vaadin.reuseDevServer</name>
+                                    <value>false</value>
+                                </systemProperty>
+                            </systemProperties>
+                        </configuration>
+                    </plugin>                    
                 </plugins>
             </build>
         </profile>

--- a/flow-tests/test-multi-war/test-war2/pom.xml
+++ b/flow-tests/test-multi-war/test-war2/pom.xml
@@ -9,7 +9,7 @@
         <version>10.0-SNAPSHOT</version>
     </parent>
     <artifactId>flow-test-multi-war2</artifactId>
-    <name>First war for multi war tests</name>
+    <name>Second war for multi war tests</name>
     <packaging>war</packaging>
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>

--- a/flow-tests/test-root-context/pom.xml
+++ b/flow-tests/test-root-context/pom.xml
@@ -95,28 +95,6 @@
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
             </plugin>
-            <!--  Run flow plugin to build frontend -->
-            <plugin>
-                <groupId>com.vaadin</groupId>
-                <artifactId>flow-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>prepare-frontend</goal>
-                            <goal>build-frontend</goal>
-                        </goals>
-                        <phase>compile</phase>
-                    </execution>
-                </executions>
-                <configuration>
-                    <productionMode>false</productionMode>
-                </configuration>
-            </plugin>
-            <!-- Run jetty before integration tests, and stop after -->
-            <plugin>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-maven-plugin</artifactId>
-            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
@@ -208,6 +186,40 @@
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>run-tests</id>
+            <activation>
+                <property>
+                    <name>!skipTests</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <!--  Run flow plugin to build frontend -->
+                    <plugin>
+                        <groupId>com.vaadin</groupId>
+                        <artifactId>flow-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>prepare-frontend</goal>
+                                    <goal>build-frontend</goal>
+                                </goals>
+                                <phase>compile</phase>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <productionMode>false</productionMode>
+                        </configuration>
+                    </plugin>
+                    <!-- Run jetty before integration tests, and stop after -->
+                    <plugin>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>

--- a/scripts/computeMatrix.js
+++ b/scripts/computeMatrix.js
@@ -17,7 +17,6 @@ const moduleWeights = {
   'flow-tests/test-npm-only-features/test-npm-bytecode-scanning/pom-prod-fallback.xml': { weight: 2 },
   'flow-tests/test-custom-route-registry': { weight: 2 },
   'flow-tests/test-embedding/test-embedding-generic': { weight: 2 },
-  'flow-tests/test-embedding/test-embedding-production-mode': { weight: 4 },
   'flow-tests/test-embedding/test-embedding-reusable-theme': { weight: 2 },
   'flow-tests/test-fusion-csrf-context': { weight: 2 },
   'flow-tests/test-frontend/vite-basics': { weight: 2 },
@@ -36,7 +35,7 @@ const moduleWeights = {
   'flow-tests/test-application-theme/test-theme-switch-live-reload': { weight: 5 },
   'flow-tests/test-pwa': { weight: 4 },
   'flow-tests/test-live-reload': { weight: 2 },
-  'flow-tests/test-mixed/pom-npm-production.xml': { weight: 3 },
+  'flow-tests/test-frontend/pom-production.xml': { weight: 3 },
   'flow-tests/test-v14-bootstrap/pom-production.xml': { weight: 2 },
   'flow-tests/test-pwa/pom-production.xml': { weight: 2 },
   'flow-tests/test-root-ui-context': { weight: 2 },
@@ -48,7 +47,7 @@ const moduleWeights = {
   // - flow-tests/test-root-ui-context
   // - flow-tests/test-live-reload
   // - flow-tests/test-dev-mode
-  'flow-tests/test-mixed/pom-npm.xml': {pos: 1, weight: 10},
+  'flow-tests/test-frontend/test-npm': {pos: 1, weight: 10},
   'flow-tests/test-application-theme/test-theme-live-reload': {pos: 1, weight: 4},
   'flow-tests/test-no-theme': {pos: 1},
   'flow-tests/test-custom-route-registry': {pos: 1, weight: 2},
@@ -57,12 +56,13 @@ const moduleWeights = {
   'flow-tests/test-embedding/test-embedding-application-theme': {pos: 1, weight: 3},
 
   // In containers 2 y 3 we put tests that need shared modules
-  'flow-tests/test-mixed/pom-pnpm-production.xml': {pos: 10},
+  'flow-tests/test-frontend/test-pnpm/pom-production.xml': {pos: 10},
   'flow-tests/test-embedding/test-embedding-generic': {pos: 2, weight: 3},
   'flow-tests/test-embedding/test-embedding-reusable-theme': {pos: 2, weight: 3},
   'flow-tests/test-fusion-csrf-context': {pos: 2, weight: 2},
   'flow-tests/test-multi-war/deployment': {pos: 2},
   'flow-tests/test-live-reload': {pos: 2, weight: 2},
+  'flow-tests/test-embedding/test-embedding-production-mode': { pos: 2, weight: 4 },
 
   'flow-tests/test-frontend/vite-basics': {pos: 3, weight: 10},
   'flow-tests/test-frontend/vite-test-assets': {pos: 3},
@@ -243,6 +243,7 @@ function toObject(parts, suite, module, prevIdx) {
  */
 function getParts(suite, prefix, slices) {
   let modules = prefix ? getModulesRecursive(prefix) : getModules();
+
   const exclusions = Object.keys(moduleSplits).filter(module => modules.includes(module));
   modules = grep(modules, [...globalExclusions, ...exclusions]);
 

--- a/scripts/computeMatrix.js
+++ b/scripts/computeMatrix.js
@@ -42,8 +42,6 @@ const moduleWeights = {
   'flow-tests/test-root-ui-context': { weight: 2 },
   'flow-tests/test-npm-only-features/test-npm-no-buildmojo': { weight: 2 },
   'flow-tests/test-ccdm': { weight: 4 },
-  'flow-tests/test-ccdm-flow-navigation/pom-production.xml': { weight: 2 },
-
 
   // When running `flow-tests/test-mixed/pom-npm.xml` together with the following
   // modules they fail, so we put it with modules that do not fail in container 1


### PR DESCRIPTION
 - Fix script for visiting modules recursively
 - Adjust weight and position parameters to optimise build
 - Group tests that use shared modules for better timings
 - Cache maven repositories
 - Configure correctly action events
 - Introduce profiles for installing shared modules, so as they can be
    used when running verify in other modules independently
 - Add check_run_annotations parameter to test reports

This PR increases the number or IT modules run from 36 to 78, now validation lasts ~11-13 mins instead of ~8-10
