### PR TITLE
fix: enable skipDefaultLibCheck in the default TS config

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/tsconfig.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/tsconfig.json
@@ -11,6 +11,7 @@
     "target": "es2019",
     "moduleResolution": "node",
     "strict": true,
+    "skipDefaultLibCheck": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "noImplicitAny": true,


### PR DESCRIPTION
## Description

Currently, when the user wants to have a custom service worker in the `frontend` folder that looks like:

```ts
/// <reference lib="webworker" />

declare var self: ServiceWorkerGlobalScope;

// ...
```

...running the `tsc` utility will report conflicts in the standard TS library due to having a reference to the `webworker` lib.

```bash
node_modules/.pnpm/typescript@4.5.5/node_modules/typescript/lib/lib.dom.d.ts:25:1 - error TS6200: Definitions of the following identifiers conflict with those in another file: ImportExportKind, TableKind, ValueType, ExportValue, Exports, ImportValue, Imports, ModuleImports, name, AlgorithmIdentifier, BigInteger, BinaryData, BlobPart, BodyInit, BufferSource, CanvasImageSource, DOMHighResTimeStamp, DOMTimeStamp, EventListenerOrEventListenerObject, Float32List, FormDataEntryValue, GLbitfield, GLboolean, GLclampf, GLenum, GLfloat, GLint, GLint64, GLintptr, GLsizei, GLsizeiptr, GLuint, GLuint64, HashAlgorithmIdentifier, HeadersInit, IDBValidKey, ImageBitmapSource, Int32List, MessageEventSource, NamedCurve, OnErrorEventHandler, PerformanceEntryList, ReadableStreamController, ReadableStreamDefaultReadResult, ReadableStreamReader, RequestInfo, TexImageSource, TimerHandler, Transferable, Uint32List, VibratePattern, XMLHttpRequestBodyInit, BinaryType, ClientTypes, ColorGamut, ColorSpaceConversion, ConnectionType, EndingType, FontFaceLoadStatus, FontFaceSetLoadStatus, HdrMetadataType, IDBCursorDirection, IDBRequestReadyState, IDBTransactionMode, ImageOrientation, KeyFormat, KeyType, KeyUsage, MediaDecodingType, MediaEncodingType, NotificationDirection, NotificationPermission, PermissionName, PermissionState, PredefinedColorSpace, PremultiplyAlpha, PushEncryptionKeyName, PushPermissionState, ReferrerPolicy, RequestCache, RequestCredentials, RequestDestination, RequestMode, RequestRedirect, ResizeQuality, ResponseType, SecurityPolicyViolationEventDisposition, ServiceWorkerState, ServiceWorkerUpdateViaCache, TransferFunction, VisibilityState, WebGLPowerPreference, WorkerType, XMLHttpRequestResponseType

25 interface AddEventListenerOptions extends EventListenerOptions {
   ~~~~~~~~~

  node_modules/.pnpm/typescript@4.5.5/node_modules/typescript/lib/lib.webworker.d.ts:25:1
    25 interface AddEventListenerOptions extends EventListenerOptions {
       ~~~~~~~~~
    Conflicts are in this file.

node_modules/.pnpm/typescript@4.5.5/node_modules/typescript/lib/lib.dom.d.ts:3953:5 - error TS2374: Duplicate index signature for type 'number'.

3953     [index: number]: string;
         ~~~~~~~~~~~~~~~~~~~~~~~~
```

There is no other way to fix these conflicts except to enable the `skipDefaultLibCheck` option in the default TS config.

This issue wasn't noticeable before Vite because Webpack is using `fork-ts-checker-webpack-plugin` for type-checking that ignores such errors for some reason.

Part of #12383 

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.
