### PR TITLE
fix: rename global js constant conflicting with require.js

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
@@ -192,9 +192,10 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
                 "window.Vaadin.devTools = window.Vaadin.devTools || {};"
                 + "window.Vaadin.devTools.definedCustomElements = window.Vaadin.devTools.definedCustomElements || [];"
                 + //
-                "const { define } = window.customElements;" + //
+                "const originalCustomElementDefineFn = window.customElements.define;"
+                + //
                 "window.customElements.define = function (tagName, ...args) {" + //
-                "define.call(this, tagName, ...args);" + //
+                "originalCustomElementDefineFn.call(this, tagName, ...args);" + //
                 "window.Vaadin.devTools.definedCustomElements.push(tagName);" + //
                 "};");
 

--- a/flow-tests/test-root-ui-context/src/main/java/com/vaadin/flow/uitest/servlet/ApplicationRunnerServlet.java
+++ b/flow-tests/test-root-ui-context/src/main/java/com/vaadin/flow/uitest/servlet/ApplicationRunnerServlet.java
@@ -330,11 +330,15 @@ public class ApplicationRunnerServlet extends VaadinServlet {
                 if (currentRequest != null) {
                     HttpSession httpSession = currentRequest.getSession(false);
                     if (httpSession != null) {
+                        // setting null session in CurrentInstance also removes
+                        // VaadinService, so we need to get service instance and
+                        // set it again after nullify session
+                        VaadinServletService service = (VaadinServletService) VaadinService
+                                .getCurrent();
                         Map<Class<?>, CurrentInstance> oldCurrent = CurrentInstance
                                 .setCurrent((VaadinSession) null);
                         try {
-                            VaadinServletService service = (VaadinServletService) VaadinService
-                                    .getCurrent();
+                            VaadinService.setCurrent(service);
                             session = service.findVaadinSession(
                                     new VaadinServletRequest(currentRequest,
                                             service));


### PR DESCRIPTION
## Description

In IndexHtmlRequestHandler the customElements.define function is
redefined to apply a custom feature after invoking the original
function. The reference to the the original function is stored in a
`define` constant and unfortunately this conflicts with require.js.
This change renames the constant in order to avoid the conflict.

In addition, it fixes an NPE in ApplicationRunnerServlet, when getting
DeploymentConfiguration in a debug window websocket request.

Fixes #14057

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
