### PR TITLE
feat: use Vaadin component container bundles in Vite dev mode (#13039) (CP: 23.0)

### DIFF
--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -5,12 +5,13 @@
  * This file will be overwritten on every run. Any custom changes should be made to vite.config.ts
  */
 import path from 'path';
+import {readFileSync} from 'fs';
 import * as net from 'net';
 
-import { processThemeResources } from '@vaadin/application-theme-plugin/theme-handle.js';
+import {processThemeResources} from '@vaadin/application-theme-plugin/theme-handle.js';
 import settings from '#settingsImport#';
-import { UserConfigFn, defineConfig, mergeConfig, PluginOption, ResolvedConfig } from 'vite';
-import { injectManifest } from 'workbox-build';
+import {defineConfig, mergeConfig, PluginOption, ResolvedConfig, UserConfigFn} from 'vite';
+import {injectManifest} from 'workbox-build';
 
 import * as rollup from 'rollup';
 import brotli from 'rollup-plugin-brotli';
@@ -115,6 +116,149 @@ function injectManifestToSWPlugin(): PluginOption {
   }
 }
 
+function vaadinBundlesPlugin(): PluginOption {
+  type ExportInfo = string | {
+    namespace?: string,
+    source: string,
+  };
+
+  type ExposeInfo = {
+    exports: ExportInfo[],
+  };
+
+  type PackageInfo = {
+    version: string,
+    exposes: Record<string, ExposeInfo>,
+  };
+
+  type BundleJson = {
+    packages: Record<string, PackageInfo>,
+  };
+
+  const disabledMessage = 'Vaadin component dependency bundles are disabled.'
+
+  const modulesDirectory = path.posix.resolve(__dirname, 'node_modules');
+
+  let vaadinBundleJson: BundleJson;
+
+  function parseModuleId(id: string): { packageName: string, modulePath: string } {
+    const [scope, scopedPackageName] = id.split('/', 3);
+    const packageName = scope.startsWith('@') ? `${scope}/${scopedPackageName}` : scope;
+    const modulePath = `.${id.substring(packageName.length)}`;
+    return {
+      packageName,
+      modulePath
+    };
+  }
+
+  function getExports(id: string): string[] | undefined {
+    const {
+      packageName,
+      modulePath
+    } = parseModuleId(id);
+    const packageInfo = vaadinBundleJson.packages[packageName];
+
+    if (!packageInfo) return;
+
+    const exposeInfo: ExposeInfo = packageInfo.exposes[modulePath];
+    if (!exposeInfo) return;
+
+    const exportsSet = new Set<string>();
+    for (const e of exposeInfo.exports) {
+      if (typeof e === 'string') {
+        exportsSet.add(e);
+      } else {
+        const {namespace, source} = e;
+        if (namespace) {
+          exportsSet.add(namespace);
+        } else {
+          const sourceExports = getExports(source);
+          if (sourceExports) {
+            sourceExports.forEach((e) => exportsSet.add(e));
+          }
+        }
+      }
+    }
+    return Array.from(exportsSet);
+  }
+
+  return {
+    name: 'vaadin:bundles',
+    enforce: 'pre',
+    apply(config, {command}) {
+      if (command !== "serve") return false;
+
+      try {
+        const vaadinBundleJsonPath = require.resolve('@vaadin/bundles/vaadin-bundle.json');
+        vaadinBundleJson = JSON.parse(readFileSync(vaadinBundleJsonPath, {encoding: 'utf8'}));
+      } catch (e: unknown) {
+        if (typeof e === 'object' && (e as {code: string}).code === 'MODULE_NOT_FOUND') {
+          vaadinBundleJson = {packages: {}};
+          console.info(`@vaadin/bundles npm package is not found, ${disabledMessage}`);
+          return false;
+        } else {
+          throw e;
+        }
+      }
+
+      const versionMismatches: Array<{name: string, bundledVersion: string, installedVersion: string}> = [];
+      for (const [name, packageInfo] of Object.entries(vaadinBundleJson.packages)) {
+        let installedVersion: string | undefined = undefined;
+        try {
+          const { version: bundledVersion } = packageInfo;
+          const installedPackageJsonFile = path.resolve(modulesDirectory, name, 'package.json');
+          const packageJson = JSON.parse(readFileSync(installedPackageJsonFile, {encoding: 'utf8'}));
+          installedVersion = packageJson.version;
+          if (installedVersion && installedVersion !== bundledVersion) {
+            versionMismatches.push({
+              name,
+              bundledVersion,
+              installedVersion
+            });
+          }
+        } catch (_) {
+          // ignore package not found
+        }
+      }
+      if (versionMismatches.length) {
+        console.info(`@vaadin/bundles has version mismatches with installed packages, ${disabledMessage}`);
+        console.info(`Packages with version mismatches: ${JSON.stringify(versionMismatches, undefined, 2)}`);
+        vaadinBundleJson = {packages: {}};
+        return false;
+      }
+
+      return true;
+    },
+    async config(config) {
+      return mergeConfig({
+        optimizeDeps: {
+          exclude: [
+            // Vaadin bundle
+            '@vaadin/bundles',
+            ...Object.keys(vaadinBundleJson.packages)
+          ]
+        }
+      }, config);
+    },
+    load(rawId) {
+      const [path, params] = rawId.split('?');
+      if (!path.startsWith(modulesDirectory)) return;
+
+      const id = path.substring(modulesDirectory.length + 1);
+      const exports = getExports(id);
+      if (exports === undefined) return;
+
+      const cacheSuffix = params ? `?${params}` : '';
+      const bundlePath = `@vaadin/bundles/vaadin.js${cacheSuffix}`;
+
+      return `import { init as VaadinBundleInit, get as VaadinBundleGet } from '${bundlePath}';
+await VaadinBundleInit('default');
+const { ${exports.join(', ')} } = (await VaadinBundleGet('./node_modules/${id}'))();
+export { ${exports.map((binding) => `${binding} as ${binding}`).join(', ')} };`;
+    }
+  }
+}
+
 function updateTheme(contextPath: string) {
   const themePath = path.resolve(themeFolder);
   if (contextPath.startsWith(themePath)) {
@@ -168,7 +312,8 @@ export const vaadinConfig: UserConfigFn = (env) => {
       alias: {
         themes: themeFolder,
         Frontend: frontendFolder
-      }
+      },
+      preserveSymlinks: true,
     },
     define: {
       OFFLINE_PATH: settings.offlinePath
@@ -193,8 +338,18 @@ export const vaadinConfig: UserConfigFn = (env) => {
         }
       }
     },
