### PR TITLE
fix: Include RouteAliases in RouteNotFoundError message

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteNotFoundError.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteNotFoundError.java
@@ -127,7 +127,7 @@ public class RouteNotFoundError extends Component
     }
 
     private Element routeTemplateToHtml(String routeTemplate,
-                                        Class<? extends Component> navigationTarget) {
+            Class<? extends Component> navigationTarget) {
         String text = routeTemplate;
         if (text == null || text.isEmpty()) {
             text = "<root>";

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteNotFoundError.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteNotFoundError.java
@@ -18,7 +18,10 @@ package com.vaadin.flow.router;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import org.apache.commons.io.IOUtils;
@@ -106,24 +109,34 @@ public class RouteNotFoundError extends Component
     private String getRoutes(BeforeEnterEvent event) {
         List<RouteData> routes = event.getSource().getRegistry()
                 .getRegisteredRoutes();
+        Map<String, Class<? extends Component>> routeTemplates = new TreeMap<>();
 
-        return routes.stream()
-                .sorted((route1, route2) -> route1.getTemplate()
-                        .compareTo(route2.getTemplate()))
-                .map(this::routeToHtml).map(Element::outerHtml)
+        for (RouteData route : routes) {
+            routeTemplates.put(route.getTemplate(),
+                    route.getNavigationTarget());
+            route.getRouteAliases().forEach(alias -> routeTemplates
+                    .put(alias.getTemplate(), alias.getNavigationTarget()));
+        }
+
+        List<Element> routeElements = new ArrayList<>();
+        routeTemplates.forEach(
+                (k, v) -> routeElements.add(routeTemplateToHtml(k, v)));
+
+        return routeElements.stream().map(Element::outerHtml)
                 .collect(Collectors.joining());
     }
 
-    private Element routeToHtml(RouteData route) {
-        String text = route.getTemplate();
+    private Element routeTemplateToHtml(String routeTemplate,
+                                        Class<? extends Component> navigationTarget) {
+        String text = routeTemplate;
         if (text == null || text.isEmpty()) {
             text = "<root>";
         }
 
-        if (!route.getTemplate().contains(":")) {
-            return elementAsLink(route.getTemplate(), text);
+        if (!routeTemplate.contains(":")) {
+            return elementAsLink(routeTemplate, text);
         } else {
-            Class<? extends Component> target = route.getNavigationTarget();
+            Class<? extends Component> target = navigationTarget;
             if (ParameterDeserializer.isAnnotatedParameter(target,
                     OptionalParameter.class)) {
                 text += " (supports optional parameter)";

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteNotFoundError.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteNotFoundError.java
@@ -136,8 +136,7 @@ public class RouteNotFoundError extends Component
         if (!routeTemplate.contains(":")) {
             return elementAsLink(routeTemplate, text);
         } else {
-            Class<? extends Component> target = navigationTarget;
-            if (ParameterDeserializer.isAnnotatedParameter(target,
+            if (ParameterDeserializer.isAnnotatedParameter(navigationTarget,
                     OptionalParameter.class)) {
                 text += " (supports optional parameter)";
             } else {

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/RouterIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/RouterIT.java
@@ -88,6 +88,14 @@ public class RouterIT extends ChromeBrowserTest {
 
         Assert.assertTrue(getDriver().getPageSource()
                 .contains("Could not navigate to 'exception'"));
+
+        Assert.assertTrue(getDriver().getPageSource()
+                .contains(RouterTestServlet.AliasLayout.class
+                        .getAnnotation(Route.class).value()));
+
+        Assert.assertTrue(getDriver().getPageSource()
+                .contains(RouterTestServlet.AliasLayout.class
+                        .getAnnotation(RouteAlias.class).value()));
     }
 
     @Test


### PR DESCRIPTION
When navigating to a non-existent route in dev mode, an error page is displayed with the list of the available routes. However, as noted by [@dmitrilc](https://github.com/dmitrilc), this list doesn't include routes defined via the `@RouteAlias` annotation. 

This PR fixes this.