### PR TITLE
fix: add wepack dev server parameter --host=127.0.0.1

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
@@ -728,6 +728,11 @@ public final class DevModeHandler implements RequestHandler {
         command.add("--port");
         command.add(String.valueOf(port));
         command.add("--watchDogPort=" + watchDog.get().getWatchDogPort());
+
+        // Workaround for issue with Node 17 webpack dev server denying
+        // request to localhost. See https://github.com/vaadin/flow/issues/12546
+        command.add("--host=127.0.0.1");
+
         command.addAll(Arrays.asList(config
                 .getStringProperty(SERVLET_PARAMETER_DEVMODE_WEBPACK_OPTIONS,
                         "-d --inline=false")


### PR DESCRIPTION
Works around connection issue with webpack-dev-server 3.11.0 and Node 17+.

Fixes #12546.