### PR TITLE
refactor: introduce http status code enumeration

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/JavaScriptNavigationStateRenderer.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.component.internal;
 
-import javax.servlet.http.HttpServletResponse;
-
 import java.util.Optional;
 
 import org.slf4j.Logger;
@@ -29,6 +27,7 @@ import com.vaadin.flow.router.NavigationEvent;
 import com.vaadin.flow.router.NavigationState;
 import com.vaadin.flow.router.NavigationTrigger;
 import com.vaadin.flow.router.internal.NavigationStateRenderer;
+import com.vaadin.flow.server.HttpStatusCode;
 
 /**
  * Handle navigation events in relation to the client side bootstrap UI
@@ -89,7 +88,7 @@ class JavaScriptNavigationStateRenderer extends NavigationStateRenderer {
 
             } else {
                 clientForwardRoute = beforeEvent.getUnknownForward();
-                return Optional.of(HttpServletResponse.SC_OK);
+                return Optional.of(HttpStatusCode.OK.getCode());
             }
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/router/HasErrorParameter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/HasErrorParameter.java
@@ -33,14 +33,14 @@ public interface HasErrorParameter<T extends Exception> extends Serializable {
      * Callback executed before rendering the exception view.
      * <p>
      * Note! returned int should be a valid
-     * {@link javax.servlet.http.HttpServletResponse} code
+     * {@link com.vaadin.flow.server.HttpStatusCode} code
      *
      * @param event
      *            the before navigation event for this request
      * @param parameter
      *            error parameter containing custom exception and caught
      *            exception
-     * @return a valid {@link javax.servlet.http.HttpServletResponse} code
+     * @return a valid {@link com.vaadin.flow.server.HttpStatusCode} code
      */
     int setErrorParameter(BeforeEnterEvent event, ErrorParameter<T> parameter);
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/InternalServerError.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/InternalServerError.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.router;
 
-import javax.servlet.http.HttpServletResponse;
-
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -31,6 +29,7 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementFactory;
 import com.vaadin.flow.router.internal.DefaultErrorHandler;
+import com.vaadin.flow.server.HttpStatusCode;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.auth.AnonymousAllowed;
 
@@ -74,7 +73,7 @@ public class InternalServerError extends Component
         } else {
             getElement().setText(exceptionText);
         }
-        return HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+        return HttpStatusCode.INTERNAL_SERVER_ERROR.getCode();
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/router/LocationChangeEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/LocationChangeEvent.java
@@ -22,11 +22,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
-import javax.servlet.http.HttpServletResponse;
-
 import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.router.internal.NavigationStateRenderer;
+import com.vaadin.flow.server.HttpStatusCode;
 
 /**
  * Event created when the location changes by any of the reasons defined at
@@ -39,7 +38,7 @@ public class LocationChangeEvent extends EventObject {
     private final NavigationTrigger trigger;
     private final Location location;
 
-    private int statusCode = HttpServletResponse.SC_OK;
+    private int statusCode = HttpStatusCode.OK.getCode();
     private NavigationHandler rerouteTarget;
 
     private List<HasElement> routeTargetChain;

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteNotFoundError.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteNotFoundError.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.router;
 
-import javax.servlet.http.HttpServletResponse;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -34,6 +32,7 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Html;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.router.internal.DefaultErrorHandler;
+import com.vaadin.flow.server.HttpStatusCode;
 import com.vaadin.flow.server.auth.AnonymousAllowed;
 
 /**
@@ -78,7 +77,7 @@ public class RouteNotFoundError extends Component
         template = template.replace("{{path}}", path);
 
         getElement().setChild(0, new Html(template).getElement());
-        return HttpServletResponse.SC_NOT_FOUND;
+        return HttpStatusCode.NOT_FOUND.getCode();
     }
 
     private static Logger getLogger() {

--- a/flow-server/src/main/java/com/vaadin/flow/router/Router.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/Router.java
@@ -19,8 +19,6 @@ import java.io.Serializable;
 import java.util.Map;
 import java.util.Optional;
 
-import javax.servlet.http.HttpServletResponse;
-
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.router.internal.DefaultRouteResolver;
 import com.vaadin.flow.router.internal.ErrorStateRenderer;
@@ -29,6 +27,7 @@ import com.vaadin.flow.router.internal.InternalRedirectHandler;
 import com.vaadin.flow.router.internal.NavigationStateRenderer;
 import com.vaadin.flow.router.internal.ResolveRequest;
 import com.vaadin.flow.server.ErrorRouteRegistry;
+import com.vaadin.flow.server.HttpStatusCode;
 import com.vaadin.flow.server.RouteRegistry;
 import com.vaadin.flow.server.SessionRouteRegistry;
 import com.vaadin.flow.server.VaadinRequest;
@@ -225,7 +224,7 @@ public class Router implements Serializable {
                 ui.getInternals().clearLastHandledNavigation();
             }
         }
-        return HttpServletResponse.SC_NOT_MODIFIED;
+        return HttpStatusCode.NOT_MODIFIED.getCode();
     }
 
     private boolean handleNavigationForLocation(UI ui, Location location) {

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.router.internal;
 
-import javax.servlet.http.HttpServletResponse;
-
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -36,7 +34,6 @@ import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.Pair;
-import com.vaadin.flow.internal.ReflectTools;
 import com.vaadin.flow.router.AfterNavigationEvent;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.BeforeEnterObserver;
@@ -60,6 +57,7 @@ import com.vaadin.flow.router.PreserveOnRefresh;
 import com.vaadin.flow.router.RouteParameters;
 import com.vaadin.flow.router.Router;
 import com.vaadin.flow.router.RouterLayout;
+import com.vaadin.flow.server.HttpStatusCode;
 import com.vaadin.flow.server.VaadinSession;
 
 import elemental.json.JsonValue;
@@ -74,9 +72,6 @@ import elemental.json.JsonValue;
  */
 public abstract class AbstractNavigationStateRenderer
         implements NavigationHandler {
-
-    private static List<Integer> statusCodes = ReflectTools
-            .getConstantIntValues(HttpServletResponse.class);
 
     private final NavigationState navigationState;
 
@@ -178,7 +173,7 @@ public abstract class AbstractNavigationStateRenderer
                 // `getPreservedChain`. Once the data is retrieved from the
                 // client, `handle` method will be invoked with the same
                 // `NavigationEvent` argument.
-                return HttpServletResponse.SC_OK;
+                return HttpStatusCode.OK.getCode();
             } else {
                 chain = maybeChain.get();
             }
@@ -405,7 +400,7 @@ public abstract class AbstractNavigationStateRenderer
                 currentAction.setReferences(this, event);
                 storeContinueNavigationAction(event.getUI(), currentAction);
 
