### PR TITLE
fix: allow server registered return calls

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ReturnChannelMap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ReturnChannelMap.java
@@ -164,4 +164,12 @@ public class ReturnChannelMap extends ServerSideFeature {
         return channels.get(Integer.valueOf(channelId));
     }
 
+    /**
+     * Return if map contains any registered channels.
+     *
+     * @return {@code true} if registered channels exist.
+     */
+    public boolean hasChannels() {
+        return !channels.isEmpty();
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/ReturnChannelHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/ReturnChannelHandler.java
@@ -82,11 +82,8 @@ public class ReturnChannelHandler extends AbstractRpcInvocationHandler {
     @Override
     protected boolean allowInert(StateNode node) {
         // Allow calls if a return channel has been registered for the node.
-        final Optional<ReturnChannelMap> returnChannelMap = node
-                .getFeatureIfInitialized(ReturnChannelMap.class);
-        return returnChannelMap.isPresent()
-                ? returnChannelMap.get().hasChannels()
-                : false;
+        return node.getFeatureIfInitialized(ReturnChannelMap.class)
+                .map(ReturnChannelMap::hasChannels).orElse(false);
     }
 
     private static Logger getLogger() {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/ReturnChannelHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/ReturnChannelHandler.java
@@ -79,6 +79,16 @@ public class ReturnChannelHandler extends AbstractRpcInvocationHandler {
         return Optional.empty();
     }
 
+    @Override
+    protected boolean allowInert(StateNode node) {
+        // Allow calls if a return channel has been registered for the node.
+        final Optional<ReturnChannelMap> returnChannelMap = node
+                .getFeatureIfInitialized(ReturnChannelMap.class);
+        return returnChannelMap.isPresent()
+                ? returnChannelMap.get().hasChannels()
+                : false;
+    }
+
     private static Logger getLogger() {
         return LoggerFactory.getLogger(ReturnChannelHandler.class.getName());
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/AbstractRpcInvocationHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/AbstractRpcInvocationHandler.java
@@ -61,7 +61,7 @@ public abstract class AbstractRpcInvocationHandler
                     + "the client side for an inactive (disabled or invisible) node id='{}'",
                     getClass().getName(), node.getId());
             return Optional.empty();
-        } else if (!allowInert() && node.isInert()) {
+        } else if (!allowInert(node) && node.isInert()) {
             getLogger().trace(
                     "Ignored RPC for invocation handler '{}' from "
                             + "the client side for an inert node id='{}'",
@@ -72,7 +72,7 @@ public abstract class AbstractRpcInvocationHandler
         }
     }
 
-    protected boolean allowInert() {
+    protected boolean allowInert(StateNode node) {
         return false;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/PublishedServerEventHandlerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/PublishedServerEventHandlerRpcHandler.java
@@ -72,7 +72,7 @@ public class PublishedServerEventHandlerRpcHandler
     }
 
     @Override
-    protected boolean allowInert() {
+    protected boolean allowInert(StateNode node) {
         return true;
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/ReturnChannelHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/ReturnChannelHandlerTest.java
@@ -20,7 +20,10 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.dom.DisabledUpdateMode;
+import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.internal.nodefeature.ElementChildrenList;
@@ -115,6 +118,33 @@ public class ReturnChannelHandlerTest {
                 observedArguments.get());
     }
 
+    @Test
+    public void modalComponent_registrationExists_invocationProcessed() {
+        ReturnChannelRegistration registration = registerUiChannel();
+
+        Div modal = new Div();
+        ui.addModal(modal);
+
+        handleMessage(registration);
+
+        Assert.assertNotNull("Channel handler should be called",
+                observedArguments.get());
+    }
+
+    @Test
+    public void modalComponent_unregisteredChannel_invocationIgnored() {
+        ReturnChannelRegistration registration = registerUiChannel();
+        registration.remove();
+
+        Div modal = new Div();
+        ui.addModal(modal);
+
+        handleMessage(registration);
+
+        Assert.assertNull("Channel handler should not be called",
+                observedArguments.get());
+    }
+
     private void handleMessage(ReturnChannelRegistration registration) {
         handleMessage(registration.getStateNodeId(),
                 registration.getChannelId());
@@ -141,5 +171,9 @@ public class ReturnChannelHandlerTest {
         invocationJson.put(JsonConstants.RPC_CHANNEL_ARGUMENTS, args);
 
         return invocationJson;
+    }
+
+    @Tag("div")
+    private class Div extends Component {
     }
 }


### PR DESCRIPTION
Allow return calls for server-side
registered return channel on targeted
node.

Fixes #13208
