### PR TITLE
fix: Check if node_modules exists

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -1248,7 +1248,7 @@ public class FrontendUtils {
                     .map(File::getAbsolutePath)
                     .collect(Collectors.joining(", "));
 
-            if (!undeletable.isEmpty()) {
+            if (!undeletable.isEmpty() && nodeModules.exists()) {
                 throw new IOException("Unable to delete files: " + undeletable);
             }
         }


### PR DESCRIPTION
Even if there were seemingly undeletable
files we should at the end check if the
node_modules folder still exists before
throwing an exception.
