### PR TITLE
test: fix join to explicitly use \n

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateWebComponentBootstrap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateWebComponentBootstrap.java
@@ -68,7 +68,7 @@ public class TaskGenerateWebComponentBootstrap
         lines.add("import { init } from '@vaadin/flow-frontend/FlowClient';");
         lines.add("init();");
 
-        return String.join(System.lineSeparator(), lines);
+        return String.join("\n", lines);
     }
 
     @Override


### PR DESCRIPTION
Test assert checks for `\n`, but
test creation used system line
separator which is not always `\n`
Explicitly use `\n` in string.

This fixes the test execution on
windows where the separator is `\r\n`
