### PR TITLE
fix: Update webpack-cli to a latest version (#13954)(CP: 2.8)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -135,7 +135,7 @@ public abstract class NodeUpdater implements FallibleCommand {
     /**
      * Gets the platform pinned versions that are not overridden by the user in
      * package.json.
-     * 
+     *
      * @return json object with the dependencies or {@code null}
      * @throws IOException
      *             when versions file could not be read
@@ -305,9 +305,9 @@ public abstract class NodeUpdater implements FallibleCommand {
     static Map<String, String> getDefaultDevDependencies() {
         Map<String, String> defaults = new HashMap<>();
 
-        defaults.put("webpack", "4.42.0");
-        defaults.put("webpack-cli", "3.3.11");
-        defaults.put("webpack-dev-server", "3.11.0");
+        defaults.put("webpack", "4.46.0");
+        defaults.put("webpack-cli", "4.10.0");
+        defaults.put("webpack-dev-server", "4.9.2");
         defaults.put("webpack-babel-multi-target-plugin", "2.5.0");
         // Defining loader until a resolution exists to issue
         // https://github.com/DanielSchaffer/webpack-babel-multi-target-plugin/issues/94

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -170,7 +170,7 @@ public class NodeUpdaterTest {
         Assert.assertEquals("^2.2.10",
                 packageJson.getObject(NodeUpdater.DEPENDENCIES)
                         .getString("@webcomponents/webcomponentsjs"));
-        Assert.assertEquals("4.42.0", packageJson
+        Assert.assertEquals("4.46.0", packageJson
                 .getObject(NodeUpdater.DEV_DEPENDENCIES).getString("webpack"));
     }
 


### PR DESCRIPTION
Update webpack-cli to v4.10.0, since 4.9.2 incompatible with @webpack-cli/serve 1.7.0.

Part-of: https://github.com/vaadin/flow/issues/13952
(cherry picked from commit 791e8d79d505e37fb187e69c088809c0ea3dedac)