### PR TITLE
fix: reliable deletion of node_modules

### DIFF
--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/CleanFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/CleanFrontendMojo.java
@@ -26,6 +26,8 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 
+import com.vaadin.flow.server.frontend.FrontendUtils;
+
 import elemental.json.Json;
 import elemental.json.JsonObject;
 import elemental.json.impl.JsonUtil;
@@ -103,15 +105,12 @@ public class CleanFrontendMojo extends FlowModeAbstractMojo {
     private void removeNodeModules() {
         // Remove node_modules folder
         File nodeModules = new File(npmFolder(), "node_modules");
-        if (nodeModules.exists()) {
-            try {
-                FileUtils.deleteDirectory(nodeModules);
-            } catch (IOException exception) {
-                getLog().debug("Exception removing node_modules", exception);
-                getLog().error(
-                        "Failed to remove '" + nodeModules.getAbsolutePath()
-                                + "'. Please remove it manually.");
-            }
+        try {
+            FrontendUtils.deleteNodeModules(nodeModules);
+        } catch (IOException exception) {
+            getLog().debug("Exception removing node_modules", exception);
+            getLog().error("Failed to remove '" + nodeModules.getAbsolutePath()
+                    + "'. Please remove it manually.");
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -1242,12 +1242,6 @@ public class FrontendUtils {
         }
 
         Path nodeModulesPath = nodeModules.toPath();
-
-        try (Stream<Path> walk = Files.walk(nodeModulesPath)) {
-            walk.map(Path::toFile)
-                    .forEach(file -> file.setWritable(true, true));
-        }
-
         try (Stream<Path> walk = Files.walk(nodeModulesPath)) {
             String undeletable = walk.sorted(Comparator.reverseOrder())
                     .map(Path::toFile).filter(file -> !file.delete())

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -1239,16 +1239,20 @@ public class FrontendUtils {
 
         Path nodeModulesPath = nodeModules.toPath();
 
-        Files.walk(nodeModulesPath).map(Path::toFile)
-                .forEach(file -> file.setWritable(true, true));
+        try (Stream<Path> walk = Files.walk(nodeModulesPath)) {
+            walk.map(Path::toFile)
+                    .forEach(file -> file.setWritable(true, true));
+        }
 
-        String undeletable = Files.walk(nodeModulesPath)
-                .sorted(Comparator.reverseOrder()).map(Path::toFile)
-                .filter(file -> !file.delete()).map(File::getAbsolutePath)
-                .collect(Collectors.joining(", "));
+        try (Stream<Path> walk = Files.walk(nodeModulesPath)) {
+            String undeletable = walk.sorted(Comparator.reverseOrder())
+                    .map(Path::toFile).filter(file -> !file.delete())
+                    .map(File::getAbsolutePath)
+                    .collect(Collectors.joining(", "));
 
-        if (!undeletable.isEmpty()) {
-            throw new IOException("Unable to delete files: " + undeletable);
+            if (!undeletable.isEmpty()) {
+                throw new IOException("Unable to delete files: " + undeletable);
+            }
         }
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -1231,6 +1231,10 @@ public class FrontendUtils {
      *             is not {@code node_modules}
      */
     public static void deleteNodeModules(File nodeModules) throws IOException {
+        if (!nodeModules.exists()) {
+            return;
+        }
+        
         if (!nodeModules.isDirectory()
                 || !nodeModules.getName().equals("node_modules")) {
             throw new IOException(nodeModules.getAbsolutePath()

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -1234,7 +1234,7 @@ public class FrontendUtils {
         if (!nodeModules.exists()) {
             return;
         }
-        
+
         if (!nodeModules.isDirectory()
                 || !nodeModules.getName().equals("node_modules")) {
             throw new IOException(nodeModules.getAbsolutePath()

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -531,7 +531,7 @@ public class TaskRunNpmInstall implements FallibleCommand {
     private void deleteNodeModules(File nodeModulesFolder)
             throws ExecutionFailedException {
         try {
-            FileUtils.forceDelete(nodeModulesFolder);
+            FrontendUtils.deleteNodeModules(nodeModulesFolder);
         } catch (IOException exception) {
             Logger log = packageUpdater.log();
             log.debug("Exception removing node_modules", exception);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -336,8 +336,10 @@ public class FrontendUtilsTest {
             throws IOException {
         File externalDir = new File(tmpDir.getRoot(), "external");
         File externalLicense = new File(externalDir, "LICENSE");
-        externalLicense.mkdirs();
+
+        externalLicense.getParentFile().mkdirs();
         externalLicense.createNewFile();
+        externalLicense.setWritable(false);
 
         File nodeModules = new File(tmpDir.getRoot(), "node_modules");
         File containing = new File(nodeModules, ".pnpm/a/node_modules/dep");
@@ -348,12 +350,12 @@ public class FrontendUtilsTest {
         File linking = new File(nodeModules, ".pnpm/b/node_modules/dep");
         linking.getParentFile().mkdirs();
         Files.createSymbolicLink(linking.toPath(),
-                Path.of("../../a/node_modules/dep"));
+                new File("../../a/node_modules/dep").toPath());
 
         File linkingExternal = new File(nodeModules,
                 ".pnpm/b/node_modules/external");
         Files.createSymbolicLink(linkingExternal.toPath(),
-                Path.of("../../../../external"));
+                new File("../../../../external").toPath());
 
         Assert.assertTrue(nodeModules.exists());
         Assert.assertTrue(linking.exists());
@@ -364,6 +366,7 @@ public class FrontendUtilsTest {
 
         Assert.assertFalse(nodeModules.exists());
         Assert.assertTrue(externalLicense.exists());
+        Assert.assertFalse(externalLicense.canWrite());
     }
 
     private ResourceProvider mockResourceProvider(VaadinService service) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -350,7 +350,8 @@ public class FrontendUtilsTest {
         Files.createSymbolicLink(linking.toPath(),
                 Path.of("../../a/node_modules/dep"));
 
-        File linkingExternal = new File(nodeModules, ".pnpm/b/node_modules/external");
+        File linkingExternal = new File(nodeModules,
+                ".pnpm/b/node_modules/external");
         Files.createSymbolicLink(linkingExternal.toPath(),
                 Path.of("../../../../external"));
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -339,7 +339,6 @@ public class FrontendUtilsTest {
 
         externalLicense.getParentFile().mkdirs();
         externalLicense.createNewFile();
-        externalLicense.setWritable(false);
 
         File nodeModules = new File(tmpDir.getRoot(), "node_modules");
         File containing = new File(nodeModules, ".pnpm/a/node_modules/dep");
@@ -366,7 +365,6 @@ public class FrontendUtilsTest {
 
         Assert.assertFalse(nodeModules.exists());
         Assert.assertTrue(externalLicense.exists());
-        Assert.assertFalse(externalLicense.canWrite());
     }
 
     private ResourceProvider mockResourceProvider(VaadinService service) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -20,6 +20,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -314,6 +315,54 @@ public class FrontendUtilsTest {
 
         assertNull("Stats cache should not be present",
                 service.getContext().getAttribute(CACHE_KEY));
+    }
+
+    @Test
+    public void deleteNodeModules_nopIfNotExists() throws IOException {
+        File nodeModules = new File(tmpDir.getRoot(), "node_modules");
+        FrontendUtils.deleteNodeModules(nodeModules);
+    }
+
+    @Test(expected = IOException.class)
+    public void deleteNodeModules_throwsIfNotNamedNodeModules()
+            throws IOException {
+        File myModules = new File(tmpDir.getRoot(), "my_modules");
+        myModules.mkdirs();
+        FrontendUtils.deleteNodeModules(myModules);
+    }
+
+    @Test
+    public void deleteNodeModules_canDeleteSymlinksAndNotFollowThem()
+            throws IOException {
+        File externalDir = new File(tmpDir.getRoot(), "external");
+        File externalLicense = new File(externalDir, "LICENSE");
+        externalLicense.mkdirs();
+        externalLicense.createNewFile();
+
+        File nodeModules = new File(tmpDir.getRoot(), "node_modules");
+        File containing = new File(nodeModules, ".pnpm/a/node_modules/dep");
+        containing.mkdirs();
+        File license = new File(containing, "LICENSE");
+        license.createNewFile();
+
+        File linking = new File(nodeModules, ".pnpm/b/node_modules/dep");
+        linking.getParentFile().mkdirs();
+        Files.createSymbolicLink(linking.toPath(),
+                Path.of("../../a/node_modules/dep"));
+
+        File linkingExternal = new File(nodeModules, ".pnpm/b/node_modules/external");
+        Files.createSymbolicLink(linkingExternal.toPath(),
+                Path.of("../../../../external"));
+
+        Assert.assertTrue(nodeModules.exists());
+        Assert.assertTrue(linking.exists());
+        Assert.assertTrue(new File(linking, "LICENSE").exists());
+        Assert.assertTrue(new File(linkingExternal, "LICENSE").exists());
+
+        FrontendUtils.deleteNodeModules(nodeModules);
+
+        Assert.assertFalse(nodeModules.exists());
+        Assert.assertTrue(externalLicense.exists());
     }
 
     private ResourceProvider mockResourceProvider(VaadinService service) {


### PR DESCRIPTION
Do not set permissions nor follow symlinks when 
deleting node_modules.

Fixes #12810
