### PR TITLE
fix: ignore quotes in CSS url directive

### DIFF
--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
@@ -40,7 +40,7 @@ const createLinkReferences = (css, target) => {
   // [0] is the full match
   // [1] matches the media query
   // [2] matches the url
-  const importMatcher = /(?:@media\\s(.+?))?(?:\\s{)?\\@import\\surl\\((.+?)\\);(?:})?/g;
+  const importMatcher = /(?:@media\\s(.+?))?(?:\\s{)?\\@import\\surl\\(\\s*['"]?(.+?)['"]?\\s*\\);(?:})?/g;
   
   var match;
   var styleCss = css;

--- a/flow-tests/test-frontend/vite-basics/frontend/themes/vite-basics/styles.css
+++ b/flow-tests/test-frontend/vite-basics/frontend/themes/vite-basics/styles.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css?family=Itim');
+
 h2 {
     color: blue;
 }

--- a/flow-tests/test-frontend/vite-basics/package.json
+++ b/flow-tests/test-frontend/vite-basics/package.json
@@ -26,7 +26,7 @@
     "glob": "7.2.3",
     "mkdirp": "1.0.4",
     "rollup-plugin-brotli": "3.1.0",
-    "typescript": "4.5.3",
+    "typescript": "4.7.4",
     "vite": "v2.9.13",
     "vite-plugin-checker": "0.3.4",
     "workbox-build": "6.5.0",
@@ -49,14 +49,14 @@
       "glob": "7.2.3",
       "mkdirp": "1.0.4",
       "rollup-plugin-brotli": "3.1.0",
-      "typescript": "4.5.3",
+      "typescript": "4.7.4",
       "vite": "v2.9.13",
       "vite-plugin-checker": "0.3.4",
       "workbox-build": "6.5.0",
       "workbox-core": "6.5.0",
       "workbox-precaching": "6.5.0"
     },
-    "hash": "c10b398f8d3a47350d5509875a404bcf1906ad8b4669f751378fefc636d80955"
+    "hash": "5194c1e2c2155047c5297e496fdc7a03d8a371eba9f531c7c0d02841390ccab3"
   },
   "overrides": {
     "@polymer/polymer": "$@polymer/polymer",

--- a/flow-tests/test-frontend/vite-basics/src/test/java/com/vaadin/viteapp/ThemeIT.java
+++ b/flow-tests/test-frontend/vite-basics/src/test/java/com/vaadin/viteapp/ThemeIT.java
@@ -1,9 +1,12 @@
 package com.vaadin.viteapp;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
 
 public class ThemeIT extends ViteDevModeIT {
 
@@ -38,4 +41,22 @@ public class ThemeIT extends ViteDevModeIT {
                 "return getComputedStyle(document.querySelector('#themedfield')).backgroundColor");
         Assert.assertEquals("rgb(173, 216, 230)", fieldBackground);
     }
+
+    @Test
+    public void documentCssImport_externalAddedToHeadAsLink() {
+        checkLogsForErrors();
+
+        final WebElement documentHead = getDriver()
+                .findElement(By.xpath("/html/head"));
+        final List<WebElement> links = documentHead
+                .findElements(By.tagName("link"));
+
+        List<String> linkUrls = links.stream()
+                .map(link -> link.getAttribute("href"))
+                .collect(Collectors.toList());
+
+        Assert.assertTrue("Missing link for external url", linkUrls
+                .contains("https://fonts.googleapis.com/css?family=Itim"));
+    }
+
 }

--- a/flow-tests/test-frontend/vite-basics/src/test/java/com/vaadin/viteapp/ThemeIT.java
+++ b/flow-tests/test-frontend/vite-basics/src/test/java/com/vaadin/viteapp/ThemeIT.java
@@ -47,7 +47,7 @@ public class ThemeIT extends ViteDevModeIT {
         checkLogsForErrors();
 
         final WebElement documentHead = getDriver()
-                .findElement(By.xpath("/html/head"));
+                .findElement(By.tagName("head"));
         final List<WebElement> links = documentHead
                 .findElements(By.tagName("link"));
 


### PR DESCRIPTION
## Description

CSS url directive allows the url to be enclosed in single or double quotes.
Currently, webpack processors removes quotes before the theme-generator is used,
but this does not happen with Vite, so URLs are set on the link elements by
createLinkReferences function with quotes and this leads to an HTTP 404 error
because the browser adds the base url to the contents of the directive.
This change modifies the regular expression that matches urls, so that
the quotes are not part of the capturing group used to get the url.

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
