### PR TITLE
fix: add Vaadin entry points to `optimizeDeps.entries`

### DIFF
--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -178,6 +178,12 @@ export const vaadinConfig: UserConfigFn = (env) => {
         allow: allowedFrontendFolders,
       }
     },
+    optimizeDeps: {
+      entries: [
+        // Pre-scan entrypoints in Vite to avoid reloading on first open
+        'generated/vaadin.ts'
+      ]
+    },
     build: {
       outDir: frontendBundleFolder,
       assetsDir: 'VAADIN/build',


### PR DESCRIPTION
## Description

Adds Vaadin entry points to `optimizeDeps.entries` in the Vite config in order to let Vite discover and pre-bundle dependencies already during the server startup, not waiting for their first request.

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
