### PR TITLE
chore: Move license checker dependency to vaadin-dev-server and plugin (#13859) (CP: 23.1)

### DIFF
--- a/flow-plugins/flow-plugin-base/pom.xml
+++ b/flow-plugins/flow-plugin-base/pom.xml
@@ -23,6 +23,10 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>license-checker</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
             <version>0.10.2</version>

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -374,6 +374,11 @@ public class BuildFrontendUtil {
     public static void runFrontendBuild(PluginAdapterBase adapter)
             throws TimeoutException, URISyntaxException {
         FeatureFlags featureFlags = getFeatureFlags(adapter);
+
+        if (featureFlags.isEnabled(FeatureFlags.NEW_LICENSE_CHECKER)) {
+            LicenseChecker.setStrictOffline(true);
+        }
+
         FrontendToolsSettings settings = getFrontendToolsSettings(adapter);
         FrontendTools tools = new FrontendTools(settings);
         tools.validateNodeAndNpmVersion();

--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>license-checker</artifactId>
-            <version>1.4.1</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
+++ b/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
@@ -32,7 +32,6 @@ import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.di.ResourceProvider;
 import com.vaadin.flow.server.VaadinContext;
 import com.vaadin.flow.server.startup.ApplicationConfiguration;
-import com.vaadin.pro.licensechecker.LicenseChecker;
 
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -99,10 +98,6 @@ public class FeatureFlags implements Serializable {
         features.add(new Feature(NEW_LICENSE_CHECKER));
         features.add(new Feature(COLLABORATION_ENGINE_BACKEND));
         loadProperties();
-
-        if (isEnabled(NEW_LICENSE_CHECKER)) {
-            LicenseChecker.setStrictOffline(true);
-        }
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-
+            <dependency>
+                <groupId>com.vaadin</groupId>
+                <artifactId>license-checker</artifactId>
+                <version>1.4.1</version>
+            </dependency>
 
             <!-- Test dependencies -->
             <dependency>

--- a/vaadin-dev-server/pom.xml
+++ b/vaadin-dev-server/pom.xml
@@ -23,6 +23,10 @@
             <artifactId>flow-server</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>license-checker</artifactId>
+        </dependency>
 
 
         <!-- API dependencies -->

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
@@ -84,6 +84,7 @@ import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder.DefaultClassFinder;
 import com.vaadin.flow.server.startup.ApplicationConfiguration;
 import com.vaadin.flow.server.startup.VaadinInitializerException;
+import com.vaadin.pro.licensechecker.LicenseChecker;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -202,8 +203,12 @@ public class DevModeInitializer implements Serializable {
         }
         // This needs to be set as there is no "current service" available in
         // this call
-        FeatureFlags.get(context)
-                .setPropertiesLocation(config.getJavaResourceFolder());
+        FeatureFlags featureFlags = FeatureFlags.get(context);
+        if (featureFlags.isEnabled(FeatureFlags.NEW_LICENSE_CHECKER)) {
+            LicenseChecker.setStrictOffline(true);
+        }
+
+        featureFlags.setPropertiesLocation(config.getJavaResourceFolder());
 
         String baseDir = config.getStringProperty(FrontendUtils.PROJECT_BASEDIR,
                 null);
@@ -347,7 +352,7 @@ public class DevModeInitializer implements Serializable {
 
         Lookup devServerLookup = Lookup.compose(lookup,
                 Lookup.of(config, ApplicationConfiguration.class));
-        if (FeatureFlags.get(context).isEnabled(FeatureFlags.VITE)) {
+        if (featureFlags.isEnabled(FeatureFlags.VITE)) {
             return new ViteHandler(devServerLookup, 0, builder.getNpmFolder(),
                     nodeTasksFuture);
         } else {


### PR DESCRIPTION
This makes it clearer that Flow (flow-server) does not depend on the license checker nor is it needed in production
