### PR TITLE
fix: remove home node_modules before install

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/AbstractGradleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/AbstractGradleTest.kt
@@ -27,7 +27,7 @@ import java.io.File
  */
 abstract class AbstractGradleTest {
 
-    val flowVersion = System.getenv("vaadin.version").takeUnless { it.isNullOrEmpty() } ?: "10.0-SNAPSHOT"
+    val flowVersion = System.getenv("vaadin.version").takeUnless { it.isNullOrEmpty() } ?: "23.1-SNAPSHOT"
 
     /**
      * The testing Gradle project. Automatically deleted after every test.

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
@@ -221,13 +221,12 @@ class MiscSingleModuleTest : AbstractGradleTest() {
     fun testSpringProjectProductionMode() {
 
         val springBootVersion = "2.2.4.RELEASE"
-        val springVersion = "17.0-SNAPSHOT"
 
         testProject.buildFile.writeText(
             """
             plugins {
                 id 'org.springframework.boot' version '$springBootVersion'
-                id 'io.spring.dependency-management' version '1.0.9.RELEASE'
+                id 'io.spring.dependency-management' version '1.0.11.RELEASE'
                 id 'java'
                 id("com.vaadin")
             }
@@ -247,7 +246,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
             
             dependencies {
                 implementation('com.vaadin:flow:$flowVersion')
-                implementation('com.vaadin:vaadin-spring:$springVersion')
+                implementation('com.vaadin:vaadin-spring:$flowVersion')
                 implementation('org.springframework.boot:spring-boot-starter-web:$springBootVersion')
                 developmentOnly 'org.springframework.boot:spring-boot-devtools'
                 testImplementation('org.springframework.boot:spring-boot-starter-test') {

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinBuildFrontendTask.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinBuildFrontendTask.kt
@@ -68,8 +68,6 @@ public open class VaadinBuildFrontendTask : DefaultTask() {
         val tokenFile = BuildFrontendUtil.getTokenFile(adapter)
         check(tokenFile.exists()) { "token file $tokenFile doesn't exist!" }
 
-        BuildFrontendUtil.updateBuildFile(adapter)
-
         BuildFrontendUtil.runNodeUpdater(adapter)
 
         if (adapter.generateBundle()) {
@@ -77,5 +75,7 @@ public open class VaadinBuildFrontendTask : DefaultTask() {
         } else {
             logger.info("Not running webpack since generateBundle is false")
         }
+
+        BuildFrontendUtil.updateBuildFile(adapter)
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -139,12 +139,9 @@ public class TaskUpdatePackages extends NodeUpdater {
 
         JsonObject overridesSection = getOverridesSection(packageJson);
         final JsonObject dependencies = packageJson.getObject(DEPENDENCIES);
-        final JsonObject devDependencies = packageJson
-                .getObject(DEV_DEPENDENCIES);
         for (String dependency : versionsJson.keys()) {
             if (!overridesSection.hasKey(dependency)
-                    && (dependencies.hasKey(dependency)
-                            || devDependencies.hasKey(dependency))
+                    && dependencies.hasKey(dependency)
                     && !isInternalPseudoDependency(
                             versionsJson.getString(dependency))) {
                 overridesSection.put(dependency, "$" + dependency);
@@ -153,7 +150,6 @@ public class TaskUpdatePackages extends NodeUpdater {
         }
         for (String dependency : overridesSection.keys()) {
             if (!dependencies.hasKey(dependency)
-                    && !devDependencies.hasKey(dependency)
                     && overridesSection.getString(dependency).startsWith("$")) {
                 overridesSection.remove(dependency);
                 versionLockingUpdated = true;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
@@ -316,6 +316,13 @@ public class NodeInstaller {
         File nodeModulesDirectory = new File(destinationDirectory,
                 FrontendUtils.NODE_MODULES);
         File npmDirectory = new File(nodeModulesDirectory, "npm");
+
+        // delete old npm directory to not end up with corrupted combination
+        // of two npm versions in node_modules/npm during upgrade
+        if (npmDirectory.exists()) {
+            FileUtils.deleteDirectory(npmDirectory);
+        }
+
         FileUtils.copyDirectory(tmpNodeModulesDir, nodeModulesDirectory);
         // create a copy of the npm scripts next to the node executable
         for (String script : Arrays.asList("npm", "npm.cmd")) {
@@ -357,6 +364,12 @@ public class NodeInstaller {
                             + FrontendUtils.NODE_MODULES);
             File nodeModulesDirectory = new File(destinationDirectory,
                     FrontendUtils.NODE_MODULES);
+            // delete old npm directory to not end up with corrupted combination
+            // of two npm versions in node_modules/npm during upgrade
+            File npmDirectory = new File(nodeModulesDirectory, "npm");
+            if (npmDirectory.exists()) {
+                FileUtils.deleteDirectory(npmDirectory);
+            }
             FileUtils.copyDirectory(tmpNodeModulesDir, nodeModulesDirectory);
         }
         deleteTempDirectory(data.getTmpDirectory());

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
@@ -365,7 +365,8 @@ public class NodeInstaller {
             File nodeModulesDirectory = new File(destinationDirectory,
                     FrontendUtils.NODE_MODULES);
             // delete old node_modules directory to not end up with corrupted
-            // combination of two npm versions in node_modules/npm during upgrade
+            // combination of two npm versions in node_modules/npm during
+            // upgrade
             if (nodeModulesDirectory.exists()) {
                 FileUtils.deleteDirectory(nodeModulesDirectory);
             }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
@@ -317,10 +317,10 @@ public class NodeInstaller {
                 FrontendUtils.NODE_MODULES);
         File npmDirectory = new File(nodeModulesDirectory, "npm");
 
-        // delete old npm directory to not end up with corrupted combination
-        // of two npm versions in node_modules/npm during upgrade
-        if (npmDirectory.exists()) {
-            FileUtils.deleteDirectory(npmDirectory);
+        // delete old node_modules directory to not end up with corrupted
+        // combination of two npm versions in node_modules/npm during upgrade
+        if (nodeModulesDirectory.exists()) {
+            FileUtils.deleteDirectory(nodeModulesDirectory);
         }
 
         FileUtils.copyDirectory(tmpNodeModulesDir, nodeModulesDirectory);
@@ -364,11 +364,10 @@ public class NodeInstaller {
                             + FrontendUtils.NODE_MODULES);
             File nodeModulesDirectory = new File(destinationDirectory,
                     FrontendUtils.NODE_MODULES);
-            // delete old npm directory to not end up with corrupted combination
-            // of two npm versions in node_modules/npm during upgrade
-            File npmDirectory = new File(nodeModulesDirectory, "npm");
-            if (npmDirectory.exists()) {
-                FileUtils.deleteDirectory(npmDirectory);
+            // delete old node_modules directory to not end up with corrupted
+            // combination of two npm versions in node_modules/npm during upgrade
+            if (nodeModulesDirectory.exists()) {
+                FileUtils.deleteDirectory(nodeModulesDirectory);
             }
             FileUtils.copyDirectory(tmpNodeModulesDir, nodeModulesDirectory);
         }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/installer/NodeInstallerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/installer/NodeInstallerTest.java
@@ -12,6 +12,7 @@ import java.util.zip.ZipOutputStream;
 import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -89,6 +90,15 @@ public class NodeInstallerTest {
             }
         }
 
+        // add a file to node/node_modules_npm that should be cleaned out
+        File nodeDirectory = new File(targetDir, "node");
+        File nodeModulesDirectory = new File(nodeDirectory, "node_modules");
+        File npmDirectory = new File(nodeModulesDirectory, "npm");
+        File garbage = new File(npmDirectory, "garbage");
+        FileUtils.forceMkdir(npmDirectory);
+        Assert.assertTrue("garbage file should be created",
+                garbage.createNewFile());
+
         NodeInstaller nodeInstaller = new NodeInstaller(targetDir,
                 Collections.emptyList())
                         .setNodeVersion(FrontendTools.DEFAULT_NODE_VERSION)
@@ -105,5 +115,7 @@ public class NodeInstallerTest {
                 new File(targetDir, "node/" + nodeExec).exists());
         Assert.assertTrue("npm should have been copied to node_modules",
                 new File(targetDir, "node/node_modules/npm/bin/npm").exists());
+        Assert.assertFalse("old npm files should have been removed",
+                garbage.exists());
     }
 }


### PR DESCRIPTION
Files left by previous node+npm installation caused
corrupted installation when unpacking on top of an
existing installation. Fixed by removing 
~/.vaadin/node/node_modules prior to
installation of newer version.
