### PR TITLE
fix: Proper handling of href when the anchor is disabled/enabled

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
@@ -28,6 +28,7 @@ import com.vaadin.flow.component.PropertyDescriptors;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.server.AbstractStreamResource;
 import com.vaadin.flow.server.StreamResource;
+import com.vaadin.flow.server.StreamResourceRegistry;
 
 /**
  * Component representing an <code>&lt;a&gt;</code> element.
@@ -184,9 +185,9 @@ public class Anchor extends HtmlContainer
         if (href instanceof String) {
             // let the method return the actual href string even if disabled
             return (String) href;
+        } else if (href instanceof AbstractStreamResource) {
+            return StreamResourceRegistry.getURI((AbstractStreamResource) href).toString();
         }
-        // this only happens if StreamResource is in use, in that case
-        // the disabled Anchor returns null, otherwise some String.
         return get(hrefDescriptor);
     }
 

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
@@ -129,8 +129,8 @@ public class Anchor extends HtmlContainer
     /**
      * Sets the URL that this anchor links to.
      * <p>
-     * A disabled Anchor removes the attribute from the HTML element, but it
-     * is stored (and reused when enabled again) in the server sided component.
+     * A disabled Anchor removes the attribute from the HTML element, but it is
+     * stored (and reused when enabled again) in the server sided component.
      * <p>
      * Use the method {@link #removeHref()} to remove the <b>href</b> attribute
      * instead of setting it to an empty string.
@@ -143,7 +143,7 @@ public class Anchor extends HtmlContainer
      */
     public void setHref(String href) {
         this.href = href;
-        if(isEnabled()) {
+        if (isEnabled()) {
             assignHref();
         }
     }
@@ -169,7 +169,7 @@ public class Anchor extends HtmlContainer
     public void setHref(AbstractStreamResource href) {
         this.href = href;
         getElement().setAttribute(ROUTER_IGNORE_ATTRIBUTE, true);
-        if(isEnabled()) {
+        if (isEnabled()) {
             assignHref();
         }
     }
@@ -194,7 +194,7 @@ public class Anchor extends HtmlContainer
     @Override
     public void onEnabledStateChanged(boolean enabled) {
         super.onEnabledStateChanged(enabled);
-        if(enabled) {
+        if (enabled) {
             assignHref();
         } else {
             getElement().removeAttribute("href");
@@ -202,9 +202,10 @@ public class Anchor extends HtmlContainer
     }
 
     private void assignHref() {
-        if(href != null) {
-            if(href instanceof AbstractStreamResource) {
-                getElement().setAttribute("href", (AbstractStreamResource) href);
+        if (href != null) {
+            if (href instanceof AbstractStreamResource) {
+                getElement().setAttribute("href",
+                        (AbstractStreamResource) href);
             } else {
                 set(hrefDescriptor, (String) href);
             }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
@@ -130,7 +130,7 @@ public class Anchor extends HtmlContainer
      * Sets the URL that this anchor links to.
      * <p>
      * A disabled Anchor removes the attribute from the HTML element, but it is
-     * stored (and reused when enabled again) in the server sided component.
+     * stored (and reused when enabled again) in the server-side component.
      * <p>
      * Use the method {@link #removeHref()} to remove the <b>href</b> attribute
      * instead of setting it to an empty string.

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
@@ -186,7 +186,8 @@ public class Anchor extends HtmlContainer
             // let the method return the actual href string even if disabled
             return (String) href;
         } else if (href instanceof AbstractStreamResource) {
-            return StreamResourceRegistry.getURI((AbstractStreamResource) href).toString();
+            return StreamResourceRegistry.getURI((AbstractStreamResource) href)
+                    .toString();
         }
         return get(hrefDescriptor);
     }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
@@ -146,9 +146,7 @@ public class Anchor extends HtmlContainer
             throw new IllegalArgumentException("Href must not be null");
         }
         this.href = href;
-        if (isEnabled()) {
-            assignHref();
-        }
+        assignHrefAttribute();
     }
 
     /**
@@ -172,9 +170,7 @@ public class Anchor extends HtmlContainer
     public void setHref(AbstractStreamResource href) {
         this.href = href;
         getElement().setAttribute(ROUTER_IGNORE_ATTRIBUTE, true);
-        if (isEnabled()) {
-            assignHref();
-        }
+        assignHrefAttribute();
     }
 
     /**
@@ -197,21 +193,21 @@ public class Anchor extends HtmlContainer
     @Override
     public void onEnabledStateChanged(boolean enabled) {
         super.onEnabledStateChanged(enabled);
-        if (enabled) {
-            assignHref();
-        } else {
-            getElement().removeAttribute("href");
-        }
+        assignHrefAttribute();
     }
 
-    private void assignHref() {
-        if (href != null) {
-            if (href instanceof AbstractStreamResource) {
-                getElement().setAttribute("href",
-                        (AbstractStreamResource) href);
-            } else {
-                set(hrefDescriptor, (String) href);
+    private void assignHrefAttribute() {
+        if (isEnabled()) {
+            if (href != null) {
+                if (href instanceof AbstractStreamResource) {
+                    getElement().setAttribute("href",
+                            (AbstractStreamResource) href);
+                } else {
+                    set(hrefDescriptor, (String) href);
+                }
             }
+        } else {
+            getElement().removeAttribute("href");
         }
     }
 

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
@@ -142,7 +142,10 @@ public class Anchor extends HtmlContainer
      *            the href to set
      */
     public void setHref(String href) {
-        this.href = Objects.requireNonNull(href);
+        if(href == null) {
+            throw new IllegalArgumentException("Href must not be null");
+        }
+        this.href = href;
         if (isEnabled()) {
             assignHref();
         }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
@@ -142,10 +142,7 @@ public class Anchor extends HtmlContainer
      *            the href to set
      */
     public void setHref(String href) {
-        if(href == null) {
-            throw new IllegalArgumentException("Href must not be null");
-        }
-        this.href = href;
+        this.href = Objects.requireNonNull(href);
         if (isEnabled()) {
             assignHref();
         }

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
@@ -142,7 +142,7 @@ public class Anchor extends HtmlContainer
      *            the href to set
      */
     public void setHref(String href) {
-        if(href == null) {
+        if (href == null) {
             throw new IllegalArgumentException("Href must not be null");
         }
         this.href = href;

--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Anchor.java
@@ -142,6 +142,9 @@ public class Anchor extends HtmlContainer
      *            the href to set
      */
     public void setHref(String href) {
+        if(href == null) {
+            throw new IllegalArgumentException("Href must not be null");
+        }
         this.href = href;
         if (isEnabled()) {
             assignHref();

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
@@ -34,6 +34,7 @@ public class AnchorTest extends ComponentTest {
         ui = null;
         UI.setCurrent(null);
     }
+
     @Test
     public void removeHref() {
         Anchor anchor = new Anchor();

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
@@ -233,6 +233,7 @@ public class AnchorTest extends ComponentTest {
         anchor.setEnabled(false);
 
         Assert.assertFalse(anchor.getElement().hasAttribute("href"));
+        Assert.assertNotEquals(href, anchor.getHref());
 
         anchor.setEnabled(true);
         Assert.assertEquals(href, anchor.getHref());

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
@@ -17,6 +17,9 @@ package com.vaadin.flow.component.html;
 
 import java.util.Optional;
 
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.server.AbstractStreamResource;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -24,6 +27,13 @@ import com.vaadin.flow.component.Text;
 
 public class AnchorTest extends ComponentTest {
 
+    private UI ui;
+
+    @After
+    public void tearDown() {
+        ui = null;
+        UI.setCurrent(null);
+    }
     @Test
     public void removeHref() {
         Anchor anchor = new Anchor();
@@ -133,5 +143,131 @@ public class AnchorTest extends ComponentTest {
     @Override
     public void testHasAriaLabelIsImplemented() {
         super.testHasAriaLabelIsImplemented();
+    }
+
+    @Test
+    public void setEnabled_anchorWithoutHref_doesNotThrow() {
+        Anchor anchor = new Anchor();
+        anchor.setEnabled(false);
+
+        anchor.setEnabled(true);
+        Assert.assertTrue(anchor.isEnabled());
+
+        anchor.setHref("foo");
+        anchor.setEnabled(false);
+        anchor.removeHref();
+        anchor.setEnabled(true);
+    }
+
+    @Test
+    public void disabledAnchor_removeHref_hrefIsEmpty() {
+        Anchor anchor = new Anchor();
+        anchor.setHref("foo");
+        anchor.setEnabled(false);
+        Assert.assertEquals("foo", anchor.getHref());
+        anchor.setHref("bar");
+        Assert.assertEquals("bar", anchor.getHref());
+        anchor.removeHref();
+        Assert.assertEquals("", anchor.getHref());
+        anchor.setEnabled(true);
+        Assert.assertEquals("", anchor.getHref());
+    }
+
+    @Test
+    public void disabledAnchor_hrefIsRemoved_enableAnchor_hrefIsRestored() {
+        Anchor anchor = new Anchor("foo", "bar");
+        anchor.setEnabled(false);
+
+        Assert.assertFalse(anchor.getElement().hasAttribute("href"));
+
+        anchor.setEnabled(true);
+        Assert.assertTrue(anchor.getElement().hasAttribute("href"));
+        Assert.assertEquals("foo", anchor.getHref());
+    }
+
+    @Test
+    public void disabledAnchor_setHrefWhenDisabled_enableAnchor_hrefIsPreserved() {
+        Anchor anchor = new Anchor("foo", "bar");
+        anchor.setEnabled(false);
+
+        anchor.setHref("baz");
+
+        anchor.setEnabled(true);
+
+        Assert.assertTrue(anchor.getElement().hasAttribute("href"));
+        Assert.assertEquals("baz", anchor.getHref());
+    }
+
+    @Test
+    public void disabledAnchor_setResourceWhenDisabled_enableAnchor_resourceIsPreserved() {
+        Anchor anchor = new Anchor("foo", "bar");
+        anchor.setEnabled(false);
+
+        mockUI();
+        anchor.setHref(new AbstractStreamResource() {
+
+            @Override
+            public String getName() {
+                return "baz";
+            }
+        });
+        anchor.setEnabled(true);
+
+        Assert.assertTrue(anchor.getElement().hasAttribute("href"));
+    }
+
+    @Test
+    public void disabledAnchor_setResource_hrefIsRemoved_enableAnchor_hrefIsRestored() {
+        mockUI();
+        AbstractStreamResource resource = new AbstractStreamResource() {
+
+            @Override
+            public String getName() {
+                return "foo";
+            }
+
+        };
+        Anchor anchor = new Anchor(resource, "bar");
+        String href = anchor.getHref();
+        anchor.setEnabled(false);
+
+        Assert.assertFalse(anchor.getElement().hasAttribute("href"));
+
+        anchor.setEnabled(true);
+        Assert.assertEquals(href, anchor.getHref());
+    }
+
+    @Test
+    public void disabledAnchor_setResourceWhenDisabled_hrefIsPreserved() {
+        mockUI();
+        AbstractStreamResource resource = new AbstractStreamResource() {
+
+            @Override
+            public String getName() {
+                return "foo";
+            }
+
+        };
+        Anchor anchor = new Anchor(resource, "bar");
+        String href = anchor.getHref();
+        anchor.setEnabled(false);
+
+        anchor.setHref(new AbstractStreamResource() {
+
+            @Override
+            public String getName() {
+                return "baz";
+            }
+        });
+
+        anchor.setEnabled(true);
+
+        Assert.assertTrue(anchor.getElement().hasAttribute("href"));
+        Assert.assertNotEquals(href, anchor.getHref());
+    }
+
+    private void mockUI() {
+        ui = new UI();
+        UI.setCurrent(ui);
     }
 }

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/AnchorTest.java
@@ -233,7 +233,7 @@ public class AnchorTest extends ComponentTest {
         anchor.setEnabled(false);
 
         Assert.assertFalse(anchor.getElement().hasAttribute("href"));
-        Assert.assertNotEquals(href, anchor.getHref());
+        Assert.assertEquals(href, anchor.getHref());
 
         anchor.setEnabled(true);
         Assert.assertEquals(href, anchor.getHref());


### PR DESCRIPTION
## Description

Disabling and enabling component using the Java API now works as expected. href is always saved in the component implementation, but not stored in element if disabled.

Fixes #10924

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
