### PR TITLE
chore: update log message after versions.json separation

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/Platform.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Platform.java
@@ -49,7 +49,7 @@ public class Platform implements Serializable {
                     versionErrorLogged = true;
                     LoggerFactory.getLogger(Platform.class)
                             .info("Unable to determine version information. "
-                                    + "No vaadin_versions.json found");
+                                    + "No vaadin-core-versions.json found");
                 }
             }
         } catch (Exception e) {


### PR DESCRIPTION
after https://github.com/vaadin/flow/pull/14014 fix, one log message needs to be updated. 