### PR TITLE
fix: shortcut event to modal component instead of UI

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ShortcutRegistration.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
+import com.vaadin.flow.component.internal.UIInternals;
 import com.vaadin.flow.dom.DomListenerRegistration;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.function.SerializableSupplier;
@@ -534,6 +535,14 @@ public class ShortcutRegistration implements Registration, Serializable {
         Component component = listenOnComponents[listenOnIndex];
         assert component != null;
 
+        if (component instanceof UI) {
+            UIInternals uiInternals = ((UI) component).getInternals();
+            if (uiInternals.hasModalComponent()) {
+                component = uiInternals.getActiveModalComponent();
+            }
+        }
+        final Component source = component;
+
         if (shortcutListenerRegistrations == null) {
             shortcutListenerRegistrations = new CompoundRegistration[listenOnComponents.length];
         }
@@ -543,8 +552,7 @@ public class ShortcutRegistration implements Registration, Serializable {
                 shortcutListenerRegistrations[listenOnIndex] = new CompoundRegistration();
                 Registration keyDownRegistration = ComponentUtil.addListener(
                         component, KeyDownEvent.class,
-                        event -> fireShortcutEvent(component),
-                        domRegistration -> {
+                        event -> fireShortcutEvent(source), domRegistration -> {
                             shortcutListenerRegistrations[listenOnIndex]
                                     .addRegistration(domRegistration);
                             configureHandlerListenerRegistration(listenOnIndex);

--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
@@ -31,6 +31,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import com.vaadin.flow.component.internal.PendingJavaScriptInvocation;
+import com.vaadin.flow.component.internal.UIInternals;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementFactory;
 import com.vaadin.flow.function.SerializableConsumer;
@@ -491,6 +492,40 @@ public class ShortcutRegistrationTest {
                 .fireEvent(new KeyDownEvent(listenOn[0], Key.KEY_A.toString()));
 
         Assert.assertNotNull(event.get());
+    }
+
+    @Test
+    public void uiRegistration_uiHasModalComponent_eventIsSentFromModalComponentInsteadOfUi() {
+        AtomicReference<ShortcutEvent> eventRef = new AtomicReference<>();
+
+        Component modal = Mockito.mock(Component.class);
+        when(modal.getUI()).thenReturn(Optional.of(ui));
+        when(modal.getEventBus()).thenReturn(new ComponentEventBus(modal));
+        when(modal.getElement()).thenReturn(new Element("tag"));
+
+        UIInternals uiInternals = Mockito.mock(UIInternals.class);
+        Mockito.when(uiInternals.hasModalComponent()).thenReturn(true);
+        Mockito.when(uiInternals.getActiveModalComponent()).thenReturn(modal);
+        Mockito.when(ui.getInternals()).thenReturn(uiInternals);
+
+        listenOn = new Component[] { ui };
+        when(ui.getUI()).thenReturn(Optional.of(ui));
+
+        new ShortcutRegistration(lifecycleOwner, () -> listenOn, eventRef::set,
+                Key.KEY_A);
+
+        mockLifecycle(true);
+        Mockito.when(lifecycleOwner.getParent())
+                .thenReturn(Optional.of(new FakeComponent()));
+
+        clientResponse(listenOn);
+
+        modal.getEventBus()
+                .fireEvent(new KeyDownEvent(listenOn[0], Key.KEY_A.toString()));
+
+        ShortcutEvent event = eventRef.get();
+        Assert.assertNotNull(event);
+        Assert.assertEquals(modal, event.getSource());
     }
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ModalDialogIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ModalDialogIT.java
@@ -39,13 +39,14 @@ public class ModalDialogIT extends ChromeBrowserTest {
         validateLatestShortcutEvent(0, ModalDialogView.UI_BUTTON);
         listenToButtonShortcutOnUI();
         pressShortcutKey(getDialogInput());
-        // no event occurred since shortcut is listened on ui which is inert
-        validateLatestShortcutEvent(0, ModalDialogView.UI_BUTTON);
+        // event occurred since when a shortcut is registered on UI, it is
+        // listened on the topmost modal component instead.
+        validateLatestShortcutEvent(1, ModalDialogView.DIALOG_BUTTON);
 
         closeDialog();
         pressShortcutKey(
                 $(NativeButtonElement.class).id(ModalDialogView.UI_BUTTON));
-        validateLatestShortcutEvent(1, ModalDialogView.UI_BUTTON);
+        validateLatestShortcutEvent(2, ModalDialogView.UI_BUTTON);
     }
 
     @Test


### PR DESCRIPTION
If the UI is overlaid by a modal component, shortcut
events to UI are ignored; so send them from the active
modal component instead.

Fixes #13205
