### PR TITLE
feat: License checker in Java instead of browser

### DIFF
--- a/flow-client/src/main/frontend/License.ts
+++ b/flow-client/src/main/frontend/License.ts
@@ -55,7 +55,7 @@ const manipulate = (element: Element, productAndMessage: ProductAndMessage) => {
         "<a href='https:$1'>https:$1</a>"
       );
 
-  element.outerHTML = `<no-license style="display: flex; align-items:center;text-align:center;justify-content:center;"><div>${htmlMessage}</div></no-license>`;
+  element.outerHTML = `<no-license style="display:flex;align-items:center;text-align:center;justify-content:center;"><div>${htmlMessage}</div></no-license>`;
 };
 
 const orgDefine = window.customElements.define.bind(window.customElements);

--- a/flow-client/src/main/frontend/License.ts
+++ b/flow-client/src/main/frontend/License.ts
@@ -1,0 +1,108 @@
+const manipulateTimeout = 1000;
+
+export interface Product {
+  name: string;
+  version: string;
+}
+
+export interface ProductAndMessage {
+  message: string;
+  messageHtml?: string;
+  product: Product;
+}
+
+export const findAll = (element: Element | ShadowRoot | Document, tag: string): Element[] => {
+  const lightDom = Array.from(element.querySelectorAll(tag));
+  const shadowDom = Array.from(element.querySelectorAll('*'))
+    .filter((e) => e.shadowRoot)
+    .flatMap((e) => findAll(e.shadowRoot!, tag));
+  return [...lightDom, ...shadowDom];
+};
+
+let licenseCheckListener = false;
+
+const manipulate = (element: Element, productAndMessage: ProductAndMessage) => {
+  if (!licenseCheckListener) {
+    // When a license check has succeeded, refresh so that all elements are properly shown again
+    window.addEventListener(
+      'message',
+      (e) => {
+        if (e.data === 'validate-license') {
+          window.location.reload();
+        }
+      },
+      false
+    );
+    licenseCheckListener = true;
+  }
+  const overlay = (element as any)._overlayElement;
+  if (overlay) {
+    if (overlay.shadowRoot) {
+      const defaultSlot = overlay.shadowRoot.querySelector('slot:not([name])');
+      if (defaultSlot && defaultSlot.assignedElements().length > 0) {
+        manipulate(defaultSlot.assignedElements()[0], productAndMessage);
+        return;
+      }
+    }
+    manipulate(overlay, productAndMessage);
+    return;
+  }
+
+  const htmlMessage = productAndMessage.messageHtml
+    ? productAndMessage.messageHtml
+    : `${productAndMessage.message} <p>Component: ${productAndMessage.product.name} ${productAndMessage.product.version}</p>`.replace(
+        /https:([^ ]*)/g,
+        "<a href='https:$1'>https:$1</a>"
+      );
+
+  element.outerHTML = `<no-license style="display: flex; align-items:center;text-align:center;justify-content:center;"><div>${htmlMessage}</div></no-license>`;
+};
+
+const orgDefine = window.customElements.define.bind(window.customElements);
+const missingLicense: { [key: string]: ProductAndMessage } = {};
+
+customElements.define = (name, constructor, options) => {
+  const orgCallback = constructor.prototype.connectedCallback;
+
+  // eslint-disable-next-line func-names
+  constructor.prototype.connectedCallback = function () {
+    const productInfo = missingLicense[this.tagName.toLowerCase()];
+    if (productInfo) {
+      setTimeout(() => manipulate(this, productInfo), manipulateTimeout);
+    }
+    if (orgCallback) {
+      orgCallback.call(this);
+    }
+  };
+  orgDefine(name, constructor, options);
+};
+
+export const licenseCheckOk = (data: Product) => {
+  // eslint-disable-next-line no-console
+  console.debug('License check ok for ', data);
+};
+
+export const licenseCheckFailed = (data: ProductAndMessage) => {
+  const tag = data.product.name;
+  missingLicense[tag] = data;
+  // eslint-disable-next-line no-console
+  console.error('License check failed for ', tag);
+
+  findAll(document, tag).forEach((element) => {
+    setTimeout(() => manipulate(element, missingLicense[tag]), manipulateTimeout);
+  });
+};
+
+export const licenseCheckNoKey = (data: ProductAndMessage) => {
+  const keyUrl = data.message;
+
+  const tag = data.product.name;
+  data.messageHtml = `No license found. <a target=_blank onclick="javascript:window.open(this.href);return false;" href="${keyUrl}">Go here to start a trial or retrieve your license.</a>`;
+  missingLicense[tag] = data;
+  // eslint-disable-next-line no-console
+  console.error('No license found when checking ', tag);
+
+  findAll(document, tag).forEach((element) => {
+    setTimeout(() => manipulate(element, missingLicense[tag]), manipulateTimeout);
+  });
+};

