### PR TITLE
!refactor: Extend DevModeHandler API

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/DevModeHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/DevModeHandler.java
@@ -71,4 +71,19 @@ public interface DevModeHandler extends RequestHandler {
      * @return the project root folder
      */
     File getProjectRoot();
+
+    /**
+     * Get the listening port of the dev server.
+     *
+     * @return the listening port
+     */
+    int getPort();
+
+    /**
+     * Waits for the dev server to start.
+     * <p>
+     * Suspends the caller's thread until the dev mode server is started (or
+     * failed to start).
+     */
+    void waitForDevServer();
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/DevModeHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/DevModeHandler.java
@@ -78,12 +78,4 @@ public interface DevModeHandler extends RequestHandler {
      * @return the listening port
      */
     int getPort();
-
-    /**
-     * Waits for the dev server to start.
-     * <p>
-     * Suspends the caller's thread until the dev mode server is started (or
-     * failed to start).
-     */
-    void waitForDevServer();
 }

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
@@ -555,9 +555,10 @@ public abstract class AbstractDevServerRunner implements DevModeHandler {
     }
 
     /**
-     * Get the listening port of the dev server.
-     *
-     * @return the listening port
+     * Waits for the dev server to start.
+     * <p>
+     * Suspends the caller's thread until the dev mode server is started (or
+     * failed to start).
      */
     public void waitForDevServer() {
         devServerStartFuture.join();

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
@@ -512,11 +512,7 @@ public abstract class AbstractDevServerRunner implements DevModeHandler {
         }
     }
 
-    /**
-     * Get the listening port of the dev server.
-     *
-     * @return the listening port
-     */
+    @Override
     public int getPort() {
         return port;
     }
@@ -558,12 +554,7 @@ public abstract class AbstractDevServerRunner implements DevModeHandler {
         return new File(System.getProperty("java.io.tmpdir"), uniqueUid);
     }
 
-    /**
-     * Waits for the dev server to start.
-     * <p>
-     * Suspends the caller's thread until the dev mode server is started (or
-     * failed to start).
-     */
+    @Override
     public void waitForDevServer() {
         devServerStartFuture.join();
     }

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
@@ -554,7 +554,11 @@ public abstract class AbstractDevServerRunner implements DevModeHandler {
         return new File(System.getProperty("java.io.tmpdir"), uniqueUid);
     }
 
-    @Override
+    /**
+     * Get the listening port of the dev server.
+     *
+     * @return the listening port
+     */
     public void waitForDevServer() {
         devServerStartFuture.join();
     }

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/AbstractDevModeTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/AbstractDevModeTest.java
@@ -155,7 +155,7 @@ public abstract class AbstractDevModeTest {
 
     protected static void waitForDevServer(DevModeHandler devModeHandler) {
         Assert.assertNotNull(devModeHandler);
-        devModeHandler.waitForDevServer();
+        ((AbstractDevServerRunner) (devModeHandler)).waitForDevServer();
     }
 
     protected static boolean hasDevServerProcess(

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/AbstractDevModeTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/AbstractDevModeTest.java
@@ -137,7 +137,7 @@ public abstract class AbstractDevModeTest {
     }
 
     protected int getDevServerPort() {
-        return ((AbstractDevServerRunner) handler).getPort();
+        return handler.getPort();
     }
 
     protected void waitForDevServer() {
@@ -155,7 +155,7 @@ public abstract class AbstractDevModeTest {
 
     protected static void waitForDevServer(DevModeHandler devModeHandler) {
         Assert.assertNotNull(devModeHandler);
-        ((AbstractDevServerRunner) (devModeHandler)).waitForDevServer();
+        devModeHandler.waitForDevServer();
     }
 
     protected static boolean hasDevServerProcess(


### PR DESCRIPTION
## Description

Move a couple of common methods from AbstractDevServerRunner to DevModeHandler: get port and wait for dev server. It allows to avoid casts to AbstractDevServerRunner and get rid of dev server dependency only for these tho methods.

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
