### PR TITLE
fix: use bundle-version instead of package version

### DIFF
--- a/flow-server/bnd.bnd
+++ b/flow-server/bnd.bnd
@@ -3,6 +3,6 @@ Bundle-Name: Vaadin Flow Server
 Bundle-Version: ${osgi.bundle.version}
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-License: http://www.apache.org/licenses/LICENSE-2.0
-Import-Package: org.atmosphere*;resolution:=optional;version='${atmosphere.runtime.version}',\
+Import-Package: org.atmosphere*;resolution:=optional;bundle-version='${atmosphere.runtime.version}',\
     org.apache.http*;resolution:=optional;,*
 Export-Package: !com.vaadin.flow.push*, com.vaadin.flow*;-noimport:=true


### PR DESCRIPTION
The customized `atmosphere-runtime:2.7.3.slf4jvaadin3` exports packages
with version `2.7.3` (i.e., not `2.7.3.slf4jvaadin3`). Depend on exporting bundle 
version instead of the package version.
