### PR TITLE
chore: Upgrade workbox-build to 6.4.2

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -398,7 +398,7 @@ public abstract class NodeUpdater implements FallibleCommand {
             defaults.put("rollup-plugin-brotli", "3.1.0");
             defaults.put("vite-plugin-checker", "0.3.4");
             defaults.put("mkdirp", "1.0.4"); // for application-theme-plugin
-            defaults.put("workbox-build", "6.4.1");
+            defaults.put("workbox-build", WORKBOX_VERSION);
         } else {
             // Webpack plugins and helpers
             defaults.put("esbuild-loader", "2.15.1");


### PR DESCRIPTION
Fixes a security alert related to "workbox-build@6.4.1 requires json-schema@^0.3.0 via @apideck/better-ajv-errors@0.2.7" when using Vite
