### PR TITLE
fix: --openssl-legacy-provider also in build-frontend (#12726)

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinBuildFrontendTask.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinBuildFrontendTask.kt
@@ -73,7 +73,7 @@ public open class VaadinBuildFrontendTask : DefaultTask() {
         BuildFrontendUtil.runNodeUpdater(adapter)
 
         if (adapter.generateBundle()) {
-            BuildFrontendUtil.runWebpack(adapter)
+            BuildFrontendUtil.runFrontendBuild(adapter)
         } else {
             logger.info("Not running webpack since generateBundle is false")
         }

--- a/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
+++ b/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/BuildFrontendUtilTest.java
@@ -1,0 +1,67 @@
+package com.vaadin.flow.plugin.base;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
+import com.vaadin.flow.server.frontend.FrontendTools;
+import com.vaadin.flow.server.frontend.FrontendUtils;
+
+public class BuildFrontendUtilTest {
+
+    @Test
+    public void testWebpackRequiredFlagsPassedToNodeEnvironment()
+            throws IOException, URISyntaxException, TimeoutException {
+        Assume.assumeFalse("Test not runnable on Windows",
+                FrontendUtils.isWindows());
+        Assume.assumeTrue("Test requires /bin/bash",
+                new File("/bin/bash").exists());
+
+        TemporaryFolder tmpDir = new TemporaryFolder();
+        tmpDir.create();
+        File baseDir = tmpDir.newFolder();
+
+        // setup: mock a webpack executable
+        File webpackBin = new File(baseDir, "node_modules/webpack/bin");
+        Assert.assertTrue(webpackBin.mkdirs());
+        File webPackExecutableMock = new File(webpackBin, "webpack.js");
+        Assert.assertTrue(webPackExecutableMock.createNewFile());
+
+        PluginAdapterBase adapter = Mockito.mock(PluginAdapterBase.class);
+        Mockito.when(adapter.npmFolder()).thenReturn(baseDir);
+        Mockito.when(adapter.projectBaseDirectory())
+                .thenReturn(tmpDir.getRoot().toPath());
+
+        FrontendTools tools = Mockito.mock(FrontendTools.class);
+
+        // given: "node" stub that exits normally only if expected environment
+        // set
+        File fakeNode = new File(baseDir, "node");
+        try (PrintWriter out = new PrintWriter(fakeNode)) {
+            out.println("#!/bin/bash");
+            out.println("[ x$NODE_OPTIONS == xexpected ]");
+            out.println("exit $?");
+        }
+        Assert.assertTrue(fakeNode.setExecutable(true));
+        Mockito.when(tools.getNodeExecutable())
+                .thenReturn(fakeNode.getAbsolutePath());
+
+        Map<String, String> environment = new HashMap<>();
+        environment.put("NODE_OPTIONS", "expected");
+        Mockito.when(tools.getWebpackNodeEnvironment()).thenReturn(environment);
+
+        // then
+        BuildFrontendUtil.runWebpack(adapter, tools);
+
+        // terminates successfully
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -23,7 +23,9 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
@@ -713,6 +715,41 @@ public class FrontendTools {
                 getNpmExecutable(false));
         npmVersionCommand.add("--version"); // NOSONAR
         return FrontendUtils.getVersion("npm", npmVersionCommand);
+    }
+
+    /**
+     * Returns flags required to pass to Node for Webpack to function. Determine
+     * whether webpack requires Node.js to be started with the
+     * --openssl-legacy-provider parameter. This is a webpack 4 workaround of
+     * the issue https://github.com/webpack/webpack/issues/14532 See:
+     * https://github.com/vaadin/flow/issues/12649
+     *
+     * @return the flags
+     */
+    public Map<String, String> getWebpackNodeEnvironment() {
+        Map<String, String> environment = new HashMap<>();
+        ProcessBuilder processBuilder = new ProcessBuilder()
+                .command(getNodeExecutable(), "-p", "crypto.createHash('md4')");
+        try {
+            Process process = processBuilder.start();
+            int errorLevel = process.waitFor();
+            if (errorLevel != 0) {
+                environment.put("NODE_OPTIONS", "--openssl-legacy-provider");
+            }
+        } catch (IOException e) {
+            getLogger().error(
+                    "IO error while determining --openssl-legacy-provider "
+                            + "parameter requirement",
+                    e);
+        } catch (InterruptedException e) {
+            getLogger().error(
+                    "Interrupted while determining --openssl-legacy-provider "
+                            + "parameter requirement",
+                    e);
+            // re-interrupt the thread
+            Thread.currentThread().interrupt();
+        }
+        return environment;
     }
 
     private File getExecutable(String dir, String location) {


### PR DESCRIPTION
Need to pass --openssl-legacy-provider to make Webpack 4 work with Node 17 in some cases. Now also when invoked as part of build-frontend.

Fixes #12732
