### PR TITLE
test: Bind to localhost to ensure the port is free

### DIFF
--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/stats/StatisticsSenderTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/stats/StatisticsSenderTest.java
@@ -165,8 +165,8 @@ public class StatisticsSenderTest extends AbstractStatisticsTest {
 
         private HttpServer createStubGatherServlet(int status, String response)
                 throws Exception {
-            HttpServer httpServer = HttpServer.create(new InetSocketAddress("localhost", 0),
-                    0);
+            HttpServer httpServer = HttpServer
+                    .create(new InetSocketAddress("localhost", 0), 0);
             httpServer.createContext("/", exchange -> {
                 this.lastRequestContent = IOUtils.toString(
                         exchange.getRequestBody(), Charset.defaultCharset());

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/stats/StatisticsSenderTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/stats/StatisticsSenderTest.java
@@ -165,7 +165,7 @@ public class StatisticsSenderTest extends AbstractStatisticsTest {
 
         private HttpServer createStubGatherServlet(int status, String response)
                 throws Exception {
-            HttpServer httpServer = HttpServer.create(new InetSocketAddress(0),
+            HttpServer httpServer = HttpServer.create(new InetSocketAddress("localhost", 0),
                     0);
             httpServer.createContext("/", exchange -> {
                 this.lastRequestContent = IOUtils.toString(


### PR DESCRIPTION
When binding to all interfaces it seems that the http server can choose a port that is in use for localhost but free for other interfaces
