### PR TITLE
test: speed up test significantly

### DIFF
--- a/flow-tests/test-application-theme/test-theme-live-reload/src/test/java/com/vaadin/flow/uitest/ui/ThemeLiveReloadIT.java
+++ b/flow-tests/test-application-theme/test-theme-live-reload/src/test/java/com/vaadin/flow/uitest/ui/ThemeLiveReloadIT.java
@@ -87,9 +87,8 @@ public class ThemeLiveReloadIT extends ChromeBrowserTest {
                 + "applying the font styles", fontFile.exists());
 
         // Live reload upon adding a new font file and a new styles.css
-        doActionAndWaitUntilLiveReloadComplete(this::copyFontFile);
-        doActionAndWaitUntilLiveReloadComplete(
-                this::createStylesCssWithFontAndRedBackground);
+        copyFontFile();
+        createStylesCssWithFontAndRedBackground();
         waitUntilCustomFont();
         waitUntilCustomBackgroundColor();
 


### PR DESCRIPTION
The wait commands never finish but the test waited for a timeout to occur. 
The behavior is correct because just copying a new file to the theme folder should not cause any reloads to happen.