### PR TITLE
test: Automatically setup chromedriver version for flow-client tests (#13484) (CP: 23.0)

### DIFF
--- a/flow-client/.gitignore
+++ b/flow-client/.gitignore
@@ -1,1 +1,2 @@
 gwt-unitCache/
+intern.json

--- a/flow-client/pom.xml
+++ b/flow-client/pom.xml
@@ -250,9 +250,56 @@
                             </sources>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>detect-chromedriver-version</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>bsh-property</goal>
+                        </goals>
+                        <configuration>
+                            <source>
+                                import io.github.bonigarcia.wdm.WebDriverManager;
+                                WebDriverManager manager = WebDriverManager.chromedriver();
+                                manager.setup();
+                                internJsonChromeDriverVersion = manager.getDownloadedDriverVersion();
+                            </source>
+                            <properties>
+                                <property>internJsonChromeDriverVersion</property>
+                            </properties>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>setup-intern-json</id>
+                        <goals>
+                            <goal>add-test-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}/src/test/npm</directory>
+                                    <includes>
+                                        <include>intern.json</include>
+                                    </includes>
+                                    <filtering>true</filtering>
+                                    <targetPath>${project.basedir}</targetPath>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.github.bonigarcia</groupId>
+                        <artifactId>webdrivermanager</artifactId>
+                        <version>${webdrivermanager.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>com.vaadin</groupId>
+                        <artifactId>vaadin-testbench-core</artifactId>
+                        <version>${testbench.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
-
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>

--- a/flow-client/src/test/npm/intern.json
+++ b/flow-client/src/test/npm/intern.json
@@ -16,7 +16,7 @@
   "tunnelOptions": {
     "version": "3.141.59",
     "drivers": [
-      {"name": "chrome", "version": "99.0.4844.51"}
+      {"name": "chrome", "version": "${internJsonChromeDriverVersion}"}
     ]
   },
   "plugins": {

--- a/flow-test-util/pom.xml
+++ b/flow-test-util/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>5.1.1</version>
+            <version>${webdrivermanager.version}</version>
         </dependency>
 
         <!-- override scope for junit -->

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,7 @@
         <maven.clean.plugin.version>3.2.0</maven.clean.plugin.version>
         <maven.exec.plugin.version>1.6.0</maven.exec.plugin.version>
         <testbench.version>8.0.0</testbench.version>
+        <webdrivermanager.version>5.1.1</webdrivermanager.version>
         <jetty.version>10.0.9</jetty.version>
         <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>
 


### PR DESCRIPTION
## Description

Chromedriver version for flow-client tests is hard-coded in intern.json file
and should be manually updated when browser gets updated.
With this change, a feasible chromedriver version is automatically detected
using webdrivermanager, as already done for testbench test, and intern.json
is created by replacing a placeholder in a template file.

(cherry picked from commit 64bbcf737c1f36f7ec64a03f381bbb70068008d9)

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
