### PR TITLE
chore: update unit tests timeout to 20 minutes

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -63,7 +63,7 @@ jobs:
           path: workspace.tar
   unit-tests:
     needs: build
-    timeout-minutes: 15
+    timeout-minutes: 20
     outputs:
       failure: ${{steps.set-failure.outputs.failure}}
     strategy:


### PR DESCRIPTION
Complement to https://github.com/vaadin/flow/pull/13973 to also increase timeout for unit tests.