### PR TITLE
fix: Return 404 for /VAADIN/ urls which do not map to a file

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -493,6 +493,13 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
         if (request.getHeader(SERVICE_WORKER_HEADER) != null) {
             return false;
         }
+
+        if (request.getPathInfo() != null
+                && request.getPathInfo().startsWith("/" + VAADIN_MAPPING)) {
+            // Do not allow routes inside /VAADIN/
+            return false;
+        }
+
         return super.canHandleRequest(request);
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -494,8 +494,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             return false;
         }
 
-        if (request.getPathInfo() != null
-                && request.getPathInfo().startsWith("/" + VAADIN_MAPPING)) {
+        if (isVaadinStaticFileRequest(request)) {
             // Do not allow routes inside /VAADIN/
             return false;
         }
@@ -530,6 +529,26 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                             ApplicationConstants.REQUEST_TYPE_PARAMETER));
         }
         return false;
+    }
+
+    /**
+     * Checks whether the request is a request for /VAADIN/*.
+     * <p>
+     * Warning: This assumes that the VaadinRequest is targeted for a
+     * VaadinServlet and does no further checks to validate this.
+     * <p>
+     * This is public only so that
+     * {@link com.vaadin.flow.server.communication.IndexHtmlRequestHandler} can
+     * access it. If you are not IndexHtmlRequestHandler, go away.
+     *
+     * @param request
+     *            the request
+     * @return {@code true} if the request is for /VAADIN/*, {@code false}
+     *         otherwise
+     */
+    public static boolean isVaadinStaticFileRequest(VaadinRequest request) {
+        return request.getPathInfo() != null
+                && request.getPathInfo().startsWith("/" + VAADIN_MAPPING);
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
@@ -256,6 +256,7 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
     protected boolean canHandleRequest(VaadinRequest request) {
         return isRequestForHtml(request)
                 && !BootstrapHandler.isFrameworkInternalRequest(request)
+                && !BootstrapHandler.isVaadinStaticFileRequest(request)
                 && request.getService().getBootstrapUrlPredicate()
                         .isValidUrl(request);
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
@@ -1557,6 +1557,19 @@ public class BootstrapHandlerTest {
     }
 
     @Test
+    public void vaadin_request_no_bootstrap_page() {
+        BootstrapHandler bootstrapHandler = new BootstrapHandler();
+        VaadinServletRequest request = Mockito.mock(VaadinServletRequest.class);
+        Mockito.when(request.getPathInfo()).thenReturn("/VAADIN/hello.js");
+        Assert.assertFalse(bootstrapHandler.canHandleRequest(request));
+
+        Mockito.when(request.getPathInfo())
+                .thenReturn("/VAADIN/bundle/notfound");
+        Assert.assertFalse(bootstrapHandler.canHandleRequest(request));
+
+    }
+
+    @Test
     public void serviceWorkerRequest_canNotHandleRequest() {
         BootstrapHandler bootstrapHandler = new BootstrapHandler();
         VaadinServletRequest request = Mockito.mock(VaadinServletRequest.class);

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandlerTest.java
@@ -281,6 +281,12 @@ public class IndexHtmlRequestHandlerTest {
     }
 
     @Test
+    public void canHandleRequest_doNotHandle_vaadinStaticResources() {
+        Assert.assertFalse(indexHtmlRequestHandler.canHandleRequest(
+                createRequestWithDestination("/VAADIN/foo.js", null, null)));
+    }
+
+    @Test
     public void canHandleRequest_handle_serviceWorkerDocumentRequest() {
         Assert.assertTrue(indexHtmlRequestHandler.canHandleRequest(
                 createRequestWithDestination("/", "empty", "same-origin")));

--- a/flow-tests/test-frontend/vite-basics/package.json
+++ b/flow-tests/test-frontend/vite-basics/package.json
@@ -2,7 +2,7 @@
   "name": "no-name",
   "license": "UNLICENSED",
   "dependencies": {
-    "@polymer/polymer": "3.2.0",
+    "@polymer/polymer": "3.4.1",
     "@vaadin/common-frontend": "0.0.17",
     "@vaadin/flow-frontend": "./target/flow-frontend",
     "@vaadin/router": "1.7.4",
@@ -21,16 +21,16 @@
     "glob": "7.1.6",
     "mkdirp": "1.0.4",
     "rollup-plugin-brotli": "3.1.0",
-    "typescript": "4.4.3",
-    "vite": "v2.7.0",
+    "typescript": "4.5.3",
+    "vite": "v2.8.0-beta.5",
     "vite-plugin-checker": "0.3.4",
-    "workbox-build": "6.4.1",
+    "workbox-build": "6.4.2",
     "workbox-core": "6.4.2",
     "workbox-precaching": "6.4.2"
   },
   "vaadin": {
     "dependencies": {
-      "@polymer/polymer": "3.2.0",
+      "@polymer/polymer": "3.4.1",
       "@vaadin/common-frontend": "0.0.17",
       "@vaadin/router": "1.7.4",
       "@vaadin/vaadin-lumo-styles": "22.0.0-alpha9",
@@ -41,13 +41,13 @@
       "glob": "7.1.6",
       "mkdirp": "1.0.4",
       "rollup-plugin-brotli": "3.1.0",
-      "typescript": "4.4.3",
-      "vite": "v2.7.0",
+      "typescript": "4.5.3",
+      "vite": "v2.8.0-beta.5",
       "vite-plugin-checker": "0.3.4",
-      "workbox-build": "6.4.1",
+      "workbox-build": "6.4.2",
       "workbox-core": "6.4.2",
       "workbox-precaching": "6.4.2"
     },
-    "hash": "5ce564d422b308509737fbbd7a036ad80c191e574bc151193226da9131b5fcb5"
+    "hash": "ebde6e0910bd4ca3eebbc855a4b06a9aa2f8621fe76bd2b4d0ef2e7bd203b822"
   }
 }

--- a/flow-tests/test-frontend/vite-basics/src/test/java/com/vaadin/viteapp/FileAccessIT.java
+++ b/flow-tests/test-frontend/vite-basics/src/test/java/com/vaadin/viteapp/FileAccessIT.java
@@ -18,7 +18,7 @@ public class FileAccessIT extends ViteDevModeIT {
          */
         assertAllowed("target/flow-frontend/Flow.js");
         assertAllowed("target/frontend/generated-flow-imports.js");
-        assertAllowed("frontend/index.ts");
+        assertAllowed("frontend/jsonloader.js");
     }
 
     private void assertAllowed(String fileInProject) throws IOException {


### PR DESCRIPTION
Never serve the index.html page for URLs inside /VAADIN/
