### PR TITLE
fix: validate node and npm on creation (#13374)

### DIFF
--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -370,6 +370,7 @@ public class BuildFrontendUtil {
 
         FrontendToolsSettings settings = getFrontendToolsSettings(adapter);
         FrontendTools tools = new FrontendTools(settings);
+        tools.validateNodeAndNpmVersion();
         if (featureFlags.isEnabled(FeatureFlags.VITE)) {
             BuildFrontendUtil.runVite(adapter, tools);
         } else {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -305,6 +305,8 @@ public class TaskRunNpmInstall implements FallibleCommand {
         settings.setAutoUpdate(autoUpdate);
         settings.setNodeVersion(nodeVersion);
         FrontendTools tools = new FrontendTools(settings);
+        tools.validateNodeAndNpmVersion();
+
         List<String> npmExecutable;
         List<String> npmInstallCommand;
         List<String> postinstallCommand;


### PR DESCRIPTION
Always when creating a FrontendTools
validate node and npm so that if the
global node is too old and we should
use the installed one we do not use
the global npm even if it was new enough.

Fixes #13364