### PR TITLE
fix: check postinstall before run

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -433,6 +433,9 @@ public class TaskRunNpmInstall implements FallibleCommand {
                         .getJsonFileContent(
                                 new File(packageFolder, "package.json"));
                 if (!containsPostinstallScript(packageJson)) {
+                    logger.debug(
+                            "Skipping postinstall for '{}' as no postinstall script was found in the package.json",
+                            postinstallPackage);
                     continue;
                 }
             } catch (IOException ioe) {


### PR DESCRIPTION
Check that there is a postinstall
script available before executing
it to not receive error in the logs.

Fixes #12861
