### PR TITLE
fix!: Avoid duplicated field bindings

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -945,6 +945,10 @@ public class Binder<BEAN> implements Serializable {
             BindingImpl<BEAN, FIELDVALUE, TARGET> binding = new BindingImpl<>(
                     this, getter, setter);
 
+            // Remove existing binding for same field to avoid potential
+            // multiple application of converter
+            getBinder().bindings.removeIf(
+                    registeredBinding -> registeredBinding.getField() == field);
             getBinder().bindings.add(binding);
             if (getBinder().getBean() != null) {
                 binding.initFieldValue(getBinder().getBean(), true);
@@ -3193,6 +3197,21 @@ public class Binder<BEAN> implements Serializable {
                         (Class<? extends HasValue<?, ?>>) memberField
                                 .getType());
                 initializeField(objectWithMemberFields, memberField, field);
+            } else if (incompleteBindings != null
+                    && incompleteBindings.get(field) != null) {
+                // A manual binding is ongoing for this field, so we should not
+                // automatically bind it, otherwise we may silently overwrite
+                // current configuration.
+                // 'bindInstanceFields' states that it doesn't override existing
+                // bindings and that incomplete bindings may be completed also
+                // after method call
+                LoggerFactory.getLogger(Binder.class.getName()).debug(
+                        "Binding for member '{}' of class '{}' will not be automatically "
+                                + "created because a custom binding has been started "
+                                + "but not yet finalized with 'bind()' invocation.",
+                        memberField.getName(),
+                        objectWithMemberFields.getClass().getName());
+                return false;
             }
             forField(field).bind(property);
             return true;
@@ -3288,7 +3307,6 @@ public class Binder<BEAN> implements Serializable {
 
         Boolean isPropertyBound = propertyHandler.apply(propertyName,
                 descriptor.get().getType());
-        assert boundProperties.containsKey(propertyName);
         return isPropertyBound;
     }
 


### PR DESCRIPTION
## Description

If custom binding is added or completed after the call to Binder.bindInstanceFields
the field is bound twice and this may lead to potential multiple application
of converters, producing wrong representation and value for the field.
This change ignores incomplete bindings during `bindInstanceFields()`
process and overwrites existing bindings when `Binding.bind()` is
invoked after `bindInstanceFields()`.

Fixes #13314

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
