### PR TITLE
chore: Give more time to build steps

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    timeout-minutes: 10
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     outputs:
       matrix-unit: ${{ steps.set-matrix.outputs.matrix-unit }}
@@ -52,7 +52,7 @@ jobs:
           path: workspace.tar
   unit-tests:
     needs: build
-    timeout-minutes: 10
+    timeout-minutes: 15
     outputs:
       failure: ${{steps.set-failure.outputs.failure}}
     strategy:


### PR DESCRIPTION
It makes no sense that the build is sometimes killed when it is storing the results of the build and has about 10 seconds remaining
