### PR TITLE
fix: apply theme in V14 legacy mode

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -182,6 +182,8 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
         private JsonObject applicationParameters;
         private BootstrapUriResolver uriResolver;
 
+        private boolean initTheme = true;
+
         /**
          * Creates a new context instance using the given parameters.
          *
@@ -272,6 +274,25 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
          */
         public VaadinSession getSession() {
             return session;
+        }
+
+        /**
+         * Should custom theme be initialized.
+         * 
+         * @return true if theme should be initialized
+         */
+        public boolean isInitTheme() {
+            return initTheme;
+        }
+
+        /**
+         * Set if custom theme should be initialized.
+         * 
+         * @param initTheme
+         *            enable or disable theme initialisation
+         */
+        public void setInitTheme(boolean initTheme) {
+            this.initTheme = initTheme;
         }
 
         /**
@@ -661,6 +682,17 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             setupDocumentBody(document);
 
             document.outputSettings().prettyPrint(false);
+
+            // In V14 legacy bootstrap mode, the theme is initialized in
+            // target/frontend/generated-flow-imports.js but not in normal
+            // bootstrap mode and for exported webcomponents; set a flag in
+            // the DOM only if initialization is needed.
+            if (config.useV14Bootstrap() && context.isInitTheme()) {
+                head.prependElement("script").attr("type", "text/javascript")
+                        .appendChild(new DataNode(
+                                "window.Vaadin = window.Vaadin || {}; window.Vaadin.theme = window.Vaadin.theme || {};"
+                                        + "window.Vaadin.theme.flowBootstrap = true;"));
+            }
 
             BootstrapUtils.getInlineTargets(context)
                     .ifPresent(targets -> handleInlineTargets(context, head,

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
@@ -78,6 +78,7 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
                 Function<VaadinRequest, String> callback) {
             super(request, response, ui.getInternals().getSession(), ui,
                     callback);
+            setInitTheme(false);
         }
 
         @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -95,15 +95,19 @@ abstract class AbstractUpdateImports implements Runnable {
 
     private final File tokenFile;
 
-    private boolean productionMode;
+    private final boolean productionMode;
+
+    protected final boolean useLegacyV14Bootstrap;
 
     AbstractUpdateImports(File frontendDirectory, File npmDirectory,
-            File generatedDirectory, File tokenFile, boolean productionMode) {
+            File generatedDirectory, File tokenFile, boolean productionMode,
+            boolean useLegacyV14Bootstrap) {
         frontendDir = frontendDirectory;
         npmDir = npmDirectory;
         generatedDir = generatedDirectory;
         this.tokenFile = tokenFile;
         this.productionMode = productionMode;
+        this.useLegacyV14Bootstrap = useLegacyV14Bootstrap;
     }
 
     @Override
@@ -113,7 +117,7 @@ abstract class AbstractUpdateImports implements Runnable {
         lines.addAll(getExportLines());
         lines.addAll(getThemeLines());
         lines.addAll(getCssLines());
-        if (!productionMode) {
+        if (!productionMode && useLegacyV14Bootstrap) {
             // This is only needed for v14bootstrap mode
             lines.add(TaskGenerateBootstrap.DEVMODE_GIZMO_IMPORT);
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -124,7 +124,7 @@ public class NodeTasks implements FallibleCommand {
         /**
          * Is in client-side bootstrapping mode.
          */
-        private boolean useDeprecatedV14Bootstrapping;
+        private boolean useLegacyV14Bootstrap;
 
         /**
          * The node.js version to be used when node.js is installed
@@ -406,7 +406,7 @@ public class NodeTasks implements FallibleCommand {
          * @return the builder, for chaining
          */
         public Builder useV14Bootstrap(boolean useDeprecatedV14Bootstrapping) {
-            this.useDeprecatedV14Bootstrapping = useDeprecatedV14Bootstrapping;
+            this.useLegacyV14Bootstrap = useDeprecatedV14Bootstrapping;
             return this;
         }
 
