### PR TITLE
WIP: feat(Vite): load JS modules dynamically

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/ThemeHolder.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/ThemeHolder.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.component.internal;
+
+import javax.annotation.Nullable;
+import java.io.Serializable;
+import java.util.Optional;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.page.AppShellConfigurator;
+import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.server.AppShellRegistry;
+import com.vaadin.flow.server.VaadinContext;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
+import com.vaadin.flow.theme.AbstractTheme;
+import com.vaadin.flow.theme.NoTheme;
+import com.vaadin.flow.theme.Theme;
+
+/**
+ * <p>
+ * For internal use only. May be renamed or removed in a future release.
+ */
+final class ThemeHolder implements Serializable {
+    AbstractTheme theme;
+
+    private ThemeHolder(@Nullable AbstractTheme theme) {
+        this.theme = theme;
+    }
+
+    public Optional<AbstractTheme> getTheme() {
+        return Optional.ofNullable(theme);
+    }
+
+    /**
+     * Finds current theme for given UI.
+     *
+     * @param ui
+     *            the UI instance
+     * @return holder of {@code AbstractTheme} value
+     */
+    static ThemeHolder of(UI ui) {
+        VaadinContext context = ui.getSession().getService().getContext();
+        return context.getAttribute(ThemeHolder.class, () -> {
+            ThemeHolder holder = new ThemeHolder(findTheme(ui));
+            context.setAttribute(ThemeHolder.class, holder);
+            return holder;
+        });
+    }
+
+    private static AbstractTheme findTheme(UI ui) {
+        VaadinService service = ui.getSession().getService();
+        VaadinContext context = service.getContext();
+        final Class<? extends AppShellConfigurator> appShell = AppShellRegistry
+                .getInstance(context).getShell();
+
+        Class<? extends AbstractTheme> themeClass = null;
+        if (appShell != null && appShell.getAnnotation(NoTheme.class) != null) {
+            Theme themeAnnotation = appShell.getAnnotation(Theme.class);
+            themeClass = themeAnnotation.themeClass();
+            if (themeClass.equals(AbstractTheme.class)) {
+                themeClass = getDefaultTheme(service);
+            }
+        } else {
+            themeClass = getDefaultTheme(service);
+        }
+        if (themeClass != null) {
+            return Instantiator.get(ui).getOrCreate(themeClass);
+        }
+        return null;
+    }
+
+    @Nullable
+    private static Class<? extends AbstractTheme> getDefaultTheme(
+            VaadinService service) {
+        try {
+            return (Class<? extends AbstractTheme>) service
+                    .getClassLoader()
+                    .loadClass(FrontendDependencies.LUMO);
+        } catch (ClassNotFoundException e) {
+            return null;
+        }
+    }
+
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -87,9 +87,10 @@ public class TaskUpdateImports extends NodeUpdater {
 
         UpdateMainImportsFile(ClassFinder classFinder, File frontendDirectory,
                 File npmDirectory, File generatedDirectory,
-                File fallBackImports, File tokenFile, boolean productionMode) {
+                File fallBackImports, File tokenFile, boolean productionMode,
+                FeatureFlags featureFlags) {
             super(frontendDirectory, npmDirectory, generatedDirectory,
-                    tokenFile, productionMode);
+                    tokenFile, productionMode, featureFlags);
             generatedFlowImports = new File(generatedDirectory, IMPORTS_NAME);
             generatedFlowDefinitions = new File(generatedDirectory,
                     IMPORTS_D_TS_NAME);
@@ -232,10 +233,10 @@ public class TaskUpdateImports extends NodeUpdater {
 
         UpdateFallBackImportsFile(ClassFinder classFinder,
                 File frontendDirectory, File npmDirectory,
-                File generatedDirectory, File tokenFile,
-                boolean productionMode) {
+                File generatedDirectory, File tokenFile, boolean productionMode,
+                FeatureFlags featureFlags) {
             super(frontendDirectory, npmDirectory, generatedDirectory,
-                    tokenFile, productionMode);
+                    tokenFile, productionMode, featureFlags);
             generatedFallBack = new File(generatedDirectory,
                     FrontendUtils.FALLBACK_IMPORTS_NAME);
             finder = classFinder;
@@ -361,6 +362,7 @@ public class TaskUpdateImports extends NodeUpdater {
         this.tokenFileData = tokenFileData;
         this.disablePnpm = disablePnpm;
         this.productionMode = productionMode;
+        this.featureFlags = featureFlags;
     }
 
     @Override
@@ -369,7 +371,7 @@ public class TaskUpdateImports extends NodeUpdater {
         if (fallbackScanner != null) {
             UpdateFallBackImportsFile fallBackUpdate = new UpdateFallBackImportsFile(
                     finder, frontendDirectory, npmFolder, generatedFolder,
-                    tokenFile, productionMode);
+                    tokenFile, productionMode, featureFlags);
             fallBackUpdate.run();
             fallBack = fallBackUpdate.getGeneratedFallbackFile();
             updateBuildFile(fallBackUpdate);
@@ -377,7 +379,7 @@ public class TaskUpdateImports extends NodeUpdater {
 
         UpdateMainImportsFile mainUpdate = new UpdateMainImportsFile(finder,
                 frontendDirectory, npmFolder, generatedFolder, fallBack,
-                tokenFile, productionMode);
+                tokenFile, productionMode, featureFlags);
         mainUpdate.run();
     }
 

--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -93,13 +93,14 @@ export const vaadinConfig: UserConfigFn = (env) => {
     runWatchDog(process.env.watchDogPort);
   }
   return {
-    root: 'frontend',
+    root: '',
     base: basePath,
     resolve: {
       alias: {
         themes: themeFolder,
         Frontend: frontendFolder
-      }
+      },
+      preserveSymlinks: true,
     },
     define: {
       // should be settings.offlinePath after manifests are fixed
@@ -121,6 +122,13 @@ export const vaadinConfig: UserConfigFn = (env) => {
     },
     plugins: [
       !devMode && brotli(),
+      {
+        name: 'disable-pre-bundling',
+        configResolved(config) {
+          // @ts-ignore
+          config.cacheDir = undefined;
+        }
+      },
       settings.pwaEnabled &&
       {
         name: 'pwa',
@@ -194,12 +202,12 @@ export const vaadinConfig: UserConfigFn = (env) => {
               spaMiddlewareForceRemoved = true;
             }
 
-            if (context.path !== '/index.html') {
+            if (context.path !== '/frontend/index.html') {
               return;
             }
             const vaadinScript: HtmlTagDescriptor = {
               tag: 'script',
-              attrs: { type: 'module', src: devMode ? '/VAADIN/generated/vaadin.ts' : './generated/vaadin.ts' },
+              attrs: { type: 'module', src: devMode ? '/VAADIN/frontend/generated/vaadin.ts' : './generated/vaadin.ts' },
               injectTo: 'head'
             };
 
@@ -208,7 +216,7 @@ export const vaadinConfig: UserConfigFn = (env) => {
             if (devMode) {
               const viteDevModeScript: HtmlTagDescriptor = {
                 tag: 'script',
-                attrs: { type: 'module', src: '/VAADIN/generated/vite-devmode.ts' },
+                attrs: { type: 'module', src: '/VAADIN/frontend/generated/vite-devmode.ts' },
                 injectTo: 'head'
               };
               scripts.push(viteDevModeScript);

--- a/flow-server/src/test/java/com/vaadin/flow/server/MockVaadinServletService.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/MockVaadinServletService.java
@@ -20,7 +20,10 @@ import javax.servlet.ServletException;
 import java.util.Collections;
 import java.util.List;
 
+import org.mockito.Mockito;
+
 import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.di.ResourceProvider;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.router.Router;
@@ -38,6 +41,8 @@ public class MockVaadinServletService extends VaadinServletService {
     private Router router;
 
     private ResourceProvider resourceProvider;
+
+    private Lookup lookup;
 
     private static class MockVaadinServlet extends VaadinServlet {
 
@@ -111,6 +116,11 @@ public class MockVaadinServletService extends VaadinServletService {
             servlet.service = this;
             if (getServlet().getServletConfig() == null) {
                 getServlet().init(new MockServletConfig());
+            }
+            this.lookup = this.getContext().getAttribute(Lookup.class);
+            if (this.lookup == null) {
+                this.lookup = Mockito.mock(Lookup.class);
+                this.getContext().setAttribute(Lookup.class, lookup);
             }
             super.init();
         } catch (ServiceException | ServletException e) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinServiceTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinServiceTest.java
@@ -369,9 +369,7 @@ public class VaadinServiceTest {
             throws ServiceException {
         VaadinService service = createService();
 
-        Lookup lookup = Mockito.mock(Lookup.class);
-
-        service.getContext().setAttribute(Lookup.class, lookup);
+        Lookup lookup = service.getContext().getAttribute(Lookup.class);
 
         InstantiatorFactory factory = createInstantiatorFactory(lookup);
 
@@ -390,9 +388,7 @@ public class VaadinServiceTest {
             throws ServiceException {
         VaadinService service = createService();
 
-        Lookup lookup = Mockito.mock(Lookup.class);
-
-        service.getContext().setAttribute(Lookup.class, lookup);
+        Lookup lookup = service.getContext().getAttribute(Lookup.class);
 
         InstantiatorFactory factory1 = createInstantiatorFactory(lookup);
         InstantiatorFactory factory2 = createInstantiatorFactory(lookup);

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinSessionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinSessionTest.java
@@ -45,6 +45,7 @@ import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.internal.CurrentInstance;
 import com.vaadin.flow.server.communication.AtmospherePushConnection;
 import com.vaadin.flow.server.startup.ApplicationConfiguration;

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/PushHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/PushHandlerTest.java
@@ -324,13 +324,15 @@ public class PushHandlerTest {
     public static BrowserLiveReload mockBrowserLiveReloadImpl(
             VaadinContext context) {
         BrowserLiveReload liveReload = Mockito.mock(BrowserLiveReload.class);
-        Lookup lookup = Lookup.of(new BrowserLiveReloadAccessor() {
-            @Override
-            public BrowserLiveReload getLiveReload(VaadinContext context) {
-                return liveReload;
-            }
-        }, BrowserLiveReloadAccessor.class);
-        context.setAttribute(Lookup.class, lookup);
+        Lookup lookup = context.getAttribute(Lookup.class);
+        Mockito.when(lookup.lookup(BrowserLiveReloadAccessor.class))
+                .thenReturn(new BrowserLiveReloadAccessor() {
+                    @Override
+                    public BrowserLiveReload getLiveReload(
+                            VaadinContext context) {
+                        return liveReload;
+                    }
+                });
         return liveReload;
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandlerTest.java
@@ -357,8 +357,7 @@ public class WebComponentBootstrapHandlerTest {
 
     private void initLookup(VaadinServletService service) throws IOException {
         VaadinContext context = service.getContext();
-        Lookup lookup = Mockito.mock(Lookup.class);
-        context.setAttribute(Lookup.class, lookup);
+        Lookup lookup = context.getAttribute(Lookup.class);
 
         ResourceProvider provider = Mockito.mock(ResourceProvider.class);
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
@@ -42,9 +42,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.Mock;
 import org.mockito.internal.util.collections.Sets;
 import org.slf4j.Logger;
 
+import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JavaScript;
@@ -85,6 +87,9 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
 
     private static final String ERROR_MSG = "foo-bar-baz";
 
+    @Mock
+    private FeatureFlags featureFlags;
+
     private class UpdateImports extends AbstractUpdateImports {
 
         private final ClassFinder finder;
@@ -93,9 +98,10 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
 
         UpdateImports(ClassFinder classFinder,
                 FrontendDependenciesScanner scanner, File npmDirectory,
-                File tokenFile, boolean productionMode) {
+                File tokenFile, boolean productionMode,
+                FeatureFlags featureFlags) {
             super(frontendDirectory, npmDirectory, generatedPath, tokenFile,
-                    productionMode);
+                    productionMode, featureFlags);
             this.scanner = scanner;
             finder = classFinder;
         }
@@ -171,7 +177,7 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
 
         ClassFinder classFinder = getClassFinder();
         updater = new UpdateImports(classFinder, getScanner(classFinder),
-                tmpRoot, tokenFile, true);
+                tmpRoot, tokenFile, true, featureFlags);
         assertTrue(nodeModulesPath.mkdirs());
         createExpectedImports(frontendDirectory, nodeModulesPath);
         assertTrue(new File(nodeModulesPath,
@@ -230,7 +236,7 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
             throws Exception {
         ClassFinder classFinder = getClassFinder();
         updater = new UpdateImports(classFinder, getScanner(classFinder),
-                tmpRoot, null, true);
+                tmpRoot, null, true, featureFlags);
 
         Files.move(frontendDirectory.toPath(),
                 new File(tmpRoot, "_frontend").toPath());
@@ -433,7 +439,7 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
         ClassFinder classFinder = getClassFinder(testClasses);
 
         updater = new UpdateImports(classFinder, getScanner(classFinder),
-                tmpRoot, new File(tmpRoot, TOKEN_FILE), true);
+                tmpRoot, new File(tmpRoot, TOKEN_FILE), true, featureFlags);
         updater.run();
 
         // Imports are collected as

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -356,8 +356,7 @@ public class FrontendUtilsTest {
 
         VaadinContext context = service.getContext();
 
-        Lookup lookup = Mockito.mock(Lookup.class);
-        context.setAttribute(Lookup.class, lookup);
+        Lookup lookup = context.getAttribute(Lookup.class);
 
         ResourceProvider provider = Mockito.mock(ResourceProvider.class);
 

--- a/flow-server/src/test/java/com/vaadin/tests/server/SerializationTest.java
+++ b/flow-server/src/test/java/com/vaadin/tests/server/SerializationTest.java
@@ -12,6 +12,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import junit.framework.TestCase;
 import org.mockito.Mockito;
 
+import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.server.VaadinContext;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinService;
@@ -139,6 +140,7 @@ public class SerializationTest extends TestCase {
         private final boolean productionMode;
         private final boolean serialize;
         private final Lock lock = new ReentrantLock();
+        private final Lookup lookup;
 
         {
             lock.lock();
@@ -146,6 +148,7 @@ public class SerializationTest extends TestCase {
 
         public MockVaadinService(boolean productionMode) {
             super();
+            this.lookup = Mockito.mock(Lookup.class);
             this.vaadinContext = Mockito.mock(VaadinContext.class);
             this.productionMode = productionMode;
             serialize = false;
@@ -153,6 +156,7 @@ public class SerializationTest extends TestCase {
 
         public MockVaadinService(boolean productionMode, boolean serialize) {
             super();
+            this.lookup = Mockito.mock(Lookup.class);
             this.vaadinContext = Mockito.mock(VaadinContext.class);
             this.productionMode = productionMode;
             this.serialize = serialize;
@@ -162,6 +166,8 @@ public class SerializationTest extends TestCase {
         public VaadinContext getContext() {
             ApplicationConfiguration applicationConfiguration = Mockito
                     .mock(ApplicationConfiguration.class);
+            Mockito.when(vaadinContext.getAttribute(Lookup.class))
+                    .thenReturn(lookup);
             Mockito.when(
                     vaadinContext.getAttribute(Mockito.any(), Mockito.any()))
                     .thenReturn(applicationConfiguration);

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/ViteHandler.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/ViteHandler.java
@@ -125,9 +125,18 @@ public final class ViteHandler extends AbstractDevServerRunner {
     public HttpURLConnection prepareConnection(String path, String method)
             throws IOException {
         if ("/index.html".equals(path)) {
-            return super.prepareConnection("/VAADIN/index.html", method);
+            return super.prepareConnection(
+                    "/VAADIN/" + getFrontendPath() + "index.html", method);
         }
 
         return super.prepareConnection(path, method);
+    }
+
+    private String getFrontendPath() {
+        File frontend = new File(
+                System.getProperty(FrontendUtils.PARAM_FRONTEND_DIR,
+                        FrontendUtils.DEFAULT_FRONTEND_DIR));
+        return getServerConfig().getParentFile().toURI()
+                .relativize(frontend.toURI()).toString();
     }
 }


### PR DESCRIPTION
Fixes #12497

Instead of processing frontend dependencies upfront, Flow loads JS modules dynamically when components are added to the page.

This also disables Vite pre-bundling of dependencies in dev mode for faster dev server startup.