### PR TITLE
feat: Support listening to browser unsubscribe in endpoint methods

### DIFF
--- a/fusion-endpoint/src/main/java/dev/hilla/EndpointSubscription.java
+++ b/fusion-endpoint/src/main/java/dev/hilla/EndpointSubscription.java
@@ -1,0 +1,58 @@
+package dev.hilla;
+
+import reactor.core.publisher.Flux;
+
+/**
+ * A subscription that wraps a Flux and allows to listen for unsubscribe events
+ * from the browser.
+ * <p>
+ * An unsubscribe event is sent when "cancel" is called in the browser but also
+ * if the browser has disconnected from the server either explicitly or been
+ * disconnected from the server for a long enough time.
+ */
+public class EndpointSubscription<TT> {
+
+    private Flux<TT> flux;
+    private Runnable onUnsubscribe;
+
+    private EndpointSubscription(Flux<TT> flux, Runnable onUnsubscribe) {
+        this.flux = flux;
+        this.onUnsubscribe = onUnsubscribe;
+    }
+
+    /**
+     * Returns the flux value provide for this subscription.
+     */
+    public Flux<TT> getFlux() {
+        return flux;
+    }
+
+    /**
+     * Returns the callback that is invoked when the browser unsubscribes from
+     * the subscription.
+     */
+    public Runnable getOnUnsubscribe() {
+        return onUnsubscribe;
+    }
+
+    /**
+     * Creates a new endpoint subscription.
+     *
+     * A subscription wraps a flux that provides the values for the subscriber
+     * (browser) and a callback that is invoked when the browser unsubscribes
+     * from the subscription.
+     *
+     * @param <T>
+     *            the type of data in the subscription
+     * @param flux
+     *            the flux that produces the data
+     * @param onDisconnect
+     *            a callback that is invoked when the browser unsubscribes
+     * @return a subscription
+     */
+    public static <T> EndpointSubscription<T> of(Flux<T> flux,
+            Runnable onDisconnect) {
+        return new EndpointSubscription<>(flux, onDisconnect);
+    }
+
+}

--- a/fusion-endpoint/src/main/java/dev/hilla/generator/GeneratorType.java
+++ b/fusion-endpoint/src/main/java/dev/hilla/generator/GeneratorType.java
@@ -35,6 +35,7 @@ import com.github.javaparser.resolution.types.ResolvedReferenceType;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.utils.Pair;
 
+import dev.hilla.EndpointSubscription;
 import dev.hilla.ExplicitNullableTypeChecker;
 import reactor.core.publisher.Flux;
 
@@ -121,6 +122,11 @@ class GeneratorType {
 
     boolean isFlux() {
         return resolvedType.isReferenceType() && isAssignableType(Flux.class);
+    }
+
+    boolean isEndpointSubscription() {
+        return resolvedType.isReferenceType()
+                && isAssignableType(EndpointSubscription.class);
     }
 
     boolean isPrimitive() {

--- a/fusion-endpoint/src/main/java/dev/hilla/generator/SchemaResolver.java
+++ b/fusion-endpoint/src/main/java/dev/hilla/generator/SchemaResolver.java
@@ -136,7 +136,7 @@ class SchemaResolver {
             return createNullableWrapper(createEnumTypeSchema());
         }
 
-        if (type.isFlux()) {
+        if (type.isFlux() || type.isEndpointSubscription()) {
             return createNullableWrapper(createFluxSchema());
         }
 


### PR DESCRIPTION
Adds support for EndpointSubscription as an endpoint return value
An endpoint subscription is the same as a Flux but in addition supports an unsubscribe event handler, triggered when the client closes the subscription (not when the flux completes or errors)
    
Fixes https://github.com/vaadin/hilla/issues/403
