### PR TITLE
fix: also consider package.json for lock versions

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -585,8 +585,15 @@ public abstract class NodeUpdater implements FallibleCommand {
         File versions = new File(generatedFolder, "versions.json");
 
         JsonObject versionsJson = getPlatformPinnedDependencies();
+        JsonObject packageJsonVersions = generateVersionsFromPackageJson();
         if (versionsJson == null) {
-            versionsJson = generateVersionsFromPackageJson();
+            versionsJson = packageJsonVersions;
+        } else {
+            for (String key : packageJsonVersions.keys()) {
+                if (!versionsJson.hasKey(key)) {
+                    versionsJson.put(key, packageJsonVersions.getString(key));
+                }
+            }
         }
         FileUtils.write(versions, stringify(versionsJson, 2) + "\n",
                 StandardCharsets.UTF_8);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -269,8 +269,9 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         // @formatter:on
 
         JsonObject versionsJson = getGeneratedVersionsContent(versions);
-        Assert.assertEquals("Generated versions json should have 1 key", 1,
-                versionsJson.keys().length);
+        Assert.assertEquals(
+                "Generated versions json should have keys for each dependency",
+                3, versionsJson.keys().length);
         Assert.assertEquals("Overlay should be pinned to user version",
                 customOverlayVersion,
                 versionsJson.getString("@vaadin/vaadin-overlay"));
@@ -321,8 +322,9 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         // @formatter:on
 
         JsonObject versionsJson = getGeneratedVersionsContent(versions);
-        Assert.assertEquals("Generated versions json should have 1 key", 1,
-                versionsJson.keys().length);
+        Assert.assertEquals(
+                "Generated versions json should have keys for package.json dependencies (also dev)",
+                3, versionsJson.keys().length);
         Assert.assertEquals("Overlay should be pinned to user version",
                 customOverlayVersion,
                 versionsJson.getString("@vaadin/vaadin-overlay"));


### PR DESCRIPTION
Even if we have a vaadin_versions.json
we should also take into account versions
defined in package.json to be locked
for transitive dependencies.

fixes #12662
