### PR TITLE
refactor: remove servlet imports used only for javadocs

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/di/OneTimeInitializerPredicate.java
+++ b/flow-server/src/main/java/com/vaadin/flow/di/OneTimeInitializerPredicate.java
@@ -15,23 +15,22 @@
  */
 package com.vaadin.flow.di;
 
-import javax.servlet.ServletContainerInitializer;
-
 /**
  * The presence of the service implementing this interface with
  * {@link #runOnce()} returning {@code true} means that
- * {@link ServletContainerInitializer}s are executed only once and the
- * implementation doesn't have to care about cleaning up data collected based on
- * previous call.
+ * {@link javax.servlet.ServletContainerInitializer}s are executed only once and
+ * the implementation doesn't have to care about cleaning up data collected
+ * based on previous call.
  * <p>
  * In some cases (e.g. OSGi) the
- * {@link ServletContainerInitializer#onStartup(java.util.Set, javax.servlet.ServletContext)}
+ * {@link javax.servlet.ServletContainerInitializer#onStartup(java.util.Set, javax.servlet.ServletContext)}
  * method may be called several times for the application (with different
  * classes provided). In this case the initializer logic should reset the data
  * passed on the previous call and set the new data. To be able to reset the
- * data correctly the {@link ServletContainerInitializer} implementation may
- * need to store additional data between calls which is excessive if the
- * {@link ServletContainerInitializer#onStartup(java.util.Set, javax.servlet.ServletContext)}
+ * data correctly the {@link javax.servlet.ServletContainerInitializer}
+ * implementation may need to store additional data between calls which is
+ * excessive if the
+ * {@link javax.servlet.ServletContainerInitializer#onStartup(java.util.Set, javax.servlet.ServletContext)}
  * is executed only once.
  *
  * @author Vaadin Ltd
@@ -42,12 +41,13 @@ import javax.servlet.ServletContainerInitializer;
 public interface OneTimeInitializerPredicate {
 
     /**
-     * Checks whether the {@link ServletContainerInitializer}s requires reset to
-     * the previous state on
-     * {@link ServletContainerInitializer#onStartup(java.util.Set, javax.servlet.ServletContext)}
+     * Checks whether the {@link javax.servlet.ServletContainerInitializer}s
+     * requires reset to the previous state on
+     * {@link javax.servlet.ServletContainerInitializer#onStartup(java.util.Set, javax.servlet.ServletContext)}
      * call.
      *
-     * @return {@code true} if {@link ServletContainerInitializer}s are executed
+     * @return {@code true} if
+     *         {@link javax.servlet.ServletContainerInitializer}s are executed
      *         only once, {@code false} otherwise
      */
     boolean runOnce();

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -16,7 +16,6 @@
 
 package com.vaadin.flow.server;
 
-import javax.servlet.http.HttpServletRequest;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -560,7 +559,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
      * Warning: This assumes that the VaadinRequest is targeted for a
      * VaadinServlet and does no further checks to validate this. You want to
      * use
