### PR TITLE
test: fix test for jetty10

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
@@ -146,12 +146,8 @@ class MiscSingleModuleTest : AbstractGradleTest() {
                 compile("org.slf4j:slf4j-simple:1.7.30")
                 compile("javax.servlet:javax.servlet-api:3.1.0")
 
-                compile("org.eclipse.jetty:jetty-continuation:${"$"}{jettyVersion}")
                 compile("org.eclipse.jetty:jetty-server:${"$"}{jettyVersion}")
-                compile("org.eclipse.jetty.websocket:websocket-server:${"$"}{jettyVersion}")
-                compile("org.eclipse.jetty.websocket:javax-websocket-server-impl:${"$"}{jettyVersion}") {
-                    exclude(module: "javax.websocket-client-api")
-                }
+                compile("org.eclipse.jetty.websocket:websocket-jetty-server:${"$"}{jettyVersion}")
             }
         """.trimIndent()
         )


### PR DESCRIPTION
Fix the jar test for jetty 10.
Do not delete package-lock for clean.

Closes #13257
