### PR TITLE
test: Exclude client classes from serialization test.

### DIFF
--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
@@ -207,6 +207,11 @@ public abstract class ClassesSerializableTest extends ClassFinder {
                 "com\\.vaadin\\.flow\\.server\\.frontend\\.AbstractTaskClientGenerator",
                 "com\\.vaadin\\.flow\\.server\\.frontend\\.EndpointGeneratorTaskFactory",
 
+                // Flow client classes
+                "com\\.vaadin\\.client\\..*",
+                "com\\.vaadin\\.flow\\.linker\\.ClientEngineLinker",
+                "com\\.vaadin\\.flow\\.linker\\.ClientEngineLinker\\$Script",
+
                 // Node downloader classes
                 "com\\.vaadin\\.flow\\.server\\.frontend\\.installer\\.DefaultArchiveExtractor",
                 "com\\.vaadin\\.flow\\.server\\.frontend\\.installer\\.ArchiveExtractor",


### PR DESCRIPTION
## Description

When running maven test on modules together with flow-client, client side
classes are detected by ClassesSerializableTest, but they cannot be
loaded because of missing dependencies.
Client classes can be ignored from test, since they are not available at
runtime.

Fixes #13164

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
