### PR TITLE
fix: use bundle-version instead of package version (#12785)

### DIFF
--- a/flow-server/bnd.bnd
+++ b/flow-server/bnd.bnd
@@ -3,7 +3,7 @@ Bundle-Name: Vaadin Flow Server
 Bundle-Version: ${osgi.bundle.version}
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-License: http://www.apache.org/licenses/LICENSE-2.0
-Import-Package: org.atmosphere*;resolution:=optional;version='${atmosphere.runtime.version}',\
+Import-Package: org.atmosphere*;resolution:=optional;bundle-version='${atmosphere.runtime.version}',\
   *
 Export-Package: com.vaadin.flow.client,\
     !com.vaadin.flow.push*, com.vaadin.flow*;-noimport:=true


### PR DESCRIPTION
The modified atmosphere-runtime:2.7.3.slf4jvaadin3 exports packages
with version 2.7.3 (i.e., not 2.7.3.slf4jvaadin3). Depend on bundle version
instead of the package version.

http://docs.osgi.org/specification/osgi.core/7.0.0/framework.module.html#framework.module.importpackage