+    optimizeDeps: {
+      entries: [
+        // Pre-scan entrypoints in Vite to avoid reloading on first open
+        'generated/vaadin.ts'
+      ],
+      exclude: [
+        '@vaadin/router'
+      ]
+    },
     plugins: [
       !devMode && brotli(),
+      devMode && vaadinBundlesPlugin(),
       settings.pwaEnabled && transpileSWPlugin(),
       settings.pwaEnabled && injectManifestToSWPlugin(),
       {

--- a/flow-tests/test-frontend/vite-basics/frontend/testscopebuttonloader.js
+++ b/flow-tests/test-frontend/vite-basics/frontend/testscopebuttonloader.js
@@ -1,0 +1,4 @@
+import '@testscope/all';
+
+import { Button } from '@testscope/button';
+window.BundleButtonClass = Button;

--- a/flow-tests/test-frontend/vite-basics/src/main/java/com/vaadin/viteapp/views/empty/MainView.java
+++ b/flow-tests/test-frontend/vite-basics/src/main/java/com/vaadin/viteapp/views/empty/MainView.java
@@ -1,6 +1,9 @@
 package com.vaadin.viteapp.views.empty;
 
 import com.vaadin.experimental.FeatureFlags;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Html;
+import com.vaadin.flow.component.HtmlComponent;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.html.Div;
@@ -14,6 +17,7 @@ import com.vaadin.flow.router.Route;
 @JsModule("./jsonloader.js")
 @JsModule("package-outside-npm/index.js")
 @JsModule("package2-outside-npm/index.js")
+@JsModule("./testscopebuttonloader.js")
 public class MainView extends Div {
 
     public static final String LOAD_AND_SHOW_JSON = "loadAndShowJson";
@@ -69,6 +73,8 @@ public class MainView extends Div {
         Paragraph outsideStatus = new Paragraph();
         outsideStatus.setId(OUTSIDE_RESULT);
         add(outsideStatus);
+
+        add(new HtmlComponent("testscope-button"));
     }
 
 }

--- a/flow-tests/test-frontend/vite-basics/src/test/java/com/vaadin/viteapp/BundlesIT.java
+++ b/flow-tests/test-frontend/vite-basics/src/test/java/com/vaadin/viteapp/BundlesIT.java
@@ -1,0 +1,43 @@
+package com.vaadin.viteapp;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class BundlesIT extends ViteDevModeIT {
+
+    @Test
+    public void bundlesIsUsed() {
+        Assert.assertTrue((Boolean) $("testscope-button").first()
+                .getProperty("isFromBundle"));
+    }
+
+    @Test
+    public void bundleExportWorks() {
+        Assert.assertTrue(
+                (Boolean) executeScript("return !!window.BundleButtonClass"));
+    }
+
+    @Test
+    public void optimizeDepsConfigHasEntrypoint() {
+        Assert.assertTrue((Boolean) executeScript(
+                "return window.ViteConfigOptimizeDeps.entries.includes('generated/vaadin.ts')"));
+    }
+
+    @Test
+    public void optimizeDepsExcludesBundles() {
+        Assert.assertTrue(isExcluded("@vaadin/bundles"));
+    }
+
+    @Test
+    public void optimizeDepsExcludeBundleContents() {
+        Assert.assertTrue(isExcluded("@testscope/all"));
+        Assert.assertTrue(isExcluded("@testscope/button"));
+    }
+
+    private boolean isExcluded(String dependency) {
+        return (Boolean) executeScript(
+                "return (window.ViteConfigOptimizeDeps.exclude || []).includes(arguments[0]);",
+                dependency);
+    }
+
+}

--- a/flow-tests/test-frontend/vite-basics/vite.config.ts
+++ b/flow-tests/test-frontend/vite-basics/vite.config.ts
@@ -1,14 +1,38 @@
-import { UserConfigFn } from 'vite';
+import {
+  PluginOption,
+  UserConfigFn
+} from 'vite';
 import { overrideVaadinConfig } from './vite.generated';
+
+/**
+ * Dumps effective contents of config.optimizeDeps for tests
+ */
+function dumpOptimizeDepsPlugin(): PluginOption {
+  let config;
+
+  return {
+    name: 'dump-optimize-deps',
+    configResolved(_config) {
+      config = _config;
+    },
+    transformIndexHtml(html) {
+      return [
+        {
+          injectTo: 'head',
+          tag: 'script',
+          children: `window.ViteConfigOptimizeDeps = ${JSON.stringify(config.optimizeDeps)};`
+        }
+      ];
+    }
+  }
+}
 
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
-  server: {
-    fs: {
-      allow: ['../package-outside-npm', '../package2-outside-npm']
-    }
-  }
+  plugins: [
+    dumpOptimizeDepsPlugin()
+  ]
 });
 
 export default overrideVaadinConfig(customConfig);

