### PR TITLE
fix: Break loop in visitor

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
@@ -705,6 +705,7 @@ public class StateNode implements Serializable {
         // not done inside loop to please Sonarcube
         forEachChild(stack::addFirst);
         StateNode previousParent = this;
+        Set<StateNode> childrenAdded = new HashSet<>();
 
         while (!stack.isEmpty()) {
             StateNode current = stack.getFirst();
@@ -712,8 +713,11 @@ public class StateNode implements Serializable {
             if (current == previousParent) {
                 visitor.accept(stack.removeFirst());
                 previousParent = current.getParent();
+            } else if (childrenAdded.contains(current)) {
+                previousParent = current;
             } else {
                 current.forEachChild(stack::addFirst);
+                childrenAdded.add(current);
                 previousParent = current;
             }
         }

--- a/flow-server/src/test/java/com/vaadin/flow/internal/StateNodeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/StateNodeTest.java
@@ -16,6 +16,7 @@
 
 package com.vaadin.flow.internal;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -294,6 +295,35 @@ public class StateNodeTest {
         root.visitNodeTreeBottomUp(node -> Assert.assertEquals(
                 ((Integer) ((TestStateNode) node).getData()),
                 data.removeLast()));
+    }
+
+    @Test
+    public void nodeTreeOnAttach_bottomUpTraversing_brokenParentInChildDoesNotEndInLoop()
+            throws NoSuchFieldException, IllegalAccessException {
+        // Set data is used to track the node during debug see
+        // TestStateNode.toString
+        TestStateNode root = new TestStateNode();
+        root.setData(0);
+        List<Integer> count = new ArrayList<>();
+
+        final Field parent = StateNode.class.getDeclaredField("parent");
+        parent.setAccessible(true);
+
+        TestStateNode childOfRoot = new TestStateNode();
+        childOfRoot.setData(1);
+
+        TestStateNode child = new TestStateNode();
+        child.setData(2);
+        setParent(child, childOfRoot);
+
+        parent.set(child, null);
+
+        setParent(childOfRoot, root);
+
+        root.visitNodeTreeBottomUp(node -> count.add(1));
+
+        Assert.assertEquals("Each node should be visited once", 3,
+                count.size());
     }
 
     @Test


### PR DESCRIPTION
Do not constantly add children
of a node that has already had
all children added once.

Fixes #13366
