### PR TITLE
chore: let action to pick the latest node 16.

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -31,7 +31,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-node@v3
         with:
-          node-version: '16.0'
+          node-version: '16'
       - uses: actions/setup-java@v3
         with:
           java-version: '11'


### PR DESCRIPTION
with current setting, it uses node 16.0.0 to build the project

