### PR TITLE
test: mark StatisticsSenderTest as not thread safe

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/stats/StatisticsStorage.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/stats/StatisticsStorage.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
 public class StatisticsStorage {
 
     private String projectId;
-    private File usageStatisticsFile;
+    File usageStatisticsFile;
 
     /**
      * Creates an instance.

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/stats/AbstractStatisticsTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/stats/AbstractStatisticsTest.java
@@ -7,6 +7,8 @@ import com.vaadin.flow.testutil.TestUtils;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 
 public abstract class AbstractStatisticsTest {
@@ -21,6 +23,9 @@ public abstract class AbstractStatisticsTest {
     protected StatisticsStorage storage;
     protected StatisticsSender sender;
 
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
     /**
      * Create a temporary file from given test resource.
      *
@@ -28,12 +33,11 @@ public abstract class AbstractStatisticsTest {
      *            Name of the test resource
      * @return Temporary file
      */
-    protected static File createTempStorage(String testResourceName)
+    private File createTempStorage(String testResourceName)
             throws IOException {
         File original = new File(
                 TestUtils.getTestResource(testResourceName).getFile());
-        File result = File.createTempFile("test", "json");
-        result.deleteOnExit();
+        File result = temporaryFolder.newFile("test.json");
         FileUtils.copyFile(original, result);
         return result;
     }

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/stats/AbstractStatisticsTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/stats/AbstractStatisticsTest.java
@@ -33,8 +33,7 @@ public abstract class AbstractStatisticsTest {
      *            Name of the test resource
      * @return Temporary file
      */
-    private File createTempStorage(String testResourceName)
-            throws IOException {
+    private File createTempStorage(String testResourceName) throws IOException {
         File original = new File(
                 TestUtils.getTestResource(testResourceName).getFile());
         File result = temporaryFolder.newFile("test.json");

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/stats/AbstractStatisticsTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/stats/AbstractStatisticsTest.java
@@ -44,6 +44,8 @@ public abstract class AbstractStatisticsTest {
     @Before
     public void setup() throws Exception {
         storage = Mockito.spy(new StatisticsStorage());
+        storage.usageStatisticsFile = File.createTempFile("test-storage",
+                "json");
         sender = Mockito.spy(new StatisticsSender(storage));
 
         // Change the file storage and reporting parameters for testing

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/stats/AbstractStatisticsTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/stats/AbstractStatisticsTest.java
@@ -2,10 +2,12 @@ package com.vaadin.base.devserver.stats;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.locks.ReentrantLock;
 
 import com.vaadin.flow.testutil.TestUtils;
 
 import org.apache.commons.io.FileUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
@@ -26,6 +28,8 @@ public abstract class AbstractStatisticsTest {
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
+    protected static final ReentrantLock lock = new ReentrantLock();
+
     /**
      * Create a temporary file from given test resource.
      *
@@ -43,6 +47,7 @@ public abstract class AbstractStatisticsTest {
 
     @Before
     public void setup() throws Exception {
+        lock.lock();
         storage = Mockito.spy(new StatisticsStorage());
         storage.usageStatisticsFile = File.createTempFile("test-storage",
                 "json");
@@ -53,5 +58,10 @@ public abstract class AbstractStatisticsTest {
                 .thenReturn("http://localhost:1234");
         Mockito.when(storage.getUsageStatisticsFile()).thenReturn(
                 createTempStorage("stats-data/usage-statistics-1.json"));
+    }
+
+    @After
+    public void teardown() throws Exception {
+        lock.unlock();
     }
 }

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/stats/StatisticsSenderTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/stats/StatisticsSenderTest.java
@@ -43,6 +43,7 @@ public class StatisticsSenderTest extends AbstractStatisticsTest {
 
     @After
     public void teardown() throws Exception {
+        super.teardown();
         if (server != null) {
             server.close();
             server = null;

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/stats/StatisticsSenderTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/stats/StatisticsSenderTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.sun.net.httpserver.HttpServer;
 import com.vaadin.flow.testutil.TestUtils;
 
+import net.jcip.annotations.NotThreadSafe;
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.Assert;
@@ -14,6 +15,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+@NotThreadSafe
 public class StatisticsSenderTest extends AbstractStatisticsTest {
 
     private static final long SEC_12H = 60 * 60 * 12;


### PR DESCRIPTION
Due to DevModeUsageStatistics
being a singleton instance the tests
should not run at the same time.

Fixes #12681
