### PR TITLE
fix: Do not assume a tool is broken if it outputs to stderr

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsLocator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsLocator.java
@@ -210,12 +210,14 @@ public class FrontendToolsLocator implements Serializable {
             return null;
         }
         if (!commandResult.stderr.isEmpty()) {
+            // "npm -v" can output deprecation warnings to stderr but it still
+            // works
             if (log().isDebugEnabled()) {
-                log().debug("Command '{}' has non-empty stderr:\n'{}'",
+                log().debug(
+                        "Command '{}' has non-empty stderr but assuming this is fine:\n'{}'",
                         commandResult.command,
                         String.join("\n", commandResult.stderr));
             }
-            return null;
         }
         return commandResult;
     }


### PR DESCRIPTION
In some cases, npm -v can prefix the version by something like this printed to stderr

(node: 1124) [LRU_CACHE_OPTION_maxAge] DeprecationWarning: The maxAge option is deprecated. please use options.ttl instead

This should not be interpreted like npm does not work.

Fixes #13195
