### PR TITLE
feat: Find a parent component with a given type

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/Component.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Component.java
@@ -684,16 +684,21 @@ public abstract class Component
     public void scrollIntoView() {
         getElement().scrollIntoView();
     }
-    
+
     /**
-     * Finds a component of given type from the parents of this component.
+     * Traverses the component tree up and returns the first component that
+     * matches the given type.
      *
-     * @param componentType the class of the component to search for
-     * @return the component as Optional or empty Optional if a parent of given type is not found
-     * @param <T> the type of the component to return
+     * @param componentType
+     *            the class of the component to search for
+     * @return the component as Optional or empty Optional if a parent of given
+     *         type is not found
+     * @param <T>
+     *            the type of the component to return
      */
     @SuppressWarnings("unchecked")
-	public <T extends Component> Optional<T> findParent(Class<T> componentType) {
+    public <T extends Component> Optional<T> findParent(
+            Class<T> componentType) {
         Optional<Component> parent = getParent();
         while (parent.isPresent()) {
             Component component = parent.get();
@@ -705,5 +710,5 @@ public abstract class Component
         }
         return Optional.empty();
     }
-    
+
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/Component.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Component.java
@@ -684,4 +684,26 @@ public abstract class Component
     public void scrollIntoView() {
         getElement().scrollIntoView();
     }
+    
+    /**
+     * Finds a component of given type from the parents of this component.
+     *
+     * @param componentType the class of the component to search for
+     * @return the component as Optional or empty Optional if a parent of given type is not found
+     * @param <T> the type of the component to return
+     */
+    @SuppressWarnings("unchecked")
+	public <T extends Component> Optional<T> findParent(Class<T> componentType) {
+        Optional<Component> parent = getParent();
+        while (parent.isPresent()) {
+            Component component = parent.get();
+            if (componentType.isAssignableFrom(component.getClass())) {
+                return Optional.of((T) component);
+            } else {
+                parent = component.getParent();
+            }
+        }
+        return Optional.empty();
+    }
+    
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/Component.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Component.java
@@ -697,7 +697,7 @@ public abstract class Component
      *            the type of the component to return
      */
     @SuppressWarnings("unchecked")
-    public <T extends Component> Optional<T> findParent(
+    public <T> Optional<T> findParent(
             Class<T> componentType) {
         Optional<Component> parent = getParent();
         while (parent.isPresent()) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/Component.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Component.java
@@ -697,7 +697,7 @@ public abstract class Component
      *            the type of the component to return
      */
     @SuppressWarnings("unchecked")
-    protected <T> Optional<T> findAncestor(Class<T> componentType) {
+    public <T> Optional<T> findAncestor(Class<T> componentType) {
         Optional<Component> parent = getParent();
         while (parent.isPresent()) {
             Component component = parent.get();

--- a/flow-server/src/main/java/com/vaadin/flow/component/Component.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Component.java
@@ -697,8 +697,7 @@ public abstract class Component
      *            the type of the component to return
      */
     @SuppressWarnings("unchecked")
-    public <T> Optional<T> findParent(
-            Class<T> componentType) {
+    protected <T> Optional<T> findAncestor(Class<T> componentType) {
         Optional<Component> parent = getParent();
         while (parent.isPresent()) {
             Component component = parent.get();

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
@@ -259,7 +259,7 @@ public class ComponentTest {
 
     }
 
-    private static class TestComponentContainer extends TestComponent {
+    static class TestComponentContainer extends TestComponent {
 
         public TestComponentContainer() {
         }
@@ -1661,6 +1661,24 @@ public class ComponentTest {
         component.getTranslation(Locale.GERMAN, "foo");
 
         Mockito.verify(component).getTranslation("foo", Locale.GERMAN);
+    }
+
+    @Test
+    public void findAncestorTest() {
+        UI ui = new UI();
+        TestComponentContainer componentContainer = new TestComponentContainer();
+        TestComponent component = new TestComponent();
+        componentContainer.add(component);
+        ui.add(componentContainer);
+
+        Assert.assertEquals(componentContainer,
+                component.findAncestor(TestComponentContainer.class).get());
+        Assert.assertEquals(ui, component.findAncestor(UI.class).get());
+        Assert.assertEquals(ui,
+                component.findAncestor(PollNotifier.class).get());
+        Assert.assertFalse(
+                component.findAncestor(TestButton.class).isPresent());
+
     }
 
     private void enabledStateChangeOnAttachCalledForParentState(


### PR DESCRIPTION
## Description

Add a helper method to seek the parent component of given type from the component tree. 

Fixes #13984

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
