### PR TITLE
fix: ignore server-modality for poll RPC invocations

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
@@ -369,8 +369,8 @@ public class ComponentUtil {
     }
 
     /**
-     * Check if the component has at least one registered listener
-     * of the given event type.
+     * Check if the component has at least one registered listener of the given
+     * event type.
      *
      * @param component
      *            the component to which the listener(s) are registered.

--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
@@ -369,10 +369,8 @@ public class ComponentUtil {
     }
 
     /**
-     * Queries the given component whether a listener has been registered for
-     * the given event type or not. This method delegates the query to the
-     * component and simply returns the result of
-     * {@link com.vaadin.flow.component.Component#hasListener(Class)}.
+     * Check if the component has at least one registered listener
+     * of the given event type.
      *
      * @param component
      *            the component to which the listener(s) are registered.
@@ -383,7 +381,7 @@ public class ComponentUtil {
      */
     public static <T extends ComponentEvent<?>> boolean hasEventListener(
             Component component, Class<? extends T> eventType) {
-        return component.getEventBus().hasListener(eventType);
+        return component.hasListener(eventType);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
@@ -369,6 +369,24 @@ public class ComponentUtil {
     }
 
     /**
+     * Queries the given component whether a listener has been registered for
+     * the given event type or not. This method delegates the query to the
+     * component and simply returns the result of
+     * {@link com.vaadin.flow.component.Component#hasListener(Class)}.
+     *
+     * @param component
+     *            the component to which the listener(s) are registered.
+     * @param eventType
+     *            the event type for which the listener(s) are registered.
+     * @return a boolean indicating whether at least one listener registered to
+     *         the component for the given event type.
+     */
+    public static <T extends ComponentEvent<?>> boolean hasEventListener(
+            Component component, Class<? extends T> eventType) {
+        return component.getEventBus().hasListener(eventType);
+    }
+
+    /**
      * Dispatches the event to all listeners registered for the event type.
      *
      * @see Component#fireEvent(ComponentEvent)

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/ReturnChannelHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/ReturnChannelHandler.java
@@ -89,10 +89,6 @@ public class ReturnChannelHandler extends AbstractRpcInvocationHandler {
                 .map(ReturnChannelMap::hasChannels).orElse(false);
     }
 
-    private static int getNodeId(JsonObject invocationJson) {
-        return (int) invocationJson.getNumber(JsonConstants.RPC_NODE);
-    }
-
     private static Logger getLogger() {
         return LoggerFactory.getLogger(ReturnChannelHandler.class.getName());
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/ReturnChannelHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/ReturnChannelHandler.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.dom.DisabledUpdateMode;
 import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.internal.nodefeature.ReturnChannelMap;
@@ -80,10 +81,16 @@ public class ReturnChannelHandler extends AbstractRpcInvocationHandler {
     }
 
     @Override
-    protected boolean allowInert(StateNode node) {
+    protected boolean allowInert(UI ui, JsonObject invocationJson) {
+        StateNode node = ui.getInternals().getStateTree()
+                .getNodeById(getNodeId(invocationJson));
         // Allow calls if a return channel has been registered for the node.
         return node.getFeatureIfInitialized(ReturnChannelMap.class)
                 .map(ReturnChannelMap::hasChannels).orElse(false);
+    }
+
+    private static int getNodeId(JsonObject invocationJson) {
+        return (int) invocationJson.getNumber(JsonConstants.RPC_NODE);
     }
 
     private static Logger getLogger() {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/AbstractRpcInvocationHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/AbstractRpcInvocationHandler.java
@@ -20,8 +20,6 @@ import java.util.List;
 import java.util.Optional;
 
 import com.vaadin.flow.component.ComponentUtil;
-import com.vaadin.flow.server.VaadinService;
-
 import com.vaadin.flow.component.PollEvent;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.internal.StateNode;
@@ -97,20 +95,14 @@ public abstract class AbstractRpcInvocationHandler
         if (!isPollingEnabledForUI(ui)) {
             getLogger().warn(
                     "Ignoring Poll RPC for UI that does not have polling enabled.");
-            if (!VaadinService.getCurrent().getDeploymentConfiguration()
-                    .isProductionMode()) {
-                getLogger().debug("Ignored payload:\n{}", invocationJson);
-            }
+            getLogger().debug("Ignored payload:\n{}", invocationJson);
             return false;
         }
 
         if (!isLegitimatePollEventInvocation(ui, invocationJson)) {
             getLogger().warn(
                     "Ignoring Poll RPC for illegitimate invocation payload.");
-            if (!VaadinService.getCurrent().getDeploymentConfiguration()
-                    .isProductionMode()) {
-                getLogger().debug("Ignored payload:\n{}", invocationJson);
-            }
+            getLogger().debug("Ignored payload:\n{}", invocationJson);
             return false;
         }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/AbstractRpcInvocationHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/AbstractRpcInvocationHandler.java
@@ -157,10 +157,9 @@ public abstract class AbstractRpcInvocationHandler
      */
     private boolean isLegitimatePollEventInvocation(UI ui,
             JsonObject invocationJson) {
-        int allowedKeysSize = 3;
-        String[] invocationKeys = invocationJson.keys();
-        if (invocationKeys == null
-                || invocationKeys.length != allowedKeysSize) {
+        List<String> allowedKeys = Arrays.asList(new String[]{JsonConstants.RPC_TYPE, JsonConstants.RPC_NODE, JsonConstants.RPC_EVENT_TYPE});
+        List<String> invocationKeys = Arrays.asList(invocationJson.keys());
+        if (!allowedKeys.containsAll(invocationKeys)) {
             return false;
         }
 
@@ -172,13 +171,8 @@ public abstract class AbstractRpcInvocationHandler
             return false;
         }
 
-        if (!invocationJson.hasKey(JsonConstants.RPC_NODE)) {
-            return false;
-        }
-        StateNode node = ui.getInternals().getStateTree()
-                .getNodeById(getNodeId(invocationJson));
         // Polling events should target only the root component in a UI:
-        return node.getParent() == null;
+        return node.equals(ui.getElement().getNode());
     }
 
     protected boolean allowInert(StateNode node) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/AbstractRpcInvocationHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/AbstractRpcInvocationHandler.java
@@ -67,8 +67,7 @@ public abstract class AbstractRpcInvocationHandler
                     + "the client side for an inactive (disabled or invisible) node id='{}'",
                     getClass().getName(), node.getId());
             return Optional.empty();
