### PR TITLE
chore: Upgrade jackson-databind (#13430)

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.databind.version}</version>
         </dependency>
 
         <!-- Jsoup for BootstrapHandler, Template, ... -->

--- a/fusion-endpoint/pom.xml
+++ b/fusion-endpoint/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.databind.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,8 @@
         <hibernate.validator.version>6.2.1.Final</hibernate.validator.version>
         <slf4j.version>1.7.35</slf4j.version>
         <polymer.version>2.6.1</polymer.version>
-        <jackson.version>2.13.1</jackson.version>
+        <jackson.version>2.13.2</jackson.version>
+        <jackson.databind.version>2.13.2.2</jackson.databind.version>
         <javax.validation.version>2.0.1.Final</javax.validation.version>
         <javax.annotation.api.version>1.3.2</javax.annotation.api.version>
         <jaxb.version>2.3.6</jaxb.version>


### PR DESCRIPTION
Seemingly this does not (always) follow jackson versioning. 2.13.2.1 of jackson-databind contains a security (DoS) fix
