### PR TITLE
 fix: separate core and commercial components version files (#14014) (CP: 9.0)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -455,9 +455,14 @@ public final class Constants implements Serializable {
     public static final String STATISTIC_ROUTING_HYBRID = "routing/hybrid";
 
     /**
-     * The name of platform versions file.
+     * The name of platform core components and tools versions file.
      */
-    public static final String VAADIN_VERSIONS_JSON = "vaadin_versions.json";
+    public static final String VAADIN_CORE_VERSIONS_JSON = "vaadin-core-versions.json";
+
+    /**
+     * The name of platform commercial components and tools versions file.
+     */
+    public static final String VAADIN_VERSIONS_JSON = "vaadin-versions.json";
 
     /**
      * @deprecated Use

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -212,8 +212,8 @@ public abstract class NodeUpdater implements FallibleCommand {
                     .parse(IOUtils.toString(content, StandardCharsets.UTF_8)));
             versionsJson = convert.getConvertedJson();
             versionsJson = new VersionsJsonFilter(getPackageJson(),
-                    DEPENDENCIES)
-                    .getFilteredVersions(versionsJson, versionsOrigin);
+                    DEPENDENCIES).getFilteredVersions(versionsJson,
+                            versionsOrigin);
         }
         return versionsJson;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -175,25 +175,45 @@ public abstract class NodeUpdater implements FallibleCommand {
      *             when versions file could not be read
      */
     JsonObject getPlatformPinnedDependencies() throws IOException {
-        URL resource = finder.getResource(Constants.VAADIN_VERSIONS_JSON);
-        if (resource == null) {
-            log().info("Couldn't find {} file to pin dependency versions."
-                    + " Transitive dependencies won't be pinned for pnpm.",
-                    Constants.VAADIN_VERSIONS_JSON);
+        URL coreVersionsResource = finder
+                .getResource(Constants.VAADIN_CORE_VERSIONS_JSON);
+        if (coreVersionsResource == null) {
+            log().info(
+                    "Couldn't find {} file to pin dependency versions for core components."
+                            + " Transitive dependencies won't be pinned for npm/pnpm.",
+                    Constants.VAADIN_CORE_VERSIONS_JSON);
+            return null;
         }
 
-        JsonObject versionsJson = null;
-        try (InputStream content = resource == null ? null
-                : resource.openStream()) {
+        JsonObject versionsJson = getFilteredVersionsFromResource(
+                coreVersionsResource, Constants.VAADIN_CORE_VERSIONS_JSON);
 
-            if (content != null) {
-                VersionsJsonConverter convert = new VersionsJsonConverter(
-                        Json.parse(IOUtils.toString(content,
-                                StandardCharsets.UTF_8)));
-                versionsJson = convert.getConvertedJson();
-                versionsJson = new VersionsJsonFilter(getPackageJson(),
-                        DEPENDENCIES).getFilteredVersions(versionsJson);
-            }
+        URL vaadinVersionsResource = finder
+                .getResource(Constants.VAADIN_VERSIONS_JSON);
+        if (vaadinVersionsResource == null) {
+            // vaadin is not on the classpath, only vaadin-core is present.
+            return versionsJson;
+        }
+
+        JsonObject vaadinVersionsJson = getFilteredVersionsFromResource(
+                vaadinVersionsResource, Constants.VAADIN_VERSIONS_JSON);
+        for (String key : vaadinVersionsJson.keys()) {
+            versionsJson.put(key, vaadinVersionsJson.getString(key));
+        }
+
+        return versionsJson;
+    }
+
+    private JsonObject getFilteredVersionsFromResource(URL versionsResource,
+            String versionsOrigin) throws IOException {
+        JsonObject versionsJson;
+        try (InputStream content = versionsResource.openStream()) {
+            VersionsJsonConverter convert = new VersionsJsonConverter(Json
+                    .parse(IOUtils.toString(content, StandardCharsets.UTF_8)));
+            versionsJson = convert.getConvertedJson();
+            versionsJson = new VersionsJsonFilter(getPackageJson(),
+                    DEPENDENCIES)
+                    .getFilteredVersions(versionsJson, versionsOrigin);
         }
         return versionsJson;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonFilter.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/VersionsJsonFilter.java
@@ -51,14 +51,15 @@ class VersionsJsonFilter {
      *
      * @param versions
      *            to be filtered for user managed ones
+     * @param versionOrigin
+     *            origin of the version (like a file), used in error message
      * @return filtered versions json
      */
-    JsonObject getFilteredVersions(JsonObject versions) {
+    JsonObject getFilteredVersions(JsonObject versions, String versionOrigin) {
         JsonObject json = Json.createObject();
         for (String key : versions.keys()) {
             final FrontendVersion version = FrontendUtils
-                    .getPackageVersionFromJson(versions, key,
-                            "vaadin_version.json");
+                    .getPackageVersionFromJson(versions, key, versionOrigin);
             if (version == null) {
                 continue;
             }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -253,7 +253,7 @@ public class NodeUpdaterTest {
     }
 
     @Test
-    public void testGetPlatformPinnedDependencies_vaadinCoreVersionIsNotPresent_outputIsEmptyJson()
+    public void testGetPlatformPinnedDependencies_vaadinCoreVersionIsNotPresent_outputIsNull()
             throws IOException {
         Logger logger = Mockito.spy(Logger.class);
         try (MockedStatic<LoggerFactory> loggerFactoryMocked = Mockito
@@ -263,14 +263,14 @@ public class NodeUpdaterTest {
                     .thenReturn(logger);
 
             Mockito.when(
-                            finder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
+                    finder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                     .thenReturn(null);
             Mockito.when(finder.getResource(Constants.VAADIN_VERSIONS_JSON))
                     .thenReturn(null);
 
             JsonObject pinnedVersions = nodeUpdater
                     .getPlatformPinnedDependencies();
-            Assert.assertEquals(0, pinnedVersions.keys().length);
+            Assert.assertNull(pinnedVersions);
 
             Mockito.verify(logger, Mockito.times(1)).info(
                     "Couldn't find {} file to pin dependency versions for core components."
@@ -290,8 +290,7 @@ public class NodeUpdaterTest {
                 mockedVaadinCoreJson.getObject("core").hasKey("button"));
         Assert.assertFalse(mockedVaadinCoreJson.hasKey("vaadin"));
 
-        FileUtils.write(coreVersionsFile, mockedVaadinCoreJson.toJson(),
-                UTF_8);
+        FileUtils.write(coreVersionsFile, mockedVaadinCoreJson.toJson(), UTF_8);
         Mockito.when(finder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(coreVersionsFile.toURI().toURL());
         Mockito.when(finder.getResource(Constants.VAADIN_VERSIONS_JSON))
@@ -315,8 +314,7 @@ public class NodeUpdaterTest {
                 mockedVaadinCoreJson.getObject("core").hasKey("button"));
         Assert.assertFalse(mockedVaadinCoreJson.hasKey("vaadin"));
 
-        FileUtils.write(coreVersionsFile, mockedVaadinCoreJson.toJson(),
-                UTF_8);
+        FileUtils.write(coreVersionsFile, mockedVaadinCoreJson.toJson(), UTF_8);
         Mockito.when(finder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(coreVersionsFile.toURI().toURL());
 
@@ -330,8 +328,7 @@ public class NodeUpdaterTest {
         Assert.assertTrue(
                 mockedVaadinJson.getObject("vaadin").hasKey("vaadin-grid-pro"));
 
-        FileUtils.write(vaadinVersionsFile, mockedVaadinJson.toJson(),
-                UTF_8);
+        FileUtils.write(vaadinVersionsFile, mockedVaadinJson.toJson(), UTF_8);
         Mockito.when(finder.getResource(Constants.VAADIN_VERSIONS_JSON))
                 .thenReturn(vaadinVersionsFile.toURI().toURL());
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunPnpmInstallTest.java
@@ -154,7 +154,8 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         ClassFinder classFinder = getClassFinder();
         File versions = temporaryFolder.newFile();
         FileUtils.write(versions, "{}", StandardCharsets.UTF_8);
-        Mockito.when(classFinder.getResource(Constants.VAADIN_VERSIONS_JSON))
+        Mockito.when(
+                classFinder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(versions.toURI().toURL());
 
         TaskRunNpmInstall task = createTask();
@@ -546,11 +547,12 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         final VersionsJsonFilter versionsJsonFilter = new VersionsJsonFilter(
                 Json.parse(packageJsonContent), NodeUpdater.DEPENDENCIES);
         // Platform defines a pinned version
-        TaskRunNpmInstall task = createTask(
-                versionsJsonFilter.getFilteredVersions(
+        TaskRunNpmInstall task = createTask(versionsJsonFilter
+                .getFilteredVersions(
                         Json.parse("{ \"@vaadin/vaadin-overlay\":\""
-                                + PINNED_VERSION + "\"}"))
-                        .toJson());
+                                + PINNED_VERSION + "\"}"),
+                        "test-versions.json")
+                .toJson());
         task.execute();
 
         File overlayPackageJson = new File(getNodeUpdater().nodeModulesFolder,
@@ -593,11 +595,12 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
         final VersionsJsonFilter versionsJsonFilter = new VersionsJsonFilter(
                 Json.parse(packageJsonContent), NodeUpdater.DEPENDENCIES);
         // Platform defines a pinned version
-        TaskRunNpmInstall task = createTask(
-                versionsJsonFilter.getFilteredVersions(
+        TaskRunNpmInstall task = createTask(versionsJsonFilter
+                .getFilteredVersions(
                         Json.parse("{ \"@vaadin/vaadin-overlay\":\""
-                                + PINNED_VERSION + "\"}"))
-                        .toJson());
+                                + PINNED_VERSION + "\"}"),
+                        "test-versions.json")
+                .toJson());
         task.execute();
 
         File overlayPackageJson = new File(getNodeUpdater().nodeModulesFolder,
@@ -676,7 +679,8 @@ public class TaskRunPnpmInstallTest extends TaskRunNpmInstallTest {
     private JsonObject getGeneratedVersionsContent(File versions)
             throws IOException {
         ClassFinder classFinder = getClassFinder();
-        Mockito.when(classFinder.getResource(Constants.VAADIN_VERSIONS_JSON))
+        Mockito.when(
+                classFinder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(versions.toURI().toURL());
 
         TaskRunNpmInstall task = new TaskRunNpmInstall(getNodeUpdater(), true,

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
@@ -89,7 +89,7 @@ public class TaskUpdatePackagesNpmTest {
         generatedPath.mkdir();
         versionJsonFile = new File(npmFolder, "versions.json");
         finder = Mockito.mock(ClassFinder.class);
-        Mockito.when(finder.getResource(Constants.VAADIN_VERSIONS_JSON))
+        Mockito.when(finder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(versionJsonFile.toURI().toURL());
     }
 
@@ -177,14 +177,14 @@ public class TaskUpdatePackagesNpmTest {
     @Test
     public void npmIsInUse_noPlatformVersionJsonPresent_noFailure()
             throws IOException {
-        Mockito.when(finder.getResource(Constants.VAADIN_VERSIONS_JSON))
+        Mockito.when(finder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(null);
         final TaskUpdatePackages task = createTask(
                 createApplicationDependencies());
         task.execute();
         Assert.assertTrue("Updates not picked", task.modified);
 
-        Mockito.when(finder.getResource(Constants.VAADIN_VERSIONS_JSON))
+        Mockito.when(finder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(versionJsonFile.toURI().toURL());
         JsonObject dependencies = getOrCreatePackageJson()
                 .getObject(DEPENDENCIES);
@@ -195,11 +195,11 @@ public class TaskUpdatePackagesNpmTest {
     @Test
     public void npmIsInUse_platformVersionsJsonAdded_versionsPinned()
             throws IOException {
-        Mockito.when(finder.getResource(Constants.VAADIN_VERSIONS_JSON))
+        Mockito.when(finder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(null);
         createTask(createApplicationDependencies()).execute();
 
-        Mockito.when(finder.getResource(Constants.VAADIN_VERSIONS_JSON))
+        Mockito.when(finder.getResource(Constants.VAADIN_CORE_VERSIONS_JSON))
                 .thenReturn(versionJsonFile.toURI().toURL());
         final String newVersion = "20.0.0";
         createVaadinVersionsJson(newVersion, newVersion, newVersion);
@@ -527,5 +527,4 @@ public class TaskUpdatePackagesNpmTest {
                     dependencies.getString(VAADIN_OVERLAY));
         }
     }
-
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/VersionsJsonFilterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/VersionsJsonFilterTest.java
@@ -124,14 +124,14 @@ public class VersionsJsonFilterTest {
 
     private void assertMissingVaadinDependencies_allDependenciesSholdBeUserHandled(
             String depKey) throws IOException {
-        String versions = IOUtils
-                .toString(
-                        Objects.requireNonNull(getClass().getClassLoader()
-                                .getResourceAsStream("versions/versions.json")),
-                        StandardCharsets.UTF_8);
-        String pkgJson = IOUtils.toString(
+        String versions = IOUtils.toString(
                 Objects.requireNonNull(getClass().getClassLoader()
-                        .getResourceAsStream("versions/no_vaadin_package.json")),
+                        .getResourceAsStream("versions/versions.json")),
+                StandardCharsets.UTF_8);
+        String pkgJson = IOUtils.toString(
+                Objects.requireNonNull(
+                        getClass().getClassLoader().getResourceAsStream(
+                                "versions/no_vaadin_package.json")),
                 StandardCharsets.UTF_8);
 
         VersionsJsonFilter filter = new VersionsJsonFilter(Json.parse(pkgJson),
@@ -148,16 +148,14 @@ public class VersionsJsonFilterTest {
 
     private void assertFilterPlatformVersions_multipleUserChanged_correctlyIgnored(
             String depKey) throws IOException {
-        String versions = IOUtils
-                .toString(
-                        Objects.requireNonNull(getClass().getClassLoader().getResourceAsStream(
-                                "versions/user_versions.json")),
-                        StandardCharsets.UTF_8);
-        String pkgJson = IOUtils
-                .toString(
-                        Objects.requireNonNull(getClass().getClassLoader().getResourceAsStream(
-                                "versions/user_package.json")),
-                        StandardCharsets.UTF_8);
+        String versions = IOUtils.toString(
+                Objects.requireNonNull(getClass().getClassLoader()
+                        .getResourceAsStream("versions/user_versions.json")),
+                StandardCharsets.UTF_8);
+        String pkgJson = IOUtils.toString(
+                Objects.requireNonNull(getClass().getClassLoader()
+                        .getResourceAsStream("versions/user_package.json")),
+                StandardCharsets.UTF_8);
 
         VersionsJsonFilter filter = new VersionsJsonFilter(Json.parse(pkgJson),
                 depKey);
@@ -196,16 +194,14 @@ public class VersionsJsonFilterTest {
 
     private void assertFilterPlatformVersions(String depKey)
             throws IOException {
-        String versions = IOUtils
-                .toString(
-                        Objects.requireNonNull(getClass().getClassLoader()
-                                .getResourceAsStream("versions/versions.json")),
-                        StandardCharsets.UTF_8);
-        String pkgJson = IOUtils
-                .toString(
-                        Objects.requireNonNull(getClass().getClassLoader()
-                                .getResourceAsStream("versions/package.json")),
-                        StandardCharsets.UTF_8);
+        String versions = IOUtils.toString(
+                Objects.requireNonNull(getClass().getClassLoader()
+                        .getResourceAsStream("versions/versions.json")),
+                StandardCharsets.UTF_8);
+        String pkgJson = IOUtils.toString(
+                Objects.requireNonNull(getClass().getClassLoader()
+                        .getResourceAsStream("versions/package.json")),
+                StandardCharsets.UTF_8);
 
         VersionsJsonFilter filter = new VersionsJsonFilter(Json.parse(pkgJson),
                 depKey);


### PR DESCRIPTION
This is a manual cherry-pick to collect
all changes that are done in #14014,
#14079, and #14083.

Related to #14092