### PR TITLE
chore: remove fusion-endpoint from jandex index

### DIFF
--- a/flow-jandex/pom.xml
+++ b/flow-jandex/pom.xml
@@ -38,11 +38,6 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>fusion-endpoint</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
             <artifactId>flow-polymer-template</artifactId>
             <version>${project.version}</version>
         </dependency>


### PR DESCRIPTION
## Description

Presence of fusion-endpoint classes in index may break quarkus builds
because of Spring API usage.

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
