### PR TITLE
test: Do not send any data from tests automatically

### DIFF
--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/stats/AbstractStatisticsTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/stats/AbstractStatisticsTest.java
@@ -44,10 +44,9 @@ public abstract class AbstractStatisticsTest {
         storage.usageStatisticsFile = File.createTempFile("test-storage",
                 "json");
         sender = Mockito.spy(new StatisticsSender(storage));
-
+        Mockito.doAnswer(answer -> null).when(sender)
+                .triggerSendIfNeeded(Mockito.any());
         // Change the file storage and reporting parameters for testing
-        Mockito.when(sender.getReportingUrl())
-                .thenReturn("http://localhost:1234");
         Mockito.when(storage.getUsageStatisticsFile()).thenReturn(
                 createTempStorage("stats-data/usage-statistics-1.json"));
     }


### PR DESCRIPTION
When calling DevModeUsageStatistics.init, there is a check to see if stats should be sent immediately. If this is triggered, then there will be two post requests going out in a test, with the response of the real test request potentially being overwritten by the response to the automatic request.
