### PR TITLE
fix: Avoid IllegalStateException when resyncing

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/communication/RequestResponseTracker.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/RequestResponseTracker.java
@@ -99,6 +99,10 @@ public class RequestResponseTracker {
      * Fires a {@link ResponseHandlingEndedEvent}.
      */
     public void endRequest() {
+        endRequest(true);
+    }
+
+    public void endRequest(boolean allowFlushPendingInvocations) {
         if (!hasActiveRequest) {
             throw new IllegalStateException(
                     "endRequest called when no request is active");
@@ -109,7 +113,8 @@ public class RequestResponseTracker {
         hasActiveRequest = false;
 
         if (registry.getUILifecycle().isRunning()
-                && registry.getServerRpcQueue().isFlushPending()) {
+                && registry.getServerRpcQueue().isFlushPending()
+                && allowFlushPendingInvocations) {
             // Send the pending RPCs immediately.
             // This might be an unnecessary optimization as ServerRpcQueue has a
             // finally scheduled command which trigger the send if we do not do


### PR DESCRIPTION
## Description

When the "force message handling" timer goes off the first thing that happens is ending
any active request. As a side effect, calling `RequestResponseTracker.endRequest` may
flush any pending RPC invocations. If this happens a new request will have started.
When `forceMessageHandling` then calls `MessageSender.resynchronize` this will fail
with an IllegalStateException in `RequestResponseTracker.startRequest` since a request
is already in flight.

Fixes #13726

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
