### PR TITLE
fix: Change reconnecting message defaults to match client-side defaults

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ReconnectDialogConfigurationMap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/ReconnectDialogConfigurationMap.java
@@ -30,9 +30,9 @@ public class ReconnectDialogConfigurationMap extends NodeMap
         implements ReconnectDialogConfiguration {
 
     public static final String DIALOG_TEXT_KEY = "dialogText";
-    public static final String DIALOG_TEXT_DEFAULT = "Server connection lost, trying to reconnect...";
+    public static final String DIALOG_TEXT_DEFAULT = "Connection lost, trying to reconnect...";
     public static final String DIALOG_TEXT_GAVE_UP_KEY = "dialogTextGaveUp";
-    public static final String DIALOG_TEXT_GAVE_UP_DEFAULT = "Server connection lost.";
+    public static final String DIALOG_TEXT_GAVE_UP_DEFAULT = "Connection lost";
     public static final String RECONNECT_ATTEMPTS_KEY = "reconnectAttempts";
     public static final int RECONNECT_ATTEMPTS_DEFAULT = 10000;
     public static final String RECONNECT_INTERVAL_KEY = "reconnectInterval";


### PR DESCRIPTION
The reconnecting message defaults on the server-side do not match the [defaults used on the client-side](https://github.com/vaadin/flow-hilla-common/blob/main/frontend/packages/common-frontend/src/ConnectionIndicator.ts) (which is what the user actually sees). This PR makes the two sets of messages match each other. 