### PR TITLE
chore: log watchdog client connection error

### DIFF
--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -292,8 +292,8 @@ function updateTheme(contextPath: string) {
 function runWatchDog(watchDogPort) {
   const client = net.Socket();
   client.setEncoding('utf8');
-  client.on('error', function () {
-    console.log('Watchdog connection error. Terminating vite process...');
+  client.on('error', function (err) {
+    console.log('Watchdog connection error. Terminating vite process...', err);
     client.destroy();
     process.exit(0);
   });

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -96,8 +96,8 @@ if (watchDogPort) {
   const runWatchDog = () => {
     const client = new require('net').Socket();
     client.setEncoding('utf8');
-    client.on('error', function () {
-      console.log('Watchdog connection error. Terminating webpack process...');
+    client.on('error', function (err) {
+      console.log('Watchdog connection error. Terminating webpack process...', err);
       client.destroy();
       process.exit(0);
     });


### PR DESCRIPTION
## Description

It may happen that the watchdog client started by webpack
fails to connect for some reason, for example when server
socket is bound to ipv4 only and client resolve localhost
with its ipv6 address (e.g. with node 17).
This change adds the detail of the connection error to the
log message, so that debugging this kind of situation may
be simpler.

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
