### PR TITLE
test: replace maven-clean-plugin execution with flow:clean-frontend

### DIFF
--- a/flow-tests/test-npm-only-features/test-npm-no-buildmojo/pom.xml
+++ b/flow-tests/test-npm-only-features/test-npm-no-buildmojo/pom.xml
@@ -56,43 +56,6 @@
 
     <build>
         <plugins>
-            <!--
-                Clean node_modules and package-lock to make sure that
-                @NpmPackage test works as it should.
-             -->
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <version>3.1.0</version>
-                <configuration>
-                    <filesets>
-                        <fileset>
-                            <directory>${project.basedir}/node_modules</directory>
-                            <includes>
-                                <include>@polymer/**/*</include>
-                                <include>@vaadin/**/*</include>
-                            </includes>
-                            <followSymlinks>false</followSymlinks>
-                        </fileset>
-                        <fileset>
-                            <directory>${project.basedir}</directory>
-                            <includes>
-                                <include>package-lock.json</include>
-                                <include>/target/**</include>
-                            </includes>
-                        </fileset>
-                    </filesets>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
             <!-- This module is mapped to default web context -->
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
@@ -121,6 +84,19 @@
             <plugin>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-maven-plugin</artifactId>
+                <executions>
+                    <!--
+                        Clean node_modules and package-lock to make sure that
+                        @NpmPackage test works as it should.
+                     -->
+                    <execution>
+                        <id>auto-clean</id>
+                        <goals>
+                            <goal>clean-frontend</goal>
+                        </goals>
+                        <phase>initialize</phase>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
## Description

Module `flow-test-npm-no-buildmojo` has a `maven-clean-plugin` execution configuration to delete `node_modules/@vaadin/*`, `node_modules/@polymer/*` and `target/package-lock.json`.  However, since `node_modules/.vaadin/vaadin.json` is not deleted, successive runs do not perform `npm install`, causing the build to fail due to missing modules.
This change replaces the `maven-clean-plugin` execution with `flow:clean-frontend`, that performs a more complete cleanup,
making multiple test runs complete successfully.

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
