### PR TITLE
Fix: do not remove package-lock on platform update

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -437,15 +437,6 @@ public class TaskUpdatePackages extends NodeUpdater {
     }
 
     private void cleanUp() throws IOException {
-        File packageLock = getPackageLockFile();
-        if (packageLock.exists()) {
-            if (!packageLock.delete()) {
-                throw new IOException("Could not remove "
-                        + packageLock.getPath() + " file. "
-                        + "This file has been generated with a different platform version. Try to remove it manually.");
-            }
-        }
-
         removeDir(nodeModulesFolder);
 
         if (flowResourcesFolder != null && flowResourcesFolder.exists()) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
@@ -227,7 +227,7 @@ public abstract class AbstractNodeUpdatePackagesTest
                 getScanner(classFinder), baseDir, generatedDir, resourcesDir,
                 false, true, TARGET, featureFlags);
         packageUpdater.execute();
-        Assert.assertFalse("NPM package-lock should be removed fro pnpm",
+        Assert.assertFalse("NPM package-lock should be removed for pnpm",
                 packageLock.exists());
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
@@ -227,7 +227,8 @@ public abstract class AbstractNodeUpdatePackagesTest
                 getScanner(classFinder), baseDir, generatedDir, resourcesDir,
                 false, true, TARGET, featureFlags);
         packageUpdater.execute();
-        Assert.assertFalse(packageLock.exists());
+        Assert.assertFalse("NPM package-lock should be removed fro pnpm",
+                packageLock.exists());
     }
 
     @Test
@@ -850,7 +851,8 @@ public abstract class AbstractNodeUpdatePackagesTest
     private void assertCleanUp() {
         Assert.assertFalse(mainNodeModules.exists());
         Assert.assertFalse(appNodeModules.exists());
-        Assert.assertFalse(packageLock.exists());
+        Assert.assertTrue("package-lock should not be removed",
+                packageLock.exists());
     }
 
     private void assertMainPackageJsonContent() throws IOException {


### PR DESCRIPTION
Leave package-lock even if platform version has updated.

Fixes #12796

