### PR TITLE
fix: Log exception for closed socket

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/StreamResource.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StreamResource.java
@@ -25,6 +25,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import org.slf4j.LoggerFactory;
+
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.ContentTypeResolver;
 
@@ -80,6 +82,13 @@ public class StreamResource extends AbstractStreamResource {
                 throws IOException {
             try (InputStream input = createInputStream(session)) {
                 copy(session, input, stream);
+            } catch (IOException ioe) {
+                if (!"Broken pipe".equals(ioe.getMessage())) {
+                    throw ioe;
+                }
+                LoggerFactory.getLogger(StreamResource.class).debug(
+                        "Broken pipe. Client has most likely cancelled link.",
+                        ioe);
             }
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/StreamResource.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StreamResource.java
@@ -83,12 +83,13 @@ public class StreamResource extends AbstractStreamResource {
             try (InputStream input = createInputStream(session)) {
                 copy(session, input, stream);
             } catch (IOException ioe) {
-                if (!"Broken pipe".equals(ioe.getMessage())) {
+                if ("Broken pipe".equals(ioe.getMessage())) {
+                    LoggerFactory.getLogger(StreamResource.class).debug(
+                            "The client browser has most likely cancelled the request.",
+                            ioe);
+                } else {
                     throw ioe;
                 }
-                LoggerFactory.getLogger(StreamResource.class).debug(
-                        "Broken pipe. Client has most likely cancelled link.",
-                        ioe);
             }
         }
 


### PR DESCRIPTION
Instead of throwing an exception if the
client has closed the stream socket, log a
message in debug mode.

Closes #12646
