### PR TITLE
test: Gradle tests must use local repo

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/AbstractGradleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/AbstractGradleTest.kt
@@ -27,7 +27,7 @@ import java.io.File
  */
 abstract class AbstractGradleTest {
 
-    val flowVersion = System.getenv("vaadin.version").takeUnless { it.isNullOrEmpty() } ?: "8.0-SNAPSHOT"
+    val flowVersion = System.getenv("vaadin.version").takeUnless { it.isNullOrEmpty() } ?: "10.0-SNAPSHOT"
 
     /**
      * The testing Gradle project. Automatically deleted after every test.

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscMultiModuleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscMultiModuleTest.kt
@@ -34,6 +34,7 @@ class MiscMultiModuleTest : AbstractGradleTest() {
             }
             allprojects {
                 repositories {
+                    mavenLocal()
                     mavenCentral()
                     jcenter()
                     maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
@@ -78,6 +79,7 @@ class MiscMultiModuleTest : AbstractGradleTest() {
             }
             allprojects {
                 repositories {
+                    mavenLocal()
                     mavenCentral()
                     jcenter()
                     maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
@@ -36,6 +36,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
                 id 'com.vaadin'
             }
             repositories {
+                mavenLocal()
                 mavenCentral()
                 jcenter()
                 maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
@@ -69,6 +70,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
                 id("com.vaadin")
             }
             repositories {
+                mavenLocal()
                 mavenCentral()
                 jcenter()
                 maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
@@ -103,6 +105,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
                 id("com.vaadin")
             }
             repositories {
+                mavenLocal()
                 mavenCentral()
                 jcenter()
                 maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
@@ -136,6 +139,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
                 id("com.vaadin")
             }
             repositories {
+                mavenLocal()
                 mavenCentral()
                 jcenter()
                 maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
@@ -176,6 +180,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
                 id("com.vaadin")
             }
             repositories {
+                mavenLocal()
                 mavenCentral()
                 jcenter()
                 maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
@@ -233,6 +238,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
             }
             
             repositories {
+                mavenLocal()
                 mavenCentral()
                 jcenter()
                 maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
@@ -318,6 +324,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
                 id("com.vaadin")
             }
             repositories {
+                mavenLocal()
                 mavenCentral()
                 jcenter()
                 maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
@@ -374,6 +381,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
                 id 'com.vaadin'
             }
             repositories {
+                mavenLocal()
                 mavenCentral()
                 jcenter()
                 maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }
@@ -425,6 +433,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
                 id 'com.vaadin'
             }
             repositories {
+                mavenLocal()
                 mavenCentral()
                 jcenter()
                 maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
@@ -40,6 +40,7 @@ class VaadinSmokeTest : AbstractGradleTest() {
                 id 'com.vaadin'
             }
             repositories {
+                mavenLocal()
                 mavenCentral()
                 jcenter()
                 maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }


### PR DESCRIPTION
Gradlel tests should by default use
local maven cache repo to get packages.
