### PR TITLE
fix: Skip type checking of default library declaration files

### DIFF
--- a/flow-server/src/main/resources/tsconfig.json
+++ b/flow-server/src/main/resources/tsconfig.json
@@ -13,6 +13,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "experimentalDecorators": true,
+    "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
       "*": [


### PR DESCRIPTION
This skips type checking for default libraries and help with integration issues

Some problem has at least been encountered in the Start project as
```
node_modules/@types/eslint/index.d.ts:450:42 - error TS2724: '"/.../node_modules/@types/estree/index"' has no exported member named 'ChainExpression'. Did you mean 'ThisExpression'?
         ChainExpression?: ((node: ESTree.ChainExpression & NodeParentExtension) => void) | undefined;
```

See https://www.typescriptlang.org/tsconfig#skipDefaultLibCheck