--- a/flow-client/src/main/frontend/VaadinDevmodeGizmo.ts
+++ b/flow-client/src/main/frontend/VaadinDevmodeGizmo.ts
@@ -4,6 +4,7 @@ import { classMap } from 'lit/directives/class-map.js';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { copy } from './copy-to-clipboard.js';
+import { licenseCheckFailed, licenseCheckNoKey, licenseCheckOk, Product } from './License';
 
 interface ServerInfo {
   vaadinVersion: string;
@@ -98,6 +99,12 @@ export class Connection extends Object {
       if (this.status === ConnectionStatus.ACTIVE) {
         this.onReload();
       }
+    } else if (json.command === 'license-check-ok') {
+      licenseCheckOk(json.data);
+    } else if (json.command === 'license-check-failed') {
+      licenseCheckFailed(json.data);
+    } else if (json.command === 'license-check-nokey') {
+      licenseCheckNoKey(json.data);
     } else {
       this.onMessage(json);
     }
@@ -139,6 +146,9 @@ export class Connection extends Object {
   }
   sendTelemetry(browserData: any) {
     this.send('reportTelemetry', { browserData });
+  }
+  sendLicenseCheck(product: Product) {
+    this.send('checkLicense', product);
   }
 }
 
@@ -1159,6 +1169,14 @@ export class VaadinDevmodeGizmo extends LitElement {
       this.log(MessageType.LOG, this.splashMessage);
     }
     this.showSplashMessage(undefined);
