### PR TITLE
fix: check if --openssl-legacy-provider required for Node (#12675)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -387,11 +387,6 @@ public class FrontendTools {
         }
         try {
             FrontendVersion foundNodeVersion = getNodeVersion();
-            if (foundNodeVersion.getMajorVersion() == 17
-                    && foundNodeVersion.getMinorVersion() == 0) {
-                throw new IllegalStateException(
-                        "Node version 17.0 is incompatible with webpack 4. Please upgrade to Node 17.1 or newer, or downgrade to Node 16.");
-            }
             FrontendUtils.validateToolVersion("node", foundNodeVersion,
                     SUPPORTED_NODE_VERSION, SHOULD_WORK_NODE_VERSION);
         } catch (UnknownVersionException e) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -255,15 +255,6 @@ public class FrontendToolsTest {
         Assert.assertTrue(file.exists());
     }
 
-    @Test
-    public void validateNodeAndNpmVersion_brokenNode17() throws Exception {
-        Mockito.when(tools.getNodeVersion())
-                .thenReturn(new FrontendVersion(17, 0));
-        Assert.assertThrows(IllegalStateException.class, () -> {
-            tools.validateNodeAndNpmVersion();
-        });
-    }
-
     @Test(expected = IllegalStateException.class)
     public void ensureNodeExecutableInHome_vaadinHomeNodeIsAFolder_throws()
             throws IOException {


### PR DESCRIPTION
Check if `node -p 'crypto.createHash("md4")'` works. If not,
pass the `--openssl-legacy-provider` flag. Workaround for:
https://github.com/webpack/webpack/issues/14532
Fixes #12649
