### PR TITLE
fix: separate core and commercial components version files

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -461,9 +461,14 @@ public final class Constants implements Serializable {
     public static final String STATISTIC_ROUTING_HYBRID = "routing/hybrid";
 
     /**
-     * The name of platform versions file.
+     * The name of platform core components and tools versions file.
      */
-    public static final String VAADIN_VERSIONS_JSON = "vaadin_versions.json";
+    public static final String VAADIN_CORE_VERSIONS_JSON = "vaadin-core-versions.json";
+
+    /**
+     * The name of platform commercial components and tools versions file.
+     */
+    public static final String VAADIN_VERSIONS_JSON = "vaadin-versions.json";
 
     /**
      * @deprecated Use

--- a/flow-server/src/main/java/com/vaadin/flow/server/Platform.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Platform.java
@@ -39,7 +39,7 @@ public class Platform implements Serializable {
      */
     public static Optional<String> getVaadinVersion() {
         try (InputStream vaadinVersionsStream = Platform.class.getClassLoader()
-                .getResourceAsStream(Constants.VAADIN_VERSIONS_JSON)) {
+                .getResourceAsStream(Constants.VAADIN_CORE_VERSIONS_JSON)) {
             if (vaadinVersionsStream != null) {
                 ObjectMapper m = new ObjectMapper();
                 JsonNode vaadinVersions = m.readTree(vaadinVersionsStream);

--- a/flow-server/src/main/java/com/vaadin/flow/server/Platform.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Platform.java
@@ -49,7 +49,7 @@ public class Platform implements Serializable {
                     versionErrorLogged = true;
                     LoggerFactory.getLogger(Platform.class)
                             .info("Unable to determine version information. "
-                                    + "No vaadin_versions.json found");
+                                    + "No vaadin-core-versions.json found");
                 }
             }
         } catch (Exception e) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -230,8 +230,8 @@ public abstract class NodeUpdater implements FallibleCommand {
                     .parse(IOUtils.toString(content, StandardCharsets.UTF_8)));
             versionsJson = convert.getConvertedJson();
             versionsJson = new VersionsJsonFilter(getPackageJson(),
-                    DEPENDENCIES)
-                    .getFilteredVersions(versionsJson, versionsOrigin);
+                    DEPENDENCIES).getFilteredVersions(versionsJson,
+                            versionsOrigin);
         }
         return versionsJson;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -193,21 +193,45 @@ public abstract class NodeUpdater implements FallibleCommand {
      *             when versions file could not be read
      */
     JsonObject getPlatformPinnedDependencies() throws IOException {
-        URL resource = finder.getResource(Constants.VAADIN_VERSIONS_JSON);
-        if (resource == null) {
-            log().info("Couldn't find {} file to pin dependency versions."
-                    + " Transitive dependencies won't be pinned for pnpm.",
-                    Constants.VAADIN_VERSIONS_JSON);
+        URL coreVersionsResource = finder
+                .getResource(Constants.VAADIN_CORE_VERSIONS_JSON);
+        if (coreVersionsResource == null) {
+            log().info(
+                    "Couldn't find {} file to pin dependency versions for core components."
+                            + " Transitive dependencies won't be pinned for npm/pnpm.",
+                    Constants.VAADIN_CORE_VERSIONS_JSON);
             return Json.createObject();
         }
 
+        JsonObject versionsJson = getFilteredVersionsFromResource(
+                coreVersionsResource, Constants.VAADIN_CORE_VERSIONS_JSON);
+
+        URL vaadinVersionsResource = finder
+                .getResource(Constants.VAADIN_VERSIONS_JSON);
+        if (vaadinVersionsResource == null) {
+            // vaadin is not on the classpath, only vaadin-core is present.
+            return versionsJson;
+        }
+
+        JsonObject vaadinVersionsJson = getFilteredVersionsFromResource(
+                vaadinVersionsResource, Constants.VAADIN_VERSIONS_JSON);
+        for (String key : vaadinVersionsJson.keys()) {
+            versionsJson.put(key, vaadinVersionsJson.getString(key));
+        }
+
+        return versionsJson;
+    }
+
+    private JsonObject getFilteredVersionsFromResource(URL versionsResource,
+            String versionsOrigin) throws IOException {
         JsonObject versionsJson;
-        try (InputStream content = resource.openStream()) {
+        try (InputStream content = versionsResource.openStream()) {
             VersionsJsonConverter convert = new VersionsJsonConverter(Json
                     .parse(IOUtils.toString(content, StandardCharsets.UTF_8)));
             versionsJson = convert.getConvertedJson();
             versionsJson = new VersionsJsonFilter(getPackageJson(),
-                    DEPENDENCIES).getFilteredVersions(versionsJson);
+                    DEPENDENCIES)
+                    .getFilteredVersions(versionsJson, versionsOrigin);
         }
         return versionsJson;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonFilter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonFilter.java
@@ -51,14 +51,15 @@ class VersionsJsonFilter {
      *
      * @param versions
      *            to be filtered for user managed ones
+     * @param versionOrigin
+     *            origin of the version (like a file), used in error message
      * @return filtered versions json
      */
-    JsonObject getFilteredVersions(JsonObject versions) {
+    JsonObject getFilteredVersions(JsonObject versions, String versionOrigin) {
         JsonObject json = Json.createObject();
         for (String key : versions.keys()) {
             final FrontendVersion version = FrontendUtils
-                    .getPackageVersionFromJson(versions, key,
-                            "vaadin_version.json");
+                    .getPackageVersionFromJson(versions, key, versionOrigin);
             if (version == null) {
                 continue;
             }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdatePackagesTest.java
@@ -103,7 +103,8 @@ public abstract class AbstractNodeUpdatePackagesTest
         classFinder = Mockito.spy(getClassFinder());
         File versions = temporaryFolder.newFile();
         FileUtils.write(versions, "{}", StandardCharsets.UTF_8);
-        Mockito.when(classFinder.getResource(Constants.VAADIN_VERSIONS_JSON))
+        Mockito.when(
+                classFinder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(versions.toURI().toURL());
 
         packageUpdater = new TaskUpdatePackages(classFinder,

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdatePackagesNpmVersionLockingTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdatePackagesNpmVersionLockingTest.java
@@ -89,7 +89,8 @@ public class NodeUpdatePackagesNpmVersionLockingTest
                 StandardCharsets.UTF_8);
         // @formatter:on
 
-        Mockito.when(classFinder.getResource(Constants.VAADIN_VERSIONS_JSON))
+        Mockito.when(
+                classFinder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(versions.toURI().toURL());
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -32,9 +32,13 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.vaadin.experimental.FeatureFlags;
+import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
 
@@ -313,6 +317,96 @@ public class NodeUpdaterTest {
                 versionsJson.toJson());
     }
 
+    @Test
+    public void testGetPlatformPinnedDependencies_vaadinCoreVersionIsNotPresent_outputIsEmptyJson()
+            throws IOException {
+        Logger logger = Mockito.spy(Logger.class);
+        try (MockedStatic<LoggerFactory> loggerFactoryMocked = Mockito
+                .mockStatic(LoggerFactory.class)) {
+            loggerFactoryMocked
+                    .when(() -> LoggerFactory.getLogger(nodeUpdater.getClass()))
+                    .thenReturn(logger);
+
+            Mockito.when(
+                    finder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
+                    .thenReturn(null);
+            Mockito.when(finder.getResource(Constants.VAADIN_VERSIONS_JSON))
+                    .thenReturn(null);
+
+            JsonObject pinnedVersions = nodeUpdater
+                    .getPlatformPinnedDependencies();
+            Assert.assertEquals(0, pinnedVersions.keys().length);
+
+            Mockito.verify(logger, Mockito.times(1)).info(
+                    "Couldn't find {} file to pin dependency versions for core components."
+                            + " Transitive dependencies won't be pinned for npm/pnpm.",
+                    Constants.VAADIN_CORE_VERSIONS_JSON);
+        }
+    }
+
+    @Test
+    public void testGetPlatformPinnedDependencies_onlyVaadinCoreVersionIsPresent_outputContainsOnlyCoreVersions()
+            throws IOException {
+        File coreVersionsFile = File.createTempFile("vaadin-core-versions",
+                ".json", temporaryFolder.newFolder());
+        JsonObject mockedVaadinCoreJson = getMockVaadinCoreVersionsJson();
+        Assert.assertTrue(mockedVaadinCoreJson.hasKey("core"));
+        Assert.assertTrue(
+                mockedVaadinCoreJson.getObject("core").hasKey("button"));
+        Assert.assertFalse(mockedVaadinCoreJson.hasKey("vaadin"));
+
+        FileUtils.write(coreVersionsFile, mockedVaadinCoreJson.toJson(),
+                StandardCharsets.UTF_8);
+        Mockito.when(finder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
+                .thenReturn(coreVersionsFile.toURI().toURL());
+        Mockito.when(finder.getResource(Constants.VAADIN_VERSIONS_JSON))
+                .thenReturn(null);
+
+        JsonObject pinnedVersions = nodeUpdater.getPlatformPinnedDependencies();
+
+        Assert.assertTrue(pinnedVersions.hasKey("@vaadin/button"));
+        Assert.assertFalse(pinnedVersions.hasKey("@vaadin/grid-pro"));
+        Assert.assertFalse(pinnedVersions.hasKey("@vaadin/vaadin-grid-pro"));
+    }
+
+    @Test
+    public void testGetPlatformPinnedDependencies_VaadinAndVaadinCoreVersionsArePresent_outputContainsBothCoreAndCommercialVersions()
+            throws IOException {
+        File coreVersionsFile = File.createTempFile("vaadin-core-versions",
+                ".json", temporaryFolder.newFolder());
+        JsonObject mockedVaadinCoreJson = getMockVaadinCoreVersionsJson();
+        Assert.assertTrue(mockedVaadinCoreJson.hasKey("core"));
+        Assert.assertTrue(
+                mockedVaadinCoreJson.getObject("core").hasKey("button"));
+        Assert.assertFalse(mockedVaadinCoreJson.hasKey("vaadin"));
+
+        FileUtils.write(coreVersionsFile, mockedVaadinCoreJson.toJson(),
+                StandardCharsets.UTF_8);
+        Mockito.when(finder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
+                .thenReturn(coreVersionsFile.toURI().toURL());
+
+        File vaadinVersionsFile = File.createTempFile("vaadin-versions",
+                ".json", temporaryFolder.newFolder());
+        JsonObject mockedVaadinJson = getMockVaadinVersionsJson();
+        Assert.assertFalse(mockedVaadinJson.hasKey("core"));
+        Assert.assertTrue(mockedVaadinJson.hasKey("vaadin"));
+        Assert.assertTrue(
+                mockedVaadinJson.getObject("vaadin").hasKey("grid-pro"));
+        Assert.assertTrue(
+                mockedVaadinJson.getObject("vaadin").hasKey("vaadin-grid-pro"));
+
+        FileUtils.write(vaadinVersionsFile, mockedVaadinJson.toJson(),
+                StandardCharsets.UTF_8);
+        Mockito.when(finder.getResource(Constants.VAADIN_VERSIONS_JSON))
+                .thenReturn(vaadinVersionsFile.toURI().toURL());
+
+        JsonObject pinnedVersions = nodeUpdater.getPlatformPinnedDependencies();
+
+        Assert.assertTrue(pinnedVersions.hasKey("@vaadin/button"));
+        Assert.assertTrue(pinnedVersions.hasKey("@vaadin/grid-pro"));
+        Assert.assertTrue(pinnedVersions.hasKey("@vaadin/vaadin-grid-pro"));
+    }
+
     private String getPolymerVersion(JsonObject object) {
         JsonObject deps = object.get("dependencies");
         String version = deps.getString("@polymer/polymer");
@@ -333,5 +427,92 @@ public class NodeUpdaterTest {
                 .thenReturn(null);
         Assert.assertEquals("foo", nodeUpdater.resolveResource("foo"));
         Assert.assertEquals("foo", nodeUpdater.resolveResource("foo"));
+    }
+
+    private JsonObject getMockVaadinCoreVersionsJson() {
+        // @formatter:off
+        return Json.parse(
+                "{\n" +
+                        "    \"bundles\": {\n" +
+                        "        \"vaadin\": {\n" +
+                        "            \"jsVersion\": \"23.2.0\",\n" +
+                        "            \"npmName\": \"@vaadin/bundles\"\n" +
+                        "        }\n" +
+                        "    },\n" +
+                        "    \"core\": {\n" +
+                        "        \"accordion\": {\n" +
+                        "            \"jsVersion\": \"23.2.0\",\n" +
+                        "            \"npmName\": \"@vaadin/accordion\"\n" +
+                        "        },\n" +
+                        "        \"app-layout\": {\n" +
+                        "            \"jsVersion\": \"23.2.0\",\n" +
+                        "            \"npmName\": \"@vaadin/app-layout\"\n" +
+                        "        },\n" +
+                        "        \"avatar\": {\n" +
+                        "            \"jsVersion\": \"23.2.0\",\n" +
+                        "            \"npmName\": \"@vaadin/avatar\"\n" +
+                        "        },\n" +
+                        "        \"avatar-group\": {\n" +
+                        "            \"jsVersion\": \"23.2.0\",\n" +
+                        "            \"npmName\": \"@vaadin/avatar-group\"\n" +
+                        "        },\n" +
+                        "        \"button\": {\n" +
+                        "            \"jsVersion\": \"23.2.0\",\n" +
+                        "            \"npmName\": \"@vaadin/button\"\n" +
+                        "        },\n" +
+                        "        \"checkbox\": {\n" +
+                        "            \"jsVersion\": \"23.2.0\",\n" +
+                        "            \"npmName\": \"@vaadin/checkbox\"\n" +
+                        "        }" +
+                        "    },\n" +
+                        "    \"platform\": \"23.2.0\"\n" +
+                        "}"
+        );
+        // @formatter:on
+    }
+
+    private JsonObject getMockVaadinVersionsJson() {
+        // @formatter:off
+        return Json.parse(
+                "{\n" +
+                        "    \"vaadin\": {\n" +
+                        "        \"board\": {\n" +
+                        "            \"jsVersion\": \"23.2.0\",\n" +
+                        "            \"npmName\": \"@vaadin/board\"\n" +
+                        "        },\n" +
+                        "        \"charts\": {\n" +
+                        "            \"jsVersion\": \"23.2.0\",\n" +
+                        "            \"npmName\": \"@vaadin/charts\"\n" +
+                        "        },\n" +
+                        "        \"grid-pro\": {\n" +
+                        "            \"jsVersion\": \"23.2.0\",\n" +
+                        "            \"npmName\": \"@vaadin/grid-pro\"\n" +
+                        "        },\n" +
+                        "        \"vaadin-board\": {\n" +
+                        "            \"component\": true,\n" +
+                        "            \"javaVersion\": \"23.2.0\",\n" +
+                        "            \"jsVersion\": \"23.2.0\",\n" +
+                        "            \"npmName\": \"@vaadin/vaadin-board\",\n" +
+                        "            \"pro\": true\n" +
+                        "        },\n" +
+                        "        \"vaadin-charts\": {\n" +
+                        "            \"component\": true,\n" +
+                        "            \"javaVersion\": \"23.2.0\",\n" +
+                        "            \"jsVersion\": \"23.2.0\",\n" +
+                        "            \"npmName\": \"@vaadin/vaadin-charts\",\n" +
+                        "            \"pro\": true\n" +
+                        "        },\n" +
+                        "        \"vaadin-grid-pro\": {\n" +
+                        "            \"component\": true,\n" +
+                        "            \"javaVersion\": \"23.2.0\",\n" +
+                        "            \"jsVersion\": \"23.2.0\",\n" +
+                        "            \"npmName\": \"@vaadin/vaadin-grid-pro\",\n" +
+                        "            \"pro\": true\n" +
+                        "        },\n" +
+                        "    },\n" +
+                        "    \"platform\": \"23.2.0\"\n" +
+                        "}"
+        );
+        // @formatter:on
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -163,7 +163,8 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         ClassFinder classFinder = getClassFinder();
         File versions = temporaryFolder.newFile();
         FileUtils.write(versions, "{}", StandardCharsets.UTF_8);
-        Mockito.when(classFinder.getResource(Constants.VAADIN_VERSIONS_JSON))
+        Mockito.when(
+                classFinder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(versions.toURI().toURL());
 
         TaskRunNpmInstall task = createTask();
@@ -503,11 +504,12 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         final VersionsJsonFilter versionsJsonFilter = new VersionsJsonFilter(
                 Json.parse(packageJsonContent), NodeUpdater.DEPENDENCIES);
         // Platform defines a pinned version
-        TaskRunNpmInstall task = createTask(
-                versionsJsonFilter.getFilteredVersions(
+        TaskRunNpmInstall task = createTask(versionsJsonFilter
+                .getFilteredVersions(
                         Json.parse("{ \"@vaadin/vaadin-overlay\":\""
-                                + PINNED_VERSION + "\"}"))
-                        .toJson());
+                                + PINNED_VERSION + "\"}"),
+                        "test-versions.json")
+                .toJson());
         task.execute();
 
         File overlayPackageJson = new File(getNodeUpdater().nodeModulesFolder,
@@ -550,11 +552,12 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         final VersionsJsonFilter versionsJsonFilter = new VersionsJsonFilter(
                 Json.parse(packageJsonContent), NodeUpdater.DEPENDENCIES);
         // Platform defines a pinned version
-        TaskRunNpmInstall task = createTask(
-                versionsJsonFilter.getFilteredVersions(
+        TaskRunNpmInstall task = createTask(versionsJsonFilter
+                .getFilteredVersions(
                         Json.parse("{ \"@vaadin/vaadin-overlay\":\""
-                                + PINNED_VERSION + "\"}"))
-                        .toJson());
+                                + PINNED_VERSION + "\"}"),
+                        "test-versions.json")
+                .toJson());
         task.execute();
 
         File overlayPackageJson = new File(getNodeUpdater().nodeModulesFolder,
@@ -656,7 +659,8 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
     private JsonObject getGeneratedVersionsContent(File versions)
             throws IOException {
         ClassFinder classFinder = getClassFinder();
-        Mockito.when(classFinder.getResource(Constants.VAADIN_VERSIONS_JSON))
+        Mockito.when(
+                classFinder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(versions.toURI().toURL());
 
         String path = getNodeUpdater().generateVersionsJson();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
@@ -93,7 +93,7 @@ public class TaskUpdatePackagesNpmTest {
         generatedPath.mkdir();
         versionJsonFile = new File(npmFolder, "versions.json");
         finder = Mockito.mock(ClassFinder.class);
-        Mockito.when(finder.getResource(Constants.VAADIN_VERSIONS_JSON))
+        Mockito.when(finder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(versionJsonFile.toURI().toURL());
 
         packageJson = new File(npmFolder, PACKAGE_JSON);
@@ -185,14 +185,14 @@ public class TaskUpdatePackagesNpmTest {
     @Test
     public void npmIsInUse_noPlatformVersionJsonPresent_noFailure()
             throws IOException {
-        Mockito.when(finder.getResource(Constants.VAADIN_VERSIONS_JSON))
+        Mockito.when(finder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(null);
         final TaskUpdatePackages task = createTask(
                 createApplicationDependencies());
         task.execute();
         Assert.assertTrue("Updates not picked", task.modified);
 
-        Mockito.when(finder.getResource(Constants.VAADIN_VERSIONS_JSON))
+        Mockito.when(finder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(versionJsonFile.toURI().toURL());
         JsonObject dependencies = getOrCreatePackageJson()
                 .getObject(DEPENDENCIES);
@@ -203,11 +203,11 @@ public class TaskUpdatePackagesNpmTest {
     @Test
     public void npmIsInUse_platformVersionsJsonAdded_versionsPinned()
             throws IOException {
-        Mockito.when(finder.getResource(Constants.VAADIN_VERSIONS_JSON))
+        Mockito.when(finder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(null);
         createTask(createApplicationDependencies()).execute();
 
-        Mockito.when(finder.getResource(Constants.VAADIN_VERSIONS_JSON))
+        Mockito.when(finder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(versionJsonFile.toURI().toURL());
         final String newVersion = "20.0.0";
         createVaadinVersionsJson(newVersion, newVersion, newVersion);
@@ -660,7 +660,7 @@ public class TaskUpdatePackagesNpmTest {
 
     private void verifyPlatformDependenciesAreAdded(boolean enablePnpm)
             throws IOException {
-        Mockito.when(finder.getResource(Constants.VAADIN_VERSIONS_JSON))
+        Mockito.when(finder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(versionJsonFile.toURI().toURL());
         final String newVersion = "20.0.0";
         createVaadinVersionsJson(newVersion, newVersion, newVersion);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/VersionsJsonFilterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/VersionsJsonFilterTest.java
@@ -83,8 +83,8 @@ public class VersionsJsonFilterTest {
 
         VersionsJsonFilter filter = new VersionsJsonFilter(Json.parse(pkgJson),
                 depKey);
-        JsonObject filteredJson = filter
-                .getFilteredVersions(Json.parse(versions));
+        JsonObject filteredJson = filter.getFilteredVersions(
+                Json.parse(versions), "versions/versions.json");
         Assert.assertTrue(filteredJson.hasKey("@vaadin/vaadin-progress-bar"));
         Assert.assertTrue(filteredJson.hasKey("@vaadin/vaadin-upload"));
         Assert.assertTrue(filteredJson.hasKey("@polymer/iron-list"));
@@ -108,8 +108,8 @@ public class VersionsJsonFilterTest {
 
         VersionsJsonFilter filter = new VersionsJsonFilter(Json.parse(pkgJson),
                 depKey);
-        JsonObject filteredJson = filter
-                .getFilteredVersions(Json.parse(versions));
+        JsonObject filteredJson = filter.getFilteredVersions(
+                Json.parse(versions), "versions/user_versions.json");
         List<String> expectedKeys = Arrays.asList("@vaadin/vaadin-notification",
                 "@vaadin/vaadin-overlay", "@vaadin/vaadin-select",
                 "@vaadin/vaadin-split-layout", "@vaadin/vaadin-tabs");
@@ -156,8 +156,8 @@ public class VersionsJsonFilterTest {
 
         VersionsJsonFilter filter = new VersionsJsonFilter(Json.parse(pkgJson),
                 depKey);
-        JsonObject filteredJson = filter
-                .getFilteredVersions(Json.parse(versions));
+        JsonObject filteredJson = filter.getFilteredVersions(
+                Json.parse(versions), "versions/versions.json");
         Assert.assertTrue(filteredJson.hasKey("@vaadin/vaadin-progress-bar"));
         Assert.assertTrue(filteredJson.hasKey("@vaadin/vaadin-upload"));
         Assert.assertTrue(filteredJson.hasKey("@polymer/iron-list"));


### PR DESCRIPTION
This is a manual cherry-pick to collect 
all changes that are done in #14014, 
#14079, and #14083.

Related to #14092 