### PR TITLE
chore: Simplify Gradle build so no dependency copying is needed (#14005) (CP: 9.0)

### DIFF
--- a/flow-plugins/flow-gradle-plugin/build.gradle
+++ b/flow-plugins/flow-gradle-plugin/build.gradle
@@ -55,7 +55,7 @@ task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
  **********************************************************************************************************************/
 
 repositories {
-    maven { url 'target/dependencies' }
+    mavenLocal()
     mavenCentral()
     maven { url = 'https://plugins.gradle.org/m2/' }
     maven { url = 'https://maven.vaadin.com/vaadin-prereleases' }

--- a/flow-plugins/flow-gradle-plugin/pom.xml
+++ b/flow-plugins/flow-gradle-plugin/pom.xml
@@ -32,30 +32,6 @@
 
     <build>
         <plugins>
-            <!-- copy all dependencies to target/dependencies -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.2.0</version>
-                <executions>
-                    <execution>
-                        <id>copy-dependencies</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>copy-dependencies</goal>
-                        </goals>
-                        <inherited>false</inherited>
-                        <configuration>
-                            <useBaseVersion>true</useBaseVersion>
-                            <addParentPoms>true</addParentPoms>
-                            <copyPom>true</copyPom>
-                            <useRepositoryLayout>true</useRepositoryLayout>
-                            <outputDirectory>${project.build.directory}/dependencies</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
             <!-- execute Gradle command -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Manual CP due to conflicts.