### PR TITLE
fix: Avoid potential slow Set#removeAll call in HierarchicalCommunicator

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicationController.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicationController.java
@@ -287,7 +287,7 @@ public class HierarchicalCommunicationController<T> implements Serializable {
             }
 
             // Finally clear any passivated items that have now been confirmed
-            oldActive.removeAll(newActiveKeyOrder);
+            newActiveKeyOrder.forEach(oldActive::remove);
             if (!oldActive.isEmpty()) {
                 passivatedByUpdate.put(Integer.valueOf(updateId), oldActive);
             }

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicationController.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicationController.java
@@ -287,6 +287,13 @@ public class HierarchicalCommunicationController<T> implements Serializable {
             }
 
             // Finally clear any passivated items that have now been confirmed
+            /*
+             * Due to the implementation of Set#removeAll, if the size of 
+             * newActiveKeyOrder is bigger than oldActive's size, then 
+             * calling oldActive.removeAll(newActiveKeyOrder) would end 
+             * up calling contains for all of newActiveKeyOrder items 
+             * which is a slow operation on lists. The following avoids that:
+             */
             newActiveKeyOrder.forEach(oldActive::remove);
             if (!oldActive.isEmpty()) {
                 passivatedByUpdate.put(Integer.valueOf(updateId), oldActive);

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicationController.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicationController.java
@@ -288,11 +288,11 @@ public class HierarchicalCommunicationController<T> implements Serializable {
 
             // Finally clear any passivated items that have now been confirmed
             /*
-             * Due to the implementation of Set#removeAll, if the size of 
-             * newActiveKeyOrder is bigger than oldActive's size, then 
-             * calling oldActive.removeAll(newActiveKeyOrder) would end 
-             * up calling contains for all of newActiveKeyOrder items 
-             * which is a slow operation on lists. The following avoids that:
+             * Due to the implementation of AbstractSet#removeAll, if the size
+             * of newActiveKeyOrder is bigger than oldActive's size, then
+             * calling oldActive.removeAll(newActiveKeyOrder) would end up
+             * calling contains method for all of newActiveKeyOrder items which
+             * is a slow operation on lists. The following avoids that:
              */
             newActiveKeyOrder.forEach(oldActive::remove);
             if (!oldActive.isEmpty()) {


### PR DESCRIPTION
## Description

The performance of calling Set#removeAll(List) is dependent on the relative sizes of the Set and List parameter. Replace Set#removeAll with List#forEach(Set::remove) to avoid this.

Fixes #13745

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
