### PR TITLE
fix: Force an older babel version (#12781)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -327,6 +327,8 @@ public abstract class NodeUpdater implements FallibleCommand {
         defaults.put("extract-loader", "5.1.0");
         defaults.put("lit-css-loader", "0.0.4");
 
+        defaults.put("@babel/core", "7.16.7");
+
         // Forcing chokidar version for now until new babel version is available
         // check out https://github.com/babel/babel/issues/11488
         defaults.put("chokidar", "^3.5.0");


### PR DESCRIPTION
This fixes some random build issues where webpack exits with code 139
