### PR TITLE
chore: Delete misleading 'should work' information

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -108,16 +108,12 @@ public class FrontendTools {
     private static final int SUPPORTED_NODE_MINOR_VERSION = 22;
     private static final int SUPPORTED_NPM_MAJOR_VERSION = 6;
     private static final int SUPPORTED_NPM_MINOR_VERSION = 14;
-    private static final int SHOULD_WORK_NPM_MAJOR_VERSION = 5;
-    private static final int SHOULD_WORK_NPM_MINOR_VERSION = 5;
 
     private static final FrontendVersion SUPPORTED_NODE_VERSION = new FrontendVersion(
             SUPPORTED_NODE_MAJOR_VERSION, SUPPORTED_NODE_MINOR_VERSION);
 
     private static final FrontendVersion SUPPORTED_NPM_VERSION = new FrontendVersion(
             SUPPORTED_NPM_MAJOR_VERSION, SUPPORTED_NPM_MINOR_VERSION);
-    private static final FrontendVersion SHOULD_WORK_NPM_VERSION = new FrontendVersion(
-            SHOULD_WORK_NPM_MAJOR_VERSION, SHOULD_WORK_NPM_MINOR_VERSION);
 
     static final String NPMRC_NOPROXY_PROPERTY_KEY = "noproxy";
     static final String NPMRC_HTTPS_PROXY_PROPERTY_KEY = "https-proxy";
@@ -625,7 +621,7 @@ public class FrontendTools {
             FrontendVersion foundNodeVersion = foundNodeVersionAndExe
                     .getFirst();
             FrontendUtils.validateToolVersion("node", foundNodeVersion,
-                    SUPPORTED_NODE_VERSION, SUPPORTED_NODE_VERSION);
+                    SUPPORTED_NODE_VERSION);
             getLogger().debug("Using node {} located at {}",
                     foundNodeVersion.getFullVersion(),
                     foundNodeVersionAndExe.getSecond());
@@ -642,7 +638,7 @@ public class FrontendTools {
         try {
             FrontendVersion foundNpmVersion = getNpmVersion();
             FrontendUtils.validateToolVersion("npm", foundNpmVersion,
-                    SUPPORTED_NPM_VERSION, SHOULD_WORK_NPM_VERSION);
+                    SUPPORTED_NPM_VERSION);
             checkForFaultyNpmVersion(foundNpmVersion);
             getLogger().debug("Using npm {} located at {}",
                     foundNpmVersion.getFullVersion(),

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -328,15 +328,6 @@ public class FrontendUtils {
             + "Check the startup logs for exceptions in running webpack-dev-server.%n"
             + "If server should be running in production mode check that production mode flag is set correctly.";
 
-    private static final String SHOULD_WORK = "%n%n======================================================================================================"
-            + "%nYour installed '%s' version (%s) is not supported but should still work. Supported versions are %d.%d+" //
-            + "%nYou can install a new one:"
-            + "%n  - by following the https://nodejs.org/en/download/ guide to install it globally"
-            + "%n  - or by running the frontend-maven-plugin goal to install it in this project:"
-            + INSTALL_NODE_LOCALLY + "%n" //
-            + DISABLE_CHECK //
-            + "%n======================================================================================================%n";
-
     private static final String TOO_OLD = "%n%n======================================================================================================"
             + "%nYour installed '%s' version (%s) is too old. Supported versions are %d.%d+" //
             + "%nPlease install a new one either:"
@@ -782,12 +773,6 @@ public class FrontendUtils {
                 supportedMinor, PARAM_IGNORE_VERSION_CHECKS);
     }
 
-    private static String buildShouldWorkString(String tool, String version,
-            int supportedMajor, int supportedMinor) {
-        return String.format(SHOULD_WORK, tool, version, supportedMajor,
-                supportedMinor, PARAM_IGNORE_VERSION_CHECKS);
-    }
-
     /**
      * Get directory where project's frontend files are located.
      *
@@ -895,14 +880,8 @@ public class FrontendUtils {
     }
 
     static void validateToolVersion(String tool, FrontendVersion toolVersion,
-            FrontendVersion supported, FrontendVersion shouldWork) {
+            FrontendVersion supported) {
         if (isVersionAtLeast(toolVersion, supported)) {
-            return;
-        }
-        if (isVersionAtLeast(toolVersion, shouldWork)) {
-            getLogger().warn(buildShouldWorkString(tool,
-                    toolVersion.getFullVersion(), supported.getMajorVersion(),
-                    supported.getMinorVersion()));
             return;
         }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -90,26 +90,18 @@ public class FrontendUtilsTest {
     @Test
     public void validateLargerThan_passesForNewVersion() {
         FrontendUtils.validateToolVersion("test", new FrontendVersion("10.0.2"),
-                new FrontendVersion(10, 0), new FrontendVersion(10, 0));
+                new FrontendVersion(10, 0));
         FrontendUtils.validateToolVersion("test", new FrontendVersion("10.1.2"),
-                new FrontendVersion(10, 0), new FrontendVersion(10, 0));
+                new FrontendVersion(10, 0));
         FrontendUtils.validateToolVersion("test", new FrontendVersion("11.0.2"),
-                new FrontendVersion(10, 0), new FrontendVersion(10, 0));
-    }
-
-    @Test
-    public void validateLargerThan_passesForSlightlyOldVersion()
-            throws UnsupportedEncodingException {
-        FrontendUtils.validateToolVersion("test", new FrontendVersion(9, 0, 0),
-                new FrontendVersion(10, 0), new FrontendVersion(8, 0));
+                new FrontendVersion(10, 0));
     }
 
     @Test
     public void validateLargerThan_throwsForOldVersion() {
         try {
             FrontendUtils.validateToolVersion("test",
-                    new FrontendVersion(7, 5, 0), new FrontendVersion(10, 0),
-                    new FrontendVersion(8, 0));
+                    new FrontendVersion(7, 5, 0), new FrontendVersion(10, 0));
             Assert.fail("No exception was thrown for old version");
         } catch (IllegalStateException e) {
             Assert.assertTrue(e.getMessage().contains(


### PR DESCRIPTION
We really have no idea if those versions work and claiming this only harm users
