### PR TITLE
fix: Warn for duplicate npm classes

### DIFF
--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/server/scanner/ReflectionsClassFinder.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/server/scanner/ReflectionsClassFinder.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.reflections.Reflections;
@@ -60,7 +61,7 @@ public class ReflectionsClassFinder implements ClassFinder {
     @Override
     public Set<Class<?>> getAnnotatedClasses(
             Class<? extends Annotation> clazz) {
-        Set<Class<?>> classes = new HashSet<>();
+        Set<Class<?>> classes = new LinkedHashSet<>();
         classes.addAll(reflections.getTypesAnnotatedWith(clazz, true));
         classes.addAll(getAnnotatedByRepeatedAnnotation(clazz));
         return classes;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -938,7 +938,7 @@ public class NodeTasks implements FallibleCommand {
             return new FrontendDependenciesScanner.FrontendDependenciesScannerFactory()
                     .createScanner(true, finder,
                             builder.generateEmbeddableWebComponents,
-                            builder.useLegacyV14Bootstrap, featureFlags);
+                            builder.useLegacyV14Bootstrap, featureFlags, true);
         } else {
             return null;
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesScanner.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesScanner.java
@@ -89,11 +89,43 @@ public interface FrontendDependenciesScanner extends Serializable {
                 boolean allDependenciesScan, ClassFinder finder,
                 boolean generateEmbeddableWebComponents,
                 boolean useV14Bootstrap, FeatureFlags featureFlags) {
+            return createScanner(allDependenciesScan, finder,
+                    generateEmbeddableWebComponents, useV14Bootstrap,
+                    featureFlags, false);
+        }
+
+        /**
+         * Produces scanner implementation based on {@code allDependenciesScan}
+         * value.
+         * <p>
+         *
+         * @param allDependenciesScan
+         *            if {@code true} then full classpath scanning strategy is
+         *            used, otherwise byte scanning strategy is produced
+         * @param finder
+         *            a class finder
+         * @param generateEmbeddableWebComponents
+         *            checks {@code WebComponentExporter} classes for
+         *            dependencies if {@code true}, doesn't check otherwise
+         * @param useV14Bootstrap
+         *            whether we are in legacy V14 bootstrap mode
+         * @param featureFlags
+         *            available feature flags and their status
+         * @param fallback
+         *            whether FullDependenciesScanner is used as fallback
+         * @return a scanner implementation strategy
+         *
+         */
+        public FrontendDependenciesScanner createScanner(
+                boolean allDependenciesScan, ClassFinder finder,
+                boolean generateEmbeddableWebComponents,
+                boolean useV14Bootstrap, FeatureFlags featureFlags,
+                boolean fallback) {
             if (allDependenciesScan) {
                 // this dep scanner can't distinguish embeddable web component
                 // frontend related annotations
                 return new FullDependenciesScanner(finder, useV14Bootstrap,
-                        featureFlags);
+                        featureFlags, fallback);
             } else {
                 return new FrontendDependencies(finder,
                         generateEmbeddableWebComponents, useV14Bootstrap,

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScanner.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScanner.java
@@ -107,6 +107,8 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
      *            whether we are in V14 bootstrap mode
      * @param featureFlags
      *            available feature flags and their status
+     * @param fallback
+     *            whether dependency scanner is used as fallback
      */
     FullDependenciesScanner(ClassFinder finder, boolean useV14Bootstrap,
             FeatureFlags featureFlags, boolean fallback) {
@@ -126,6 +128,8 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
      *            whether we are in V14 bootstrap mode
      * @param featureFlags
      *            available feature flags and their status
+     * @param fallback
+     *            whether dependency scanner is used as fallback
      */
     FullDependenciesScanner(ClassFinder finder,
             SerializableBiFunction<Class<?>, Class<? extends Annotation>, List<? extends Annotation>> annotationFinder,
@@ -250,13 +254,13 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
                     logs.add(value + " " + version + " " + clazz.getName());
                     if (result.containsKey(value)
                             && !result.get(value).equals(version)) {
-                        String foundVersions = "[" + version + ", "
-                                + result.get(value) + "]";
                         if (!fallback) {
                             // Only log warning if full scanner is not used as
                             // fallback scanner. For fallback the bytecode
                             // scanner will have informed about multiple
                             // versions
+                            String foundVersions = "[" + result.get(value)
+                                    + ", " + version + "]";
                             getLogger().warn(
                                     "Multiple npm versions for {} found:  {}. First version found '{}' will be considered.",
                                     value, foundVersions, result.get(value));

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScanner.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScanner.java
@@ -62,6 +62,7 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
     private static final String COULD_NOT_LOAD_ERROR_MSG = "Could not load annotation class ";
 
     private static final String VALUE = "value";
+    private static final String VERSION = "version";
 
     private ThemeDefinition themeDefinition;
     private AbstractTheme themeInstance;
@@ -77,6 +78,7 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
     private final SerializableBiFunction<Class<?>, Class<? extends Annotation>, List<? extends Annotation>> annotationFinder;
 
     private final boolean useV14Bootstrap;
+    private final boolean fallback;
 
     /**
      * Creates a new scanner instance which discovers all dependencies in the
@@ -92,7 +94,24 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
     FullDependenciesScanner(ClassFinder finder, boolean useV14Bootstrap,
             FeatureFlags featureFlags) {
         this(finder, AnnotationReader::getAnnotationsFor, useV14Bootstrap,
-                featureFlags);
+                featureFlags, false);
+    }
+
+    /**
+     * Creates a new scanner instance which discovers all dependencies in the
+     * classpath.
+     *
+     * @param finder
+     *            a class finder
+     * @param useV14Bootstrap
+     *            whether we are in V14 bootstrap mode
+     * @param featureFlags
+     *            available feature flags and their status
+     */
+    FullDependenciesScanner(ClassFinder finder, boolean useV14Bootstrap,
+            FeatureFlags featureFlags, boolean fallback) {
+        this(finder, AnnotationReader::getAnnotationsFor, useV14Bootstrap,
+                featureFlags, fallback);
     }
 
     /**
@@ -110,9 +129,11 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
      */
     FullDependenciesScanner(ClassFinder finder,
             SerializableBiFunction<Class<?>, Class<? extends Annotation>, List<? extends Annotation>> annotationFinder,
-            boolean useV14Bootstrap, FeatureFlags featureFlags) {
+            boolean useV14Bootstrap, FeatureFlags featureFlags,
+            boolean fallback) {
         super(finder, featureFlags);
 
+        this.fallback = fallback;
         this.useV14Bootstrap = useV14Bootstrap;
 
         long start = System.currentTimeMillis();
@@ -221,11 +242,28 @@ class FullDependenciesScanner extends AbstractDependenciesScanner {
                 classes.add(clazz.getName());
                 List<? extends Annotation> packageAnnotations = annotationFinder
                         .apply(clazz, loadedAnnotation);
-                packageAnnotations.forEach(pckg -> {
-                    String value = getAnnotationValueAsString(pckg, VALUE);
-                    String vers = getAnnotationValueAsString(pckg, "version");
-                    logs.add(value + " " + vers + " " + clazz.getName());
-                    result.put(value, vers);
+                packageAnnotations.forEach(annotation -> {
+                    String value = getAnnotationValueAsString(annotation,
+                            VALUE);
+                    String version = getAnnotationValueAsString(annotation,
+                            VERSION);
+                    logs.add(value + " " + version + " " + clazz.getName());
+                    if (result.containsKey(value)
+                            && !result.get(value).equals(version)) {
+                        String foundVersions = "[" + version + ", "
+                                + result.get(value) + "]";
+                        if (!fallback) {
+                            // Only log warning if full scanner is not used as
+                            // fallback scanner. For fallback the bytecode
+                            // scanner will have informed about multiple
+                            // versions
+                            getLogger().warn(
+                                    "Multiple npm versions for {} found:  {}. First version found '{}' will be considered.",
+                                    value, foundVersions, result.get(value));
+                        }
+                    } else {
+                        result.put(value, version);
+                    }
                 });
             }
             debug("npm dependencies", logs);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScannerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FullDependenciesScannerTest.java
@@ -309,7 +309,7 @@ public class FullDependenciesScannerTest {
                     }
                     Assert.fail();
                     return null;
-                }, false, null);
+                }, false, null, false);
 
         List<String> modules = scanner.getModules();
         Assert.assertEquals(25, modules.size());
@@ -383,7 +383,7 @@ public class FullDependenciesScannerTest {
 
         return new FullDependenciesScanner(finder,
                 (type, annotation) -> findAnnotations(type, annotationType),
-                false, null);
+                false, null, false);
     }
 
     private FullDependenciesScanner setUpThemeScanner(
@@ -404,7 +404,7 @@ public class FullDependenciesScannerTest {
                 .thenReturn(noThemeClasses);
 
         return new FullDependenciesScanner(finder, annotationFinder, false,
-                null) {
+                null, false) {
             @Override
             protected Class<? extends AbstractTheme> getLumoTheme() {
                 return FakeLumoTheme.class;

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FullScannerPwaTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FullScannerPwaTest.java
@@ -28,7 +28,7 @@ public class FullScannerPwaTest extends AbstractScannerPwaTest {
 
         FullDependenciesScanner fullDependenciesScanner = new FullDependenciesScanner(
                 finder, (type, annotation) -> findPwaAnnotations(type), false,
-                null);
+                null, false);
         return fullDependenciesScanner.getPwaConfiguration();
     }
 


### PR DESCRIPTION
If encountering multiple NpmPackage
annotations with different versions log
a warning and inform of choice taken.

Fixes #13285
