### PR TITLE
test: Find elements by part attribute instead of id (#10331)

### DIFF
--- a/flow-tests/test-embedding/test-embedding-application-theme/src/test/java/com/vaadin/flow/webcomponent/ApplicationThemeComponentIT.java
+++ b/flow-tests/test-embedding/test-embedding-application-theme/src/test/java/com/vaadin/flow/webcomponent/ApplicationThemeComponentIT.java
@@ -112,18 +112,14 @@ public class ApplicationThemeComponentIT extends ChromeBrowserTest {
 
         TestBenchElement myField = embeddedComponent.$(TestBenchElement.class)
             .id(MY_POLYMER_ID);
-        TestBenchElement input = myField.$(TestBenchElement.class)
-            .id("vaadin-text-field-input-0");
+        TestBenchElement input = myField.$("div")
+                .attribute("part", "input-field").first();
         Assert.assertEquals("Polymer text field should have red background",
             "rgba(255, 0, 0, 1)", input.getCssValue("background-color"));
 
         myField = embeddedComponent.$(TestBenchElement.class).id(MY_LIT_ID);
-        final SpanElement radio = myField.$(SpanElement.class).all().stream()
-            .filter(element -> "radio".equals(element.getAttribute("part")))
-            .findFirst().orElseGet(null);
-
-        Assert.assertNotNull("Element with part='radio' was not found", radio);
-
+        final SpanElement radio = myField.$(SpanElement.class)
+            .attribute("part", "radio").first();
         Assert.assertEquals("Lit radiobutton should have red background",
             "rgba(255, 0, 0, 1)", radio.getCssValue("background-color"));
     }

--- a/flow-tests/test-embedding/test-embedding-reusable-theme/src/test/java/com/vaadin/flow/webcomponent/ApplicationThemeComponentIT.java
+++ b/flow-tests/test-embedding/test-embedding-reusable-theme/src/test/java/com/vaadin/flow/webcomponent/ApplicationThemeComponentIT.java
@@ -109,18 +109,14 @@ public class ApplicationThemeComponentIT extends ChromeBrowserTest {
 
         TestBenchElement myField = embeddedComponent.$(TestBenchElement.class)
             .id(MY_POLYMER_ID);
-        TestBenchElement input = myField.$(TestBenchElement.class)
-            .id("vaadin-text-field-input-0");
+        TestBenchElement input = myField.$("div")
+                .attribute("part", "input-field").first();
         Assert.assertEquals("Polymer text field should have red background",
             "rgba(255, 0, 0, 1)", input.getCssValue("background-color"));
 
         myField = embeddedComponent.$(TestBenchElement.class).id(MY_LIT_ID);
-        final SpanElement radio = myField.$(SpanElement.class).all().stream()
-            .filter(element -> "radio".equals(element.getAttribute("part")))
-            .findFirst().orElseGet(null);
-
-        Assert.assertNotNull("Element with part='radio' was not found", radio);
-
+        final SpanElement radio = myField.$(SpanElement.class)
+            .attribute("part", "radio").first();
         Assert.assertEquals("Lit radiobutton should have red background",
             "rgba(255, 0, 0, 1)", radio.getCssValue("background-color"));
     }


### PR DESCRIPTION
## Description

Searching for vaadin-text-field children in shadow DOM by id sometimes fails because the internal index not always reflects the position of parent container, meaning that an element with id 'vaadin-text-field-input-0' could be a child of any  themed-component elements. Searching the element by part attribute makes the test reliable.

Fixes #10331

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
