### PR TITLE
fix: Clean up flux subscription on browser disconnect

### DIFF
--- a/fusion-endpoint/src/main/java/dev/hilla/push/PushMessageHandler.java
+++ b/fusion-endpoint/src/main/java/dev/hilla/push/PushMessageHandler.java
@@ -1,7 +1,6 @@
 package dev.hilla.push;
 
 import java.security.Principal;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -165,6 +164,28 @@ public class PushMessageHandler {
 
     }
 
+    /**
+     * Called when the browser establishes a new connection.
+     *
+     * Only ever called once for the same connectionId parameter.
+     *
+     * @param connectionId
+     *            the id of the connection
+     */
+    public void handleBrowserConnect(String connectionId) {
+        fluxSubscriptionDisposables.put(connectionId,
+                new ConcurrentHashMap<>());
+    }
+
+    /**
+     * Called when the browser connection has been lost.
+     *
+     * Only ever called once for the same connectionId parameter. The same
+     * connectionId parameter will never be used after this call.
+     *
+     * @param connectionId
+     *            the id of the connection
+     */
     public void handleBrowserDisconnect(String connectionId) {
         disposeConnectionInfo(connectionId);
     }
@@ -207,12 +228,6 @@ public class PushMessageHandler {
                 .get(connectionId);
         if (fluxMap != null) {
             Disposable subscriptionInfo = fluxMap.remove(subscriptionId);
-            if (fluxMap.isEmpty()) {
-                // Remove the map unless somebody else already added something
-                // there
-                fluxSubscriptionDisposables.remove(connectionId, fluxMap);
-            }
-
             if (subscriptionInfo != null) {
                 dispose(subscriptionInfo);
             }

--- a/fusion-endpoint/src/main/java/dev/hilla/push/PushMessageHandler.java
+++ b/fusion-endpoint/src/main/java/dev/hilla/push/PushMessageHandler.java
@@ -142,10 +142,8 @@ public class PushMessageHandler {
                 disposeSubscriptionInfo(connectionId, fluxId);
                 send(sender, new ClientMessageComplete(fluxId));
             });
-            fluxSubscriptionDisposables
-                    .computeIfAbsent(connectionId,
-                            id -> new ConcurrentHashMap<>())
-                    .put(fluxId, endpointFluxSubscriber);
+            fluxSubscriptionDisposables.get(connectionId).put(fluxId,
+                    endpointFluxSubscriber);
 
         } catch (EndpointNotFoundException e) {
             sender.accept(new ClientMessageError(fluxId, "No such endpoint"));

--- a/fusion-endpoint/src/main/java/dev/hilla/push/SocketIoHandler.java
+++ b/fusion-endpoint/src/main/java/dev/hilla/push/SocketIoHandler.java
@@ -4,7 +4,6 @@ import java.util.function.Consumer;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.vaadin.flow.component.dependency.NpmPackage;
 
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -67,12 +66,16 @@ public class SocketIoHandler {
                                 .debug("Received push message from the client: "
                                         + message);
                     }
-                    pushMessageHandler.handleMessage(message, sender);
+                    pushMessageHandler.handleMessage(socket.getId(), message,
+                            sender);
                 } catch (JsonProcessingException e1) {
                     getLogger().warn(
                             "Unexpected problem when receiving push message",
                             e1);
                 }
+            });
+            socket.on("disconnect", ev -> {
+                pushMessageHandler.handleBrowserDisconnect(socket.getId());
             });
         });
     }

--- a/fusion-endpoint/src/main/java/dev/hilla/push/SocketIoHandler.java
+++ b/fusion-endpoint/src/main/java/dev/hilla/push/SocketIoHandler.java
@@ -40,6 +40,7 @@ public class SocketIoHandler {
         SocketIoNamespace hillaNamespace = socketIoServer.namespace("hilla");
         hillaNamespace.on("connection", event -> {
             SocketIoSocket socket = (SocketIoSocket) event[0];
+            pushMessageHandler.handleBrowserConnect(socket.getId());
 
             Consumer<AbstractClientMessage> sender = message -> {
                 try {

--- a/fusion-endpoint/src/test/java/dev/hilla/push/PushMessageHandlerTest.java
+++ b/fusion-endpoint/src/test/java/dev/hilla/push/PushMessageHandlerTest.java
@@ -220,8 +220,10 @@ public class PushMessageHandlerTest {
         pushMessageHandler.handleMessage(CONNECTION_ID, unsubscribeMessage,
                 ignoreAll());
         Assert.assertEquals(List.of(), unexpectedMessages);
-        Assert.assertEquals(0,
+        Assert.assertEquals(1,
                 pushMessageHandler.fluxSubscriptionDisposables.size());
+        Assert.assertTrue(pushMessageHandler.fluxSubscriptionDisposables
+                .get(CONNECTION_ID).isEmpty());
     }
 
     @Test


### PR DESCRIPTION
When the browser disconnects, we need to close all subscriptions. With socket.io, the browser will not reuse the same socket when it reconnects so on reconnect there will be new subscriptions created

Test based on #13728 