### PR TITLE
fix: Import unsafeCSS when using Vite and @CssImport

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -506,10 +506,13 @@ abstract class AbstractUpdateImports implements Runnable {
                     .collect(Collectors.joining(", ", "{", "}"));
         }
 
+        if (!lines.contains(THEMABLE_MIXIN_IMPORT)) {
+            // Imports are always needed for Vite CSS handling and extra imports
+            // is no harm
+            addLines(lines, THEMABLE_MIXIN_IMPORT);
+        }
+
         if (cssData.getThemefor() != null || cssData.getId() != null) {
-            if (!lines.contains(THEMABLE_MIXIN_IMPORT)) {
-                addLines(lines, THEMABLE_MIXIN_IMPORT);
-            }
             String themeFor = cssData.getThemefor() != null
                     ? cssData.getThemefor()
                     : "";

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
@@ -49,11 +49,11 @@ import org.slf4j.Logger;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.Constants;
-import com.vaadin.flow.server.frontend.NodeTestComponents.SimpleCssImport;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.CssData;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
@@ -77,6 +77,12 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
+
+    @Route(value = "simplecss")
+    @CssImport("./foo.css")
+    public static class SimpleCssImport extends Component {
+
+    }
 
     private File tmpRoot;
     private File generatedPath;

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractUpdateImportsTest.java
@@ -53,6 +53,7 @@ import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.JsModule;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.frontend.NodeTestComponents.SimpleCssImport;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.CssData;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
@@ -434,6 +435,23 @@ public abstract class AbstractUpdateImportsTest extends NodeUpdateTestUtil {
         NodeTestComponents.TranslatedImports translatedImports;
         NodeTestComponents.LocalP3Template localP3Template;
         NodeTestComponents.JavaScriptOrder javaScriptOrder;
+    }
+
+    @Test
+    public void plainCssImportWorks() throws MalformedURLException {
+        Class<?>[] testClasses = { SimpleCssImport.class };
+        ClassFinder classFinder = getClassFinder(testClasses);
+
+        updater = new UpdateImports(classFinder, getScanner(classFinder),
+                tmpRoot, new File(tmpRoot, TOKEN_FILE), true);
+        updater.run();
+
+        Assert.assertTrue("Should import unsafeCSS",
+                updater.getCssLines().stream()
+                        .anyMatch(line -> line.matches("import.*unsafeCSS.*")));
+        Assert.assertTrue("Should use unsafeCSS",
+                updater.getCssLines().stream().anyMatch(line -> line
+                        .matches(".*unsafeCSS\\(\\$cssFromFile_.*")));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTestComponents.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTestComponents.java
@@ -111,6 +111,11 @@ public class NodeTestComponents extends NodeUpdateTestUtil {
     public static class FlatImport extends Component {
     }
 
+    @CssImport("./foo.css")
+    public static class SimpleCssImport extends Component {
+
+    }
+
     @JsModule("@vaadin/vaadin-mixed-component/src/vaadin-mixed-component.js")
     @JsModule("@vaadin/vaadin-mixed-component/src/vaadin-something-else.js")
     @JsModule("@vaadin/vaadin-mixed-component/src/vaadin-something-else")

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTestComponents.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeTestComponents.java
@@ -111,11 +111,6 @@ public class NodeTestComponents extends NodeUpdateTestUtil {
     public static class FlatImport extends Component {
     }
 
-    @CssImport("./foo.css")
-    public static class SimpleCssImport extends Component {
-
-    }
-
     @JsModule("@vaadin/vaadin-mixed-component/src/vaadin-mixed-component.js")
     @JsModule("@vaadin/vaadin-mixed-component/src/vaadin-something-else.js")
     @JsModule("@vaadin/vaadin-mixed-component/src/vaadin-something-else")


### PR DESCRIPTION
When using `@CssImport("some.css")` we need an import for `unsafeCSS`