### PR TITLE
fix: Always use defined node version

### DIFF
--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -109,7 +109,7 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
      * </p>
      * Example: <code>"https://nodejs.org/dist/"</code>.
      */
-    @Parameter(property = "node.download.root", defaultValue = NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT)
+    @Parameter(property = InitParameters.NODE_DOWNLOAD_ROOT, defaultValue = NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT)
     private String nodeDownloadRoot;
 
     /**
@@ -117,7 +117,7 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
      * Vaadin, for example `"v16.0.0"`. Defaults to null which uses the
      * Vaadin-default node version - see {@link FrontendTools} for details.
      */
-    @Parameter(property = "node.version", defaultValue = FrontendTools.DEFAULT_NODE_VERSION)
+    @Parameter(property = InitParameters.NODE_VERSION, defaultValue = FrontendTools.DEFAULT_NODE_VERSION)
     private String nodeVersion;
 
     /**

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.commons.io.FileUtils;
+import org.slf4j.LoggerFactory;
 import org.zeroturnaround.exec.InvalidExitValueException;
 import org.zeroturnaround.exec.ProcessExecutor;
 
@@ -196,8 +197,7 @@ public class BuildFrontendUtil {
      *            - the PluginAdapterBase.
      * @return the Token {@link File}.
      */
-    public static File propagateBuildInfo(PluginAdapterBase adapter)
-            throws URISyntaxException {
+    public static File propagateBuildInfo(PluginAdapterBase adapter) {
 
         // For forked processes not accessing to System.properties we leave a
         // token file with the information about the build
@@ -212,8 +212,13 @@ public class BuildFrontendUtil {
                 adapter.eagerServerLoad());
         buildInfo.put(NPM_TOKEN, adapter.npmFolder().getAbsolutePath());
         buildInfo.put(NODE_VERSION, adapter.nodeVersion());
-        buildInfo.put(NODE_DOWNLOAD_ROOT,
-                adapter.nodeDownloadRoot().toString());
+        try {
+            buildInfo.put(NODE_DOWNLOAD_ROOT,
+                    adapter.nodeDownloadRoot().toString());
+        } catch (URISyntaxException e) {
+            LoggerFactory.getLogger("BuildInfo")
+                    .error("NODE_DOWNLOAD_ROOT defined incorrectly", e);
+        }
         buildInfo.put(GENERATED_TOKEN,
                 adapter.generatedFolder().getAbsolutePath());
         buildInfo.put(FRONTEND_TOKEN,

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -216,8 +216,9 @@ public class BuildFrontendUtil {
             buildInfo.put(NODE_DOWNLOAD_ROOT,
                     adapter.nodeDownloadRoot().toString());
         } catch (URISyntaxException e) {
-            LoggerFactory.getLogger("BuildInfo")
-                    .error("NODE_DOWNLOAD_ROOT defined incorrectly", e);
+            LoggerFactory.getLogger("BuildInfo").error(
+                    "Configuration 'nodeDownloadRoot'  (property 'node.download.root') is defined incorrectly",
+                    e);
         }
         buildInfo.put(GENERATED_TOKEN,
                 adapter.generatedFolder().getAbsolutePath());

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -58,6 +58,8 @@ import static com.vaadin.flow.server.Constants.FRONTEND_TOKEN;
 import static com.vaadin.flow.server.Constants.GENERATED_TOKEN;
 import static com.vaadin.flow.server.Constants.NPM_TOKEN;
 import static com.vaadin.flow.server.Constants.PROJECT_FRONTEND_GENERATED_DIR_TOKEN;
+import static com.vaadin.flow.server.InitParameters.NODE_DOWNLOAD_ROOT;
+import static com.vaadin.flow.server.InitParameters.NODE_VERSION;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_ENABLE_DEV_SERVER;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_INITIAL_UIDL;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE;
@@ -194,7 +196,8 @@ public class BuildFrontendUtil {
      *            - the PluginAdapterBase.
      * @return the Token {@link File}.
      */
-    public static File propagateBuildInfo(PluginAdapterBase adapter) {
+    public static File propagateBuildInfo(PluginAdapterBase adapter)
+            throws URISyntaxException {
 
         // For forked processes not accessing to System.properties we leave a
         // token file with the information about the build
@@ -208,6 +211,8 @@ public class BuildFrontendUtil {
         buildInfo.put(SERVLET_PARAMETER_INITIAL_UIDL,
                 adapter.eagerServerLoad());
         buildInfo.put(NPM_TOKEN, adapter.npmFolder().getAbsolutePath());
+        buildInfo.put(NODE_VERSION, adapter.nodeVersion());
+        buildInfo.put(NODE_DOWNLOAD_ROOT, adapter.nodeDownloadRoot().toString());
         buildInfo.put(GENERATED_TOKEN,
                 adapter.generatedFolder().getAbsolutePath());
         buildInfo.put(FRONTEND_TOKEN,
@@ -462,6 +467,8 @@ public class BuildFrontendUtil {
             JsonObject buildInfo = JsonUtil.parse(json);
 
             buildInfo.remove(NPM_TOKEN);
+            buildInfo.remove(NODE_VERSION);
+            buildInfo.remove(NODE_DOWNLOAD_ROOT);
             buildInfo.remove(GENERATED_TOKEN);
             buildInfo.remove(FRONTEND_TOKEN);
             buildInfo.remove(Constants.SERVLET_PARAMETER_ENABLE_PNPM);

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -212,7 +212,8 @@ public class BuildFrontendUtil {
                 adapter.eagerServerLoad());
         buildInfo.put(NPM_TOKEN, adapter.npmFolder().getAbsolutePath());
         buildInfo.put(NODE_VERSION, adapter.nodeVersion());
-        buildInfo.put(NODE_DOWNLOAD_ROOT, adapter.nodeDownloadRoot().toString());
+        buildInfo.put(NODE_DOWNLOAD_ROOT,
+                adapter.nodeDownloadRoot().toString());
         buildInfo.put(GENERATED_TOKEN,
                 adapter.generatedFolder().getAbsolutePath());
         buildInfo.put(FRONTEND_TOKEN,

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -63,6 +63,8 @@ public class InitParameters implements Serializable {
     public static final String SERVLET_PARAMETER_MAX_MESSAGE_SUSPEND_TIMEOUT = "maxMessageSuspendTimeout";
     public static final String SERVLET_PARAMETER_JSBUNDLE = "module.bundle";
     public static final String SERVLET_PARAMETER_POLYFILLS = "module.polyfills";
+    public static final String NODE_VERSION = "node.version";
+    public static final String NODE_DOWNLOAD_ROOT = "node.download.root";
 
     /**
      * Configuration name for the parameter that determines whether Brotli

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -44,6 +44,9 @@ import com.vaadin.flow.server.frontend.installer.NodeInstaller;
 import com.vaadin.flow.server.frontend.installer.ProxyConfig;
 import com.vaadin.flow.server.startup.ApplicationConfiguration;
 
+import static com.vaadin.flow.server.InitParameters.NODE_DOWNLOAD_ROOT;
+import static com.vaadin.flow.server.InitParameters.NODE_VERSION;
+
 /**
  * Provides access to frontend tools (node.js and npm, pnpm) and optionally
  * installs the tools if needed.
@@ -428,6 +431,10 @@ public class FrontendTools {
                 .getBooleanProperty(InitParameters.NODE_AUTO_UPDATE, false);
         boolean useGlobalPnpm = applicationConfiguration.getBooleanProperty(
                 InitParameters.SERVLET_PARAMETER_GLOBAL_PNPM, false);
+        final String nodeVersion = applicationConfiguration.getStringProperty(NODE_VERSION,
+                FrontendTools.DEFAULT_NODE_VERSION);
+        final String nodeDownloadRoot = applicationConfiguration.getStringProperty(
+                NODE_DOWNLOAD_ROOT, NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT);
 
         FrontendToolsSettings settings = new FrontendToolsSettings(
                 projectRoot.getAbsolutePath(),
@@ -435,6 +442,8 @@ public class FrontendTools {
         settings.setForceAlternativeNode(useHomeNodeExec);
         settings.setAutoUpdate(nodeAutoUpdate);
         settings.setUseGlobalPnpm(useGlobalPnpm);
+        settings.setNodeVersion(nodeVersion);
+        settings.setNodeDownloadRoot(URI.create(nodeDownloadRoot));
         return settings;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -431,10 +431,11 @@ public class FrontendTools {
                 .getBooleanProperty(InitParameters.NODE_AUTO_UPDATE, false);
         boolean useGlobalPnpm = applicationConfiguration.getBooleanProperty(
                 InitParameters.SERVLET_PARAMETER_GLOBAL_PNPM, false);
-        final String nodeVersion = applicationConfiguration.getStringProperty(NODE_VERSION,
-                FrontendTools.DEFAULT_NODE_VERSION);
-        final String nodeDownloadRoot = applicationConfiguration.getStringProperty(
-                NODE_DOWNLOAD_ROOT, NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT);
+        final String nodeVersion = applicationConfiguration.getStringProperty(
+                NODE_VERSION, FrontendTools.DEFAULT_NODE_VERSION);
+        final String nodeDownloadRoot = applicationConfiguration
+                .getStringProperty(NODE_DOWNLOAD_ROOT,
+                        NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT);
 
         FrontendToolsSettings settings = new FrontendToolsSettings(
                 projectRoot.getAbsolutePath(),

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractConfigurationFactory.java
@@ -44,6 +44,8 @@ import static com.vaadin.flow.server.Constants.NPM_TOKEN;
 import static com.vaadin.flow.server.Constants.PROJECT_FRONTEND_GENERATED_DIR_TOKEN;
 import static com.vaadin.flow.server.Constants.VAADIN_PREFIX;
 import static com.vaadin.flow.server.InitParameters.BUILD_FOLDER;
+import static com.vaadin.flow.server.InitParameters.NODE_DOWNLOAD_ROOT;
+import static com.vaadin.flow.server.InitParameters.NODE_VERSION;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_ENABLE_DEV_SERVER;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_INITIAL_UIDL;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_PRODUCTION_MODE;
@@ -113,6 +115,15 @@ public class AbstractConfigurationFactory implements Serializable {
         if (buildInfo.hasKey(NPM_TOKEN)) {
             params.put(PROJECT_BASEDIR, buildInfo.getString(NPM_TOKEN));
             verifyFolderExists(params, buildInfo.getString(NPM_TOKEN));
+        }
+
+        if (buildInfo.hasKey(NODE_VERSION)) {
+            params.put(NODE_VERSION,
+                    buildInfo.getString(NODE_VERSION));
+        }
+        if (buildInfo.hasKey(NODE_DOWNLOAD_ROOT)) {
+            params.put(NODE_DOWNLOAD_ROOT,
+                    buildInfo.getString(NODE_DOWNLOAD_ROOT));
         }
 
         if (buildInfo.hasKey(FRONTEND_TOKEN)) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractConfigurationFactory.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/AbstractConfigurationFactory.java
@@ -118,8 +118,7 @@ public class AbstractConfigurationFactory implements Serializable {
         }
 
         if (buildInfo.hasKey(NODE_VERSION)) {
-            params.put(NODE_VERSION,
-                    buildInfo.getString(NODE_VERSION));
+            params.put(NODE_VERSION, buildInfo.getString(NODE_VERSION));
         }
         if (buildInfo.hasKey(NODE_DOWNLOAD_ROOT)) {
             params.put(NODE_DOWNLOAD_ROOT,

--- a/flow-server/src/test/java/com/vaadin/flow/server/DeploymentConfigurationFactoryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DeploymentConfigurationFactoryTest.java
@@ -347,6 +347,8 @@ public class DeploymentConfigurationFactoryTest {
                 InitParameters.SERVLET_PARAMETER_DEVMODE_WEBPACK_OPTIONS,
                 InitParameters.SERVLET_PARAMETER_DEVMODE_VITE_OPTIONS,
                 InitParameters.COMPILED_WEB_COMPONENTS_PATH,
+                InitParameters.NODE_VERSION,
+                InitParameters.NODE_DOWNLOAD_ROOT,
                 InitParameters.BUILD_FOLDER));
         Field[] initParamFields = InitParameters.class.getDeclaredFields();
         String mockTokenJsonString = generateJsonStringFromFields(

--- a/flow-server/src/test/java/com/vaadin/flow/server/DeploymentConfigurationFactoryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DeploymentConfigurationFactoryTest.java
@@ -347,8 +347,7 @@ public class DeploymentConfigurationFactoryTest {
                 InitParameters.SERVLET_PARAMETER_DEVMODE_WEBPACK_OPTIONS,
                 InitParameters.SERVLET_PARAMETER_DEVMODE_VITE_OPTIONS,
                 InitParameters.COMPILED_WEB_COMPONENTS_PATH,
-                InitParameters.NODE_VERSION,
-                InitParameters.NODE_DOWNLOAD_ROOT,
+                InitParameters.NODE_VERSION, InitParameters.NODE_DOWNLOAD_ROOT,
                 InitParameters.BUILD_FOLDER));
         Field[] initParamFields = InitParameters.class.getDeclaredFields();
         String mockTokenJsonString = generateJsonStringFromFields(


### PR DESCRIPTION
If defined always use the node version
and download root url is defined.

Closes #12686