--- a/flow-tests/test-frontend/vite-context-path/package.json
+++ b/flow-tests/test-frontend/vite-context-path/package.json
@@ -5,16 +5,13 @@
     "@polymer/polymer": "3.4.1",
     "@testscope/all": "../vite-test-assets/packages/@testscope/all",
     "@testscope/button": "../vite-test-assets/packages/@testscope/button",
-    "@vaadin/bundles": "../vite-test-assets/packages/@vaadin/bundles",
+    "@vaadin/bundles": "../vite-test-assets/packages/@vaadin/bundles-old",
     "@vaadin/common-frontend": "0.0.17",
     "@vaadin/flow-frontend": "./target/flow-frontend",
     "@vaadin/router": "1.7.4",
     "@vaadin/vaadin-lumo-styles": "22.0.0-alpha9",
     "construct-style-sheets-polyfill": "3.0.4",
-    "copy-to-clipboard": "^3.3.1",
-    "lit": "2.0.0",
-    "package-outside-npm": "file:package-outside-npm",
-    "package2-outside-npm": "./package2-outside-npm"
+    "lit": "2.1.4"
   },
   "devDependencies": {
     "@vaadin/application-theme-plugin": "./target/plugins/application-theme-plugin",
@@ -38,7 +35,7 @@
       "@vaadin/router": "1.7.4",
       "@vaadin/vaadin-lumo-styles": "22.0.0-alpha9",
       "construct-style-sheets-polyfill": "3.0.4",
-      "lit": "2.0.0"
+      "lit": "2.1.4"
     },
     "devDependencies": {
       "glob": "7.1.6",
@@ -51,6 +48,6 @@
       "workbox-core": "6.4.2",
       "workbox-precaching": "6.4.2"
     },
