### PR TITLE
test: fix memory leak in tests during build

### DIFF
--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -35,10 +35,12 @@
             com.vaadin.flow.testcategory.PushTests,
         </excludedGroups>
 
+        <jetty.scantrigger></jetty.scantrigger>
+
         <vaadin.devmode.liveReload.enabled>false</vaadin.devmode.liveReload.enabled>
         <vaadin.pnpm.enable>true</vaadin.pnpm.enable>
         <vaadin.allow.appshell.annotations>false</vaadin.allow.appshell.annotations>
-
+        <useDeprecatedV14Bootstrapping>false</useDeprecatedV14Bootstrapping>
         <vaadin.devmode.vite.options>--host</vaadin.devmode.vite.options>
 
         <!-- make sure we do not leave webpack-dev-server running after IT -->
@@ -121,6 +123,10 @@
                     <groupId>com.vaadin</groupId>
                     <artifactId>flow-maven-plugin</artifactId>
                     <version>${project.version}</version>
+                    <configuration>
+                        <useDeprecatedV14Bootstrapping>${vaadin.useDeprecatedV14Bootstrapping}</useDeprecatedV14Bootstrapping>
+                        <pnpmEnable>${vaadin.pnpm.enable}</pnpmEnable>
+                    </configuration>
                     <executions>
                         <execution>
                             <goals>
@@ -249,20 +255,12 @@
                                  in all modules so no non-standard value leaks to another module -->
                             <force>true</force>
                             <systemProperty>
-                                <name>vaadin.useDeprecatedV14Bootstrapping</name>
-                                <value>${vaadin.useDeprecatedV14Bootstrapping}</value>
-                            </systemProperty>
-                            <systemProperty>
                                 <name>vaadin.reuseDevServer</name>
                                 <value>${vaadin.reuseDevServer}</value>
                             </systemProperty>
                             <systemProperty>
                                 <name>vaadin.devmode.liveReload.enabled</name>
                                 <value>${vaadin.devmode.liveReload.enabled}</value>
-                            </systemProperty>
-                            <systemProperty>
-                                <name>vaadin.pnpm.enable</name>
-                                <value>${vaadin.pnpm.enable}</value>
                             </systemProperty>
                             <systemProperty>
                                 <name>vaadin.allow.appshell.annotations</name>
@@ -275,7 +273,7 @@
                             <!-- Allow test clients not on localhost to connect to Vite-->
                             <systemProperty>
                                 <name>vaadin.devmode.vite.options</name>
-                                <value>--host</value>
+                                <value>${vaadin.devmode.vite.options}</value>
                             </systemProperty>
                         </systemProperties>
                     </configuration>

--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -34,6 +34,15 @@
             com.vaadin.flow.testcategory.ScreenshotTests,
             com.vaadin.flow.testcategory.PushTests,
         </excludedGroups>
+
+        <vaadin.devmode.liveReload.enabled>false</vaadin.devmode.liveReload.enabled>
+        <vaadin.pnpm.enable>true</vaadin.pnpm.enable>
+        <vaadin.allow.appshell.annotations>false</vaadin.allow.appshell.annotations>
+
+        <vaadin.devmode.vite.options>--host</vaadin.devmode.vite.options>
+
+        <!-- make sure we do not leave webpack-dev-server running after IT -->
+        <vaadin.reuseDevServer>false</vaadin.reuseDevServer>
     </properties>
 
     <dependencies>
@@ -104,26 +113,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>properties-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>set-system-properties</goal>
-                        </goals>
-                        <configuration>
-                            <properties>
-                                <property>
-                                    <name>vaadin.devmode.liveReload.enabled
-                                    </name>
-                                    <value>false</value>
-                                </property>
-                            </properties>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
         <pluginManagement>
@@ -256,11 +245,37 @@
                         <stopKey>foo</stopKey>
                         <stopWait>5</stopWait>
                         <systemProperties>
+                            <!-- All system props are defined here as they need to be overridden 
+                                 in all modules so no non-standard value leaks to another module -->
+                            <force>true</force>
                             <systemProperty>
