### PR TITLE
chore: fix potential NPE in usagestatistics

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/UsageStatistics.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/UsageStatistics.java
@@ -125,8 +125,12 @@ public class UsageStatistics {
     private static void setupDefaultEntries() {
         String version = System.getProperty("java.version");
 
-        // Ignore pre, build and opt fields
-        version = version.replaceAll("[-_+].*", "");
+        if (version != null) {
+            // Ignore pre, build and opt fields
+            version = version.replaceAll("[-_+].*", "");
+        } else {
+            version = "unknown";
+        }
 
         markAsUsed("java", version);
     }


### PR DESCRIPTION
Related to https://github.com/vaadin/flow/pull/12718#discussion_r784755431. 

Tried to have a test of the setting system property to null, but then it throws NPE when calling `System.setProperty("xx", null);`