### PR TITLE
test: DialogShortcutIT Wait for child element presence before performing assertions

### DIFF
--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ComplexDialogShortcutIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ComplexDialogShortcutIT.java
@@ -1,12 +1,10 @@
 package com.vaadin.flow.uitest.ui;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 
 import static com.vaadin.flow.uitest.ui.DialogShortcutView.REUSABLE_DIALOG_ID;
 
-@Ignore("Flaky test #10481, #10487, #10491")
 public class ComplexDialogShortcutIT extends DialogShortcutIT {
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DialogShortcutIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DialogShortcutIT.java
@@ -9,14 +9,12 @@ import com.vaadin.flow.testutil.ChromeBrowserTest;
 import com.vaadin.testbench.TestBenchElement;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 import static com.vaadin.flow.uitest.ui.DialogShortcutView.REUSABLE_DIALOG_ID;
 
-@Ignore("Flaky test #10481, #10487, #10491")
 public class DialogShortcutIT extends ChromeBrowserTest {
 
     private TestBenchElement eventLog;
@@ -201,8 +199,8 @@ public class DialogShortcutIT extends ChromeBrowserTest {
 
     private void validateShortcutEvent(int indexFromTop, int eventCounter,
             String eventSourceId) {
-        final WebElement latestEvent = eventLog.findElements(By.tagName("div"))
-                .get(indexFromTop);
+        final WebElement latestEvent = eventLog.findElement(
+                By.xpath(String.format("div[%d]", indexFromTop + 1)));
         Assert.assertEquals(
                 "Invalid latest event with " + indexFromTop + ":" + ":"
                         + eventSourceId,

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DialogShortcutIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/DialogShortcutIT.java
@@ -199,8 +199,8 @@ public class DialogShortcutIT extends ChromeBrowserTest {
 
     private void validateShortcutEvent(int indexFromTop, int eventCounter,
             String eventSourceId) {
-        final WebElement latestEvent = eventLog.findElement(
-                By.xpath(String.format("div[%d]", indexFromTop + 1)));
+        final WebElement latestEvent = waitUntil(driver -> eventLog.findElement(
+                By.xpath(String.format("div[%d]", indexFromTop + 1))));
         Assert.assertEquals(
                 "Invalid latest event with " + indexFromTop + ":" + ":"
                         + eventSourceId,


### PR DESCRIPTION
## Description

Sometimes findElements(By.tagName("div")) returns an empty list, maybe because server roundtrip has not yet completed.
This change adds a wait condition to ensure the presence of the newly added element before doing assertions.

Fixes #10481
Fixes #10487
Fixes #10491

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