@@ -726,8 +726,7 @@ public class NodeTasks implements FallibleCommand {
             frontendDependencies = new FrontendDependenciesScanner.FrontendDependenciesScannerFactory()
                     .createScanner(!builder.useByteCodeScanner, classFinder,
                             builder.generateEmbeddableWebComponents,
-                            builder.useDeprecatedV14Bootstrapping,
-                            featureFlags);
+                            builder.useLegacyV14Bootstrap, featureFlags);
 
             if (builder.generateEmbeddableWebComponents) {
                 FrontendWebComponentGenerator generator = new FrontendWebComponentGenerator(
@@ -774,7 +773,7 @@ public class NodeTasks implements FallibleCommand {
             addGenerateTsConfigTask(builder);
         }
 
-        if (!builder.useDeprecatedV14Bootstrapping) {
+        if (!builder.useLegacyV14Bootstrap) {
             addBootstrapTasks(builder);
 
             TaskGenerateHilla hillaTask = builder.lookup
@@ -831,21 +830,20 @@ public class NodeTasks implements FallibleCommand {
                     builder.npmFolder, builder.webappResourcesDirectory,
                     builder.resourceOutputDirectory,
                     new File(builder.generatedFolder, IMPORTS_NAME),
-                    builder.useDeprecatedV14Bootstrapping,
-                    builder.flowResourcesFolder, pwaConfiguration,
-                    builder.frontendGeneratedFolder, builder.buildDirectory));
+                    builder.useLegacyV14Bootstrap, builder.flowResourcesFolder,
+                    pwaConfiguration, builder.frontendGeneratedFolder,
+                    builder.buildDirectory));
         }
 
         if (builder.enableImportsUpdate) {
-            commands.add(
-                    new TaskUpdateImports(classFinder, frontendDependencies,
-                            finder -> getFallbackScanner(builder, finder,
-                                    featureFlags),
-                            builder.npmFolder, builder.generatedFolder,
-                            builder.frontendDirectory, builder.tokenFile,
-                            builder.tokenFileData, builder.enablePnpm,
-                            builder.buildDirectory, builder.productionMode,
-                            featureFlags));
+            commands.add(new TaskUpdateImports(classFinder,
+                    frontendDependencies,
+                    finder -> getFallbackScanner(builder, finder, featureFlags),
+                    builder.npmFolder, builder.generatedFolder,
+                    builder.frontendDirectory, builder.tokenFile,
+                    builder.tokenFileData, builder.enablePnpm,
+                    builder.buildDirectory, builder.productionMode,
+                    builder.useLegacyV14Bootstrap, featureFlags));
 
             commands.add(new TaskUpdateThemeImport(builder.npmFolder,
                     frontendDependencies.getThemeDefinition(),
@@ -929,8 +927,7 @@ public class NodeTasks implements FallibleCommand {
             return new FrontendDependenciesScanner.FrontendDependenciesScannerFactory()
                     .createScanner(true, finder,
                             builder.generateEmbeddableWebComponents,
-                            builder.useDeprecatedV14Bootstrapping,
-                            featureFlags);
+                            builder.useLegacyV14Bootstrap, featureFlags);
         } else {
             return null;
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -76,7 +76,8 @@ public class TaskUpdateImports extends NodeUpdater {
     private final JsonObject tokenFileData;
 
     private final boolean enablePnpm;
-    private boolean productionMode;
+    private final boolean productionMode;
+    private final boolean useLegacyV14Bootstrap;
 
     private class UpdateMainImportsFile extends AbstractUpdateImports {
         private static final String EXPORT_MODULES_DEF = "export declare const addCssBlock: (block: string, before?: boolean) => void;";
@@ -88,9 +89,10 @@ public class TaskUpdateImports extends NodeUpdater {
 
         UpdateMainImportsFile(ClassFinder classFinder, File frontendDirectory,
                 File npmDirectory, File generatedDirectory,
-                File fallBackImports, File tokenFile, boolean productionMode) {
+                File fallBackImports, File tokenFile, boolean productionMode,
+                boolean useLegacyV14Bootstrap) {
             super(frontendDirectory, npmDirectory, generatedDirectory,
-                    tokenFile, productionMode);
+                    tokenFile, productionMode, useLegacyV14Bootstrap);
             generatedFlowImports = new File(generatedDirectory, IMPORTS_NAME);
             generatedFlowDefinitions = new File(generatedDirectory,
                     IMPORTS_D_TS_NAME);
@@ -153,7 +155,16 @@ public class TaskUpdateImports extends NodeUpdater {
                 if (!theme.getHeaderInlineContents().isEmpty()) {
                     lines.add("");
                     if (hasApplicationTheme) {
-                        lines.add("// Handled in the application theme");
+                        if (useLegacyV14Bootstrap) {
+                            lines.add(
+                                    "import {applyTheme} from 'generated/theme.js';");
+                            lines.add(
+                                    "if (window.Vaadin.theme.flowBootstrap) {");
+                            lines.add("  applyTheme(document);");
+                            lines.add("}");
+                        } else {
+                            lines.add("// Handled in the application theme");
+                        }
                     }
                     theme.getHeaderInlineContents()
                             .forEach(html -> addLines(lines,
@@ -233,10 +244,10 @@ public class TaskUpdateImports extends NodeUpdater {
 
         UpdateFallBackImportsFile(ClassFinder classFinder,
                 File frontendDirectory, File npmDirectory,
-                File generatedDirectory, File tokenFile,
-                boolean productionMode) {
+                File generatedDirectory, File tokenFile, boolean productionMode,
+                boolean useLegacyV14Bootstrap) {
             super(frontendDirectory, npmDirectory, generatedDirectory,
-                    tokenFile, productionMode);
+                    tokenFile, productionMode, useLegacyV14Bootstrap);
             generatedFallBack = new File(generatedDirectory,
                     FrontendUtils.FALLBACK_IMPORTS_NAME);
             finder = classFinder;
@@ -353,7 +364,7 @@ public class TaskUpdateImports extends NodeUpdater {
             File npmFolder, File generatedPath, File frontendDirectory,
             File tokenFile, JsonObject tokenFileData, boolean enablePnpm,
             String buildDir, boolean productionMode,
-            FeatureFlags featureFlags) {
+            boolean useLegacyV14Bootstrap, FeatureFlags featureFlags) {
         super(finder, frontendDepScanner, npmFolder, generatedPath, null,
                 buildDir, featureFlags);
         this.frontendDirectory = frontendDirectory;
@@ -362,6 +373,7 @@ public class TaskUpdateImports extends NodeUpdater {
         this.tokenFileData = tokenFileData;
         this.enablePnpm = enablePnpm;
         this.productionMode = productionMode;
+        this.useLegacyV14Bootstrap = useLegacyV14Bootstrap;
     }
 
     @Override
@@ -370,7 +382,7 @@ public class TaskUpdateImports extends NodeUpdater {
         if (fallbackScanner != null) {
             UpdateFallBackImportsFile fallBackUpdate = new UpdateFallBackImportsFile(
                     finder, frontendDirectory, npmFolder, generatedFolder,
-                    tokenFile, productionMode);
+                    tokenFile, productionMode, useLegacyV14Bootstrap);
             fallBackUpdate.run();
             fallBack = fallBackUpdate.getGeneratedFallbackFile();
             updateBuildFile(fallBackUpdate);
@@ -378,7 +390,7 @@ public class TaskUpdateImports extends NodeUpdater {
 
         UpdateMainImportsFile mainUpdate = new UpdateMainImportsFile(finder,
                 frontendDirectory, npmFolder, generatedFolder, fallBack,
-                tokenFile, productionMode);
+                tokenFile, productionMode, useLegacyV14Bootstrap);
         mainUpdate.run();
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -152,19 +152,16 @@ public class TaskUpdateImports extends NodeUpdater {
                         && !"".equals(themeDef.getName());
                 // There is no application theme in use, write theme includes
                 // here. Otherwise they are written by the theme
+                if (useLegacyV14Bootstrap && hasApplicationTheme) {
+                    lines.add("import {applyTheme} from 'generated/theme.js';");
+                    lines.add("if (window.Vaadin.theme.flowBootstrap) {");
+                    lines.add("  applyTheme(document);");
+                    lines.add("}");
+                }
                 if (!theme.getHeaderInlineContents().isEmpty()) {
                     lines.add("");
                     if (hasApplicationTheme) {
-                        if (useLegacyV14Bootstrap) {
-                            lines.add(
-                                    "import {applyTheme} from 'generated/theme.js';");
-                            lines.add(
-                                    "if (window.Vaadin.theme.flowBootstrap) {");
-                            lines.add("  applyTheme(document);");
-                            lines.add("}");
-                        } else {
-                            lines.add("// Handled in the application theme");
-                        }
+                        lines.add("// Handled in the application theme");
                     }
                     theme.getHeaderInlineContents()
                             .forEach(html -> addLines(lines,

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdateImportsTest.java
@@ -85,7 +85,8 @@ public abstract class AbstractNodeUpdateImportsTest extends NodeUpdateTestUtil {
         ClassFinder classFinder = getClassFinder();
         updater = new TaskUpdateImports(classFinder, getScanner(classFinder),
                 finder -> null, tmpRoot, generatedPath, frontendDirectory, null,
-                null, false, TARGET, true, Mockito.mock(FeatureFlags.class)) {
+                null, false, TARGET, true, false,
+                Mockito.mock(FeatureFlags.class)) {
             @Override
             Logger log() {
                 return logger;

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
@@ -95,7 +95,7 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
                 FrontendDependenciesScanner scanner, File npmDirectory,
                 File tokenFile, boolean productionMode) {
             super(frontendDirectory, npmDirectory, generatedPath, tokenFile,
-                    productionMode);
+                    productionMode, false);
             this.scanner = scanner;
             finder = classFinder;
         }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/ComponentFlagsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/ComponentFlagsTest.java
@@ -147,6 +147,6 @@ public class ComponentFlagsTest extends NodeUpdateTestUtil {
         return new TaskUpdateImports(classFinder,
                 getScanner(classFinder, featureFlags), finder -> null, tmpRoot,
                 generatedPath, frontendDirectory, null, null, false, TARGET,
-                true, featureFlags);
+                true, false, featureFlags);
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateImportsTest.java
@@ -123,7 +123,7 @@ public class NodeUpdateImportsTest extends NodeUpdateTestUtil {
                 finder -> new FrontendDependenciesScannerFactory()
                         .createScanner(true, finder, true),
                 tmpRoot, generatedPath, frontendDirectory, tokenFile,
-                fallBackData, false, TARGET, true,
+                fallBackData, false, TARGET, true, false,
                 Mockito.mock(FeatureFlags.class)) {
             @Override
             Logger log() {
@@ -262,7 +262,7 @@ public class NodeUpdateImportsTest extends NodeUpdateTestUtil {
                 finder -> new FrontendDependenciesScannerFactory()
                         .createScanner(true, finder, true),
                 tmpRoot, generatedPath, frontendDirectory, tokenFile, null,
-                false, TARGET, true, Mockito.mock(FeatureFlags.class)) {
+                false, TARGET, true, false, Mockito.mock(FeatureFlags.class)) {
             @Override
             Logger log() {
                 return logger;
@@ -332,7 +332,7 @@ public class NodeUpdateImportsTest extends NodeUpdateTestUtil {
                 new FrontendDependenciesScannerFactory().createScanner(false,
                         classFinder, true),
                 finder -> null, tmpRoot, generatedPath, frontendDirectory,
-                tokenFile, null, false, TARGET, true,
+                tokenFile, null, false, TARGET, true, false,
                 Mockito.mock(FeatureFlags.class)) {
             @Override
             Logger log() {
@@ -378,7 +378,7 @@ public class NodeUpdateImportsTest extends NodeUpdateTestUtil {
                 new FrontendDependenciesScannerFactory().createScanner(false,
                         classFinder, true),
                 finder -> null, tmpRoot, generatedPath, frontendDirectory,
-                tokenFile, null, false, TARGET, true,
+                tokenFile, null, false, TARGET, true, false,
                 Mockito.mock(FeatureFlags.class)) {
             @Override
             Logger log() {
@@ -415,7 +415,7 @@ public class NodeUpdateImportsTest extends NodeUpdateTestUtil {
                 finder -> new FrontendDependenciesScannerFactory()
                         .createScanner(true, finder, true),
                 tmpRoot, generatedPath, frontendDirectory, tokenFile,
-                fallBackData, false, TARGET, true,
+                fallBackData, false, TARGET, true, false,
                 Mockito.mock(FeatureFlags.class)) {
             @Override
             Logger log() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/UpdateThemedImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/UpdateThemedImportsTest.java
@@ -149,7 +149,7 @@ public class UpdateThemedImportsTest extends NodeUpdateTestUtil {
         };
         updater = new TaskUpdateImports(finder, deps, cf -> null, tmpRoot,
                 generatedPath, frontendDirectory, null, null, false, TARGET,
-                true, Mockito.mock(FeatureFlags.class));
+                true, false, Mockito.mock(FeatureFlags.class));
     }
 
     @Test


### PR DESCRIPTION
This PR brings in the parts of 204d2cfddb8f438fbd48b0d0fcbea5fe55408f5b
that set a DOM flag to enable theme initialization in `generated-flow-imports.js`.
It is only activated in V14 legacy bootstrap mode.

Fixes #13041