### PR TITLE
test: Fix test for Java 17.0.3+

### DIFF
--- a/flow-tests/test-pwa/src/test/java/com/vaadin/flow/pwatest/ui/PwaTestIT.java
+++ b/flow-tests/test-pwa/src/test/java/com/vaadin/flow/pwatest/ui/PwaTestIT.java
@@ -24,6 +24,7 @@ import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -87,7 +88,7 @@ public class PwaTestIT extends ChromeDeviceTest {
                 .findElements(By.xpath("//link[@rel='manifest'][@href]"));
         Assert.assertEquals(1, elements.size());
         String href = elements.get(0).getAttribute("href");
-        Assert.assertTrue(href + " didn't respond with resource", exists(href));
+        assertExists(href);
         // Verify user values in manifest.webmanifest
         if (!href.startsWith(getRootURL())) {
             href = getRootURL() + '/' + href;
@@ -119,8 +120,7 @@ public class PwaTestIT extends ChromeDeviceTest {
                 ? matcher.group(1)
                 : getRootURL() + "/" + matcher.group(1);
 
-        Assert.assertTrue("Service worker not served at: " + serviceWorkerUrl,
-                exists(serviceWorkerUrl));
+        assertExists(serviceWorkerUrl);
 
         String serviceWorkerJS = readStringFromUrl(serviceWorkerUrl);
         // parse the precache resources (the app bundles) from service worker JS
@@ -233,31 +233,45 @@ public class PwaTestIT extends ChromeDeviceTest {
         Assert.assertEquals(expected, icons.size());
         for (WebElement element : icons) {
             String href = element.getAttribute("href");
-            Assert.assertTrue(href + " didn't respond with resource",
-                    exists(href));
+            assertExists(href);
         }
     }
 
     private void checkResources(String... resources) {
         for (String url : resources) {
-            Assert.assertTrue(url + " didn't respond with resource",
-                    exists(url));
+            assertExists(url);
         }
     }
 
-    private boolean exists(String url) {
+    private void assertExists(String url) {
         // If the mimetype can be guessed from the file name, check consistency
         // with the actual served file
         String expectedMimeType = URLConnection.guessContentTypeFromName(url);
+        if ("text/javascript".equals(expectedMimeType)) {
+            expectedMimeType = "application/javascript";
+        }
         String script = "const mimeType = arguments[0];"
                 + "const resolve = arguments[2];" //
                 + "fetch(arguments[1], {method: 'GET'})" //
-                + ".then(response => resolve(response.status===200" //
-                + "      && !response.redirected" //
-                + "      && (mimeType===null || response.headers.get('Content-Type').replace(';charset=utf-8','')===mimeType)))" //
-                + ".catch(err => resolve(false));";
-        return (boolean) ((JavascriptExecutor) getDriver())
+                + ".then(response => resolve({status: response.status," //
+                + "      redirected: response.redirected," //
+                + "      mimeType: response.headers.get('Content-Type')}))" //
+                + ".catch(err => resolve());";
+        Map data = (Map) ((JavascriptExecutor) getDriver())
                 .executeAsyncScript(script, expectedMimeType, url);
+
+        if (expectedMimeType != null) {
+            String mimeType = ((String) data.get("mimeType"))
+                    .replaceAll(";[ ]?charset=utf-8", "");
+
+            Assert.assertEquals(url + " has an unexpected mime type",
+                    expectedMimeType, mimeType);
+        }
+        Assert.assertEquals(url + " has an unexpected redirect", false,
+                data.get("redirected"));
+        Assert.assertEquals(url + " has an unexpected response code", 200L,
+                data.get("status"));
+
     }
 
     private static String readStringFromUrl(String url) throws IOException {


### PR DESCRIPTION
Java 17.0.3+ return "text/javascript" for URLConnection.getFileNameMap().getContentTypeFor("foo.js")
Older versions return null

