### PR TITLE
fix!: Supported node is updated to 16.14

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -61,11 +61,11 @@ import static com.vaadin.flow.server.InitParameters.NODE_VERSION;
  */
 public class FrontendTools {
 
-    public static final String DEFAULT_NODE_VERSION = "v17.3.0";
+    public static final String DEFAULT_NODE_VERSION = "v16.14.0";
     /**
      * This is the version shipped with the default Node version.
      */
-    public static final String DEFAULT_NPM_VERSION = "8.3.0";
+    public static final String DEFAULT_NPM_VERSION = "8.3.1";
 
     public static final String DEFAULT_PNPM_VERSION = "5.18.10";
 
@@ -104,10 +104,10 @@ public class FrontendTools {
     private static final FrontendVersion WHITESPACE_ACCEPTING_NPM_VERSION = new FrontendVersion(
             7, 0);
 
-    private static final int SUPPORTED_NODE_MAJOR_VERSION = 12;
-    private static final int SUPPORTED_NODE_MINOR_VERSION = 22;
-    private static final int SUPPORTED_NPM_MAJOR_VERSION = 6;
-    private static final int SUPPORTED_NPM_MINOR_VERSION = 14;
+    private static final int SUPPORTED_NODE_MAJOR_VERSION = 16;
+    private static final int SUPPORTED_NODE_MINOR_VERSION = 14;
+    private static final int SUPPORTED_NPM_MAJOR_VERSION = 8;
+    private static final int SUPPORTED_NPM_MINOR_VERSION = 3;
 
     private static final FrontendVersion SUPPORTED_NODE_VERSION = new FrontendVersion(
             SUPPORTED_NODE_MAJOR_VERSION, SUPPORTED_NODE_MINOR_VERSION);
@@ -164,7 +164,7 @@ public class FrontendTools {
     private final URI nodeDownloadRoot;
 
     private final boolean ignoreVersionChecks;
-    private final boolean forceAlternativeNode;
+    private boolean forceAlternativeNode;
     private final boolean useGlobalPnpm;
     private final boolean autoUpdate;
 
@@ -539,6 +539,8 @@ public class FrontendTools {
                                 : "Globally",
                         installedNodeVersion.getFullVersion(),
                         SUPPORTED_NODE_VERSION.getFullVersion());
+                // Global node is not supported use alternative for everything
+                forceAlternativeNode = true;
                 return null;
             }
         } catch (UnknownVersionException e) {
@@ -1005,6 +1007,26 @@ public class FrontendTools {
                     .map(File::getAbsolutePath);
             if (command.isPresent()) {
                 returnCommand = Collections.singletonList(command.get());
+                if (!alternativeDirChecked && cliTool.equals(BuildTool.NPM)) {
+                    try {
+                        List<String> npmVersionCommand = new ArrayList<>(
+                                returnCommand);
+                        npmVersionCommand.add("--version"); // NOSONAR
+                        final FrontendVersion npmVersion = FrontendUtils
+                                .getVersion("npm", npmVersionCommand);
+                        if (npmVersion.isOlderThan(SUPPORTED_NPM_VERSION)) {
+                            getLogger().warn(
+                                    "Global npm is older than {}. Using npm form .vaadin.",
+                                    SUPPORTED_NPM_VERSION.getFullVersion());
+                            returnCommand = new ArrayList<>();
+                            // Force installation if not installed
+                            getNodeBinary();
+                        }
+                    } catch (UnknownVersionException uve) {
+                        getLogger().error("Could not determine npm version",
+                                uve);
+                    }
+                }
             }
         }
         if (!alternativeDirChecked && returnCommand.isEmpty()) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -109,7 +109,7 @@ public class FrontendTools {
     private static final int SUPPORTED_NPM_MAJOR_VERSION = 8;
     private static final int SUPPORTED_NPM_MINOR_VERSION = 3;
 
-    private static final FrontendVersion SUPPORTED_NODE_VERSION = new FrontendVersion(
+    static final FrontendVersion SUPPORTED_NODE_VERSION = new FrontendVersion(
             SUPPORTED_NODE_MAJOR_VERSION, SUPPORTED_NODE_MINOR_VERSION);
 
     private static final FrontendVersion SUPPORTED_NPM_VERSION = new FrontendVersion(

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -206,7 +206,7 @@ public class FrontendToolsTest {
         FrontendStubs.ToolStubInfo npmStub = FrontendStubs.ToolStubInfo.none();
         createStubNode(nodeStub, npmStub, baseDir);
 
-        tools.installNode("v16.14.10", null);
+        tools.installNode("v16.14.0", null);
 
         List<String> nodeVersionCommand = new ArrayList<>();
         nodeVersionCommand.add(tools.getNodeExecutable());

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -47,6 +47,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -145,22 +146,24 @@ public class FrontendToolsTest {
     }
 
     @Test
+    // Test will test correctly when supported node is newer than 16.14
     public void nodeIsBeingLocated_supportedNodeInstalled_autoUpdateFalse_NodeNotUpdated()
             throws FrontendUtils.UnknownVersionException {
         FrontendVersion updatedNodeVersion = getUpdatedAlternativeNodeVersion(
-                "13.10.1", () -> tools.getNodeExecutable());
+                "16.14.0", () -> tools.getNodeExecutable());
 
         Assert.assertEquals(
                 "Locate Node version: Node version updated even if it should not have been touched.",
-                "13.10.1", updatedNodeVersion.getFullVersion());
+                "16.14.0", updatedNodeVersion.getFullVersion());
     }
 
     @Test
+    // Test will test correctly when supported node is newer than 16.14
     public void nodeIsBeingLocated_supportedNodeInstalled_autoUpdateTrue_NodeUpdated()
             throws FrontendUtils.UnknownVersionException {
         settings.setAutoUpdate(true);
         FrontendVersion updatedNodeVersion = getUpdatedAlternativeNodeVersion(
-                "13.10.1", () -> tools.getNodeExecutable());
+                "16.14.0", () -> tools.getNodeExecutable());
 
         Assert.assertEquals(
                 "Locate Node version: Node version was not auto updated.",
@@ -227,14 +230,15 @@ public class FrontendToolsTest {
     }
 
     @Test
+    // Test will test correctly when supported node is newer than 16.14
     public void forceAlternativeDirectory_supportedNodeInstalled_autoUpdateFalse_NodeNotUpdated()
             throws FrontendUtils.UnknownVersionException {
         FrontendVersion updatedNodeVersion = getUpdatedAlternativeNodeVersion(
-                "13.10.1", () -> tools.forceAlternativeNodeExecutable());
+                "16.14.0", () -> tools.forceAlternativeNodeExecutable());
 
         Assert.assertEquals(
                 "Force alternative directory: Node version updated even if it should not have been touched.",
-                "13.10.1", updatedNodeVersion.getFullVersion());
+                "16.14.0", updatedNodeVersion.getFullVersion());
     }
 
     @Test
@@ -242,7 +246,7 @@ public class FrontendToolsTest {
             throws FrontendUtils.UnknownVersionException {
         settings.setAutoUpdate(true);
         FrontendVersion updatedNodeVersion = getUpdatedAlternativeNodeVersion(
-                "13.10.1", () -> tools.forceAlternativeNodeExecutable());
+                "16.14.0", () -> tools.forceAlternativeNodeExecutable());
 
         Assert.assertEquals(
                 "Force alternative directory: Node version was not auto updated.",

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -379,7 +379,7 @@ public class FrontendToolsTest {
             nodeCommands = new Pair<>("node", "node/node");
         }
         File file = new File(baseDir, nodeCommands.getSecond());
-        if (file == null) {
+        if (!file.exists()) {
             file = frontendToolsLocator.tryLocateTool(nodeCommands.getFirst())
                     .orElse(null);
             List<String> versionCommand = Lists.newArrayList();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -148,7 +148,6 @@ public class FrontendToolsTest {
     }
 
     @Test
-    // Test will test correctly when supported node is newer than 16.14
     public void nodeIsBeingLocated_supportedNodeInstalled_autoUpdateFalse_NodeNotUpdated()
             throws FrontendUtils.UnknownVersionException {
         FrontendVersion updatedNodeVersion = getUpdatedAlternativeNodeVersion(
@@ -160,7 +159,6 @@ public class FrontendToolsTest {
     }
 
     @Test
-    // Test will test correctly when supported node is newer than 16.14
     public void nodeIsBeingLocated_supportedNodeInstalled_autoUpdateTrue_NodeUpdated()
             throws FrontendUtils.UnknownVersionException {
         settings.setAutoUpdate(true);
@@ -197,7 +195,6 @@ public class FrontendToolsTest {
     }
 
     @Test
-    // Test will test correctly when supported node is newer than 16.14
     public void nodeIsBeingLocated_unsupportedNodeInstalled_fallbackToNodeInstalledToAlternativeDirectory()
             throws IOException, FrontendUtils.UnknownVersionException {
         // Unsupported node version
@@ -233,7 +230,6 @@ public class FrontendToolsTest {
     }
 
     @Test
-    // Test will test correctly when supported node is newer than 16.14
     public void forceAlternativeDirectory_supportedNodeInstalled_autoUpdateFalse_NodeNotUpdated()
             throws FrontendUtils.UnknownVersionException {
         FrontendVersion updatedNodeVersion = getUpdatedAlternativeNodeVersion(

--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/FrontendStubs.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/FrontendStubs.java
@@ -248,8 +248,8 @@ public class FrontendStubs {
      */
     public static class ToolStubBuilder {
 
-        private static final String DEFAULT_NPM_VERSION = "6.14.10";
-        private static final String DEFAULT_NODE_VERSION = "13.0.0";
+        private static final String DEFAULT_NPM_VERSION = "8.3.0";
+        private static final String DEFAULT_NODE_VERSION = "16.14.0";
 
         private String version;
         private String cacheDir;


### PR DESCRIPTION
Due to requirement of npm 8.3+ the supported
node version is updated to 16.14 and
the autoinstalled node is set to the current lts v16.14.0.

Also autoinstall an use .vaadin if node version is less than
the supported version 8.3

Fixes #12995
