### PR TITLE
fix: Delay license check if websocket connection not available

### DIFF
--- a/flow-client/src/main/frontend/vaadin-dev-tools.ts
+++ b/flow-client/src/main/frontend/vaadin-dev-tools.ts
@@ -138,8 +138,15 @@ export class Connection extends Object {
   }
 
   private send(command: string, data: any) {
-    const message = { command, data };
-    this.webSocket!.send(JSON.stringify(message));
+    const message = JSON.stringify({ command, data });
+    if (!this.webSocket) {
+      // eslint-disable-next-line no-console
+      console.error(`Unable to send message ${command}. No websocket is available`);
+    } else if (this.webSocket.readyState !== WebSocket.OPEN) {
+      this.webSocket.addEventListener('open', () => this.webSocket!.send(message));
+    } else {
+      this.webSocket.send(message);
+    }
   }
 
   setFeature(featureId: string, enabled: boolean) {


### PR DESCRIPTION
If you open a view with `<vaadin-chart>` on it you might see
```
Uncaught DOMException: Failed to execute 'send' on 'WebSocket': Still in CONNECTING state.
   at Connection.send
    at Connection.sendLicenseCheck
```
and the chart is not displayed at all. Navigating to another view and back "fixes" the issue.

This fixes the problem by delaying sending of any data over the websocket until it is available
