### PR TITLE
fix: Do not accidentally invoke a global node through postinstall scripts

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -435,8 +435,10 @@ public class FrontendUtils {
             String path = environment.get(pathEnvVar);
             if (path == null || path.isEmpty()) {
                 path = commandPath;
-            } else if (!path.contains(commandPath)) {
-                path += File.pathSeparatorChar + commandPath;
+            } else {
+                // Ensure that a custom node is first in the path so it is used
+                // e.g. for postinstall scripts that run "node something"
+                path = commandPath + File.pathSeparatorChar + path;
             }
             environment.put(pathEnvVar, path);
         }


### PR DESCRIPTION
If a postinstall script contains e.g. "node install.js" like esbuild then it will use "node" from PATH to run the script.
In this case, the Vaadin installed node must come first, before any other node versions mentioned in the PATH
