### PR TITLE
fix: Do not include AppShellConfigurator interface as an implementation #13608

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinAppShellInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/VaadinAppShellInitializer.java
@@ -126,6 +126,8 @@ public class VaadinAppShellInitializer
         List<String> offendingAnnotations = new ArrayList<>();
 
         classes.stream()
+                // do not include the interface itself. Fix for Open Liberty
+                .filter(clazz -> clazz != AppShellConfigurator.class)
                 // sort classes by putting the app shell in first position
                 .sorted((a, b) -> registry.isShell(a) ? -1
                         : registry.isShell(b) ? 1 : 0)
@@ -162,6 +164,8 @@ public class VaadinAppShellInitializer
 
         List<String> classesImplementingPageConfigurator = classes.stream()
                 .filter(clz -> PageConfigurator.class.isAssignableFrom(clz))
+                // do not include the interface itself. Fix for Open Liberty
+                .filter(clazz -> clazz != PageConfigurator.class)
                 .map(Class::getName).collect(Collectors.toList());
 
         if (!classesImplementingPageConfigurator.isEmpty()) {


### PR DESCRIPTION
Filter out AppShellConfigurator interface as Open Liberty includes the implementation itself.

Fixes #13608