### PR TITLE
chore(deps): bump spring.boot.version from 2.6.6 to 2.6.7 (#13591)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
 
         <!-- Dependencies -->
         <spring.version>5.3.18</spring.version>
-        <spring.boot.version>2.6.6</spring.boot.version>
+        <spring.boot.version>2.6.7</spring.boot.version>
         <gwt.version>2.8.2</gwt.version>
         <hibernate.validator.version>6.2.1.Final</hibernate.validator.version>
         <slf4j.version>1.7.35</slf4j.version>


### PR DESCRIPTION
Bumps `spring.boot.version` from 2.6.6 to 2.6.7.

Updates `spring-boot-autoconfigure` from 2.6.6 to 2.6.7
- [Release notes](https://github.com/spring-projects/spring-boot/releases)
- [Commits](https://github.com/spring-projects/spring-boot/compare/v2.6.6...v2.6.7)

Updates `spring-boot-test-autoconfigure` from 2.6.6 to 2.6.7
- [Release notes](https://github.com/spring-projects/spring-boot/releases)
- [Commits](https://github.com/spring-projects/spring-boot/compare/v2.6.6...v2.6.7)

Updates `spring-boot-dependencies` from 2.6.6 to 2.6.7
- [Release notes](https://github.com/spring-projects/spring-boot/releases)
- [Commits](https://github.com/spring-projects/spring-boot/compare/v2.6.6...v2.6.7)

---
updated-dependencies:
- dependency-name: org.springframework.boot:spring-boot-autoconfigure
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: org.springframework.boot:spring-boot-test-autoconfigure
  dependency-type: direct:development
  update-type: version-update:semver-patch
- dependency-name: org.springframework.boot:spring-boot-dependencies
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

