### PR TITLE
chore: add controller package name to spring.factories

### DIFF
--- a/fusion-endpoint/src/main/resources/META-INF/spring.factories
+++ b/fusion-endpoint/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,1 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=FusionController
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=dev.hilla.FusionController


### PR DESCRIPTION
Related to https://github.com/vaadin/flow/pull/12741, the `FusionController` package name was unintentionally removed by the IDE during refactoring.