-                                <name>vaadin.useDeprecatedV14Bootstrapping
-                                </name>
-                                <value>${vaadin.useDeprecatedV14Bootstrapping}
-                                </value>
+                                <name>vaadin.useDeprecatedV14Bootstrapping</name>
+                                <value>${vaadin.useDeprecatedV14Bootstrapping}</value>
+                            </systemProperty>
+                            <systemProperty>
+                                <name>vaadin.reuseDevServer</name>
+                                <value>${vaadin.reuseDevServer}</value>
+                            </systemProperty>
+                            <systemProperty>
+                                <name>vaadin.devmode.liveReload.enabled</name>
+                                <value>${vaadin.devmode.liveReload.enabled}</value>
+                            </systemProperty>
+                            <systemProperty>
+                                <name>vaadin.pnpm.enable</name>
+                                <value>${vaadin.pnpm.enable}</value>
+                            </systemProperty>
+                            <systemProperty>
+                                <name>vaadin.allow.appshell.annotations</name>
+                                <value>${vaadin.allow.appshell.annotations}</value>
+                            </systemProperty>
+                            <systemProperty>
+                                <name>jetty.scantrigger</name>
+                                <value>${jetty.scantrigger}</value>
+                            </systemProperty>
+                            <!-- Allow test clients not on localhost to connect to Vite-->
+                            <systemProperty>
+                                <name>vaadin.devmode.vite.options</name>
+                                <value>--host</value>
                             </systemProperty>
                         </systemProperties>
                     </configuration>

--- a/flow-tests/test-application-theme/test-theme-component-live-reload/pom.xml
+++ b/flow-tests/test-application-theme/test-theme-component-live-reload/pom.xml
@@ -14,6 +14,7 @@
     <packaging>war</packaging>
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <vaadin.devmode.liveReload.enabled>true</vaadin.devmode.liveReload.enabled>
     </properties>
 
     <dependencies>
@@ -60,26 +61,6 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>properties-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>set-system-properties</goal>
-                        </goals>
-                        <configuration>
-                            <properties>
-                                <property>
-                                    <!-- make sure live reload is enabled -->
-                                    <name>vaadin.devmode.liveReload.enabled</name>
-                                    <value>true</value>
-                                </property>
-                            </properties>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/flow-tests/test-application-theme/test-theme-live-reload/pom.xml
+++ b/flow-tests/test-application-theme/test-theme-live-reload/pom.xml
@@ -14,6 +14,7 @@
     <packaging>war</packaging>
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <vaadin.devmode.liveReload.enabled>true</vaadin.devmode.liveReload.enabled>
     </properties>
 
     <dependencies>
@@ -54,26 +55,6 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>properties-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>set-system-properties</goal>
-                        </goals>
-                        <configuration>
-                            <properties>
-                                <property>
-                                    <!-- make sure live reload is enabled -->
-                                    <name>vaadin.devmode.liveReload.enabled</name>
-                                    <value>true</value>
-                                </property>
-                            </properties>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/flow-tests/test-application-theme/test-theme-switch-live-reload/pom.xml
+++ b/flow-tests/test-application-theme/test-theme-switch-live-reload/pom.xml
@@ -14,6 +14,8 @@
     <packaging>war</packaging>
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <vaadin.reuseDevServer>true</vaadin.reuseDevServer>
+        <vaadin.devmode.liveReload.enabled>true</vaadin.devmode.liveReload.enabled>
     </properties>
 
     <dependencies>
@@ -66,30 +68,6 @@
                         </scanTargetPattern>
                     </scanTargetPatterns>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>properties-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>set-system-properties</goal>
-                        </goals>
-                        <configuration>
-                            <properties>
-                                <property>
-                                    <!-- make sure live reload is enabled -->
-                                    <name>vaadin.devmode.liveReload.enabled</name>
-                                    <value>true</value>
-                                </property>
-                                <property>
-                                    <name>vaadin.reuseDevServer</name>
-                                    <value>true</value>
-                                </property>
-                            </properties>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/flow-tests/test-ccdm-flow-navigation/pom-production.xml
+++ b/flow-tests/test-ccdm-flow-navigation/pom-production.xml
@@ -34,13 +34,6 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <configuration>
-                    <systemProperties>
-                        <systemProperty>
-                            <!-- make sure we do not leave webpack-dev-server running after IT -->
-                            <name>vaadin.reuseDevServer</name>
-                            <value>false</value>
-                        </systemProperty>
-                    </systemProperties>
                     <webApp>
                         <!-- use a non-root context -->
                         <contextPath>/context-path</contextPath>

--- a/flow-tests/test-ccdm-flow-navigation/pom.xml
+++ b/flow-tests/test-ccdm-flow-navigation/pom.xml
@@ -39,13 +39,6 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <configuration>
-                    <systemProperties>
-                        <systemProperty>
-                            <!-- make sure we do not leave webpack-dev-server running after IT -->
-                            <name>vaadin.reuseDevServer</name>
-                            <value>false</value>
-                        </systemProperty>
-                    </systemProperties>
                     <webApp>
                         <!-- use a non-root context -->
                         <contextPath>/context-path</contextPath>

