### PR TITLE
fix: Fix ip binding problem with Vite 3

### DIFF
--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -384,6 +384,7 @@ export const vaadinConfig: UserConfigFn = (env) => {
       VITE_ENABLED: 'true'
     },
     server: {
+      host: '127.0.0.1',
       fs: {
         allow: allowedFrontendFolders
       }

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
@@ -78,7 +78,7 @@ public abstract class AbstractDevServerRunner implements DevModeHandler {
 
     private static final String START_FAILURE = "Couldn't start dev server because";
 
-    private static final String DEV_SERVER_HOST = "http://localhost";
+    private static final String DEV_SERVER_HOST = "http://127.0.0.1";
 
     private static final String FAILED_MSG = "\n------------------ Frontend compilation failed. ------------------\n\n";
     private static final String SUCCEED_MSG = "\n----------------- Frontend compiled successfully. -----------------\n\n";


### PR DESCRIPTION
Use 127.0.0.1 both for the Vite server and when connecting to it to ensure it works

Fixes #14021
