### PR TITLE
fix: Always get url mapping using helpers when using Spring Boot

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/DevModeBrowserLauncher.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/DevModeBrowserLauncher.java
@@ -99,8 +99,9 @@ public class DevModeBrowserLauncher
         String host = "http://localhost:" + port;
 
         String path = "/";
-        String vaadinServletMapping = app.getEnvironment()
-                .getProperty("vaadin.urlMapping");
+        String vaadinServletMapping = RootMappedCondition
+                .getUrlMapping(app.getBeanFactory(), app.getEnvironment());
+
         ServletContext servletContext = app.getServletContext();
         if (servletContext != null) {
             String contextPath = servletContext.getContextPath();

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/DevModeBrowserLauncher.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/DevModeBrowserLauncher.java
@@ -100,7 +100,7 @@ public class DevModeBrowserLauncher
 
         String path = "/";
         String vaadinServletMapping = RootMappedCondition
-                .getUrlMapping(app.getBeanFactory(), app.getEnvironment());
+                .getUrlMapping(app.getEnvironment());
 
         ServletContext servletContext = app.getServletContext();
         if (servletContext != null) {

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/RootMappedCondition.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/RootMappedCondition.java
@@ -56,9 +56,6 @@ public class RootMappedCondition implements Condition {
      * Gets the url mapping in a way compatible with both plain Spring and
      * Spring Boot.
      *
-     * This is a helper needed only when VaadinConfigurationProperties is not
-     * available for injection, e.g. in a condition.
-     *
      * @param environment
      *            the application environment
      * @return the url mapping or null if none is defined

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/RootMappedCondition.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/RootMappedCondition.java
@@ -15,12 +15,17 @@
  */
 package com.vaadin.flow.spring;
 
-import org.springframework.context.annotation.Condition;
-import org.springframework.context.annotation.ConditionContext;
-import org.springframework.core.type.AnnotatedTypeMetadata;
-import org.springframework.web.servlet.DispatcherServlet;
+import java.lang.reflect.InvocationTargetException;
 
 import com.vaadin.flow.server.VaadinServlet;
+
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.web.servlet.DispatcherServlet;
 
 /**
  * Condition to check whether the Vaadin servlet is mapped to the root
@@ -43,8 +48,43 @@ public class RootMappedCondition implements Condition {
     @Override
     public boolean matches(ConditionContext context,
             AnnotatedTypeMetadata metadata) {
-        return isRootMapping(
-                context.getEnvironment().getProperty(URL_MAPPING_PROPERTY));
+
+        String urlMapping = getUrlMapping(context.getBeanFactory(),
+                context.getEnvironment());
+        return isRootMapping(urlMapping);
+    }
+
+    /**
+     * Gets the url mapping in a way compatible with both plain Spring and
+     * Spring Boot.
+     *
+     * This is a helper needed only when VaadinConfigurationProperties is not
+     * available for injection, e.g. in a condition.
+     *
+     * @param beanFactory
+     *            the bean factory
+     * @param environment
+     *            the application environment
+     * @return the url mapping or null if none is defined
+     */
+    public static String getUrlMapping(ListableBeanFactory beanFactory,
+            Environment environment) {
+        if (SpringUtil.isSpringBoot()) {
+            try {
+                return (String) Class.forName(
+                        "com.vaadin.flow.spring.VaadinConfigurationProperties")
+                        .getMethod("getUrlMapping", Environment.class)
+                        .invoke(null, environment);
+            } catch (IllegalAccessException | IllegalArgumentException
+                    | InvocationTargetException | NoSuchMethodException
+                    | SecurityException | ClassNotFoundException e) {
+                LoggerFactory.getLogger(RootMappedCondition.class)
+                        .error("Unable to find urlMapping from properties", e);
+                return null;
+            }
+        } else {
+            return environment.getProperty(URL_MAPPING_PROPERTY);
+        }
     }
 
     /**

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/RootMappedCondition.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/RootMappedCondition.java
@@ -20,7 +20,6 @@ import java.lang.reflect.InvocationTargetException;
 import com.vaadin.flow.server.VaadinServlet;
 
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.context.annotation.Condition;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.core.env.Environment;
@@ -49,8 +48,7 @@ public class RootMappedCondition implements Condition {
     public boolean matches(ConditionContext context,
             AnnotatedTypeMetadata metadata) {
 
-        String urlMapping = getUrlMapping(context.getBeanFactory(),
-                context.getEnvironment());
+        String urlMapping = getUrlMapping(context.getEnvironment());
         return isRootMapping(urlMapping);
     }
 
@@ -61,14 +59,11 @@ public class RootMappedCondition implements Condition {
      * This is a helper needed only when VaadinConfigurationProperties is not
      * available for injection, e.g. in a condition.
      *
-     * @param beanFactory
-     *            the bean factory
      * @param environment
      *            the application environment
      * @return the url mapping or null if none is defined
      */
-    public static String getUrlMapping(ListableBeanFactory beanFactory,
-            Environment environment) {
+    public static String getUrlMapping(Environment environment) {
         if (SpringUtil.isSpringBoot()) {
             try {
                 return (String) Class.forName(

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringUtil.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringUtil.java
@@ -1,0 +1,26 @@
+package com.vaadin.flow.spring;
+
+/** Helpers related to Spring. */
+public class SpringUtil {
+
+    /**
+     * Checks if this is Spring Boot and not plain Spring.
+     *
+     * @return true if this is Spring Boot, false if it is Spring without Boot
+     */
+    public static boolean isSpringBoot() {
+        Class<?> resourcesClass = resolveClass(
+                SpringVaadinServletService.SPRING_BOOT_WEBPROPERTIES_CLASS);
+        return (resourcesClass != null);
+    }
+
+    private static Class<?> resolveClass(String clazzName) {
+        try {
+            return Class.forName(clazzName, false,
+                    SpringVaadinServletService.class.getClassLoader());
+        } catch (LinkageError | ClassNotFoundException e) {
+            return null;
+        }
+    }
+
+}

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringVaadinServletService.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringVaadinServletService.java
@@ -47,7 +47,7 @@ public class SpringVaadinServletService extends VaadinServletService {
 
     private final Registration serviceDestroyRegistration;
 
-    private static final String SPRING_BOOT_WEBPROPROPERTIES_CLASS = "org.springframework.boot.autoconfigure.web.WebProperties";
+    static final String SPRING_BOOT_WEBPROPERTIES_CLASS = "org.springframework.boot.autoconfigure.web.WebProperties";
 
     /**
      * Creates an instance connected to the given servlet and using the given
@@ -161,8 +161,7 @@ public class SpringVaadinServletService extends VaadinServletService {
      * ClassNotFound or similar exceptions in plain Spring.
      */
     private boolean isSpringBootConfigured() {
-        Class<?> resourcesClass = resolveClass(
-                SPRING_BOOT_WEBPROPROPERTIES_CLASS);
+        Class<?> resourcesClass = resolveClass(SPRING_BOOT_WEBPROPERTIES_CLASS);
         if (resourcesClass != null) {
             return context.getBeanNamesForType(resourcesClass).length != 0;
         }

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinConfigurationProperties.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinConfigurationProperties.java
@@ -20,6 +20,8 @@ import java.util.Collections;
 import java.util.List;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.core.env.Environment;
 
 /**
  * Configuration properties for Vaadin Spring Boot.
@@ -30,6 +32,22 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  */
 @ConfigurationProperties(prefix = "vaadin")
 public class VaadinConfigurationProperties {
+
+    /**
+     * Gets the url mapping using the given environment.
+     *
+     * This is a helper needed only when VaadinConfigurationProperties is not
+     * available for injection, e.g. in a condition.
+     *
+     * @param environment
+     *            the application environment
+     * @return the url mapping or null if none is defined
+     */
+    public static String getUrlMapping(Environment environment) {
+        return Binder.get(environment)
+                .bind("vaadin", VaadinConfigurationProperties.class)
+                .map(conf -> conf.getUrlMapping()).orElse(null);
+    }
 
     /**
      * Base URL mapping of the Vaadin servlet.

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinConfigurationProperties.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinConfigurationProperties.java
@@ -36,8 +36,8 @@ public class VaadinConfigurationProperties {
     /**
      * Gets the url mapping using the given environment.
      *
-     * This is a helper needed only when VaadinConfigurationProperties is not
-     * available for injection, e.g. in a condition.
+     * This is needed only when VaadinConfigurationProperties is not available
+     * for injection, e.g. in a condition.
      *
      * @param environment
      *            the application environment

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinMVCWebAppInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinMVCWebAppInitializer.java
@@ -15,14 +15,16 @@
  */
 package com.vaadin.flow.spring;
 
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRegistration.Dynamic;
-
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRegistration.Dynamic;
+
+import com.vaadin.flow.server.Constants;
 
 import org.springframework.core.env.Environment;
 import org.springframework.util.ClassUtils;
@@ -30,8 +32,6 @@ import org.springframework.web.WebApplicationInitializer;
 import org.springframework.web.context.ContextLoaderListener;
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
 import org.springframework.web.servlet.DispatcherServlet;
-
-import com.vaadin.flow.server.Constants;
 
 /**
  * Abstract Vaadin Spring MVC {@link WebApplicationInitializer}.
@@ -56,8 +56,11 @@ public abstract class VaadinMVCWebAppInitializer
         context.refresh();
 
         Environment env = context.getBean(Environment.class);
-        String mapping = env
-                .getProperty(RootMappedCondition.URL_MAPPING_PROPERTY, "/*");
+        String mapping = RootMappedCondition
+                .getUrlMapping(context.getBeanFactory(), env);
+        if (mapping == null) {
+            mapping = "/*";
+        }
 
         boolean rootMapping = RootMappedCondition.isRootMapping(mapping);
 

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinMVCWebAppInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinMVCWebAppInitializer.java
@@ -56,8 +56,7 @@ public abstract class VaadinMVCWebAppInitializer
         context.refresh();
 
         Environment env = context.getBean(Environment.class);
-        String mapping = RootMappedCondition
-                .getUrlMapping(context.getBeanFactory(), env);
+        String mapping = RootMappedCondition.getUrlMapping(env);
         if (mapping == null) {
             mapping = "/*";
         }

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/DevModeBrowserLauncherVaadinAndServletMappingTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/DevModeBrowserLauncherVaadinAndServletMappingTest.java
@@ -21,7 +21,7 @@ import org.springframework.mock.web.MockServletContext;
 import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource(properties = { "server.port = 1234",
-        "vaadin.urlMapping=/ui/*" })
+        "vaadin.url-mapping=/ui/*" })
 public class DevModeBrowserLauncherVaadinAndServletMappingTest
         extends AbstractDevModeBrowserLauncherTest {
 

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/RootMappedConditionTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/RootMappedConditionTest.java
@@ -1,0 +1,24 @@
+package com.vaadin.flow.spring;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+public class RootMappedConditionTest {
+
+    @Test
+    public void lookupProperty() {
+        assertUrlMapping("url-mapping");
+        assertUrlMapping("urlmapping");
+        assertUrlMapping("urlMapping");
+        assertUrlMapping("URL-mapping");
+        assertUrlMapping("URLMAPPING");
+    }
+
+    private void assertUrlMapping(String key) {
+        MockEnvironment environment = new MockEnvironment();
+        environment.setProperty("vaadin." + key, "abc");
+        Assert.assertEquals("abc",
+                RootMappedCondition.getUrlMapping(environment));
+    }
+}


### PR DESCRIPTION
The properties in application.properties use a relaxed mapping strategy in
Spring Boot so all variants of "url-mapping","urlmapping","urlMapping" are
mapped to the same value in VaadinConfigurationProperties.

Fixes https://github.com/vaadin/spring/issues/478