### PR TITLE
refactor: make isAttached iterative

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
@@ -574,7 +574,15 @@ public class StateNode implements Serializable {
      *         this node is not attached
      */
     public boolean isAttached() {
-        return parent != null && parent.isAttached();
+        if (getParent() == null) {
+            return false;
+        } else {
+            StateNode root = getParent();
+            while (root.getParent() != null) {
+                root = root.getParent();
+            }
+            return root.isAttached();
+        }
     }
 
     /**


### PR DESCRIPTION
Since isAttached is trivially tail-recursive, use a loop instead of recursion.
Reduces memory consumption in tests that construct deep trees.
