### PR TITLE
fix: let vaadinPush.js script always be served by Vaadin

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/communication/AtmospherePushConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/AtmospherePushConnection.java
@@ -727,7 +727,7 @@ public class AtmospherePushConnection implements PushConnection {
             Console.log("Loading " + pushJs);
             ResourceLoader loader = registry.getResourceLoader();
             String pushScriptUrl = registry.getApplicationConfiguration()
-                    .getContextRootUrl() + pushJs;
+                    .getServiceUrl() + pushJs;
             ResourceLoadListener loadListener = new ResourceLoadListener() {
                 @Override
                 public void onLoad(ResourceLoadEvent event) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -1615,8 +1615,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
         // Parameter appended to JS to bypass caches after version upgrade.
         String versionQueryParam = "?v=" + Version.getFullVersion();
         // Load client-side dependencies for push support
-        String pushJSPath = context.getService()
-                .getContextRootRelativePath(request);
+        String pushJSPath = BootstrapHandlerHelper.getServiceUrl(request) + "/";
 
         if (request.getService().getDeploymentConfiguration()
                 .isProductionMode()) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/MockServletServiceSessionSetup.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/MockServletServiceSessionSetup.java
@@ -424,6 +424,12 @@ public class MockServletServiceSessionSetup {
 
     public VaadinRequest createRequest(MockServletServiceSessionSetup mocks,
             String path, String queryString) {
+        return createRequest(mocks, path, "", queryString);
+    }
+
+    public VaadinRequest createRequest(MockServletServiceSessionSetup mocks,
+            String path, String servletPath, String queryString) {
+
         QueryParameters queryParams = QueryParameters.fromString(queryString);
         Map<String, List<String>> params = queryParams.getParameters();
         HttpServletRequest httpServletRequest = Mockito
@@ -437,7 +443,7 @@ public class MockServletServiceSessionSetup {
 
             @Override
             public String getServletPath() {
-                return "";
+                return servletPath;
             }
 
             @Override
@@ -456,7 +462,7 @@ public class MockServletServiceSessionSetup {
             @Override
             public StringBuffer getRequestURL() {
                 return new StringBuffer(
-                        "http://localhost:8888" + getPathInfo());
+                        "http://localhost:8888" + servletPath + getPathInfo());
             }
         };
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandlerTest.java
@@ -206,6 +206,24 @@ public class JavaScriptBootstrapHandlerTest {
     }
 
     @Test
+    public void should_respondPushScript_when_nonRootServletPath()
+            throws Exception {
+        mocks.getDeploymentConfiguration().setPushMode(PushMode.AUTOMATIC);
+
+        VaadinRequest request = mocks.createRequest(mocks, "/", "/vaadin/",
+                "v-r=init&foo&location=");
+        jsInitHandler.handleRequest(session, request, response);
+
+        Assert.assertEquals(200, response.getErrorCode());
+        Assert.assertEquals("application/json", response.getContentType());
+        JsonObject json = Json.parse(response.getPayload());
+
+        // Using regex, because version depends on the build
+        Assert.assertTrue(json.getString("pushScript").matches(
+                "^\\./VAADIN/static/push/vaadinPush\\.js\\?v=[\\w\\.\\-]+$"));
+    }
+
+    @Test
     public void should_invoke_modifyPushConfiguration() throws Exception {
         AppShellRegistry registry = Mockito.mock(AppShellRegistry.class);
         mocks.setAppShellRegistry(registry);

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ActivatePushView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ActivatePushView.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.page.Push;
+import com.vaadin.flow.router.Route;
+import com.vaadin.flow.shared.communication.PushMode;
+
+@Route("com.vaadin.flow.uitest.ui.ActivatePushView")
+public class ActivatePushView extends Div {
+
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        attachEvent.getUI().getPushConfiguration()
+                .setPushMode(PushMode.AUTOMATIC);
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/VaadinPushScriptIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/VaadinPushScriptIT.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.shared.ApplicationConstants;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testcategory.IgnoreOSGi;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+@Category(IgnoreOSGi.class)
+public class VaadinPushScriptIT extends ChromeBrowserTest {
+
+    @Test
+    public void pushScriptURL_urlMapping_fromJavascriptBootstrapHandler() {
+        // Push script url set by server side bootstrap handler
+        getDriver().get(
+                getRootURL() + "/view/" + PushSettingsView.class.getName());
+        waitForDevServer();
+        assertThatPushScriptUrlIsRelativeToUrlMapping(
+                findElement(By.tagName("body")));
+    }
+
+    @Test
+    public void pushScriptURL_urlMapping_fromClientSide() {
+        // Push script URL computed by client side (AtmospherePushConnection)
+        // as consequence of server side push configuration change
+        getDriver().get(
+                getRootURL() + "/view/" + ActivatePushView.class.getName());
+        waitForDevServer();
+
+        assertThatPushScriptUrlIsRelativeToUrlMapping(
+                findElement(By.tagName("head")));
+    }
+
+    private void assertThatPushScriptUrlIsRelativeToUrlMapping(
+            WebElement scriptContainer) {
+        String pushScriptUrl = scriptContainer
+                .findElements(By.tagName("script")).stream()
+                .map(script -> script.getAttribute("src"))
+                .filter(scriptUrl -> scriptUrl != null && scriptUrl
+                        .contains(ApplicationConstants.VAADIN_PUSH_DEBUG_JS))
+                .findFirst().orElse(null);
+
+        Assert.assertNotNull(ApplicationConstants.VAADIN_PUSH_DEBUG_JS
+                + " script not loaded by page", pushScriptUrl);
+        Assert.assertTrue("Push script not relative to Vaadin servlet mapping",
+                pushScriptUrl.contains(
+                        "/view/" + ApplicationConstants.VAADIN_PUSH_DEBUG_JS));
+    }
+
+}


### PR DESCRIPTION
## Description

vaadinPush script url doesn't took into account potential servlet path and was always relative to context path; this can cause the script not to be served by Vaadin StaticFileHandler, but directly by container or non Vaadin handlers (for example in Spring applications).
This change makes the script URL relative to servlet path, so it is forced to be served by Vaadin StaticFileHandler.

Fixes #13153

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
