### PR TITLE
fix: Do not run any Maven goals automatically in Eclipse / VS Code

### DIFF
--- a/flow-plugins/flow-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
+++ b/flow-plugins/flow-maven-plugin/src/main/resources/META-INF/m2e/lifecycle-mapping-metadata.xml
@@ -5,24 +5,12 @@
       <pluginExecutionFilter>
         <goals>
           <goal>validate</goal>
+          <goal>prepare-frontend</goal>
           <goal>build-frontend</goal>
         </goals>
       </pluginExecutionFilter>
       <action>
         <ignore></ignore>
-      </action>
-    </pluginExecution>
-    <pluginExecution>
-      <pluginExecutionFilter>
-        <goals>
-          <goal>prepare-frontend</goal>
-        </goals>
-      </pluginExecutionFilter>
-      <action>
-        <execute>
-          <runOnIncremental>false</runOnIncremental>
-          <runOnConfiguration>true</runOnConfiguration>
-        </execute>
       </action>
     </pluginExecution>
   </pluginExecutions>


### PR DESCRIPTION
It seems like especially VS Code can start running `prepare-frontend` over and over again in some cases which will interfere with an externally running `mvn spring-boot:run` process that will continuously restart because of an updated `target/classes/META-INF/VAADIN/config/flow-build-info.json`

There should be no need nowadays to run `prepare-frontend` from Eclipse at all as it is run through the dev server if needed.

