### PR TITLE
fix: Disable strict peer dependencies to make pnpm 7 work

### DIFF
--- a/flow-server/src/main/resources/npmrc
+++ b/flow-server/src/main/resources/npmrc
@@ -4,3 +4,4 @@
 # This file sets the default parameters for manual `pnpm install`.
 #
 shamefully-hoist=true
+strict-peer-dependencies=false


### PR DESCRIPTION
Workaround for #13667