### PR TITLE
fix: prevent using @fs URLs in Vite

### DIFF
--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -23,6 +23,8 @@ const themeFolder = path.resolve(frontendFolder, settings.themeFolder);
 const frontendBundleFolder = path.resolve(__dirname, settings.frontendBundleOutput);
 const addonFrontendFolder = path.resolve(__dirname, settings.addonFrontendFolder);
 
+const frontendPath = path.posix.relative(__dirname, settings.frontendFolder) + '/';
+
 const projectStaticAssetsFolders = [
   path.resolve(__dirname, 'src', 'main', 'resources', 'META-INF', 'resources'),
   path.resolve(__dirname, 'src', 'main', 'resources', 'static'),
@@ -162,9 +164,10 @@ export const vaadinConfig: UserConfigFn = (env) => {
     runWatchDog(process.env.watchDogPort);
   }
   return {
-    root: 'frontend',
+    root: devMode ? '' : frontendFolder,
     base: '',
     resolve: {
+      preserveSymlinks: true,
       alias: {
         themes: themeFolder,
         Frontend: frontendFolder
@@ -220,7 +223,7 @@ export const vaadinConfig: UserConfigFn = (env) => {
         transformIndexHtml: {
           enforce: 'pre',
           transform(_html, { path, server }) {
-            if (path !== '/index.html') {
+            if (path !== `/${devMode ? frontendPath : ''}index.html`) {
               return;
             }
 
@@ -229,12 +232,12 @@ export const vaadinConfig: UserConfigFn = (env) => {
               return [
                 {
                   tag: 'script',
-                  attrs: { type: 'module', src: `${basePath}generated/vite-devmode.ts` },
+                  attrs: { type: 'module', src: `${basePath}${frontendPath}generated/vite-devmode.ts` },
                   injectTo: 'head',
                 },
                 {
                   tag: 'script',
-                  attrs: { type: 'module', src: `${basePath}generated/vaadin.ts` },
+                  attrs: { type: 'module', src: `${basePath}${frontendPath}generated/vaadin.ts` },
                   injectTo: 'head',
                 }
               ]

--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -23,6 +23,7 @@ const themeFolder = path.resolve(frontendFolder, settings.themeFolder);
 const frontendBundleFolder = path.resolve(__dirname, settings.frontendBundleOutput);
 const addonFrontendFolder = path.resolve(__dirname, settings.addonFrontendFolder);
 
+// The URL path prefix for the frontend directory: relative, `/` separators
 const frontendPath = path.posix.relative(__dirname, settings.frontendFolder) + '/';
 
 const projectStaticAssetsFolders = [

--- a/flow-tests/test-frontend/vite-basics/frontend/deploader.js
+++ b/flow-tests/test-frontend/vite-basics/frontend/deploader.js
@@ -1,0 +1,1 @@
+import('@vaadin/flow-frontend/package.json');

--- a/flow-tests/test-frontend/vite-basics/package.json
+++ b/flow-tests/test-frontend/vite-basics/package.json
@@ -22,7 +22,7 @@
     "mkdirp": "1.0.4",
     "rollup-plugin-brotli": "3.1.0",
     "typescript": "4.5.3",
-    "vite": "v2.8.0-beta.5",
+    "vite": "v2.8.2",
     "vite-plugin-checker": "0.3.4",
     "workbox-build": "6.4.2",
     "workbox-core": "6.4.2",
@@ -42,12 +42,12 @@
       "mkdirp": "1.0.4",
       "rollup-plugin-brotli": "3.1.0",
       "typescript": "4.5.3",
-      "vite": "v2.8.0-beta.5",
+      "vite": "v2.8.2",
       "vite-plugin-checker": "0.3.4",
       "workbox-build": "6.4.2",
       "workbox-core": "6.4.2",
       "workbox-precaching": "6.4.2"
     },
-    "hash": "ebde6e0910bd4ca3eebbc855a4b06a9aa2f8621fe76bd2b4d0ef2e7bd203b822"
+    "hash": "c1ebbcd7c4ebeb25f7f6b0038575c932b6bc6083191ecb1bcf10ee42c953b3fe"
   }
 }

--- a/flow-tests/test-frontend/vite-basics/src/test/java/com/vaadin/viteapp/BasicsIT.java
+++ b/flow-tests/test-frontend/vite-basics/src/test/java/com/vaadin/viteapp/BasicsIT.java
@@ -1,12 +1,13 @@
 package com.vaadin.viteapp;
 
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.JavascriptExecutor;
+
 import com.vaadin.flow.component.html.testbench.ParagraphElement;
 import com.vaadin.flow.testutil.DevModeGizmoElement;
 import com.vaadin.testbench.TestBenchElement;
 import com.vaadin.viteapp.views.empty.MainView;
-
-import org.junit.Assert;
-import org.junit.Test;
 
 public class BasicsIT extends ViteDevModeIT {
 
@@ -48,5 +49,18 @@ public class BasicsIT extends ViteDevModeIT {
         $("button").id(MainView.LOAD_AND_SHOW_JSON).click();
         Assert.assertEquals("{\"hello\":\"World\"}",
                 $("*").id(MainView.JSON_CONTAINER).getText());
+    }
+
+    @Test
+    public void hasNeatNodeModulesPath() {
+        final String processedJs = (String) ((JavascriptExecutor) getDriver())
+                .executeAsyncScript(
+                        "const done = arguments[arguments.length - 1];"
+                                + "fetch('frontend/deploader.js', {"
+                                + "headers: {Accept: 'application/javascript'}"
+                                + "}).then(response => response.text()).then(done);");
+        Assert.assertEquals(
+                "import('/VAADIN/node_modules/@vaadin/flow-frontend/package.json?import');",
+                processedJs);
     }
 }

--- a/flow-tests/test-frontend/vite-basics/src/test/java/com/vaadin/viteapp/BasicsIT.java
+++ b/flow-tests/test-frontend/vite-basics/src/test/java/com/vaadin/viteapp/BasicsIT.java
@@ -56,7 +56,7 @@ public class BasicsIT extends ViteDevModeIT {
         final String processedJs = (String) ((JavascriptExecutor) getDriver())
                 .executeAsyncScript(
                         "const done = arguments[arguments.length - 1];"
-                                + "fetch('frontend/deploader.js', {"
+                                + "fetch('/VAADIN/frontend/deploader.js', {"
                                 + "headers: {Accept: 'application/javascript'}"
                                 + "}).then(response => response.text()).then(done);");
         Assert.assertEquals(

--- a/flow-tests/test-frontend/vite-production/vite.config.ts
+++ b/flow-tests/test-frontend/vite-production/vite.config.ts
@@ -1,0 +1,9 @@
+import { UserConfigFn } from 'vite';
+import { overrideVaadinConfig } from './vite.generated';
+
+const customConfig: UserConfigFn = (env) => ({
+  // Here you can add custom Vite parameters
+  // https://vitejs.dev/config/
+});
+
+export default overrideVaadinConfig(customConfig);

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/ViteHandler.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/ViteHandler.java
@@ -24,6 +24,9 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.regex.Pattern;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.VaadinServletContext;
@@ -31,9 +34,6 @@ import com.vaadin.flow.server.frontend.FrontendTools;
 import com.vaadin.flow.server.frontend.FrontendUtils;
 
 import static com.vaadin.flow.server.Constants.VAADIN_MAPPING;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Handles communication with a Vite server.
@@ -72,8 +72,7 @@ public final class ViteHandler extends AbstractDevServerRunner {
         frontendPath = FrontendUtils.getUnixRelativePath(npmFolder.toPath(),
                 new File(getApplicationConfiguration().getStringProperty(
                         FrontendUtils.PARAM_FRONTEND_DIR,
-                        System.getProperty(FrontendUtils.PARAM_FRONTEND_DIR,
-                                FrontendUtils.DEFAULT_FRONTEND_DIR))).toPath());
+                        FrontendUtils.DEFAULT_FRONTEND_DIR)).toPath());
     }
 
     @Override

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/ViteHandler.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/ViteHandler.java
@@ -136,7 +136,7 @@ public final class ViteHandler extends AbstractDevServerRunner {
     public HttpURLConnection prepareConnection(String path, String method)
             throws IOException {
         if ("/index.html".equals(path)) {
-            path = "/" + VAADIN_MAPPING + frontendPath + "/index.html";
+            path = prependFrontendPath(path);
         }
 
         return super.prepareConnection(getContextPath() + path, method);
@@ -146,5 +146,10 @@ public final class ViteHandler extends AbstractDevServerRunner {
         VaadinServletContext servletContext = (VaadinServletContext) getApplicationConfiguration()
                 .getContext();
         return servletContext.getContext().getContextPath();
+    }
+
+    @SuppressWarnings("squid:S1075")
+    private String prependFrontendPath(String path) {
+        return "/" + VAADIN_MAPPING + frontendPath + path;
     }
 }

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/ViteHandler.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/ViteHandler.java
@@ -50,6 +50,8 @@ public final class ViteHandler extends AbstractDevServerRunner {
      */
     public static final String VITE_SERVER = "node_modules/vite/bin/vite.js";
 
+    private final String frontendPath;
+
     /**
      * Creates and starts the dev mode handler if none has been started yet.
      *
@@ -67,6 +69,11 @@ public final class ViteHandler extends AbstractDevServerRunner {
     public ViteHandler(Lookup lookup, int runningPort, File npmFolder,
             CompletableFuture<Void> waitFor) {
         super(lookup, runningPort, npmFolder, waitFor);
+        frontendPath = FrontendUtils.getUnixRelativePath(npmFolder.toPath(),
+                new File(getApplicationConfiguration().getStringProperty(
+                        FrontendUtils.PARAM_FRONTEND_DIR,
+                        System.getProperty(FrontendUtils.PARAM_FRONTEND_DIR,
+                                FrontendUtils.DEFAULT_FRONTEND_DIR))).toPath());
     }
 
     @Override
@@ -130,9 +137,7 @@ public final class ViteHandler extends AbstractDevServerRunner {
     public HttpURLConnection prepareConnection(String path, String method)
             throws IOException {
         if ("/index.html".equals(path)) {
-            return super.prepareConnection(
-                    getContextPath() + "/" + VAADIN_MAPPING + "index.html",
-                    method);
+            path = "/" + VAADIN_MAPPING + frontendPath + "/index.html";
         }
 
         return super.prepareConnection(getContextPath() + path, method);


### PR DESCRIPTION
## Description

In Vite development mode, serves the application so that:
- `/VAADIN/frontend/` maps to the sources from the frontend directory
- `/VAADIN/node_modules/` maps to the `node_modules` installed

This configuration works better for Vite, as it needs to serve the `node_modules/` directory.

After this change, Vite does not use the `@fs` fallback URL mapping with absolute paths.

Fixes #12957

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
