### PR TITLE
chore: update timeout to 20 minutes

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -7,7 +7,7 @@ on:
     types: [opened, synchronize, reopened]
 jobs:
   build:
-    timeout-minutes: 15
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     outputs:
       matrix-unit: ${{ steps.set-matrix.outputs.matrix-unit }}


### PR DESCRIPTION
When the number of tests grows the timeout 
also needed to be increased. This is not a 
permanent solution, the #13972 is created to 
investigate this.
