### PR TITLE
fix: also consider package.json for lock versions

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -196,8 +196,15 @@ public class TaskRunNpmInstall implements FallibleCommand {
                 "versions.json");
 
         JsonObject versionsJson = getLockedVersions();
+        JsonObject packageJsonVersions = generateVersionsFromPackageJson();
         if (versionsJson == null) {
-            versionsJson = generateVersionsFromPackageJson();
+            versionsJson = packageJsonVersions;
+        } else {
+            for (String key : packageJsonVersions.keys()) {
+                if (!versionsJson.hasKey(key)) {
+                    versionsJson.put(key, packageJsonVersions.getString(key));
+                }
+            }
         }
         FileUtils.write(versions, stringify(versionsJson, 2) + "\n",
                 StandardCharsets.UTF_8);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -130,8 +130,8 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         // @formatter:on
 
         JsonObject versionsJson = getGeneratedVersionsContent(versions);
-        Assert.assertEquals("Generated versions json should have 1 key", 1,
-                versionsJson.keys().length);
+        Assert.assertEquals("Generated versions json should have keys for each dependency",
+                3, versionsJson.keys().length);
         Assert.assertEquals("Overlay should be pinned to user version",
                 customOverlayVersion,
                 versionsJson.getString("@vaadin/vaadin-overlay"));
@@ -182,8 +182,8 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         // @formatter:on
 
         JsonObject versionsJson = getGeneratedVersionsContent(versions);
-        Assert.assertEquals("Generated versions json should have 1 key", 1,
-                versionsJson.keys().length);
+        Assert.assertEquals("Generated versions json should have keys for each dependency",
+                3, versionsJson.keys().length);
         Assert.assertEquals("Overlay should be pinned to user version",
                 customOverlayVersion,
                 versionsJson.getString("@vaadin/vaadin-overlay"));


### PR DESCRIPTION
Even if we have a vaadin_versions.json
we should also take into account versions
defined in package.json to be locked
for transitive dependencies.

fixes #12662
