### PR TITLE
test: remove duplicates from the module list

### DIFF
--- a/scripts/computeMatrix.js
+++ b/scripts/computeMatrix.js
@@ -246,6 +246,7 @@ function getParts(suite, prefix, slices) {
 
   const exclusions = Object.keys(moduleSplits).filter(module => modules.includes(module));
   modules = grep(modules, [...globalExclusions, ...exclusions]);
+  modules = modules.filter((value, index, array) => array.indexOf(value) === index);
 
   const excSlices = exclusions.reduce((prev, module) => prev + moduleSplits[module], 0);
   const parts = splitArray(modules, slices - excSlices, moduleWeights);


### PR DESCRIPTION
There are modules that are run twice because the recursive visit returns duplicates in cases with profiles for shared modules.