### PR TITLE
fix: distinct dom-module ids

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -497,7 +497,7 @@ abstract class AbstractUpdateImports implements Runnable {
         if (cssData.getId() != null) {
             optionalsMap.put("moduleId", cssData.getId());
         } else if (cssData.getThemefor() != null) {
-            optionalsMap.put("moduleId", getThemeIdPrefix());
+            optionalsMap.put("moduleId", getThemeIdPrefix() + "_" + i);
         }
         String optionals = "";
         if (!optionalsMap.isEmpty()) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdateImportsTest.java
@@ -139,9 +139,9 @@ public abstract class AbstractNodeUpdateImportsTest extends NodeUpdateTestUtil {
         expectedLines.add(
                 "registerStyles('', $css_4, {include: 'bar', moduleId: 'baz'});");
         expectedLines.add(
-                "registerStyles('foo-bar', $css_5, {moduleId: 'flow_css_mod'});");
+                "registerStyles('foo-bar', $css_5, {moduleId: 'flow_css_mod_5'});");
         expectedLines.add(
-                "registerStyles('foo-bar', $css_6, {include: 'bar', moduleId: 'flow_css_mod'});");
+                "registerStyles('foo-bar', $css_6, {include: 'bar', moduleId: 'flow_css_mod_6'});");
 
         assertFalse(importsFile.exists());
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
@@ -31,6 +31,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -323,9 +325,9 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
         expectedLines.add(
                 "registerStyles('', $css_4, {include: 'bar', moduleId: 'baz'});");
         expectedLines.add(
-                "registerStyles('foo-bar', $css_5, {moduleId: 'flow_css_mod'});");
+                "registerStyles('foo-bar', $css_5, {moduleId: 'flow_css_mod_5'});");
         expectedLines.add(
-                "registerStyles('foo-bar', $css_6, {include: 'bar', moduleId: 'flow_css_mod'});");
+                "registerStyles('foo-bar', $css_6, {include: 'bar', moduleId: 'flow_css_mod_6'});");
 
         expectedLines.add("import 'generated-modules-foo';");
         expectedLines.add("import 'generated-modules-bar';");
@@ -338,6 +340,17 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
                             + updater.resultingLines,
                     updater.resultingLines.contains(line));
         }
+
+        // All generated module ids are distinct
+        Pattern moduleIdPattern = Pattern
+                .compile(".*moduleId: '(flow_css_mod_[^']*)'.*");
+        List<String> moduleIds = updater.resultingLines.stream()
+                .map(moduleIdPattern::matcher).filter(Matcher::matches)
+                .map(m -> m.group(1)).collect(Collectors.toList());
+        long uniqueModuleIds = moduleIds.stream().distinct().count();
+        Assert.assertTrue("expected modules", moduleIds.size() > 0);
+        Assert.assertEquals("duplicates in generated " + moduleIds,
+                moduleIds.size(), uniqueModuleIds);
 
         String output = logger.getLogs();
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateImportsTest.java
@@ -155,7 +155,7 @@ public class NodeUpdateImportsTest extends NodeUpdateTestUtil {
         MatcherAssert.assertThat(mainContent, CoreMatchers.containsString(
                 "import $cssFromFile_5 from 'Frontend/foo.css';"));
         MatcherAssert.assertThat(mainContent, CoreMatchers.containsString(
-                "registerStyles('foo-bar', $css_5, {moduleId: 'flow_css_mod'});"));
+                "registerStyles('foo-bar', $css_5, {moduleId: 'flow_css_mod_5'});"));
 
         // Contains theme imports
         MatcherAssert.assertThat(mainContent, CoreMatchers.containsString(
@@ -211,7 +211,7 @@ public class NodeUpdateImportsTest extends NodeUpdateTestUtil {
         MatcherAssert.assertThat(fallBackContent, CoreMatchers.containsString(
                 "import $cssFromFile_0 from 'Frontend/b-css.css';"));
         MatcherAssert.assertThat(fallBackContent, CoreMatchers.containsString(
-                "registerStyles('extra-foo', $css_2, {include: 'extra-bar', moduleId: 'fallback_flow_css_mod'});"));
+                "registerStyles('extra-foo', $css_2, {include: 'extra-bar', moduleId: 'fallback_flow_css_mod_2'});"));
 
         // Does not contains JS module imports
         MatcherAssert.assertThat(fallBackContent, CoreMatchers.not(CoreMatchers


### PR DESCRIPTION
Fix a regression where identical ids were
generated for distinct `@CssImport`s

Fixes #13211