### PR TITLE
fix: reliable deletion of node_modules

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/CleanFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/CleanFrontendMojo.java
@@ -29,6 +29,8 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
+import com.vaadin.flow.server.frontend.FrontendUtils;
+
 import elemental.json.Json;
 import elemental.json.JsonObject;
 import elemental.json.impl.JsonUtil;
@@ -134,15 +136,12 @@ public class CleanFrontendMojo extends FlowModeAbstractMojo {
     private void removeNodeModules() {
         // Remove node_modules folder
         File nodeModules = new File(npmFolder, "node_modules");
-        if (nodeModules.exists()) {
-            try {
-                FileUtils.deleteDirectory(nodeModules);
-            } catch (IOException exception) {
-                getLog().debug("Exception removing node_modules", exception);
-                getLog().error(
-                        "Failed to remove '" + nodeModules.getAbsolutePath()
-                                + "'. Please remove it manually.");
-            }
+        try {
+            FrontendUtils.deleteNodeModules(nodeModules);
+        } catch (IOException exception) {
+            getLog().debug("Exception removing node_modules", exception);
+            getLog().error("Failed to remove '" + nodeModules.getAbsolutePath()
+                    + "'. Please remove it manually.");
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -24,15 +24,18 @@ import java.io.UncheckedIOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Scanner;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
@@ -1064,4 +1067,39 @@ public class FrontendUtils {
         System.out.print(String.format(format, message));
     }
 
+    /**
+     * Try to remove the {@code node_modules} directory, if it exists inside the
+     * given base directory. Note that pnpm uses symlinks internally, so delete
+     * utilities that follow symlinks when deleting and/or modifying permissions
+     * may not work as intended.
+     *
+     * @param nodeModules
+     *            the {@code node_modules} directory
+     * @throws IOException
+     *             on failure to delete any one file, or if the directory name
+     *             is not {@code node_modules}
+     */
+    public static void deleteNodeModules(File nodeModules) throws IOException {
+        if (!nodeModules.exists()) {
+            return;
+        }
+
+        if (!nodeModules.isDirectory()
+                || !nodeModules.getName().equals("node_modules")) {
+            throw new IOException(nodeModules.getAbsolutePath()
+                    + " does not look like a node_modules directory");
+        }
+
+        Path nodeModulesPath = nodeModules.toPath();
+        try (Stream<Path> walk = Files.walk(nodeModulesPath)) {
+            String undeletable = walk.sorted(Comparator.reverseOrder())
+                    .map(Path::toFile).filter(file -> !file.delete())
+                    .map(File::getAbsolutePath)
+                    .collect(Collectors.joining(", "));
+
+            if (!undeletable.isEmpty() && nodeModules.exists()) {
+                throw new IOException("Unable to delete files: " + undeletable);
+            }
+        }
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -476,7 +476,7 @@ public class TaskRunNpmInstall implements FallibleCommand {
     private void deleteNodeModules(File nodeModulesFolder)
             throws ExecutionFailedException {
         try {
-            FileUtils.forceDelete(nodeModulesFolder);
+            FrontendUtils.deleteNodeModules(nodeModulesFolder);
         } catch (IOException exception) {
             Logger log = packageUpdater.log();
             log.debug("Exception removing node_modules", exception);


### PR DESCRIPTION
Do not set permissions nor follow symlinks when
deleting node_modules.

Combines eab25b37b49c8e1c19e07b8107853d40c0eaacc8 and 415b7c73bfe1deac9b3f0a664c1ee725fb4626ae for Flow 2.8.

Fixes #12810
