### PR TITLE
Revert "feat: Annotate OptionalParameter with @Nullable (#13903)"

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/OptionalParameter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/OptionalParameter.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.flow.router;
 
-import javax.annotation.Nullable;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -30,6 +29,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.PARAMETER)
 @Documented
-@Nullable
 public @interface OptionalParameter {
 }


### PR DESCRIPTION
This change causes various issues for Flow OSGi integration, and it's not clear after a quick analysis what goes wrong with routing function in OSGi with nullable annotation.

Temporal solution for https://github.com/vaadin/flow/issues/13933.