--- a/flow-tests/test-ccdm/pom-production.xml
+++ b/flow-tests/test-ccdm/pom-production.xml
@@ -42,13 +42,6 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <configuration>
-                    <systemProperties>
-                        <systemProperty>
-                            <!-- make sure we do not leave webpack-dev-server running after IT -->
-                            <name>vaadin.reuseDevServer</name>
-                            <value>false</value>
-                        </systemProperty>
-                    </systemProperties>
                     <webApp>
                         <contextPath>/foo</contextPath>
                     </webApp>

--- a/flow-tests/test-ccdm/pom.xml
+++ b/flow-tests/test-ccdm/pom.xml
@@ -44,13 +44,6 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <configuration>
-                    <systemProperties>
-                        <systemProperty>
-                            <!-- make sure we do not leave webpack-dev-server running after IT -->
-                            <name>vaadin.reuseDevServer</name>
-                            <value>false</value>
-                        </systemProperty>
-                    </systemProperties>
                     <webApp>
                         <contextPath>/foo</contextPath>
                     </webApp>

--- a/flow-tests/test-embedding/test-embedding-reusable-theme/pom.xml
+++ b/flow-tests/test-embedding/test-embedding-reusable-theme/pom.xml
@@ -57,18 +57,6 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <version>${jetty.version}</version>
-                <!-- do not allow faulty app shell annotations for module -->
-                <!-- This should be removed when flow-tests do not break app shell annotation-->
-                <!-- flow-tests should not allow faulty annotations -->
-                <configuration>
-                    <systemProperties>
-                        <systemProperty>
-                            <name>vaadin.allow.appshell.annotations</name>
-                            <value>false</value>
-                        </systemProperty>
-                    </systemProperties>
-                </configuration>
             </plugin>
 
             <plugin>

--- a/flow-tests/test-frontend/vite-basics/pom.xml
+++ b/flow-tests/test-frontend/vite-basics/pom.xml
@@ -68,6 +68,10 @@
                 </executions>
             </plugin>
             <plugin>
+                 <groupId>org.eclipse.jetty</groupId>
+                 <artifactId>jetty-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>

--- a/flow-tests/test-frontend/vite-basics/pom.xml
+++ b/flow-tests/test-frontend/vite-basics/pom.xml
@@ -68,19 +68,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-maven-plugin</artifactId>
-                <configuration>
-                    <systemProperties>
-                        <!-- Allow test clients not on localhost to connect to Vite-->
-                        <systemProperty>
-                            <name>vaadin.devmode.vite.options</name>
-                            <value>--host</value>
-                        </systemProperty>
-                    </systemProperties>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>

--- a/flow-tests/test-fusion-csrf-context/pom.xml
+++ b/flow-tests/test-fusion-csrf-context/pom.xml
@@ -84,13 +84,6 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <configuration>
-                    <systemProperties>
-                        <systemProperty>
-                            <!-- make sure we do not leave webpack-dev-server running after IT -->
-                            <name>vaadin.reuseDevServer</name>
-                            <value>false</value>
-                        </systemProperty>
-                    </systemProperties>
                     <webApp>
                         <contextPath>/foo</contextPath>
                     </webApp>

--- a/flow-tests/test-fusion-csrf/pom.xml
+++ b/flow-tests/test-fusion-csrf/pom.xml
@@ -68,15 +68,6 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <configuration>
-                    <systemProperties>
-                        <systemProperty>
-                            <!-- make sure we do not leave webpack-dev-server running after IT -->
-                            <name>vaadin.reuseDevServer</name>
-                            <value>false</value>
-                        </systemProperty>
-                    </systemProperties>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>com.vaadin</groupId>

--- a/flow-tests/test-jetty-reload/pom.xml
+++ b/flow-tests/test-jetty-reload/pom.xml
@@ -14,6 +14,8 @@
     <packaging>war</packaging>
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <vaadin.reuseDevServer>true</vaadin.reuseDevServer>
+        <jetty.scantrigger>${project.build.directory}/scantrigger</jetty.scantrigger>
     </properties>
 
     <dependencies>
@@ -71,17 +73,6 @@
                             </includes>
                         </scanTargetPattern>
                     </scanTargetPatterns>
-                    <systemProperties>
-                        <force>true</force>
-                        <systemProperty>
-                            <name>jetty.scantrigger</name>
-                            <value>${project.build.directory}/scantrigger</value>
-                        </systemProperty>
-                        <systemProperty>
-                            <name>vaadin.reuseDevServer</name>
-                            <value>true</value>
-                        </systemProperty>
-                    </systemProperties>
                 </configuration>
             </plugin>
         </plugins>

