### PR TITLE
refactor: Make ViewAccessControl more extensible

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/auth/ViewAccessCheckerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/auth/ViewAccessCheckerTest.java
@@ -68,14 +68,6 @@ public class ViewAccessCheckerTest {
     }
 
     @Test
-    public void cannotUseWithoutServlet() {
-        Result request = setupRequest(AnonymousAllowedView.class, null, true);
-        CurrentInstance.clearAll();
-        this.viewAccessChecker.beforeEnter(request.event);
-        Assert.assertEquals(NotFoundException.class, request.getRerouteError());
-    }
-
-    @Test
     public void anonymousAccessToAnonymousViewAllowed() {
         Result result = checkAccess(AnonymousAllowedView.class, null);
         Assert.assertTrue(result.wasTargetViewRendered());
@@ -456,7 +448,8 @@ public class ViewAccessCheckerTest {
     public void loggedInUserRoleAccess_to_noAnnotationPermitAllByGrandParentView_allowed() {
         Result result = checkAccess(
                 NoAnnotationPermitAllByGrandParentView.class, User.NORMAL_USER);
-        Assert.assertTrue(result.wasTargetViewRendered());
+        Assert.assertTrue("Target view should have been rendered",
+                result.wasTargetViewRendered());
     }
 
     @Test
@@ -660,6 +653,13 @@ public class ViewAccessCheckerTest {
                 .createRequest(principal, roles);
         Mockito.when(vaadinServletRequest.getHttpServletRequest())
                 .thenReturn(httpServletRequest);
+        Mockito.when(vaadinServletRequest.getUserPrincipal())
+                .thenAnswer(anasert -> httpServletRequest.getUserPrincipal());
+        Mockito.when(vaadinServletRequest.isUserInRole(Mockito.any()))
+                .thenAnswer(answer -> httpServletRequest
+                        .isUserInRole(answer.getArgument(0)));
+        Mockito.when(vaadinServletRequest.getSession())
+                .thenAnswer(answer -> httpServletRequest.getSession());
         CurrentInstance.set(VaadinRequest.class, vaadinServletRequest);
 
         Router router = Mockito.mock(Router.class);


### PR DESCRIPTION
Makes it possible to fetch the principal and roles from other sources than the HTTP request