-                return Optional.of(HttpServletResponse.SC_OK);
+                return Optional.of(HttpStatusCode.OK.getCode());
             }
         }
 
@@ -654,11 +649,11 @@ public abstract class AbstractNavigationStateRenderer
      * @param beforeEvent
      *            the {@link BeforeLeaveEvent} or {@link BeforeEnterEvent} being
      *            triggered to an observer.
-     * @return a HTTP status code wrapped as an {@link Optional}. If the
+     * @return an HTTP status code wrapped as an {@link Optional}. If the
      *         {@link Optional} is empty, the process will proceed with next
      *         observer or just move forward, otherwise the process will return
      *         immediately with the provided http code.
-     * @see HttpServletResponse
+     * @see HttpStatusCode
      */
     protected Optional<Integer> handleTriggeredBeforeEvent(
             NavigationEvent event, BeforeEvent beforeEvent) {
@@ -845,9 +840,9 @@ public abstract class AbstractNavigationStateRenderer
 
     private static void validateStatusCode(int statusCode,
             Class<? extends Component> targetClass) {
-        if (!statusCodes.contains(statusCode)) {
+        if (!HttpStatusCode.isValidStatusCode(statusCode)) {
             String msg = String.format(
-                    "Error state code must be a valid HttpServletResponse value. Received invalid value of '%s' for '%s'",
+                    "Error state code must be a valid HttpStatusCode value. Received invalid value of '%s' for '%s'",
                     statusCode, targetClass.getName());
             throw new IllegalStateException(msg);
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/HttpStatusCode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/HttpStatusCode.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server;
+
+import java.util.stream.Stream;
+
+/**
+ * HTTP status codes as defined in RFC 2068.
+ */
+public enum HttpStatusCode {
+
+    /**
+     * Status code (100) indicating the client can continue.
+     */
+    CONTINUE(100),
+
+    /**
+     * Status code (101) indicating the server is switching protocols according
+     * to Upgrade header.
+     */
+    SWITCHING_PROTOCOLS(101),
+
+    /**
+     * Status code (200) indicating the request succeeded normally.
+     */
+    OK(200),
+
+    /**
+     * Status code (201) indicating the request succeeded and created a new
+     * resource on the server.
+     */
+    CREATED(201),
+
+    /**
+     * Status code (202) indicating that a request was accepted for processing,
+     * but was not completed.
+     */
+    ACCEPTED(202),
+
+    /**
+     * Status code (203) indicating that the meta information presented by the
+     * client did not originate from the server.
+     */
+    NON_AUTHORITATIVE_INFORMATION(203),
+
+    /**
+     * Status code (204) indicating that the request succeeded but that there
+     * was no new information to return.
+     */
+    NO_CONTENT(204),
+
+    /**
+     * Status code (205) indicating that the agent <em>SHOULD</em> reset the
+     * document view which caused the request to be sent.
+     */
+    RESET_CONTENT(205),
+
+    /**
+     * Status code (206) indicating that the server has fulfilled the partial
+     * GET request for the resource.
+     */
+    PARTIAL_CONTENT(206),
+
+    /**
+     * Status code (300) indicating that the requested resource corresponds to
+     * any one of a set of representations, each with its own specific location.
+     */
+    MULTIPLE_CHOICES(300),
+
+    /**
+     * Status code (301) indicating that the resource has permanently moved to a
+     * new location, and that future references should use a new URI with their
+     * requests.
+     */
+    MOVED_PERMANENTLY(301),
+
+    /**
+     * Status code (302) indicating that the resource has temporarily moved to
+     * another location, but that future references should still use the
+     * original URI to access the resource.
+     *
+     * This definition is being retained for backwards compatibility. FOUND is
+     * now the preferred definition.
+     */
+    MOVED_TEMPORARILY(302),
+
+    /**
+     * Status code (302) indicating that the resource reside temporarily under a
+     * different URI. Since the redirection might be altered on occasion, the
+     * client should continue to use the Request-URI for future
+     * requests.(HTTP/1.1) To represent the status code (302), it is recommended
+     * to use this variable.
+     */
+    FOUND(302),
+
+    /**
+     * Status code (303) indicating that the response to the request can be
+     * found under a different URI.
+     */
+    SEE_OTHER(303),
+
+    /**
+     * Status code (304) indicating that a conditional GET operation found that
+     * the resource was available and not modified.
+     */
+    NOT_MODIFIED(304),
+
+    /**
+     * Status code (305) indicating that the requested resource <em>MUST</em> be
+     * accessed through the proxy given by the <code><em>Location</em></code>
+     * field.
+     */
+    USE_PROXY(305),
+
+    /**
+     * Status code (307) indicating that the requested resource resides
+     * temporarily under a different URI. The temporary URI <em>SHOULD</em> be
+     * given by the <code><em>Location</em></code> field in the response.
+     */
+    TEMPORARY_REDIRECT(307),
+
+    /**
+     * Status code (400) indicating the request sent by the client was
+     * syntactically incorrect.
+     */
+    BAD_REQUEST(400),
+
+    /**
+     * Status code (401) indicating that the request requires HTTP
+     * authentication.
+     */
+    UNAUTHORIZED(401),
+
+    /**
+     * Status code (402) reserved for future use.
+     */
+    PAYMENT_REQUIRED(402),
+
+    /**
+     * Status code (403) indicating the server understood the request but
+     * refused to fulfill it.
+     */
+    FORBIDDEN(403),
+
+    /**
+     * Status code (404) indicating that the requested resource is not
+     * available.
+     */
+    NOT_FOUND(404),
+
+    /**
+     * Status code (405) indicating that the method specified in the
+     * <code><em>Request-Line</em></code> is not allowed for the resource
+     * identified by the <code><em>Request-URI</em></code>.
+     */
+    METHOD_NOT_ALLOWED(405),
+
+    /**
+     * Status code (406) indicating that the resource identified by the request
+     * is only capable of generating response entities which have content
+     * characteristics not acceptable according to the accept headers sent in
+     * the request.
+     */
+    NOT_ACCEPTABLE(406),
+
+    /**
+     * Status code (407) indicating that the client <em>MUST</em> first
+     * authenticate itself with the proxy.
+     */
+    PROXY_AUTHENTICATION_REQUIRED(407),
+
+    /**
+     * Status code (408) indicating that the client did not produce a request
+     * within the time that the server was prepared to wait.
+     */
+    REQUEST_TIMEOUT(408),
+
+    /**
+     * Status code (409) indicating that the request could not be completed due
+     * to a conflict with the current state of the resource.
+     */
+    CONFLICT(409),
+
+    /**
+     * Status code (410) indicating that the resource is no longer available at
+     * the server and no forwarding address is known. This condition
+     * <em>SHOULD</em> be considered permanent.
+     */
+    GONE(410),
+
+    /**
+     * Status code (411) indicating that the request cannot be handled without a
+     * defined <code><em>Content-Length</em></code>.
+     */
+    LENGTH_REQUIRED(411),
+
+    /**
+     * Status code (412) indicating that the precondition given in one or more
+     * of the request-header fields evaluated to false when it was tested on the
+     * server.
+     */
+    PRECONDITION_FAILED(412),
+
+    /**
+     * Status code (413) indicating that the server is refusing to process the
+     * request because the request entity is larger than the server is willing
+     * or able to process.
+     */
+    REQUEST_ENTITY_TOO_LARGE(413),
+
+    /**
+     * Status code (414) indicating that the server is refusing to service the
+     * request because the <code><em>Request-URI</em></code> is longer than the
+     * server is willing to interpret.
+     */
+    REQUEST_URI_TOO_LONG(414),
+
+    /**
+     * Status code (415) indicating that the server is refusing to service the
+     * request because the entity of the request is in a format not supported by
+     * the requested resource for the requested method.
+     */
+    UNSUPPORTED_MEDIA_TYPE(415),
+
+    /**
+     * Status code (416) indicating that the server cannot serve the requested
+     * byte range.
+     */
+    REQUESTED_RANGE_NOT_SATISFIABLE(416),
+
+    /**
+     * Status code (417) indicating that the server could not meet the
+     * expectation given in the Expect request header.
+     */
+    EXPECTATION_FAILED(417),
+
+    /**
+     * Status code (500) indicating an error inside the HTTP server which
+     * prevented it from fulfilling the request.
+     */
+    INTERNAL_SERVER_ERROR(500),
+
+    /**
+     * Status code (501) indicating the HTTP server does not support the
+     * functionality needed to fulfill the request.
+     */
+    NOT_IMPLEMENTED(501),
+
+    /**
+     * Status code (502) indicating that the HTTP server received an invalid
+     * response from a server it consulted when acting as a proxy or gateway.
+     */
+    BAD_GATEWAY(502),
+
+    /**
+     * Status code (503) indicating that the HTTP server is temporarily
+     * overloaded, and unable to handle the request.
+     */
+    SERVICE_UNAVAILABLE(503),
+
+    /**
+     * Status code (504) indicating that the server did not receive a timely
+     * response from the upstream server while acting as a gateway or proxy.
+     */
+    GATEWAY_TIMEOUT(504),
+
+    /**
+     * Status code (505) indicating that the server does not support or refuses
+     * to support the HTTP protocol version that was used in the request
+     * message.
+     */
+    HTTP_VERSION_NOT_SUPPORTED(505);
+
+    private final int code;
+
+    HttpStatusCode(int code) {
+        this.code = code;
+    }
+
+    /**
+     * Gets the integer representation of the HTTP status code.
+     *
+     * @return integer representation of the HTTP status code.
+     */
+    public int getCode() {
+        return code;
+    }
+
+    /**
+     * Checks if the given status code is valid.
+     *
+     * The only valid status codes are the ones listed in this enumeration.
+     *
+     * @param statusCode
+     *            status code to be checked
+     * @return {@literal true} if the status code is valid, otherwise
+     *         {@literal false}.
+     */
+    public static boolean isValidStatusCode(int statusCode) {
+        return Stream.of(HttpStatusCode.values())
+                .anyMatch(st -> st.code == statusCode);
+    }
+
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/StaticFileServer.java
@@ -235,7 +235,7 @@ public class StaticFileServer implements StaticFileHandler {
         if (HandlerHelper.isPathUnsafe(filenameWithPath)) {
             getLogger().info(HandlerHelper.UNSAFE_PATH_ERROR_MESSAGE_PATTERN,
                     filenameWithPath);
-            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            response.setStatus(HttpStatusCode.BAD_REQUEST.getCode());
             return true;
         }
 
@@ -291,7 +291,7 @@ public class StaticFileServer implements StaticFileHandler {
         if (browserHasNewestVersion(request, timestamp)) {
             // Browser is up to date, nothing further to do than set the
             // response code
-            response.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
+            response.setStatus(HttpStatusCode.NOT_MODIFIED.getCode());
             return true;
         }
         responseWriter.writeResponseContents(filenameWithPath, resourceUrl,

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -18,7 +18,6 @@ package com.vaadin.flow.server;
 
 import javax.servlet.Servlet;
 import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServletResponse;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -1570,7 +1569,7 @@ public abstract class VaadinService implements Serializable {
             }
 
             // Request not handled by any RequestHandler
-            response.sendError(HttpServletResponse.SC_NOT_FOUND,
+            response.sendError(HttpStatusCode.NOT_FOUND.getCode(),
                     "Request was not handled by any registered handler.");
 
         } catch (final SessionExpiredException e) {
@@ -1725,7 +1724,7 @@ public abstract class VaadinService implements Serializable {
                 // (https://github.com/vaadin/framework/issues/4167)
                 response.setHeader("Content-Type", "text/plain");
 
-                response.sendError(HttpServletResponse.SC_FORBIDDEN,
+                response.sendError(HttpStatusCode.FORBIDDEN.getCode(),
                         "Session expired");
             }
         } catch (IOException e) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/FaviconHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/FaviconHandler.java
@@ -15,10 +15,9 @@
  */
 package com.vaadin.flow.server.communication;
 
-import javax.servlet.http.HttpServletResponse;
-
 import java.io.IOException;
 
+import com.vaadin.flow.server.HttpStatusCode;
 import com.vaadin.flow.server.RequestHandler;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
@@ -46,7 +45,7 @@ public class FaviconHandler implements RequestHandler {
                 && httpRequest.getServletPath().isEmpty()
                 && "/favicon.ico".equals(httpRequest.getPathInfo());
         if (isFavicon) {
-            response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            response.setStatus(HttpStatusCode.NOT_FOUND.getCode());
         }
         return isFavicon;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/HeartbeatHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/HeartbeatHandler.java
@@ -16,14 +16,13 @@
 
 package com.vaadin.flow.server.communication;
 
-import javax.servlet.http.HttpServletResponse;
-
 import java.io.IOException;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.internal.UIInternals;
 import com.vaadin.flow.server.HandlerHelper;
 import com.vaadin.flow.server.HandlerHelper.RequestType;
+import com.vaadin.flow.server.HttpStatusCode;
 import com.vaadin.flow.server.SessionExpiredHandler;
 import com.vaadin.flow.server.SynchronizedRequestHandler;
 import com.vaadin.flow.server.VaadinRequest;
@@ -76,7 +75,7 @@ public class HeartbeatHandler extends SynchronizedRequestHandler
             // (https://github.com/vaadin/framework/issues/4167)
             response.setHeader("Content-Type", "text/plain");
         } else {
-            response.sendError(HttpServletResponse.SC_NOT_FOUND,
+            response.sendError(HttpStatusCode.NOT_FOUND.getCode(),
                     "UI not found");
         }
 
@@ -97,7 +96,8 @@ public class HeartbeatHandler extends SynchronizedRequestHandler
             return false;
         }
 
-        response.sendError(HttpServletResponse.SC_FORBIDDEN, "Session expired");
+        response.sendError(HttpStatusCode.FORBIDDEN.getCode(),
+                "Session expired");
         return true;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
@@ -16,7 +16,6 @@
 package com.vaadin.flow.server.communication;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.Part;
 
 import java.io.BufferedWriter;
@@ -42,6 +41,7 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.internal.Pair;
 import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.server.ErrorEvent;
+import com.vaadin.flow.server.HttpStatusCode;
 import com.vaadin.flow.server.NoInputStreamException;
 import com.vaadin.flow.server.NoOutputStreamException;
 import com.vaadin.flow.server.StreamReceiver;
@@ -448,7 +448,7 @@ public class StreamReceiverHandler implements Serializable {
                 }
             }
         } else {
-            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            response.setStatus(HttpStatusCode.INTERNAL_SERVER_ERROR.getCode());
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamRequestHandler.java
@@ -20,11 +20,10 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Optional;
 
-import javax.servlet.http.HttpServletResponse;
-
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.internal.UrlUtil;
 import com.vaadin.flow.server.AbstractStreamResource;
+import com.vaadin.flow.server.HttpStatusCode;
 import com.vaadin.flow.server.RequestHandler;
 import com.vaadin.flow.server.StreamReceiver;
 import com.vaadin.flow.server.StreamResource;
@@ -90,7 +89,7 @@ public class StreamRequestHandler implements RequestHandler {
             abstractStreamResource = StreamRequestHandler.getPathUri(pathInfo)
                     .flatMap(session.getResourceRegistry()::getResource);
             if (!abstractStreamResource.isPresent()) {
-                response.sendError(HttpServletResponse.SC_NOT_FOUND,
+                response.sendError(HttpStatusCode.NOT_FOUND.getCode(),
                         "Resource is not found for path=" + pathInfo);
                 return true;
             }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamResourceHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamResourceHandler.java
@@ -16,12 +16,12 @@
 package com.vaadin.flow.server.communication;
 
 import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Serializable;
 
+import com.vaadin.flow.server.HttpStatusCode;
 import com.vaadin.flow.server.StreamResource;
 import com.vaadin.flow.server.StreamResourceWriter;
 import com.vaadin.flow.server.VaadinRequest;
@@ -75,7 +75,7 @@ public class StreamResourceHandler implements Serializable {
                         "Stream resource produces null input stream");
             }
         } catch (Exception exception) {
-            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            response.setStatus(HttpStatusCode.INTERNAL_SERVER_ERROR.getCode());
             throw exception;
 
         } finally {
@@ -90,7 +90,7 @@ public class StreamResourceHandler implements Serializable {
             outputStream = response.getOutputStream();
             writer.accept(outputStream, session);
         } catch (Exception exception) {
-            response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            response.setStatus(HttpStatusCode.INTERNAL_SERVER_ERROR.getCode());
             throw exception;
         } finally {
             if (outputStream != null) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentProvider.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentProvider.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.server.communication;
 
-import javax.servlet.http.HttpServletResponse;
-
 import java.io.IOException;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
@@ -31,6 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.webcomponent.WebComponentConfiguration;
+import com.vaadin.flow.server.HttpStatusCode;
 import com.vaadin.flow.server.SynchronizedRequestHandler;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
@@ -140,7 +139,7 @@ public class WebComponentProvider extends SynchronizedRequestHandler {
             IOUtils.write(generated, response.getOutputStream(),
                     StandardCharsets.UTF_8);
         } else {
-            response.sendError(HttpServletResponse.SC_NOT_FOUND,
+            response.sendError(HttpStatusCode.NOT_FOUND.getCode(),
                     "No web component for " + Optional
                             .ofNullable(componentInfo.tag).orElse("<null>"));
         }

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.router;
 
-import javax.servlet.http.HttpServletResponse;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -61,6 +59,7 @@ import com.vaadin.flow.router.RouterTest.CombinedObserverTarget.Leave;
 import com.vaadin.flow.router.internal.DefaultErrorHandler;
 import com.vaadin.flow.router.internal.HasUrlParameterFormat;
 import com.vaadin.flow.router.internal.RouteUtil;
+import com.vaadin.flow.server.HttpStatusCode;
 import com.vaadin.flow.server.InvalidRouteConfigurationException;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.startup.ApplicationRouteRegistry;
@@ -780,7 +779,7 @@ public class RouterTest extends RoutingTestBase {
         public int setErrorParameter(BeforeEnterEvent event,
                 ErrorParameter<NotFoundException> parameter) {
             getElement().setText(EXCEPTION_TEXT);
-            return HttpServletResponse.SC_NOT_FOUND;
+            return HttpStatusCode.NOT_FOUND.getCode();
         }
     }
 
@@ -791,7 +790,7 @@ public class RouterTest extends RoutingTestBase {
         public int setErrorParameter(BeforeEnterEvent event,
                 ErrorParameter<NotFoundException> parameter) {
             getElement().setText(EXCEPTION_TEXT);
-            return HttpServletResponse.SC_NOT_FOUND;
+            return HttpStatusCode.NOT_FOUND.getCode();
         }
     }
 
@@ -803,7 +802,7 @@ public class RouterTest extends RoutingTestBase {
         public int setErrorParameter(BeforeEnterEvent event,
                 ErrorParameter<NotFoundException> parameter) {
             getElement().setText(EXCEPTION_TEXT);
-            return HttpServletResponse.SC_NOT_FOUND;
+            return HttpStatusCode.NOT_FOUND.getCode();
         }
     }
 
@@ -814,7 +813,7 @@ public class RouterTest extends RoutingTestBase {
         public int setErrorParameter(BeforeEnterEvent event,
                 ErrorParameter<NotFoundException> parameter) {
             getElement().setText(EXCEPTION_TEXT);
-            return HttpServletResponse.SC_NOT_FOUND;
+            return HttpStatusCode.NOT_FOUND.getCode();
         }
     }
 
@@ -827,7 +826,7 @@ public class RouterTest extends RoutingTestBase {
         public int setErrorParameter(BeforeEnterEvent event,
                 ErrorParameter<NotFoundException> parameter) {
             trigger = event.getTrigger();
-            return HttpServletResponse.SC_NOT_FOUND;
+            return HttpStatusCode.NOT_FOUND.getCode();
         }
     }
 
@@ -926,7 +925,7 @@ public class RouterTest extends RoutingTestBase {
             } else {
                 getElement().setText("Illegal argument exception.");
             }
-            return HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+            return HttpStatusCode.INTERNAL_SERVER_ERROR.getCode();
         }
     }
 
@@ -1940,7 +1939,7 @@ public class RouterTest extends RoutingTestBase {
 
         Assert.assertEquals(
                 "Routing with mismatching parameters should have failed -",
-                HttpServletResponse.SC_INTERNAL_SERVER_ERROR, result);
+                HttpStatusCode.INTERNAL_SERVER_ERROR.getCode(), result);
         String message = "No route 'param' accepting the parameters [hello] was found.";
         String exceptionText = String.format(EXCEPTION_WRAPPER_MESSAGE,
                 locationString, message);
@@ -1992,7 +1991,7 @@ public class RouterTest extends RoutingTestBase {
 
         Assert.assertEquals(
                 "Routing with mismatching parameters should have failed -",
-                HttpServletResponse.SC_INTERNAL_SERVER_ERROR, result);
+                HttpStatusCode.INTERNAL_SERVER_ERROR.getCode(), result);
         String message = "Given route parameter 'class java.lang.Long' is of the wrong type. Required 'class java.lang.String'.";
         String exceptionText = String.format(EXCEPTION_WRAPPER_MESSAGE,
                 locationString, message);
@@ -2012,7 +2011,7 @@ public class RouterTest extends RoutingTestBase {
 
         Assert.assertEquals(
                 "Routing with mismatching parameters should have failed -",
-                HttpServletResponse.SC_INTERNAL_SERVER_ERROR, result);
+                HttpStatusCode.INTERNAL_SERVER_ERROR.getCode(), result);
         String message = "No route 'param' accepting the parameters [this, must, work] was found.";
         String exceptionText = String.format(EXCEPTION_WRAPPER_MESSAGE,
                 locationString, message);
@@ -2032,7 +2031,7 @@ public class RouterTest extends RoutingTestBase {
 
         Assert.assertEquals(
                 "Routing with mismatching parameters should have failed -",
-                HttpServletResponse.SC_INTERNAL_SERVER_ERROR, result);
+                HttpStatusCode.INTERNAL_SERVER_ERROR.getCode(), result);
         String message = "No route 'param' accepting the parameters [this, must, work] was found.";
         String exceptionText = String.format(EXCEPTION_WRAPPER_MESSAGE,
                 locationString, message);
@@ -2126,7 +2125,7 @@ public class RouterTest extends RoutingTestBase {
 
         setNavigationTargets(FooNavigationTarget.class);
 
-        Assert.assertEquals(HttpServletResponse.SC_NOT_FOUND, router.navigate(
+        Assert.assertEquals(HttpStatusCode.NOT_FOUND.getCode(), router.navigate(
                 ui, new Location(""), NavigationTrigger.PROGRAMMATIC));
     }
 
@@ -2260,7 +2259,7 @@ public class RouterTest extends RoutingTestBase {
                 NavigationTrigger.PROGRAMMATIC);
 
         Assert.assertEquals("Non existent route should have returned.",
-                HttpServletResponse.SC_NOT_FOUND, result);
+                HttpStatusCode.NOT_FOUND.getCode(), result);
 
         String message = String.format(
                 "Invalid wildcard parameter in class %s. Only String is supported for wildcard parameters.",
@@ -2285,7 +2284,7 @@ public class RouterTest extends RoutingTestBase {
                 NavigationTrigger.PROGRAMMATIC);
 
         Assert.assertEquals("Non existent route should have returned.",
-                HttpServletResponse.SC_NOT_FOUND, result);
+                HttpStatusCode.NOT_FOUND.getCode(), result);
 
         String exceptionText1 = String.format("Could not navigate to '%s'",
                 locationString);
@@ -2307,7 +2306,7 @@ public class RouterTest extends RoutingTestBase {
         int result = router.navigate(ui, new Location(locationString),
                 NavigationTrigger.PROGRAMMATIC);
         Assert.assertEquals("Non existent route should have returned.",
-                HttpServletResponse.SC_NOT_FOUND, result);
+                HttpStatusCode.NOT_FOUND.getCode(), result);
 
         Assert.assertEquals("Expected event amount was wrong", 1,
                 ErrorTarget.events.size());
@@ -2327,7 +2326,7 @@ public class RouterTest extends RoutingTestBase {
         int result = router.navigate(ui, new Location("exception"),
                 NavigationTrigger.PROGRAMMATIC);
         Assert.assertEquals("Non existent route should have returned.",
-                HttpServletResponse.SC_INTERNAL_SERVER_ERROR, result);
+                HttpStatusCode.INTERNAL_SERVER_ERROR.getCode(), result);
     }
 
     @Test
@@ -2354,7 +2353,7 @@ public class RouterTest extends RoutingTestBase {
         @Override
         public int setErrorParameter(BeforeEnterEvent event,
                 ErrorParameter<NullPointerException> parameter) {
-            return HttpServletResponse.SC_UNAUTHORIZED;
+            return HttpStatusCode.UNAUTHORIZED.getCode();
         }
     }
 
@@ -2365,7 +2364,7 @@ public class RouterTest extends RoutingTestBase {
         @Override
         public int setErrorParameter(BeforeEnterEvent event,
                 ErrorParameter<NullPointerException> parameter) {
-            return HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+            return HttpStatusCode.INTERNAL_SERVER_ERROR.getCode();
         }
     }
 
@@ -2379,7 +2378,7 @@ public class RouterTest extends RoutingTestBase {
                 NavigationTrigger.PROGRAMMATIC);
         Assert.assertEquals(
                 "Null pointer should return the server error of the custom implementation.",
-                HttpServletResponse.SC_INTERNAL_SERVER_ERROR, result);
+                HttpStatusCode.INTERNAL_SERVER_ERROR.getCode(), result);
 
         Assert.assertEquals(
                 "Expected the extending class to be used instead of the super class",
@@ -2405,7 +2404,7 @@ public class RouterTest extends RoutingTestBase {
         int result = router.navigate(ui, new Location("exception"),
                 NavigationTrigger.PROGRAMMATIC);
         Assert.assertEquals("Non existent route should have returned.",
-                HttpServletResponse.SC_NOT_FOUND, result);
+                HttpStatusCode.NOT_FOUND.getCode(), result);
 
         Assert.assertEquals(
                 "Expected the extending class to be used instead of the super class",
@@ -2423,7 +2422,7 @@ public class RouterTest extends RoutingTestBase {
         int result = router.navigate(ui, new Location("exception"),
                 NavigationTrigger.PROGRAMMATIC);
         Assert.assertEquals("Non existent route should have returned.",
-                HttpServletResponse.SC_NOT_FOUND, result);
+                HttpStatusCode.NOT_FOUND.getCode(), result);
 
         Assert.assertEquals(
                 "Expected the extending class to be used instead of the super class",
@@ -2443,7 +2442,7 @@ public class RouterTest extends RoutingTestBase {
         int result = router.navigate(ui, new Location("exception"),
                 NavigationTrigger.PROGRAMMATIC);
         Assert.assertEquals("Non existent route should have returned.",
-                HttpServletResponse.SC_NOT_FOUND, result);
+                HttpStatusCode.NOT_FOUND.getCode(), result);
 
         Component parenComponent = ComponentUtil
                 .findParentComponent(ui.getElement().getChild(0)).get();
@@ -2468,7 +2467,7 @@ public class RouterTest extends RoutingTestBase {
                 NavigationTrigger.PROGRAMMATIC);
 
         Assert.assertEquals("Target should have rerouted to exception target.",
-                HttpServletResponse.SC_INTERNAL_SERVER_ERROR, result);
+                HttpStatusCode.INTERNAL_SERVER_ERROR.getCode(), result);
 
         Assert.assertEquals(IllegalTarget.class, getUIComponent());
 
@@ -2490,7 +2489,7 @@ public class RouterTest extends RoutingTestBase {
                 NavigationTrigger.PROGRAMMATIC);
 
         Assert.assertEquals("Target should have rerouted to exception target.",
-                HttpServletResponse.SC_INTERNAL_SERVER_ERROR, result);
+                HttpStatusCode.INTERNAL_SERVER_ERROR.getCode(), result);
 
         Assert.assertEquals(IllegalTarget.class, getUIComponent());
 
@@ -2516,7 +2515,7 @@ public class RouterTest extends RoutingTestBase {
         int result = router.navigate(ui, new Location("toNotFound/error"),
                 NavigationTrigger.PROGRAMMATIC);
         Assert.assertEquals("Target should have rerouted to exception target.",
-                HttpServletResponse.SC_NOT_FOUND, result);
+                HttpStatusCode.NOT_FOUND.getCode(), result);
 
         Assert.assertEquals(RouteNotFoundError.class, getUIComponent());
     }
@@ -2557,10 +2556,10 @@ public class RouterTest extends RoutingTestBase {
 
         Assert.assertEquals(
                 "Target should have failed on an internal exception.",
-                HttpServletResponse.SC_INTERNAL_SERVER_ERROR, result);
+                HttpStatusCode.INTERNAL_SERVER_ERROR.getCode(), result);
 
         String validationMessage = String.format(
-                "Error state code must be a valid HttpServletResponse value. Received invalid value of '%s' for '%s'",
+                "Error state code must be a valid HttpStatusCode value. Received invalid value of '%s' for '%s'",
                 0, FaultyErrorView.class.getName());
 
         String errorMessage = String.format(
@@ -2670,7 +2669,7 @@ public class RouterTest extends RoutingTestBase {
                 NavigationTrigger.PROGRAMMATIC);
 
         Assert.assertEquals("First transition failed",
-                HttpServletResponse.SC_OK, status1);
+                HttpStatusCode.OK.getCode(), status1);
         Assert.assertEquals(PostponingAndResumingNavigationTarget.class,
                 getUIComponent());
 
@@ -2680,7 +2679,7 @@ public class RouterTest extends RoutingTestBase {
         int status2 = router.navigate(ui, new Location(""),
                 NavigationTrigger.PROGRAMMATIC);
         Assert.assertEquals("Second transition failed",
-                HttpServletResponse.SC_OK, status2);
+                HttpStatusCode.OK.getCode(), status2);
 
         Assert.assertEquals(RootNavigationTarget.class, getUIComponent());
         Assert.assertEquals(
@@ -2703,14 +2702,14 @@ public class RouterTest extends RoutingTestBase {
                 NavigationTrigger.PROGRAMMATIC);
 
         Assert.assertEquals("First transition failed",
-                HttpServletResponse.SC_OK, status1);
+                HttpStatusCode.OK.getCode(), status1);
         Assert.assertEquals(PostponingForeverNavigationTarget.class,
                 getUIComponent());
 
         int status2 = router.navigate(ui, new Location(""),
                 NavigationTrigger.PROGRAMMATIC);
         Assert.assertEquals("Second transition failed",
-                HttpServletResponse.SC_OK, status2);
+                HttpStatusCode.OK.getCode(), status2);
 
         Assert.assertEquals(PostponingForeverNavigationTarget.class,
                 getUIComponent());
@@ -2744,15 +2743,15 @@ public class RouterTest extends RoutingTestBase {
                 NavigationTrigger.PROGRAMMATIC);
 
         Assert.assertEquals("First transition failed",
-                HttpServletResponse.SC_OK, status1);
+                HttpStatusCode.OK.getCode(), status1);
         Assert.assertEquals(FooBarNavigationTarget.class, getUIComponent());
 
         event.postpone().proceed();
 
         Assert.assertEquals("Second transition failed",
-                HttpServletResponse.SC_OK, status2);
+                HttpStatusCode.OK.getCode(), status2);
         Assert.assertEquals("Third transition failed",
-                HttpServletResponse.SC_OK, status3);
+                HttpStatusCode.OK.getCode(), status3);
 
         Assert.assertEquals(FooBarNavigationTarget.class, getUIComponent());
         Assert.assertEquals("Expected event amount was wrong", 2,
@@ -2772,14 +2771,14 @@ public class RouterTest extends RoutingTestBase {
                 NavigationTrigger.PROGRAMMATIC);
 
         Assert.assertEquals("First transition failed",
-                HttpServletResponse.SC_OK, status1);
+                HttpStatusCode.OK.getCode(), status1);
         Assert.assertEquals(PostponingAndResumingCompoundNavigationTarget.class,
                 getUIComponent());
 
         int status2 = router.navigate(ui, new Location(""),
                 NavigationTrigger.PROGRAMMATIC);
         Assert.assertEquals("Second transition failed",
-                HttpServletResponse.SC_OK, status2);
+                HttpStatusCode.OK.getCode(), status2);
 
         Assert.assertNotNull(
                 PostponingAndResumingCompoundNavigationTarget.postpone);
@@ -3186,7 +3185,7 @@ public class RouterTest extends RoutingTestBase {
         int result = router.navigate(ui, new Location("programmatic"),
                 NavigationTrigger.PROGRAMMATIC);
         Assert.assertEquals("Non existent route should have returned.",
-                HttpServletResponse.SC_NOT_FOUND, result);
+                HttpStatusCode.NOT_FOUND.getCode(), result);
 
         Assert.assertEquals(NavigationTrigger.PROGRAMMATIC,
                 FileNotFound.trigger);

--- a/flow-server/src/test/java/com/vaadin/flow/server/HttpStatusCodeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/HttpStatusCodeTest.java
@@ -1,0 +1,34 @@
+package com.vaadin.flow.server;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HttpStatusCodeTest {
+
+    @Test
+    public void isValidStatusCode_invalidCode_returnsFalse() {
+        Set<Integer> validCodes = Stream.of(HttpStatusCode.values())
+                .map(HttpStatusCode::getCode).collect(Collectors.toSet());
+
+        IntStream.rangeClosed(-1000, 1000)
+                .filter(sc -> !validCodes.contains(sc))
+                .forEach(sc -> Assert.assertFalse(
+                        sc + " should be invalid, but was not",
+                        HttpStatusCode.isValidStatusCode(sc)));
+    }
+
+    @Test
+    public void isValidStatusCode_validCode_returnsTrue() {
+        Stream.of(HttpStatusCode.values()).mapToInt(HttpStatusCode::getCode)
+                .forEach(sc -> Assert.assertTrue(
+                        sc + " should be valid, but was not",
+                        HttpStatusCode.isValidStatusCode(sc)));
+
+    }
+
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/HttpStatusCodeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/HttpStatusCodeTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.flow.server;
 
 import java.util.Set;

--- a/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
@@ -931,7 +931,7 @@ public class StaticFileServerTest implements Serializable {
 
         Assert.assertTrue(fileServer.serveStaticResource(request, response));
         Assert.assertEquals(0, out.getOutput().length);
-        Assert.assertEquals(HttpServletResponse.SC_BAD_REQUEST,
+        Assert.assertEquals(HttpStatusCode.BAD_REQUEST.getCode(),
                 responseCode.get());
     }
 
@@ -1115,7 +1115,7 @@ public class StaticFileServerTest implements Serializable {
 
         Assert.assertTrue(fileServer.serveStaticResource(request, response));
         Assert.assertEquals(0, out.getOutput().length);
-        Assert.assertEquals(HttpServletResponse.SC_NOT_MODIFIED,
+        Assert.assertEquals(HttpStatusCode.NOT_MODIFIED.getCode(),
                 responseCode.get());
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/StreamReceiverHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/StreamReceiverHandlerTest.java
@@ -4,7 +4,6 @@ import javax.servlet.ReadListener;
 import javax.servlet.ServletException;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.Part;
 
 import java.io.ByteArrayOutputStream;
@@ -30,6 +29,7 @@ import com.vaadin.flow.component.internal.UIInternals;
 import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.internal.StateTree;
 import com.vaadin.flow.server.ErrorHandler;
+import com.vaadin.flow.server.HttpStatusCode;
 import com.vaadin.flow.server.MockVaadinServletService;
 import com.vaadin.flow.server.StreamReceiver;
 import com.vaadin.flow.server.StreamResourceRegistry;
@@ -251,7 +251,7 @@ public class StreamReceiverHandlerTest {
                 stateNode, 1);
 
         Mockito.verify(response)
-                .setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                .setStatus(HttpStatusCode.INTERNAL_SERVER_ERROR.getCode());
     }
 
     @Test
@@ -265,7 +265,7 @@ public class StreamReceiverHandlerTest {
                 stateNode, 1);
 
         Mockito.verify(response)
-                .setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                .setStatus(HttpStatusCode.INTERNAL_SERVER_ERROR.getCode());
     }
 
     @Test
@@ -287,7 +287,7 @@ public class StreamReceiverHandlerTest {
                 streamReceiver, stateNode);
 
         Mockito.verify(response)
-                .setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                .setStatus(HttpStatusCode.INTERNAL_SERVER_ERROR.getCode());
         Assert.assertTrue(isGetContentLengthLongCalled);
     }
 
@@ -312,7 +312,7 @@ public class StreamReceiverHandlerTest {
                 streamReceiver, stateNode);
 
         Mockito.verify(response)
-                .setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                .setStatus(HttpStatusCode.INTERNAL_SERVER_ERROR.getCode());
     }
 
     /**
@@ -333,7 +333,7 @@ public class StreamReceiverHandlerTest {
                 null);
 
         Mockito.verify(response)
-                .setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                .setStatus(HttpStatusCode.INTERNAL_SERVER_ERROR.getCode());
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/StreamResourceHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/StreamResourceHandlerTest.java
@@ -17,7 +17,6 @@ package com.vaadin.flow.server.communication;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletResponse;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -26,6 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import com.vaadin.flow.server.HttpStatusCode;
 import com.vaadin.flow.server.InputStreamFactory;
 import com.vaadin.flow.server.MockVaadinServletService;
 import com.vaadin.flow.server.MockVaadinSession;
@@ -68,7 +68,7 @@ public class StreamResourceHandlerTest {
             // Ignore exception, it's expected. We need to check the status
         }
         Mockito.verify(response)
-                .setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                .setStatus(HttpStatusCode.INTERNAL_SERVER_ERROR.getCode());
     }
 
     @Test
@@ -84,7 +84,7 @@ public class StreamResourceHandlerTest {
             // Ignore exception, it's expected. We need to check the status
         }
         Mockito.verify(response)
-                .setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                .setStatus(HttpStatusCode.INTERNAL_SERVER_ERROR.getCode());
     }
 
     @Test
@@ -104,7 +104,7 @@ public class StreamResourceHandlerTest {
             // Ignore exception, it's expected. We need to check the status
         }
         Mockito.verify(response)
-                .setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+                .setStatus(HttpStatusCode.INTERNAL_SERVER_ERROR.getCode());
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/WebComponentProviderTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/WebComponentProviderTest.java
@@ -17,7 +17,6 @@
 package com.vaadin.flow.server.communication;
 
 import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServletResponse;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -46,6 +45,7 @@ import com.vaadin.flow.component.webcomponent.WebComponentConfiguration;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.CurrentInstance;
 import com.vaadin.flow.server.DefaultDeploymentConfiguration;
+import com.vaadin.flow.server.HttpStatusCode;
 import com.vaadin.flow.server.MockInstantiator;
 import com.vaadin.flow.server.VaadinContext;
 import com.vaadin.flow.server.VaadinRequest;
@@ -170,7 +170,7 @@ public class WebComponentProviderTest {
                 .thenReturn("/web-component/my-component.js");
         Assert.assertTrue("Provider should handle web-component request",
                 provider.synchronizedHandleRequest(session, request, response));
-        Mockito.verify(response).sendError(HttpServletResponse.SC_NOT_FOUND,
+        Mockito.verify(response).sendError(HttpStatusCode.NOT_FOUND.getCode(),
                 "No web component for my-component");
     }
 

--- a/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/UnauthenticatedExceptionHandler.java
+++ b/flow-tests/test-ccdm/src/main/java/com/vaadin/flow/ccdmtest/UnauthenticatedExceptionHandler.java
@@ -20,8 +20,7 @@ import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.ErrorParameter;
 import com.vaadin.flow.router.HasErrorParameter;
-
-import javax.servlet.http.HttpServletResponse;
+import com.vaadin.flow.server.HttpStatusCode;
 
 @Tag(Tag.DIV)
 public class UnauthenticatedExceptionHandler extends Component
@@ -33,6 +32,6 @@ public class UnauthenticatedExceptionHandler extends Component
         setId("errorView");
         getElement().setText(
                 "Tried to navigate to a view without being authenticated");
-        return HttpServletResponse.SC_UNAUTHORIZED;
+        return HttpStatusCode.UNAUTHORIZED.getCode();
     }
 }

--- a/flow-tests/test-custom-route-registry/src/main/java/com/vaadin/flow/custom/CustomNotFoundView.java
+++ b/flow-tests/test-custom-route-registry/src/main/java/com/vaadin/flow/custom/CustomNotFoundView.java
@@ -16,8 +16,6 @@
 
 package com.vaadin.flow.custom;
 
-import javax.servlet.http.HttpServletResponse;
-
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.html.Span;
@@ -25,6 +23,7 @@ import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.ErrorParameter;
 import com.vaadin.flow.router.HasErrorParameter;
 import com.vaadin.flow.router.NotFoundException;
+import com.vaadin.flow.server.HttpStatusCode;
 
 /**
  * Custom view for the NofFoundException to be used with the
@@ -41,6 +40,6 @@ public class CustomNotFoundView extends Component
         notFound.setId("error");
         getElement().appendChild(notFound.getElement());
 
-        return HttpServletResponse.SC_NOT_FOUND;
+        return HttpStatusCode.NOT_FOUND.getCode();
     }
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/routing/PushRouteNotFoundView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/routing/PushRouteNotFoundView.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.uitest.ui.routing;
 
-import javax.servlet.http.HttpServletResponse;
-
 import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementFactory;
@@ -25,6 +23,7 @@ import com.vaadin.flow.router.ErrorParameter;
 import com.vaadin.flow.router.NotFoundException;
 import com.vaadin.flow.router.ParentLayout;
 import com.vaadin.flow.router.RouteNotFoundError;
+import com.vaadin.flow.server.HttpStatusCode;
 
 @ParentLayout(PushLayout.class)
 public class PushRouteNotFoundView extends RouteNotFoundError {
@@ -39,7 +38,7 @@ public class PushRouteNotFoundView extends RouteNotFoundError {
         String path = event.getLocation().getPath();
         if (PUSH_NON_EXISTENT_PATH.equals(path)) {
             isPushPath = true;
-            return HttpServletResponse.SC_NOT_FOUND;
+            return HttpStatusCode.NOT_FOUND.getCode();
         } else {
             return super.setErrorParameter(event, parameter);
         }

--- a/flow-tests/test-root-ui-context/src/main/java/com/vaadin/flow/uitest/servlet/ApplicationRunnerServlet.java
+++ b/flow-tests/test-root-ui-context/src/main/java/com/vaadin/flow/uitest/servlet/ApplicationRunnerServlet.java
@@ -53,6 +53,7 @@ import com.vaadin.flow.router.NavigationTrigger;
 import com.vaadin.flow.router.Router;
 import com.vaadin.flow.server.Attributes;
 import com.vaadin.flow.server.DefaultDeploymentConfiguration;
+import com.vaadin.flow.server.HttpStatusCode;
 import com.vaadin.flow.server.ServiceException;
 import com.vaadin.flow.server.SystemMessages;
 import com.vaadin.flow.server.SystemMessagesProvider;
@@ -280,7 +281,7 @@ public class ApplicationRunnerServlet extends VaadinServlet {
                     public int navigate(UI ui, Location location,
                             NavigationTrigger trigger, JsonValue state) {
                         ui.getPage().getHistory().pushState(null, location);
-                        return HttpServletResponse.SC_OK;
+                        return HttpStatusCode.OK.getCode();
                     }
                 };
                 return router;

--- a/flow-tests/test-root-ui-context/src/main/java/com/vaadin/flow/uitest/servlet/ErrorTarget.java
+++ b/flow-tests/test-root-ui-context/src/main/java/com/vaadin/flow/uitest/servlet/ErrorTarget.java
@@ -1,12 +1,11 @@
 package com.vaadin.flow.uitest.servlet;
 
-import javax.servlet.http.HttpServletResponse;
-
 import com.vaadin.flow.dom.ElementFactory;
 import com.vaadin.flow.router.ErrorParameter;
 import com.vaadin.flow.router.NotFoundException;
 import com.vaadin.flow.router.RouteNotFoundError;
 import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.server.HttpStatusCode;
 
 public class ErrorTarget extends RouteNotFoundError {
 
@@ -17,6 +16,6 @@ public class ErrorTarget extends RouteNotFoundError {
                 "This is the error view. Next element contains the error path "),
                 ElementFactory.createDiv(event.getLocation().getPath())
                         .setAttribute("id", "error-path"));
-        return HttpServletResponse.SC_NOT_FOUND;
+        return HttpStatusCode.NOT_FOUND.getCode();
     }
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/test/NPEHandler.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/test/NPEHandler.java
@@ -15,14 +15,13 @@
  */
 package com.vaadin.flow.spring.test;
 
-import javax.servlet.http.HttpServletResponse;
-
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.ErrorParameter;
 import com.vaadin.flow.router.HasErrorParameter;
+import com.vaadin.flow.server.HttpStatusCode;
 
 public class NPEHandler extends Div
         implements HasErrorParameter<NullPointerException> {
@@ -34,7 +33,7 @@ public class NPEHandler extends Div
         setId("npe-handle");
         LoggerFactory.getLogger(NPEHandler.class).error("NPE is thrown",
                 parameter.getCaughtException());
-        return HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+        return HttpStatusCode.INTERNAL_SERVER_ERROR.getCode();
     }
 
 }

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
@@ -23,7 +23,6 @@ import java.net.HttpURLConnection;
 import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.URL;
-import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.List;
@@ -50,6 +49,7 @@ import com.vaadin.flow.internal.DevModeHandler;
 import com.vaadin.flow.internal.UrlUtil;
 import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.HandlerHelper;
+import com.vaadin.flow.server.HttpStatusCode;
 import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.StaticFileServer;
 import com.vaadin.flow.server.VaadinRequest;
@@ -687,7 +687,7 @@ public abstract class AbstractDevServerRunner implements DevModeHandler {
                         .find()) {
             getLogger().info("Blocked attempt to access file: {}",
                     requestFilename);
-            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            response.setStatus(HttpStatusCode.FORBIDDEN.getCode());
             return true;
         }
 


### PR DESCRIPTION
## Description

Introduction of a custom HTTP status code enumeration aims to minimize the use of javax.servlet APIs, in order to simplify migration to `jakarta.servlet` package.

Fixes #13595

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