--- a/flow-tests/test-live-reload/pom.xml
+++ b/flow-tests/test-live-reload/pom.xml
@@ -14,6 +14,7 @@
     <packaging>war</packaging>
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <vaadin.devmode.liveReload.enabled>true</vaadin.devmode.liveReload.enabled>
     </properties>
 
     <dependencies>
@@ -65,26 +66,6 @@
                         <contextPath>/context</contextPath>
                     </webApp>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>properties-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>set-system-properties</goal>
-                        </goals>
-                        <configuration>
-                            <properties>
-                                <property>
-                                    <!-- make sure live reload is enabled -->
-                                    <name>vaadin.devmode.liveReload.enabled</name>
-                                    <value>true</value>
-                                </property>
-                            </properties>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/flow-tests/test-mixed/pom-npm.xml
+++ b/flow-tests/test-mixed/pom-npm.xml
@@ -14,6 +14,7 @@
     <packaging>war</packaging>
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <vaadin.pnpm.enable>false</vaadin.pnpm.enable>
     </properties>
 
     <dependencies>
@@ -67,24 +68,6 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <configuration>
-                    <systemProperties>
-                        <systemProperty>
-                            <!-- this avoids an issue in chrome not loading the components
-                                 randomly when webpack dev server is not in debug mode -->
-                            <name>vaadin.devmode.webpack.options</name>
-                            <value>--debug</value>
-                        </systemProperty>
-                        <systemProperty>
-                            <!-- make sure we do not leave webpack-dev-server running after IT -->
-                            <name>vaadin.reuseDevServer</name>
-                            <value>false</value>
-                        </systemProperty>
-                        <systemProperty>
-                            <!-- disable PNPM -->
-                            <name>vaadin.pnpm.enable</name>
-                            <value>false</value>
-                        </systemProperty>
-                    </systemProperties>
                     <webApp>
                         <!-- We deploy the app with a context in the servlet container in order to test
                              that bootstrap code resolves correctly the application context and do

--- a/flow-tests/test-mixed/pom.xml
+++ b/flow-tests/test-mixed/pom.xml
@@ -67,20 +67,6 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <configuration>
-                    <systemProperties>
-                        <systemProperty>
-                            <!-- this avoids an issue in chrome not loading
-                                the components randomly when webpack dev server is not in debug mode -->
-                            <name>vaadin.devmode.webpack.options</name>
-                            <value>--mode=development</value>
-                        </systemProperty>
-                        <systemProperty>
-                            <!-- make sure we do not leave webpack-dev-server
-                                running after IT -->
-                            <name>vaadin.reuseDevServer</name>
-                            <value>false</value>
-                        </systemProperty>
-                    </systemProperties>
                     <webApp>
                         <!-- We deploy the app with a context in the servlet
                             container in order to test that bootstrap code resolves correctly the application

--- a/flow-tests/test-npm-only-features/pom.xml
+++ b/flow-tests/test-npm-only-features/pom.xml
@@ -38,26 +38,6 @@
         <module>test-npm-performance-regression</module>
     </modules>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-maven-plugin</artifactId>
-                <version>${jetty.version}</version>
-                <configuration>
-                    <systemProperties>
-                        <systemProperty>
-                            <!-- make sure we do not leave webpack-dev-server running after IT -->
-                            <name>vaadin.reuseDevServer</name>
-                            <value>false</value>
-                        </systemProperty>
-                    </systemProperties>
-                </configuration>
-            </plugin>
-
-        </plugins>
-    </build>
-
     <profiles>
         <profile>
             <id>productionMode</id>

--- a/flow-tests/test-root-context/pom.xml
+++ b/flow-tests/test-root-context/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <vaadin.allow.appshell.annotations>true</vaadin.allow.appshell.annotations>
     </properties>
 
     <dependencies>

--- a/flow-tests/test-root-ui-context/pom.xml
+++ b/flow-tests/test-root-ui-context/pom.xml
@@ -14,6 +14,7 @@
         <maven.deploy.skip>true</maven.deploy.skip>
         <!-- please remove after https://github.com/vaadin/flow/issues/7559 is fixed -->
         <vaadin.useDeprecatedV14Bootstrapping>true</vaadin.useDeprecatedV14Bootstrapping>
+        <vaadin.allow.appshell.annotations>true</vaadin.allow.appshell.annotations>
     </properties>
 
     <dependencies>
@@ -66,15 +67,6 @@
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <systemProperties>
-                        <systemProperty>
-                            <!-- Allow annotations due to push tests -->
-                            <name>vaadin.allow.appshell.annotations</name>
-                            <value>true</value>
-                        </systemProperty>
-                    </systemProperties>
-                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Sets reuseDevServer to false for all modules to ensure that webpack is killed when jetty is stopped
