### PR TITLE
fix: Include vaadin-spring in flow-bom

### DIFF
--- a/flow-bom/pom.xml
+++ b/flow-bom/pom.xml
@@ -78,6 +78,11 @@
                 <artifactId>flow-jandex</artifactId>
                 <version>${project.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.vaadin</groupId>
+                <artifactId>vaadin-spring</artifactId>
+                <version>${project.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>


### PR DESCRIPTION
This is needed so that when overriding the Flow version in a project you will get the correct vaadin-spring version also
