### PR TITLE
fix: Force an older babel version (#12781)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -384,6 +384,7 @@ public abstract class NodeUpdater implements FallibleCommand {
         Map<String, String> defaults = new HashMap<>();
 
         defaults.put("typescript", "4.4.3");
+        defaults.put("@babel/core", "7.16.7");
 
         final String WORKBOX_VERSION = "6.4.2";
 


### PR DESCRIPTION
This fixes some random build issues where webpack exits with code 139
