### PR TITLE
feat: Enable usage of pnpm >5

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -1092,7 +1092,7 @@ public class FrontendTools {
             pnpmCommand = getNpmCliToolExecutable(BuildTool.NPX, "--yes",
                     "--quiet", "pnpm");
             if (!validatePnpmVersion(pnpmCommand)) {
-                new IllegalStateException(
+                throw new IllegalStateException(
                         "Found too old globally installed 'pnpm'. Please upgrade 'pnpm' to at least "
                                 + SUPPORTED_PNPM_VERSION.getFullVersion());
             }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -1086,12 +1086,16 @@ public class FrontendTools {
                             "Found too old globally installed 'pnpm'. Please upgrade 'pnpm' to at least "
                                     + SUPPORTED_PNPM_VERSION.getFullVersion()));
         } else {
-            // install pnpm version < 6.0.0, later requires ensuring
-            // NodeJS >= 12.17 and doesn't support Node 10,
+            // install latest pnpm version as the minimum node requirement is
+            // now at nodejs 16.14.0
             // see https://pnpm.io/installation#compatibility
-            final String pnpmSpecifier = "pnpm@" + DEFAULT_PNPM_VERSION;
             pnpmCommand = getNpmCliToolExecutable(BuildTool.NPX, "--yes",
-                    "--quiet", pnpmSpecifier);
+                    "--quiet", "pnpm");
+            if (!validatePnpmVersion(pnpmCommand)) {
+                new IllegalStateException(
+                        "Found too old globally installed 'pnpm'. Please upgrade 'pnpm' to at least "
+                                + SUPPORTED_PNPM_VERSION.getFullVersion());
+            }
         }
         return pnpmCommand;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -504,14 +504,14 @@ public class TaskRunNpmInstall implements FallibleCommand {
             return;
         }
 
-        String pnpmFileName = "pnpmfile.js";
+        String pnpmFileName = ".pnpmfile.cjs";
         final List<String> pnpmExecutable = tools.getSuitablePnpm();
         pnpmExecutable.add("--version");
         try {
             final FrontendVersion pnpmVersion = FrontendUtils.getVersion("pnpm",
                     pnpmExecutable);
-            if (pnpmVersion.isNewerThan(new FrontendVersion("6.0"))) {
-                pnpmFileName = ".pnpmfile.cjs";
+            if (pnpmVersion.isOlderThan(new FrontendVersion("6.0"))) {
+                pnpmFileName = "pnpmfile.js";
             }
         } catch (FrontendUtils.UnknownVersionException e) {
             packageUpdater.log().error("Failed to determine pnpm version", e);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -275,9 +275,21 @@ public class TaskRunNpmInstall implements FallibleCommand {
         long startTime = System.currentTimeMillis();
 
         Logger logger = packageUpdater.log();
+
+        String baseDir = packageUpdater.npmFolder.getAbsolutePath();
+
+        FrontendToolsSettings settings = new FrontendToolsSettings(baseDir,
+                () -> FrontendUtils.getVaadinHomeDirectory().getAbsolutePath());
+        settings.setNodeDownloadRoot(nodeDownloadRoot);
+        settings.setForceAlternativeNode(requireHomeNodeExec);
+        settings.setUseGlobalPnpm(useGlobalPnpm);
+        settings.setAutoUpdate(autoUpdate);
+        settings.setNodeVersion(nodeVersion);
+        FrontendTools tools = new FrontendTools(settings);
+
         if (enablePnpm) {
             try {
-                createPnpmFile(packageUpdater.versionsPath);
+                createPnpmFile(packageUpdater.versionsPath, tools);
             } catch (IOException exception) {
                 throw new ExecutionFailedException(
                         "Failed to read frontend version data from vaadin-core "
@@ -295,16 +307,6 @@ public class TaskRunNpmInstall implements FallibleCommand {
             }
         }
 
-        String baseDir = packageUpdater.npmFolder.getAbsolutePath();
-
-        FrontendToolsSettings settings = new FrontendToolsSettings(baseDir,
-                () -> FrontendUtils.getVaadinHomeDirectory().getAbsolutePath());
-        settings.setNodeDownloadRoot(nodeDownloadRoot);
-        settings.setForceAlternativeNode(requireHomeNodeExec);
-        settings.setUseGlobalPnpm(useGlobalPnpm);
-        settings.setAutoUpdate(autoUpdate);
-        settings.setNodeVersion(nodeVersion);
-        FrontendTools tools = new FrontendTools(settings);
         List<String> npmExecutable;
         List<String> npmInstallCommand;
         List<String> postinstallCommand;
@@ -496,13 +498,27 @@ public class TaskRunNpmInstall implements FallibleCommand {
      * not supposed that it can be modified by the user. This is done in the
      * same way as for webpack.generated.js.
      */
-    private void createPnpmFile(String versionsPath) throws IOException {
+    private void createPnpmFile(String versionsPath, FrontendTools tools)
+            throws IOException {
         if (versionsPath == null) {
             return;
         }
 
+        String pnpmFileName = "pnpmfile.js";
+        final List<String> pnpmExecutable = tools.getSuitablePnpm();
+        pnpmExecutable.add("--version");
+        try {
+            final FrontendVersion pnpmVersion = FrontendUtils.getVersion("pnpm",
+                    pnpmExecutable);
+            if (pnpmVersion.isNewerThan(new FrontendVersion("6.0"))) {
+                pnpmFileName = ".pnpmfile.cjs";
+            }
+        } catch (FrontendUtils.UnknownVersionException e) {
+            packageUpdater.log().error("Failed to determine pnpm version", e);
+        }
+
         File pnpmFile = new File(packageUpdater.npmFolder.getAbsolutePath(),
-                "pnpmfile.js");
+                pnpmFileName);
         try (InputStream content = TaskRunNpmInstall.class
                 .getResourceAsStream("/pnpmfile.js")) {
             if (content == null) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -172,9 +172,15 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         task.execute();
 
         File file = new File(getNodeUpdater().npmFolder, "pnpmfile.js");
-        Assert.assertTrue(file.exists());
-        String content = FileUtils.readFileToString(file,
-                StandardCharsets.UTF_8);
+        File cjsFile = new File(getNodeUpdater().npmFolder, ".pnpmfile.cjs");
+        Assert.assertTrue(file.exists() || cjsFile.exists());
+        String content;
+        if (file.exists()) {
+            content = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
+        } else {
+            content = FileUtils.readFileToString(cjsFile,
+                    StandardCharsets.UTF_8);
+        }
         MatcherAssert.assertThat(content,
                 CoreMatchers.containsString("JSON.parse(fs.readFileSync"));
     }
@@ -188,9 +194,15 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         task.execute();
 
         File file = new File(getNodeUpdater().npmFolder, "pnpmfile.js");
-        Assert.assertTrue(file.exists());
-        String content = FileUtils.readFileToString(file,
-                StandardCharsets.UTF_8);
+        File cjsFile = new File(getNodeUpdater().npmFolder, ".pnpmfile.cjs");
+        Assert.assertTrue(file.exists() || cjsFile.exists());
+        String content;
+        if (file.exists()) {
+            content = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
+        } else {
+            content = FileUtils.readFileToString(cjsFile,
+                    StandardCharsets.UTF_8);
+        }
         MatcherAssert.assertThat(content,
                 CoreMatchers.containsString("JSON.parse(fs.readFileSync"));
     }


### PR DESCRIPTION
Allow usage of pnpm 6 by
then generating `.pnpmfile.cjs`
instead of `pnpmfile.js`

Closes #12953
