### PR TITLE
test: Adapt ComponentThemeLiveReloadIT for changes in vaadin-text-field structure

### DIFF
--- a/flow-tests/test-application-theme/test-theme-component-live-reload/src/test/java/com/vaadin/flow/uitest/ui/ComponentThemeLiveReloadIT.java
+++ b/flow-tests/test-application-theme/test-theme-component-live-reload/src/test/java/com/vaadin/flow/uitest/ui/ComponentThemeLiveReloadIT.java
@@ -41,7 +41,6 @@ import com.vaadin.testbench.TestBenchElement;
 import static com.vaadin.flow.uitest.ui.ComponentThemeLiveReloadView.ATTACH_IDENTIFIER;
 import static com.vaadin.flow.uitest.ui.ComponentThemeLiveReloadView.THEMED_COMPONENT_ID;
 
-@Ignore("Temporary solution for https://github.com/vaadin/flow/issues/11928")
 @NotThreadSafe
 public class ComponentThemeLiveReloadIT extends ChromeBrowserTest {
 
@@ -166,9 +165,9 @@ public class ComponentThemeLiveReloadIT extends ChromeBrowserTest {
             TestBenchElement themedTextField = $(TestBenchElement.class)
                     .id(THEMED_COMPONENT_ID);
             TestBenchElement input = themedTextField.$(DivElement.class)
-                    .attribute("class", "vaadin-text-field-container").first()
-                    .$(DivElement.class).attribute("part", "input-field")
-                    .first();
+                    .attribute("class", "vaadin-field-container").first()
+                    .$("vaadin-input-container")
+                    .attribute("part", "input-field").first();
             return borderRadius.equals(input.getCssValue("border-radius"));
         } catch (StaleElementReferenceException e) {
             return false;


### PR DESCRIPTION
## Description

The test performs some check on vaadin-text-field internal elements,
but it seems it is not up to date with the current web component structure.
This change adapts search criteria used to find internal elements.

Fixes #11928

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