-        } else if (!ignoreInertForRpcInvocation(ui, invocationJson)
-                && !allowInert(node) && node.isInert()) {
+        } else if (!allowInert(ui, invocationJson) && node.isInert()) {
             getLogger().trace(
                     "Ignored RPC for invocation handler '{}' from "
                             + "the client side for an inert node id='{}'",
@@ -80,19 +79,16 @@ public abstract class AbstractRpcInvocationHandler
     }
 
     /**
-     * Specifies whether inert status should be ignored for an RPC invocation or
-     * not. The default behaviour is to let the polling events be handled, while
-     * ignoring other requests.
+     * Checks whether a Poll RPC invocation is valid or not.
      *
      * @param ui
      *            the current UI instance
      * @param invocationJson
      *            the JsonObject containing invocation properties
-     * @return a boolean indicating that the inert status should be ignored for
-     *         the current invocation or not.
+     * @return a boolean indicating that the Poll RPC invocation is valid or
+     *         not.
      */
-    protected boolean ignoreInertForRpcInvocation(UI ui,
-            JsonObject invocationJson) {
+    private boolean isValidPollInvocation(UI ui, JsonObject invocationJson) {
 
         if (!isPollEventInvocation(invocationJson)) {
             return false;
@@ -152,7 +148,7 @@ public abstract class AbstractRpcInvocationHandler
      * {@link com.vaadin.flow.shared.JsonConstants#RPC_EVENT_TYPE} before this
      * method is called.
      *
-     * @see #ignoreInertForRpcInvocation(UI, JsonObject)
+     * @see #isValidPollInvocation(UI, JsonObject)
      *
      * @param ui
      *            the UI instance which the Rpc event is coming from.
@@ -184,8 +180,20 @@ public abstract class AbstractRpcInvocationHandler
         return node.equals(ui.getElement().getNode());
     }
 
-    protected boolean allowInert(StateNode node) {
-        return false;
+    /**
+     * Specifies whether inert status should be ignored for an RPC invocation or
+     * not. The default behaviour is to let the polling events be handled, while
+     * ignoring other requests.
+     *
+     * @param ui
+     *            the UI instance that RPC invocation originated from.
+     * @param invocationJson
+     *            the JsonObject containing invocation properties.
+     * @return a boolean indicating that the inert status should be ignored for
+     *         the current invocation or not.
+     */
+    protected boolean allowInert(UI ui, JsonObject invocationJson) {
+        return isValidPollInvocation(ui, invocationJson);
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/AbstractRpcInvocationHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/AbstractRpcInvocationHandler.java
@@ -206,7 +206,7 @@ public abstract class AbstractRpcInvocationHandler
                 .getLogger(AbstractRpcInvocationHandler.class.getName());
     }
 
-    private static int getNodeId(JsonObject invocationJson) {
+    protected static int getNodeId(JsonObject invocationJson) {
         return (int) invocationJson.getNumber(JsonConstants.RPC_NODE);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/PublishedServerEventHandlerRpcHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/rpc/PublishedServerEventHandlerRpcHandler.java
@@ -72,7 +72,7 @@ public class PublishedServerEventHandlerRpcHandler
     }
 
     @Override
-    protected boolean allowInert(StateNode node) {
+    protected boolean allowInert(UI ui, JsonObject invocationJson) {
         return true;
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentUtilTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.component;
 
+import com.vaadin.flow.shared.Registration;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -70,5 +71,21 @@ public class ComponentUtilTest {
         Assert.assertNull(
                 "Storage should be cleared after removing the last attribute",
                 component.attributes);
+    }
+
+    @Test
+    public void addListenerToComponent_hasListener_returnsTrue() {
+        Assert.assertFalse(
+                ComponentUtil.hasEventListener(component, PollEvent.class));
+
+        Registration listener = ComponentUtil.addListener(component,
+                PollEvent.class, event -> {
+                });
+        Assert.assertTrue(
+                ComponentUtil.hasEventListener(component, PollEvent.class));
+
+        listener.remove();
+        Assert.assertFalse(
+                ComponentUtil.hasEventListener(component, PollEvent.class));
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/AbstractRpcInvocationHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/AbstractRpcInvocationHandlerTest.java
@@ -23,19 +23,14 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.dom.ElementFactory;
 import com.vaadin.flow.dom.ElementUtil;
-import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.StateNode;
-import com.vaadin.flow.server.VaadinService;
-import com.vaadin.flow.server.VaadinServletService;
 import com.vaadin.flow.shared.JsonConstants;
 import com.vaadin.flow.shared.Registration;
 import elemental.json.Json;
 import elemental.json.JsonObject;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,23 +63,6 @@ public class AbstractRpcInvocationHandlerTest {
     }
 
     private TestRpcInvocationHandler handler = new TestRpcInvocationHandler();
-
-    private VaadinServletService vaadinService;
-    private DeploymentConfiguration deploymentConfiguration;
-
-    @Before
-    public void init() {
-
-        deploymentConfiguration = Mockito.mock(DeploymentConfiguration.class);
-        Mockito.when(deploymentConfiguration.isProductionMode())
-                .thenReturn(false);
-
-        vaadinService = Mockito.mock(VaadinServletService.class);
-        Mockito.when(vaadinService.getDeploymentConfiguration())
-                .thenReturn(deploymentConfiguration);
-
-        VaadinService.setCurrent(vaadinService);
-    }
 
     @Test
     public void handleVisibleAndEnabledNode_nodeIsHandled() {
@@ -223,30 +201,7 @@ public class AbstractRpcInvocationHandlerTest {
     }
 
     @Test
-    public void inertUIWithoutPollListenerInProdMode_passingLegitimatePollingPayload_doesNotLogIgnoredPayloadInDebugLevel() {
-
-        Logger logger = spy(Logger.class);
-        try (MockedStatic<LoggerFactory> mockedLoggerFactory = mockStatic(
-                LoggerFactory.class)) {
-            mockedLoggerFactory
-                    .when(() -> LoggerFactory.getLogger(
-                            AbstractRpcInvocationHandler.class.getName()))
-                    .thenReturn(logger);
-            Mockito.when(deploymentConfiguration.isProductionMode())
-                    .thenReturn(true);
-
-            UI ui = createInertUI();
-            JsonObject invocationJson = createLegitimatePollingRpcInvocationPayload(
-                    ui);
-            handler.handle(ui, invocationJson);
-
-            verify(logger, times(1)).warn(anyString());
-            verify(logger, times(0)).debug(anyString(), (Object) any());
-        }
-    }
-
-    @Test
-    public void inertUIWithoutPollListenerInDevMode_passingLegitimatePollingPayload_logsIgnoredPayloadInDebugLevel() {
+    public void inertUIWithoutPollListener_passingLegitimatePollingPayload_logsIgnoredPayloadInDebugLevel() {
 
         Logger logger = spy(Logger.class);
         try (MockedStatic<LoggerFactory> mockedLoggerFactory = mockStatic(
@@ -267,30 +222,7 @@ public class AbstractRpcInvocationHandlerTest {
     }
 
     @Test
-    public void inertUIWithPollListenerInProdMode_passingIllegitimatePollingPayload_doesNotLogIgnoredPayloadInDebugLevel() {
-
-        Logger logger = spy(Logger.class);
-        try (MockedStatic<LoggerFactory> mockedLoggerFactory = mockStatic(
-                LoggerFactory.class)) {
-            mockedLoggerFactory
-                    .when(() -> LoggerFactory.getLogger(
-                            AbstractRpcInvocationHandler.class.getName()))
-                    .thenReturn(logger);
-            Mockito.when(deploymentConfiguration.isProductionMode())
-                    .thenReturn(true);
-
-            UI ui = createInertUIWithPollListener();
-            JsonObject invocationJson = createIllegitimatePayloadKeysPollingRpcInvocationPayload(
-                    ui);
-            handler.handle(ui, invocationJson);
-
-            verify(logger, times(1)).warn(anyString());
-            verify(logger, times(0)).debug(anyString(), (Object) any());
-        }
-    }
-
-    @Test
-    public void inertUIWithPollListenerInDevMode_passingIllegitimatePollingPayload_logsIgnoredPayloadInDebugLevel() {
+    public void inertUIWithPollListener_passingIllegitimatePollingPayload_logsIgnoredPayloadInDebugLevel() {
 
         Logger logger = spy(Logger.class);
         try (MockedStatic<LoggerFactory> mockedLoggerFactory = mockStatic(

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/AbstractRpcInvocationHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/rpc/AbstractRpcInvocationHandlerTest.java
@@ -183,8 +183,7 @@ public class AbstractRpcInvocationHandlerTest {
     public void inertUIWithPollListener_passingIllegitimateNoNodeKeyForPollingPayload_throwsAssertionError() {
 
         UI ui = createInertUIWithPollListener();
-        JsonObject invocationJson = createIllegitimatePayloadNoNodeKeyForPollingRpcInvocationPayload(
-                ui);
+        JsonObject invocationJson = createIllegitimatePayloadNoNodeKeyForPollingRpcInvocationPayload();
         Assert.assertThrows(AssertionError.class,
                 () -> handler.handle(ui, invocationJson));
     }
@@ -309,8 +308,7 @@ public class AbstractRpcInvocationHandlerTest {
         return payload;
     }
 
-    private JsonObject createIllegitimatePayloadNoNodeKeyForPollingRpcInvocationPayload(
-            UI ui) {
+    private JsonObject createIllegitimatePayloadNoNodeKeyForPollingRpcInvocationPayload() {
         JsonObject payload = Json.createObject();
         payload.put(JsonConstants.RPC_TYPE, JsonConstants.RPC_TYPE_EVENT);
         payload.put(JsonConstants.CHANGE_TYPE, "change");


### PR DESCRIPTION
## Description
The inert status of the UI as the result of
server-modality should be ignored for
some RPC calls such as polling events. 

Fixes #13337 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
