### PR TITLE
chore: update webdrivermanager version

### DIFF
--- a/flow-test-util/pom.xml
+++ b/flow-test-util/pom.xml
@@ -40,13 +40,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>5.0.3</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
-            </exclusions>
+            <version>5.1.0</version>
         </dependency>
 
         <!-- override scope for junit -->


### PR DESCRIPTION
Remove exclusion for guava since https://github.com/bonigarcia/webdrivermanager/issues/779 has been fixed and released.
