### PR TITLE
fix: separate core and commercial components version files

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -461,9 +461,14 @@ public final class Constants implements Serializable {
     public static final String STATISTIC_ROUTING_HYBRID = "routing/hybrid";
 
     /**
-     * The name of platform versions file.
+     * The name of platform core components and tools versions file.
      */
-    public static final String VAADIN_VERSIONS_JSON = "vaadin_versions.json";
+    public static final String VAADIN_CORE_VERSIONS_JSON = "vaadin-core-versions.json";
+
+    /**
+     * The name of platform commercial components and tools versions file.
+     */
+    public static final String VAADIN_VERSIONS_JSON = "vaadin-versions.json";
 
     /**
      * @deprecated Use

--- a/flow-server/src/main/java/com/vaadin/flow/server/Platform.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Platform.java
@@ -39,7 +39,7 @@ public class Platform implements Serializable {
      */
     public static Optional<String> getVaadinVersion() {
         try (InputStream vaadinVersionsStream = Platform.class.getClassLoader()
-                .getResourceAsStream(Constants.VAADIN_VERSIONS_JSON)) {
+                .getResourceAsStream(Constants.VAADIN_CORE_VERSIONS_JSON)) {
             if (vaadinVersionsStream != null) {
                 ObjectMapper m = new ObjectMapper();
                 JsonNode vaadinVersions = m.readTree(vaadinVersionsStream);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -230,8 +230,8 @@ public abstract class NodeUpdater implements FallibleCommand {
                     .parse(IOUtils.toString(content, StandardCharsets.UTF_8)));
             versionsJson = convert.getConvertedJson();
             versionsJson = new VersionsJsonFilter(getPackageJson(),
-                    DEPENDENCIES).getFilteredVersions(versionsJson,
-                            versionsOrigin);
+                    DEPENDENCIES)
+                    .getFilteredVersions(versionsJson, versionsOrigin);
         }
         return versionsJson;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -193,22 +193,50 @@ public abstract class NodeUpdater implements FallibleCommand {
      *             when versions file could not be read
      */
     JsonObject getPlatformPinnedDependencies() throws IOException {
-        URL resource = finder.getResource(Constants.VAADIN_VERSIONS_JSON);
-        if (resource == null) {
-            log().info("Couldn't find {} file to pin dependency versions."
-                    + " Transitive dependencies won't be pinned for pnpm.",
-                    Constants.VAADIN_VERSIONS_JSON);
+        URL coreVersionsResource = finder
+                .getResource(Constants.VAADIN_CORE_VERSIONS_JSON);
+        if (coreVersionsResource == null) {
+            log().info(
+                    "Couldn't find {} file to pin dependency versions for core components."
+                            + " Transitive dependencies won't be pinned for npm/pnpm.",
+                    Constants.VAADIN_CORE_VERSIONS_JSON);
             return Json.createObject();
         }
 
         JsonObject versionsJson;
-        try (InputStream content = resource.openStream()) {
+        try (InputStream content = coreVersionsResource.openStream()) {
             VersionsJsonConverter convert = new VersionsJsonConverter(Json
                     .parse(IOUtils.toString(content, StandardCharsets.UTF_8)));
             versionsJson = convert.getConvertedJson();
             versionsJson = new VersionsJsonFilter(getPackageJson(),
-                    DEPENDENCIES).getFilteredVersions(versionsJson);
+                    DEPENDENCIES).getFilteredVersions(versionsJson,
+                            Constants.VAADIN_CORE_VERSIONS_JSON);
         }
+
+        URL commVersionsResource = finder
+                .getResource(Constants.VAADIN_VERSIONS_JSON);
+        if (commVersionsResource == null) {
+            log().info(
+                    "Couldn't find {} file to pin dependency versions for commercial components."
+                            + " Transitive dependencies won't be pinned for npm/pnpm.",
+                    Constants.VAADIN_VERSIONS_JSON);
+            return versionsJson;
+        }
+
+        JsonObject commVersionsJson;
+        try (InputStream content = commVersionsResource.openStream()) {
+            VersionsJsonConverter convert = new VersionsJsonConverter(Json
+                    .parse(IOUtils.toString(content, StandardCharsets.UTF_8)));
+            commVersionsJson = convert.getConvertedJson();
+            commVersionsJson = new VersionsJsonFilter(getPackageJson(),
+                    DEPENDENCIES).getFilteredVersions(commVersionsJson,
+                            Constants.VAADIN_VERSIONS_JSON);
+        }
+
+        for (String key : commVersionsJson.keys()) {
+            versionsJson.put(key, commVersionsJson.getString(key));
+        }
+
         return versionsJson;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -216,8 +216,8 @@ public abstract class NodeUpdater implements FallibleCommand {
         URL commVersionsResource = finder
                 .getResource(Constants.VAADIN_VERSIONS_JSON);
         if (commVersionsResource == null) {
-            log().info(
-                    "Couldn't find {} file to pin dependency versions for commercial components."
+            log().trace(
+                    "{} file is not present in the classpath, so cannot pin dependency versions for commercial components."
                             + " Transitive dependencies won't be pinned for npm/pnpm.",
                     Constants.VAADIN_VERSIONS_JSON);
             return versionsJson;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonFilter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonFilter.java
@@ -51,14 +51,15 @@ class VersionsJsonFilter {
      *
      * @param versions
      *            to be filtered for user managed ones
+     * @param versionOrigin
+     *            origin of the version (like a file), used in error message
      * @return filtered versions json
      */
-    JsonObject getFilteredVersions(JsonObject versions) {
+    JsonObject getFilteredVersions(JsonObject versions, String versionOrigin) {
         JsonObject json = Json.createObject();
         for (String key : versions.keys()) {
             final FrontendVersion version = FrontendUtils
-                    .getPackageVersionFromJson(versions, key,
-                            "vaadin_version.json");
+                    .getPackageVersionFromJson(versions, key, versionOrigin);
             if (version == null) {
                 continue;
             }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
@@ -103,7 +103,8 @@ public abstract class AbstractNodeUpdatePackagesTest
         classFinder = Mockito.spy(getClassFinder());
         File versions = temporaryFolder.newFile();
         FileUtils.write(versions, "{}", StandardCharsets.UTF_8);
-        Mockito.when(classFinder.getResource(Constants.VAADIN_VERSIONS_JSON))
+        Mockito.when(
+                classFinder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(versions.toURI().toURL());
 
         packageUpdater = new TaskUpdatePackages(classFinder,

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdatePackagesNpmVersionLockingTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdatePackagesNpmVersionLockingTest.java
@@ -89,7 +89,8 @@ public class NodeUpdatePackagesNpmVersionLockingTest
                 StandardCharsets.UTF_8);
         // @formatter:on
 
-        Mockito.when(classFinder.getResource(Constants.VAADIN_VERSIONS_JSON))
+        Mockito.when(
+                classFinder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(versions.toURI().toURL());
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -163,7 +163,8 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         ClassFinder classFinder = getClassFinder();
         File versions = temporaryFolder.newFile();
         FileUtils.write(versions, "{}", StandardCharsets.UTF_8);
-        Mockito.when(classFinder.getResource(Constants.VAADIN_VERSIONS_JSON))
+        Mockito.when(
+                classFinder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(versions.toURI().toURL());
 
         TaskRunNpmInstall task = createTask();
@@ -503,11 +504,12 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         final VersionsJsonFilter versionsJsonFilter = new VersionsJsonFilter(
                 Json.parse(packageJsonContent), NodeUpdater.DEPENDENCIES);
         // Platform defines a pinned version
-        TaskRunNpmInstall task = createTask(
-                versionsJsonFilter.getFilteredVersions(
+        TaskRunNpmInstall task = createTask(versionsJsonFilter
+                .getFilteredVersions(
                         Json.parse("{ \"@vaadin/vaadin-overlay\":\""
-                                + PINNED_VERSION + "\"}"))
-                        .toJson());
+                                + PINNED_VERSION + "\"}"),
+                        "test-versions.json")
+                .toJson());
         task.execute();
 
         File overlayPackageJson = new File(getNodeUpdater().nodeModulesFolder,
@@ -550,11 +552,12 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         final VersionsJsonFilter versionsJsonFilter = new VersionsJsonFilter(
                 Json.parse(packageJsonContent), NodeUpdater.DEPENDENCIES);
         // Platform defines a pinned version
-        TaskRunNpmInstall task = createTask(
-                versionsJsonFilter.getFilteredVersions(
+        TaskRunNpmInstall task = createTask(versionsJsonFilter
+                .getFilteredVersions(
                         Json.parse("{ \"@vaadin/vaadin-overlay\":\""
-                                + PINNED_VERSION + "\"}"))
-                        .toJson());
+                                + PINNED_VERSION + "\"}"),
+                        "test-versions.json")
+                .toJson());
         task.execute();
 
         File overlayPackageJson = new File(getNodeUpdater().nodeModulesFolder,
@@ -656,7 +659,8 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
     private JsonObject getGeneratedVersionsContent(File versions)
             throws IOException {
         ClassFinder classFinder = getClassFinder();
-        Mockito.when(classFinder.getResource(Constants.VAADIN_VERSIONS_JSON))
+        Mockito.when(
+                classFinder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(versions.toURI().toURL());
 
         String path = getNodeUpdater().generateVersionsJson();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
@@ -93,7 +93,7 @@ public class TaskUpdatePackagesNpmTest {
         generatedPath.mkdir();
         versionJsonFile = new File(npmFolder, "versions.json");
         finder = Mockito.mock(ClassFinder.class);
-        Mockito.when(finder.getResource(Constants.VAADIN_VERSIONS_JSON))
+        Mockito.when(finder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(versionJsonFile.toURI().toURL());
 
         packageJson = new File(npmFolder, PACKAGE_JSON);
@@ -185,14 +185,14 @@ public class TaskUpdatePackagesNpmTest {
     @Test
     public void npmIsInUse_noPlatformVersionJsonPresent_noFailure()
             throws IOException {
-        Mockito.when(finder.getResource(Constants.VAADIN_VERSIONS_JSON))
+        Mockito.when(finder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(null);
         final TaskUpdatePackages task = createTask(
                 createApplicationDependencies());
         task.execute();
         Assert.assertTrue("Updates not picked", task.modified);
 
-        Mockito.when(finder.getResource(Constants.VAADIN_VERSIONS_JSON))
+        Mockito.when(finder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(versionJsonFile.toURI().toURL());
         JsonObject dependencies = getOrCreatePackageJson()
                 .getObject(DEPENDENCIES);
@@ -203,11 +203,11 @@ public class TaskUpdatePackagesNpmTest {
     @Test
     public void npmIsInUse_platformVersionsJsonAdded_versionsPinned()
             throws IOException {
-        Mockito.when(finder.getResource(Constants.VAADIN_VERSIONS_JSON))
+        Mockito.when(finder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(null);
         createTask(createApplicationDependencies()).execute();
 
-        Mockito.when(finder.getResource(Constants.VAADIN_VERSIONS_JSON))
+        Mockito.when(finder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(versionJsonFile.toURI().toURL());
         final String newVersion = "20.0.0";
         createVaadinVersionsJson(newVersion, newVersion, newVersion);
@@ -660,7 +660,7 @@ public class TaskUpdatePackagesNpmTest {
 
     private void verifyPlatformDependenciesAreAdded(boolean enablePnpm)
             throws IOException {
-        Mockito.when(finder.getResource(Constants.VAADIN_VERSIONS_JSON))
+        Mockito.when(finder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(versionJsonFile.toURI().toURL());
         final String newVersion = "20.0.0";
         createVaadinVersionsJson(newVersion, newVersion, newVersion);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/VersionsJsonFilterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/VersionsJsonFilterTest.java
@@ -83,8 +83,8 @@ public class VersionsJsonFilterTest {
 
         VersionsJsonFilter filter = new VersionsJsonFilter(Json.parse(pkgJson),
                 depKey);
-        JsonObject filteredJson = filter
-                .getFilteredVersions(Json.parse(versions));
+        JsonObject filteredJson = filter.getFilteredVersions(
+                Json.parse(versions), "versions/versions.json");
         Assert.assertTrue(filteredJson.hasKey("@vaadin/vaadin-progress-bar"));
         Assert.assertTrue(filteredJson.hasKey("@vaadin/vaadin-upload"));
         Assert.assertTrue(filteredJson.hasKey("@polymer/iron-list"));
@@ -108,8 +108,8 @@ public class VersionsJsonFilterTest {
 
         VersionsJsonFilter filter = new VersionsJsonFilter(Json.parse(pkgJson),
                 depKey);
-        JsonObject filteredJson = filter
-                .getFilteredVersions(Json.parse(versions));
+        JsonObject filteredJson = filter.getFilteredVersions(
+                Json.parse(versions), "versions/user_versions.json");
         List<String> expectedKeys = Arrays.asList("@vaadin/vaadin-notification",
                 "@vaadin/vaadin-overlay", "@vaadin/vaadin-select",
                 "@vaadin/vaadin-split-layout", "@vaadin/vaadin-tabs");
@@ -156,8 +156,8 @@ public class VersionsJsonFilterTest {
 
         VersionsJsonFilter filter = new VersionsJsonFilter(Json.parse(pkgJson),
                 depKey);
-        JsonObject filteredJson = filter
-                .getFilteredVersions(Json.parse(versions));
+        JsonObject filteredJson = filter.getFilteredVersions(
+                Json.parse(versions), "versions/versions.json");
         Assert.assertTrue(filteredJson.hasKey("@vaadin/vaadin-progress-bar"));
         Assert.assertTrue(filteredJson.hasKey("@vaadin/vaadin-upload"));
         Assert.assertTrue(filteredJson.hasKey("@polymer/iron-list"));


### PR DESCRIPTION
## Description

Previously, the vaadin_versions.json contained
both core and commercial components listed
which led to including them all in package.json
even if the user only used vaadin-core. Now
platform generates vaadin-core-version.json in
vaadin-core and vaadin-version.json to include
commercial components in vaadin artifact.
This commit will adopt having separate files
while generating package.json and pinning the
platform dependencies.

Fixes: #13749

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
