### PR TITLE
fix: Keep polling for dev mode server if an exception occurs

### DIFF
--- a/vaadin-dev-server/src/main/resources/com/vaadin/base/devserver/dev-mode-not-ready.html
+++ b/vaadin-dev-server/src/main/resources/com/vaadin/base/devserver/dev-mode-not-ready.html
@@ -49,14 +49,19 @@ window.Vaadin = {Flow: {devServerIsNotLoaded: true}};
 
 const delay = 200;
 const poll = () => {
-  fetch(window.location.href, {headers: {'X-DevModePoll': 'true'}}).then(response => {
-    if (response.headers.has("X-DevModePending")) {
-      setTimeout(poll, delay);
-    } else {
-      // App ready
-      document.location.reload();
-    }
-  })};
+  try {
+    fetch(window.location.href, { headers: { 'X-DevModePoll': 'true' } }).then(response => {
+      if (response.headers.has("X-DevModePending")) {
+        setTimeout(poll, delay);
+      } else {
+        // App ready
+        document.location.reload();
+      }
+    })
+  } catch (e) {
+    setTimeout(poll, delay);
+  }
+};
 
 setTimeout(poll, delay);
 


### PR DESCRIPTION
If the server is restarting, fetch can result in Uncaught (in promise) TypeError: Failed to fetch