+  }
+
+  checkLicense(productInfo: Product) {
+    if (this.frontendConnection) {
+      this.frontendConnection.sendLicenseCheck(productInfo);
+    } else {
+      licenseCheckFailed({ message: 'Internal error: no connection', product: productInfo });
+    }
   }
 
   log(type: MessageType, message: string, details?: string, link?: string) {

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -493,8 +493,8 @@ public class BuildFrontendUtil {
             throw new RuntimeException(
                     "Stats file " + statsFile + " does not exist");
         }
-        List<Product> commercialComponents = findComponents(nodeModulesFolder,
-                statsFile);
+        List<Product> commercialComponents = findCommercialComponents(
+                nodeModulesFolder, statsFile);
 
         for (Product component : commercialComponents) {
             try {
@@ -520,8 +520,8 @@ public class BuildFrontendUtil {
         return LoggerFactory.getLogger(BuildFrontendUtil.class);
     }
 
-    private static List<Product> findComponents(File nodeModulesFolder,
-            File statsFile) {
+    private static List<Product> findCommercialComponents(
+            File nodeModulesFolder, File statsFile) {
         List<Product> components = new ArrayList<>();
         try (InputStream in = new FileInputStream(statsFile)) {
             String contents = IOUtils.toString(in, StandardCharsets.UTF_8);

--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -58,6 +58,11 @@
         </dependency>
 
         <!-- Library dependencies -->
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>license-checker</artifactId>
+            <version>1.3.1</version>
+        </dependency>
 
         <dependency>
             <groupId>com.vaadin.external.gwt</groupId>

--- a/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
+++ b/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
@@ -67,6 +67,9 @@ public class FeatureFlags implements Serializable {
     public static final Feature HILLA_PUSH = new Feature(
             "Push support in Hilla", "hillaPush",
             "https://github.com/vaadin/hilla/issues/56", true, null);
+    public static final Feature NEW_LICENSE_CHECKER = new Feature(
+            "New license checker", "newLicenseChecker",
+            "https://github.com/vaadin/platform/issues/2938", false, null);
     private List<Feature> features = new ArrayList<>();
 
     File propertiesFolder = null;
@@ -88,6 +91,7 @@ public class FeatureFlags implements Serializable {
         features.add(new Feature(MAP_COMPONENT));
         features.add(new Feature(SPREADSHEET_COMPONENT));
         features.add(new Feature(HILLA_PUSH));
+        features.add(new Feature(NEW_LICENSE_CHECKER));
         loadProperties();
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReload.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReload.java
@@ -84,7 +84,12 @@ public interface BrowserLiveReload {
 
     /**
      * Called when any message is received through the connection.
+     *
+     * @param resource
+     *            the atmosphere resource that received the message
+     * @param msg
+     *            the received message
      */
-    void onMessage(String msg);
+    void onMessage(AtmosphereResource resource, String msg);
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
@@ -175,6 +175,7 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
     }
 
     private void addLicenseChecker(Document indexDocument) {
+        // maybeCheck is invoked by the WC license checker
         addScript(indexDocument, "" + //
                 "window.Vaadin = window.Vaadin || {};" + //
                 "window.Vaadin.VaadinLicenseChecker = {" + //

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PushHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PushHandler.java
@@ -589,7 +589,7 @@ public class PushHandler {
             Optional<BrowserLiveReload> liveReload = BrowserLiveReloadAccessor
                     .getLiveReloadFromService(service);
             if (liveReload.isPresent()) {
-                liveReload.get().onMessage(msg);
+                liveReload.get().onMessage(request.resource(), msg);
             } else {
                 getLogger().error(
                         "Received message for debug window but there is no debug window connection available");

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/CvdlProducts.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/CvdlProducts.java
@@ -1,0 +1,123 @@
+package com.vaadin.flow.server.frontend;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import com.vaadin.pro.licensechecker.LicenseChecker;
+import com.vaadin.pro.licensechecker.LocalProKey;
+import com.vaadin.pro.licensechecker.Product;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import elemental.json.Json;
+import elemental.json.JsonObject;
+
+/** Utilities for commercial product handling. */
+public class CvdlProducts {
+
+    private static final String CVDL_PACKAGE_KEY = "cvdlName";
+
+    /**
+     * Returns product information if the given npm module refers to a Vaadin
+     * commercial component.
+     *
+     * @param nodeModules
+     *            the node modules folder
+     * @param npmModule
+     *            the name of the npm module to check
+     */
+    public static Product getProductIfCvdl(File nodeModules, String npmModule) {
+        File packageJsonFile = new File(new File(nodeModules, npmModule),
+                "package.json");
+
+        try {
+            JsonObject packageJson = Json.parse(FileUtils
+                    .readFileToString(packageJsonFile, StandardCharsets.UTF_8));
+            if (packageJson.hasKey(CVDL_PACKAGE_KEY)) {
+                return new Product(packageJson.getString(CVDL_PACKAGE_KEY),
+                        packageJson.getString("version"));
+            } else if (packageJson.hasKey("license")) {
+                String packageName = packageJson.getString("name");
+                String license = packageJson.getString("license");
+                if (packageName.startsWith("@vaadin/") && license
+                        .startsWith("https://raw.githubusercontent.com")) {
+                    // Free components have "Apache-2.0"
+                    String cvdlName = packageName;
+                    cvdlName = cvdlName.replace("@", "");
+                    cvdlName = cvdlName.replace("/", "-");
+                    cvdlName = cvdlName.replace("charts", "chart");
+                    return new Product(cvdlName,
+                            packageJson.getString("version"));
+                }
+            }
+            return null;
+        } catch (IOException e) {
+            throw new RuntimeException(
+                    "Unable to read package.json file " + packageJsonFile, e);
+        }
+    }
+
+    public static boolean includeInFallbackBundle(String module,
+            File nodeModules) {
+        if (module.startsWith(".") || module.startsWith("Frontend/")) {
+            // Project internal file
+            return true;
+        }
+
+        String npmModule = getNpmModule(module);
+        if (npmModule == null) {
+            // Unclear when this would happen
+            return true;
+        }
+
+        Product product = CvdlProducts.getProductIfCvdl(nodeModules, npmModule);
+        if (product != null) {
+            if (LocalProKey.get() == null) {
+                // No proKey, do not bother free users with a license check
+                getLogger().debug(
+                        "No proKey found. Dropping '{}' from the fallback bundle without asking for validation",
+                        module);
+                return false;
+            } else {
+                try {
+                    LicenseChecker.checkLicense(product.getName(),
+                            product.getVersion());
+                    return true;
+                } catch (Exception e) {
+                    // Silently drop from the fallback bundle (it is a
+                    // production build).
+                    // Otherwise we would bother all free users with a license
+                    // check
+                    getLogger().debug(
+                            "License check failed. Dropping '{}' from the fallback bundle",
+                            module, e);
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private static String getNpmModule(String module) {
+        // npm modules are either @org/pkg or pkg
+        String[] parts = module.split("/");
+        if (parts.length < 2) {
+            // What would this be?
+            return null;
+        }
+        if (parts[0].startsWith("@")) {
+            return parts[0] + "/" + parts[1];
+        } else {
+            return parts[0];
+        }
+
+    }
+
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(CvdlProducts.class);
+    }
+
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/CvdlProducts.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/CvdlProducts.java
@@ -106,7 +106,7 @@ public class CvdlProducts {
 
     private static String getNpmModule(String module) {
         // npm modules are either @org/pkg or pkg
-        String[] parts = module.split("/");
+        String[] parts = module.split("/", -1);
         if (parts.length < 2) {
             // What would this be?
             return null;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/CvdlProducts.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/CvdlProducts.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.flow.server.frontend;
 
 import java.io.File;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/CvdlProducts.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/CvdlProducts.java
@@ -32,6 +32,9 @@ public class CvdlProducts {
     public static Product getProductIfCvdl(File nodeModules, String npmModule) {
         File packageJsonFile = new File(new File(nodeModules, npmModule),
                 "package.json");
+        if (!packageJsonFile.exists()) {
+            return null;
+        }
 
         try {
             JsonObject packageJson = Json.parse(FileUtils

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.component.dependency.JsModule;
@@ -41,13 +42,9 @@ import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 import com.vaadin.flow.theme.AbstractTheme;
 import com.vaadin.flow.theme.Theme;
 import com.vaadin.flow.theme.ThemeDefinition;
-import com.vaadin.pro.licensechecker.LicenseChecker;
-import com.vaadin.pro.licensechecker.LocalProKey;
-import com.vaadin.pro.licensechecker.Product;
 
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import elemental.json.Json;
 import elemental.json.JsonArray;
@@ -276,7 +273,7 @@ public class TaskUpdateImports extends NodeUpdater {
             LinkedHashSet<String> set = new LinkedHashSet<>(
                     fallbackScanner.getModules());
             set.removeAll(frontDeps.getModules());
-            return filter(new ArrayList<String>(set));
+            return filter(set.stream()).collect(Collectors.toList());
         }
 
         @Override
@@ -284,7 +281,7 @@ public class TaskUpdateImports extends NodeUpdater {
             LinkedHashSet<String> set = new LinkedHashSet<>(
                     fallbackScanner.getScripts());
             set.removeAll(frontDeps.getScripts());
-            return filter(set);
+            return filter(set.stream()).collect(Collectors.toSet());
         }
 
         @Override
@@ -480,25 +477,12 @@ public class TaskUpdateImports extends NodeUpdater {
         return array;
     }
 
-    private List<String> filter(List<String> modules) {
+    private Stream<String> filter(Stream<String> modules) {
         if (!productionMode) {
             return modules;
         }
-
-        return modules
-                .stream().filter(module -> CvdlProducts
-                        .includeInFallbackBundle(module, nodeModulesFolder))
-                .collect(Collectors.toList());
-    }
-
-    private Set<String> filter(Set<String> modules) {
-        if (!productionMode) {
-            return modules;
-        }
-        return modules
-                .stream().filter(module -> CvdlProducts
-                        .includeInFallbackBundle(module, nodeModulesFolder))
-                .collect(Collectors.toSet());
+        return modules.filter(module -> CvdlProducts
+                .includeInFallbackBundle(module, nodeModulesFolder));
     }
 
     private JsonArray makeFallbackCssImports(AbstractUpdateImports updater) {
@@ -540,7 +524,7 @@ public class TaskUpdateImports extends NodeUpdater {
         return String.format(
                 "If the build fails, check that npm packages are installed.\n\n"
                         + "  To fix the build remove `%s` and `node_modules` directory to reset modules.\n"
-                        + "  In addition you may run `%s install` to fix `node_modules` töree structure.%s",
+                        + "  In addition you may run `%s install` to fix `node_modules` tree structure.%s",
                 lockFile, command, note);
     }
 

--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -5,12 +5,12 @@
  * This file will be overwritten on every run. Any custom changes should be made to vite.config.ts
  */
 import path from 'path';
-import { readFileSync, existsSync } from 'fs';
+import { readFileSync, existsSync, writeFileSync } from 'fs';
 import * as net from 'net';
 
 import { processThemeResources } from '#buildFolder#/plugins/application-theme-plugin/theme-handle';
 import settings from '#settingsImport#';
-import { defineConfig, mergeConfig, PluginOption, ResolvedConfig, UserConfigFn } from 'vite';
+import { defineConfig, mergeConfig, PluginOption, ResolvedConfig, UserConfigFn, OutputOptions, AssetInfo, ChunkInfo } from 'vite';
 import { injectManifest } from 'workbox-build';
 
 import * as rollup from 'rollup';
@@ -25,6 +25,7 @@ const themeFolder = path.resolve(frontendFolder, settings.themeFolder);
 const frontendBundleFolder = path.resolve(__dirname, settings.frontendBundleOutput);
 const addonFrontendFolder = path.resolve(__dirname, settings.addonFrontendFolder);
 const themeResourceFolder = path.resolve(__dirname, settings.themeResourceFolder);
+const statsFile = path.resolve(frontendBundleFolder, '..', 'config', 'stats.json');
 
 const projectStaticAssetsFolders = [
   path.resolve(__dirname, 'src', 'main', 'resources', 'META-INF', 'resources'),
@@ -132,6 +133,30 @@ function injectManifestToSWPlugin(): PluginOption {
   };
 }
 
+function statsExtracterPlugin(): PluginOption {
+  return {
+    name: 'vaadin:stats',
+    enforce: 'post',
+    async writeBundle(options: OutputOptions, bundle: { [fileName: string]: AssetInfo | ChunkInfo }) {
+      const modules = Object.values(bundle).flatMap((b) => (b.modules ? Object.keys(b.modules) : []));
+      const nodeModulesFolders = modules.filter((id) => id.includes('node_modules'));
+      const npmModules = nodeModulesFolders
+        .map((id) => id.replace(/.*node_modules./, ''))
+        .map((id) => {
+          const parts = id.split('/');
+          if (id.startsWith('@')) {
+            return parts[0] + '/' + parts[1];
+          } else {
+            return parts[0];
+          }
+        })
+        .sort()
+        .filter((value, index, self) => self.indexOf(value) === index);
+
+      writeFileSync(statsFile, JSON.stringify({ npmModules }, null, 1));
+    }
+  };
+}
 function vaadinBundlesPlugin(): PluginOption {
   type ExportInfo =
     | string
@@ -374,6 +399,7 @@ export const vaadinConfig: UserConfigFn = (env) => {
       devMode && vaadinBundlesPlugin(),
       settings.offlineEnabled && buildSWPlugin(),
       settings.offlineEnabled && injectManifestToSWPlugin(),
+      !devMode && statsExtracterPlugin(),
       {
         name: 'vaadin:custom-theme',
         config() {

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -52,12 +52,8 @@ const buildDirectory = '[to-be-generated-by-flow]';
 // Flow plugins
 const BuildStatusPlugin = require(buildDirectory + '/plugins/build-status-plugin');
 const ThemeLiveReloadPlugin = require(buildDirectory + '/plugins/theme-live-reload-plugin');
-const {
-  ApplicationThemePlugin,
-  processThemeResources,
-  extractThemeName,
-  findParentThemes
-} = require(buildDirectory + '/plugins/application-theme-plugin');
+const { ApplicationThemePlugin, processThemeResources, extractThemeName, findParentThemes } = require(buildDirectory +
+  '/plugins/application-theme-plugin');
 const themeLoader = buildDirectory + '/plugins/theme-loader';
 
 // Folders in the project which can contain static assets.
@@ -339,13 +335,32 @@ module.exports = {
 
     function (compiler) {
       // V14 bootstrapping needs the bundle names
-      compiler.hooks.afterEmit.tapAsync("FlowStatsHelper", (compilation, done) => {
+      compiler.hooks.afterEmit.tapAsync('FlowStatsHelper', (compilation, done) => {
+        const st = compilation.getStats().toJson();
+        const modules = st.modules;
+        const nodeModulesFolders = modules
+          .map((module) => module.identifier)
+          .filter((id) => id.includes('node_modules'));
+        const npmModules = nodeModulesFolders
+          .map((id) => id.replace(/.*node_modules./, ''))
+          .map((id) => {
+            const parts = id.split('/');
+            if (id.startsWith('@')) {
+              return parts[0] + '/' + parts[1];
+            } else {
+              return parts[0];
+            }
+          })
+          .sort()
+          .filter((value, index, self) => self.indexOf(value) === index);
+
         let miniStats = {
-          assetsByChunkName: compilation.getStats().toJson().assetsByChunkName
+          assetsByChunkName: st.assetsByChunkName,
+          npmModules: npmModules
         };
+
         if (!devMode) {
-          fs.writeFile(statsFile, JSON.stringify(miniStats, null, 1),
-            () => done());
+          fs.writeFile(statsFile, JSON.stringify(miniStats, null, 1), () => done());
         } else {
           stats = miniStats;
           done();

--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
@@ -210,6 +210,7 @@ public abstract class ClassesSerializableTest extends ClassFinder {
                 "com\\.vaadin\\.flow\\.server\\.frontend\\.Task.*",
                 "com\\.vaadin\\.flow\\.server\\.frontend\\.AbstractTaskClientGenerator",
                 "com\\.vaadin\\.flow\\.server\\.frontend\\.EndpointGeneratorTaskFactory",
+                "com\\.vaadin\\.flow\\.server\\.frontend\\.CvdlProducts",
 
                 // Flow client classes
                 "com\\.vaadin\\.client\\..*",

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DebugWindowConnection.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DebugWindowConnection.java
@@ -37,6 +37,9 @@ import org.slf4j.LoggerFactory;
 import elemental.json.Json;
 import elemental.json.JsonObject;
 
+import com.vaadin.pro.licensechecker.Product;
+import com.vaadin.pro.licensechecker.LicenseChecker;
+
 /**
  * {@link BrowserLiveReload} implementation class.
  * <p>
@@ -164,7 +167,7 @@ public class DebugWindowConnection implements BrowserLiveReload {
     }
 
     @Override
-    public void onMessage(String message) {
+    public void onMessage(AtmosphereResource resource, String message) {
         if (message.isEmpty()) {
             getLogger().debug("Received live reload heartbeat");
             return;
@@ -178,6 +181,34 @@ public class DebugWindowConnection implements BrowserLiveReload {
         } else if ("reportTelemetry".equals(command)) {
             JsonObject data = json.getObject("data");
             DevModeUsageStatistics.handleBrowserData(data);
+        } else if ("checkLicense".equals(command)) {
+            JsonObject data = json.getObject("data");
+            String name = data.getString("name");
+            String version = data.getString("version");
+            Product product = new Product(name, version);
+            boolean ok;
+            String errorMessage = "";
+
+            try {
+                LicenseChecker.checkLicense(product.getName(),
+                        product.getVersion(), keyUrl -> {
+                            send(resource, "license-check-nokey",
+                                    new ProductAndMessage(product, keyUrl));
+                        });
+                ok = true;
+            } catch (Exception e) {
+                ok = false;
+                errorMessage = e.getMessage();
+            }
+            if (ok) {
+                send(resource, "license-check-ok", product);
+            } else {
+                ProductAndMessage pm = new ProductAndMessage(product,
+                        errorMessage);
+                send(resource, "license-check-failed", pm);
+            }
+        } else {
+            getLogger().info("Unknown command from the browser: " + command);
         }
     }
 

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/ProductAndMessage.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/ProductAndMessage.java
@@ -1,0 +1,21 @@
+package com.vaadin.base.devserver;
+
+import com.vaadin.pro.licensechecker.Product;
+
+public class ProductAndMessage {
+    private Product product;
+    private String message;
+
+    public ProductAndMessage(Product product, String message) {
+        this.product = product;
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public Product getProduct() {
+        return product;
+    }
+}

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/ProductAndMessage.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/ProductAndMessage.java
@@ -1,10 +1,25 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.base.devserver;
 
 import java.io.Serializable;
 
 import com.vaadin.pro.licensechecker.Product;
 
-public class ProductAndMessage implements Serializable {
+class ProductAndMessage implements Serializable {
     private Product product;
     private String message;
 

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/ProductAndMessage.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/ProductAndMessage.java
@@ -1,8 +1,10 @@
 package com.vaadin.base.devserver;
 
+import java.io.Serializable;
+
 import com.vaadin.pro.licensechecker.Product;
 
-public class ProductAndMessage {
+public class ProductAndMessage implements Serializable {
     private Product product;
     private String message;
 


### PR DESCRIPTION
For development mode:
- Checks the license from the Java side to avoid cookies
- Replaces commercial components with a login/validation link if the subscription could not be validated

For production mode:
- Requires a license during a production build for commercial components
- Removes commercial components from the fallback bundle if there is no license
- Speeds up production build for free users as charts/maps/... are not compiled in the fallback bundle

Fixes https://github.com/vaadin/platform/issues/2938