### PR TITLE
fix: Set Vite hot reload port to match the server port

### DIFF
--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -364,6 +364,19 @@ const allowedFrontendFolders = [
   path.resolve(frontendFolder, '../node_modules')
 ];
 
+function setHmrPortToServerPort(): PluginOption {
+  return {
+    name: 'set-hmr-port-to-server-port',
+    configResolved(config) {
+      if (config.server.strictPort && config.server.hmr !== false) {
+        if (config.server.hmr === true) config.server.hmr = {};
+        config.server.hmr = config.server.hmr || {};
+        config.server.hmr.clientPort = config.server.port;
+      }
+    }
+  };
+}
+
 export const vaadinConfig: UserConfigFn = (env) => {
   const devMode = env.mode === 'development';
 
@@ -388,6 +401,7 @@ export const vaadinConfig: UserConfigFn = (env) => {
     },
     server: {
       host: '127.0.0.1',
+      strictPort: true,
       fs: {
         allow: allowedFrontendFolders
       }
@@ -423,6 +437,7 @@ export const vaadinConfig: UserConfigFn = (env) => {
     plugins: [
       !devMode && brotli(),
       devMode && vaadinBundlesPlugin(),
+      devMode && setHmrPortToServerPort(),
       settings.offlineEnabled && buildSWPlugin(),
       settings.offlineEnabled && injectManifestToSWPlugin(),
       !devMode && statsExtracterPlugin(),


### PR DESCRIPTION
This is needed in Vite 3 to avoid an initial attempt to connect Vite's websocket channel to localhost:8080 which logs a browser warning
