### PR TITLE
test: Ensure file is closed after reading lines

### DIFF
--- a/flow-tests/test-npm-only-features/test-npm-performance-regression/src/test/java/com/vaadin/flow/testnpmonlyfeatures/performanceregression/StartupPerformanceIT.java
+++ b/flow-tests/test-npm-only-features/test-npm-performance-regression/src/test/java/com/vaadin/flow/testnpmonlyfeatures/performanceregression/StartupPerformanceIT.java
@@ -84,19 +84,17 @@ public class StartupPerformanceIT extends ChromeBrowserTest {
         Pattern endPattern = createPattern(endFragment);
         AtomicInteger startTime = new AtomicInteger();
         AtomicInteger endTime = new AtomicInteger();
-        try {
-            try (Stream<String> lines = Files.lines(getLogPath())) {
-                lines.forEach(line -> {
-                    Matcher matcherFirst = startPattern.matcher(line);
-                    if (matcherFirst.matches() && startTime.get() == 0) {
-                        startTime.set(Integer.parseInt(matcherFirst.group(1)));
-                    }
-                    Matcher matcherEnd = endPattern.matcher(line);
-                    if (matcherEnd.matches()) {
-                        endTime.set(Integer.parseInt(matcherEnd.group(1)));
-                    }
-                });
-            }
+        try (Stream<String> lines = Files.lines(getLogPath())) {
+            lines.forEach(line -> {
+                Matcher matcherFirst = startPattern.matcher(line);
+                if (matcherFirst.matches() && startTime.get() == 0) {
+                    startTime.set(Integer.parseInt(matcherFirst.group(1)));
+                }
+                Matcher matcherEnd = endPattern.matcher(line);
+                if (matcherEnd.matches()) {
+                    endTime.set(Integer.parseInt(matcherEnd.group(1)));
+                }
+            });
             if (startTime.get() == 0 && failIfNotFound) {
                 throw new RuntimeException("No match: " + startFragment);
             }

--- a/flow-tests/test-npm-only-features/test-npm-performance-regression/src/test/java/com/vaadin/flow/testnpmonlyfeatures/performanceregression/StartupPerformanceIT.java
+++ b/flow-tests/test-npm-only-features/test-npm-performance-regression/src/test/java/com/vaadin/flow/testnpmonlyfeatures/performanceregression/StartupPerformanceIT.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -84,16 +85,18 @@ public class StartupPerformanceIT extends ChromeBrowserTest {
         AtomicInteger startTime = new AtomicInteger();
         AtomicInteger endTime = new AtomicInteger();
         try {
-            Files.lines(getLogPath()).forEach(line -> {
-                Matcher matcherFirst = startPattern.matcher(line);
-                if (matcherFirst.matches() && startTime.get() == 0) {
-                    startTime.set(Integer.parseInt(matcherFirst.group(1)));
-                }
-                Matcher matcherEnd = endPattern.matcher(line);
-                if (matcherEnd.matches()) {
-                    endTime.set(Integer.parseInt(matcherEnd.group(1)));
-                }
-            });
+            try (Stream<String> lines = Files.lines(getLogPath())) {
+                lines.forEach(line -> {
+                    Matcher matcherFirst = startPattern.matcher(line);
+                    if (matcherFirst.matches() && startTime.get() == 0) {
+                        startTime.set(Integer.parseInt(matcherFirst.group(1)));
+                    }
+                    Matcher matcherEnd = endPattern.matcher(line);
+                    if (matcherEnd.matches()) {
+                        endTime.set(Integer.parseInt(matcherEnd.group(1)));
+                    }
+                });
+            }
             if (startTime.get() == 0 && failIfNotFound) {
                 throw new RuntimeException("No match: " + startFragment);
             }


### PR DESCRIPTION
## Description

Used a try-with-resources statement to ensure that log file gets closed
after iterating over its contents.

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
