### PR TITLE
fix: use configured push parameter

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PushRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PushRequestHandler.java
@@ -102,10 +102,13 @@ public class PushRequestHandler
             getLogger().debug("Using pre-initialized Atmosphere for servlet {}",
                     vaadinServletConfig.getServletName());
         }
-        pushHandler.setLongPollingSuspendTimeout(
-                atmosphere.getAtmosphereConfig().getInitParameter(
-                        InitParameters.SERVLET_PARAMETER_PUSH_SUSPEND_TIMEOUT_LONGPOLLING,
-                        -1));
+        String timeout = service.getDeploymentConfiguration().getStringProperty(
+                InitParameters.SERVLET_PARAMETER_PUSH_SUSPEND_TIMEOUT_LONGPOLLING,
+                "-1");
+        atmosphere.addInitParameter(
+                InitParameters.SERVLET_PARAMETER_PUSH_SUSPEND_TIMEOUT_LONGPOLLING,
+                timeout);
+        pushHandler.setLongPollingSuspendTimeout(Integer.parseInt(timeout));
         for (AtmosphereHandlerWrapper handlerWrapper : atmosphere
                 .getAtmosphereHandlers().values()) {
             AtmosphereHandler handler = handlerWrapper.atmosphereHandler;


### PR DESCRIPTION
Get the push suspend timout
parameter from the configuration
as atmosphere doesn't read it
from anywhere.

Fixes #12559
