### PR TITLE
fix: Always register EndpointController

### DIFF
--- a/fusion-endpoint/src/main/java/dev/hilla/EndpointController.java
+++ b/fusion-endpoint/src/main/java/dev/hilla/EndpointController.java
@@ -65,7 +65,6 @@ import dev.hilla.exception.EndpointException;
  */
 @RestController
 @Import({ EndpointControllerConfiguration.class, EndpointProperties.class })
-@ConditionalOnBean(annotation = Endpoint.class)
 @NpmPackage(value = "@hilla/frontend", version = "1.0.1")
 @NpmPackage(value = "@hilla/form", version = "1.0.1")
 public class EndpointController {


### PR DESCRIPTION
This allows the controller to return 404 when no endpoints are registered instead of letting the index html handler return an HTML page

Fixes https://github.com/vaadin/hilla/issues/359
