### PR TITLE
feat: add flag for CE backend support

### DIFF
--- a/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
+++ b/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
@@ -71,6 +71,10 @@ public class FeatureFlags implements Serializable {
     public static final Feature NEW_LICENSE_CHECKER = new Feature(
             "New license checker", "newLicenseChecker",
             "https://github.com/vaadin/platform/issues/2938", false, null);
+    public static final Feature COLLABORATION_ENGINE_BACKEND = new Feature(
+            "Collaboration Engine backend for clustering support",
+            "collaborationEngineBackend",
+            "https://github.com/vaadin/platform/issues/1988", true, null);
     private List<Feature> features = new ArrayList<>();
 
     File propertiesFolder = null;
@@ -93,6 +97,7 @@ public class FeatureFlags implements Serializable {
         features.add(new Feature(SPREADSHEET_COMPONENT));
         features.add(new Feature(HILLA_PUSH));
         features.add(new Feature(NEW_LICENSE_CHECKER));
+        features.add(new Feature(COLLABORATION_ENGINE_BACKEND));
         loadProperties();
 
         if (isEnabled(NEW_LICENSE_CHECKER)) {


### PR DESCRIPTION
This is to add a feature-flag for Collaboration Engine backend support (aka clustering support).