### PR TITLE
fix: save platform version in node_modules

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/Platform.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Platform.java
@@ -46,7 +46,7 @@ public class Platform implements Serializable {
                 return Optional.of(vaadinVersions.get("platform").asText());
             } else {
                 if (!versionErrorLogged) {
-                    versionErrorLogged = true; // NOSONAR
+                    versionErrorLogged = true;
                     LoggerFactory.getLogger(Platform.class)
                             .info("Unable to determine version information. "
                                     + "No vaadin_versions.json found");

--- a/flow-server/src/main/java/com/vaadin/flow/server/Platform.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Platform.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server;
+
+import java.io.InputStream;
+import java.io.Serializable;
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provides information about the current version of Vaadin Platform.
+ *
+ * @since 23.0
+ */
+public class Platform implements Serializable {
+
+    private static boolean versionErrorLogged = false;
+
+    /**
+     * Returns the platform version string, e.g., {@code "23.0.0"}.
+     *
+     * @return the platform version or {@link Optional#empty()} if unavailable.
+     */
+    public static Optional<String> getVaadinVersion() {
+        try (InputStream vaadinVersionsStream = Platform.class.getClassLoader()
+                .getResourceAsStream(Constants.VAADIN_VERSIONS_JSON)) {
+            if (vaadinVersionsStream != null) {
+                ObjectMapper m = new ObjectMapper();
+                JsonNode vaadinVersions = m.readTree(vaadinVersionsStream);
+                return Optional.of(vaadinVersions.get("platform").asText());
+            } else {
+                if (!versionErrorLogged) {
+                    versionErrorLogged = true; // NOSONAR
+                    LoggerFactory.getLogger(Platform.class)
+                            .info("Unable to determine version information. "
+                                    + "No vaadin_versions.json found");
+                }
+            }
+        } catch (Exception e) {
+            LoggerFactory.getLogger(Platform.class)
+                    .error("Unable to determine version information", e);
+        }
+
+        return Optional.empty();
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -594,14 +594,13 @@ public abstract class NodeUpdater implements FallibleCommand {
                     UTF_8.name());
             return Json.parse(fileContent);
         } else {
-            return null;
+            return Json.createObject();
         }
     }
 
     void updateVaadinJsonContents(Map<String, String> newContent)
             throws IOException {
-        JsonObject fileContent = Optional.ofNullable(getVaadinJsonContents())
-                .orElse(Json.createObject());
+        JsonObject fileContent = getVaadinJsonContents();
         newContent.forEach(fileContent::put);
         File vaadinJsonFile = getVaadinJsonFile();
         FileUtils.forceMkdirParent(vaadinJsonFile);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -78,6 +79,11 @@ public abstract class NodeUpdater implements FallibleCommand {
      */
     public static final String GENERATED_PREFIX = "GENERATED/";
 
+    // .vaadin/vaadin.json contains local installation data inside node_modules
+    // This will help us know to execute even when another developer has pushed
+    // a new hash to the code repository.
+    private static final String VAADIN_JSON = ".vaadin/vaadin.json";
+
     static final String DEPENDENCIES = "dependencies";
     static final String VAADIN_DEP_KEY = "vaadin";
     static final String HASH_KEY = "hash";
@@ -96,6 +102,8 @@ public abstract class NodeUpdater implements FallibleCommand {
     private static final String DEP_VERSION_DEFAULT = "1.0.0";
     private static final String ROUTER_VERSION = "1.7.4";
     protected static final String POLYMER_VERSION = "3.4.1";
+
+    static final String VAADIN_VERSION = "vaadinVersion";
 
     /**
      * Base directory for {@link Constants#PACKAGE_JSON},
@@ -573,6 +581,32 @@ public abstract class NodeUpdater implements FallibleCommand {
         String content = stringify(json, 2) + "\n";
         FileUtils.writeStringToFile(packageFile, content, UTF_8.name());
         return content;
+    }
+
+    File getVaadinJsonFile() {
+        return new File(nodeModulesFolder, VAADIN_JSON);
+    }
+
+    JsonObject getVaadinJsonContents() throws IOException {
+        File vaadinJsonFile = getVaadinJsonFile();
+        if (vaadinJsonFile.exists()) {
+            String fileContent = FileUtils.readFileToString(vaadinJsonFile,
+                    UTF_8.name());
+            return Json.parse(fileContent);
+        } else {
+            return null;
+        }
+    }
+
+    void updateVaadinJsonContents(Map<String, String> newContent)
+            throws IOException {
+        JsonObject fileContent = Optional.ofNullable(getVaadinJsonContents())
+                .orElse(Json.createObject());
+        newContent.forEach(fileContent::put);
+        File vaadinJsonFile = getVaadinJsonFile();
+        FileUtils.forceMkdirParent(vaadinJsonFile);
+        String content = stringify(fileContent, 2) + "\n";
+        FileUtils.writeStringToFile(vaadinJsonFile, content, UTF_8.name());
     }
 
     Logger log() {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -223,7 +223,7 @@ public class TaskRunNpmInstall implements FallibleCommand {
     private boolean isVaadinHashUpdated() {
         try {
             JsonObject content = packageUpdater.getVaadinJsonContents();
-            if (content != null && content.hasKey(HASH_KEY)) {
+            if (content.hasKey(HASH_KEY)) {
                 final JsonObject packageJson = packageUpdater.getPackageJson();
                 return !content.getString(HASH_KEY).equals(packageJson
                         .getObject(VAADIN_DEP_KEY).getString(HASH_KEY));

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -56,7 +56,6 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
  */
 public class TaskUpdatePackages extends NodeUpdater {
 
-    private static final String VERSION = "version";
     protected static final String VAADIN_APP_PACKAGE_HASH = "vaadinAppPackageHash";
     private final boolean forceCleanUp;
     private final boolean enablePnpm;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -257,7 +257,7 @@ public class TaskUpdatePackages extends NodeUpdater {
 
         // FIXME do not do cleanup of node_modules every time platform is
         // updated ?
-        doCleanUp = doCleanUp || !enablePnpm && isPlatformVersionUpdated();
+        doCleanUp = doCleanUp || (!enablePnpm && isPlatformVersionUpdated());
 
         // Remove obsolete devDependencies
         dependencyCollection = new ArrayList<>(

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -33,6 +34,7 @@ import org.apache.commons.io.FileUtils;
 import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.internal.StringUtil;
+import com.vaadin.flow.server.Platform;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 
@@ -55,7 +57,6 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.NODE_MODULES;
 public class TaskUpdatePackages extends NodeUpdater {
 
     private static final String VERSION = "version";
-    private static final String VAADIN_CORE = "@vaadin/vaadin-core";
     protected static final String VAADIN_APP_PACKAGE_HASH = "vaadinAppPackageHash";
     private final boolean forceCleanUp;
     private final boolean enablePnpm;
@@ -253,12 +254,10 @@ public class TaskUpdatePackages extends NodeUpdater {
         int removed = removeLegacyProperties(packageJson);
         removed += cleanDependencies(dependencyCollection, packageJson,
                 DEPENDENCIES);
-        if (dependencies != null) {
-            // FIXME do not do cleanup of node_modules every time platform is
-            // updated ?
-            doCleanUp = doCleanUp
-                    || !enablePnpm && isPlatformVersionUpdated(dependencies);
-        }
+
+        // FIXME do not do cleanup of node_modules every time platform is
+        // updated ?
+        doCleanUp = doCleanUp || !enablePnpm && isPlatformVersionUpdated();
 
         // Remove obsolete devDependencies
         dependencyCollection = new ArrayList<>(
@@ -365,29 +364,30 @@ public class TaskUpdatePackages extends NodeUpdater {
     }
 
     /**
-     * Compares vaadin-core dependency version (which is the same as the
-     * platform version) from the {@code dependencies} object with the current
-     * vaadin-core version (retrieved from file system: package.json,
-     * package-lock.json). In case there was no existing vaadin-core version,
-     * then version is considered updated.
+     * Compares current platform version with the one last recorded as installed
+     * in node_modules/.vaadin/vaadin_version. In case there was no existing
+     * vaadin-core version, then version is considered updated.
      *
-     * @param dependencies
-     *            dependencies object with the vaadin-core version
      * @return {@code true} if the version has changed, {@code false} if not
      * @throws IOException
      *             when file reading fails
      */
-    private boolean isPlatformVersionUpdated(JsonObject dependencies)
-            throws IOException {
-        String vaadinCoreVersion = null;
-        if (dependencies.hasKey(VAADIN_CORE)) {
-            vaadinCoreVersion = dependencies.getString(VAADIN_CORE);
+    private boolean isPlatformVersionUpdated() throws IOException {
+        // if no record of current version is present, version is not
+        // considered updated
+        Optional<String> platformVersion = Platform.getVaadinVersion();
+        if (platformVersion.isPresent()) {
+            JsonObject vaadinJsonContents = getVaadinJsonContents();
+            // If no record of previous version, version is considered updated;
+            if (vaadinJsonContents == null
+                    || !vaadinJsonContents.hasKey(NodeUpdater.VAADIN_VERSION)) {
+                return true;
+            }
+            return !Objects.equals(
+                    vaadinJsonContents.getString(NodeUpdater.VAADIN_VERSION),
+                    platformVersion.get());
         }
-
-        final String existingVaadinVersion = getExistingVaadinCoreVersion();
-        // if no existing vaadin-core version is present, version is not
-        // "updated"
-        return !Objects.equals(vaadinCoreVersion, existingVaadinVersion);
+        return false;
     }
 
     /**
@@ -450,62 +450,6 @@ public class TaskUpdatePackages extends NodeUpdater {
         if (generatedNodeModules.exists()) {
             FrontendUtils.deleteNodeModules(generatedNodeModules);
         }
-    }
-
-    private String getExistingVaadinCoreVersion() throws IOException {
-        String vaadinCoreVersion = getVaadinCoreVersion(getPackageJson());
-        if (vaadinCoreVersion != null) {
-            return vaadinCoreVersion;
-        }
-
-        vaadinCoreVersion = getPackageLockVaadinCoreVersion();
-        return vaadinCoreVersion;
-    }
-
-    private String getPackageLockVaadinCoreVersion() throws IOException {
-        JsonObject dependencies = getPackageLockDependencies();
-        if (dependencies == null) {
-            return null;
-        }
-
-        if (!dependencies.hasKey(VAADIN_CORE)) {
-            return null;
-        }
-        JsonObject shrinkWrap = dependencies.getObject(VAADIN_CORE);
-        if (shrinkWrap.hasKey(VERSION)) {
-            return shrinkWrap.get(VERSION).asString();
-        }
-        return null;
-    }
-
-    private JsonObject getPackageLockDependencies() throws IOException {
-        File packageLock = getPackageLockFile();
-        if (!packageLock.exists()) {
-            return null;
-        }
-        JsonObject packageLockJson = getJsonFileContent(packageLock);
-        if (packageLockJson == null) {
-            return null;
-        }
-        if (!packageLockJson.hasKey(DEPENDENCIES)) {
-            return null;
-        }
-        JsonObject dependencies = packageLockJson.getObject(DEPENDENCIES);
-        return dependencies;
-    }
-
-    private String getVaadinCoreVersion(JsonObject packageJson) {
-        if (packageJson == null) {
-            return null;
-        }
-        if (packageJson.hasKey(DEPENDENCIES)) {
-            JsonObject dependencies = packageJson.getObject(DEPENDENCIES);
-            if (dependencies.hasKey(VAADIN_CORE)) {
-                JsonValue value = dependencies.get(VAADIN_CORE);
-                return value.asString();
-            }
-        }
-        return null;
     }
 
     private void deletePnpmLockFile() throws IOException {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -379,8 +379,7 @@ public class TaskUpdatePackages extends NodeUpdater {
         if (platformVersion.isPresent() && nodeModulesFolder.exists()) {
             JsonObject vaadinJsonContents = getVaadinJsonContents();
             // If no record of previous version, version is considered updated;
-            if (vaadinJsonContents == null
-                    || !vaadinJsonContents.hasKey(NodeUpdater.VAADIN_VERSION)) {
+            if (!vaadinJsonContents.hasKey(NodeUpdater.VAADIN_VERSION)) {
                 return true;
             }
             return !Objects.equals(

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -365,7 +365,7 @@ public class TaskUpdatePackages extends NodeUpdater {
     /**
      * Compares current platform version with the one last recorded as installed
      * in node_modules/.vaadin/vaadin_version. In case there was no existing
-     * vaadin-core version, then version is considered updated.
+     * platform, then platform is considered updated.
      *
      * @return {@code true} if the version has changed, {@code false} if not
      * @throws IOException

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -365,7 +365,8 @@ public class TaskUpdatePackages extends NodeUpdater {
     /**
      * Compares current platform version with the one last recorded as installed
      * in node_modules/.vaadin/vaadin_version. In case there was no existing
-     * platform, then platform is considered updated.
+     * platform version recorder and node_modules exists, then platform is
+     * considered updated.
      *
      * @return {@code true} if the version has changed, {@code false} if not
      * @throws IOException
@@ -375,7 +376,7 @@ public class TaskUpdatePackages extends NodeUpdater {
         // if no record of current version is present, version is not
         // considered updated
         Optional<String> platformVersion = Platform.getVaadinVersion();
-        if (platformVersion.isPresent()) {
+        if (platformVersion.isPresent() && nodeModulesFolder.exists()) {
             JsonObject vaadinJsonContents = getVaadinJsonContents();
             // If no record of previous version, version is considered updated;
             if (vaadinJsonContents == null

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
@@ -63,7 +63,7 @@ public abstract class AbstractNodeUpdatePackagesTest
     private static final String DEPENDENCIES = "dependencies";
     private static final String DEV_DEPENDENCIES = "devDependencies";
 
-    private static final String SHRINKWRAP = "@vaadin/vaadin-shrinkwrap";
+    private static final String VAADIN_CORE = "@vaadin/vaadin-core";
 
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -173,7 +173,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         makeNodeModulesAndPackageLock();
 
         // Change the versions
-        getDependencies(packageUpdater.getPackageJson()).put(SHRINKWRAP,
+        getDependencies(packageUpdater.getPackageJson()).put(VAADIN_CORE,
                 "1.1.1");
 
         // run it again with existing generated package.json and mismatched
@@ -280,7 +280,7 @@ public abstract class AbstractNodeUpdatePackagesTest
      */
     private void assertVersionAndCleanUp() throws IOException {
         JsonValue value = getDependencies(packageUpdater.getPackageJson())
-                .get(SHRINKWRAP);
+                .get(VAADIN_CORE);
         Assert.assertEquals("1.2.3", value.asString());
 
         // Check that clean up was done
@@ -300,7 +300,7 @@ public abstract class AbstractNodeUpdatePackagesTest
 
         // Change the version
         JsonObject json = packageUpdater.getPackageJson();
-        getDependencies(json).put(SHRINKWRAP, "1.1.1");
+        getDependencies(json).put(VAADIN_CORE, "1.1.1");
         Files.write(packageJson.toPath(),
                 Collections.singletonList(json.toJson()));
 
@@ -395,7 +395,7 @@ public abstract class AbstractNodeUpdatePackagesTest
             throws IOException {
         versionsDoNotMatch_inMainJson_cleanUp(true);
         JsonValue value = getDependencies(packageUpdater.getPackageJson())
-                .get(SHRINKWRAP);
+                .get(VAADIN_CORE);
         Assert.assertEquals("1.2.3", value.asString());
 
         // nothing is removed except package-lock
@@ -416,7 +416,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         packages.put("@vaadin/vaadin-checkbox", "2.2.10");
         packages.put("@polymer/iron-icon", "3.0.1");
         packages.put("@vaadin/vaadin-time-picker", "2.0.2");
-        packages.put(SHRINKWRAP, "1.1.1");
+        packages.put(VAADIN_CORE, "1.1.1");
 
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
@@ -884,7 +884,7 @@ public abstract class AbstractNodeUpdatePackagesTest
     private void updateVersion() throws IOException {
         // Change the version
         JsonObject json = packageUpdater.getPackageJson();
-        getDependencies(json).put(SHRINKWRAP, "1.1.1");
+        getDependencies(json).put(VAADIN_CORE, "1.1.1");
         Files.write(packageJson.toPath(),
                 Collections.singletonList(stringify(json)));
     }
@@ -894,7 +894,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         JsonObject deps = Json.createObject();
         JsonObject shrinkWrap = Json.createObject();
         object.put(DEPENDENCIES, deps);
-        deps.put(SHRINKWRAP, shrinkWrap);
+        deps.put(VAADIN_CORE, shrinkWrap);
         shrinkWrap.put("version", version);
         return object;
     }
@@ -910,7 +910,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         packages.put("@vaadin/vaadin-checkbox", "2.2.10");
         packages.put("@polymer/iron-icon", "3.0.1");
         packages.put("@vaadin/vaadin-time-picker", "2.0.2");
-        packages.put(SHRINKWRAP, "1.2.3");
+        packages.put(VAADIN_CORE, "1.2.3");
 
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
@@ -924,7 +924,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         makeNodeModulesAndPackageLock();
 
         JsonObject packageJson = getPackageJson(this.packageJson);
-        packageJson.put(SHRINKWRAP, "1.1.1");
+        packageJson.put(VAADIN_CORE, "1.1.1");
         Files.write(packageLock.toPath(),
                 Collections.singletonList(stringify(packageJson)));
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
@@ -299,27 +299,6 @@ public abstract class AbstractNodeUpdatePackagesTest
     }
 
     @Test
-    public void versionsMatch_inVaadinJson_noCleanUp() throws IOException {
-        // Generate package json in a proper format first
-        packageCreator.execute();
-
-        makeNodeModulesAndPackageLock();
-
-        packageUpdater.updateVaadinJsonContents(
-                Collections.singletonMap(VAADIN_VERSION, "1.1.1"));
-
-        try (MockedStatic<Platform> platform = Mockito
-                .mockStatic(Platform.class)) {
-            platform.when(Platform::getVaadinVersion)
-                    .thenReturn(Optional.of("1.1.1"));
-            packageUpdater.execute();
-            Assert.assertTrue(mainNodeModules.exists());
-            Assert.assertTrue(appNodeModules.exists());
-            Assert.assertTrue(packageLock.exists());
-        }
-    }
-
-    @Test
     public void versionsDoNotMatch_inVaadinJson_cleanUpNpm()
             throws IOException {
         // Generate package json in a proper format first

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
@@ -34,10 +35,12 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.Platform;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
@@ -62,8 +65,7 @@ public abstract class AbstractNodeUpdatePackagesTest
 
     private static final String DEPENDENCIES = "dependencies";
     private static final String DEV_DEPENDENCIES = "devDependencies";
-
-    private static final String VAADIN_CORE = "@vaadin/vaadin-core";
+    private static final String VAADIN_VERSION = "vaadinVersion";
 
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -142,45 +144,6 @@ public abstract class AbstractNodeUpdatePackagesTest
         Assert.assertTrue(packageCreator.modified);
         Assert.assertTrue(packageUpdater.modified);
         assertMainPackageJsonContent();
-    }
-
-    @Test
-    public void versions_doNotMatch_inGeneratedPackage_cleanUp()
-            throws IOException {
-        // Generate package json in a proper format first
-        packageCreator.execute();
-        packageUpdater.execute();
-
-        updateVersion();
-
-        makeNodeModulesAndPackageLock();
-
-        // run it again with existing generated package.json and mismatched
-        // versions
-        packageUpdater.execute();
-
-        assertVersionAndCleanUp();
-    }
-
-    @Test
-    public void versions_doNotMatch_inMainPackage_cleanUp() throws IOException {
-        // Generate package json in a proper format first
-        packageCreator.execute();
-        packageUpdater.execute();
-
-        updateVersion();
-
-        makeNodeModulesAndPackageLock();
-
-        // Change the versions
-        getDependencies(packageUpdater.getPackageJson()).put(VAADIN_CORE,
-                "1.1.1");
-
-        // run it again with existing generated package.json and mismatched
-        // versions
-        packageUpdater.execute();
-
-        assertVersionAndCleanUp();
     }
 
     @Test
@@ -275,42 +238,6 @@ public abstract class AbstractNodeUpdatePackagesTest
 
     // Some npm-dependency pinning tests are in TaskRunNpmInstallTest
 
-    /**
-     * @throws IOException
-     */
-    private void assertVersionAndCleanUp() throws IOException {
-        JsonValue value = getDependencies(packageUpdater.getPackageJson())
-                .get(VAADIN_CORE);
-        Assert.assertEquals("1.2.3", value.asString());
-
-        // Check that clean up was done
-        assertCleanUp();
-    }
-
-    @Test
-    public void versions_doNotMatch_inFlowDepsPackage_cleanUp()
-            throws IOException {
-        // Generate package json in a proper format first
-        packageCreator.execute();
-        packageUpdater.execute();
-
-        updateVersion();
-
-        makeNodeModulesAndPackageLock();
-
-        // Change the version
-        JsonObject json = packageUpdater.getPackageJson();
-        getDependencies(json).put(VAADIN_CORE, "1.1.1");
-        Files.write(packageJson.toPath(),
-                Collections.singletonList(json.toJson()));
-
-        // run it again with existing generated package.json and mismatched
-        // versions
-        packageUpdater.execute();
-
-        assertVersionAndCleanUp();
-    }
-
     @Test
     public void unmatchedDevDependency_devDependencyIsRemoved()
             throws IOException {
@@ -372,41 +299,77 @@ public abstract class AbstractNodeUpdatePackagesTest
     }
 
     @Test
-    public void versions_doNotMatch_inPackageLock_cleanUp() throws IOException {
+    public void versionsMatch_inVaadinJson_noCleanUp() throws IOException {
+        // Generate package json in a proper format first
+        packageCreator.execute();
+
         makeNodeModulesAndPackageLock();
 
-        Files.write(packageLock.toPath(),
-                Collections.singletonList(stringify(makePackageLock("1.1.1"))));
+        packageUpdater.updateVaadinJsonContents(
+                Collections.singletonMap(VAADIN_VERSION, "1.1.1"));
 
-        packageCreator.execute();
-        packageUpdater.execute();
-
-        assertVersionAndCleanUp();
+        try (MockedStatic<Platform> platform = Mockito
+                .mockStatic(Platform.class)) {
+            platform.when(Platform::getVaadinVersion)
+                    .thenReturn(Optional.of("1.1.1"));
+            packageUpdater.execute();
+            Assert.assertTrue(mainNodeModules.exists());
+            Assert.assertTrue(appNodeModules.exists());
+            Assert.assertTrue(packageLock.exists());
+        }
     }
 
     @Test
-    public void versionsDoNotMatch_inMainJson_npm_cleanUp() throws IOException {
-        versionsDoNotMatch_inMainJson_cleanUp(false);
-        assertVersionAndCleanUp();
-    }
-
-    @Test
-    public void versionsDoNotMatch_inMainJson_pnpm_cleanUp()
+    public void versionsDoNotMatch_inVaadinJson_cleanUpNpm()
             throws IOException {
-        versionsDoNotMatch_inMainJson_cleanUp(true);
-        JsonValue value = getDependencies(packageUpdater.getPackageJson())
-                .get(VAADIN_CORE);
-        Assert.assertEquals("1.2.3", value.asString());
+        // Generate package json in a proper format first
+        packageCreator.execute();
 
-        // nothing is removed except package-lock
-        Assert.assertTrue(mainNodeModules.exists());
-        Assert.assertTrue(appNodeModules.exists());
-        // package-lock is removed
-        Assert.assertFalse(packageLock.exists());
+        makeNodeModulesAndPackageLock();
+
+        packageUpdater.updateVaadinJsonContents(
+                Collections.singletonMap(VAADIN_VERSION, "1.1.1"));
+
+        try (MockedStatic<Platform> platform = Mockito
+                .mockStatic(Platform.class)) {
+            platform.when(Platform::getVaadinVersion)
+                    .thenReturn(Optional.of("1.2.3"));
+            packageUpdater.execute();
+            assertCleanUp();
+        }
+    }
+
+    @Test
+    public void versionsDoNotMatch_inVaadinJson_cleanUpPnpm()
+            throws IOException {
+        packageUpdater = new TaskUpdatePackages(classFinder,
+                Mockito.mock(FrontendDependencies.class), baseDir, generatedDir,
+                resourcesDir, false, true, TARGET, featureFlags);
+
+        // Generate package json in a proper format first
+        packageCreator.execute();
+
+        makeNodeModulesAndPackageLock();
+
+        packageUpdater.updateVaadinJsonContents(
+                Collections.singletonMap(VAADIN_VERSION, "1.1.1"));
+
+        try (MockedStatic<Platform> platform = Mockito
+                .mockStatic(Platform.class)) {
+            platform.when(Platform::getVaadinVersion)
+                    .thenReturn(Optional.of("1.2.3"));
+            packageUpdater.execute();
+            // nothing is removed except package-lock
+            Assert.assertTrue(mainNodeModules.exists());
+            Assert.assertTrue(appNodeModules.exists());
+            // package-lock is removed
+            Assert.assertFalse(packageLock.exists());
+        }
     }
 
     @Test
     public void versionsMatch_noCleanUp() throws IOException {
+        // TODO: Fixme
         FrontendDependencies frontendDependencies = Mockito
                 .mock(FrontendDependencies.class);
 
@@ -416,7 +379,7 @@ public abstract class AbstractNodeUpdatePackagesTest
         packages.put("@vaadin/vaadin-checkbox", "2.2.10");
         packages.put("@polymer/iron-icon", "3.0.1");
         packages.put("@vaadin/vaadin-time-picker", "2.0.2");
-        packages.put(VAADIN_CORE, "1.1.1");
+        // packages.put(VAADIN_CORE, "1.1.1");
 
         Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
 
@@ -881,54 +844,13 @@ public abstract class AbstractNodeUpdatePackagesTest
         return json.getObject(DEPENDENCIES);
     }
 
-    private void updateVersion() throws IOException {
-        // Change the version
-        JsonObject json = packageUpdater.getPackageJson();
-        getDependencies(json).put(VAADIN_CORE, "1.1.1");
-        Files.write(packageJson.toPath(),
-                Collections.singletonList(stringify(json)));
-    }
-
     private JsonObject makePackageLock(String version) {
         JsonObject object = Json.createObject();
         JsonObject deps = Json.createObject();
         JsonObject shrinkWrap = Json.createObject();
         object.put(DEPENDENCIES, deps);
-        deps.put(VAADIN_CORE, shrinkWrap);
         shrinkWrap.put("version", version);
         return object;
-    }
-
-    private void versionsDoNotMatch_inMainJson_cleanUp(boolean isPnpm)
-            throws IOException {
-        FrontendDependencies frontendDependencies = Mockito
-                .mock(FrontendDependencies.class);
-
-        Map<String, String> packages = new HashMap<>();
-        packages.put("@polymer/iron-list", "3.0.2");
-        packages.put("@vaadin/vaadin-confirm-dialog", "1.1.4");
-        packages.put("@vaadin/vaadin-checkbox", "2.2.10");
-        packages.put("@polymer/iron-icon", "3.0.1");
-        packages.put("@vaadin/vaadin-time-picker", "2.0.2");
-        packages.put(VAADIN_CORE, "1.2.3");
-
-        Mockito.when(frontendDependencies.getPackages()).thenReturn(packages);
-
-        packageUpdater = new TaskUpdatePackages(classFinder,
-                frontendDependencies, baseDir, generatedDir, resourcesDir,
-                false, isPnpm, TARGET, featureFlags);
-
-        // Generate package json in a proper format first
-        packageCreator.execute();
-
-        makeNodeModulesAndPackageLock();
-
-        JsonObject packageJson = getPackageJson(this.packageJson);
-        packageJson.put(VAADIN_CORE, "1.1.1");
-        Files.write(packageLock.toPath(),
-                Collections.singletonList(stringify(packageJson)));
-
-        packageUpdater.execute();
     }
 
     private void assertPackageJsonFlowDeps() throws IOException {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTestComponents.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTestComponents.java
@@ -205,10 +205,6 @@ public class NodeTestComponents extends NodeUpdateTestUtil {
     public static class ExtraImport {
     }
 
-    @NpmPackage(value = "@vaadin/vaadin-core", version = "1.2.3")
-    public static class SimulatedPlatformUpdate {
-    }
-
     @JavaScript("javascript/a.js")
     @JavaScript("javascript/b.js")
     @JavaScript("javascript/c.js")

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTestComponents.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTestComponents.java
@@ -205,8 +205,8 @@ public class NodeTestComponents extends NodeUpdateTestUtil {
     public static class ExtraImport {
     }
 
-    @NpmPackage(value = "@vaadin/vaadin-shrinkwrap", version = "1.2.3")
-    public static class VaadinShrinkWrap extends Component {
+    @NpmPackage(value = "@vaadin/vaadin-core", version = "1.2.3")
+    public static class SimulatedPlatformUpdate {
     }
 
     @JavaScript("javascript/a.js")

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScannerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScannerTest.java
@@ -49,7 +49,6 @@ import com.vaadin.flow.server.frontend.NodeTestComponents.VaadinBowerComponent;
 import com.vaadin.flow.server.frontend.NodeTestComponents.VaadinElementMixin;
 import com.vaadin.flow.server.frontend.NodeTestComponents.VaadinMixedComponent;
 import com.vaadin.flow.server.frontend.NodeTestComponents.VaadinNpmComponent;
-import com.vaadin.flow.server.frontend.NodeTestComponents.VaadinShrinkWrap;
 import com.vaadin.flow.theme.AbstractTheme;
 import com.vaadin.flow.theme.NoTheme;
 import com.vaadin.flow.theme.Theme;
@@ -179,13 +178,10 @@ public class FullDependenciesScannerTest {
         Assert.assertEquals(packages.get("@foo/var-component"), "1.1.0");
         Assert.assertEquals(packages.get("@webcomponents/webcomponentsjs"),
                 "2.2.10");
-        Assert.assertEquals(packages.get("@vaadin/vaadin-shrinkwrap"), "1.2.3");
 
         Assert.assertEquals(5, packages.size());
 
         Set<String> visitedClasses = scanner.getClasses();
-        Assert.assertTrue(
-                visitedClasses.contains(VaadinShrinkWrap.class.getName()));
         Assert.assertTrue(
                 visitedClasses.contains(LocalP3Template.class.getName()));
         Assert.assertTrue(visitedClasses

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScannerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScannerTest.java
@@ -179,7 +179,7 @@ public class FullDependenciesScannerTest {
         Assert.assertEquals(packages.get("@webcomponents/webcomponentsjs"),
                 "2.2.10");
 
-        Assert.assertEquals(5, packages.size());
+        Assert.assertEquals(4, packages.size());
 
         Set<String> visitedClasses = scanner.getClasses();
         Assert.assertTrue(

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/ServerInfo.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/ServerInfo.java
@@ -15,22 +15,15 @@
  */
 package com.vaadin.base.devserver;
 
-import java.io.InputStream;
 import java.io.Serializable;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.Platform;
 import com.vaadin.flow.server.Version;
-
-import org.slf4j.LoggerFactory;
 
 /**
  * Data for a info message to the debug window.
  */
 public class ServerInfo implements Serializable {
-
-    private static boolean versionErrorLogged = false;
 
     private final String flowVersion;
     private final String vaadinVersion;
@@ -64,25 +57,7 @@ public class ServerInfo implements Serializable {
     }
 
     private String fetchVaadinVersion() {
-        try (InputStream vaadinVersionsStream = getClass().getClassLoader()
-                .getResourceAsStream(Constants.VAADIN_VERSIONS_JSON)) {
-            if (vaadinVersionsStream != null) {
-                ObjectMapper m = new ObjectMapper();
-                JsonNode vaadinVersions = m.readTree(vaadinVersionsStream);
-                return vaadinVersions.get("platform").asText();
-            } else {
-                if (!versionErrorLogged) {
-                    versionErrorLogged = true; // NOSONAR
-                    LoggerFactory.getLogger(getClass()).info(
-                            "Unable to determine version information. No vaadin_versions.json found");
-                }
-            }
-        } catch (Exception e) {
-            LoggerFactory.getLogger(getClass())
-                    .error("Unable to determine version information", e);
-        }
-
-        return "?";
+        return Platform.getVaadinVersion().orElse("?");
     }
 
     public String getFlowVersion() {


### PR DESCRIPTION
To decide whether additional cleanup is needed, store the 
platform version in `node_modules/.vaadin/vaadin.json`, then 
compare with the platform published version. Was previously 
checking `vaadin-shrinkwrap` in `package.json`, but this 
package is removed in V23.

Part of #13008