### PR TITLE
test: Start chromedriver with --silent

### DIFF
--- a/flow-test-util/src/main/java/com/vaadin/flow/testutil/ChromeBrowserTest.java
+++ b/flow-test-util/src/main/java/com/vaadin/flow/testutil/ChromeBrowserTest.java
@@ -128,7 +128,7 @@ public class ChromeBrowserTest extends ViewOrUITest {
 
         int port = PortProber.findFreePort();
         ChromeDriverService service = new ChromeDriverService.Builder()
-                .usingPort(port).build();
+                .usingPort(port).withSilent(true).build();
         ChromeDriver chromeDriver = new ChromeDriver(service, headlessOptions);
         return TestBench.createDriver(chromeDriver);
     }


### PR DESCRIPTION
Should reduce log output by 3000 rows or so
