### PR TITLE
fix: Read url mapping using the correct property name

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/RootMappedCondition.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/RootMappedCondition.java
@@ -38,7 +38,7 @@ import com.vaadin.flow.server.VaadinServlet;
  */
 public class RootMappedCondition implements Condition {
 
-    public static final String URL_MAPPING_PROPERTY = "vaadin.urlMapping";
+    public static final String URL_MAPPING_PROPERTY = "vaadin.url-mapping";
 
     @Override
     public boolean matches(ConditionContext context,


### PR DESCRIPTION
The property in the application.properties file is vaadin.url-mapping while the old code read a non-existant vaadin.urlMapping property