### PR TITLE
chore: link to Hilla repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -8,7 +8,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        NOTE: Issues concerning Vaadin Fusion should go to the Fusion repository https://github.com/vaadin/fusion
+        NOTE: Issues concerning Hilla (formerly Vaadin Fusion) should go to the Hilla repository https://github.com/vaadin/hilla
   - type: markdown
     attributes:
       value: |


### PR DESCRIPTION
Bug report template references hilla (not fusion)
