### PR TITLE
chore: exclude commons-codec from httpClient

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -122,7 +122,7 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.5.13</version>
-			<exclusions>
+            <exclusions>
                 <exclusion>
                     <groupId>commons-codec</groupId>
                     <artifactId>commons-codec</artifactId>

--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -121,6 +121,13 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
+			<version>4.5.13</version>
+			<exclusions>
+                <exclusion>
+                    <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- Overrides the dependency version of httpclient -->
         <dependency>

--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -121,11 +121,11 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-			<version>4.5.13</version>
+            <version>4.5.13</version>
 			<exclusions>
                 <exclusion>
                     <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
+                    <artifactId>commons-codec</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
this current dependency setting failed in platform 
[link](https://bender.vaadin.com/viewLog.html?buildId=299463&buildTypeId=VaadinPlatform_TestReleasePlatformSnapshotToMavenVaadinPrerelease&tab=buildLog)

let us exclude this version properly. 

```
	[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (enforce) @ vaadin ---
[08:59:47]	[INFO] artifact org.webjars.npm:mobile-drag-drop: checking for updates from central
[08:59:47]	[INFO] artifact org.webjars.npm:mobile-drag-drop: checking for updates from vaadin-prereleases
[08:59:47]	[WARNING] 
[08:59:47]	Dependency convergence error for commons-codec:commons-codec:1.11 paths to dependency are:
[08:59:47]	+-com.vaadin:vaadin:14.8-SNAPSHOT
[08:59:47]	  +-com.vaadin:vaadin-core:14.8-SNAPSHOT
[08:59:47]	    +-com.vaadin:flow-server:2.7-SNAPSHOT
[08:59:47]	      +-org.apache.httpcomponents:httpclient:4.5.13
[08:59:47]	        +-commons-codec:commons-codec:1.11
[08:59:47]	and
[08:59:47]	+-com.vaadin:vaadin:14.8-SNAPSHOT
[08:59:47]	  +-com.vaadin:vaadin-core:14.8-SNAPSHOT
[08:59:47]	    +-com.vaadin:flow-server:2.7-SNAPSHOT
[08:59:47]	      +-commons-codec:commons-codec:1.15
[08:59:47]	
```