### PR TITLE
fix: Use service already assigned

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlWriter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlWriter.java
@@ -160,7 +160,7 @@ public class UidlWriter implements Serializable {
         response.put(ApplicationConstants.CLIENT_TO_SERVER_ID,
                 nextClientToServerMessageId);
 
-        SystemMessages messages = ui.getSession().getService()
+        SystemMessages messages = service
                 .getSystemMessages(ui.getLocale(), null);
 
         JsonObject meta = new MetadataWriter().createMetadata(ui, false, async,
@@ -190,7 +190,7 @@ public class UidlWriter implements Serializable {
             response.put(JsonConstants.UIDL_KEY_EXECUTE,
                     encodeExecuteJavaScriptList(executeJavaScriptList));
         }
-        if (ui.getSession().getService().getDeploymentConfiguration()
+        if (service.getDeploymentConfiguration()
                 .isRequestTiming()) {
             response.put("timings", createPerformanceData(ui));
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlWriter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlWriter.java
@@ -160,8 +160,8 @@ public class UidlWriter implements Serializable {
         response.put(ApplicationConstants.CLIENT_TO_SERVER_ID,
                 nextClientToServerMessageId);
 
-        SystemMessages messages = service
-                .getSystemMessages(ui.getLocale(), null);
+        SystemMessages messages = service.getSystemMessages(ui.getLocale(),
+                null);
 
         JsonObject meta = new MetadataWriter().createMetadata(ui, false, async,
                 messages);
@@ -190,8 +190,7 @@ public class UidlWriter implements Serializable {
             response.put(JsonConstants.UIDL_KEY_EXECUTE,
                     encodeExecuteJavaScriptList(executeJavaScriptList));
         }
-        if (service.getDeploymentConfiguration()
-                .isRequestTiming()) {
+        if (service.getDeploymentConfiguration().isRequestTiming()) {
             response.put("timings", createPerformanceData(ui));
         }
         uiInternals.incrementServerId();


### PR DESCRIPTION
Code cleanup

fixes: https://github.com/vaadin/flow/issues/12807

Note, exception is thrown here: https://github.com/vaadin/flow/blob/2.8/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlWriter.java#L178

But earlier session.getService() did not throw https://github.com/vaadin/flow/blob/2.8/flow-server/src/main/java/com/vaadin/flow/server/communication/UidlWriter.java#L157

Hence I assume using stored service reference will make code less prone to throw