-    "hash": "1fbd15f1fc5035e3b4c52bd7b61168316b3b8ea359e30c73c01d39373962b5da"
+    "hash": "9e28d81c2b643176481210207d77fc2f89c0285e989d5f672a7f710434fb06fb"
   }
 }

--- a/flow-tests/test-frontend/vite-context-path/src/main/java/com/vaadin/viteapp/views/empty/MainView.java
+++ b/flow-tests/test-frontend/vite-context-path/src/main/java/com/vaadin/viteapp/views/empty/MainView.java
@@ -1,12 +1,15 @@
 package com.vaadin.viteapp.views.empty;
 
+import com.vaadin.flow.component.HtmlComponent;
+import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.router.Route;
 
 @Route("")
+@JsModule("@testscope/all")
 public class MainView extends Div {
     public MainView() {
-        add(new H2("Hello world!"));
+        add(new H2("Hello world!"), new HtmlComponent("testscope-button"));
     }
 }

--- a/flow-tests/test-frontend/vite-context-path/src/test/java/com/vaadin/viteapp/BundlesIT.java
+++ b/flow-tests/test-frontend/vite-context-path/src/test/java/com/vaadin/viteapp/BundlesIT.java
@@ -1,0 +1,44 @@
+package com.vaadin.viteapp;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+import com.vaadin.testbench.TestBenchElement;
+
+public class BundlesIT extends ChromeBrowserTest {
+
+    @BeforeClass
+    public static void driver() {
+        WebDriverManager.chromedriver().setup();
+    }
+
+    @Before
+    public void openView() {
+        getDriver().get(getRootURL() + "/my-context");
+        waitForDevServer();
+        getCommandExecutor().waitForVaadin();
+    }
+
+    @Test
+    public void bundlesIsNotUsedWhenHasVersionMismatch() {
+        Assert.assertFalse((Boolean) $("testscope-button").first()
+                .getProperty("isFromBundle"));
+    }
+
+    @Test
+    public void optimizeDepsNotExcludeBundleContents() {
+        Assert.assertFalse(isExcluded("@testscope/all"));
+        Assert.assertFalse(isExcluded("@testscope/button"));
+    }
+
+    private boolean isExcluded(String dependency) {
+        return (Boolean) executeScript(
+                "return (window.ViteConfigOptimizeDeps.exclude || []).includes(arguments[0]);",
+                dependency);
+    }
+
+}

--- a/flow-tests/test-frontend/vite-context-path/vite.config.ts
+++ b/flow-tests/test-frontend/vite-context-path/vite.config.ts
@@ -1,9 +1,35 @@
 import { UserConfigFn } from 'vite';
 import { overrideVaadinConfig } from './vite.generated';
 
