### PR TITLE
chore: Upgrade jackson-databind (#13430) (CP: 9.0)

### DIFF
--- a/flow-plugins/flow-maven-plugin/pom.xml
+++ b/flow-plugins/flow-maven-plugin/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <maven.version>3.8.3</maven.version>
-        <jackson.version>2.13.0</jackson.version>
+        <jackson.version>2.13.1</jackson.version>
     </properties>
 
     <dependencies>

--- a/flow-plugins/flow-maven-plugin/pom.xml
+++ b/flow-plugins/flow-maven-plugin/pom.xml
@@ -13,7 +13,6 @@
 
     <properties>
         <maven.version>3.8.3</maven.version>
-        <jackson.version>2.13.1</jackson.version>
     </properties>
 
     <dependencies>

--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.databind.version}</version>
         </dependency>
 
         <!-- Jsoup for BootstrapHandler, Template, ... -->

--- a/fusion-endpoint/pom.xml
+++ b/fusion-endpoint/pom.xml
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.databind.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <hibernate.validator.version>6.2.0.Final</hibernate.validator.version>
         <slf4j.version>1.7.32</slf4j.version>
         <polymer.version>2.6.1</polymer.version>
-        <jackson.version>2.13.0</jackson.version>
+        <jackson.version>2.13.1</jackson.version>
         <validation.api.version>2.0.1.Final</validation.api.version>
         <javax.annotation.api.version>1.3.2</javax.annotation.api.version>
         <jaxb.version>2.3.5</jaxb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <hibernate.validator.version>6.2.0.Final</hibernate.validator.version>
         <slf4j.version>1.7.32</slf4j.version>
         <polymer.version>2.6.1</polymer.version>
-        <jackson.version>2.13.1</jackson.version>
+        <jackson.version>2.13.2</jackson.version>
         <validation.api.version>2.0.1.Final</validation.api.version>
         <javax.annotation.api.version>1.3.2</javax.annotation.api.version>
         <jaxb.version>2.3.5</jaxb.version>

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
         <slf4j.version>1.7.32</slf4j.version>
         <polymer.version>2.6.1</polymer.version>
         <jackson.version>2.13.2</jackson.version>
+        <jackson.databind.version>2.13.2.2</jackson.databind.version>
         <validation.api.version>2.0.1.Final</validation.api.version>
         <javax.annotation.api.version>1.3.2</javax.annotation.api.version>
         <jaxb.version>2.3.5</jaxb.version>


### PR DESCRIPTION
Seemingly this does not (always) follow jackson versioning. 2.13.2.1 of jackson-databind contains a security (DoS) fix
