### PR TITLE
chore: use 17.0.2 for now in PR validation

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -32,10 +32,10 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '16.0'
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - uses: actions/cache@v1
         with:
           path: ~/.m2/repository
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v3
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -131,7 +131,7 @@ jobs:
         with:
           version: '5.15.0'
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17.0.2'
           distribution: 'temurin'


### PR DESCRIPTION
the currenly java 17 (17.0.3) failed our build
also update the vendor as adopt Openjdk has been moved to Eclipse Temurin

