### PR TITLE
test: ModalDialogIT Wait for child element presence before performing assertions

### DIFF
--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ModalDialogIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ModalDialogIT.java
@@ -1,5 +1,7 @@
 package com.vaadin.flow.uitest.ui;
 
+import java.util.List;
+
 import com.vaadin.flow.component.html.testbench.DivElement;
 import com.vaadin.flow.component.html.testbench.NativeButtonElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
@@ -124,8 +126,8 @@ public class ModalDialogIT extends ChromeBrowserTest {
 
     private void validateShortcutEvent(int indexFromTop, int eventCounter,
             String eventSourceId) {
-        final WebElement latestEvent = eventLog.findElements(By.tagName("div"))
-                .get(indexFromTop);
+        final WebElement latestEvent = eventLog.findElement(
+                By.xpath(String.format("div[%d]", indexFromTop + 1)));
         Assert.assertEquals("Invalid latest event",
                 eventCounter + "-" + eventSourceId, latestEvent.getText());
     }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ModalDialogIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ModalDialogIT.java
@@ -1,7 +1,5 @@
 package com.vaadin.flow.uitest.ui;
 
-import java.util.List;
-
 import com.vaadin.flow.component.html.testbench.DivElement;
 import com.vaadin.flow.component.html.testbench.NativeButtonElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ModalDialogIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ModalDialogIT.java
@@ -124,8 +124,8 @@ public class ModalDialogIT extends ChromeBrowserTest {
 
     private void validateShortcutEvent(int indexFromTop, int eventCounter,
             String eventSourceId) {
-        final WebElement latestEvent = eventLog.findElement(
-                By.xpath(String.format("div[%d]", indexFromTop + 1)));
+        final WebElement latestEvent = waitUntil(driver -> eventLog.findElement(
+                By.xpath(String.format("div[%d]", indexFromTop + 1))));
         Assert.assertEquals("Invalid latest event",
                 eventCounter + "-" + eventSourceId, latestEvent.getText());
     }


### PR DESCRIPTION
## Description

Sometimes `findElements(By.tagName("div"))` returns an empty list, maybe because server roundtrip has not yet completed.
This change adds wait condition to ensure the presence of the newly added element before doing assertions.

Fixes #12756

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.
