### PR TITLE
fix: Only run new license checker when flag is enabled

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -478,7 +478,8 @@ public class TaskUpdateImports extends NodeUpdater {
     }
 
     private Stream<String> filter(Stream<String> modules) {
-        if (!productionMode) {
+        if (!productionMode
+                || !featureFlags.isEnabled(FeatureFlags.NEW_LICENSE_CHECKER)) {
             return modules;
         }
         return modules.filter(module -> CvdlProducts

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -478,12 +478,12 @@ public class TaskUpdateImports extends NodeUpdater {
     }
 
     private Stream<String> filter(Stream<String> modules) {
-        if (!productionMode
-                || !featureFlags.isEnabled(FeatureFlags.NEW_LICENSE_CHECKER)) {
-            return modules;
+        if (productionMode
+                && featureFlags.isEnabled(FeatureFlags.NEW_LICENSE_CHECKER)) {
+            return modules.filter(module -> CvdlProducts
+                    .includeInFallbackBundle(module, nodeModulesFolder));
         }
-        return modules.filter(module -> CvdlProducts
-                .includeInFallbackBundle(module, nodeModulesFolder));
+        return modules;
     }
 
     private JsonArray makeFallbackCssImports(AbstractUpdateImports updater) {


### PR DESCRIPTION
The checker is invoked in three places:
1. After production build with the plugin
2. For fallback chunk in production build
3. Development time through dev mode gizmo

With this addition, all the three places are guarded by the feature flag
