### PR TITLE
fix: do not select from session if parent has a better match

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/SessionRouteRegistry.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/SessionRouteRegistry.java
@@ -181,7 +181,7 @@ public class SessionRouteRegistry extends AbstractRouteRegistry {
 
     /**
      * When session registry contains a matching route, check if it is not an
-     * exact match and parenmt registry contains an exact or closer match.
+     * exact match and parent registry contains an exact or closer match.
      *
      * @param url
      *            url to check for exact match
@@ -227,8 +227,7 @@ public class SessionRouteRegistry extends AbstractRouteRegistry {
      * @return amount of matching segments from the start
      */
     private int equalParts(List<String> urlParts, List<String> target) {
-        int maxSize = urlParts.size() > target.size() ? target.size()
-                : urlParts.size();
+        int maxSize = Math.min(urlParts.size(), target.size());
         int matches = 0;
         for (int i = 0; i < maxSize; i++) {
             if (urlParts.get(i).equals(target.get(i))) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/SessionRouteRegistryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/SessionRouteRegistryTest.java
@@ -1033,6 +1033,80 @@ public class SessionRouteRegistryTest {
         Assert.assertEquals("", url.get());
     }
 
+    @Test
+    public void sessionScopeContainsTemplateRoute_applicationRegistryExactMatchIsReturned() {
+        registry.setRoute(":first/:second", Templated.class,
+                Collections.emptyList());
+        registry.setRoute("other/view", NonTemplated.class,
+                Collections.emptyList());
+
+        SessionRouteRegistry sessionRegistry = getRegistry(session);
+        Assert.assertEquals("ApplicationRegisty Templated should be found.",
+                Templated.class,
+                sessionRegistry.getNavigationTarget("oh/my").get());
+        Assert.assertEquals("ApplicationRegistry NonTemplated should be found",
+                NonTemplated.class,
+                sessionRegistry.getNavigationTarget("other/view").get());
+
+        sessionRegistry.setRoute(":one/:two", Secondary.class,
+                Collections.emptyList());
+
+        Assert.assertEquals(
+                "SessionRegistry should override ApplicationRegistry Templated",
+                Secondary.class,
+                sessionRegistry.getNavigationTarget("oh/my").get());
+
+        Assert.assertEquals(
+                "ApplicationRegistry exact match should be returned instead of SessionRegistry wildcard match",
+                NonTemplated.class,
+                sessionRegistry.getNavigationTarget("other/view").get());
+
+        sessionRegistry.setRoute("other/:one", MyRoute.class,
+                Collections.emptyList());
+
+        Assert.assertEquals(
+                "ApplicationRegistry exact match should be returned instead of any SessionRegistry wildcard match",
+                NonTemplated.class,
+                sessionRegistry.getNavigationTarget("other/view").get());
+        Assert.assertEquals(
+                "SessionRegistry best match with least wildcards should be returned",
+                MyRoute.class,
+                sessionRegistry.getNavigationTarget("other/plank").get());
+
+    }
+
+    @Test
+    public void sessionScopeContainsTemplateRoute_applicationRegistryBetterMatchIsReturned() {
+        registry.setRoute("other/view/parent", NonTemplated.class,
+                Collections.emptyList());
+        registry.setRoute("other/alias/:extra?", Templated.class,
+                Collections.emptyList());
+
+        SessionRouteRegistry sessionRegistry = getRegistry(session);
+        sessionRegistry.setRoute("other/view/:session", MyRoute.class,
+                Collections.emptyList());
+        sessionRegistry.setRoute("other/:match/:session?", Secondary.class,
+                Collections.emptyList());
+
+        Assert.assertEquals(
+                "MyRoute should be selected as the matching parts are equal",
+                MyRoute.class,
+                sessionRegistry.getNavigationTarget("other/view/offset").get());
+        Assert.assertEquals(
+                "Exact macth in ApplicationRegistry should be selected",
+                NonTemplated.class,
+                sessionRegistry.getNavigationTarget("other/view/parent").get());
+        Assert.assertEquals(
+                "Closer macth in ApplicationRegistry should be selected",
+                Templated.class,
+                sessionRegistry.getNavigationTarget("other/alias").get());
+        Assert.assertEquals(
+                "Closer macth in ApplicationRegistry should be selected",
+                Templated.class,
+                sessionRegistry.getNavigationTarget("other/alias/extra").get());
+
+    }
+
     private <T> T serializeAndDeserialize(T instance) throws Throwable {
         ByteArrayOutputStream bs = new ByteArrayOutputStream();
         ObjectOutputStream out = new ObjectOutputStream(bs);
@@ -1110,6 +1184,16 @@ public class SessionRouteRegistryTest {
     @RouteAlias("")
     private static class ParameterizedRouteWithRootAlias extends Component {
 
+    }
+
+    @Route(":first/:second")
+    @Tag("div")
+    public static class Templated extends Component {
+    }
+
+    @Route("other/view")
+    @Tag("div")
+    public static class NonTemplated extends Component {
     }
 
     /**


### PR DESCRIPTION
Check if parent registry contains a better match
than the session registry.

Fixes #13348
