### PR TITLE
fix: Always use defined node version

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -57,6 +57,8 @@ import static com.vaadin.flow.server.Constants.GENERATED_TOKEN;
 import static com.vaadin.flow.server.Constants.NPM_TOKEN;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_ENABLE_DEV_SERVER;
+import static com.vaadin.flow.server.InitParameters.NODE_DOWNLOAD_ROOT;
+import static com.vaadin.flow.server.InitParameters.NODE_VERSION;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FRONTEND;
 import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
 import static com.vaadin.flow.server.frontend.FrontendUtils.TOKEN_FILE;
@@ -218,7 +220,7 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo {
         String nodePath;
         FrontendTools tools = new FrontendTools(npmFolder.getAbsolutePath(),
                 ()-> FrontendUtils.getVaadinHomeDirectory().getAbsolutePath(),
-                nodeVersion, nodeDownloadRootURI);
+                nodeVersion, nodeDownloadRootURI, requireHomeNodeExec);
         if (requireHomeNodeExec) {
             nodePath = tools
                     .forceAlternativeNodeExecutable();
@@ -292,6 +294,8 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo {
             buildInfo.remove(NPM_TOKEN);
             buildInfo.remove(GENERATED_TOKEN);
             buildInfo.remove(FRONTEND_TOKEN);
+            buildInfo.remove(NODE_VERSION);
+            buildInfo.remove(NODE_DOWNLOAD_ROOT);
             buildInfo.remove(Constants.SERVLET_PARAMETER_ENABLE_PNPM);
             buildInfo.remove(Constants.REQUIRE_HOME_NODE_EXECUTABLE);
 

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -27,6 +27,8 @@ import org.apache.maven.plugins.annotations.Parameter;
 import com.vaadin.flow.server.Constants;
 
 import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
+import static com.vaadin.flow.server.InitParameters.NODE_DOWNLOAD_ROOT;
+import static com.vaadin.flow.server.InitParameters.NODE_VERSION;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FRONTEND;
 
 /**
@@ -95,7 +97,7 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo {
      * Vaadin, for example `"v14.15.4"`. Defaults to null which uses the
      * Vaadin-default node version - see {@link FrontendTools} for details.
      */
-    @Parameter(property = "node.version", defaultValue = FrontendTools.DEFAULT_NODE_VERSION)
+    @Parameter(property = NODE_VERSION, defaultValue = FrontendTools.DEFAULT_NODE_VERSION)
     protected String nodeVersion;
 
     /**
@@ -106,7 +108,7 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo {
      * <p></p>
      * Example: <code>"https://nodejs.org/dist/"</code>.
      */
-    @Parameter(property = "node.download.root", defaultValue = NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT)
+    @Parameter(property = NODE_DOWNLOAD_ROOT, defaultValue = NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT)
     protected String nodeDownloadRoot;
 
     /**

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
@@ -52,6 +52,8 @@ import static com.vaadin.flow.server.Constants.GENERATED_TOKEN;
 import static com.vaadin.flow.server.Constants.NPM_TOKEN;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_COMPATIBILITY_MODE;
 import static com.vaadin.flow.server.Constants.SERVLET_PARAMETER_PRODUCTION_MODE;
+import static com.vaadin.flow.server.InitParameters.NODE_DOWNLOAD_ROOT;
+import static com.vaadin.flow.server.InitParameters.NODE_VERSION;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FRONTEND;
 import static com.vaadin.flow.server.frontend.FrontendUtils.TOKEN_FILE;
 
@@ -143,7 +145,7 @@ public class PrepareFrontendMojo extends FlowModeAbstractMojo {
         try {
             FrontendTools tools = new FrontendTools(npmFolder.getAbsolutePath(),
                     () -> FrontendUtils.getVaadinHomeDirectory().getAbsolutePath(),
-                    nodeVersion, nodeDownloadRootURI);
+                    nodeVersion, nodeDownloadRootURI, requireHomeNodeExec);
             tools.validateNodeAndNpmVersion();
         } catch (IllegalStateException exception) {
             throw new MojoExecutionException(exception.getMessage(), exception);
@@ -197,6 +199,8 @@ public class PrepareFrontendMojo extends FlowModeAbstractMojo {
         buildInfo.put(Constants.SERVLET_PARAMETER_ENABLE_PNPM, pnpmEnable);
         buildInfo.put(Constants.REQUIRE_HOME_NODE_EXECUTABLE,
                 requireHomeNodeExec);
+        buildInfo.put(NODE_VERSION, nodeVersion);
+        buildInfo.put(NODE_DOWNLOAD_ROOT, nodeDownloadRoot);
 
         try {
             FileUtils.forceMkdir(token.getParentFile());

--- a/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DeploymentConfigurationFactory.java
@@ -54,6 +54,8 @@ import static com.vaadin.flow.server.Constants.FRONTEND_TOKEN;
 import static com.vaadin.flow.server.Constants.NPM_TOKEN;
 import static com.vaadin.flow.server.Constants.VAADIN_PREFIX;
 import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
+import static com.vaadin.flow.server.InitParameters.NODE_DOWNLOAD_ROOT;
+import static com.vaadin.flow.server.InitParameters.NODE_VERSION;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_COMPATIBILITY_MODE;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_ENABLE_DEV_SERVER;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE;
@@ -246,6 +248,15 @@ public final class DeploymentConfigurationFactory implements Serializable {
             initParameters.setProperty(PROJECT_BASEDIR,
                     buildInfo.getString(NPM_TOKEN));
             verifyFolderExists(initParameters, buildInfo.getString(NPM_TOKEN));
+        }
+
+        if (buildInfo.hasKey(NODE_VERSION)) {
+            initParameters.setProperty(NODE_VERSION,
+                    buildInfo.getString(NODE_VERSION));
+        }
+        if (buildInfo.hasKey(NODE_DOWNLOAD_ROOT)) {
+            initParameters.setProperty(NODE_DOWNLOAD_ROOT,
+                    buildInfo.getString(NODE_DOWNLOAD_ROOT));
         }
 
         if (buildInfo.hasKey(FRONTEND_TOKEN)) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
@@ -27,6 +27,7 @@ import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 import java.net.HttpURLConnection;
 import java.net.ServerSocket;
+import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -54,8 +55,11 @@ import com.vaadin.flow.internal.Pair;
 import com.vaadin.flow.server.communication.StreamRequestHandler;
 import com.vaadin.flow.server.frontend.FrontendTools;
 import com.vaadin.flow.server.frontend.FrontendUtils;
+import com.vaadin.flow.server.frontend.installer.NodeInstaller;
 
 import static com.vaadin.flow.server.Constants.VAADIN_MAPPING;
+import static com.vaadin.flow.server.InitParameters.NODE_DOWNLOAD_ROOT;
+import static com.vaadin.flow.server.InitParameters.NODE_VERSION;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_WEBPACK_ERROR_PATTERN;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_WEBPACK_OPTIONS;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_DEVMODE_WEBPACK_SUCCESS_PATTERN;
@@ -623,11 +627,15 @@ public final class DevModeHandler implements RequestHandler {
         ProcessBuilder processBuilder = new ProcessBuilder()
                 .directory(npmFolder);
 
+        final String nodeVersion = config.getStringProperty(NODE_VERSION,
+                FrontendTools.DEFAULT_NODE_VERSION);
+        final String nodeDownloadRoot = config.getStringProperty(
+                NODE_DOWNLOAD_ROOT, NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT);
         boolean useHomeNodeExec = config.getBooleanProperty(
                 InitParameters.REQUIRE_HOME_NODE_EXECUTABLE, false);
         FrontendTools tools = new FrontendTools(npmFolder.getAbsolutePath(),
                 () -> FrontendUtils.getVaadinHomeDirectory().getAbsolutePath(),
-                useHomeNodeExec);
+                nodeVersion, URI.create(nodeDownloadRoot), useHomeNodeExec);
         tools.validateNodeAndNpmVersion();
 
         if (requiresOpenSslLegacyProvider(npmFolder,

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -71,6 +71,8 @@ public class InitParameters implements Serializable {
     public static final String SERVLET_PARAMETER_MAX_MESSAGE_SUSPEND_TIMEOUT = "maxMessageSuspendTimeout";
     public static final String SERVLET_PARAMETER_JSBUNDLE = "module.bundle";
     public static final String SERVLET_PARAMETER_POLYFILLS = "module.polyfills";
+    public static final String NODE_VERSION = "node.version";
+    public static final String NODE_DOWNLOAD_ROOT = "node.download.root";
 
     /**
      * Configuration name for the parameter that determines whether Brotli

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -299,7 +299,7 @@ public class FrontendTools {
     public String getNodeExecutable() {
         Pair<String, String> nodeCommands = getNodeCommands();
         File file = getExecutable(baseDir, nodeCommands.getSecond());
-        if (file == null) {
+        if (file == null && !forceAlternativeNode) {
             file = frontendToolsLocator.tryLocateTool(nodeCommands.getFirst())
                     .orElse(null);
         }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -620,8 +620,7 @@ public class FrontendToolsTest {
         createStubNode(false, true, vaadinHomeDir);
 
         assertThat(tools.getNodeExecutable(), containsString("node"));
-        assertThat(tools.getNodeExecutable(),
-                not(containsString(DEFAULT_NODE)));
+
         List<String> npmExecutable = tools.getNpmExecutable();
         assertThat(npmExecutable.get(0), containsString("node"));
         assertThat(npmExecutable.get(1), containsString(NPM_CLI_STRING));


### PR DESCRIPTION
Use node version and url properties if defined.
Force home node also in plugin if set.

part of #12686

