### PR TITLE
Annotate OptionalParameter with @Nullable

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/OptionalParameter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/OptionalParameter.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.router;
 
+import javax.annotation.Nullable;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -29,5 +30,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.PARAMETER)
 @Documented
+@Nullable
 public @interface OptionalParameter {
 }


### PR DESCRIPTION
To make it clear that `OptionalParameter` can be null (with the benefit of providing better hints from IDEs and code analyzers).