### PR TITLE
fix: Use correct view when using eagerServerLoad (#14036) (CP: 9.0)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/QueryParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/QueryParameters.java
@@ -114,6 +114,9 @@ public class QueryParameters implements Serializable {
      * @return query parameters information
      */
     public static QueryParameters fromString(String queryString) {
+        if (queryString == null) {
+            return empty();
+        }
         return new QueryParameters(parseQueryString(queryString));
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
@@ -31,6 +31,7 @@ import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.router.InvalidLocationException;
 import com.vaadin.flow.router.Location;
 import com.vaadin.flow.router.LocationUtil;
+import com.vaadin.flow.router.QueryParameters;
 import com.vaadin.flow.server.AppShellRegistry;
 import com.vaadin.flow.server.BootstrapHandler;
 import com.vaadin.flow.server.HandlerHelper;
@@ -90,9 +91,32 @@ public class JavaScriptBootstrapHandler extends BootstrapHandler {
         }
 
         private static Location initRoute(VaadinRequest request) {
+            // This can be called in two ways:
+            // 1. From the JS during the second phase of a two phase init. In
+            // this case, the
+            // location is included in the REQUEST_LOCATION_PARAMETER and the
+            // request always
+            // goes to the servlet path
+            // 2. During the first request if eagerServerLoad is enabled. In
+            // this case, the
+            // location comes from the pathinfo + query parameters in the
+            // request
             String pathAndParams = request.getParameter(
                     ApplicationConstants.REQUEST_LOCATION_PARAMETER);
-            return new Location(pathAndParams);
+            if (pathAndParams != null) {
+                return new Location(pathAndParams);
+            }
+
+            // Case 2, use the request
+            if (request instanceof VaadinServletRequest) {
+                return new Location(request.getPathInfo(),
+                        QueryParameters
+                                .fromString(((VaadinServletRequest) request)
+                                        .getQueryString()));
+            } else {
+                return new Location(request.getPathInfo(),
+                        QueryParameters.empty());
+            }
         }
 
     }

--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -221,6 +221,7 @@
                         <systemProperties>
                             <!-- All system props are defined here as they need to be overridden
                                  in all modules so no non-standard value leaks to another module -->
+                            <force>true</force>
                             <vaadin.reuseDevServer>${vaadin.reuseDevServer}</vaadin.reuseDevServer>
                             <vaadin.devmode.liveReload.enabled>${vaadin.devmode.liveReload.enabled}</vaadin.devmode.liveReload.enabled>
                             <vaadin.allow.appshell.annotations>${vaadin.allow.appshell.annotations}</vaadin.allow.appshell.annotations>

--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -222,13 +222,31 @@
                             <!-- All system props are defined here as they need to be overridden
                                  in all modules so no non-standard value leaks to another module -->
                             <force>true</force>
-                            <vaadin.reuseDevServer>${vaadin.reuseDevServer}</vaadin.reuseDevServer>
-                            <vaadin.devmode.liveReload.enabled>${vaadin.devmode.liveReload.enabled}</vaadin.devmode.liveReload.enabled>
-                            <vaadin.allow.appshell.annotations>${vaadin.allow.appshell.annotations}</vaadin.allow.appshell.annotations>
-			                <vaadin.eagerServerLoad>${vaadin.eagerServerLoad}</vaadin.eagerServerLoad>
-                            <jetty.scantrigger>${jetty.scantrigger}</jetty.scantrigger>
+                            <systemProperty>
+                                <name>vaadin.reuseDevServer</name>
+                                <value>${vaadin.reuseDevServer}</value>
+                            </systemProperty>
+                            <systemProperty>
+                                <name>vaadin.devmode.liveReload.enabled</name>
+                                <value>${vaadin.devmode.liveReload.enabled}</value>
+                            </systemProperty>
+                            <systemProperty>
+                                <name>vaadin.allow.appshell.annotations</name>
+                                <value>${vaadin.allow.appshell.annotations}</value>
+                            </systemProperty>
+                            <systemProperty>
+                                <name>vaadin.eagerServerLoad</name>
+                                <value>${vaadin.eagerServerLoad}</value>
+                            </systemProperty>
+                            <systemProperty>
+                                <name>jetty.scantrigger</name>
+                                <value>${jetty.scantrigger}</value>
+                            </systemProperty>
                             <!-- Allow test clients not on localhost to connect to Vite-->
-                            <vaadin.devmode.vite.options>${vaadin.devmode.vite.options}</vaadin.devmode.vite.options>
+                            <systemProperty>
+                                <name>vaadin.devmode.vite.options</name>
+                                <value>${vaadin.devmode.vite.options}</value>
+                            </systemProperty>
                         </systemProperties>
                     </configuration>
                 </plugin>

--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -42,7 +42,7 @@
         <vaadin.allow.appshell.annotations>false</vaadin.allow.appshell.annotations>
         <useDeprecatedV14Bootstrapping>false</useDeprecatedV14Bootstrapping>
         <vaadin.devmode.vite.options>--host</vaadin.devmode.vite.options>
-
+        <vaadin.eagerServerLoad>false</vaadin.eagerServerLoad>
         <!-- make sure we do not leave webpack-dev-server running after IT -->
         <vaadin.reuseDevServer>false</vaadin.reuseDevServer>
     </properties>
@@ -219,30 +219,15 @@
                         <stopKey>foo</stopKey>
                         <stopWait>5</stopWait>
                         <systemProperties>
-                            <!-- All system props are defined here as they need to be overridden 
+                            <!-- All system props are defined here as they need to be overridden
                                  in all modules so no non-standard value leaks to another module -->
-                            <force>true</force>
-                            <systemProperty>
-                                <name>vaadin.reuseDevServer</name>
-                                <value>${vaadin.reuseDevServer}</value>
-                            </systemProperty>
-                            <systemProperty>
-                                <name>vaadin.devmode.liveReload.enabled</name>
-                                <value>${vaadin.devmode.liveReload.enabled}</value>
-                            </systemProperty>
-                            <systemProperty>
-                                <name>vaadin.allow.appshell.annotations</name>
-                                <value>${vaadin.allow.appshell.annotations}</value>
-                            </systemProperty>
-                            <systemProperty>
-                                <name>jetty.scantrigger</name>
-                                <value>${jetty.scantrigger}</value>
-                            </systemProperty>
+                            <vaadin.reuseDevServer>${vaadin.reuseDevServer}</vaadin.reuseDevServer>
+                            <vaadin.devmode.liveReload.enabled>${vaadin.devmode.liveReload.enabled}</vaadin.devmode.liveReload.enabled>
+                            <vaadin.allow.appshell.annotations>${vaadin.allow.appshell.annotations}</vaadin.allow.appshell.annotations>
+			                <vaadin.eagerServerLoad>${vaadin.eagerServerLoad}</vaadin.eagerServerLoad>
+                            <jetty.scantrigger>${jetty.scantrigger}</jetty.scantrigger>
                             <!-- Allow test clients not on localhost to connect to Vite-->
-                            <systemProperty>
-                                <name>vaadin.devmode.vite.options</name>
-                                <value>${vaadin.devmode.vite.options}</value>
-                            </systemProperty>
+                            <vaadin.devmode.vite.options>${vaadin.devmode.vite.options}</vaadin.devmode.vite.options>
                         </systemProperties>
                     </configuration>
                 </plugin>
@@ -320,6 +305,7 @@
 
                 <module>test-root-context</module>
 
+                <module>test-eager-bootstrap</module>
                 <module>test-v14-bootstrap</module>
                 <module>test-v14-bootstrap/pom-production.xml</module>
 

--- a/flow-tests/test-eager-bootstrap/pom.xml
+++ b/flow-tests/test-eager-bootstrap/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.vaadin</groupId>
+        <artifactId>flow-tests</artifactId>
+        <version>9.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>flow-test-eager-bootstrap</artifactId>
+    <name>Flow eager bootstrap (includes UIDL in first request) test</name>
+    <packaging>war</packaging>
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <vaadin.eagerServerLoad>true</vaadin.eagerServerLoad>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-test-resources</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-dev-server</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.vaadin</groupId>
+                <artifactId>flow-maven-plugin</artifactId>
+                <configuration>
+                    <productionMode>false</productionMode>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>${jetty.version}</version>
+                <executions>
+                    <!-- start and stop jetty (running our app) when running
+                        integration tests -->
+                    <execution>
+                        <id>start-jetty</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>stop-jetty</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/flow-tests/test-eager-bootstrap/src/main/java/com/vaadin/flow/eagerbootstrap/HelloView.java
+++ b/flow-tests/test-eager-bootstrap/src/main/java/com/vaadin/flow/eagerbootstrap/HelloView.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.eagerbootstrap;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route("hello")
+public class HelloView extends Div {
+    public HelloView() {
+        setId("view");
+        setText("This is the Hello view");
+    }
+}

--- a/flow-tests/test-eager-bootstrap/src/main/java/com/vaadin/flow/eagerbootstrap/RootView.java
+++ b/flow-tests/test-eager-bootstrap/src/main/java/com/vaadin/flow/eagerbootstrap/RootView.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.eagerbootstrap;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route("")
+public class RootView extends Div {
+    public RootView() {
+        setId("view");
+        setText("This is the root view");
+    }
+}

--- a/flow-tests/test-eager-bootstrap/src/test/java/com/vaadin/flow/servlet/BasicViewsIT.java
+++ b/flow-tests/test-eager-bootstrap/src/test/java/com/vaadin/flow/servlet/BasicViewsIT.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.servlet;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class BasicViewsIT extends ChromeBrowserTest {
+
+    @Test
+    public void rootViewShown() throws Exception {
+        getDriver().get(getRootURL() + "/");
+        Assert.assertEquals("This is the root view",
+                $("*").id("view").getText());
+    }
+
+    @Test
+    public void helloViewShown() throws Exception {
+        getDriver().get(getRootURL() + "/hello");
+        Assert.assertEquals("This is the Hello view",
+                $("*").id("view").getText());
+    }
+
+    @Test
+    public void invalidViewShowsNotFound() throws Exception {
+        getDriver().get(getRootURL() + "/nonexistant");
+
+        Assert.assertTrue(getDriver().getPageSource()
+                .contains("Could not navigate to 'nonexistant'"));
+    }
+
+}

--- a/flow-tests/test-eager-bootstrap/src/test/java/com/vaadin/flow/servlet/LowLevelFetchIT.java
+++ b/flow-tests/test-eager-bootstrap/src/test/java/com/vaadin/flow/servlet/LowLevelFetchIT.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.servlet;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class LowLevelFetchIT extends ChromeBrowserTest {
+
+    public static class OtherResponseCodeException extends IOException {
+
+        private int responseCode;
+
+        public OtherResponseCodeException(int responseCode) {
+            this.responseCode = responseCode;
+        }
+
+        public int getResponseCode() {
+            return responseCode;
+        }
+
+    }
+
+    @Test
+    public void rootViewContainsRootUIDL() throws Exception {
+        open(); // This is only to wait for the dev server...
+        String source = getUrl(getRootURL() + "/");
+        Assert.assertTrue(source.contains(
+                "\"key\":\"text\",\"feat\":7,\"value\":\"This is the root view\""));
+    }
+
+    private String getUrl(String urlString) throws IOException {
+        URL url = new URL(urlString);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.connect();
+
+        if (conn.getResponseCode() != 200) {
+            throw new OtherResponseCodeException(conn.getResponseCode());
+        }
+
+        return IOUtils.toString(conn.getInputStream(), StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void helloViewContainsHelloViewUidl() throws Exception {
+        open(); // This is only to wait for the dev server...
+        String source = getUrl(getRootURL() + "/hello");
+        Assert.assertTrue(source.contains(
+                "\"key\":\"text\",\"feat\":7,\"value\":\"This is the Hello view\""));
+    }
+
+    @Test
+    public void notFoundViewReturns404() throws Exception {
+        open(); // This is only to wait for the dev server...
+        try {
+            getUrl(getRootURL() + "/notfound");
+        } catch (OtherResponseCodeException e) {
+            Assert.assertEquals(404, e.getResponseCode());
+            return;
+        }
+        Assert.fail("Should have thrown OtherResponseCodeException");
+    }
+
+    @Override
+    protected String getTestPath() {
+        return "";
+    }
+
+}


### PR DESCRIPTION
* fix: Use correct view when using eagerServerLoad

Returns 404 for non-existent views

Helps with #13421

(cherry picked from commit 87c220a753fc281204847b768d64bb583a1d0276)
