### PR TITLE
fix: add empty export to vaadin-featureflags.ts

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateFeatureFlags.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateFeatureFlags.java
@@ -56,6 +56,9 @@ public class TaskGenerateFeatureFlags extends AbstractTaskClientGenerator {
                     feature.getId(), featureFlags.isEnabled(feature)));
         });
 
+        // See https://github.com/vaadin/flow/issues/14184
+        lines.add("export {};");
+
         return String.join(System.lineSeparator(), lines);
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateFeatureFlagsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateFeatureFlagsTest.java
@@ -96,6 +96,13 @@ public class TaskGenerateFeatureFlagsTest {
         assertFeatureFlagGlobal(content, FeatureFlags.EXAMPLE, true);
     }
 
+    @Test
+    public void should_containEmptyExport() throws ExecutionFailedException {
+        taskGenerateFeatureFlags.execute();
+        String content = taskGenerateFeatureFlags.getFileContent();
+        Assert.assertTrue(content.contains("export {};"));
+    }
+
     private static void assertFeatureFlagGlobal(String content, Feature feature,
             boolean enabled) {
         Assert.assertTrue(content


### PR DESCRIPTION
## Description

Adding a workaround as recommended by [TypeScript docs](https://www.typescriptlang.org/tsconfig#non-module-files).

Fixes #14184

## Type of change

- Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
