### PR TITLE
refactor: add `vaadin:` prefix to internal Vite plugins

### DIFF
--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -122,7 +122,7 @@ export const vaadinConfig: UserConfigFn = (env) => {
       !devMode && brotli(),
       settings.pwaEnabled &&
       {
-        name: 'pwa',
+        name: 'vaadin:pwa',
         enforce: 'post',
         apply: 'build',
         async configResolved(config) {
@@ -172,7 +172,7 @@ export const vaadinConfig: UserConfigFn = (env) => {
         }
       },
       {
-        name: 'custom-theme',
+        name: 'vaadin:custom-theme',
         config() {
           processThemeResources(themeOptions, console);
         },
@@ -181,7 +181,7 @@ export const vaadinConfig: UserConfigFn = (env) => {
         }
       },
       {
-        name: 'force-remove-spa-middleware',
+        name: 'vaadin:force-remove-spa-middleware',
         transformIndexHtml: {
           enforce: 'pre',
           transform(_html, { server }) {
@@ -196,7 +196,7 @@ export const vaadinConfig: UserConfigFn = (env) => {
         }
       },
       {
-        name: 'inject-entrypoint-script',
+        name: 'vaadin:inject-entrypoint-script',
         transformIndexHtml: {
           enforce: 'pre',
           transform(_html, { path, server }) {


### PR DESCRIPTION
## Description

Added `vaadin:` prefix to all the Vaadin internal Vite plugins defined in `vite.generated.ts` to prevent their possible interference with the user's custom plugins.

A follow-up to https://github.com/vaadin/flow/pull/12857#discussion_r794499392.

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
