### PR TITLE
test: Add VAADIN mapping to OSGi servlet registrations

### DIFF
--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/osgi/Activator.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/osgi/Activator.java
@@ -225,7 +225,10 @@ public class Activator {
                 HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_ASYNC_SUPPORTED,
                 true);
         properties.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_PATTERN,
-                mapping);
+                // Adds serve static files from VAADIN in the context root
+                // for non-root servlet mapping.
+                // see https://github.com/vaadin/flow/issues/13769
+                new String[] { mapping, "/VAADIN/*" });
         return properties;
     }
 


### PR DESCRIPTION
## Description

Add a `/VAADIN/*` servlet mapping for OSGi test servlet, since it's mandatory for non-root mappings.

Part-of https://github.com/vaadin/flow/issues/13769

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
