### PR TITLE
fix: Scan Hilla packages by default

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinServletContextInitializer.java
@@ -134,7 +134,8 @@ public class VaadinServletContextInitializer
             .of(Component.class.getPackage().getName(),
                     Theme.class.getPackage().getName(),
                     // LitRenderer uses script annotation
-                    "com.vaadin.flow.data.renderer", "com.vaadin.shrinkwrap")
+                    "com.vaadin.flow.data.renderer", "com.vaadin.shrinkwrap",
+                    "dev.hilla")
             .collect(Collectors.toList());
 
     /**


### PR DESCRIPTION
The removes the need to manually specify dev.hilla in the whitelist, something that should be considered an internal detail

