### PR TITLE
feat: allow disabling validation status change listener registration on binder

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -1227,7 +1227,8 @@ public class Binder<BEAN> implements Serializable {
             onValueChange = getField().addValueChangeListener(
                     event -> handleFieldValueChange(event));
 
-            if (getField() instanceof HasValidator) {
+            if (getBinder().isFieldsValidationStatusChangeListenerEnabled()
+                    && getField() instanceof HasValidator) {
                 HasValidator<FIELDVALUE> hasValidatorField = (HasValidator<FIELDVALUE>) getField();
                 onValidationStatusChange = hasValidatorField
                         .addValidationStatusChangeListener(
@@ -1684,6 +1685,8 @@ public class Binder<BEAN> implements Serializable {
     private Set<Binding<BEAN, ?>> changedBindings = new LinkedHashSet<>();
 
     private boolean validatorsDisabled = false;
+
+    private boolean fieldsValidationStatusChangeListenerEnabled = true;
 
     /**
      * Creates a binder using a custom {@link PropertySet} implementation for
@@ -3525,6 +3528,30 @@ public class Binder<BEAN> implements Serializable {
      */
     public boolean isValidatorsDisabled() {
         return validatorsDisabled;
+    }
+
+    /**
+     * Control whether bound fields implementing {@link HasValidator} subscribe
+     * for field's {@code ValidationStatusChangeEvent}s and will
+     * {@code validate} upon receiving them.
+     *
+     * @param fieldsValidationStatusChangeListenerEnabled
+     *            Boolean value.
+     */
+    public void setFieldsValidationStatusChangeListenerEnabled(
+            boolean fieldsValidationStatusChangeListenerEnabled) {
+        this.fieldsValidationStatusChangeListenerEnabled = fieldsValidationStatusChangeListenerEnabled;
+    }
+
+    /**
+     * Returns if the bound fields implementing {@link HasValidator} subscribe
+     * for field's {@code ValidationStatusChangeEvent}s and will
+     * {@code validate} upon receiving them.
+     *
+     * @return Boolean value
+     */
+    public boolean isFieldsValidationStatusChangeListenerEnabled() {
+        return fieldsValidationStatusChangeListenerEnabled;
     }
 
     /**

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderValidationStatusChangeListenerTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderValidationStatusChangeListenerTest.java
@@ -65,6 +65,16 @@ public class BinderValidationStatusChangeListenerTest
     }
 
     @Test
+    public void binderWithFieldsValidationStatusChangeListenerDisabled_bindIsCalled_noValidationStatusListenerIsCalled() {
+        binder.setFieldsValidationStatusChangeListenerEnabled(false);
+        var field = Mockito.spy(
+                TestHasValidatorDatePicker.DatePickerHasValidatorDefaults.class);
+        binder.bind(field, BIRTH_DATE_PROPERTY);
+        Mockito.verify(field, Mockito.never())
+                .addValidationStatusChangeListener(Mockito.any());
+    }
+
+    @Test
     public void fieldWithHasValidatorOnlyGetDefaultValidatorOverridden_bindIsCalled_addValidationStatusListenerIsCalled() {
         var field = Mockito.spy(
                 TestHasValidatorDatePicker.DataPickerHasValidatorGetDefaultValidatorOverridden.class);
@@ -100,6 +110,17 @@ public class BinderValidationStatusChangeListenerTest
         field.fireValidationStatusChangeEvent(false);
         Assert.assertEquals(1, componentErrors.size());
         Assert.assertEquals(INVALID_DATE_FORMAT, componentErrors.get(field));
+    }
+
+    @Test
+    public void binderWithFieldsValidationStatusChangeListenerDisabled_fieldValidationStatusChangesToFalse_binderHandleErrorIsNotCalled() {
+        binder.setFieldsValidationStatusChangeListenerEnabled(false);
+        var field = new TestHasValidatorDatePicker.DataPickerHasValidatorOverridden();
+        binder.bind(field, BIRTH_DATE_PROPERTY);
+        Assert.assertEquals(0, componentErrors.size());
+
+        field.fireValidationStatusChangeEvent(false);
+        Assert.assertEquals(0, componentErrors.size());
     }
 
     @Test


### PR DESCRIPTION
## Description

Add binder-level flag to allow disabling of 
validation status change listener registration 
for HasValidator fields.

Related to https://github.com/vaadin/flow/pull/13940#issuecomment-1174668400 and https://github.com/vaadin/flow/pull/13940#issuecomment-1174668400

## Type of change

- [ ] Bugfix
- [X] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed a self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
