### PR TITLE
refactor: format `vite.generated.ts` with Prettier

### DIFF
--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -5,13 +5,13 @@
  * This file will be overwritten on every run. Any custom changes should be made to vite.config.ts
  */
 import path from 'path';
-import {readFileSync} from 'fs';
+import { readFileSync } from 'fs';
 import * as net from 'net';
 
-import {processThemeResources} from '@vaadin/application-theme-plugin/theme-handle.js';
+import { processThemeResources } from '@vaadin/application-theme-plugin/theme-handle.js';
 import settings from '#settingsImport#';
-import {defineConfig, mergeConfig, PluginOption, ResolvedConfig, UserConfigFn} from 'vite';
-import {injectManifest} from 'workbox-build';
+import { defineConfig, mergeConfig, PluginOption, ResolvedConfig, UserConfigFn } from 'vite';
+import { injectManifest } from 'workbox-build';
 
 import * as rollup from 'rollup';
 import brotli from 'rollup-plugin-brotli';
@@ -64,15 +64,15 @@ function buildSWPlugin(): PluginOption {
         'vite:esbuild',
         'rollup-plugin-dynamic-import-variables',
         'vite:esbuild-transpile',
-        'vite:terser',
-      ]
+        'vite:terser'
+      ];
       const rollupPlugins: rollup.Plugin[] = config.plugins.filter((p) => {
-        return includedPluginNames.includes(p.name)
+        return includedPluginNames.includes(p.name);
       });
       rollupPlugins.push(
         replace({
           'process.env.NODE_ENV': JSON.stringify(config.mode),
-          ...config.define,
+          ...config.define
         })
       );
 
@@ -81,14 +81,14 @@ function buildSWPlugin(): PluginOption {
         format: 'es',
         exports: 'none',
         sourcemap: config.command === 'serve' || config.build.sourcemap,
-        inlineDynamicImports: true,
-      }
+        inlineDynamicImports: true
+      };
 
       const rollupConfig: rollup.RollupOptions = {
         input: path.resolve(settings.clientServiceWorkerSource),
         output: rollupOutput,
-        plugins: rollupPlugins,
-      }
+        plugins: rollupPlugins
+      };
 
       const bundle = await rollup.rollup(rollupConfig);
       try {
@@ -96,8 +96,8 @@ function buildSWPlugin(): PluginOption {
       } finally {
         await bundle.close();
       }
-    },
-  }
+    }
+  };
 }
 
 function injectManifestToSWPlugin(): PluginOption {
@@ -108,7 +108,7 @@ function injectManifestToSWPlugin(): PluginOption {
     }
 
     return { manifest, warnings: [] };
-  }
+  };
 
   return {
     name: 'vaadin:inject-manifest-to-sw',
@@ -126,35 +126,37 @@ function injectManifestToSWPlugin(): PluginOption {
         maximumFileSizeToCacheInBytes: 100 * 1024 * 1024 // 100mb,
       });
     }
