### PR TITLE
Support @NonNullApi

### DIFF
--- a/fusion-endpoint/src/main/java/dev/hilla/ExplicitNullableTypeChecker.java
+++ b/fusion-endpoint/src/main/java/dev/hilla/ExplicitNullableTypeChecker.java
@@ -27,6 +27,8 @@ import java.util.stream.Stream;
 
 import com.github.javaparser.ast.expr.AnnotationExpr;
 
+import org.springframework.lang.NonNullApi;
+
 /**
  * A checker for TypeScript null compatibility in Vaadin endpoint methods
  * parameter and return types.
@@ -66,13 +68,26 @@ public class ExplicitNullableTypeChecker {
      * Checks if the parsed node should be required (not nullable) in the
      * generated Typescript code based on the list of annotations.
      *
+     * @param requiredByContext
+     *            {@code true} if the context of the node defines that the node
+     *            is required
      * @param annotations
      *            a list of node annotations to check
      * @return a result of check
      */
-    public static boolean isRequired(List<AnnotationExpr> annotations) {
+    public static boolean isRequired(boolean requiredByContext,
+            List<AnnotationExpr> annotations) {
+        if (requiredByContext) {
+            return !hasAnnotation(annotations, "nullable");
+        }
+
+        return hasAnnotation(annotations, "nonnull");
+    }
+
+    private static boolean hasAnnotation(List<AnnotationExpr> annotations,
+            String annotationName) {
         return annotations != null && annotations.stream()
-                .anyMatch(annotation -> "nonnull".equalsIgnoreCase(
+                .anyMatch(annotation -> annotationName.equalsIgnoreCase(
                         annotation.getName().getIdentifier()));
     }
 

--- a/fusion-endpoint/src/main/java/dev/hilla/generator/GeneratorType.java
+++ b/fusion-endpoint/src/main/java/dev/hilla/generator/GeneratorType.java
@@ -19,6 +19,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
@@ -28,6 +29,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.resolution.declarations.ResolvedTypeParameterDeclaration;
 import com.github.javaparser.resolution.types.ResolvedPrimitiveType;
@@ -44,23 +46,28 @@ class GeneratorType {
     private final Type type;
     private final ResolvedType resolvedType;
     private final boolean isResolvable;
+    private final boolean requiredByContext;
 
-    GeneratorType(Type type) {
+    GeneratorType(Type type, boolean requiredByContext) {
         this.type = type;
         this.resolvedType = type.resolve();
         isResolvable = true;
+        this.requiredByContext = requiredByContext;
     }
 
-    GeneratorType(ResolvedType resolvedType) {
+    GeneratorType(ResolvedType resolvedType, boolean requiredByContext) {
         this.type = null;
         this.resolvedType = resolvedType;
         isResolvable = true;
+        this.requiredByContext = requiredByContext;
     }
 
-    GeneratorType(Type type, ResolvedType resolvedType) {
+    GeneratorType(Type type, ResolvedType resolvedType,
+            boolean requiredByContext) {
         this.type = type;
         this.resolvedType = resolvedType;
         isResolvable = false;
+        this.requiredByContext = requiredByContext;
     }
 
     boolean hasType() {
@@ -131,9 +138,24 @@ class GeneratorType {
         return resolvedType.isReferenceType();
     }
 
-    boolean isRequired() {
-        return isPrimitive() || hasType() && ExplicitNullableTypeChecker
-                .isRequired(type.getAnnotations());
+    boolean isRequired(List<AnnotationExpr> additionalAnnotations) {
+        if (isPrimitive()) {
+            return true;
+        }
+        if (!hasType()) {
+            return false;
+        }
+        List<AnnotationExpr> allAnnotations = new ArrayList<>();
+        List<AnnotationExpr> typeAnnotations = type.getAnnotations();
+        if (typeAnnotations != null) {
+            allAnnotations.addAll(typeAnnotations);
+        }
+        if (additionalAnnotations != null) {
+            allAnnotations.addAll(additionalAnnotations);
+        }
+
+        return hasType() && ExplicitNullableTypeChecker
+                .isRequired(requiredByContext, allAnnotations);
     }
 
     boolean isString() {
@@ -195,14 +217,16 @@ class GeneratorType {
             Type componentType = type.asArrayType().getComponentType();
 
             if (isResolvable) {
-                return new GeneratorType(componentType);
+                return new GeneratorType(componentType, requiredByContext);
             }
 
             return new GeneratorType(componentType,
-                    resolvedType.asArrayType().getComponentType());
+                    resolvedType.asArrayType().getComponentType(),
+                    requiredByContext);
         }
 
-        return new GeneratorType(resolvedType.asArrayType().getComponentType());
+        return new GeneratorType(resolvedType.asArrayType().getComponentType(),
+                requiredByContext);
     }
 
     List<GeneratorType> getTypeArguments() {
@@ -211,7 +235,8 @@ class GeneratorType {
                     .map(typeArguments -> {
                         if (isResolvable) {
                             return typeArguments.stream()
-                                    .map(GeneratorType::new)
+                                    .map(type -> new GeneratorType(type,
+                                            requiredByContext))
                                     .collect(Collectors.toList());
                         }
 
@@ -220,7 +245,8 @@ class GeneratorType {
 
                         return zip(typeArguments, typeParameters,
                                 (argument, parameterPair) -> new GeneratorType(
-                                        argument, parameterPair.b))
+                                        argument, parameterPair.b,
+                                        requiredByContext))
                                                 .collect(Collectors.toList());
                     }).orElseGet(this::getTypeArgumentsFallback);
         }
@@ -231,12 +257,17 @@ class GeneratorType {
     private List<GeneratorType> getTypeArgumentsFallback() {
         return resolvedType.asReferenceType().getTypeParametersMap().stream()
                 .filter(Objects::nonNull)
-                .map(parameter -> new GeneratorType(parameter.b))
+                .map(parameter -> new GeneratorType(parameter.b,
+                        requiredByContext))
                 .collect(Collectors.toList());
     }
 
     private boolean isType(ResolvedReferenceType type, Class<?>... classes) {
         return Arrays.stream(classes).map(Class::getName).anyMatch(
                 className -> className.equals(type.getQualifiedName()));
+    }
+
+    boolean isRequiredByContext() {
+        return requiredByContext;
     }
 }

--- a/fusion-endpoint/src/main/java/dev/hilla/generator/OpenAPIObjectGenerator.java
+++ b/fusion-endpoint/src/main/java/dev/hilla/generator/OpenAPIObjectGenerator.java
@@ -41,6 +41,7 @@ import com.github.javaparser.ParserConfiguration;
 import com.github.javaparser.ParserConfiguration.LanguageLevel;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.PackageDeclaration;
 import com.github.javaparser.ast.body.BodyDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.EnumDeclaration;
@@ -96,6 +97,7 @@ import io.swagger.v3.oas.models.servers.Server;
 import io.swagger.v3.oas.models.tags.Tag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.lang.NonNullApi;
 
 import com.vaadin.flow.server.auth.AnonymousAllowed;
 import dev.hilla.endpointransfermapper.EndpointTransferMapper;
@@ -127,6 +129,7 @@ public class OpenAPIObjectGenerator {
     private boolean needsDeferrableImport = false;
     private static EndpointTransferMapper endpointTransferMapper = new EndpointTransferMapper();
     private CombinedTypeSolver typeSolver;
+    private Set<String> nonNullApiPackages = new HashSet<>();
 
     private static Logger getLogger() {
         return LoggerFactory.getLogger(OpenAPIObjectGenerator.class);
@@ -188,13 +191,15 @@ public class OpenAPIObjectGenerator {
         return openApiModel;
     }
 
-    Schema parseResolvedTypeToSchema(GeneratorType type) {
-        return new SchemaResolver(type, usedTypes).resolve();
+    Schema parseResolvedTypeToSchema(GeneratorType type,
+            boolean requiredByContext) {
+        return new SchemaResolver(type, usedTypes, requiredByContext).resolve();
     }
 
     Schema parseResolvedTypeToSchema(GeneratorType type,
-            List<AnnotationExpr> annotations) {
-        return new SchemaResolver(type, annotations, usedTypes).resolve();
+            List<AnnotationExpr> annotations, boolean requiredByContext) {
+        return new SchemaResolver(type, annotations, usedTypes,
+                requiredByContext).resolve();
     }
 
     Class<?> getClassFromReflection(GeneratorType type)
@@ -228,6 +233,11 @@ public class OpenAPIObjectGenerator {
         javaSourcePaths.stream()
                 .map(path -> new SourceRoot(path, parserConfiguration))
                 .forEach(sourceRoot -> parseSourceRoot(sourceRoot,
+                        this::findPackageAnnotations));
+
+        javaSourcePaths.stream()
+                .map(path -> new SourceRoot(path, parserConfiguration))
+                .forEach(sourceRoot -> parseSourceRoot(sourceRoot,
                         this::findEndpointExposed));
 
         javaSourcePaths.stream()
@@ -238,7 +248,7 @@ public class OpenAPIObjectGenerator {
         for (Map.Entry<String, GeneratorType> entry : new ArrayList<>(
                 usedTypes.entrySet())) {
             List<Schema> schemas = createSchemasFromQualifiedNameAndType(
-                    entry.getKey(), entry.getValue());
+                    entry.getKey(), entry.getValue(), false);
             schemas.forEach(schema -> {
                 if (qualifiedNameToPath.get(schema.getName()) != null) {
                     schema.addExtension(EXTENSION_VAADIN_FILE_PATH,
@@ -338,6 +348,26 @@ public class OpenAPIObjectGenerator {
             openApiModel.addExtension(EXTENSION_VAADIN_CONNECT_DEFERRABLE,
                     true);
         }
+        return SourceRoot.Callback.Result.DONT_SAVE;
+    }
+
+    private SourceRoot.Callback.Result findPackageAnnotations(Path localPath,
+            Path absolutePath, ParseResult<CompilationUnit> result) {
+
+        result.ifSuccessful(compilationUnit -> {
+            if (localPath.getFileName()
+                    .equals(java.nio.file.Paths.get("package-info.java"))) {
+                PackageDeclaration pkgDecl = compilationUnit
+                        .getPackageDeclaration().get();
+                boolean nonNullApiAnnotation = pkgDecl.getAnnotations().stream()
+                        .anyMatch(annotation -> NonNullApi.class.getSimpleName()
+                                .equals(annotation.getName().getIdentifier()));
+                if (nonNullApiAnnotation) {
+                    nonNullApiPackages.add((pkgDecl.getNameAsString()));
+                }
+            }
+        });
+
         return SourceRoot.Callback.Result.DONT_SAVE;
     }
 
@@ -459,8 +489,8 @@ public class OpenAPIObjectGenerator {
                 .findFirst().orElse(null);
     }
 
-    private List<Schema> parseNonEndpointClassAsSchema(
-            String fullQualifiedName) {
+    private List<Schema> parseNonEndpointClassAsSchema(String fullQualifiedName,
+            boolean requiredByContext) {
         TypeDeclaration<?> typeDeclaration = nonEndpointMap
                 .get(fullQualifiedName);
         if (typeDeclaration == null || typeDeclaration.isEnumDeclaration()) {
@@ -469,7 +499,7 @@ public class OpenAPIObjectGenerator {
         List<Schema> result = new ArrayList<>();
 
         Schema schema = schemaGenerator.createSingleSchema(fullQualifiedName,
-                typeDeclaration);
+                typeDeclaration, requiredByContext);
         generatedSchema.add(fullQualifiedName);
 
         NodeList<ClassOrInterfaceType> extendedTypes = null;
@@ -479,13 +509,14 @@ public class OpenAPIObjectGenerator {
         }
         if (extendedTypes == null || extendedTypes.isEmpty()) {
             result.add(schema);
-            result.addAll(generatedRelatedSchemas(schema));
+            result.addAll(generatedRelatedSchemas(schema, requiredByContext));
         } else {
             ComposedSchema parentSchema = new ComposedSchema();
             parentSchema.setName(fullQualifiedName);
             result.add(parentSchema);
             extendedTypes.forEach(parentType -> {
-                GeneratorType type = new GeneratorType(parentType.resolve());
+                GeneratorType type = new GeneratorType(parentType.resolve(),
+                        false);
                 String parentQualifiedName = type.asResolvedType()
                         .asReferenceType().getQualifiedName();
                 String parentRef = SchemaResolver
@@ -495,16 +526,19 @@ public class OpenAPIObjectGenerator {
             });
             // The inserting order matters for `allof` property.
             parentSchema.addAllOfItem(schema);
-            result.addAll(generatedRelatedSchemas(parentSchema));
+            result.addAll(
+                    generatedRelatedSchemas(parentSchema, requiredByContext));
         }
         return result;
     }
 
     private List<Schema> createSchemasFromQualifiedNameAndType(
-            String qualifiedName, GeneratorType type) {
-        List<Schema> list = parseNonEndpointClassAsSchema(qualifiedName);
+            String qualifiedName, GeneratorType type,
+            boolean requiredByContext) {
+        List<Schema> list = parseNonEndpointClassAsSchema(qualifiedName,
+                requiredByContext);
         if (list.isEmpty()) {
-            return parseReferencedTypeAsSchema(type);
+            return parseReferencedTypeAsSchema(type, requiredByContext);
         } else {
             return list;
         }
@@ -572,6 +606,7 @@ public class OpenAPIObjectGenerator {
             CompilationUnit compilationUnit) {
         Map<String, PathItem> newPathItems = new HashMap<>();
         Collection<MethodDeclaration> methods = typeDeclaration.getMethods();
+        boolean nonNullApi = hasNonNullApi(compilationUnit);
         for (MethodDeclaration methodDeclaration : methods) {
             if (isAccessForbidden(typeDeclaration, methodDeclaration)) {
                 continue;
@@ -581,11 +616,11 @@ public class OpenAPIObjectGenerator {
             Operation post = createPostOperation(methodDeclaration);
             if (methodDeclaration.getParameters().isNonEmpty()) {
                 post.setRequestBody(createRequestBody(methodDeclaration,
-                        resolvedTypeParametersMap));
+                        resolvedTypeParametersMap, nonNullApi));
             }
 
             ApiResponses responses = createApiResponses(methodDeclaration,
-                    resolvedTypeParametersMap);
+                    resolvedTypeParametersMap, nonNullApi);
             post.setResponses(responses);
             post.tags(Collections.singletonList(tagName));
             PathItem pathItem = new PathItem().post(post);
@@ -607,6 +642,17 @@ public class OpenAPIObjectGenerator {
                         .putAll(createPathItems(endpointName, tagName, pair.a,
                                 pair.b, compilationUnit)));
         return newPathItems;
+    }
+
+    private boolean hasNonNullApi(CompilationUnit compilationUnit) {
+        Optional<PackageDeclaration> maybePkg = compilationUnit
+                .getPackageDeclaration();
+        if (!maybePkg.isPresent()) {
+            return false;
+        }
+
+        PackageDeclaration pkgDecl = maybePkg.get();
+        return nonNullApiPackages.contains(pkgDecl.getNameAsString());
     }
 
     private boolean isAccessForbidden(
@@ -638,9 +684,10 @@ public class OpenAPIObjectGenerator {
     }
 
     private ApiResponses createApiResponses(MethodDeclaration methodDeclaration,
-            ResolvedTypeParametersMap resolvedTypeParametersMap) {
+            ResolvedTypeParametersMap resolvedTypeParametersMap,
+            boolean nonNullApi) {
         ApiResponse successfulResponse = createApiSuccessfulResponse(
-                methodDeclaration, resolvedTypeParametersMap);
+                methodDeclaration, resolvedTypeParametersMap, nonNullApi);
         ApiResponses responses = new ApiResponses();
         responses.addApiResponse("200", successfulResponse);
         return responses;
@@ -648,7 +695,8 @@ public class OpenAPIObjectGenerator {
 
     private ApiResponse createApiSuccessfulResponse(
             MethodDeclaration methodDeclaration,
-            ResolvedTypeParametersMap resolvedTypeParametersMap) {
+            ResolvedTypeParametersMap resolvedTypeParametersMap,
+            boolean nonNullApi) {
         Content successfulContent = new Content();
         // "description" is a REQUIRED property of Response
         ApiResponse successfulResponse = new ApiResponse().description("");
@@ -662,7 +710,7 @@ public class OpenAPIObjectGenerator {
         });
         if (!methodDeclaration.getType().isVoidType()) {
             MediaType mediaItem = createReturnMediaType(methodDeclaration,
-                    resolvedTypeParametersMap);
+                    resolvedTypeParametersMap, nonNullApi);
             successfulContent.addMediaType("application/json", mediaItem);
             successfulResponse.content(successfulContent);
         }
@@ -670,12 +718,13 @@ public class OpenAPIObjectGenerator {
     }
 
     private MediaType createReturnMediaType(MethodDeclaration methodDeclaration,
-            ResolvedTypeParametersMap resolvedTypeParametersMap) {
+            ResolvedTypeParametersMap resolvedTypeParametersMap,
+            boolean requiredByContext) {
         MediaType mediaItem = new MediaType();
         GeneratorType generatorType = createSchemaType(methodDeclaration,
-                resolvedTypeParametersMap);
+                resolvedTypeParametersMap, requiredByContext);
         Schema schema = parseResolvedTypeToSchema(generatorType,
-                methodDeclaration.getAnnotations());
+                methodDeclaration.getAnnotations(), requiredByContext);
         schema.setDescription("");
         mediaItem.schema(schema);
         return mediaItem;
@@ -685,7 +734,8 @@ public class OpenAPIObjectGenerator {
         if (!type.isReferenceType()) {
             return null;
         }
-        String className = getFullyQualifiedName(new GeneratorType(type));
+        String className = getFullyQualifiedName(
+                new GeneratorType(type, false));
         String mappedClassName = endpointTransferMapper
                 .getTransferType(className);
         if (mappedClassName == null) {
@@ -708,7 +758,8 @@ public class OpenAPIObjectGenerator {
         if (!resolvedType.isReferenceType()) {
             return null;
         }
-        String className = getFullyQualifiedName(new GeneratorType(type));
+        String className = getFullyQualifiedName(
+                new GeneratorType(type, false));
         String mappedClassName = endpointTransferMapper
                 .getTransferType(className);
         if (mappedClassName == null) {
@@ -731,7 +782,8 @@ public class OpenAPIObjectGenerator {
     }
 
     private RequestBody createRequestBody(MethodDeclaration methodDeclaration,
-            ResolvedTypeParametersMap resolvedTypeParametersMap) {
+            ResolvedTypeParametersMap resolvedTypeParametersMap,
+            boolean requiredByContext) {
         Map<String, String> paramsDescription = new HashMap<>();
         methodDeclaration.getJavadoc().ifPresent(javadoc -> {
             for (JavadocBlockTag blockTag : javadoc.getBlockTags()) {
@@ -753,10 +805,10 @@ public class OpenAPIObjectGenerator {
 
         methodDeclaration.getParameters().forEach(parameter -> {
             GeneratorType generatorType = createSchemaType(parameter,
-                    resolvedTypeParametersMap);
+                    resolvedTypeParametersMap, requiredByContext);
 
             Schema paramSchema = parseResolvedTypeToSchema(generatorType,
-                    parameter.getAnnotations());
+                    parameter.getAnnotations(), requiredByContext);
 
             paramSchema.setDescription("");
             usedTypes.putAll(collectUsedTypesFromSchema(paramSchema));
@@ -778,39 +830,47 @@ public class OpenAPIObjectGenerator {
     }
 
     private GeneratorType createSchemaType(MethodDeclaration methodDeclaration,
-            ResolvedTypeParametersMap resolvedTypeParametersMap) {
+            ResolvedTypeParametersMap resolvedTypeParametersMap,
+            boolean requiredByContext) {
         Type type = methodDeclaration.getType();
         ResolvedType resolvedType = methodDeclaration.resolve().getReturnType();
-        return createSchemaType(type, resolvedType, resolvedTypeParametersMap);
+        return createSchemaType(type, resolvedType, resolvedTypeParametersMap,
+                requiredByContext);
     }
 
     private GeneratorType createSchemaType(Parameter parameter,
-            ResolvedTypeParametersMap resolvedTypeParametersMap) {
+            ResolvedTypeParametersMap resolvedTypeParametersMap,
+            boolean requiredByContext) {
         Type type = parameter.getType();
         ResolvedType resolvedType = parameter.resolve().getType();
-        return createSchemaType(type, resolvedType, resolvedTypeParametersMap);
+        return createSchemaType(type, resolvedType, resolvedTypeParametersMap,
+                requiredByContext);
     }
 
     private GeneratorType createSchemaType(Type type, ResolvedType resolvedType,
-            ResolvedTypeParametersMap resolvedTypeParametersMap) {
+            ResolvedTypeParametersMap resolvedTypeParametersMap,
+            boolean requiredByContext) {
         ResolvedType mappedType = toMappedType(type);
 
         if (mappedType != null) {
             resolvedType = mappedType;
             return new GeneratorType(
-                    resolvedTypeParametersMap.replaceAll(resolvedType));
+                    resolvedTypeParametersMap.replaceAll(resolvedType),
+                    requiredByContext);
         } else {
             return new GeneratorType(type,
-                    resolvedTypeParametersMap.replaceAll(resolvedType));
+                    resolvedTypeParametersMap.replaceAll(resolvedType),
+                    requiredByContext);
         }
     }
 
     @SuppressWarnings("squid:S1872")
-    private List<Schema> parseReferencedTypeAsSchema(GeneratorType type) {
+    private List<Schema> parseReferencedTypeAsSchema(GeneratorType type,
+            boolean requiredByContext) {
         List<Schema> results = new ArrayList<>();
 
-        Schema schema = schemaGenerator
-                .createSingleSchemaFromResolvedType(type);
+        Schema schema = schemaGenerator.createSingleSchemaFromResolvedType(type,
+                requiredByContext);
         ResolvedReferenceType resolvedReferenceType = type.asResolvedType()
                 .asReferenceType();
         String qualifiedName = resolvedReferenceType.getQualifiedName();
@@ -826,7 +886,7 @@ public class OpenAPIObjectGenerator {
 
         if (directAncestors.isEmpty() || type.isEnum()) {
             results.add(schema);
-            results.addAll(generatedRelatedSchemas(schema));
+            results.addAll(generatedRelatedSchemas(schema, requiredByContext));
         } else {
             ComposedSchema parentSchema = new ComposedSchema();
             parentSchema.name(qualifiedName);
@@ -837,22 +897,24 @@ public class OpenAPIObjectGenerator {
                 String parentRef = SchemaResolver
                         .getFullQualifiedNameRef(ancestorQualifiedName);
                 parentSchema.addAllOfItem(new ObjectSchema().$ref(parentRef));
-                usedTypes.put(ancestorQualifiedName,
-                        new GeneratorType(directAncestor));
+                usedTypes.put(ancestorQualifiedName, new GeneratorType(
+                        directAncestor, type.isRequiredByContext()));
             }
             parentSchema.addAllOfItem(schema);
-            results.addAll(generatedRelatedSchemas(parentSchema));
+            results.addAll(
+                    generatedRelatedSchemas(parentSchema, requiredByContext));
         }
         return results;
     }
 
-    private List<Schema> generatedRelatedSchemas(Schema schema) {
+    private List<Schema> generatedRelatedSchemas(Schema schema,
+            boolean requiredByContext) {
         List<Schema> result = new ArrayList<>();
         collectUsedTypesFromSchema(schema).entrySet().stream()
                 .filter(s -> !generatedSchema.contains(s.getKey()))
                 .forEach(s -> result.addAll(
                         createSchemasFromQualifiedNameAndType(s.getKey(),
-                                s.getValue())));
+                                s.getValue(), requiredByContext)));
         return result;
     }
 

--- a/fusion-endpoint/src/test/java/dev/hilla/generator/SchemaResolverTest.java
+++ b/fusion-endpoint/src/test/java/dev/hilla/generator/SchemaResolverTest.java
@@ -65,7 +65,7 @@ public class SchemaResolverTest {
 
         Map<String, GeneratorType> usedTypes = new HashMap<>();
         SchemaResolver schemaResolver = new SchemaResolver(
-                new GeneratorType(arrayType), usedTypes);
+                new GeneratorType(arrayType, false), usedTypes, false);
 
         Schema schema = schemaResolver.resolve();
         Assert.assertTrue(schema instanceof ArraySchema);
@@ -82,7 +82,7 @@ public class SchemaResolverTest {
 
         Map<String, GeneratorType> usedTypes = new HashMap<>();
         SchemaResolver schemaResolver = new SchemaResolver(
-                new GeneratorType(numberType), usedTypes);
+                new GeneratorType(numberType, false), usedTypes, false);
         Schema schema = schemaResolver.resolve();
         Assert.assertTrue(schema instanceof NumberSchema);
         Assert.assertNull(schema.getNullable());
@@ -95,7 +95,7 @@ public class SchemaResolverTest {
 
         Map<String, GeneratorType> usedTypes = new HashMap<>();
         SchemaResolver schemaResolver = new SchemaResolver(
-                new GeneratorType(numberType), usedTypes);
+                new GeneratorType(numberType, false), usedTypes, false);
         Schema schema = schemaResolver.resolve();
         Assert.assertTrue(schema instanceof NumberSchema);
         Assert.assertTrue(schema.getNullable());
@@ -107,7 +107,7 @@ public class SchemaResolverTest {
         ResolvedType resolvedType = mockReferencedTypeOf(String.class);
         Map<String, GeneratorType> usedTypes = new HashMap<>();
         SchemaResolver schemaResolver = new SchemaResolver(
-                new GeneratorType(resolvedType), usedTypes);
+                new GeneratorType(resolvedType, false), usedTypes, false);
         Schema schema = schemaResolver.resolve();
 
         Assert.assertTrue(schema instanceof StringSchema);
@@ -128,7 +128,7 @@ public class SchemaResolverTest {
 
         Map<String, GeneratorType> usedTypes = new HashMap<>();
         SchemaResolver schemaResolver = new SchemaResolver(
-                new GeneratorType(resolvedType), usedTypes);
+                new GeneratorType(resolvedType, false), usedTypes, false);
         Schema schema = schemaResolver.resolve();
 
         Assert.assertTrue(schema instanceof ArraySchema);
@@ -144,7 +144,7 @@ public class SchemaResolverTest {
                 ResolvedPrimitiveType.BOOLEAN);
         Map<String, GeneratorType> usedTypes = new HashMap<>();
         SchemaResolver schemaResolver = new SchemaResolver(
-                new GeneratorType(resolvedType), usedTypes);
+                new GeneratorType(resolvedType, false), usedTypes, false);
         Schema schema = schemaResolver.resolve();
 
         Assert.assertTrue(schema instanceof BooleanSchema);
@@ -157,7 +157,7 @@ public class SchemaResolverTest {
         ResolvedType resolvedType = mockReferencedTypeOf(Boolean.class);
         Map<String, GeneratorType> usedTypes = new HashMap<>();
         SchemaResolver schemaResolver = new SchemaResolver(
-                new GeneratorType(resolvedType), usedTypes);
+                new GeneratorType(resolvedType, false), usedTypes, false);
         Schema schema = schemaResolver.resolve();
 
         Assert.assertTrue(schema instanceof BooleanSchema);
@@ -172,14 +172,14 @@ public class SchemaResolverTest {
         Mockito.doReturn(resolvedType).when(type).resolve();
 
         GeneratorType generatorType = Mockito
-                .spy(new GeneratorType(resolvedType));
+                .spy(new GeneratorType(resolvedType, false));
         Mockito.doReturn(Arrays.asList(null,
-                new GeneratorType(mockReferencedTypeOf(Number.class))))
+                new GeneratorType(mockReferencedTypeOf(Number.class), false)))
                 .when(generatorType).getTypeArguments();
 
         Map<String, GeneratorType> usedTypes = new HashMap<>();
         SchemaResolver schemaResolver = new SchemaResolver(generatorType,
-                usedTypes);
+                usedTypes, false);
         Schema schema = schemaResolver.resolve();
 
         Assert.assertTrue(schema instanceof MapSchema);
@@ -194,7 +194,7 @@ public class SchemaResolverTest {
         ResolvedType resolvedType = mockReferencedTypeOf(Date.class);
         Map<String, GeneratorType> usedTypes = new HashMap<>();
         SchemaResolver schemaResolver = new SchemaResolver(
-                new GeneratorType(resolvedType), usedTypes);
+                new GeneratorType(resolvedType, false), usedTypes, false);
         Schema schema = schemaResolver.resolve();
 
         Assert.assertTrue(schema instanceof DateSchema);
@@ -207,7 +207,7 @@ public class SchemaResolverTest {
         ResolvedType resolvedType = mockReferencedTypeOf(Instant.class);
         Map<String, GeneratorType> usedTypes = new HashMap<>();
         SchemaResolver schemaResolver = new SchemaResolver(
-                new GeneratorType(resolvedType), usedTypes);
+                new GeneratorType(resolvedType, false), usedTypes, false);
         Schema schema = schemaResolver.resolve();
 
         Assert.assertTrue(schema instanceof DateTimeSchema);
@@ -228,7 +228,7 @@ public class SchemaResolverTest {
 
         Map<String, GeneratorType> usedTypes = new HashMap<>();
         SchemaResolver schemaResolver = new SchemaResolver(
-                new GeneratorType(resolvedType), usedTypes);
+                new GeneratorType(resolvedType, false), usedTypes, false);
         Schema schema = schemaResolver.resolve();
 
         Assert.assertTrue(schema instanceof StringSchema);
@@ -242,14 +242,15 @@ public class SchemaResolverTest {
         ResolvedType resolvedType = mockReferencedTypeOf(Optional.class);
         Mockito.doReturn(resolvedType).when(type).resolve();
 
-        GeneratorType generatorType = Mockito.spy(new GeneratorType(type));
+        GeneratorType generatorType = Mockito
+                .spy(new GeneratorType(type, false));
         Mockito.doReturn(Arrays.asList(
-                new GeneratorType(mockReferencedTypeOf(TestBean.class))))
+                new GeneratorType(mockReferencedTypeOf(TestBean.class), false)))
                 .when(generatorType).getTypeArguments();
 
         Map<String, GeneratorType> usedTypes = new HashMap<>();
         SchemaResolver schemaResolver = new SchemaResolver(generatorType,
-                usedTypes);
+                usedTypes, false);
         Schema schema = schemaResolver.resolve();
 
         Assert.assertTrue(schema instanceof ComposedSchema);
@@ -268,7 +269,7 @@ public class SchemaResolverTest {
         ResolvedType resolvedType = mockReferencedTypeOf(Class.class);
         Map<String, GeneratorType> usedTypes = new HashMap<>();
         SchemaResolver schemaResolver = new SchemaResolver(
-                new GeneratorType(resolvedType), usedTypes);
+                new GeneratorType(resolvedType, false), usedTypes, false);
         Schema schema = schemaResolver.resolve();
 
         Assert.assertNotNull(schema);
@@ -283,7 +284,7 @@ public class SchemaResolverTest {
         Mockito.doReturn(resolvedType).when(type).resolve();
         Map<String, GeneratorType> usedTypes = new HashMap<>();
         SchemaResolver schemaResolver = new SchemaResolver(
-                new GeneratorType(type), usedTypes);
+                new GeneratorType(type, false), usedTypes, false);
 
         Schema schema = schemaResolver.resolve();
 
@@ -310,7 +311,7 @@ public class SchemaResolverTest {
         Map<String, GeneratorType> usedTypes = new HashMap<>();
 
         SchemaResolver schemaResolver = new SchemaResolver(
-                new GeneratorType(type), usedTypes);
+                new GeneratorType(type, false), usedTypes, false);
         Schema schema = schemaResolver.resolve();
         Assert.assertTrue(schema instanceof ComposedSchema);
         Assert.assertEquals(1, ((ComposedSchema) schema).getAllOf().size());

--- a/fusion-endpoint/src/test/java/dev/hilla/generator/endpoints/nonnullapiendpoint/NonNullApiEndpoint.java
+++ b/fusion-endpoint/src/test/java/dev/hilla/generator/endpoints/nonnullapiendpoint/NonNullApiEndpoint.java
@@ -1,0 +1,37 @@
+package dev.hilla.generator.endpoints.nonnullapiendpoint;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+import com.vaadin.flow.server.auth.AnonymousAllowed;
+
+import dev.hilla.Endpoint;
+import reactor.core.publisher.Flux;
+
+@Endpoint
+@AnonymousAllowed
+public class NonNullApiEndpoint {
+
+    public String hello(String hello) {
+        return "Hello " + hello;
+    }
+
+    @Nullable
+    public String helloNullable(@Nullable String hello) {
+        return null;
+    }
+
+    public Flux<String> helloFlux(String hello) {
+        return Flux.just("Hello");
+    }
+
+    public Map<List<String>, Set<Map<Integer, String>>> helloNestedTypes(
+            Map<Integer, List<String>> param) {
+        return new HashMap<>();
+    }
+
+}

--- a/fusion-endpoint/src/test/java/dev/hilla/generator/endpoints/nonnullapiendpoint/NonNullApiEndpointTest.java
+++ b/fusion-endpoint/src/test/java/dev/hilla/generator/endpoints/nonnullapiendpoint/NonNullApiEndpointTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package dev.hilla.generator.endpoints.nonnullapiendpoint;
+
+import java.util.Collections;
+
+import org.junit.Test;
+
+import dev.hilla.generator.endpoints.AbstractEndpointGenerationTest;
+
+public class NonNullApiEndpointTest extends AbstractEndpointGenerationTest {
+
+    public NonNullApiEndpointTest() {
+        super(Collections.singletonList(NonNullApiEndpoint.class));
+    }
+
+    @Test
+    public void notNullApiAffectsTheWholePackage() {
+        verifyOpenApiObjectAndGeneratedTs();
+    }
+}

--- a/fusion-endpoint/src/test/java/dev/hilla/generator/endpoints/nonnullapiendpoint/package-info.java
+++ b/fusion-endpoint/src/test/java/dev/hilla/generator/endpoints/nonnullapiendpoint/package-info.java
@@ -1,0 +1,2 @@
+@org.springframework.lang.NonNullApi
+package dev.hilla.generator.endpoints.nonnullapiendpoint;

--- a/fusion-endpoint/src/test/resources/dev/hilla/generator/endpoints/nonnullapiendpoint/expected-NonNullApiEndpoint.ts
+++ b/fusion-endpoint/src/test/resources/dev/hilla/generator/endpoints/nonnullapiendpoint/expected-NonNullApiEndpoint.ts
@@ -1,0 +1,55 @@
+/**
+* This module is generated from NonNullApiEndpoint.java
+* All changes to this file are overridden. Please consider to make changes in the corresponding Java file if necessary.
+* @module NonNullApiEndpoint
+*/
+// @ts-ignore
+import client from './connect-client.default';
+// @ts-ignore
+import {
+  Subscription
+}
+from '@hilla/frontend';
+function _helloFlux (
+  hello: string
+):
+Subscription<string> {
+  return client.subscribe (
+    'NonNullApiEndpoint', 'helloFlux', {
+      hello
+    }
+  );
+}
+function _helloNestedTypes (
+  param: Record<string, Array<string>>
+): Promise<Record<string, Array<Record<string, string>>>> {
+  return client.call (
+    'NonNullApiEndpoint', 'helloNestedTypes', {
+      param
+    }
+  );
+}
+function _helloNullable (
+  hello: string | undefined
+): Promise<string | undefined> {
+  return client.call (
+    'NonNullApiEndpoint', 'helloNullable', {
+      hello
+    }
+  );
+}
+function _hello (
+  hello: string
+): Promise<string> {
+  return client.call (
+    'NonNullApiEndpoint', 'hello', {
+      hello
+    }
+  );
+}
+export {
+  _helloFlux as helloFlux,
+  _helloNestedTypes as helloNestedTypes,
+  _helloNullable as helloNullable,
+  _hello as hello,
+};


### PR DESCRIPTION
`@NonNullApi` can be used as a package level annotation, on `package-info.java`, to define that all method return types and parameter types should be considered `@Nonnull`. Individual parameter or return types can be overridden to allow null using`@Nullable`.

For https://github.com/vaadin/hilla/issues/107
