### PR TITLE
chore: Upgrade to Node 17 + npm 8.3

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -56,11 +56,11 @@ import com.vaadin.flow.server.startup.ApplicationConfiguration;
  */
 public class FrontendTools {
 
-    public static final String DEFAULT_NODE_VERSION = "v16.13.0";
+    public static final String DEFAULT_NODE_VERSION = "v17.3.0";
     /**
      * This is the version shipped with the default Node version.
      */
-    public static final String DEFAULT_NPM_VERSION = "8.1.0";
+    public static final String DEFAULT_NPM_VERSION = "8.3.0";
 
     public static final String DEFAULT_PNPM_VERSION = "5.18.10";
 


### PR DESCRIPTION
npm 8.3 includes the package version override feature which allows us to deal with dependency conflicts in a better way
