### PR TITLE
fix: change build-frontend goal phase

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinBuildFrontendTask.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinBuildFrontendTask.kt
@@ -44,7 +44,7 @@ public open class VaadinBuildFrontendTask : DefaultTask() {
 
         // we need the flow-build-info.json to be created, which is what the vaadinPrepareFrontend task does
         dependsOn("vaadinPrepareFrontend")
-        // Maven's task run in the LifecyclePhase.PREPARE_PACKAGE phase
+        // Maven's task run in the LifecyclePhase.PROCESS_CLASSES phase
 
         // We need access to the produced classes, to be able to analyze e.g.
         // @CssImport annotations used by the project.

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -54,7 +54,7 @@ import com.vaadin.flow.theme.Theme;
  *
  * @since 2.0
  */
-@Mojo(name = "build-frontend", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, defaultPhase = LifecyclePhase.PREPARE_PACKAGE)
+@Mojo(name = "build-frontend", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME, defaultPhase = LifecyclePhase.PROCESS_CLASSES)
 public class BuildFrontendMojo extends FlowModeAbstractMojo
         implements PluginAdapterBuild {
 


### PR DESCRIPTION
Change the build-frontend goal
defaultPhase from prepare-package
to process-classes.

This will make it so that if defined
the build task will also be executed
for server run.

Fixes #13349