### PR TITLE
feat: Fallback to alternative node when preferred is unsupported

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -520,7 +520,7 @@ public class FrontendTools {
      *
      * Returns the input executable if version is supported, otherwise
      * {@literal null}.
-     * 
+     *
      * @param nodeExecutable
      *            node executable to be checked
      * @return input node executable if supported, otherwise {@literal null}.
@@ -618,9 +618,12 @@ public class FrontendTools {
             return;
         }
         try {
-            FrontendVersion foundNodeVersion = getNodeVersion();
+            Pair<FrontendVersion, String> foundNodeVersionAndExe = getNodeVersionAndExecutable();
+            FrontendVersion foundNodeVersion = foundNodeVersionAndExe.getFirst();
             FrontendUtils.validateToolVersion("node", foundNodeVersion,
                     SUPPORTED_NODE_VERSION, SUPPORTED_NODE_VERSION);
+            getLogger().info("Using node {} located at {}",
+                    foundNodeVersion.getFullVersion(), foundNodeVersionAndExe.getSecond());
         } catch (UnknownVersionException e) {
             getLogger().warn("Error checking if node is new enough", e);
         }
@@ -630,6 +633,8 @@ public class FrontendTools {
             FrontendUtils.validateToolVersion("npm", foundNpmVersion,
                     SUPPORTED_NPM_VERSION, SHOULD_WORK_NPM_VERSION);
             checkForFaultyNpmVersion(foundNpmVersion);
+            getLogger().info("Using npm {} located at {}",
+                    foundNpmVersion.getFullVersion(), getNpmExecutable(false).get(0));
         } catch (UnknownVersionException e) {
             getLogger().warn("Error checking if npm is new enough", e);
         }
@@ -640,10 +645,16 @@ public class FrontendTools {
      * Gets the version of the node executable.
      */
     public FrontendVersion getNodeVersion() throws UnknownVersionException {
+        return getNodeVersionAndExecutable().getFirst();
+    }
+
+    private Pair<FrontendVersion, String> getNodeVersionAndExecutable()
+            throws UnknownVersionException {
+        String executable = getNodeBinary();
         List<String> nodeVersionCommand = new ArrayList<>();
-        nodeVersionCommand.add(getNodeBinary());
+        nodeVersionCommand.add(executable);
         nodeVersionCommand.add("--version"); // NOSONAR
-        return FrontendUtils.getVersion("node", nodeVersionCommand);
+        return new Pair<>(FrontendUtils.getVersion("node", nodeVersionCommand), executable);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -619,11 +619,13 @@ public class FrontendTools {
         }
         try {
             Pair<FrontendVersion, String> foundNodeVersionAndExe = getNodeVersionAndExecutable();
-            FrontendVersion foundNodeVersion = foundNodeVersionAndExe.getFirst();
+            FrontendVersion foundNodeVersion = foundNodeVersionAndExe
+                    .getFirst();
             FrontendUtils.validateToolVersion("node", foundNodeVersion,
                     SUPPORTED_NODE_VERSION, SUPPORTED_NODE_VERSION);
             getLogger().info("Using node {} located at {}",
-                    foundNodeVersion.getFullVersion(), foundNodeVersionAndExe.getSecond());
+                    foundNodeVersion.getFullVersion(),
+                    foundNodeVersionAndExe.getSecond());
         } catch (UnknownVersionException e) {
             getLogger().warn("Error checking if node is new enough", e);
         }
@@ -634,7 +636,8 @@ public class FrontendTools {
                     SUPPORTED_NPM_VERSION, SHOULD_WORK_NPM_VERSION);
             checkForFaultyNpmVersion(foundNpmVersion);
             getLogger().info("Using npm {} located at {}",
-                    foundNpmVersion.getFullVersion(), getNpmExecutable(false).get(0));
+                    foundNpmVersion.getFullVersion(),
+                    getNpmExecutable(false).get(0));
         } catch (UnknownVersionException e) {
             getLogger().warn("Error checking if npm is new enough", e);
         }
