### PR TITLE
fix: Let DataCommunicator#flush keep track of its StateTree (CP: 9.0)

### DIFF
--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
@@ -1567,6 +1567,26 @@ public class DataCommunicatorTest {
                 600, queryCaptor.getValue().getLimit());
     }
 
+    // Simulates a flush request enqueued during a page reload with
+    // @PreserveOnRefresh
+    // see https://github.com/vaadin/flow/issues/14067
+    @Test
+    public void reattach_differentUI_requestFlushExecuted() {
+        dataCommunicator.setDataProvider(createDataProvider(), null);
+        dataCommunicator.setRequestedRange(0, 50);
+
+        MockUI newUI = new MockUI();
+        // simulates preserve on refresh
+        // DataCommunicator has a flushRequest pending
+        // that should be rescheduled on the new state tree
+        newUI.getInternals().moveElementsFrom(ui);
+        ui = newUI;
+        fakeClientCommunication();
+
+        Assert.assertEquals("Expected initial full reset.",
+                Range.withLength(0, 50), lastSet);
+    }
+
     @Tag("test-component")
     private static class TestComponent extends Component {
 


### PR DESCRIPTION
fix: Let DataCommunicator#flush keep track of which StateTree is supposed to execute its flushRequest (#14068)

* DataCommunicator#flush can be stuck when moving between UI instances, for instance when the @PreserveOnRefresh annotation is present.

Co-authored-by: Marco Collovati <mcollovati@gmail.com>

(cherry picked from commit c55bdcc6dd9dac75be42291b5752d1d86d5a9997)