### PR TITLE
feat: add task for generating client-side feature flags file

### DIFF
--- a/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
+++ b/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
@@ -55,6 +55,9 @@ public class FeatureFlags implements Serializable {
     public static final Feature VITE = new Feature(
             "Use Vite for faster front-end builds", "viteForFrontendBuild",
             "https://github.com/vaadin/platform/issues/2448", true);
+    public static final Feature MAP_COMPONENT = new Feature(
+            "Enable the Map component", "enableMapComponent",
+            "https://github.com/vaadin/platform/issues/2611", true);
 
     private List<Feature> features = new ArrayList<>();
 
@@ -74,6 +77,7 @@ public class FeatureFlags implements Serializable {
         this.lookup = lookup;
         features.add(new Feature(EXAMPLE));
         features.add(new Feature(VITE));
+        features.add(new Feature(MAP_COMPONENT));
         loadProperties();
     }
 

--- a/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
+++ b/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
@@ -56,7 +56,7 @@ public class FeatureFlags implements Serializable {
             "Use Vite for faster front-end builds", "viteForFrontendBuild",
             "https://github.com/vaadin/platform/issues/2448", true);
     public static final Feature MAP_COMPONENT = new Feature(
-            "Enable the Map component", "enableMapComponent",
+            "Map component (Pro)", "mapComponent",
             "https://github.com/vaadin/platform/issues/2611", true);
 
     private List<Feature> features = new ArrayList<>();

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -199,6 +199,14 @@ public class FrontendUtils {
     public static final String BOOTSTRAP_FILE_NAME = "vaadin.ts";
 
     /**
+     * File name of the feature flags file that is generated in frontend
+     * {@link #GENERATED} folder. The feature flags file contains code to define
+     * feature flags as globals that might be used by Vaadin web components or
+     * application code.
+     */
+    public static final String FEATURE_FLAGS_FILE_NAME = "feature-flags.ts";
+
+    /**
      * File name of the index.html in client side.
      */
     public static final String INDEX_HTML = "index.html";

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -204,7 +204,7 @@ public class FrontendUtils {
      * feature flags as globals that might be used by Vaadin web components or
      * application code.
      */
-    public static final String FEATURE_FLAGS_FILE_NAME = "feature-flags.ts";
+    public static final String FEATURE_FLAGS_FILE_NAME = "vaadin-featureflags.ts";
 
     /**
      * File name of the index.html in client side.

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -696,6 +696,7 @@ public class NodeTasks implements FallibleCommand {
             TaskGenerateOpenAPI.class,
             TaskGenerateEndpoint.class,
             TaskGenerateBootstrap.class,
+            TaskGenerateFeatureFlags.class,
             TaskInstallWebpackPlugins.class,
             TaskUpdatePackages.class,
             TaskRunNpmInstall.class,
@@ -791,6 +792,9 @@ public class NodeTasks implements FallibleCommand {
 
             commands.add(new TaskGenerateBootstrap(frontendDependencies,
                     builder.frontendDirectory, builder.productionMode));
+
+            commands.add(new TaskGenerateFeatureFlags(builder.frontendDirectory,
+                    featureFlags));
         }
 
         if (builder.jarFiles != null && builder.flowResourcesFolder != null) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrap.java
@@ -24,6 +24,7 @@ import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 import com.vaadin.flow.theme.ThemeDefinition;
 
 import static com.vaadin.flow.server.frontend.FrontendUtils.BOOTSTRAP_FILE_NAME;
+import static com.vaadin.flow.server.frontend.FrontendUtils.FEATURE_FLAGS_FILE_NAME;
 import static com.vaadin.flow.server.frontend.FrontendUtils.GENERATED;
 import static com.vaadin.flow.server.frontend.FrontendUtils.INDEX_JS;
 import static com.vaadin.flow.server.frontend.FrontendUtils.INDEX_TS;
@@ -57,6 +58,7 @@ public class TaskGenerateBootstrap extends AbstractTaskClientGenerator {
     @Override
     protected String getFileContent() {
         List<String> lines = new ArrayList<>();
+        lines.add(String.format("import './%s';%n", FEATURE_FLAGS_FILE_NAME));
         lines.add(String.format("import '%s';%n", getIndexTsEntryPath()));
         if (!productionMode) {
             lines.add(DEVMODE_GIZMO_IMPORT);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateFeatureFlags.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateFeatureFlags.java
@@ -49,10 +49,10 @@ public class TaskGenerateFeatureFlags extends AbstractTaskClientGenerator {
         lines.add("// @ts-nocheck");
         lines.add("window.Vaadin = window.Vaadin || {};");
         lines.add(
-                "window.Vaadin.experimental = window.Vaadin.experimental || {};");
+                "window.Vaadin.featureFlags = window.Vaadin.featureFlags || {};");
 
         featureFlags.getFeatures().forEach(feature -> {
-            lines.add(String.format("window.Vaadin.experimental.%s = %s;",
+            lines.add(String.format("window.Vaadin.featureFlags.%s = %s;",
                     feature.getId(), featureFlags.isEnabled(feature)));
         });
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateFeatureFlags.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateFeatureFlags.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.frontend;
+
+import com.vaadin.experimental.FeatureFlags;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.vaadin.flow.server.frontend.FrontendUtils.*;
+
+/**
+ * A task for generating the feature flags file
+ * {@link FrontendUtils#FEATURE_FLAGS_FILE_NAME} during `package` Maven goal.
+ * <p>
+ * For internal use only. May be renamed or removed in a future release.
+ *
+ * @author Vaadin Ltd
+ */
+public class TaskGenerateFeatureFlags extends AbstractTaskClientGenerator {
+
+    private final File frontendGeneratedDirectory;
+    private final FeatureFlags featureFlags;
+
+    TaskGenerateFeatureFlags(File frontendDirectory,
+            FeatureFlags featureFlags) {
+        this.frontendGeneratedDirectory = new File(frontendDirectory,
+                GENERATED);
+        this.featureFlags = featureFlags;
+    }
+
+    @Override
+    protected String getFileContent() {
+        List<String> lines = new ArrayList<>();
+        lines.add("// @ts-nocheck");
+        lines.add("window.Vaadin = window.Vaadin || {};");
+        lines.add(
+                "window.Vaadin.experimental = window.Vaadin.experimental || {};");
+
+        featureFlags.getFeatures().forEach(feature -> {
+            lines.add(String.format("window.Vaadin.experimental.%s = %s;",
+                    feature.getId(), featureFlags.isEnabled(feature)));
+        });
+
+        return String.join(System.lineSeparator(), lines);
+    }
+
+    @Override
+    protected File getGeneratedFile() {
+        return new File(frontendGeneratedDirectory, FEATURE_FLAGS_FILE_NAME);
+    }
+
+    @Override
+    protected boolean shouldGenerate() {
+        return true;
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrapTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateBootstrapTest.java
@@ -38,6 +38,7 @@ import com.vaadin.flow.theme.ThemeDefinition;
 
 import static com.vaadin.flow.server.frontend.FrontendUtils.FRONTEND;
 import static com.vaadin.flow.server.frontend.FrontendUtils.INDEX_TS;
+import static com.vaadin.flow.server.frontend.FrontendUtils.FEATURE_FLAGS_FILE_NAME;
 import static com.vaadin.flow.server.frontend.NodeUpdateTestUtil.getClassFinder;
 
 public class TaskGenerateBootstrapTest {
@@ -95,6 +96,14 @@ public class TaskGenerateBootstrapTest {
         taskGenerateBootstrap.execute();
         String content = taskGenerateBootstrap.getFileContent();
         Assert.assertTrue(content.contains("import '../index';"));
+    }
+
+    @Test
+    public void should_importFeatureFlagTS() throws ExecutionFailedException {
+        taskGenerateBootstrap.execute();
+        String content = taskGenerateBootstrap.getFileContent();
+        Assert.assertTrue(content.contains(
+                String.format("import './%s';", FEATURE_FLAGS_FILE_NAME)));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateFeatureFlagsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateFeatureFlagsTest.java
@@ -37,20 +37,18 @@ public class TaskGenerateFeatureFlagsTest {
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-    private File frontendFolder;
     private TaskGenerateFeatureFlags taskGenerateFeatureFlags;
     private FeatureFlags featureFlags;
 
     @Before
     public void setUp() throws Exception {
-
         VaadinContext context = new MockVaadinContext();
         ApplicationConfiguration configuration = Mockito
                 .mock(ApplicationConfiguration.class);
         context.setAttribute(ApplicationConfiguration.class, configuration);
 
+        File frontendFolder = temporaryFolder.newFolder(FRONTEND);
         featureFlags = FeatureFlags.get(context);
-        frontendFolder = temporaryFolder.newFolder(FRONTEND);
         taskGenerateFeatureFlags = new TaskGenerateFeatureFlags(frontendFolder,
                 featureFlags);
     }
@@ -64,14 +62,14 @@ public class TaskGenerateFeatureFlagsTest {
     }
 
     @Test
-    public void should_setupExperimentalGlobal()
+    public void should_setupFeatureFlagsGlobal()
             throws ExecutionFailedException {
         taskGenerateFeatureFlags.execute();
         String content = taskGenerateFeatureFlags.getFileContent();
         Assert.assertTrue(
                 content.contains("window.Vaadin = window.Vaadin || {};"));
         Assert.assertTrue(content.contains(
-                "window.Vaadin.experimental = window.Vaadin.experimental || {};"));
+                "window.Vaadin.featureFlags = window.Vaadin.featureFlags || {};"));
     }
 
     @Test
@@ -101,7 +99,7 @@ public class TaskGenerateFeatureFlagsTest {
     private static void assertFeatureFlagGlobal(String content, Feature feature,
             boolean enabled) {
         Assert.assertTrue(content
-                .contains(String.format("window.Vaadin.experimental.%s = %s",
+                .contains(String.format("window.Vaadin.featureFlags.%s = %s",
                         feature.getId(), enabled)));
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateFeatureFlagsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateFeatureFlagsTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.frontend;
+
+import com.vaadin.experimental.Feature;
+import com.vaadin.experimental.FeatureFlags;
+import com.vaadin.flow.server.ExecutionFailedException;
+import com.vaadin.flow.server.MockVaadinContext;
+import com.vaadin.flow.server.VaadinContext;
+import com.vaadin.flow.server.startup.ApplicationConfiguration;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
+
+import java.io.File;
+
+import static com.vaadin.flow.server.frontend.FrontendUtils.FRONTEND;
+
+public class TaskGenerateFeatureFlagsTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private File frontendFolder;
+    private TaskGenerateFeatureFlags taskGenerateFeatureFlags;
+    private FeatureFlags featureFlags;
+
+    @Before
+    public void setUp() throws Exception {
+
+        VaadinContext context = new MockVaadinContext();
+        ApplicationConfiguration configuration = Mockito
+                .mock(ApplicationConfiguration.class);
+        context.setAttribute(ApplicationConfiguration.class, configuration);
+
+        featureFlags = FeatureFlags.get(context);
+        frontendFolder = temporaryFolder.newFolder(FRONTEND);
+        taskGenerateFeatureFlags = new TaskGenerateFeatureFlags(frontendFolder,
+                featureFlags);
+    }
+
+    @Test
+    public void should_disableTypeChecksForGlobals()
+            throws ExecutionFailedException {
+        taskGenerateFeatureFlags.execute();
+        String content = taskGenerateFeatureFlags.getFileContent();
+        Assert.assertTrue(content.startsWith("// @ts-nocheck"));
+    }
+
+    @Test
+    public void should_setupExperimentalGlobal()
+            throws ExecutionFailedException {
+        taskGenerateFeatureFlags.execute();
+        String content = taskGenerateFeatureFlags.getFileContent();
+        Assert.assertTrue(
+                content.contains("window.Vaadin = window.Vaadin || {};"));
+        Assert.assertTrue(content.contains(
+                "window.Vaadin.experimental = window.Vaadin.experimental || {};"));
+    }
+
+    @Test
+    public void should_defineAllFeatureFlags() throws ExecutionFailedException {
+        taskGenerateFeatureFlags.execute();
+        String content = taskGenerateFeatureFlags.getFileContent();
+
+        featureFlags.getFeatures().forEach(feature -> {
+            assertFeatureFlagGlobal(content, feature, false);
+        });
+    }
+
+    @Test
+    public void should_defineCorrectEnabledValue()
+            throws ExecutionFailedException {
+        // Enable example feature
+        featureFlags.getFeatures().stream()
+                .filter(feature -> feature.equals(FeatureFlags.EXAMPLE))
+                .forEach(feature -> feature.setEnabled(true));
+
+        taskGenerateFeatureFlags.execute();
+        String content = taskGenerateFeatureFlags.getFileContent();
+
+        assertFeatureFlagGlobal(content, FeatureFlags.EXAMPLE, true);
+    }
+
+    private static void assertFeatureFlagGlobal(String content, Feature feature,
+            boolean enabled) {
+        Assert.assertTrue(content
+                .contains(String.format("window.Vaadin.experimental.%s = %s",
+                        feature.getId(), enabled)));
+    }
+}


### PR DESCRIPTION
## Description

Adds a task for generating a `feature-flags.ts` file that defines globals for all feature flags. The globals can then be used by Vaadin web components, or application code, to check whether a feature was enabled in the Java app. The file is then imported from the bootstrap file.

This also adds a feature flag for the map component that is currently in development, which would be the first Vaadin component to make use of these globals. See PR here: https://github.com/vaadin/web-components/pull/3321

We want to move this flag into this repo in order to re-use the existing constructs around feature flags, provide a consistent experience for using them for our users, and to support toggling the flag using the debug tools in Flow and Hilla apps.

Part of https://github.com/vaadin/flow-components/issues/2495

## Type of change

- [x] Feature (not sure if you want to tag this as feature, feel free to modify)