### PR TITLE
fix: cleanup url before resolving resource path in css-loader

### DIFF
--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -201,6 +201,16 @@ module.exports = {
             loader: 'css-loader',
             options: {
               url: (url, resourcePath) => {
+                // css urls may contain query string or fragment identifiers
+                // that should removed before resolving real path
+                // e.g
+                //  ../webfonts/fa-solid-900.svg#fontawesome
+                //  ../webfonts/fa-brands-400.eot?#iefix
+                if(url.includes('?'))
+                    url = url.substring(0, url.indexOf('?'));
+                if(url.includes('#'))
+                    url = url.substring(0, url.indexOf('#'));
+
                 // Only translate files from node_modules
                 const resolve = resourcePath.match(/(\\|\/)node_modules\1/)
                   && fs.existsSync(path.resolve(path.dirname(resourcePath), url));


### PR DESCRIPTION
## Description

URLs in CSS may contain a query string or fragment, that prevents a
correct resolution of resource real path and, consequently,
its inclusion in the output bundle.  An example of this kind of url
are SVG Fragment Identifiers, such ones in fontawesome css:

`url("../webfonts/fa-solid-900.svg#fontawesome")`

When this URL is present on CSS file, the svg file will not be available
at runtime.
With this change, incoming URLs are cleaned up by removing potential
query string and fragment before resolving the real path against filesystem.
## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