-     * {@link HandlerHelper#isFrameworkInternalRequest(String, HttpServletRequest)}
+     * {@link HandlerHelper#isFrameworkInternalRequest(String, javax.servlet.http.HttpServletRequest)}
      * instead.
      * <p>
      * This is public only so that

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinRequest.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinRequest.java
@@ -16,9 +16,7 @@
 
 package com.vaadin.flow.server;
 
-import javax.servlet.ServletRequest;
 import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -140,7 +138,7 @@ public interface VaadinRequest {
      * Returns the portion of the request URI that indicates the context of the
      * request. The context path always comes first in a request URI.
      *
-     * @see HttpServletRequest#getContextPath()
+     * @see javax.servlet.http.HttpServletRequest#getContextPath()
      *
      * @return a String specifying the portion of the request URI that indicates
      *         the context of the request
@@ -152,7 +150,7 @@ public interface VaadinRequest {
      * no session.
      *
      * @see WrappedSession
-     * @see HttpServletRequest#getSession()
+     * @see javax.servlet.http.HttpServletRequest#getSession()
      *
      * @return the wrapped session for this request
      */
@@ -168,7 +166,7 @@ public interface VaadinRequest {
      *            there's no current session
      *
      * @see WrappedSession
-     * @see HttpServletRequest#getSession(boolean)
+     * @see javax.servlet.http.HttpServletRequest#getSession(boolean)
      *
      * @return the wrapped session for this request
      */
@@ -192,7 +190,7 @@ public interface VaadinRequest {
      *
      * @return the preferred Locale
      *
-     * @see ServletRequest#getLocale()
+     * @see javax.servlet.ServletRequest#getLocale()
      */
     Locale getLocale();
 
@@ -203,7 +201,7 @@ public interface VaadinRequest {
      * @return a string containing the IP address, or <code>null</code> if the
      *         address is not available
      *
-     * @see ServletRequest#getRemoteAddr()
+     * @see javax.servlet.ServletRequest#getRemoteAddr()
      */
     String getRemoteAddr();
 
@@ -213,20 +211,20 @@ public interface VaadinRequest {
      *
      * @return a boolean indicating if the request is secure
      *
-     * @see ServletRequest#isSecure()
+     * @see javax.servlet.ServletRequest#isSecure()
      */
     boolean isSecure();
 
     /**
      * Gets the value of a request header, e.g. a http header for a
-     * {@link HttpServletRequest}.
+     * {@link javax.servlet.http.HttpServletRequest}.
      *
      * @param headerName
      *            the name of the header
      * @return the header value, or <code>null</code> if the header is not
      *         present in the request
      *
-     * @see HttpServletRequest#getHeader(String)
+     * @see javax.servlet.http.HttpServletRequest#getHeader(String)
      */
     String getHeader(String headerName);
 
@@ -247,7 +245,7 @@ public interface VaadinRequest {
      * @return an array of all the <code>Cookies</code> included with this
      *         request, or <code>null</code> if the request has no cookies
      *
-     * @see HttpServletRequest#getCookies()
+     * @see javax.servlet.http.HttpServletRequest#getCookies()
      */
     Cookie[] getCookies();
 
@@ -260,7 +258,7 @@ public interface VaadinRequest {
      * @return a string indicating the authentication scheme, or
      *         <code>null</code> if the request was not authenticated.
      *
-     * @see HttpServletRequest#getAuthType()
+     * @see javax.servlet.http.HttpServletRequest#getAuthType()
      */
     String getAuthType();
 
@@ -273,7 +271,7 @@ public interface VaadinRequest {
      * @return a String specifying the login of the user making this request, or
      *         <code>null</code> if the user login is not known.
      *
-     * @see HttpServletRequest#getRemoteUser()
+     * @see javax.servlet.http.HttpServletRequest#getRemoteUser()
      */
     String getRemoteUser();
 
@@ -286,7 +284,7 @@ public interface VaadinRequest {
      *         user making this request; <code>null</code> if the user has not
      *         been authenticated
      *
-     * @see HttpServletRequest#getUserPrincipal()
+     * @see javax.servlet.http.HttpServletRequest#getUserPrincipal()
      */
     Principal getUserPrincipal();
 
@@ -302,7 +300,7 @@ public interface VaadinRequest {
      *         to a given role; <code>false</code> if the user has not been
      *         authenticated
      *
-     * @see HttpServletRequest#isUserInRole(String)
+     * @see javax.servlet.http.HttpServletRequest#isUserInRole(String)
      */
     boolean isUserInRole(String role);
 
@@ -314,7 +312,7 @@ public interface VaadinRequest {
      * @param name
      *            a String specifying the name of the attribute to remove
      *
-     * @see ServletRequest#removeAttribute(String)
+     * @see javax.servlet.ServletRequest#removeAttribute(String)
      */
     void removeAttribute(String name);
 
@@ -326,7 +324,7 @@ public interface VaadinRequest {
      * @return an Enumeration of strings containing the names of the request's
      *         attributes
      *
-     * @see ServletRequest#getAttributeNames()
+     * @see javax.servlet.ServletRequest#getAttributeNames()
      */
     Enumeration<String> getAttributeNames();
 
@@ -339,7 +337,7 @@ public interface VaadinRequest {
      *
      * @return an Enumeration of preferred Locale objects for the client
      *
-     * @see HttpServletRequest#getLocales()
+     * @see javax.servlet.http.HttpServletRequest#getLocales()
      */
     Enumeration<Locale> getLocales();
 
@@ -352,7 +350,7 @@ public interface VaadinRequest {
      * @return a String containing the fully qualified name of the client, or
      *         <code>null</code> if the information is not available.
      *
-     * @see HttpServletRequest#getRemoteHost()
+     * @see javax.servlet.http.HttpServletRequest#getRemoteHost()
      */
     String getRemoteHost();
 
@@ -363,7 +361,7 @@ public interface VaadinRequest {
      * @return an integer specifying the port number, or -1 if the information
      *         is not available.
      *
-     * @see ServletRequest#getRemotePort()
+     * @see javax.servlet.ServletRequest#getRemotePort()
      */
     int getRemotePort();
 
@@ -375,7 +373,7 @@ public interface VaadinRequest {
      * @return a String containing the name of the character encoding, or null
      *         if the request does not specify a character encoding
      *
-     * @see ServletRequest#getCharacterEncoding()
+     * @see javax.servlet.ServletRequest#getCharacterEncoding()
      */
     String getCharacterEncoding();
 
@@ -396,7 +394,7 @@ public interface VaadinRequest {
      * @throws IOException
      *             if an input or output exception occurred
      *
-     * @see ServletRequest#getReader()
+     * @see javax.servlet.ServletRequest#getReader()
      */
     BufferedReader getReader() throws IOException;
 
@@ -407,7 +405,7 @@ public interface VaadinRequest {
      * @return a String specifying the name of the method with which this
      *         request was made
      *
-     * @see HttpServletRequest#getMethod()
+     * @see javax.servlet.http.HttpServletRequest#getMethod()
      */
     String getMethod();
 
@@ -430,7 +428,7 @@ public interface VaadinRequest {
      *         GMT, or -1 if the named header was not included with the request
      * @throws IllegalArgumentException
      *             If the header value can't be converted to a date
-     * @see HttpServletRequest#getDateHeader(String)
+     * @see javax.servlet.http.HttpServletRequest#getDateHeader(String)
      */
     long getDateHeader(String name);
 
@@ -444,7 +442,7 @@ public interface VaadinRequest {
      * @return an enumeration of all the header names sent with this request; if
      *         the request has no headers, an empty enumeration; if the
      *         implementation does not allow this method, <code>null</code>
-     * @see HttpServletRequest#getHeaderNames()
+     * @see javax.servlet.http.HttpServletRequest#getHeaderNames()
      */
     Enumeration<String> getHeaderNames();
 
@@ -470,7 +468,7 @@ public interface VaadinRequest {
      *         the request does not have any headers of that name return an
      *         empty enumeration. If the header information is not available,
      *         return <code>null</code>
-     * @see HttpServletRequest#getHeaders(String)
+     * @see javax.servlet.http.HttpServletRequest#getHeaders(String)
      */
     Enumeration<String> getHeaders(String name);
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinResponse.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinResponse.java
@@ -20,9 +20,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 
-import javax.servlet.ServletResponse;
 import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletResponse;
 
 import com.vaadin.flow.internal.CurrentInstance;
 
@@ -42,7 +40,7 @@ public interface VaadinResponse {
      *
      * @param statusCode
      *            the status code to set
-     * @see HttpServletResponse#setStatus(int)
+     * @see javax.servlet.http.HttpServletResponse#setStatus(int)
      *
      */
     void setStatus(int statusCode);
@@ -55,7 +53,7 @@ public interface VaadinResponse {
      * @param contentType
      *            a string specifying the MIME type of the content
      *
-     * @see ServletResponse#setContentType(String)
+     * @see javax.servlet.ServletResponse#setContentType(String)
      */
     void setContentType(String contentType);
 
@@ -68,7 +66,7 @@ public interface VaadinResponse {
      * @param value
      *            the header value.
      *
-     * @see HttpServletResponse#setHeader(String, String)
+     * @see javax.servlet.http.HttpServletResponse#setHeader(String, String)
      */
     void setHeader(String name, String value);
 
@@ -81,7 +79,7 @@ public interface VaadinResponse {
      * @param timestamp
      *            the number of milliseconds since epoch
      *
-     * @see HttpServletResponse#setDateHeader(String, long)
+     * @see javax.servlet.http.HttpServletResponse#setDateHeader(String, long)
      */
     void setDateHeader(String name, long timestamp);
 
@@ -97,7 +95,7 @@ public interface VaadinResponse {
      *             if an input or output exception occurred
      *
      * @see #getWriter()
-     * @see ServletResponse#getOutputStream()
+     * @see javax.servlet.ServletResponse#getOutputStream()
      */
     OutputStream getOutputStream() throws IOException;
 
@@ -114,7 +112,7 @@ public interface VaadinResponse {
      *             if an input or output exception occurred
      *
      * @see #getOutputStream()
-     * @see ServletResponse#getWriter()
+     * @see javax.servlet.ServletResponse#getWriter()
      */
     PrintWriter getWriter() throws IOException;
 
@@ -139,7 +137,7 @@ public interface VaadinResponse {
      * @throws IOException
      *             if an input or output exception occurs
      *
-     * @see HttpServletResponse#sendError(int, String)
+     * @see javax.servlet.http.HttpServletResponse#sendError(int, String)
      */
     void sendError(int errorCode, String message) throws IOException;
 
@@ -159,7 +157,7 @@ public interface VaadinResponse {
      * @param cookie
      *            the Cookie to return to the client
      *
-     * @see HttpServletResponse#addCookie(Cookie)
+     * @see javax.servlet.http.HttpServletResponse#addCookie(Cookie)
      */
     void addCookie(Cookie cookie);
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinService.java
@@ -16,9 +16,6 @@
 
 package com.vaadin.flow.server;
 
-import javax.servlet.Servlet;
-import javax.servlet.ServletContext;
-
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.InputStream;
@@ -467,7 +464,7 @@ public abstract class VaadinService implements Serializable {
      * @param resourceName
      *            a String specifying the name of a file
      * @return a String specifying the file's MIME type
-     * @see ServletContext#getMimeType(String)
+     * @see javax.servlet.ServletContext#getMimeType(String)
      */
     public abstract String getMimeType(String resourceName);
 
@@ -2098,7 +2095,7 @@ public abstract class VaadinService implements Serializable {
      * this service.
      *
      * @see #addServiceDestroyListener(ServiceDestroyListener)
-     * @see Servlet#destroy()
+     * @see javax.servlet.Servlet#destroy()
      */
     public void destroy() {
         ServiceDestroyEvent event = new ServiceDestroyEvent(this);

--- a/flow-server/src/main/java/com/vaadin/flow/server/WrappedSession.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/WrappedSession.java
@@ -19,11 +19,9 @@ package com.vaadin.flow.server;
 import java.io.Serializable;
 import java.util.Set;
 
-import javax.servlet.http.HttpSession;
-
 /**
  * A generic session, wrapping a more specific session implementation, e.g.
- * {@link HttpSession}.
+ * {@link javax.servlet.http.HttpSession}.
  *
  * @author Vaadin Ltd
  * @since 1.0
@@ -69,14 +67,14 @@ public interface WrappedSession extends Serializable {
      *
      * @return an unmodifiable set of the current attribute names
      *
-     * @see HttpSession#getAttributeNames()
+     * @see javax.servlet.http.HttpSession#getAttributeNames()
      */
     Set<String> getAttributeNames();
 
     /**
      * Invalidates this session then unbinds any objects bound to it.
      *
-     * @see HttpSession#invalidate()
+     * @see javax.servlet.http.HttpSession#invalidate()
      */
     void invalidate();
 
@@ -85,7 +83,7 @@ public interface WrappedSession extends Serializable {
      *
      * @return a unique session id string
      *
-     * @see HttpSession#getId()
+     * @see javax.servlet.http.HttpSession#getId()
      */
     String getId();
 
@@ -98,7 +96,7 @@ public interface WrappedSession extends Serializable {
      *
      * @throws IllegalStateException
      *             if this method is called on an invalidated session
-     * @see HttpSession#getCreationTime()
+     * @see javax.servlet.http.HttpSession#getCreationTime()
      */
     long getCreationTime();
 
@@ -117,7 +115,7 @@ public interface WrappedSession extends Serializable {
      * @throws IllegalStateException
      *             if this method is called on an invalidated session
      *
-     * @see HttpSession#getLastAccessedTime()
+     * @see javax.servlet.http.HttpSession#getLastAccessedTime()
      */
     long getLastAccessedTime();
 
@@ -131,7 +129,7 @@ public interface WrappedSession extends Serializable {
      *         yet joined
      * @throws IllegalStateException
      *             if this method is called on an invalidated session
-     * @see HttpSession#isNew()
+     * @see javax.servlet.http.HttpSession#isNew()
      */
     boolean isNew();
 
@@ -144,7 +142,7 @@ public interface WrappedSession extends Serializable {
      *            the name of the object to remove from this session
      * @throws IllegalStateException
      *             if this method is called on an invalidated session
-     * @see HttpSession#removeAttribute(String)
+     * @see javax.servlet.http.HttpSession#removeAttribute(String)
      */
     void removeAttribute(String name);
 
@@ -155,7 +153,7 @@ public interface WrappedSession extends Serializable {
      *
      * @param interval
      *            An integer specifying the number of seconds
-     * @see HttpSession#setMaxInactiveInterval(int)
+     * @see javax.servlet.http.HttpSession#setMaxInactiveInterval(int)
      */
     void setMaxInactiveInterval(int interval);
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ApplicationConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ApplicationConfiguration.java
@@ -15,8 +15,6 @@
  */
 package com.vaadin.flow.server.startup;
 
-import javax.servlet.Servlet;
-
 import java.util.Enumeration;
 
 import com.vaadin.flow.di.Lookup;
@@ -31,7 +29,7 @@ import com.vaadin.flow.server.frontend.FallbackChunk;
  * <p>
  * Configuration is based on {@link VaadinContext} which provides application
  * level data in contrast to {@link DeploymentConfiguration} which provides a
- * {@link Servlet} level configuration.
+ * container level configuration (e.g. Servlet).
  *
  * @author Vaadin Ltd
  * @since


### PR DESCRIPTION
## Description

Some flow component imports servlet classes only to link them on javadocs.
To simplify migration to jakarta package, import has been removed and
replace in javadoc link tag with fully qualified class name.

Fixes #13596

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
