### PR TITLE
feat: Make the Router lookup method available for others to use

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
@@ -39,7 +39,9 @@ import com.vaadin.flow.i18n.LocaleChangeEvent;
 import com.vaadin.flow.i18n.LocaleChangeObserver;
 import com.vaadin.flow.internal.ReflectionCache;
 import com.vaadin.flow.internal.StateNode;
+import com.vaadin.flow.internal.StateTree;
 import com.vaadin.flow.internal.nodefeature.VirtualChildrenList;
+import com.vaadin.flow.router.Router;
 import com.vaadin.flow.server.Attributes;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.shared.Registration;
@@ -600,6 +602,33 @@ public class ComponentUtil {
     public static <T> T getData(Component component, Class<T> type) {
         return getData(component,
                 (attributes, ignore) -> attributes.getAttribute(type), type);
+    }
+
+    /**
+     * Gets the router instance for the given component.
+     *
+     * Falls back to the router for the currently active VaadinService if the
+     * component is not attached.
+     *
+     * @return a router instance
+     * @throws IllegalStateException
+     *             if no router instance is available
+     */
+    public static Router getRouter(HasElement component) {
+        Router router = null;
+        if (component.getElement().getNode().isAttached()) {
+            StateTree tree = (StateTree) component.getElement().getNode()
+                    .getOwner();
+            router = tree.getUI().getInternals().getRouter();
+        }
+        if (router == null) {
+            router = VaadinService.getCurrent().getRouter();
+        }
+        if (router == null) {
+            throw new IllegalStateException(
+                    "Implicit router instance is not available.");
+        }
+        return router;
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
@@ -610,7 +610,9 @@ public class ComponentUtil {
      * Falls back to the router for the currently active VaadinService if the
      * component is not attached.
      *
-     * @param component component for which the requested router instance serves navigation
+     * @param component
+     *            component for which the requested router instance serves
+     *            navigation
      * @return a router instance
      * @throws IllegalStateException
      *             if no router instance is available

--- a/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/ComponentUtil.java
@@ -610,6 +610,7 @@ public class ComponentUtil {
      * Falls back to the router for the currently active VaadinService if the
      * component is not attached.
      *
+     * @param component component for which the requested router instance serves navigation
      * @return a router instance
      * @throws IllegalStateException
      *             if no router instance is available

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouterLink.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouterLink.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.Focusable;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasStyle;
@@ -435,20 +436,7 @@ public class RouterLink extends Component implements HasText, HasComponents,
     }
 
     private Router getRouter() {
-        Router router = null;
-        if (getElement().getNode().isAttached()) {
-            StateTree tree = (StateTree) getElement().getNode().getOwner();
-            router = tree.getUI().getInternals().getRouter();
-        }
-        if (router == null) {
-            router = VaadinService.getCurrent().getRouter();
-        }
-        if (router == null) {
-            throw new IllegalStateException(
-                    "Implicit router instance is not available. "
-                            + "Use overloaded method with explicit router parameter.");
-        }
-        return router;
+        return ComponentUtil.getRouter(this);
     }
 
     /**


### PR DESCRIPTION
When building a navigation menu component which is not based on RouterLink, there is the same need as RouterLink has: to create links to certain views. That requires a Router reference.