### PR TITLE
fix: Do not log conversion error in StringToUuidConverter (#12882) (CP: 2.7)

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/converter/StringToUuidConverter.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/converter/StringToUuidConverter.java
@@ -74,8 +74,6 @@ public class StringToUuidConverter implements Converter<String, UUID> {
         try {
             uuid = UUID.fromString(value);
         } catch (java.lang.IllegalArgumentException e) {
-            LoggerFactory.getLogger(StringToUuidConverter.class.getName()).warn(
-                    "Unable to convert String to UUID: " + value, e);
             return Result.error(this.errorMessageProvider.apply(context));
         }
         return Result.ok(uuid); // Return the UUID object, converted from String.


### PR DESCRIPTION
No other converter logs a conversion error, which makes sense as you do not want to see all invalid input in your server logs
