### PR TITLE
fix: respect PWA offline property in the Vite config

### DIFF
--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -189,8 +189,8 @@ export const vaadinConfig: UserConfigFn = (env) => {
     },
     plugins: [
       !devMode && brotli(),
-      settings.pwaEnabled && transpileSWPlugin(),
-      settings.pwaEnabled && injectManifestToSWPlugin(),
+      settings.offlineEnabled && transpileSWPlugin(),
+      settings.offlineEnabled && injectManifestToSWPlugin(),
       {
         name: 'vaadin:custom-theme',
         config() {

--- a/flow-tests/test-frontend/pom.xml
+++ b/flow-tests/test-frontend/pom.xml
@@ -35,6 +35,7 @@
                 <module>vite-context-path/pom-production.xml</module>
                 <module>vite-context-path</module>
                 <module>vite-pwa-disabled-offline</module>
+                <module>vite-pwa-disabled-offline/pom-production.xml</module>
                 <module>vite-pwa-production</module>
                 <module>vite-pwa-production-custom-offline-path</module>
                 <!-- npm and pnpm dev mode and prod mode -->


### PR DESCRIPTION
## Description

This PR fixes the Vite config so that it would respect the `offline` property of the `PWA` annotation and disable the service worker build when `offline == false`.

Seems like these changes have got lost after a rebase in the original PR introducing the `offline` property.

A follow-up to #13019

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
