### PR TITLE
Allow dev mode startup spinner to animate fully

### DIFF
--- a/vaadin-dev-server/src/main/resources/com/vaadin/base/devserver/dev-mode-not-ready.html
+++ b/vaadin-dev-server/src/main/resources/com/vaadin/base/devserver/dev-mode-not-ready.html
@@ -34,7 +34,7 @@
   border-radius: 50%;
   border: 2px solid #2CA6FF;
   border-top-color: rgba(50,50,50,1);
-  animation: spinner .6s linear infinite;
+  animation: spinner .2s linear infinite;
 }
 
 @keyframes spinner {


### PR DESCRIPTION
Instead of 1/3 of the animation, allow it to run fully before reloading the page.

This change makes it spin really fast, but at the moment it doesn't look too nice either, when the animation is cut short and then it starts again.