-  }
+  };
 }
 
 function vaadinBundlesPlugin(): PluginOption {
-  type ExportInfo = string | {
-    namespace?: string,
-    source: string,
-  };
+  type ExportInfo =
+    | string
+    | {
+        namespace?: string;
+        source: string;
+      };
 
   type ExposeInfo = {
-    exports: ExportInfo[],
+    exports: ExportInfo[];
   };
 
   type PackageInfo = {
-    version: string,
-    exposes: Record<string, ExposeInfo>,
+    version: string;
+    exposes: Record<string, ExposeInfo>;
   };
 
   type BundleJson = {
-    packages: Record<string, PackageInfo>,
+    packages: Record<string, PackageInfo>;
   };
 
-  const disabledMessage = 'Vaadin component dependency bundles are disabled.'
+  const disabledMessage = 'Vaadin component dependency bundles are disabled.';
 
   const modulesDirectory = path.posix.resolve(__dirname, 'node_modules');
 
   let vaadinBundleJson: BundleJson;
 
-  function parseModuleId(id: string): { packageName: string, modulePath: string } {
+  function parseModuleId(id: string): { packageName: string; modulePath: string } {
     const [scope, scopedPackageName] = id.split('/', 3);
     const packageName = scope.startsWith('@') ? `${scope}/${scopedPackageName}` : scope;
     const modulePath = `.${id.substring(packageName.length)}`;
@@ -165,10 +167,7 @@ function vaadinBundlesPlugin(): PluginOption {
   }
 
   function getExports(id: string): string[] | undefined {
-    const {
-      packageName,
-      modulePath
-    } = parseModuleId(id);
+    const { packageName, modulePath } = parseModuleId(id);
     const packageInfo = vaadinBundleJson.packages[packageName];
 
     if (!packageInfo) return;
@@ -181,7 +180,7 @@ function vaadinBundlesPlugin(): PluginOption {
       if (typeof e === 'string') {
         exportsSet.add(e);
       } else {
-        const {namespace, source} = e;
+        const { namespace, source } = e;
         if (namespace) {
           exportsSet.add(namespace);
         } else {
@@ -198,15 +197,15 @@ function vaadinBundlesPlugin(): PluginOption {
   return {
     name: 'vaadin:bundles',
     enforce: 'pre',
-    apply(config, {command}) {
-      if (command !== "serve") return false;
+    apply(config, { command }) {
+      if (command !== 'serve') return false;
 
       try {
         const vaadinBundleJsonPath = require.resolve('@vaadin/bundles/vaadin-bundle.json');
-        vaadinBundleJson = JSON.parse(readFileSync(vaadinBundleJsonPath, {encoding: 'utf8'}));
+        vaadinBundleJson = JSON.parse(readFileSync(vaadinBundleJsonPath, { encoding: 'utf8' }));
       } catch (e: unknown) {
-        if (typeof e === 'object' && (e as {code: string}).code === 'MODULE_NOT_FOUND') {
-          vaadinBundleJson = {packages: {}};
+        if (typeof e === 'object' && (e as { code: string }).code === 'MODULE_NOT_FOUND') {
+          vaadinBundleJson = { packages: {} };
           console.info(`@vaadin/bundles npm package is not found, ${disabledMessage}`);
           return false;
         } else {
@@ -214,13 +213,13 @@ function vaadinBundlesPlugin(): PluginOption {
         }
       }
 
-      const versionMismatches: Array<{name: string, bundledVersion: string, installedVersion: string}> = [];
+      const versionMismatches: Array<{ name: string; bundledVersion: string; installedVersion: string }> = [];
       for (const [name, packageInfo] of Object.entries(vaadinBundleJson.packages)) {
         let installedVersion: string | undefined = undefined;
         try {
           const { version: bundledVersion } = packageInfo;
           const installedPackageJsonFile = path.resolve(modulesDirectory, name, 'package.json');
-          const packageJson = JSON.parse(readFileSync(installedPackageJsonFile, {encoding: 'utf8'}));
+          const packageJson = JSON.parse(readFileSync(installedPackageJsonFile, { encoding: 'utf8' }));
           installedVersion = packageJson.version;
           if (installedVersion && installedVersion !== bundledVersion) {
             versionMismatches.push({
@@ -236,22 +235,25 @@ function vaadinBundlesPlugin(): PluginOption {
       if (versionMismatches.length) {
         console.info(`@vaadin/bundles has version mismatches with installed packages, ${disabledMessage}`);
         console.info(`Packages with version mismatches: ${JSON.stringify(versionMismatches, undefined, 2)}`);
-        vaadinBundleJson = {packages: {}};
+        vaadinBundleJson = { packages: {} };
         return false;
       }
 
       return true;
     },
     async config(config) {
-      return mergeConfig({
-        optimizeDeps: {
-          exclude: [
-            // Vaadin bundle
-            '@vaadin/bundles',
-            ...Object.keys(vaadinBundleJson.packages)
-          ]
-        }
-      }, config);
+      return mergeConfig(
+        {
+          optimizeDeps: {
+            exclude: [
+              // Vaadin bundle
+              '@vaadin/bundles',
+              ...Object.keys(vaadinBundleJson.packages)
+            ]
+          }
+        },
+        config
+      );
     },
     load(rawId) {
       const [path, params] = rawId.split('?');
@@ -269,7 +271,7 @@ await VaadinBundleInit('default');
 const { ${exports.join(', ')} } = (await VaadinBundleGet('./node_modules/${id}'))();
 export { ${exports.map((binding) => `${binding} as ${binding}`).join(', ')} };`;
     }
-  }
+  };
 }
 
 function updateTheme(contextPath: string) {
@@ -326,7 +328,7 @@ export const vaadinConfig: UserConfigFn = (env) => {
         themes: themeFolder,
         Frontend: frontendFolder
       },
-      preserveSymlinks: true,
+      preserveSymlinks: true
     },
     define: {
       OFFLINE_PATH: settings.offlinePath,
@@ -334,7 +336,7 @@ export const vaadinConfig: UserConfigFn = (env) => {
     },
     server: {
       fs: {
-        allow: allowedFrontendFolders,
+        allow: allowedFrontendFolders
       }
     },
     optimizeDeps: {
@@ -357,9 +359,7 @@ export const vaadinConfig: UserConfigFn = (env) => {
         // Pre-scan entrypoints in Vite to avoid reloading on first open
         'generated/vaadin.ts'
       ],
-      exclude: [
-        '@vaadin/router'
-      ]
+      exclude: ['@vaadin/router']
     },
     plugins: [
       !devMode && brotli(),
@@ -405,25 +405,25 @@ export const vaadinConfig: UserConfigFn = (env) => {
                 {
                   tag: 'script',
                   attrs: { type: 'module', src: `${basePath}generated/vite-devmode.ts` },
-                  injectTo: 'head',
+                  injectTo: 'head'
                 },
                 {
                   tag: 'script',
                   attrs: { type: 'module', src: `${basePath}generated/vaadin.ts` },
-                  injectTo: 'head',
+                  injectTo: 'head'
                 }
-              ]
+              ];
             }
 
             return [
               {
                 tag: 'script',
                 attrs: { type: 'module', src: './generated/vaadin.ts' },
-                injectTo: 'head',
+                injectTo: 'head'
               }
-            ]
-          },
-        },
+            ];
+          }
+        }
       },
       checker({
         typescript: true


### PR DESCRIPTION
## Description

Fixes formatting issues for `vite.generated.ts` by running it through Prettier.

A follow-up to #13039, #12928.

## Type of change

- [x] Refactoring

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
