### PR TITLE
fix: handle service worker content in production mode when running on non root servlet mapping (#13073)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
@@ -441,10 +441,15 @@ public class StaticFileServer implements StaticFileHandler {
         // http://localhost:8888/context/servlet/VAADIN/folder/file.js
         // ->
         // /VAADIN/folder/file.js
+        //
+        // http://localhost:8888/context/servlet/sw.js
+        // ->
+        // /sw.js
         if (request.getPathInfo() == null) {
             return request.getServletPath();
         } else if (request.getPathInfo().startsWith("/" + VAADIN_MAPPING)
-                || APP_THEME_PATTERN.matcher(request.getPathInfo()).find()) {
+                || APP_THEME_PATTERN.matcher(request.getPathInfo()).find()
+                || request.getPathInfo().startsWith("/sw.js")) {
             return request.getPathInfo();
         }
         return request.getServletPath() + request.getPathInfo();

--- a/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
@@ -215,6 +215,27 @@ public class StaticFileServerTest implements Serializable {
         }
     }
 
+    @Test
+    public void getRequestFilename_shouldAlwaysBeResolvedAsRootResourceForServiceWorkerRequest() {
+        for (String swFile : new String[] { "/sw.js", "/sw.js.gz" }) {
+            Assert.assertEquals(swFile, getRequestFilename("", "", swFile));
+            Assert.assertEquals(swFile, getRequestFilename("", "/foo", swFile));
+            Assert.assertEquals(swFile,
+                    getRequestFilename("", "/foo/bar", swFile));
+            Assert.assertEquals(swFile, getRequestFilename("/ctx", "", swFile));
+            Assert.assertEquals(swFile,
+                    getRequestFilename("/ctx", "/foo", swFile));
+            Assert.assertEquals(swFile,
+                    getRequestFilename("/ctx", "/foo/bar", swFile));
+            Assert.assertEquals(swFile,
+                    getRequestFilename("/ctx/sub", "", swFile));
+            Assert.assertEquals(swFile,
+                    getRequestFilename("/ctx/sub", "/foo", swFile));
+            Assert.assertEquals(swFile,
+                    getRequestFilename("/ctx/sub", "/foo/bar", swFile));
+        }
+    }
+
     private String getRequestFilename(String encodedContextPath,
             String servletPath, String pathInfo) {
         setupRequestURI(encodedContextPath, servletPath, pathInfo);

--- a/flow-tests/test-ccdm-flow-navigation/src/main/java/com/vaadin/flow/navigate/DefaultMappingServlet.java
+++ b/flow-tests/test-ccdm-flow-navigation/src/main/java/com/vaadin/flow/navigate/DefaultMappingServlet.java
@@ -1,0 +1,9 @@
+package com.vaadin.flow.navigate;
+
+import javax.servlet.annotation.WebServlet;
+
+import com.vaadin.flow.server.VaadinServlet;
+
+@WebServlet(urlPatterns = { "/*" })
+public class DefaultMappingServlet extends VaadinServlet {
+}

--- a/flow-tests/test-ccdm-flow-navigation/src/main/java/com/vaadin/flow/navigate/NestedMappingServlet.java
+++ b/flow-tests/test-ccdm-flow-navigation/src/main/java/com/vaadin/flow/navigate/NestedMappingServlet.java
@@ -1,0 +1,9 @@
+package com.vaadin.flow.navigate;
+
+import javax.servlet.annotation.WebServlet;
+
+import com.vaadin.flow.server.VaadinServlet;
+
+@WebServlet(urlPatterns = { "/nested/*" })
+public class NestedMappingServlet extends VaadinServlet {
+}

--- a/flow-tests/test-ccdm-flow-navigation/src/test/java/com/vaadin/flow/navigate/ServiceWorkerOnNestedMappingIT.java
+++ b/flow-tests/test-ccdm-flow-navigation/src/test/java/com/vaadin/flow/navigate/ServiceWorkerOnNestedMappingIT.java
@@ -1,0 +1,20 @@
+package com.vaadin.flow.navigate;
+
+import org.junit.After;
+
+public class ServiceWorkerOnNestedMappingIT extends ServiceWorkerIT {
+
+    @Override
+    protected String getRootURL() {
+        return super.getRootURL() + "/nested";
+    }
+
+    @After
+    public void tearDown() {
+        if (getDriver() != null) {
+            checkLogsForErrors(message -> !message.toLowerCase()
+                    .contains("failed to register a serviceworker"));
+        }
+    }
+
+}


### PR DESCRIPTION
## Description

In production mode service worker content is loaded from `META-INF/VAADIN/webapp/sw.js` classpath resource. When running on a "non root" servlet mapping, sw.js was not served at all because servlet path was prepended to file name when getting resource from classpath.
This change handles the special case of "sw.js" in `StaticFileServer.getRequestFilename`, in order to ignore servlet path on the returned file name.

Fixes #13073

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
