### PR TITLE
fix!: no double decode query parameters

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/LocationUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/LocationUtil.java
@@ -144,14 +144,15 @@ public class LocationUtil {
         }
         String query;
 
+        // URI::getRawQuery as decoding of parameters is done in
+        // QueryParameters. For issue with URI::getQuery, see:
+        // https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8214423
         try {
-            query = new java.net.URI(location).getQuery();
+            query = new java.net.URI(location).getRawQuery();
         } catch (URISyntaxException ignore) { // NOSONAR
             query = null;
         }
-
         if (query == null) {
-            // decoding of parameters is done in QueryParameters
             query = location.substring(beginIndex + 1);
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/router/QueryParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/QueryParameters.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.router;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -127,17 +128,11 @@ public class QueryParameters implements Serializable {
     private static List<String> makeQueryParamList(String paramAndValue) {
         int index = paramAndValue.indexOf('=');
         if (index == -1) {
-            return Collections.singletonList(paramAndValue);
+            return Collections.singletonList(decode(paramAndValue));
         }
         String param = paramAndValue.substring(0, index);
-        String value = paramAndValue.substring(index + 1).replace("+", "%2B");
-        try {
-            value = URLDecoder.decode(value, "utf-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(
-                    "Unable to decode parameter value: " + value, e);
-        }
-        return Arrays.asList(param, value);
+        String value = paramAndValue.substring(index + 1);
+        return Arrays.asList(decode(param), decode(value));
     }
 
     private static List<String> getParameterValues(List<String> paramAndValue) {
@@ -177,11 +172,15 @@ public class QueryParameters implements Serializable {
     }
 
     /**
-     * Turns query parameters into query string that contains all parameter
-     * names and their values. No guarantee on parameters' appearance order is
-     * made.
+     * Returns a UTF-8 encoded query string containing all parameter names and
+     * values suitable for appending to a URL after the {@code ?} character.
+     * Parameters may appear in different order than in the query string they
+     * were originally parsed from, and may be differently encoded (for example,
+     * if a space was encoded as {@code %20} in the initial URL it will be
+     * encoded as {@code +} in the result.
      *
-     * @return query string
+     * @return query string suitable for appending to a URL
+     * @see URLEncoder#encode(String, String)
      */
     public String getQueryString() {
         return parameters.entrySet().stream()
@@ -193,10 +192,28 @@ public class QueryParameters implements Serializable {
             Entry<String, List<String>> entry) {
         List<String> params = entry.getValue();
         if (params.size() == 1 && "".equals(params.get(0))) {
-            return Stream.of(entry.getKey());
+            return Stream.of(encode(entry.getKey()));
         }
         String param = entry.getKey();
-        return params.stream().map(value -> "".equals(value) ? param
-                : param + PARAMETER_VALUES_SEPARATOR + value);
+        return params.stream().map(value -> "".equals(value) ? encode(param)
+                : encode(param) + PARAMETER_VALUES_SEPARATOR + encode(value));
+    }
+
+    private static String decode(String parameter) {
+        try {
+            return URLDecoder.decode(parameter, "utf-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(
+                    "Unable to decode parameter: " + parameter, e);
+        }
+    }
+
+    private static String encode(String parameter) {
+        try {
+            return URLEncoder.encode(parameter, "utf-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(
+                    "Unable to encode parameter: " + parameter, e);
+        }
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/QueryParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/QueryParameters.java
@@ -178,8 +178,8 @@ public class QueryParameters implements Serializable {
      * values suitable for appending to a URL after the {@code ?} character.
      * Parameters may appear in different order than in the query string they
      * were originally parsed from, and may be differently encoded (for example,
-     * if a space was encoded as {@code +} in the initial URL it will be
-     * encoded as {@code %20} in the result.
+     * if a space was encoded as {@code +} in the initial URL it will be encoded
+     * as {@code %20} in the result.
      *
      * @return query string suitable for appending to a URL
      * @see URLEncoder#encode(String, String)
@@ -197,10 +197,12 @@ public class QueryParameters implements Serializable {
         if (values.size() == 1 && "".equals(values.get(0))) {
             return Stream.of(UrlUtil.encodeURIComponent(entry.getKey()));
         }
-        return values.stream().map(value -> "".equals(value) ?
-                UrlUtil.encodeURIComponent(param) :
-                UrlUtil.encodeURIComponent(param) + PARAMETER_VALUES_SEPARATOR
-                        + UrlUtil.encodeURIComponent(value));
+        return values.stream()
+                .map(value -> "".equals(value)
+                        ? UrlUtil.encodeURIComponent(param)
+                        : UrlUtil.encodeURIComponent(param)
+                                + PARAMETER_VALUES_SEPARATOR
+                                + UrlUtil.encodeURIComponent(value));
     }
 
     private static String decode(String parameter) {

--- a/flow-server/src/main/java/com/vaadin/flow/router/QueryParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/QueryParameters.java
@@ -28,6 +28,8 @@ import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.internal.UrlUtil;
+
 /**
  * Holds query parameters information.
  *
@@ -190,13 +192,15 @@ public class QueryParameters implements Serializable {
 
     private Stream<String> getParameterAndValues(
             Entry<String, List<String>> entry) {
-        List<String> params = entry.getValue();
-        if (params.size() == 1 && "".equals(params.get(0))) {
-            return Stream.of(encode(entry.getKey()));
-        }
         String param = entry.getKey();
-        return params.stream().map(value -> "".equals(value) ? encode(param)
-                : encode(param) + PARAMETER_VALUES_SEPARATOR + encode(value));
+        List<String> values = entry.getValue();
+        if (values.size() == 1 && "".equals(values.get(0))) {
+            return Stream.of(UrlUtil.encodeURIComponent(entry.getKey()));
+        }
+        return values.stream().map(value -> "".equals(value) ?
+                UrlUtil.encodeURIComponent(param) :
+                UrlUtil.encodeURIComponent(param) + PARAMETER_VALUES_SEPARATOR
+                        + UrlUtil.encodeURIComponent(value));
     }
 
     private static String decode(String parameter) {
@@ -205,15 +209,6 @@ public class QueryParameters implements Serializable {
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(
                     "Unable to decode parameter: " + parameter, e);
-        }
-    }
-
-    private static String encode(String parameter) {
-        try {
-            return URLEncoder.encode(parameter, "utf-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(
-                    "Unable to encode parameter: " + parameter, e);
         }
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/QueryParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/QueryParameters.java
@@ -178,8 +178,8 @@ public class QueryParameters implements Serializable {
      * values suitable for appending to a URL after the {@code ?} character.
      * Parameters may appear in different order than in the query string they
      * were originally parsed from, and may be differently encoded (for example,
-     * if a space was encoded as {@code %20} in the initial URL it will be
-     * encoded as {@code +} in the result.
+     * if a space was encoded as {@code +} in the initial URL it will be
+     * encoded as {@code %20} in the result.
      *
      * @return query string suitable for appending to a URL
      * @see URLEncoder#encode(String, String)

--- a/flow-server/src/test/java/com/vaadin/flow/router/LocationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/LocationTest.java
@@ -326,10 +326,12 @@ public class LocationTest {
 
     @Test
     public void locationWithUrlEncodedCharacters() {
-        Location location = new Location("foo?bar=a%20b%20%C3%B1%20%26%20%3F");
+        Location location = new Location("foo?bar=a%20b%20%C3%B1%20%26%20%3F&baz=xyz");
         Assert.assertEquals(Arrays.asList("a b ñ & ?"),
                 location.getQueryParameters().getParameters().get("bar"));
-        Assert.assertEquals("bar=a%20b%20%C3%B1%20%26%20%3F",
+        Assert.assertEquals(Arrays.asList("xyz"),
+                location.getQueryParameters().getParameters().get("baz"));
+        Assert.assertEquals("bar=a%20b%20%C3%B1%20%26%20%3F&baz=xyz",
                 location.getQueryParameters().getQueryString());
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/router/LocationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/LocationTest.java
@@ -130,7 +130,7 @@ public class LocationTest {
         queryParameters = new Location("home?%25HF").getQueryParameters();
         Assert.assertEquals("'%25' should be decoded in map", "%HF",
                 queryParameters.getParameters().keySet().iterator().next());
-        Assert.assertEquals("'%2B' should not be decoded in query param string",
+        Assert.assertEquals("'%25' should not be decoded in query param string",
                 "%25HF", queryParameters.getQueryString());
 
         queryParameters = new Location("home?p=%26&q=%20").getQueryParameters();
@@ -139,7 +139,7 @@ public class LocationTest {
         Assert.assertEquals("'%20' should be decoded in map", " ",
                 queryParameters.getParameters().get("q").get(0));
         Assert.assertEquals(
-                "'%26' and '%2B' should not be decoded in query param string",
+                "'%26' and '%20' should not be decoded in query param string",
                 "p=%26&q=%20", queryParameters.getQueryString());
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/router/LocationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/LocationTest.java
@@ -112,14 +112,35 @@ public class LocationTest {
 
     @Test
     public void queryValue_decodedCorrectly() {
-        Location location = new Location("home?value+part");
-        Assert.assertEquals("'+' should not be decoded to space", "value+part",
-                location.getQueryParameters().getQueryString());
+        QueryParameters queryParameters = new Location("home?value+part")
+                .getQueryParameters();
+        Assert.assertEquals("'+' should be decoded in map", "value part",
+                queryParameters.getParameters().keySet().iterator().next());
+        Assert.assertEquals("'+' should not be decoded in query param string",
+                "value+part", queryParameters.getQueryString());
 
-        location = new Location("home?someValue1%2BsomeValue2");
-        Assert.assertEquals("'+' should not be double decoded",
+        queryParameters = new Location("home?someValue1%2BsomeValue2")
+                .getQueryParameters();
+        Assert.assertEquals("'%2B' should be decoded in map",
                 "someValue1+someValue2",
-                location.getQueryParameters().getQueryString());
+                queryParameters.getParameters().keySet().iterator().next());
+        Assert.assertEquals("'%2B' should not be decoded in query param string",
+                "someValue1%2BsomeValue2", queryParameters.getQueryString());
+
+        queryParameters = new Location("home?%25HF").getQueryParameters();
+        Assert.assertEquals("'%25' should be decoded in map", "%HF",
+                queryParameters.getParameters().keySet().iterator().next());
+        Assert.assertEquals("'%2B' should not be decoded in query param string",
+                "%25HF", queryParameters.getQueryString());
+
+        queryParameters = new Location("home?p=%26&q=+").getQueryParameters();
+        Assert.assertEquals("'%26' should be decoded in map", "&",
+                queryParameters.getParameters().get("p").get(0));
+        Assert.assertEquals("'%20' should be decoded in map", " ",
+                queryParameters.getParameters().get("q").get(0));
+        Assert.assertEquals(
+                "'%26' and '%2B' should not be decoded in query param string",
+                "p=%26&q=+", queryParameters.getQueryString());
     }
 
     @Test
@@ -306,7 +327,9 @@ public class LocationTest {
     @Test
     public void locationWithUrlEncodedCharacters() {
         Location location = new Location("foo?bar=a%20b%20%C3%B1%20%26%20%3F");
-        Assert.assertEquals("bar=a b ñ & ?",
+        Assert.assertEquals(Arrays.asList("a b ñ & ?"),
+                location.getQueryParameters().getParameters().get("bar"));
+        Assert.assertEquals("bar=a+b+%C3%B1+%26+%3F",
                 location.getQueryParameters().getQueryString());
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/router/LocationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/LocationTest.java
@@ -117,7 +117,7 @@ public class LocationTest {
         Assert.assertEquals("'+' should be decoded in map", "value part",
                 queryParameters.getParameters().keySet().iterator().next());
         Assert.assertEquals("'+' should not be decoded in query param string",
-                "value+part", queryParameters.getQueryString());
+                "value%20part", queryParameters.getQueryString());
 
         queryParameters = new Location("home?someValue1%2BsomeValue2")
                 .getQueryParameters();
@@ -133,14 +133,14 @@ public class LocationTest {
         Assert.assertEquals("'%2B' should not be decoded in query param string",
                 "%25HF", queryParameters.getQueryString());
 
-        queryParameters = new Location("home?p=%26&q=+").getQueryParameters();
+        queryParameters = new Location("home?p=%26&q=%20").getQueryParameters();
         Assert.assertEquals("'%26' should be decoded in map", "&",
                 queryParameters.getParameters().get("p").get(0));
         Assert.assertEquals("'%20' should be decoded in map", " ",
                 queryParameters.getParameters().get("q").get(0));
         Assert.assertEquals(
                 "'%26' and '%2B' should not be decoded in query param string",
-                "p=%26&q=+", queryParameters.getQueryString());
+                "p=%26&q=%20", queryParameters.getQueryString());
     }
 
     @Test
@@ -329,7 +329,7 @@ public class LocationTest {
         Location location = new Location("foo?bar=a%20b%20%C3%B1%20%26%20%3F");
         Assert.assertEquals(Arrays.asList("a b ñ & ?"),
                 location.getQueryParameters().getParameters().get("bar"));
-        Assert.assertEquals("bar=a+b+%C3%B1+%26+%3F",
+        Assert.assertEquals("bar=a%20b%20%C3%B1%20%26%20%3F",
                 location.getQueryParameters().getQueryString());
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/router/LocationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/LocationTest.java
@@ -326,7 +326,8 @@ public class LocationTest {
 
     @Test
     public void locationWithUrlEncodedCharacters() {
-        Location location = new Location("foo?bar=a%20b%20%C3%B1%20%26%20%3F&baz=xyz");
+        Location location = new Location(
+                "foo?bar=a%20b%20%C3%B1%20%26%20%3F&baz=xyz");
         Assert.assertEquals(Arrays.asList("a b ñ & ?"),
                 location.getQueryParameters().getParameters().get("bar"));
         Assert.assertEquals(Arrays.asList("xyz"),

--- a/flow-server/src/test/java/com/vaadin/flow/router/QueryParametersTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/QueryParametersTest.java
@@ -32,9 +32,9 @@ import org.junit.Test;
 
 public class QueryParametersTest {
 
-    private String simpleInputQueryString = "one=1&two=2&three=3&four&five=4%2F5%266%2B7&six=val+ue";
+    private final String simpleInputQueryString = "one=1&two=2&three=3&four&five=4%2F5%266%2B7&six=one+%2B+one%20%3D%20two";
 
-    private String complexInputQueryString = "one=1&one=11&two=2&two=22&three=3&four&five=4%2F5%266%2B7&six=val+ue";
+    private final String complexInputQueryString = "one=1&one=11&two=2&two=22&three=3&four&five=4%2F5%266%2B7&six=one+%2B+one%20%3D%20two";
 
     private Map<String, String> getSimpleInputParameters() {
         Map<String, String> inputParameters = new HashMap<>();
@@ -106,7 +106,8 @@ public class QueryParametersTest {
         expectedFullParams.put("three", Collections.singletonList("3"));
         expectedFullParams.put("four", Collections.singletonList(""));
         expectedFullParams.put("five", Collections.singletonList("4/5&6+7"));
-        expectedFullParams.put("six", Collections.singletonList("val+ue"));
+        expectedFullParams.put("six",
+                Collections.singletonList("one + one = two"));
         assertEquals(expectedFullParams, simpleParams.getParameters());
     }
 
@@ -159,7 +160,8 @@ public class QueryParametersTest {
         expectedFullParams.put("three", Collections.singletonList("3"));
         expectedFullParams.put("four", Collections.singletonList(""));
         expectedFullParams.put("five", Collections.singletonList("4/5&6+7"));
-        expectedFullParams.put("six", Collections.singletonList("val+ue"));
+        expectedFullParams.put("six",
+                Collections.singletonList("one + one = two"));
         assertEquals(expectedFullParams, fullParams.getParameters());
     }
 


### PR DESCRIPTION
Fix 1: Don't double-decode query parameters.

Fix 2: URI.getQuery is broken, making it impossible to distinguish `&` separating 
parameters from literal ampersands:
https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8214423'

Fix 3: Return a properly encoded query string from
QueryParamaters.getQueryString instead of justing joining the decoded
strings in the map. This is a potentially breaking change.

Fixes #12887