### PR TITLE
refactor: use the cvdlName getter for retrieving the product name

### DIFF
--- a/flow-client/src/main/frontend/License.ts
+++ b/flow-client/src/main/frontend/License.ts
@@ -1,4 +1,4 @@
-const manipulateTimeout = 1000;
+const noLicenseFallbackTimeout = 1000;
 
 export interface Product {
   name: string;
@@ -11,17 +11,17 @@ export interface ProductAndMessage {
   product: Product;
 }
 
-export const findAll = (element: Element | ShadowRoot | Document, tag: string): Element[] => {
-  const lightDom = Array.from(element.querySelectorAll(tag));
+export const findAll = (element: Element | ShadowRoot | Document, tags: string[]): Element[] => {
+  const lightDom = Array.from(element.querySelectorAll(tags.join(', ')));
   const shadowDom = Array.from(element.querySelectorAll('*'))
     .filter((e) => e.shadowRoot)
-    .flatMap((e) => findAll(e.shadowRoot!, tag));
+    .flatMap((e) => findAll(e.shadowRoot!, tags));
   return [...lightDom, ...shadowDom];
 };
 
 let licenseCheckListener = false;
 
-const manipulate = (element: Element, productAndMessage: ProductAndMessage) => {
+const showNoLicenseFallback = (element: Element, productAndMessage: ProductAndMessage) => {
   if (!licenseCheckListener) {
     // When a license check has succeeded, refresh so that all elements are properly shown again
     window.addEventListener(
@@ -40,11 +40,11 @@ const manipulate = (element: Element, productAndMessage: ProductAndMessage) => {
     if (overlay.shadowRoot) {
       const defaultSlot = overlay.shadowRoot.querySelector('slot:not([name])');
       if (defaultSlot && defaultSlot.assignedElements().length > 0) {
-        manipulate(defaultSlot.assignedElements()[0], productAndMessage);
+        showNoLicenseFallback(defaultSlot.assignedElements()[0], productAndMessage);
         return;
       }
     }
-    manipulate(overlay, productAndMessage);
+    showNoLicenseFallback(overlay, productAndMessage);
     return;
   }
 
@@ -58,27 +58,37 @@ const manipulate = (element: Element, productAndMessage: ProductAndMessage) => {
   element.outerHTML = `<no-license style="display:flex;align-items:center;text-align:center;justify-content:center;"><div>${htmlMessage}</div></no-license>`;
 };
 
-const missingLicense: { [key: string]: ProductAndMessage } = {};
+const productTagNames: Record<string, string[]> = {};
+const productMissingLicense: Record<string, ProductAndMessage> = {};
 
 /* eslint-disable func-names */
 const overrideCustomElementsDefine = () => {
   const { define } = window.customElements;
 
-  window.customElements.define = function (name, constructor, options) {
-    const { cvdlName, connectedCallback } = constructor.prototype;
+  window.customElements.define = function (
+    tagName,
+    constructor: CustomElementConstructor & { cvdlName?: string },
+    options
+  ) {
+    const { cvdlName } = constructor;
+    if (cvdlName) {
+      productTagNames[cvdlName] = productTagNames[cvdlName] ?? [];
+      productTagNames[cvdlName].push(tagName);
 
-    const productInfo = cvdlName && missingLicense[cvdlName.toLowerCase()];
-    if (productInfo) {
-      constructor.prototype.connectedCallback = function () {
-        setTimeout(() => manipulate(this, productInfo), manipulateTimeout);
+      const productInfo = productMissingLicense[cvdlName];
+      if (productInfo) {
+        const { connectedCallback } = constructor.prototype;
+        constructor.prototype.connectedCallback = function () {
+          setTimeout(() => showNoLicenseFallback(this, productInfo), noLicenseFallbackTimeout);
 
-        if (connectedCallback) {
-          connectedCallback.call(this);
-        }
-      };
+          if (connectedCallback) {
+            connectedCallback.call(this);
+          }
+        };
+      }
     }
 
-    define.call(this, name, constructor, options);
+    define.call(this, tagName, constructor, options);
   };
 };
 /* eslint-enable func-names */
@@ -89,28 +99,34 @@ export const licenseCheckOk = (data: Product) => {
 };
 
 export const licenseCheckFailed = (data: ProductAndMessage) => {
-  const tag = data.product.name;
-  missingLicense[tag] = data;
+  const productName = data.product.name;
+  productMissingLicense[productName] = data;
   // eslint-disable-next-line no-console
-  console.error('License check failed for ', tag);
+  console.error('License check failed for ', productName);
 
-  findAll(document, tag).forEach((element) => {
-    setTimeout(() => manipulate(element, missingLicense[tag]), manipulateTimeout);
-  });
+  const tags = productTagNames[productName];
+  if (tags?.length > 0) {
+    findAll(document, tags).forEach((element) => {
+      setTimeout(() => showNoLicenseFallback(element, productMissingLicense[productName]), noLicenseFallbackTimeout);
+    });
+  }
 };
 
 export const licenseCheckNoKey = (data: ProductAndMessage) => {
   const keyUrl = data.message;
 
-  const tag = data.product.name;
+  const productName = data.product.name;
   data.messageHtml = `No license found. <a target=_blank onclick="javascript:window.open(this.href);return false;" href="${keyUrl}">Go here to start a trial or retrieve your license.</a>`;
-  missingLicense[tag] = data;
+  productMissingLicense[productName] = data;
   // eslint-disable-next-line no-console
-  console.error('No license found when checking ', tag);
+  console.error('No license found when checking ', productName);
 
-  findAll(document, tag).forEach((element) => {
-    setTimeout(() => manipulate(element, missingLicense[tag]), manipulateTimeout);
-  });
+  const tags = productTagNames[productName];
+  if (tags?.length > 0) {
+    findAll(document, tags).forEach((element) => {
+      setTimeout(() => showNoLicenseFallback(element, productMissingLicense[productName]), noLicenseFallbackTimeout);
+    });
+  }
 };
 
 overrideCustomElementsDefine();

--- a/flow-client/src/main/frontend/License.ts
+++ b/flow-client/src/main/frontend/License.ts
@@ -67,7 +67,7 @@ const overrideCustomElementsDefine = () => {
   window.customElements.define = function (name, constructor, options) {
     const { cvdlName, connectedCallback } = constructor.prototype;
 
-    const productInfo = cvdlName ?? missingLicense[cvdlName.toLowerCase()];
+    const productInfo = cvdlName && missingLicense[cvdlName.toLowerCase()];
     if (productInfo) {
       constructor.prototype.connectedCallback = function () {
         setTimeout(() => manipulate(this, productInfo), manipulateTimeout);

--- a/flow-client/src/main/frontend/License.ts
+++ b/flow-client/src/main/frontend/License.ts
@@ -67,11 +67,14 @@ const overrideCustomElementsDefine = () => {
   window.customElements.define = function (name, constructor, options) {
     const { cvdlName, connectedCallback } = constructor.prototype;
 
-    const productInfo = cvdlName && missingLicense[cvdlName.toLowerCase()];
+    const productInfo = cvdlName ?? missingLicense[cvdlName.toLowerCase()];
     if (productInfo) {
       constructor.prototype.connectedCallback = function () {
         setTimeout(() => manipulate(this, productInfo), manipulateTimeout);
-        connectedCallback.call(this);
+
+        if (connectedCallback) {
+          connectedCallback.call(this);
+        }
       };
     }
 


### PR DESCRIPTION
## Description

The PR modifies `License.ts` to make it use the `cvdlName` getter for retrieving the product name instead of relying on tag names. The getter has been recently added to the Vaadin web components (see vaadin/web-components#3832).

## Type of change

- [x] Internal

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
