### PR TITLE
chore: remove unecessary jetty-maven-plugin scan configuration

### DIFF
--- a/flow-tests/test-application-theme/test-theme-switch-live-reload/pom.xml
+++ b/flow-tests/test-application-theme/test-theme-switch-live-reload/pom.xml
@@ -57,16 +57,7 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <configuration>
-                    <!-- Scan AppShell in 1 second intervals -->
                     <scanIntervalSeconds>1</scanIntervalSeconds>
-                    <scanTargetPatterns>
-                        <scanTargetPattern>
-                            <directory>${project.basedir}/src/main/java</directory>
-                            <includes>
-                                <include>**/ThemeSwitchLiveReloadView.java</include>
-                            </includes>
-                        </scanTargetPattern>
-                    </scanTargetPatterns>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
## Description

jetty-maven-plugins is configured to scan changes in source directory,
but this is not necessary to trigger automatic reload becuase the test
compiles the source code into `target/classes`, that is already watched
by the plugin.

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
