### PR TITLE
Add extra log information for failing visitor

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
@@ -598,6 +598,11 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
         try (InputStream is = url.openStream()) {
             ClassReader cr = new ClassReader(is);
             cr.accept(visitor, ClassReader.EXPAND_FRAMES);
+        } catch (Exception e) {
+            log().error(
+                    "Visiting class {} failed with {}.\nThis might be a broken class in the project.",
+                    className, e.getMessage());
+            throw e;
         }
 
         // all classes visited by the scanner, used for performance (#5933)


### PR DESCRIPTION
Add error log for when a class
visitor fails with an exception for
easier debugging.

Fixes #12759
