### PR TITLE
fix: Not fetch entire page if number of requested items is less

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -1003,7 +1003,7 @@ public class DataCommunicator<T> implements Serializable {
 
                 stream = streamBuilder.build();
             } else {
-                stream = doFetchFromDataProvider(offset, pageSize);
+                stream = doFetchFromDataProvider(offset, limit);
             }
             limit = pages * pageSize;
         } else {

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
@@ -1195,13 +1195,13 @@ public class DataCommunicatorTest {
     }
 
     @Test
-    public void fetchFromProvider_limitLessThanPageSize_singleQuery() {
+    public void fetchFromProvider_limitLessThanPageSize_singleQuery_fetchedLessThanPage() {
         AbstractDataProvider<Item, Object> dataProvider = createDataProvider(
                 100);
         dataProvider = Mockito.spy(dataProvider);
 
         dataCommunicator.setDataProvider(dataProvider, null);
-        Stream<Item> stream = dataCommunicator.fetchFromProvider(10, 40);
+        Stream<Item> stream = dataCommunicator.fetchFromProvider(10, 42);
 
         ArgumentCaptor<Query> queryCaptor = ArgumentCaptor
                 .forClass(Query.class);
@@ -1209,16 +1209,16 @@ public class DataCommunicatorTest {
         Mockito.verify(dataProvider).fetch(queryCaptor.capture());
 
         List<Item> items = stream.collect(Collectors.toList());
-        Assert.assertEquals(50, items.size());
+        Assert.assertEquals(42, items.size());
 
-        Assert.assertEquals(IntStream.range(10, 60).mapToObj(Item::new)
+        Assert.assertEquals(IntStream.range(10, 52).mapToObj(Item::new)
                 .collect(Collectors.toList()), items);
 
         Query query = queryCaptor.getValue();
         Assert.assertEquals(10, query.getOffset());
-        Assert.assertEquals(50, query.getLimit());
+        Assert.assertEquals(42, query.getLimit());
         Assert.assertEquals(0, query.getPage());
-        Assert.assertEquals(50, query.getPageSize());
+        Assert.assertEquals(42, query.getPageSize());
     }
 
     @Test


### PR DESCRIPTION
## Description

Fixes bug that caused Grid with multi select mode to select not only the item that was clicked on, but also every item below

Fixes:
https://github.com/vaadin-component-factory/selection-grid-flow/issues/34
https://github.com/vaadin-component-factory/selection-grid-flow/issues/16#issuecomment-809987669

Co-authored-by: @s76527

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
