### PR TITLE
Revert "fix: Force an older babel version"

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -390,7 +390,6 @@ public abstract class NodeUpdater implements FallibleCommand {
         Map<String, String> defaults = new HashMap<>();
 
         defaults.put("typescript", "4.5.3");
-        defaults.put("@babel/core", "7.16.7");
 
         final String WORKBOX_VERSION = "6.4.2";
 


### PR DESCRIPTION
Reverts vaadin/flow#12781

This fix is no longer needed as `@babel/core` 7.6.11 is released with a fix.