### PR TITLE
Improve dev mode startup message and styling

### DIFF
--- a/vaadin-dev-server/src/main/resources/com/vaadin/base/devserver/dev-mode-not-ready.html
+++ b/vaadin-dev-server/src/main/resources/com/vaadin/base/devserver/dev-mode-not-ready.html
@@ -9,7 +9,7 @@
     justify-content: center;
     margin: 0;
     padding: 1rem;
-    min-height: 100%;
+    min-height: 100vh;
     box-sizing: border-box;
   }
 

--- a/vaadin-dev-server/src/main/resources/com/vaadin/base/devserver/dev-mode-not-ready.html
+++ b/vaadin-dev-server/src/main/resources/com/vaadin/base/devserver/dev-mode-not-ready.html
@@ -72,7 +72,7 @@ setTimeout(poll, delay);
 </head>
 <body>
   <div class="message">
-    Building front-end development bundle, please wait
+    Building front-end development bundle
    </div>
 </body>
 </html>

--- a/vaadin-dev-server/src/main/resources/com/vaadin/base/devserver/dev-mode-not-ready.html
+++ b/vaadin-dev-server/src/main/resources/com/vaadin/base/devserver/dev-mode-not-ready.html
@@ -1,45 +1,48 @@
 <html>
 <head>
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="dark light">
 <style>
-.flex-center {
+  body {
     display: flex;
-    width: 100%;
+    align-items: center;
     justify-content: center;
-    margin-top: 1rem;
-}
-
-.message {
-    position: relative;
-    background-color: rgba(50,50,50,1);
-    color: rgba(255,255,255,.9);
-    border-radius: 1rem;
+    margin: 0;
+    padding: 1rem;
+    min-height: 100%;
     box-sizing: border-box;
-    padding: 0.5em 1em 0.5em 2.25em;
-    line-height: 1;
-    font-family: system-ui;
-}
+  }
 
-/* Spinner */
-.message:before {
-  content: '';
-  box-sizing: border-box;
-  position: absolute;
-  top: 50%;
-  left: 1rem;
-  width: 20px;
-  height: 20px;
-  margin-top: -10px;
-  margin-left: -10px;
-  border-radius: 50%;
-  border: 2px solid #2CA6FF;
-  border-top-color: rgba(50,50,50,1);
-  animation: spinner .6s linear infinite;
-}
+  .message {
+    background-color: rgba(50,50,50,1);
+    color: white;
+    border-radius: 2rem;
+    box-sizing: border-box;
+    padding: 0.75em 1.5em 0.75em 0.75em;
+    font: 0.875rem/1.2 system-ui, ui-sans-serif, sans-serif;
+    display: flex;
+    align-items: center;
+    gap: 0.75em;
+    box-shadow: inset 0 0 0 1px rgba(255,255,255,.1), 0 3px 8px -3px rgba(0,0,0,0.6);
+  }
 
-@keyframes spinner {
-  to {transform: rotate(360deg);}
-}
+  /* Spinner */
+  .message::before {
+    content: '';
+    flex: none;
+    width: 1em;
+    height: 1em;
+    border-radius: 50%;
+    border: 2px solid #2CA6FF;
+    border-top-color: transparent;
+    animation: spinner .5s linear infinite;
+    -webkit-mask-image: radial-gradient(circle at 50% 2px, transparent 40%, #000 70%);
+    mask-image: radial-gradient(circle at 50% 2px, transparent 40%, #000 70%);
+  }
+
+  @keyframes spinner {
+    to {transform: rotate(360deg);}
+  }
 </style>
 <script type="text/javascript">
 
@@ -68,10 +71,8 @@ setTimeout(poll, delay);
 </script>
 </head>
 <body>
- <div class="flex-center">
   <div class="message">
-    The frontend development build has not yet finished. Please wait...
+    Building front-end development bundle, please wait
    </div>
-  </div>
 </body>
 </html>


### PR DESCRIPTION
Simplify the message. Avoid "please", just state what is happening.

Avoid the ellipsis character as it might imply truncated text. The spinner indicates ongoing progress.

Center the message within the viewport. Adapt to light and dark OS theme automatically.

Before:

Light | Dark
---|---
![Screen Shot 2022-05-11 at 12 38 45](https://user-images.githubusercontent.com/66382/167819424-2c96bd9e-91d4-413e-9ef7-f31765a1392e.png)|![Screen Shot 2022-05-11 at 12 38 45](https://user-images.githubusercontent.com/66382/167819424-2c96bd9e-91d4-413e-9ef7-f31765a1392e.png) |


After:
Light | Dark
---|---
![Screen Shot 2022-05-11 at 12 35 44](https://user-images.githubusercontent.com/66382/167818871-3c16d4b6-a472-44c8-9baa-900d8a6e4a60.png) | ![Screen Shot 2022-05-11 at 12 36 00](https://user-images.githubusercontent.com/66382/167818909-8f85579e-f89e-4a11-98e6-9b2215e6c5aa.png)

