### PR TITLE
fix: Slow npm warning when no package-lock

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -238,6 +238,12 @@ public final class Constants implements Serializable {
     public static final String PACKAGE_JSON = "package.json";
 
     /**
+     * Name of the <code>npm</code> version locking ile.
+     */
+
+    public static final String PACKAGE_LOCK_JSON = "package-lock.json";
+
+    /**
      * Target folder constant.
      */
     public static final String TARGET = "target";

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -51,6 +51,7 @@ import elemental.json.JsonValue;
 
 import static com.vaadin.flow.server.Constants.COMPATIBILITY_RESOURCES_FRONTEND_DEFAULT;
 import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
+import static com.vaadin.flow.server.Constants.PACKAGE_LOCK_JSON;
 import static com.vaadin.flow.server.Constants.RESOURCES_FRONTEND_DEFAULT;
 import static com.vaadin.flow.server.frontend.FrontendUtils.FLOW_NPM_PACKAGE_NAME;
 import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
@@ -168,8 +169,12 @@ public abstract class NodeUpdater implements FallibleCommand {
         this.featureFlags = featureFlags;
     }
 
-    private File getPackageJsonFile() {
+    protected File getPackageJsonFile() {
         return new File(npmFolder, PACKAGE_JSON);
+    }
+
+    protected File getPackageLockFile() {
+        return new File(npmFolder, PACKAGE_LOCK_JSON);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -140,7 +140,6 @@ public class TaskRunNpmInstall implements FallibleCommand {
     public void execute() throws ExecutionFailedException {
         String toolName = enablePnpm ? "pnpm" : "npm";
         if (packageUpdater.modified || shouldRunNpmInstall()) {
-            String waitMessage;
             // Log a stronger request for patience if package-lock.json is
             // missing as "npm install" in this case can take minutes
             // https://github.com/vaadin/flow/issues/12825

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -140,9 +140,19 @@ public class TaskRunNpmInstall implements FallibleCommand {
     public void execute() throws ExecutionFailedException {
         String toolName = enablePnpm ? "pnpm" : "npm";
         if (packageUpdater.modified || shouldRunNpmInstall()) {
+            String waitMessage;
+            // Log a stronger request for patience if package-lock.json is
+            // missing as "npm install" in this case can take minutes
+            // https://github.com/vaadin/flow/issues/12825
+            File packageLockFile = packageUpdater.getPackageLockFile();
+            if (!enablePnpm && !packageLockFile.exists()) {
+                waitMessage = "This may take several minutes, please stand by...";
+            } else {
+                waitMessage = "This may take a moment, please stand by...";
+            }
             packageUpdater.log().info("Running `" + toolName + " install` to "
                     + "resolve and optionally download frontend dependencies. "
-                    + "This may take a moment, please stand by...");
+                    + waitMessage);
             runNpmInstall();
 
             updateLocalHash();

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -145,14 +145,15 @@ public class TaskRunNpmInstall implements FallibleCommand {
             // missing as "npm install" in this case can take minutes
             // https://github.com/vaadin/flow/issues/12825
             File packageLockFile = packageUpdater.getPackageLockFile();
-            if (!enablePnpm && !packageLockFile.exists()) {
-                waitMessage = "This may take several minutes, please stand by...";
-            } else {
-                waitMessage = "This may take a moment, please stand by...";
-            }
             packageUpdater.log().info("Running `" + toolName + " install` to "
                     + "resolve and optionally download frontend dependencies. "
-                    + waitMessage);
+                    + "This may take a moment, please stand by...");
+            if (!enablePnpm && !packageLockFile.exists()) {
+                packageUpdater.log().warn("Missing package-lock.json may cause "
+                        + "npm package installation to take several minutes; "
+                        + "it is recommended to keep this file persistently "
+                        + "in your project");
+            }
             runNpmInstall();
 
             updateLocalHash();

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -36,6 +36,7 @@ import org.slf4j.Logger;
 import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.function.SerializableFunction;
+import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.CssData;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
@@ -493,7 +494,8 @@ public class TaskUpdateImports extends NodeUpdater {
     }
 
     private String getAbsentPackagesMessage() {
-        String lockFile = enablePnpm ? "pnpm-lock.yaml" : "package-lock.json";
+        String lockFile = enablePnpm ? "pnpm-lock.yaml"
+                : Constants.PACKAGE_LOCK_JSON;
         String command = enablePnpm ? "pnpm" : "npm";
         String note = "";
         if (enablePnpm) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -497,10 +497,6 @@ public class TaskUpdatePackages extends NodeUpdater {
         return dependencies;
     }
 
-    private File getPackageLockFile() {
-        return new File(npmFolder, "package-lock.json");
-    }
-
     private String getShrinkWrapVersion(JsonObject packageJson) {
         if (packageJson == null) {
             return null;


### PR DESCRIPTION
Just log an additional warning when package-lock.json is missing.

Fixes #12825.