### PR TITLE
fix: Do not serve static resources from dev server if dev server startup failed

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
@@ -671,7 +671,8 @@ public abstract class AbstractDevServerRunner implements DevModeHandler {
     public boolean serveDevModeRequest(HttpServletRequest request,
             HttpServletResponse response) throws IOException {
         // Do not serve requests if dev server starting or failed to start.
-        if (isDevServerFailedToStart.get() || !devServerStartFuture.isDone()) {
+        if (isDevServerFailedToStart.get() || !devServerStartFuture.isDone()
+                || devServerStartFuture.isCompletedExceptionally()) {
             return false;
         }
         // Since we have 'publicPath=/VAADIN/' in the dev server config,

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
@@ -175,7 +175,7 @@ public abstract class AbstractDevServerRunner implements DevModeHandler {
         }
     }
 
-    private void doStartDevModeServer() throws ExecutionFailedException {
+    void doStartDevModeServer() throws ExecutionFailedException {
         // If port is defined, means that the dev server is already running
         if (port > 0) {
             if (!checkConnection()) {

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/AbstractDevServerRunnerTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/AbstractDevServerRunnerTest.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
@@ -25,7 +24,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import com.vaadin.base.devserver.startup.AbstractDevModeTest;
 import com.vaadin.flow.internal.DevModeHandler;
-import com.vaadin.flow.internal.ReflectTools;
+import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.frontend.FrontendTools;
 import com.vaadin.flow.server.frontend.FrontendToolsSettings;
 
@@ -56,6 +55,10 @@ public class AbstractDevServerRunnerTest extends AbstractDevModeTest {
         @Override
         protected String getServerName() {
             return "Dummy server";
+        }
+
+        @Override
+        void doStartDevModeServer() throws ExecutionFailedException {
         }
 
         @Override
@@ -114,7 +117,8 @@ public class AbstractDevServerRunnerTest extends AbstractDevModeTest {
                     requestedPath.set((String) invocation.getArguments()[0]);
                     return Mockito.mock(HttpURLConnection.class);
                 });
-        devServer.serveDevModeRequest(request, response);
+        Assert.assertTrue("Dev server should have served the resource",
+                devServer.serveDevModeRequest(request, response));
         Assert.assertEquals("foo%20bar", requestedPath.get());
 
     }


### PR DESCRIPTION
This happens when the dev server startup fails, i.e. DevModeInitializer.runNodeTasks throws an exception,
then "action" in the constructor throws an exception and devServerStartFuture completes with an exception.
After this when the browser reloads, it needs to go to AbstractDevModeHandler.handleRequest which checks
if an exception happened and sets isDevServerFailedToStart accordingly.

However before getting to AbstractDevModeHandler.handleRequest the static file server checks if the requested
path is a static resource by calling AbstractDevModeHandler.serveDevModeRequest. This throws an exception
because it only checks that the dev server is not still starting and then it tries to access it using port 0.

Fixes #13772
