### PR TITLE
fix: require Safari 14 minimum

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/shared/BrowserDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/BrowserDetails.java
@@ -608,11 +608,10 @@ public class BrowserDetails implements Serializable {
         }
         // Safari 14+
         if (isSafari() && getBrowserMajorVersion() < 14) {
-            if (getOperatingSystemMajorVersion() > 14) {
-                return false;
-            }
-            if (getOperatingSystemMajorVersion() == 14
-                    && getOperatingSystemMinorVersion() >= 7) {
+            if (isIPhone() && (getOperatingSystemMajorVersion() > 14
+                    || (getOperatingSystemMajorVersion() == 14
+                            && getOperatingSystemMinorVersion() >= 7))) {
+                // #11654
                 return false;
             }
             return true;

--- a/flow-server/src/main/java/com/vaadin/flow/shared/BrowserDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/BrowserDetails.java
@@ -606,8 +606,8 @@ public class BrowserDetails implements Serializable {
         if (isEdge() && getBrowserMajorVersion() < 79) {
             return true;
         }
-        // Safari 13+
-        if (isSafari() && getBrowserMajorVersion() < 13) {
+        // Safari 14+
+        if (isSafari() && getBrowserMajorVersion() < 14) {
             if (getOperatingSystemMajorVersion() > 14) {
                 return false;
             }

--- a/flow-server/src/test/java/com/vaadin/flow/shared/BrowserDetailsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/shared/BrowserDetailsTest.java
@@ -63,6 +63,7 @@ public class BrowserDetailsTest extends TestCase {
     private static final String SAFARI10_WINDOWS = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.1.2 Safari/603.3.8";
     private static final String SAFARI11_MAC = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.1 Safari/605.1.15";
     private static final String SAFARI13_MAC = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_2) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.4 Safari/605.1.15";
+    private static final String SAFARI14_MAC = "Mozilla/5.0 (Macintosh; Intel Mac OS X 11_6_2) AppleWebKit/611.3.10.1.5 (KHTML, like Gecko) Version/14.1.2 Safari/611.3.10.1.5";
 
     private static final String IPHONE_IOS_5_1 = "Mozilla/5.0 (iPhone; CPU iPhone OS 5_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9B179 Safari/7534.48.3";
     private static final String IPHONE_IOS_4_0 = "Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_0 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8A293 Safari/6531.22.7";
@@ -559,7 +560,8 @@ public class BrowserDetailsTest extends TestCase {
         assertTooOld(EDGE_18);
         assertTooOld(SAFARI11_MAC);
         assertNotTooOld(EDGE_79);
-        assertNotTooOld(SAFARI13_MAC);
+        assertTooOld(SAFARI13_MAC);
+        assertNotTooOld(SAFARI14_MAC);
     }
 
     public void testEclipseMac_safari91() {


### PR DESCRIPTION
Safari 13 does not support the EventTarget constructor,
used in @vaadin/components-base:
https://caniuse.com/?search=EventTarget()

Fixes #13271