### PR TITLE
fix: set shortcut listener to modal only if owner is child

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ShortcutRegistrationTest.java
@@ -502,6 +502,7 @@ public class ShortcutRegistrationTest {
         when(modal.getUI()).thenReturn(Optional.of(ui));
         when(modal.getEventBus()).thenReturn(new ComponentEventBus(modal));
         when(modal.getElement()).thenReturn(new Element("tag"));
+        when(modal.isVisible()).thenReturn(true);
 
         UIInternals uiInternals = Mockito.mock(UIInternals.class);
         Mockito.when(uiInternals.hasModalComponent()).thenReturn(true);
@@ -515,8 +516,7 @@ public class ShortcutRegistrationTest {
                 Key.KEY_A);
 
         mockLifecycle(true);
-        Mockito.when(lifecycleOwner.getParent())
-                .thenReturn(Optional.of(new FakeComponent()));
+        Mockito.when(lifecycleOwner.getParent()).thenReturn(Optional.of(modal));
 
         clientResponse(listenOn);
 

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ModalDialogView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ModalDialogView.java
@@ -16,6 +16,9 @@
 
 package com.vaadin.flow.uitest.ui;
 
+import java.util.List;
+import java.util.Map;
+
 import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
@@ -25,10 +28,14 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Input;
 import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.BeforeEvent;
+import com.vaadin.flow.router.HasUrlParameter;
+import com.vaadin.flow.router.Location;
+import com.vaadin.flow.router.OptionalParameter;
 import com.vaadin.flow.router.Route;
 
 @Route(value = "com.vaadin.flow.uitest.ui.ModalDialogView")
-public class ModalDialogView extends Div {
+public class ModalDialogView extends Div implements HasUrlParameter<String> {
 
     public static final String EVENT_LOG = "event-log";
     public static final String UI_BUTTON = "ui-button";
@@ -56,6 +63,20 @@ public class ModalDialogView extends Div {
                 createOpenDialogButton(false, OPEN_MODELESS_BUTTON), testButton,
                 eventLog);
         setId("main-div");
+    }
+
+    @Override
+    public void setParameter(BeforeEvent event,
+            @OptionalParameter String parameter) {
+        Location location = event.getLocation();
+        Map<String, List<String>> queryParameters = location
+                .getQueryParameters().getParameters();
+        if (queryParameters.containsKey("open_dialog")) {
+            boolean modal = queryParameters.get("open_dialog")
+                    .contains("modal");
+            final Dialog dialog = new Dialog(modal);
+            dialog.open();
+        }
     }
 
     private void logClickEvent(ClickEvent<?> event) {
@@ -124,7 +145,7 @@ public class ModalDialogView extends Div {
         }
 
         public void open() {
-            final UI ui = ModalDialogView.this.getUI().get();
+            final UI ui = UI.getCurrent();
             if (modal) {
                 ui.addModal(this);
             } else {

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ModalDialogIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ModalDialogIT.java
@@ -58,10 +58,12 @@ public class ModalDialogIT extends ChromeBrowserTest {
         // shortcuts on view should not trigger while dialog is open
         pressShortcutKey(
                 $(NativeButtonElement.class).id(ModalDialogView.UI_BUTTON));
+        Assert.assertTrue("No event should be logged",
+                eventLog.$(DivElement.class).all().isEmpty());
 
         closeDialog();
 
-        // shortcuts on view should not trigger when dialog has been closed
+        // shortcuts on view should trigger when dialog has been closed
         pressShortcutKey(
                 $(NativeButtonElement.class).id(ModalDialogView.UI_BUTTON));
         validateLatestShortcutEvent(0, ModalDialogView.UI_BUTTON);

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ModalDialogIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ModalDialogIT.java
@@ -16,9 +16,9 @@ public class ModalDialogIT extends ChromeBrowserTest {
     private TestBenchElement modalDialogButton;
     private TestBenchElement modelessDialogButton;
 
-    @Before
-    public void init() {
-        open();
+    @Override
+    protected void open(String... parameters) {
+        super.open(parameters);
         eventLog = $(DivElement.class).id(ModalDialogView.EVENT_LOG);
         modalDialogButton = $(NativeButtonElement.class)
                 .id(ModalDialogView.OPEN_MODAL_BUTTON);
@@ -29,6 +29,8 @@ public class ModalDialogIT extends ChromeBrowserTest {
     // #7799
     @Test
     public void modalDialogOpened_sameShortcutsListeningOnUi_noShortcutTriggered() {
+        open();
+
         pressShortcutKey(
                 $(NativeButtonElement.class).id(ModalDialogView.UI_BUTTON));
         validateLatestShortcutEvent(0, ModalDialogView.UI_BUTTON);
@@ -50,7 +52,25 @@ public class ModalDialogIT extends ChromeBrowserTest {
     }
 
     @Test
+    public void modalDialogOpenInitially_dialogClosed_shortcutsInViewTrigger() {
+        open("open_dialog=modal");
+
+        // shortcuts on view should not trigger while dialog is open
+        pressShortcutKey(
+                $(NativeButtonElement.class).id(ModalDialogView.UI_BUTTON));
+
+        closeDialog();
+
+        // shortcuts on view should not trigger when dialog has been closed
+        pressShortcutKey(
+                $(NativeButtonElement.class).id(ModalDialogView.UI_BUTTON));
+        validateLatestShortcutEvent(0, ModalDialogView.UI_BUTTON);
+    }
+
+    @Test
     public void modalDialogOpened_sameShortcutListeningOnUiAndDialog_onlyDialogShortcutExecuted() {
+        open();
+
         pressShortcutKey(
                 $(NativeButtonElement.class).id(ModalDialogView.UI_BUTTON));
         validateLatestShortcutEvent(0, ModalDialogView.UI_BUTTON);
@@ -72,6 +92,8 @@ public class ModalDialogIT extends ChromeBrowserTest {
 
     @Test
     public void modelessDialogOpened_sharesShortcutWithUI_bothExecuted() {
+        open();
+
         pressShortcutKey(
                 $(NativeButtonElement.class).id(ModalDialogView.UI_BUTTON));
         validateLatestShortcutEvent(0, ModalDialogView.UI_BUTTON);
@@ -91,6 +113,8 @@ public class ModalDialogIT extends ChromeBrowserTest {
 
     @Test
     public void modelessDialogOpened_sameShortcutListeningOnUiAndDialog_bothExecuted() {
+        open();
+
         pressShortcutKey(
                 $(NativeButtonElement.class).id(ModalDialogView.UI_BUTTON));
         validateLatestShortcutEvent(0, ModalDialogView.UI_BUTTON);


### PR DESCRIPTION
The previous fix for #13205 (PR #13263) moved all shortcut
registration event sources from UI to the modal component 
if one was active; this caused shortcuts owned by components
not under the modal tree to also be moved if they were registered
when a modal component was active, and hence they stopped
working when the modal component tree was removed. This
modifies the previous fix to only change the event source if the 
shortcut owner is under the an active modal tree.