### PR TITLE
fix: do not clean manual dev references

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -148,8 +148,11 @@ public class TaskUpdatePackages extends NodeUpdater {
                 versionLockingUpdated = true;
             }
         }
+        final JsonObject devDependencies = packageJson
+                .getObject(DEV_DEPENDENCIES);
         for (String dependency : overridesSection.keys()) {
             if (!dependencies.hasKey(dependency)
+                    && !devDependencies.hasKey(dependency)
                     && overridesSection.getString(dependency).startsWith("$")) {
                 overridesSection.remove(dependency);
                 versionLockingUpdated = true;


### PR DESCRIPTION
If a devDependency reference has
been manually added to override
do not clean those.
