### PR TITLE
fix: clean and do not add plugins

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -297,11 +297,11 @@ public abstract class NodeUpdater implements FallibleCommand {
                 + (npmFolder.toPath().relativize(targetFolder) + "/")
                         .replace('\\', '/');
 
-        // Clean  previously installed plugins
+        // Clean previously installed plugins
         for (String depKey : devDependencies.keys()) {
             String depVersion = devDependencies.getString(depKey);
-            if (depKey.startsWith(atVaadinPrefix) && depVersion.startsWith(
-                    pluginTargetPrefix)) {
+            if (depKey.startsWith(atVaadinPrefix)
+                    && depVersion.startsWith(pluginTargetPrefix)) {
                 devDependencies.remove(depKey);
             }
         }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -238,7 +238,7 @@ public class NodeUpdaterTest {
     }
 
     @Test
-    public void removedDisusedPlugins() throws IOException {
+    public void removedAllOldAndExistingPlugins() throws IOException {
         File packageJson = new File(npmFolder, "package.json");
         FileWriter packageJsonWriter = new FileWriter(packageJson);
         packageJsonWriter.write("{\"devDependencies\": {"
@@ -249,7 +249,7 @@ public class NodeUpdaterTest {
         JsonObject actualDevDeps = nodeUpdater.getPackageJson()
                 .getObject(NodeUpdater.DEV_DEPENDENCIES);
         Assert.assertFalse(actualDevDeps.hasKey("some-old-plugin"));
-        Assert.assertTrue(
+        Assert.assertFalse(
                 actualDevDeps.hasKey("@vaadin/application-theme-plugin"));
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskInstallWebpackPluginsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskInstallWebpackPluginsTest.java
@@ -94,7 +94,7 @@ public class TaskInstallWebpackPluginsTest {
     }
 
     @Test
-    public void pluginsAddedToPackageJson() throws IOException {
+    public void pluginsNotAddedToPackageJson() throws IOException {
         File resourceFolder = temporaryFolder.newFolder();
         ClassFinder finder = Mockito.mock(ClassFinder.class);
         NodeUpdater nodeUpdater = new NodeUpdater(finder,
@@ -114,16 +114,8 @@ public class TaskInstallWebpackPluginsTest {
         final JsonObject devDependencies = packageJson
                 .getObject(DEV_DEPENDENCIES);
         for (String plugin : WebpackPluginsUtil.getPlugins()) {
-            Assert.assertTrue("packageJson is missing " + plugin,
+            Assert.assertFalse("Plugin " + plugin + " added to packageJson",
                     devDependencies.hasKey("@vaadin/" + plugin));
-
-            final String pluginFolder = "./" + rootFolder.toPath()
-                    .relativize(getPluginFolder(plugin).toPath()).toString()
-                    .replace('\\', '/');
-
-            Assert.assertEquals("Plugin is pointing to wrong directory",
-                    pluginFolder,
-                    devDependencies.getString("@vaadin/" + plugin));
         }
     }
 


### PR DESCRIPTION
Plugins are used as full path
and not through node_modules.

Do not add plugins to package.json
and clean away any existing plugins

Fixes #13247