+/**
+ * Dumps effective contents of config.optimizeDeps for tests
+ */
+function dumpOptimizeDepsPlugin(): PluginOption {
+  let config;
+
+  return {
+    name: 'dump-optimize-deps',
+    configResolved(_config) {
+      config = _config;
+    },
+    transformIndexHtml(html) {
+      return [
+        {
+          injectTo: 'head',
+          tag: 'script',
+          children: `window.ViteConfigOptimizeDeps = ${JSON.stringify(config.optimizeDeps)};`
+        }
+      ];
+    }
+  }
+}
+
 const customConfig: UserConfigFn = (env) => ({
   // Here you can add custom Vite parameters
   // https://vitejs.dev/config/
+  plugins: [
+    dumpOptimizeDepsPlugin()
+  ]
 });
 
 export default overrideVaadinConfig(customConfig);

--- a/flow-tests/test-frontend/vite-production/package.json
+++ b/flow-tests/test-frontend/vite-production/package.json
@@ -11,10 +11,7 @@
     "@vaadin/router": "1.7.4",
     "@vaadin/vaadin-lumo-styles": "22.0.0-alpha9",
     "construct-style-sheets-polyfill": "3.0.4",
-    "copy-to-clipboard": "^3.3.1",
-    "lit": "2.0.0",
-    "package-outside-npm": "file:package-outside-npm",
-    "package2-outside-npm": "./package2-outside-npm"
+    "lit": "2.0.0"
   },
   "devDependencies": {
     "@vaadin/application-theme-plugin": "./target/plugins/application-theme-plugin",
@@ -51,6 +48,6 @@
       "workbox-core": "6.4.2",
       "workbox-precaching": "6.4.2"
     },
-    "hash": "1fbd15f1fc5035e3b4c52bd7b61168316b3b8ea359e30c73c01d39373962b5da"
+    "hash": "1bcda35280e3531e661975533150ac4314b38195f2b7b2c4afb2ea43597626a6"
   }
 }

--- a/flow-tests/test-frontend/vite-production/src/main/java/com/vaadin/viteapp/views/empty/MainView.java
+++ b/flow-tests/test-frontend/vite-production/src/main/java/com/vaadin/viteapp/views/empty/MainView.java
@@ -1,5 +1,7 @@
 package com.vaadin.viteapp.views.empty;
 
+import com.vaadin.flow.component.HtmlComponent;
+import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.Image;
@@ -8,6 +10,7 @@ import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.router.Route;
 
 @Route("")
+@JsModule("@testscope/button")
 public class MainView extends Div {
 
     public static final String PLANT = "plant";
@@ -28,6 +31,8 @@ public class MainView extends Div {
         add(button);
         setSizeFull();
         getStyle().set("text-align", "center");
+
+        add(new HtmlComponent("testscope-button"));
     }
 
 }

--- a/flow-tests/test-frontend/vite-production/src/test/java/com/vaadin/viteapp/BundlesIT.java
+++ b/flow-tests/test-frontend/vite-production/src/test/java/com/vaadin/viteapp/BundlesIT.java
@@ -1,0 +1,25 @@
+package com.vaadin.viteapp;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class BundlesIT extends ChromeBrowserTest {
+
+    @BeforeClass
+    public static void driver() {
+        WebDriverManager.chromedriver().setup();
+    }
+
+    @Test
+    public void bundlesIsNotUsed() {
+        getDriver().get(getRootURL());
+        waitForClientRouter();
+        Assert.assertFalse((Boolean) $("testscope-button").first()
+                .getProperty("isFromBundle"));
+    }
+
+}

--- a/flow-tests/test-frontend/vite-production/vite.config.ts
+++ b/flow-tests/test-frontend/vite-production/vite.config.ts
@@ -1,0 +1,9 @@
+import { UserConfigFn } from 'vite';
+import { overrideVaadinConfig } from './vite.generated';
+
+const customConfig: UserConfigFn = (env) => ({
+  // Here you can add custom Vite parameters
+  // https://vitejs.dev/config/
+});
+
+export default overrideVaadinConfig(customConfig);

--- a/flow-tests/test-frontend/vite-test-assets/.gitignore
+++ b/flow-tests/test-frontend/vite-test-assets/.gitignore
@@ -1,0 +1,1 @@
+!packages/**/package.json

