### PR TITLE
feat: notify component about identifier provider changes

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataView.java
@@ -164,6 +164,28 @@ public abstract class AbstractDataView<T> implements DataView<T> {
         }
     }
 
+    /**
+     * Add an identifier provider change listener that is fired when a custom
+     * identifier provider is set with
+     * {@link #setIdentifierProvider(IdentifierProvider)}.
+     * <p>
+     * Can be used by components to get notified that a new identifier provider
+     * has been set through the data view.
+     *
+     * @param listener
+     *            identifier provider change listener to register
+     * @return registration for removing the listener
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public Registration addIdentifierProviderChangeListener(
+            ComponentEventListener<IdentifierProviderChangeEvent<T, ?>> listener) {
+        Objects.requireNonNull(listener,
+                "IdentifierProviderChangeListener cannot be null");
+        return ComponentUtil.addListener(component,
+                IdentifierProviderChangeEvent.class,
+                (ComponentEventListener) listener);
+    }
+
     protected boolean equals(T item, T compareTo) {
         return Objects.equals(
                 Objects.requireNonNull(getIdentifierProvider().apply(item),

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataView.java
@@ -143,6 +143,8 @@ public abstract class AbstractDataView<T> implements DataView<T> {
                 "Item identity provider cannot be null");
         ComponentUtil.setData(component, IdentifierProvider.class,
                 identifierProvider);
+        ComponentUtil.fireEvent(component, new IdentifierProviderChangeEvent<>(
+                component, identifierProvider));
     }
 
     @SuppressWarnings("unchecked")

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/IdentifierProviderChangeEvent.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/IdentifierProviderChangeEvent.java
@@ -1,0 +1,43 @@
+package com.vaadin.flow.data.provider;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentEvent;
+
+/**
+ * Event notifying the component that its identifier provider has been changed
+ * through a data view.
+ *
+ * @param <T>
+ *            the type of item used by the identifier provider
+ * @param <C>
+ *            the event source type
+ */
+public class IdentifierProviderChangeEvent<T, C extends Component>
+        extends ComponentEvent<C> {
+
+    private final IdentifierProvider<T> identifierProvider;
+
+    /**
+     * Creates a new event using the given source and the new identifier
+     * provider.
+     *
+     * @param source
+     *            the source component
+     * @param identifierProvider
+     *            the new identifier provider
+     */
+    public IdentifierProviderChangeEvent(C source,
+            IdentifierProvider<T> identifierProvider) {
+        super(source, false);
+        this.identifierProvider = identifierProvider;
+    }
+
+    /**
+     * Returns the new identifier provider for the component.
+     *
+     * @return the new identifier provider
+     */
+    public IdentifierProvider<T> getIdentifierProvider() {
+        return identifierProvider;
+    }
+}

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractListDataViewTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractListDataViewTest.java
@@ -28,12 +28,12 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.function.SerializableBiConsumer;
 import com.vaadin.flow.function.SerializableComparator;
 import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.function.ValueProvider;
+import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.tests.data.bean.Item;
 import org.junit.Assert;
 import org.junit.Before;
@@ -292,11 +292,29 @@ public class AbstractListDataViewTest {
     public void setIdentifierProvider_firesIdentifierProviderChangeEvent() {
         ComponentEventListener mockEventListener = Mockito
                 .mock(ComponentEventListener.class);
-        ComponentUtil.addListener(component,
-                IdentifierProviderChangeEvent.class, mockEventListener);
+        beanDataView.addIdentifierProviderChangeListener(mockEventListener);
         beanDataView.setIdentifierProvider(Item::getId);
 
         Mockito.verify(mockEventListener, Mockito.times(1))
+                .onComponentEvent(Mockito.any());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void addIdentifierProviderChangeListener_doesNotAcceptNull() {
+        beanDataView.addIdentifierProviderChangeListener(null);
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test()
+    public void addIdentifierProviderChangeListener_removeListener_listenerIsNotNotified() {
+        ComponentEventListener mockEventListener = Mockito
+                .mock(ComponentEventListener.class);
+        Registration registration = beanDataView
+                .addIdentifierProviderChangeListener(mockEventListener);
+        registration.remove();
+        beanDataView.setIdentifierProvider(Item::getId);
+
+        Mockito.verify(mockEventListener, Mockito.times(0))
                 .onComponentEvent(Mockito.any());
     }
 

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractListDataViewTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractListDataViewTest.java
@@ -27,6 +27,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.function.SerializableBiConsumer;
 import com.vaadin.flow.function.SerializableComparator;
@@ -283,6 +285,19 @@ public class AbstractListDataViewTest {
 
         Assert.assertTrue(
                 beanDataView.contains(new Item(4L, "non present", "descr1")));
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void setIdentifierProvider_firesIdentifierProviderChangeEvent() {
+        ComponentEventListener mockEventListener = Mockito
+                .mock(ComponentEventListener.class);
+        ComponentUtil.addListener(component,
+                IdentifierProviderChangeEvent.class, mockEventListener);
+        beanDataView.setIdentifierProvider(Item::getId);
+
+        Mockito.verify(mockEventListener, Mockito.times(1))
+                .onComponentEvent(Mockito.any());
     }
 
     @Test


### PR DESCRIPTION
## Description

Components like `Grid` or `MultiSelectComboBox` are supposed to reuse the identifier provider of the Flow data classes to identify items, for example to manage a selection state. However retrieving the identifier provider from a component is problematic at the moment as developers can set an identifier provider on any data view, and there is no way to react to that apart from extending individual implementations of data view classes to implement a custom notification mechanism that the `setIdentifierProvider` method was called.

This change introduces a `IdentifierProviderChangeEvent` that is fired when the developer sets an identifier provider on a data view. Components like `Grid` or `MultiSelectComboBox` can listen for this event, and retrieve the new identifier provider from it.

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
