### PR TITLE
feat: Add scrollIntoView method to Component

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/Component.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Component.java
@@ -682,6 +682,6 @@ public abstract class Component
      * window.
      */
     public void scrollIntoView() {
-        getElement().callJsFunction("scrollIntoView");
+        getElement().scrollIntoView();
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/Component.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Component.java
@@ -676,4 +676,11 @@ public abstract class Component
         }
         return locale;
     }
+
+    /**
+     * Scrolls the current component into the visible area of the browser window.
+     */
+    public void scrollIntoView() {
+        getElement().callJsFunction("scrollIntoView");
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/Component.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Component.java
@@ -678,7 +678,8 @@ public abstract class Component
     }
 
     /**
-     * Scrolls the current component into the visible area of the browser window.
+     * Scrolls the current component into the visible area of the browser
+     * window.
      */
     public void scrollIntoView() {
         getElement().callJsFunction("scrollIntoView");

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -1603,4 +1603,17 @@ public class Element extends Node<Element> {
         }
     }
 
+    /**
+     * Executes the similarly named DOM method on the client side.
+     *
+     * @see <a href=
+     *      "https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView">Mozilla
+     *      docs</a>
+     */
+    public void scrollIntoView() {
+        // for an unknown reason, needs to be called deferred to work on a newly
+        // created element
+        executeJs(
+                "var el = this; setTimeout(function() {el.scrollIntoView();}, 0);");
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -1609,11 +1609,13 @@ public class Element extends Node<Element> {
      * @see <a href=
      *      "https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView">Mozilla
      *      docs</a>
+     * @return the element
      */
-    public void scrollIntoView() {
+    public Element scrollIntoView() {
         // for an unknown reason, needs to be called deferred to work on a newly
         // created element
         executeJs(
                 "var el = this; setTimeout(function() {el.scrollIntoView();}, 0);");
+        return getSelf();
     }
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/scroll/ScrollableView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/scroll/ScrollableView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2000-2021 Vaadin Ltd.
+ * Copyright 2000-2022 Vaadin Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/scroll/ScrollableView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/scroll/ScrollableView.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.scroll;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "com.vaadin.flow.uitest.ui.scroll.ScrollableView")
+public class ScrollableView extends Div {
+
+    public static final String TEST_VIEW_ID = "ScrollableView";
+
+    public ScrollableView() {
+        setId(TEST_VIEW_ID);
+
+        Span button = new Span("Click to scroll");
+        button.setId("button");
+        button.addClickListener(e -> {
+            getComponentAt(500).scrollIntoView();
+        });
+        add(button);
+
+        for (int i = 0; i < 1000; i++) {
+            Div div = new Div();
+            div.setId("div-" + i);
+            div.setText("div-" + i);
+            add(div);
+        }
+
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/scroll/ScrollableView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/scroll/ScrollableView.java
@@ -41,5 +41,7 @@ public class ScrollableView extends Div {
             add(div);
         }
 
+        getComponentAt(500).scrollIntoView();
+
     }
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/scroll/ScrollableViewIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/scroll/ScrollableViewIT.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.scroll;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+
+public class ScrollableViewIT extends ChromeBrowserTest {
+
+    @Override
+    protected Class<? extends Component> getViewClass() {
+        return ScrollableView.class;
+    }
+
+    @Override
+    public void setup() throws Exception {
+        super.setup();
+        open();
+    }
+
+    @Test
+    public void scrollIntoView() {
+        Assert.assertTrue(getScrollY() == 0);
+        findElement(By.id("button")).click();
+        Assert.assertTrue(getScrollY() > 0);
+    }
+
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/scroll/ScrollableViewIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/scroll/ScrollableViewIT.java
@@ -36,6 +36,8 @@ public class ScrollableViewIT extends ChromeBrowserTest {
 
     @Test
     public void scrollIntoView() {
+        Assert.assertTrue(getScrollY() != 0);
+        scrollBy(0, -getScrollY());
         Assert.assertTrue(getScrollY() == 0);
         findElement(By.id("button")).click();
         Assert.assertTrue(getScrollY() > 0);


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

This change adds back a scrollIntoView method that we had in past framework versions.

The implementation is a trivial shorthand to the similarly named DOM method, and very handy in UI development.
It has been requested by multiple SoF and forum users, but apparently nobody wants to write this trivial enhancement issues as I couldn't find an existing issue for this.

The implementation leaves door open for overloading the method with a version with additional parameters, but already this method should solve most use cases.

## Type of change

- [ ] Bugfix
- [x] Feature

