### PR TITLE
fix: upgrade lit from 2.2.1 to 2.2.3 (#13848) (CP: 23.1)

### DIFF
--- a/flow-client/package.json
+++ b/flow-client/package.json
@@ -53,6 +53,6 @@
   },
   "dependencies": {
     "@vaadin/common-frontend": "0.0.16",
-    "lit": "2.2.1"
+    "lit": "2.2.3"
   }
 }


### PR DESCRIPTION
Upgrades the dependency in flow-client which was missing from the last commit
