### PR TITLE
fix: Move the clean-frontend phase to be before clean (#13763)

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/CleanFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/CleanFrontendMojo.java
@@ -48,7 +48,7 @@ import elemental.json.impl.JsonUtil;
  *
  * @since 9.0
  */
-@Mojo(name = "clean-frontend", defaultPhase = LifecyclePhase.CLEAN)
+@Mojo(name = "clean-frontend", defaultPhase = LifecyclePhase.PRE_CLEAN)
 public class CleanFrontendMojo extends FlowModeAbstractMojo {
 
     public static final String VAADIN = "vaadin";

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FrontendDanceMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FrontendDanceMojo.java
@@ -23,6 +23,6 @@ import org.apache.maven.plugins.annotations.Mojo;
  *
  * @since
  */
-@Mojo(name = "dance", defaultPhase = LifecyclePhase.CLEAN)
+@Mojo(name = "dance", defaultPhase = LifecyclePhase.PRE_CLEAN)
 public class FrontendDanceMojo extends CleanFrontendMojo {
 }


### PR DESCRIPTION
Move clean-frontend to pre-clean as if
mvn clean is executed before clean-frontend
clean will remove the target folder making
removal of node_modules fail on windows
if there is a symlink to target/flow-frontend

touches #13760

