### PR TITLE
fix: don't mention Webpack in error messages when Vite is used

### DIFF
--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -423,9 +423,9 @@ public class BuildFrontendUtil {
                 NODE_MODULES + executable);
         if (!buildExecutable.isFile()) {
             throw new IllegalStateException(String.format(
-                    "Unable to locate webpack executable by path '%s'. Double"
+                    "Unable to locate %s executable by path '%s'. Double"
                             + " check that the plugin is executed correctly",
-                    buildExecutable.getAbsolutePath()));
+                    toolName, buildExecutable.getAbsolutePath()));
         }
 
         String nodePath;
@@ -461,7 +461,8 @@ public class BuildFrontendUtil {
                     toolName, e.getResult().outputUTF8()), e);
         } catch (IOException | InterruptedException e) {
             throw new IllegalStateException(
-                    "Failed to run webpack due to an error", e);
+                    String.format("Failed to run %s due to an error", toolName),
+                    e);
         }
     }
 


### PR DESCRIPTION
## Description

There are some error messages that always mention Webpack as the trouble source even though they are also used for Vite. This PR fixes such messages so that they mention the frontend tool that is actually used.

Fixes #12767

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