--- a/flow-tests/test-frontend/vite-test-assets/packages/@testscope/all/all.js
+++ b/flow-tests/test-frontend/vite-test-assets/packages/@testscope/all/all.js
@@ -1,0 +1,1 @@
+import '@testscope/button'

--- a/flow-tests/test-frontend/vite-test-assets/packages/@testscope/all/package.json
+++ b/flow-tests/test-frontend/vite-test-assets/packages/@testscope/all/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@testscope/all",
+  "version": "1.0.0",
+  "description": "",
+  "type": "module",
+  "main": "all.js",
+  "module": "all.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Vaadin Ltd",
+  "license": "Apache-2.0"
+}

--- a/flow-tests/test-frontend/vite-test-assets/packages/@testscope/button/package.json
+++ b/flow-tests/test-frontend/vite-test-assets/packages/@testscope/button/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@testscope/button",
+  "version": "1.0.0",
+  "description": "",
+  "type": "module",
+  "main": "testscope-button.js",
+  "module": "testscope-button.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Vaadin Ltd",
+  "license": "Apache-2.0"
+}

--- a/flow-tests/test-frontend/vite-test-assets/packages/@testscope/button/src/testscope-button.js
+++ b/flow-tests/test-frontend/vite-test-assets/packages/@testscope/button/src/testscope-button.js
@@ -1,0 +1,17 @@
+export class Button extends HTMLElement {
+  static get is() {
+    return 'testscope-button';
+  }
+
+  connectedCallback() {
+    if (!this.textContent) {
+      this.textContent = 'testscope-button NOT from bundle';
+    }
+  }
+
+  get isFromBundle() {
+    return false;
+  }
+}
+
+customElements.define('testscope-button', Button);

--- a/flow-tests/test-frontend/vite-test-assets/packages/@testscope/button/testscope-button.js
+++ b/flow-tests/test-frontend/vite-test-assets/packages/@testscope/button/testscope-button.js
@@ -1,0 +1,1 @@
+export * from './src/testscope-button.js'

--- a/flow-tests/test-frontend/vite-test-assets/packages/@vaadin/bundles-old/package.json
+++ b/flow-tests/test-frontend/vite-test-assets/packages/@vaadin/bundles-old/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@test/bundles",
+  "version": "0.1.0",
+  "description": "",
+  "type": "module",
+  "main": "vaadin.js",
+  "module": "vaadin.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Vaadin Ltd",
+  "license": "Apache-2.0"
+}

