### PR TITLE
fix: Force an older babel version (#12781)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -312,6 +312,7 @@ public abstract class NodeUpdater implements FallibleCommand {
         // Defining loader until a resolution exists to issue
         // https://github.com/DanielSchaffer/webpack-babel-multi-target-plugin/issues/94
         defaults.put("babel-loader", "8.2.2");
+        defaults.put("@babel/core", "7.16.7");
         // Defining html-webpack-plugin due to same issue as babel-loader
         defaults.put("html-webpack-plugin", "4.5.2");
         defaults.put("copy-webpack-plugin", "5.1.2");


### PR DESCRIPTION
This fixes some random build issues where webpack exits with code 139

