### PR TITLE
Fix: Use /HILLA/push as the Hilla push endpoint

### DIFF
--- a/fusion-endpoint/src/main/java/dev/hilla/EndpointController.java
+++ b/fusion-endpoint/src/main/java/dev/hilla/EndpointController.java
@@ -65,8 +65,8 @@ import dev.hilla.exception.EndpointException;
  */
 @RestController
 @Import({ EndpointControllerConfiguration.class, EndpointProperties.class })
-@NpmPackage(value = "@hilla/frontend", version = "1.1.0-alpha3")
-@NpmPackage(value = "@hilla/form", version = "1.1.0-alpha3")
+@NpmPackage(value = "@hilla/frontend", version = "1.1.0-beta3")
+@NpmPackage(value = "@hilla/form", version = "1.1.0-beta3")
 public class EndpointController {
     static final String ENDPOINT_METHODS = "/{endpoint}/{method}";
 

--- a/fusion-endpoint/src/main/java/dev/hilla/push/EngineIoHandler.java
+++ b/fusion-endpoint/src/main/java/dev/hilla/push/EngineIoHandler.java
@@ -56,7 +56,7 @@ public final class EngineIoHandler
         mEngineIoServer = engineIoServer;
     }
 
-    @RequestMapping(value = "/VAADIN/hillapush/", method = { RequestMethod.GET,
+    @RequestMapping(value = "/HILLA/push", method = { RequestMethod.GET,
             RequestMethod.POST,
             RequestMethod.OPTIONS }, headers = "Connection!=Upgrade")
     public void httpHandler(HttpServletRequest request,

--- a/fusion-endpoint/src/main/java/dev/hilla/push/SocketIoWebsocketConfigurer.java
+++ b/fusion-endpoint/src/main/java/dev/hilla/push/SocketIoWebsocketConfigurer.java
@@ -29,7 +29,7 @@ public class SocketIoWebsocketConfigurer implements WebSocketConfigurer {
 
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-        registry.addHandler(engineIoHandler, "/VAADIN/hillapush/")
+        registry.addHandler(engineIoHandler, "/HILLA/push")
                 .addInterceptors(engineIoHandler);
     }
 


### PR DESCRIPTION
This avoids conflict with the VaadinServlet when it is bound to /VAADIN/*

Related to https://github.com/vaadin/hilla/pull/424
