### PR TITLE
fix: Optimize Binder#doWriteIfValid to avoid duplicate field level validations

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -2258,12 +2258,12 @@ public class Binder<BEAN> implements Serializable {
                     currentBindings);
 
             // Field level validation can be skipped as it was done already
-            boolean validatorsInUse = isValidatorsDisabled();
+            boolean validatorsNotInUse = isValidatorsDisabled();
             setValidatorsDisabled(true);
             currentBindings
                     .forEach(binding -> ((BindingImpl<BEAN, ?, ?>) binding)
                             .writeFieldValue(bean));
-            setValidatorsDisabled(validatorsInUse);
+            setValidatorsDisabled(validatorsNotInUse);
 
             // Now run bean level validation against the updated bean
             binderResults = validateBean(bean);

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -2257,9 +2257,14 @@ public class Binder<BEAN> implements Serializable {
             Map<Binding<BEAN, ?>, Object> oldValues = getBeanState(bean,
                     currentBindings);
 
+            // Field level validation can be skipped as it was done already
+            boolean validatorsInUse = isValidatorsDisabled();
+            setValidatorsDisabled(true);
             currentBindings
                     .forEach(binding -> ((BindingImpl<BEAN, ?, ?>) binding)
                             .writeFieldValue(bean));
+            setValidatorsDisabled(validatorsInUse);
+
             // Now run bean level validation against the updated bean
             binderResults = validateBean(bean);
             if (binderResults.stream().anyMatch(ValidationResult::isError)) {

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -2263,7 +2263,7 @@ public class Binder<BEAN> implements Serializable {
             currentBindings
                     .forEach(binding -> ((BindingImpl<BEAN, ?, ?>) binding)
                             .writeFieldValue(bean));
-            setValidatorsDisabled(validatorsNotInUse);
+            setValidatorsDisabled(validatorsDisabledStatus);
 
             // Now run bean level validation against the updated bean
             binderResults = validateBean(bean);

--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -2258,7 +2258,7 @@ public class Binder<BEAN> implements Serializable {
                     currentBindings);
 
             // Field level validation can be skipped as it was done already
-            boolean validatorsNotInUse = isValidatorsDisabled();
+            boolean validatorsDisabledStatus = isValidatorsDisabled();
             setValidatorsDisabled(true);
             currentBindings
                     .forEach(binding -> ((BindingImpl<BEAN, ?, ?>) binding)

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -1779,12 +1779,12 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         }).bind(Person::getFirstName, Person::setFirstName);
         binder.readBean(item);
         nameField.setValue("Mike");
-        assertTrue("Validation should be run only once", 1 == count.get());
+        assertEquals("Validation should be run only once for value change", 1, count.get());
         try {
             binder.writeBean(item);
         } catch (ValidationException e) {
         }
-        assertTrue("Validation should be run only once", 2 == count.get());
+        assertEquals("Validation should be run only once for writing the bean", 2, count.get());
     }
 
     @Test

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -1766,6 +1766,27 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
     }
 
     @Test
+    public void validationShouldNotRunTwiceWhenWriting() {
+        TestTextField nameField = new TestTextField();
+        AtomicInteger count = new AtomicInteger(0);
+        binder.forField(nameField).withValidator((value, context) -> {
+            count.incrementAndGet();
+            if (value.equals("Mike")) {
+                return ValidationResult.ok();
+            } else {
+                return ValidationResult.error("value must be Mike");
+            }
+        }).bind(Person::getFirstName, Person::setFirstName);
+        binder.readBean(item);
+        nameField.setValue("Mike");
+        try {
+            binder.writeBean(item);
+        } catch (ValidationException e) {
+        }
+        assertTrue("Validation should be run only once",1 == count.get());
+    }
+
+    @Test
     public void setValidationErrorHandler_handlerIsSet_handlerMethodsAreCalled() {
         TestTextField testField = new TestTextField();
 

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -1785,8 +1785,8 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
             binder.writeBean(item);
         } catch (ValidationException e) {
         }
-        assertEquals("Validation should be run only once for writing the bean", 2,
-                count.get());
+        assertEquals("Validation should be run only once for writing the bean",
+                2, count.get());
     }
 
     @Test

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -1779,11 +1779,12 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         }).bind(Person::getFirstName, Person::setFirstName);
         binder.readBean(item);
         nameField.setValue("Mike");
+        assertTrue("Validation should be run only once",1 == count.get());
         try {
             binder.writeBean(item);
         } catch (ValidationException e) {
         }
-        assertTrue("Validation should be run only once",1 == count.get());
+        assertTrue("Validation should be run only once",2 == count.get());
     }
 
     @Test

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -1779,12 +1779,14 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         }).bind(Person::getFirstName, Person::setFirstName);
         binder.readBean(item);
         nameField.setValue("Mike");
-        assertEquals("Validation should be run only once for value change", 1, count.get());
+        assertEquals("Validation should be run only once for value change", 1,
+                count.get());
         try {
             binder.writeBean(item);
         } catch (ValidationException e) {
         }
-        assertEquals("Validation should be run only once for writing the bean", 2, count.get());
+        assertEquals("Validation should be run only once for writing the bean", 2,
+                count.get());
     }
 
     @Test

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderTest.java
@@ -1779,12 +1779,12 @@ public class BinderTest extends BinderTestBase<Binder<Person>, Person> {
         }).bind(Person::getFirstName, Person::setFirstName);
         binder.readBean(item);
         nameField.setValue("Mike");
-        assertTrue("Validation should be run only once",1 == count.get());
+        assertTrue("Validation should be run only once", 1 == count.get());
         try {
             binder.writeBean(item);
         } catch (ValidationException e) {
         }
-        assertTrue("Validation should be run only once",2 == count.get());
+        assertTrue("Validation should be run only once", 2 == count.get());
     }
 
     @Test


### PR DESCRIPTION
This is useful optimization for the case where you have e.g. validator that checks that input is not in the database, hence avoiding duplicate DB query.