### PR TITLE
test: Delete seemingly unnecessary war deployment

### DIFF
--- a/flow-tests/test-embedding/test-embedding-production-mode/pom.xml
+++ b/flow-tests/test-embedding/test-embedding-production-mode/pom.xml
@@ -58,22 +58,6 @@
                         </contextHandler>
                     </contextHandlers>
                 </configuration>
-                <executions>
-                    <!-- overriding start-jetty to get a war going for prod -->
-                    <execution>
-                        <id>start-jetty</id>
-                        <phase>none</phase>
-                    </execution>
-                    <!-- actual start: -->
-                    <execution>
-                        <id>start-jetty-war</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>deploy-war</goal>
-                        </goals>
-                    </execution>
-                    <!-- stop is inherited -->
-                </executions>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
The `deploy-war` target no longer exists in Jetty 10
