### PR TITLE
Fix statistic test failure

### DIFF
--- a/flow-server/src/test/java/com/vaadin/experimental/FeatureFlagsTest.java
+++ b/flow-server/src/test/java/com/vaadin/experimental/FeatureFlagsTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Collection;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import com.vaadin.flow.internal.UsageStatistics;
@@ -154,13 +155,17 @@ public class FeatureFlagsTest {
     @Test
     public void disabledFeatureFlagsNotMarkedInStatsWhenLoading()
             throws IOException {
-        Collection<UsageEntry> originalEntries = UsageStatistics.getEntries().collect(Collectors.toList());
+        Collection<UsageEntry> originalEntries = getUsageStatisticsEntries();
         UsageStatistics.clearEntries();
         createFeatureFlagsFile("");
         featureFlags.loadProperties();
         Assert.assertFalse(
                 hasUsageStatsEntry("flow/featureflags/exampleFeatureFlag"));
         restoreUsageStatistics(originalEntries);
+    }
+
+    private List<UsageEntry> getUsageStatisticsEntries() {
+        return UsageStatistics.getEntries().collect(Collectors.toList());
     }
 
     @Test
@@ -176,7 +181,7 @@ public class FeatureFlagsTest {
     @Test
     public void disabledFeatureFlagsNotMarkedInStatsWhenToggled()
             throws IOException {
-        Collection<UsageEntry> originalEntries = UsageStatistics.getEntries().collect(Collectors.toList());
+        Collection<UsageEntry> originalEntries = getUsageStatisticsEntries();
         createFeatureFlagsFile(
                 "com.vaadin.experimental.exampleFeatureFlag=true\n");
         UsageStatistics.clearEntries();
@@ -189,7 +194,7 @@ public class FeatureFlagsTest {
     @Test
     public void enabledFeatureFlagsMarkedInStatsWhenToggled()
             throws IOException {
-        Collection<UsageEntry> originalEntries = UsageStatistics.getEntries().collect(Collectors.toList());
+        Collection<UsageEntry> originalEntries = getUsageStatisticsEntries();
         createFeatureFlagsFile(
                 "com.vaadin.experimental.exampleFeatureFlag=false\n");
         UsageStatistics.clearEntries();
@@ -228,6 +233,7 @@ public class FeatureFlagsTest {
     }
 
     private void restoreUsageStatistics(Collection<UsageEntry> entries) {
-        entries.forEach(entry -> UsageStatistics.markAsUsed(entry.getName(), entry.getVersion()));
+        entries.forEach(entry -> UsageStatistics.markAsUsed(entry.getName(),
+                entry.getVersion()));
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServiceTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServiceTest.java
@@ -98,7 +98,8 @@ public class VaadinServiceTest {
 
         // this test needs a fresh empty statistics, so we need to clear
         // them for resusing forks for unit tests
-        List<UsageEntry> originalEntries = UsageStatistics.getEntries().collect(Collectors.toList());
+        List<UsageEntry> originalEntries = UsageStatistics.getEntries()
+                .collect(Collectors.toList());
         UsageStatistics.clearEntries();
 
         VaadinServiceInitListener initListener = event -> {
@@ -114,7 +115,8 @@ public class VaadinServiceTest {
         Assert.assertTrue(UsageStatistics.getEntries().anyMatch(
                 e -> Constants.STATISTIC_ROUTING_SERVER.equals(e.getName())));
 
-        originalEntries.forEach(entry -> UsageStatistics.markAsUsed(entry.getName(), entry.getVersion()));
+        originalEntries.forEach(entry -> UsageStatistics
+                .markAsUsed(entry.getName(), entry.getVersion()));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServiceTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServiceTest.java
@@ -42,6 +42,7 @@ import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.CurrentInstance;
 import com.vaadin.flow.internal.UsageStatistics;
+import com.vaadin.flow.internal.UsageStatistics.UsageEntry;
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.flow.router.RouteData;
 import com.vaadin.flow.router.Router;
@@ -97,6 +98,7 @@ public class VaadinServiceTest {
 
         // this test needs a fresh empty statistics, so we need to clear
         // them for resusing forks for unit tests
+        List<UsageEntry> originalEntries = UsageStatistics.getEntries().collect(Collectors.toList());
         UsageStatistics.clearEntries();
 
         VaadinServiceInitListener initListener = event -> {
@@ -111,6 +113,8 @@ public class VaadinServiceTest {
 
         Assert.assertTrue(UsageStatistics.getEntries().anyMatch(
                 e -> Constants.STATISTIC_ROUTING_SERVER.equals(e.getName())));
+
+        originalEntries.forEach(entry -> UsageStatistics.markAsUsed(entry.getName(), entry.getVersion()));
     }
 
     @Test


### PR DESCRIPTION
`UsageStatisticsExporterTest` is failing when running `mvn verify` because it assumes nonempty entries, but some other tests clear the entries.