--- a/flow-tests/test-frontend/vite-test-assets/packages/@vaadin/bundles-old/vaadin-bundle.json
+++ b/flow-tests/test-frontend/vite-test-assets/packages/@vaadin/bundles-old/vaadin-bundle.json
@@ -1,0 +1,43 @@
+{
+  "packages": {
+    "@testscope/all": {
+      "version": "0.1.0",
+      "exposes": {
+        "./all.js": {
+          "exports": []
+        },
+        ".": {
+          "exports": [
+            {
+              "source": "@testscope/all/all.js"
+            }
+          ]
+        }
+      }
+    },
+    "@testscope/button": {
+      "version": "1.0.0-alpha1",
+      "exposes": {
+        "./testscope-button.js": {
+          "exports": [
+            {
+              "source": "@testscope/button/src/testscope-button.js"
+            }
+          ]
+        },
+        "./src/testscope-button.js": {
+          "exports": [
+            "Button"
+          ]
+        },
+        ".": {
+          "exports": [
+            {
+              "source": "@testscope/button/testscope-button.js"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/flow-tests/test-frontend/vite-test-assets/packages/@vaadin/bundles-old/vaadin.js
+++ b/flow-tests/test-frontend/vite-test-assets/packages/@vaadin/bundles-old/vaadin.js
@@ -1,0 +1,1 @@
+throw new Error('Unexpected use of the bundle!');

--- a/flow-tests/test-frontend/vite-test-assets/packages/@vaadin/bundles/package.json
+++ b/flow-tests/test-frontend/vite-test-assets/packages/@vaadin/bundles/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@vaadin/bundles",
+  "version": "1.0.0",
+  "description": "",
+  "type": "module",
+  "main": "vaadin.js",
+  "module": "vaadin.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Vaadin Ltd",
+  "license": "Apache-2.0"
+}

--- a/flow-tests/test-frontend/vite-test-assets/packages/@vaadin/bundles/vaadin-bundle.json
+++ b/flow-tests/test-frontend/vite-test-assets/packages/@vaadin/bundles/vaadin-bundle.json
@@ -1,0 +1,43 @@
+{
+  "packages": {
+    "@testscope/all": {
+      "version": "1.0.0",
+      "exposes": {
+        "./all.js": {
+          "exports": []
+        },
+        ".": {
+          "exports": [
+            {
+              "source": "@testscope/all/all.js"
+            }
+          ]
+        }
+      }
+    },
+    "@testscope/button": {
+      "version": "1.0.0",
+      "exposes": {
+        "./testscope-button.js": {
+          "exports": [
+            {
+              "source": "@testscope/button/src/testscope-button.js"
+            }
+          ]
+        },
+        "./src/testscope-button.js": {
+          "exports": [
+            "Button"
+          ]
+        },
+        ".": {
+          "exports": [
+            {
+              "source": "@testscope/button/testscope-button.js"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/flow-tests/test-frontend/vite-test-assets/packages/@vaadin/bundles/vaadin.js
+++ b/flow-tests/test-frontend/vite-test-assets/packages/@vaadin/bundles/vaadin.js
@@ -1,0 +1,88 @@
+// Call data for test assertion, real bundles don’t provide this object
+const TestBundleData = {
+  init: {
+    shareScopes: {}
+  },
+  moduleFactoryResults: {},
+};
+window.TestBundleData = TestBundleData;
+
+function wrapModuleFactory(module, moduleScopeFn) {
+  return () => {
+    if (TestBundleData.moduleFactoryResults[module]) {
+      return TestBundleData.moduleFactoryResults[module];
+    } else {
+      const exports = moduleScopeFn() || {};
+      TestBundleData.moduleFactoryResults[module] = exports;
+      return exports;
+    }
+  };
+}
+
+const moduleMap = {};
+
+function defineModule(module, moduleScopeFn) {
+  moduleMap[module] = wrapModuleFactory(module, moduleScopeFn);
+}
+
+function internalImport(module) {
+  return moduleMap[module]();
+}
+
+defineModule("./node_modules/@testscope/all", () => {
+  // re-export from package alias
+  return internalImport("./node_modules/@testscope/all/all.js");
+});
+
+defineModule("./node_modules/@testscope/all/all.js", () => {
+  // imports package for side effects, empty export
+  internalImport("./node_modules/@testscope/button");
+  return {};
+});
+
+defineModule("./node_modules/@testscope/button", () => {
+  // re-export from package alias
+  return internalImport("./node_modules/@testscope/button/testscope-button.js");
+});
+
+defineModule("./node_modules/@testscope/button/testscope-button.js", () => {
+  // re-export from another module
+  return internalImport("./node_modules/@testscope/button/src/testscope-button.js");
+});
+
+defineModule("./node_modules/@testscope/button/src/testscope-button.js", () => {
+  class Button extends HTMLElement {
+    static get is() {
+      return 'testscope-button';
+    }
+
+    connectedCallback() {
+      if (!this.textContent) {
+        this.textContent = 'testscope-button from bundle';
+      }
+    }
+
+    get isFromBundle() {
+      return true;
+    }
+  }
+
+  customElements.define('testscope-button', Button);
+
+  // export the web component class
+  return { Button };
+});
+
+export function init(shareScope) {
+  if (!TestBundleData.init.shareScopes[shareScope]) {
+    TestBundleData.init.shareScopes[shareScope] = true;
+  }
+}
+
+export async function get(module) {
+  if (moduleMap[module]) {
+    return Promise.resolve(moduleMap[module]);
+  } else {
+    throw new Error(`Module ${module} does not exist in container.`);
+  }
+}


### PR DESCRIPTION
Enables using use pre-bundled modules from @vaadin/bundles in Vite development mode, if available

Disables bundle usage if different package versions are installed

Fixes #12941
