### PR TITLE
chore: Override commons-codec version to a safe one

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -139,7 +139,12 @@
             <artifactId>httpclient</artifactId>
             <version>4.5.13</version>
         </dependency>
-
+        <!-- Overrides the dependency version of httpclient -->
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.15</version>
+        </dependency>
         <!-- TESTING DEPENDENCIES -->
         <dependency>
             <groupId>com.vaadin</groupId>


### PR DESCRIPTION
Affected versions of this package are vulnerable to Information Exposure