@@ -654,7 +657,8 @@ public class FrontendTools {
         List<String> nodeVersionCommand = new ArrayList<>();
         nodeVersionCommand.add(executable);
         nodeVersionCommand.add("--version"); // NOSONAR
-        return new Pair<>(FrontendUtils.getVersion("node", nodeVersionCommand), executable);
+        return new Pair<>(FrontendUtils.getVersion("node", nodeVersionCommand),
+                executable);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -75,15 +75,6 @@ public class FrontendTools {
     private static final String MSG_PREFIX = "%n%n======================================================================================================";
     private static final String MSG_SUFFIX = "%n======================================================================================================%n";
 
-    private static final String NODE_NOT_FOUND = MSG_PREFIX
-            + "%nVaadin requires node.js & npm to be installed. Please install the latest LTS version of node.js (with npm) either by:"
-            + "%n  1) following the https://nodejs.org/en/download/ guide to install it globally. This is the recommended way."
-            + "%n  2) running the following Maven plugin goal to install it in this project:"
-            + INSTALL_NODE_LOCALLY
-            + "%n%nNote that in case you don't install it globally, you'll need to install it again for another Vaadin project."
-            + "%nIn case you have just installed node.js globally, it was not discovered, so you need to restart your system to get the path variables updated."
-            + MSG_SUFFIX;
-
     private static final String PNPM_NOT_FOUND = MSG_PREFIX
             + "%nVaadin application is configured to use globally installed pnpm ('pnpm.global=true'), but no pnpm tool has been found on your system."
             + "%nPlease install pnpm tool following the instruction given here https://pnpm.io/installation, "
@@ -117,15 +108,11 @@ public class FrontendTools {
     private static final int SUPPORTED_NODE_MINOR_VERSION = 22;
     private static final int SUPPORTED_NPM_MAJOR_VERSION = 6;
     private static final int SUPPORTED_NPM_MINOR_VERSION = 14;
-    private static final int SHOULD_WORK_NODE_MAJOR_VERSION = 8;
-    private static final int SHOULD_WORK_NODE_MINOR_VERSION = 9;
     private static final int SHOULD_WORK_NPM_MAJOR_VERSION = 5;
     private static final int SHOULD_WORK_NPM_MINOR_VERSION = 5;
 
     private static final FrontendVersion SUPPORTED_NODE_VERSION = new FrontendVersion(
             SUPPORTED_NODE_MAJOR_VERSION, SUPPORTED_NODE_MINOR_VERSION);
-    private static final FrontendVersion SHOULD_WORK_NODE_VERSION = new FrontendVersion(
-            SHOULD_WORK_NODE_MAJOR_VERSION, SHOULD_WORK_NODE_MINOR_VERSION);
 
     private static final FrontendVersion SUPPORTED_NPM_VERSION = new FrontendVersion(
             SUPPORTED_NPM_MAJOR_VERSION, SUPPORTED_NPM_MINOR_VERSION);
@@ -462,6 +449,7 @@ public class FrontendTools {
             file = frontendToolsLocator.tryLocateTool(nodeCommands.getFirst())
                     .orElse(null);
         }
+        file = rejectUnsupportedNodeVersion(file);
         if (file == null) {
             file = updateAlternateIfNeeded(getExecutable(getAlternativeDir(),
                     nodeCommands.getSecond()));
@@ -472,7 +460,9 @@ public class FrontendTools {
             file = new File(installNode(nodeVersion, nodeDownloadRoot));
         }
         if (file == null) {
-            throw new IllegalStateException(String.format(NODE_NOT_FOUND));
+            // This should never happen, because node is automatically installed
+            // if not detected globally or at project level
+            throw new IllegalStateException("Node not found");
         }
         return file.getAbsolutePath();
     }
@@ -503,7 +493,7 @@ public class FrontendTools {
             boolean installDefault = false;
             final FrontendVersion defaultVersion = new FrontendVersion(
                     nodeVersion);
-            if (installedNodeVersion.isOlderThan(SHOULD_WORK_NODE_VERSION)) {
+            if (installedNodeVersion.isOlderThan(SUPPORTED_NODE_VERSION)) {
                 getLogger().info("Updating unsupported node version {} to {}",
                         installedNodeVersion.getFullVersion(),
                         defaultVersion.getFullVersion());
@@ -523,6 +513,40 @@ public class FrontendTools {
             getLogger().error("Failed to get version for installed node.", e);
         }
         return file;
+    }
+
+    /**
+     * Ensures that given node executable is supported by Vaadin.
+     *
+     * Returns the input executable if version is supported, otherwise
+     * {@literal null}.
+     * 
+     * @param nodeExecutable
+     *            node executable to be checked
+     * @return input node executable if supported, otherwise {@literal null}.
+     */
+    private File rejectUnsupportedNodeVersion(File nodeExecutable) {
+        if (nodeExecutable == null) {
+            return null;
+        }
+        try {
+            List<String> versionCommand = Lists.newArrayList();
+            versionCommand.add(nodeExecutable.getAbsolutePath());
+            versionCommand.add("--version"); // NOSONAR
+            final FrontendVersion installedNodeVersion = FrontendUtils
+                    .getVersion("node", versionCommand);
+
+            if (installedNodeVersion.isOlderThan(SUPPORTED_NODE_VERSION)) {
+                getLogger().info(
+                        "Installed node version {} is not supported. Minimum supported version is {}.",
+                        installedNodeVersion.getFullVersion(),
+                        SUPPORTED_NODE_VERSION.getFullVersion());
+                return null;
+            }
+        } catch (UnknownVersionException e) {
+            getLogger().error("Failed to get version for installed node.", e);
+        }
+        return nodeExecutable;
     }
 
     /**
@@ -596,7 +620,7 @@ public class FrontendTools {
         try {
             FrontendVersion foundNodeVersion = getNodeVersion();
             FrontendUtils.validateToolVersion("node", foundNodeVersion,
-                    SUPPORTED_NODE_VERSION, SHOULD_WORK_NODE_VERSION);
+                    SUPPORTED_NODE_VERSION, SUPPORTED_NODE_VERSION);
         } catch (UnknownVersionException e) {
             getLogger().warn("Error checking if node is new enough", e);
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -538,7 +538,9 @@ public class FrontendTools {
 
             if (installedNodeVersion.isOlderThan(SUPPORTED_NODE_VERSION)) {
                 getLogger().info(
-                        "Installed node version {} is not supported. Minimum supported version is {}.",
+                        "{} installed node version {} is not supported. Minimum supported version is {}.",
+                        nodeExecutable.getPath().startsWith(baseDir) ? "Project"
+                                : "Globally",
                         installedNodeVersion.getFullVersion(),
                         SUPPORTED_NODE_VERSION.getFullVersion());
                 return null;
@@ -623,7 +625,7 @@ public class FrontendTools {
                     .getFirst();
             FrontendUtils.validateToolVersion("node", foundNodeVersion,
                     SUPPORTED_NODE_VERSION, SUPPORTED_NODE_VERSION);
-            getLogger().info("Using node {} located at {}",
+            getLogger().debug("Using node {} located at {}",
                     foundNodeVersion.getFullVersion(),
                     foundNodeVersionAndExe.getSecond());
         } catch (UnknownVersionException e) {
@@ -635,7 +637,7 @@ public class FrontendTools {
             FrontendUtils.validateToolVersion("npm", foundNpmVersion,
                     SUPPORTED_NPM_VERSION, SHOULD_WORK_NPM_VERSION);
             checkForFaultyNpmVersion(foundNpmVersion);
-            getLogger().info("Using npm {} located at {}",
+            getLogger().debug("Using npm {} located at {}",
                     foundNpmVersion.getFullVersion(),
                     getNpmExecutable(false).get(0));
         } catch (UnknownVersionException e) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
@@ -248,7 +248,7 @@ public class NodeInstaller {
 
             extractFile(data.getArchive(), data.getTmpDirectory());
         } catch (DownloadException e) {
-            String errorMessage = "Download of Node.js failed. This may be due to lost of internet connection. "
+            String errorMessage = "Could not download Node.js. This may be due to lost of internet connection. "
                     + "If you are behind a proxy server you should configure your proxy settings. "
                     + "Check your connection and proxy settings and try again, "
                     + "or follow the https://nodejs.org/en/download/ guide to install Node.js globally.";

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
@@ -248,12 +248,13 @@ public class NodeInstaller {
 
             extractFile(data.getArchive(), data.getTmpDirectory());
         } catch (DownloadException e) {
-            String errorMessage = "Could not download Node.js. This may be due to lost of internet connection. "
-                    + "If you are behind a proxy server you should configure your proxy settings. "
-                    + "Check your connection and proxy settings and try again, "
-                    + "or follow the https://nodejs.org/en/download/ guide to install Node.js globally.";
-            getLogger().error(errorMessage);
-            throw new InstallationException(errorMessage, e);
+            getLogger().error(
+                    "Node.js download failed. This may be due to loss of internet connection.\n"
+                            + "If you are behind a proxy server you should configure your proxy settings.\n"
+                            + "Verify connection and proxy settings or follow the https://nodejs.org/en/download/ guide to install Node.js globally.");
+            throw new InstallationException(
+                    "Could not download Node.js. Check your connection and proxy settings.",
+                    e);
         } catch (ArchiveExtractionException e) {
             throw new InstallationException(
                     "Could not extract the Node archive", e);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
@@ -248,7 +248,12 @@ public class NodeInstaller {
 
             extractFile(data.getArchive(), data.getTmpDirectory());
         } catch (DownloadException e) {
-            throw new InstallationException("Could not download Node.js", e);
+            String errorMessage = "Download of Node.js failed. This may be due to lost of internet connection. "
+                    + "If you are behind a proxy server you should configure your proxy settings. "
+                    + "Check your connection and proxy settings and try again, "
+                    + "or follow the https://nodejs.org/en/download/ guide to install Node.js globally.";
+            getLogger().error(errorMessage);
+            throw new InstallationException(errorMessage, e);
         } catch (ArchiveExtractionException e) {
             throw new InstallationException(
                     "Could not extract the Node archive", e);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -148,11 +148,11 @@ public class FrontendToolsTest {
     public void nodeIsBeingLocated_supportedNodeInstalled_autoUpdateFalse_NodeNotUpdated()
             throws FrontendUtils.UnknownVersionException {
         FrontendVersion updatedNodeVersion = getUpdatedAlternativeNodeVersion(
-                "10.14.2", () -> tools.getNodeExecutable());
+                "13.10.1", () -> tools.getNodeExecutable());
 
         Assert.assertEquals(
                 "Locate Node version: Node version updated even if it should not have been touched.",
-                "10.14.2", updatedNodeVersion.getFullVersion());
+                "13.10.1", updatedNodeVersion.getFullVersion());
     }
 
     @Test
@@ -160,13 +160,57 @@ public class FrontendToolsTest {
             throws FrontendUtils.UnknownVersionException {
         settings.setAutoUpdate(true);
         FrontendVersion updatedNodeVersion = getUpdatedAlternativeNodeVersion(
-                "10.14.2", () -> tools.getNodeExecutable());
+                "13.10.1", () -> tools.getNodeExecutable());
 
         Assert.assertEquals(
                 "Locate Node version: Node version was not auto updated.",
                 new FrontendVersion(FrontendTools.DEFAULT_NODE_VERSION)
                         .getFullVersion(),
                 updatedNodeVersion.getFullVersion());
+    }
+
+    @Test
+    public void nodeIsBeingLocated_unsupportedNodeInstalled_defaultNodeVersionInstalledToAlternativeDirectory()
+            throws FrontendUtils.UnknownVersionException, IOException {
+        // Unsupported node version
+        FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo
+                .builder(FrontendStubs.Tool.NODE).withVersion("8.9.3").build();
+        FrontendStubs.ToolStubInfo npmStub = FrontendStubs.ToolStubInfo.none();
+        createStubNode(nodeStub, npmStub, baseDir);
+
+        List<String> nodeVersionCommand = new ArrayList<>();
+        nodeVersionCommand.add(tools.getNodeExecutable());
+        nodeVersionCommand.add("--version");
+        FrontendVersion usedNodeVersion = FrontendUtils.getVersion("node",
+                nodeVersionCommand);
+
+        Assert.assertEquals(
+                "Locate unsupported Node version: Default Node version was not used.",
+                new FrontendVersion(FrontendTools.DEFAULT_NODE_VERSION)
+                        .getFullVersion(),
+                usedNodeVersion.getFullVersion());
+    }
+
+    @Test
+    public void nodeIsBeingLocated_unsupportedNodeInstalled_fallbackToNodeInstalledToAlternativeDirectory()
+            throws IOException, FrontendUtils.UnknownVersionException {
+        // Unsupported node version
+        FrontendStubs.ToolStubInfo nodeStub = FrontendStubs.ToolStubInfo
+                .builder(FrontendStubs.Tool.NODE).withVersion("8.9.3").build();
+        FrontendStubs.ToolStubInfo npmStub = FrontendStubs.ToolStubInfo.none();
+        createStubNode(nodeStub, npmStub, baseDir);
+
+        tools.installNode("v13.10.1", null);
+
+        List<String> nodeVersionCommand = new ArrayList<>();
+        nodeVersionCommand.add(tools.getNodeExecutable());
+        nodeVersionCommand.add("--version");
+        FrontendVersion usedNodeVersion = FrontendUtils.getVersion("node",
+                nodeVersionCommand);
+
+        Assert.assertEquals(
+                "Locate unsupported Node version: Expecting Node in alternative directory to be used, but was not.",
+                "13.10.1", usedNodeVersion.getFullVersion());
     }
 
     @Test
@@ -186,11 +230,11 @@ public class FrontendToolsTest {
     public void forceAlternativeDirectory_supportedNodeInstalled_autoUpdateFalse_NodeNotUpdated()
             throws FrontendUtils.UnknownVersionException {
         FrontendVersion updatedNodeVersion = getUpdatedAlternativeNodeVersion(
-                "10.14.2", () -> tools.forceAlternativeNodeExecutable());
+                "13.10.1", () -> tools.forceAlternativeNodeExecutable());
 
         Assert.assertEquals(
                 "Force alternative directory: Node version updated even if it should not have been touched.",
-                "10.14.2", updatedNodeVersion.getFullVersion());
+                "13.10.1", updatedNodeVersion.getFullVersion());
     }
 
     @Test
@@ -198,7 +242,7 @@ public class FrontendToolsTest {
             throws FrontendUtils.UnknownVersionException {
         settings.setAutoUpdate(true);
         FrontendVersion updatedNodeVersion = getUpdatedAlternativeNodeVersion(
-                "10.14.2", () -> tools.forceAlternativeNodeExecutable());
+                "13.10.1", () -> tools.forceAlternativeNodeExecutable());
 
         Assert.assertEquals(
                 "Force alternative directory: Node version was not auto updated.",

--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/FrontendStubs.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/FrontendStubs.java
@@ -249,7 +249,7 @@ public class FrontendStubs {
     public static class ToolStubBuilder {
 
         private static final String DEFAULT_NPM_VERSION = "6.14.10";
-        private static final String DEFAULT_NODE_VERSION = "8.0.0";
+        private static final String DEFAULT_NODE_VERSION = "13.0.0";
 
         private String version;
         private String cacheDir;


### PR DESCRIPTION
## Description

When project or global node version is detected but deemed incompatible with Vaadin, alternative node installation (~./vaadin/node) is used as fallback (and downloaded if not present).

Fixes #12494 

## Type of change

- [ ] Bugfix
- [X] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [X] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
