### PR TITLE
fix: upgrade lit default version from 2.2.1 to 2.2.3

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -369,7 +369,7 @@ public abstract class NodeUpdater implements FallibleCommand {
 
         defaults.put("@polymer/polymer", POLYMER_VERSION);
 
-        defaults.put("lit", "2.2.1");
+        defaults.put("lit", "2.2.3");
 
         // Constructable style sheets is only implemented for chrome,
         // polyfill needed for FireFox et.al. at the moment


### PR DESCRIPTION
## Description
The defaults come into effect when
the user clears out or deletes the
package.json, and it is being generated
from scratch.