### PR TITLE
chore: update parent project to 2.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-parent</artifactId>
-        <version>2.0.4</version>
+        <version>2.0.5</version>
     </parent>
 
     <modules>
@@ -41,7 +41,7 @@
         <name>Vaadin Ltd</name>
         <url>https://vaadin.com</url>
     </organization>
-    <url>https://vaadin.com</url>
+    <url>https://vaadin.com/flow</url>
     <licenses>
         <license>
             <name>Apache License Version 2.0</name>


### PR DESCRIPTION
the older parent version generate invalid url for projects.