### PR TITLE
feat: Allow navigation with RouterLinks when inert

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUI.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptBootstrapUI.java
@@ -119,13 +119,6 @@ public class JavaScriptBootstrapUI extends UI {
     public void connectClient(String clientElementTag, String clientElementId,
             String flowRoute, String appShellTitle, JsonValue historyState) {
 
-        if (getElement().getNode().isInert()) {
-            // In inert state navigation is blocked, but client side callback
-            // must be called.
-            cancelClient();
-            return;
-        }
-
         if (appShellTitle != null && !appShellTitle.isEmpty()) {
             getInternals().setAppShellTitle(appShellTitle);
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/NavigationRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/NavigationRpcHandler.java
@@ -24,7 +24,6 @@ import com.vaadin.flow.component.page.History.HistoryStateChangeHandler;
 import com.vaadin.flow.router.Location;
 import com.vaadin.flow.router.NavigationTrigger;
 import com.vaadin.flow.shared.JsonConstants;
-import org.slf4j.LoggerFactory;
 
 import elemental.json.JsonObject;
 import elemental.json.JsonValue;
@@ -62,20 +61,6 @@ public class NavigationRpcHandler implements RpcInvocationHandler {
             NavigationTrigger trigger = triggeredByLink
                     ? NavigationTrigger.ROUTER_LINK
                     : NavigationTrigger.HISTORY;
-            // When the UI is made inert, all router link navigation is
-            // ignored. For the part of the UI that is not inert, navigation
-            // could be allowed by using something else than router links (with
-            // server side listeners).
-            // Blocking browser history back / forward navigation is not done
-            // as it would be dubious and even impossible on the client side.
-            if (trigger == NavigationTrigger.ROUTER_LINK
-                    && ui.getElement().getNode().isInert()) {
-                LoggerFactory.getLogger(NavigationRpcHandler.class.getName())
-                        .trace("Ignored router link click for location '{}' because the UI is inert.",
-                                location);
-                return Optional.empty();
-            }
-
             HistoryStateChangeEvent event = new HistoryStateChangeEvent(history,
                     state, new Location(location), trigger);
             historyStateChangeHandler.onHistoryStateChange(event);

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/NavigationRpcHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/NavigationRpcHandlerTest.java
@@ -44,7 +44,7 @@ public class NavigationRpcHandlerTest {
     }
 
     @Test
-    public void handleRouterLinkClick_uiIsInert_navigationNotTriggered() {
+    public void handleRouterLinkClick_uiIsInert_navigationTriggered() {
         ui.addModal(new RouterLink());
         ui.getInternals().getStateTree().collectChanges(nodeChange -> {
         });
@@ -52,7 +52,9 @@ public class NavigationRpcHandlerTest {
         invocation.put(JsonConstants.RPC_NAVIGATION_ROUTERLINK, true);
         rpcHandler.handle(ui, invocation);
 
-        Mockito.verifyNoInteractions(historyStateChangeHandler);
+        Mockito.verify(historyStateChangeHandler, Mockito.times(1))
+                .onHistoryStateChange(
+                        Mockito.any(History.HistoryStateChangeEvent.class));
     }
 
     @Test

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/InertComponentIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/InertComponentIT.java
@@ -96,7 +96,8 @@ public class InertComponentIT extends ChromeBrowserTest {
 
         waitForElementPresent(By.id(ModalDialogView.OPEN_MODAL_BUTTON));
 
-        Assert.assertNotNull(findElement(By.id(ModalDialogView.OPEN_MODAL_BUTTON)));
+        Assert.assertNotNull(
+                findElement(By.id(ModalDialogView.OPEN_MODAL_BUTTON)));
     }
 
     private Optional<NativeButtonElement> getNewModalBoxButton() {

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/InertComponentIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/InertComponentIT.java
@@ -7,6 +7,7 @@ import java.util.stream.Stream;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 
 import com.vaadin.flow.component.html.testbench.AnchorElement;
@@ -77,7 +78,7 @@ public class InertComponentIT extends ChromeBrowserTest {
     }
 
     @Test
-    public void modalComponentAdded_routerLinkClicked_noNavigation() {
+    public void modalComponentAdded_routerLinkClicked_navigation() {
         open();
 
         final long initialBoxCount = getBoxCount();
@@ -93,8 +94,9 @@ public class InertComponentIT extends ChromeBrowserTest {
 
         linkToAnotherPage.get().click();
 
-        validateBoxCount(initialBoxCount + 1,
-                "Expected to stay on the same page.");
+        waitForElementPresent(By.id(ModalDialogView.OPEN_MODAL_BUTTON));
+
+        Assert.assertNotNull(findElement(By.id(ModalDialogView.OPEN_MODAL_BUTTON)));
     }
 
     private Optional<NativeButtonElement> getNewModalBoxButton() {


### PR DESCRIPTION
## Description

Server-side modality feature attempted to block navigation when a modal component is active. This blocks some legitimate use cases when one wants to use RouterLinks inside a modal component. With the current router implementation, it is not practically possible to separate between RouterLinks that are inside a modal from those that are outside (inert). Moreover, navigation cannot be fully controlled on the server side anyway. Therefore, the development team decided to reverse the decision to block RouterLinks when the UI is inert. This PR allows navigation via RouterLinks even when the UI is inert.

Fixes #13270

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
