### PR TITLE
Revert "refactor: make Webpack use web-component.html (#13165)"

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -860,7 +860,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
         private List<Element> setupDocumentHead(Element head,
                 BootstrapContext context) {
             setupMetaAndTitle(head, context);
-            setupCss(head, context, true);
+            setupCss(head, context);
 
             JsonObject initialUIDL = getInitialUidl(context.getUI());
             Map<LoadMode, JsonArray> dependenciesToProcessOnServer = popDependenciesToProcessOnServer(
@@ -1160,28 +1160,13 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             return null;
         }
 
-        /**
-         * Append styles for the body element (if requested) and for error
-         * dialogs.
-         *
-         * @param head
-         *            the head element
-         * @param context
-         *            the bootstrap context
-         * @param includeBodyStyles
-         *            true to include body styles, false to exclude them
-         */
-        protected void setupCss(Element head, BootstrapContext context,
-                boolean includeBodyStyles) {
+        private void setupCss(Element head, BootstrapContext context) {
             Element styles = head.appendElement("style").attr("type",
                     CSS_TYPE_ATTRIBUTE_VALUE);
-            if (includeBodyStyles) {
-                // Add any body style that is defined for the application using
-                // @BodySize
-                String bodySizeContent = BootstrapUtils
-                        .getBodySizeContent(context);
-                styles.appendText(bodySizeContent);
-            }
+            // Add any body style that is defined for the application using
+            // @BodySize
+            String bodySizeContent = BootstrapUtils.getBodySizeContent(context);
+            styles.appendText(bodySizeContent);
 
             // Basic reconnect and system error dialog styles just to make them
             // visible and outside of normal flow

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
@@ -60,6 +60,7 @@ import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 
+import static com.vaadin.flow.server.frontend.FrontendUtils.EXPORT_CHUNK;
 import static com.vaadin.flow.shared.ApplicationConstants.CONTENT_TYPE_TEXT_JAVASCRIPT_UTF_8;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -107,46 +108,50 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
         public Document getBootstrapPage(BootstrapContext context) {
             VaadinService service = context.getSession().getService();
 
-            try {
-                JsonObject initialUIDL = getInitialUidl(context.getUI());
+            if (FeatureFlags.get(service.getContext())
+                    .isEnabled(FeatureFlags.VITE)) {
+                try {
+                    Document document = Jsoup.parse(
+                            FrontendUtils.getWebComponentHtmlContent(service));
+                    Element head = document.head();
 
-                Document document = Jsoup.parse(
-                        FrontendUtils.getWebComponentHtmlContent(service));
-                Element head = document.head();
+                    // Specify the application ID for scripts of the
+                    // web-component.html
+                    head.select("script[src]").attr("data-app-id",
+                            context.getUI().getInternals().getAppId());
 
-                // The application ID is needed for the Flow client to connect
-                // to the server.
-                head.select("script[src]").attr("data-app-id",
-                        context.getUI().getInternals().getAppId());
+                    // Add `crossorigin` to fix basic auth in Safari #6560
+                    head.select("script[src], link[href]").attr("crossorigin",
+                            "true");
 
-                // Fixes basic auth in Safari #6560
-                head.select("script[src], link[href]").attr("crossorigin",
-                        "true");
+                    JsonObject initialUIDL = getInitialUidl(context.getUI());
 
-                setupCss(head, context, false);
-                if (FeatureFlags.get(service.getContext())
-                        .isEnabled(FeatureFlags.VITE)) {
-                    // A workaround for
-                    // https://github.com/vitejs/vite/issues/5142
                     head.prependChild(createInlineJavaScriptElement(
                             "window.JSCompiler_renameProperty = function(a) { return a; }"));
-                } else {
-                    // A workaround for HtmlWebpackPlugin that doesn't support
-                    // `scriptLoading: module` for Webpack 4.
-                    head.select("script[src]").attr("type", "module");
+
+                    head.prependChild(getBootstrapScript(initialUIDL, context));
+
+                    if (context.getPushMode().isEnabled()) {
+                        head.prependChild(createJavaScriptModuleElement(
+                                getPushScript(context), true));
+                    }
+
+                    return document;
+                } catch (IOException e) {
+                    throw new BootstrapException(
+                            "Unable to read the web-component.html file.", e);
                 }
+            }
 
-                head.prependChild(getBootstrapScript(initialUIDL, context));
+            return super.getBootstrapPage(context);
+        }
 
-                if (context.getPushMode().isEnabled()) {
-                    head.prependChild(createJavaScriptModuleElement(
-                            getPushScript(context), true));
-                }
-
-                return document;
-            } catch (IOException e) {
-                throw new BootstrapException(
-                        "Unable to read the web-component.html file.", e);
+        @Override
+        protected List<String> getChunkKeys(JsonObject chunks) {
+            if (chunks.hasKey(EXPORT_CHUNK)) {
+                return Collections.singletonList(EXPORT_CHUNK);
+            } else {
+                return super.getChunkKeys(chunks);
             }
         }
     }

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -111,13 +111,18 @@ if (watchDogPort) {
 const webPackEntries = {};
 if (useClientSideIndexFileForBootstrapping) {
   webPackEntries.bundle = clientSideIndexEntryPoint;
+  const dirName = path.dirname(fileNameOfTheFlowGeneratedMainEntryPoint);
+  const baseName = path.basename(fileNameOfTheFlowGeneratedMainEntryPoint, '.js');
+  if (
+    fs
+      .readdirSync(dirName)
+      .filter((fileName) => !fileName.startsWith(baseName) && fileName.endsWith('.js') && fileName.includes('-')).length
+  ) {
+    // if there are vaadin exported views, add a second entry
+    webPackEntries.export = fileNameOfTheFlowGeneratedMainEntryPoint;
+  }
 } else {
   webPackEntries.bundle = fileNameOfTheFlowGeneratedMainEntryPoint;
-}
-
-const hasExportedWebComponents = fs.existsSync(path.resolve(frontendFolder, 'web-component.html'));
-if (hasExportedWebComponents) {
-  webPackEntries.export = path.resolve(frontendGeneratedFolder, 'vaadin-web-component.ts');
 }
 
 const appShellUrl = '.';
@@ -371,15 +376,6 @@ module.exports = {
         inject: 'head',
         scriptLoading: 'defer',
         chunks: ['bundle']
-      }),
-
-    hasExportedWebComponents &&
-      new HtmlWebpackPlugin({
-        template: './web-component.html',
-        filename: 'web-component.html',
-        inject: 'head',
-        scriptLoading: 'defer',
-        chunks: ['export']
       }),
 
     // Service worker for offline

--- a/flow-server/src/test/resources/META-INF/VAADIN/webapp/web-component.html
+++ b/flow-server/src/test/resources/META-INF/VAADIN/webapp/web-component.html
@@ -1,1 +1,0 @@
-<!doctype html><html><head><script defer="defer" src="/VAADIN/build/vaadin-export-2222.cache.js"></script></head></html>


### PR DESCRIPTION
## Description

This reverts commit 878e94e7

Recent WebComponentBootstrapHandler changes https://github.com/vaadin/flow/pull/13165 prevents Vaadin Portlet from rendering portlet's content. See more details in the pull request comments.

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
