### PR TITLE
fix: --openssl-legacy-provider also in build-frontend

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinBuildFrontendTask.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinBuildFrontendTask.kt
@@ -73,7 +73,7 @@ public open class VaadinBuildFrontendTask : DefaultTask() {
         BuildFrontendUtil.runNodeUpdater(adapter)
 
         if (adapter.generateBundle()) {
-            BuildFrontendUtil.runWebpack(adapter)
+            BuildFrontendUtil.runFrontendBuild(adapter)
         } else {
             logger.info("Not running webpack since generateBundle is false")
         }

--- a/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
+++ b/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
@@ -1,0 +1,58 @@
+package com.vaadin.flow.plugin.base;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
+import com.vaadin.flow.server.frontend.FrontendTools;
+
+public class BuildFrontendUtilTest {
+
+    @Test
+    public void testWebpackRequiredFlagsPassedToNodeEnvironment()
+            throws IOException, URISyntaxException, TimeoutException {
+        TemporaryFolder tmpDir = new TemporaryFolder();
+        tmpDir.create();
+        File baseDir = tmpDir.newFolder();
+
+        // setup: mock a webpack executable
+        File webpackBin = new File(baseDir, "node_modules/webpack/bin");
+        Assert.assertTrue(webpackBin.mkdirs());
+        File webPackExecutableMock = new File(webpackBin, "webpack.js");
+        Assert.assertTrue(webPackExecutableMock.createNewFile());
+
+        PluginAdapterBase adapter = Mockito.mock(PluginAdapterBase.class);
+        Mockito.when(adapter.npmFolder()).thenReturn(baseDir);
+        Mockito.when(adapter.projectBaseDirectory()).thenReturn(tmpDir.getRoot()
+                .toPath());
+
+        FrontendTools tools = Mockito.mock(FrontendTools.class);
+
+        // given: "node" stub that exits normally only if expected environment set
+        File fakeNode = new File(baseDir, "node");
+        try (PrintWriter out = new PrintWriter(fakeNode)) {
+            out.println("!/bin/sh");
+            out.println("[ x$NODE_OPTIONS == xexpected ]");
+            out.println("exit $?");
+        }
+        Assert.assertTrue(fakeNode.setExecutable(true));
+        Mockito.when(tools.getNodeExecutable()).thenReturn(fakeNode.getAbsolutePath());
+
+        Map<String, String> environment = new HashMap<>();
+        environment.put("NODE_OPTIONS", "expected");
+        Mockito.when(tools.getWebpackNodeEnvironment()).thenReturn(environment);
+
+        // then
+        BuildFrontendUtil.runWebpack(adapter, tools);
+
+        // terminates successfully
+    }
+}

--- a/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
+++ b/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
@@ -31,12 +31,13 @@ public class BuildFrontendUtilTest {
 
         PluginAdapterBase adapter = Mockito.mock(PluginAdapterBase.class);
         Mockito.when(adapter.npmFolder()).thenReturn(baseDir);
-        Mockito.when(adapter.projectBaseDirectory()).thenReturn(tmpDir.getRoot()
-                .toPath());
+        Mockito.when(adapter.projectBaseDirectory())
+                .thenReturn(tmpDir.getRoot().toPath());
 
         FrontendTools tools = Mockito.mock(FrontendTools.class);
 
-        // given: "node" stub that exits normally only if expected environment set
+        // given: "node" stub that exits normally only if expected environment
+        // set
         File fakeNode = new File(baseDir, "node");
         try (PrintWriter out = new PrintWriter(fakeNode)) {
             out.println("!/bin/sh");
@@ -44,7 +45,8 @@ public class BuildFrontendUtilTest {
             out.println("exit $?");
         }
         Assert.assertTrue(fakeNode.setExecutable(true));
-        Mockito.when(tools.getNodeExecutable()).thenReturn(fakeNode.getAbsolutePath());
+        Mockito.when(tools.getNodeExecutable())
+                .thenReturn(fakeNode.getAbsolutePath());
 
         Map<String, String> environment = new HashMap<>();
         environment.put("NODE_OPTIONS", "expected");

--- a/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
+++ b/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
@@ -23,6 +23,8 @@ public class BuildFrontendUtilTest {
             throws IOException, URISyntaxException, TimeoutException {
         Assume.assumeFalse("Test not runnable on Windows",
                 FrontendUtils.isWindows());
+        Assume.assumeTrue("Test requires /bin/bash",
+                new File("/bin/bash").exists());
 
         TemporaryFolder tmpDir = new TemporaryFolder();
         tmpDir.create();
@@ -45,7 +47,7 @@ public class BuildFrontendUtilTest {
         // set
         File fakeNode = new File(baseDir, "node");
         try (PrintWriter out = new PrintWriter(fakeNode)) {
-            out.println("!/bin/sh");
+            out.println("#!/bin/bash");
             out.println("[ x$NODE_OPTIONS == xexpected ]");
             out.println("exit $?");
         }

--- a/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
+++ b/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
@@ -9,16 +9,21 @@ import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 import com.vaadin.flow.server.frontend.FrontendTools;
+import com.vaadin.flow.server.frontend.FrontendUtils;
 
 public class BuildFrontendUtilTest {
 
     @Test
     public void testWebpackRequiredFlagsPassedToNodeEnvironment()
             throws IOException, URISyntaxException, TimeoutException {
+        Assume.assumeFalse("Test not runnable on Windows",
+                FrontendUtils.isWindows());
+
         TemporaryFolder tmpDir = new TemporaryFolder();
         tmpDir.create();
         File baseDir = tmpDir.newFolder();

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
@@ -292,10 +292,11 @@ public abstract class AbstractDevServerRunner implements DevModeHandler {
     /**
      * Gets the commands to run to start the dev server.
      * 
-     * @param nodeExec
-     *            the path to the node binary
+     * @param tools
+     *            the frontend tools object
      */
-    protected abstract List<String> getServerStartupCommand(String nodeExec);
+    protected abstract List<String> getServerStartupCommand(
+            FrontendTools tools);
 
     /**
      * Defines the environment variables to use when starting the dev server.
@@ -335,7 +336,7 @@ public abstract class AbstractDevServerRunner implements DevModeHandler {
         FrontendTools tools = new FrontendTools(config, getProjectRoot());
         tools.validateNodeAndNpmVersion();
 
-        List<String> command = getServerStartupCommand(tools.getNodeBinary());
+        List<String> command = getServerStartupCommand(tools);
 
         FrontendUtils.console(FrontendUtils.GREEN, START);
         if (getLogger().isDebugEnabled()) {

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/ViteHandler.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/ViteHandler.java
@@ -26,6 +26,7 @@ import java.util.regex.Pattern;
 
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.server.InitParameters;
+import com.vaadin.flow.server.frontend.FrontendTools;
 import com.vaadin.flow.server.frontend.FrontendUtils;
 
 import org.slf4j.Logger;
@@ -66,9 +67,10 @@ public final class ViteHandler extends AbstractDevServerRunner {
     }
 
     @Override
-    protected List<String> getServerStartupCommand(String nodeExec) {
+    protected List<String> getServerStartupCommand(
+            FrontendTools frontendTools) {
         List<String> command = new ArrayList<>();
-        command.add(nodeExec);
+        command.add(frontendTools.getNodeExecutable());
         command.add(getServerBinary().getAbsolutePath());
         command.add("--config");
         command.add(getServerConfig().getAbsolutePath());

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/WebpackHandler.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/WebpackHandler.java
@@ -16,13 +16,13 @@
 package com.vaadin.base.devserver;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import com.vaadin.base.devserver.DevServerOutputTracker.Result;
 import com.vaadin.flow.di.Lookup;
@@ -92,12 +92,9 @@ public final class WebpackHandler extends AbstractDevServerRunner {
     }
 
     @Override
-    protected List<String> getServerStartupCommand(String nodeExec) {
+    protected List<String> getServerStartupCommand(FrontendTools tools) {
         List<String> command = new ArrayList<>();
-        command.add(nodeExec);
-        if (requiresOpenSslLegacyProvider(nodeExec)) {
-            command.add("--openssl-legacy-provider");
-        }
+        command.add(tools.getNodeExecutable());
         command.add(getServerBinary().getAbsolutePath());
         command.add("--config");
         command.add(getServerConfig().getAbsolutePath());
@@ -126,9 +123,9 @@ public final class WebpackHandler extends AbstractDevServerRunner {
     protected void updateServerStartupEnvironment(FrontendTools frontendTools,
             Map<String, String> environment) {
         super.updateServerStartupEnvironment(frontendTools, environment);
-        if (requiresOpenSslLegacyProvider(frontendTools.getNodeExecutable())) {
-            environment.put("NODE_OPTIONS", "--openssl-legacy-provider");
-        }
+        // use environment variable as flags must be passed to Webpack
+        // subprocess
+        environment.putAll(frontendTools.getWebpackNodeEnvironment());
     }
 
     @Override
@@ -158,33 +155,5 @@ public final class WebpackHandler extends AbstractDevServerRunner {
         return Pattern.compile(getApplicationConfiguration().getStringProperty(
                 InitParameters.SERVLET_PARAMETER_DEVMODE_WEBPACK_ERROR_PATTERN,
                 DEFAULT_ERROR_PATTERN));
-    }
-
-    private boolean requiresOpenSslLegacyProvider(String nodeExec) {
-        // Determine whether webpack requires Node.js to be started with the
-        // --openssl-legacy-provider parameter. This is a webpack 4 workaround
-        // of the issue https://github.com/webpack/webpack/issues/14532
-        // See: https://github.com/vaadin/flow/issues/12649
-        ProcessBuilder processBuilder = new ProcessBuilder()
-                .directory(getProjectRoot())
-                .command(nodeExec, "-p", "crypto.createHash('md4')");
-        try {
-            Process process = processBuilder.start();
-            int errorLevel = process.waitFor();
-            return errorLevel != 0;
-        } catch (IOException e) {
-            getLogger().error(
-                    "IO error while determining --openssl-legacy-provider "
-                            + "parameter requirement",
-                    e);
-        } catch (InterruptedException e) {
-            getLogger().error(
-                    "Interrupted while determining --openssl-legacy-provider "
-                            + "parameter requirement",
-                    e);
-            // re-interrupt the thread
-            Thread.currentThread().interrupt();
-        }
-        return false;
     }
 }

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/AbstractDevServerRunnerTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/AbstractDevServerRunnerTest.java
@@ -16,6 +16,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import com.vaadin.base.devserver.startup.AbstractDevModeTest;
 import com.vaadin.flow.internal.DevModeHandler;
+import com.vaadin.flow.server.frontend.FrontendTools;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -46,7 +47,7 @@ public class AbstractDevServerRunnerTest extends AbstractDevModeTest {
         }
 
         @Override
-        protected List<String> getServerStartupCommand(String nodeExec) {
+        protected List<String> getServerStartupCommand(FrontendTools tools) {
             List<String> commands = new ArrayList<>();
             commands.add("echo");
             return commands;


### PR DESCRIPTION
Need to pass --openssl-legacy-provider to make
Webpack 4 work with Node 17 in some cases. Now
also when invoked as part of `build-frontend`.

Fixes #12732