### PR TITLE
test: workaround for internal selenium grid

### DIFF
--- a/flow-tests/test-frontend/vite-pwa-custom-offline-path/pom-production.xml
+++ b/flow-tests/test-frontend/vite-pwa-custom-offline-path/pom-production.xml
@@ -24,6 +24,22 @@
         </dependencies>
     </dependencyManagement>
 
+    <dependencies>
+        <!-- Temporary fix to workaround errors with internal selenium grid -->
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-devtools-v100</artifactId>
+            <version>4.2.2</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
     <build>
         <defaultGoal>jetty:run</defaultGoal>
         <plugins>

--- a/flow-tests/test-frontend/vite-pwa-custom-offline-path/pom.xml
+++ b/flow-tests/test-frontend/vite-pwa-custom-offline-path/pom.xml
@@ -20,6 +20,19 @@
             <artifactId>vaadin-dev-server</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- Temporary fix to workaround errors with internal selenium grid -->
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-devtools-v100</artifactId>
+            <version>4.2.2</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>

--- a/flow-tests/test-frontend/vite-pwa-production/pom.xml
+++ b/flow-tests/test-frontend/vite-pwa-production/pom.xml
@@ -31,6 +31,20 @@
             <artifactId>flow-test-lumo</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- Temporary fix to workaround errors with internal selenium grid -->
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-devtools-v100</artifactId>
+            <version>4.2.2</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/flow-tests/test-frontend/vite-pwa/pom.xml
+++ b/flow-tests/test-frontend/vite-pwa/pom.xml
@@ -35,6 +35,19 @@
             <artifactId>flow-test-lumo</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- Temporary fix to workaround errors with internal selenium grid -->
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-devtools-v100</artifactId>
+            <version>4.2.2</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Test using dev tools are not working with internal selenium grid
because it is not up to date. Adding dependency to support chrome 100
