### PR TITLE
fix: Let DataCommunicator#flush keep track of its StateTree (CP: 2.7)

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -379,7 +379,7 @@ public class DataCommunicator<T> implements Serializable {
     }
 
     private String getInvalidContractMessage(String method) {
-        return String.format("The data provider hasn't ever called %s() " + "method on the provided query. "
+        return String.format("The data provider hasn't ever called %s() method on the provided query. "
                 + "It means that the the data provider breaks the contract "
                 + "and the returned stream contains unxpected data.", method);
     }

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -35,6 +35,8 @@ import com.vaadin.flow.function.SerializableComparator;
 import com.vaadin.flow.function.SerializableConsumer;
 import com.vaadin.flow.internal.ExecutionContext;
 import com.vaadin.flow.internal.JsonUtils;
+import com.vaadin.flow.internal.NodeOwner;
+import com.vaadin.flow.internal.NullOwner;
 import com.vaadin.flow.internal.Range;
 import com.vaadin.flow.internal.StateNode;
 import com.vaadin.flow.shared.Registration;
@@ -48,13 +50,13 @@ import elemental.json.JsonObject;
 import elemental.json.JsonValue;
 
 /**
- * DataProvider base class. This class is the base for all DataProvider
- * communication implementations. It uses data generators ({@link BiFunction}s)
- * to write {@link JsonObject}s representing each data object to be sent to the
+ * DataProvider base class. This class is the base for all DataProvider communication implementations. It uses data
+ * generators ({@link BiFunction}s) to write {@link JsonObject}s representing each data object to be sent to the
  * client-side.
  *
  * @param <T>
  *            the bean type
+ *
  * @since 1.0
  */
 public class DataCommunicator<T> implements Serializable {
@@ -100,9 +102,8 @@ public class DataCommunicator<T> implements Serializable {
 
     private Registration dataProviderUpdateRegistration;
     private HashSet<T> updatedData = new HashSet<>();
-
-    private SerializableConsumer<ExecutionContext> flushRequest;
-    private SerializableConsumer<ExecutionContext> flushUpdatedDataRequest;
+    private FlushRequest flushRequest;
+    private FlushRequest flushUpdatedDataRequest;
 
     private static class SizeVerifier<T> implements Consumer<T>, Serializable {
 
@@ -118,10 +119,8 @@ public class DataCommunicator<T> implements Serializable {
         public void accept(T t) {
             size++;
             if (size > limit) {
-                throw new IllegalStateException(String.format(
-                        "The number of items returned by "
-                                + "the data provider exceeds the limit specified by the query (%d).",
-                        limit));
+                throw new IllegalStateException(String.format("The number of items returned by "
+                        + "the data provider exceeds the limit specified by the query (%d).", limit));
             }
         }
 
@@ -139,8 +138,7 @@ public class DataCommunicator<T> implements Serializable {
      * @param stateNode
      *            the state node used to communicate for
      */
-    public DataCommunicator(DataGenerator<T> dataGenerator,
-            ArrayUpdater arrayUpdater,
+    public DataCommunicator(DataGenerator<T> dataGenerator, ArrayUpdater arrayUpdater,
             SerializableConsumer<JsonArray> dataUpdater, StateNode stateNode) {
         this.dataGenerator = dataGenerator;
         this.arrayUpdater = arrayUpdater;
@@ -165,12 +163,10 @@ public class DataCommunicator<T> implements Serializable {
         if (length > MAXIMUM_ALLOWED_ITEMS) {
             getLogger().warn(
                     "Attempted to fetch more items from server than allowed "
-                            + "in one go: number of items requested '{}', maximum "
-                            + "items allowed '{}'.",
+                            + "in one go: number of items requested '{}', maximum " + "items allowed '{}'.",
                     length, MAXIMUM_ALLOWED_ITEMS);
         }
-        requestedRange = Range.withLength(start,
-                Math.min(length, MAXIMUM_ALLOWED_ITEMS));
+        requestedRange = Range.withLength(start, Math.min(length, MAXIMUM_ALLOWED_ITEMS));
 
         requestFlush();
     }
@@ -194,8 +190,7 @@ public class DataCommunicator<T> implements Serializable {
      *            updated data object; not {@code null}
      */
     public void refresh(T data) {
-        Objects.requireNonNull(data,
-                "DataCommunicator can not refresh null object");
+        Objects.requireNonNull(data, "DataCommunicator can not refresh null object");
         getKeyMapper().refresh(data);
         dataGenerator.refreshData(data);
         updatedData.add(data);
@@ -228,23 +223,20 @@ public class DataCommunicator<T> implements Serializable {
     /**
      * Sets the current data provider for this DataCommunicator.
      * <p>
-     * The returned consumer can be used to set some other filter value that
-     * should be included in queries sent to the data provider. It is only valid
-     * until another data provider is set.
+     * The returned consumer can be used to set some other filter value that should be included in queries sent to the
+     * data provider. It is only valid until another data provider is set.
      *
      * @param dataProvider
      *            the data provider to set, not <code>null</code>
      * @param initialFilter
-     *            the initial filter value to use, or <code>null</code> to not
-     *            use any initial filter value
+     *            the initial filter value to use, or <code>null</code> to not use any initial filter value
      *
      * @param <F>
      *            the filter type
      *
      * @return a consumer that accepts a new filter value to use
      */
-    public <F> SerializableConsumer<F> setDataProvider(
-            DataProvider<T, F> dataProvider, F initialFilter) {
+    public <F> SerializableConsumer<F> setDataProvider(DataProvider<T, F> dataProvider, F initialFilter) {
         Objects.requireNonNull(dataProvider, "data provider cannot be null");
         filter = initialFilter;
 
@@ -261,8 +253,7 @@ public class DataCommunicator<T> implements Serializable {
 
         return filter -> {
             if (this.dataProvider != dataProvider) {
-                throw new IllegalStateException(
-                        "Filter slot is no longer valid after data provider has been changed");
+                throw new IllegalStateException("Filter slot is no longer valid after data provider has been changed");
             }
 
             if (!Objects.equals(this.filter, filter)) {
@@ -273,9 +264,8 @@ public class DataCommunicator<T> implements Serializable {
     }
 
     /**
-     * Gets the {@link DataKeyMapper} used by this {@link DataCommunicator}. Key
-     * mapper can be used to map keys sent to the client-side back to their
-     * respective data objects.
+     * Gets the {@link DataKeyMapper} used by this {@link DataCommunicator}. Key mapper can be used to map keys sent to
+     * the client-side back to their respective data objects.
      *
      * @return key mapper
      */
@@ -284,9 +274,8 @@ public class DataCommunicator<T> implements Serializable {
     }
 
     /**
-     * Sets the {@link DataKeyMapper} used in this {@link DataCommunicator}. Key
-     * mapper can be used to map keys sent to the client-side back to their
-     * respective data objects.
+     * Sets the {@link DataKeyMapper} used in this {@link DataCommunicator}. Key mapper can be used to map keys sent to
+     * the client-side back to their respective data objects.
      *
      * @param keyMapper
      *            the keyMapper
@@ -337,8 +326,8 @@ public class DataCommunicator<T> implements Serializable {
     }
 
     /**
-     * Getter method for finding the size of DataProvider. Can be overridden by
-     * a subclass that uses a specific type of DataProvider and/or query.
+     * Getter method for finding the size of DataProvider. Can be overridden by a subclass that uses a specific type of
+     * DataProvider and/or query.
      *
      * @return the size of data provider with current filter
      */
@@ -363,17 +352,16 @@ public class DataCommunicator<T> implements Serializable {
      *            the starting index of the range
      * @param limit
      *            the max number of results
+     *
      * @return the list of items in given range
      *
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     protected Stream<T> fetchFromProvider(int offset, int limit) {
-        QueryTrace query = new QueryTrace(offset, limit, backEndSorting,
-                inMemorySorting, filter);
+        QueryTrace query = new QueryTrace(offset, limit, backEndSorting, inMemorySorting, filter);
         Stream<T> stream = getDataProvider().fetch(query);
         if (stream.isParallel()) {
-            getLogger().debug(
-                    "Data provider {} has returned parallel stream on 'fetch' call",
+            getLogger().debug("Data provider {} has returned parallel stream on 'fetch' call",
                     getDataProvider().getClass());
             stream = stream.collect(Collectors.toList()).stream();
             assert !stream.isParallel();
@@ -382,23 +370,18 @@ public class DataCommunicator<T> implements Serializable {
         stream = stream.peek(verifier);
 
         if (!query.isLimitCalled()) {
-            throw new IllegalStateException(
-                    getInvalidContractMessage("getLimit"));
+            throw new IllegalStateException(getInvalidContractMessage("getLimit"));
         }
         if (!query.isOffsetCalled()) {
-            throw new IllegalStateException(
-                    getInvalidContractMessage("getOffset"));
+            throw new IllegalStateException(getInvalidContractMessage("getOffset"));
         }
         return stream;
     }
 
     private String getInvalidContractMessage(String method) {
-        return String.format(
-                "The data provider hasn't ever called %s() "
-                        + "method on the provided query. "
-                        + "It means that the the data provider breaks the contract "
-                        + "and the returned stream contains unxpected data.",
-                method);
+        return String.format("The data provider hasn't ever called %s() " + "method on the provided query. "
+                + "It means that the the data provider breaks the contract "
+                + "and the returned stream contains unxpected data.", method);
     }
 
     private void handleAttach() {
@@ -406,14 +389,13 @@ public class DataCommunicator<T> implements Serializable {
             dataProviderUpdateRegistration.remove();
         }
 
-        dataProviderUpdateRegistration = getDataProvider()
-                .addDataProviderListener(event -> {
-                    if (event instanceof DataRefreshEvent) {
-                        handleDataRefreshEvent((DataRefreshEvent<T>) event);
-                    } else {
-                        reset();
-                    }
-                });
+        dataProviderUpdateRegistration = getDataProvider().addDataProviderListener(event -> {
+            if (event instanceof DataRefreshEvent) {
+                handleDataRefreshEvent((DataRefreshEvent<T>) event);
+            } else {
+                reset();
+            }
+        });
 
         // Ensure the initialize check is done
         requestFlush();
@@ -432,28 +414,28 @@ public class DataCommunicator<T> implements Serializable {
     }
 
     private void requestFlush() {
-        if (flushRequest == null) {
-            flushRequest = context -> {
+        requestFlush(false);
+    }
+
+    private void requestFlush(boolean forced) {
+        if (flushRequest == null || !flushRequest.canExecute(stateNode) || forced) {
+            flushRequest = FlushRequest.register(stateNode, context -> {
                 if (!context.isClientSideInitialized()) {
                     reset();
                     arrayUpdater.initialize();
                 }
                 flush();
                 flushRequest = null;
-            };
-            stateNode.runWhenAttached(ui -> ui.getInternals().getStateTree()
-                    .beforeClientResponse(stateNode, flushRequest));
+            });
         }
     }
 
     private void requestFlushUpdatedData() {
-        if (flushUpdatedDataRequest == null) {
-            flushUpdatedDataRequest = context -> {
+        if (flushUpdatedDataRequest == null || !flushUpdatedDataRequest.canExecute(stateNode)) {
+            flushUpdatedDataRequest = FlushRequest.register(stateNode, context -> {
                 flushUpdatedData();
                 flushUpdatedDataRequest = null;
-            };
-            stateNode.runWhenAttached(ui -> ui.getInternals().getStateTree()
-                    .beforeClientResponse(stateNode, flushUpdatedDataRequest));
+            });
         }
     }
 
@@ -461,28 +443,24 @@ public class DataCommunicator<T> implements Serializable {
         Set<String> oldActive = new HashSet<>(activeKeyOrder);
 
         Range effectiveRequested;
-        final Range previousActive = Range.withLength(activeStart,
-                activeKeyOrder.size());
+        final Range previousActive = Range.withLength(activeStart, activeKeyOrder.size());
 
         // Phase 1: Find all items that the client should have
         if (resendEntireRange) {
             assumedSize = getDataProviderSize();
         }
-        effectiveRequested = requestedRange
-                .restrictTo(Range.withLength(0, assumedSize));
+        effectiveRequested = requestedRange.restrictTo(Range.withLength(0, assumedSize));
 
         resendEntireRange |= !(previousActive.intersects(effectiveRequested)
                 || (previousActive.isEmpty() && effectiveRequested.isEmpty()));
 
-        Activation activation = collectKeysToFlush(previousActive,
-                effectiveRequested);
+        Activation activation = collectKeysToFlush(previousActive, effectiveRequested);
 
         // If the returned stream from the DataProvider is smaller than it
         // should, a new query for the actual size needs to be done
         if (activation.isSizeRecheckNeeded()) {
             assumedSize = getDataProviderSize();
-            effectiveRequested = requestedRange
-                    .restrictTo(Range.withLength(0, assumedSize));
+            effectiveRequested = requestedRange.restrictTo(Range.withLength(0, assumedSize));
         }
 
         activeKeyOrder = activation.getActiveKeys();
@@ -490,8 +468,7 @@ public class DataCommunicator<T> implements Serializable {
 
         // Phase 2: Collect changes to send
         Update update = arrayUpdater.startUpdate(assumedSize);
-        boolean updated = collectChangesToSend(previousActive,
-                effectiveRequested, update);
+        boolean updated = collectChangesToSend(previousActive, effectiveRequested, update);
 
         resendEntireRange = false;
         assumeEmptyClient = false;
@@ -507,15 +484,13 @@ public class DataCommunicator<T> implements Serializable {
         if (updatedData.isEmpty()) {
             return;
         }
-        dataUpdater.accept(updatedData.stream().map(this::generateJson)
-                .collect(JsonUtils.asArray()));
+        dataUpdater.accept(updatedData.stream().map(this::generateJson).collect(JsonUtils.asArray()));
         updatedData.clear();
     }
 
     private void unregisterPassivatedKeys() {
         /*
-         * Actually unregister anything that was removed in an update that the
-         * client has confirmed that it has applied.
+         * Actually unregister anything that was removed in an update that the client has confirmed that it has applied.
          */
         if (!confirmedUpdates.isEmpty()) {
             confirmedUpdates.forEach(this::doUnregister);
@@ -536,13 +511,10 @@ public class DataCommunicator<T> implements Serializable {
         }
     }
 
-    private void passivateInactiveKeys(Set<String> oldActive, Update update,
-            boolean updated) {
+    private void passivateInactiveKeys(Set<String> oldActive, Update update, boolean updated) {
         /*
-         * We cannot immediately unregister keys that we have asked the client
-         * to remove, since the client might send a message using that key
-         * before our message about removal arrives at the client and is
-         * applied.
+         * We cannot immediately unregister keys that we have asked the client to remove, since the client might send a
+         * message using that key before our message about removal arrives at the client and is applied.
          */
         if (updated) {
             int updateId = nextUpdateId++;
@@ -556,50 +528,41 @@ public class DataCommunicator<T> implements Serializable {
         }
     }
 
-    private boolean collectChangesToSend(final Range previousActive,
-            final Range effectiveRequested, Update update) {
+    private boolean collectChangesToSend(final Range previousActive, final Range effectiveRequested, Update update) {
         boolean updated = false;
         if (assumeEmptyClient || resendEntireRange) {
             if (!assumeEmptyClient) {
                 /*
-                 * TODO: Not necessary to clear something that would be set back
-                 * a few lines later in the code.
+                 * TODO: Not necessary to clear something that would be set back a few lines later in the code.
                  *
-                 * It's not that straightforward because one has to care about
-                 * indexes aligned with pageSize (because of the code on the
-                 * client side).
+                 * It's not that straightforward because one has to care about indexes aligned with pageSize (because of
+                 * the code on the client side).
                  */
-                update.clear(previousActive.getStart(),
-                        previousActive.length());
+                update.clear(previousActive.getStart(), previousActive.length());
             }
 
             update.set(activeStart, getJsonItems(effectiveRequested));
             updated = true;
         } else if (!previousActive.equals(effectiveRequested)) {
             /*
-             * There are some parts common between what we have and what we
-             * should have, but the beginning and/or the end has too many or too
-             * few items.
+             * There are some parts common between what we have and what we should have, but the beginning and/or the
+             * end has too many or too few items.
              */
 
             // Clear previously active items missing from requested
-            withMissing(previousActive, effectiveRequested,
-                    range -> update.clear(range.getStart(), range.length()));
+            withMissing(previousActive, effectiveRequested, range -> update.clear(range.getStart(), range.length()));
 
             // Set requested items missing from previously active
-            withMissing(effectiveRequested, previousActive,
-                    range -> update.set(range.getStart(), getJsonItems(range)));
+            withMissing(effectiveRequested, previousActive, range -> update.set(range.getStart(), getJsonItems(range)));
             updated = true;
         }
         return updated;
     }
 
-    private Activation collectKeysToFlush(final Range previousActive,
-            final Range effectiveRequested) {
+    private Activation collectKeysToFlush(final Range previousActive, final Range effectiveRequested) {
         /*
-         * Collecting all items even though only some small sub range would
-         * actually be useful can be optimized away once we have some actual
-         * test coverage for the logic here.
+         * Collecting all items even though only some small sub range would actually be useful can be optimized away
+         * once we have some actual test coverage for the logic here.
          */
         if (resendEntireRange) {
             return activate(effectiveRequested);
@@ -607,8 +570,7 @@ public class DataCommunicator<T> implements Serializable {
             List<String> newActiveKeyOrder = new ArrayList<>();
             boolean sizeRecheckNeeded = false;
 
-            Range[] partitionWith = effectiveRequested
-                    .partitionWith(previousActive);
+            Range[] partitionWith = effectiveRequested.partitionWith(previousActive);
 
             Activation activation = activate(partitionWith[0]);
             newActiveKeyOrder.addAll(activation.getActiveKeys());
@@ -621,8 +583,7 @@ public class DataCommunicator<T> implements Serializable {
                 // needs to be returned
                 return Activation.empty();
             }
-            newActiveKeyOrder.addAll(activeKeyOrder.subList(overlap.getStart(),
-                    overlap.getEnd()));
+            newActiveKeyOrder.addAll(activeKeyOrder.subList(overlap.getStart(), overlap.getEnd()));
 
             activation = activate(partitionWith[2]);
             newActiveKeyOrder.addAll(activation.getActiveKeys());
@@ -632,22 +593,18 @@ public class DataCommunicator<T> implements Serializable {
     }
 
     private List<JsonValue> getJsonItems(Range range) {
-        return range.stream()
-                .mapToObj(index -> activeKeyOrder.get(index - activeStart))
-                .map(keyMapper::get).map(this::generateJson)
-                .collect(Collectors.toList());
+        return range.stream().mapToObj(index -> activeKeyOrder.get(index - activeStart)).map(keyMapper::get)
+                .map(this::generateJson).collect(Collectors.toList());
     }
 
-    private static final void withMissing(Range expected, Range actual,
-            Consumer<Range> action) {
+    private static final void withMissing(Range expected, Range actual, Consumer<Range> action) {
         Range[] partition = expected.partitionWith(actual);
 
         applyIfNotEmpty(partition[0], action);
         applyIfNotEmpty(partition[2], action);
     }
 
-    private static final void applyIfNotEmpty(Range range,
-            Consumer<Range> action) {
+    private static final void applyIfNotEmpty(Range range, Consumer<Range> action) {
         if (!range.isEmpty()) {
             action.accept(range);
         }
@@ -666,8 +623,7 @@ public class DataCommunicator<T> implements Serializable {
             if (mapperHasKey) {
                 // Ensure latest instance from provider is used
                 keyMapper.refresh(bean);
-                passivatedByUpdate.values().stream()
-                        .forEach(set -> set.remove(key));
+                passivatedByUpdate.values().stream().forEach(set -> set.remove(key));
             }
             activeKeys.add(key);
         });
@@ -701,6 +657,25 @@ public class DataCommunicator<T> implements Serializable {
 
         public static Activation empty() {
             return new Activation(Collections.emptyList(), false);
+        }
+    }
+
+    private static class FlushRequest implements Serializable {
+
+        private NodeOwner owner;
+
+        static FlushRequest register(StateNode stateNode, SerializableConsumer<ExecutionContext> action) {
+            FlushRequest request = new FlushRequest();
+            request.owner = stateNode.getOwner();
+            stateNode.runWhenAttached(ui -> {
+                request.owner = stateNode.getOwner();
+                ui.getInternals().getStateTree().beforeClientResponse(stateNode, action);
+            });
+            return request;
+        }
+
+        boolean canExecute(StateNode stateNode) {
+            return owner instanceof NullOwner || owner == stateNode.getOwner();
         }
     }
 

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/DataCommunicatorTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -131,12 +132,10 @@ public class DataCommunicatorTest {
             }
         };
 
-        Mockito.when(arrayUpdater.startUpdate(Mockito.anyInt()))
-                .thenReturn(update);
+        Mockito.when(arrayUpdater.startUpdate(Mockito.anyInt())).thenReturn(update);
 
-        dataCommunicator = new DataCommunicator<>(dataGenerator, arrayUpdater,
-                data -> {
-                }, element.getNode());
+        dataCommunicator = new DataCommunicator<>(dataGenerator, arrayUpdater, data -> {
+        }, element.getNode());
     }
 
     @Test
@@ -145,17 +144,13 @@ public class DataCommunicatorTest {
         fakeClientCommunication();
 
         Assert.assertEquals(Range.withLength(0, 0), lastSet);
-        Assert.assertNull(
-                "Only requestAll should clear items. This may make us loop.",
-                lastClear);
+        Assert.assertNull("Only requestAll should clear items. This may make us loop.", lastClear);
 
         dataCommunicator.setRequestedRange(0, 0);
         fakeClientCommunication();
 
         Assert.assertEquals(Range.withLength(0, 0), lastSet);
-        Assert.assertNull(
-                "Only requestAll should clear items. Which would make us loop.",
-                lastClear);
+        Assert.assertNull("Only requestAll should clear items. Which would make us loop.", lastClear);
     }
 
     @Test
@@ -165,15 +160,12 @@ public class DataCommunicatorTest {
         dataCommunicator.setRequestedRange(0, 50);
         fakeClientCommunication();
 
-        Assert.assertEquals(
-                "Expected request range for 50 items on first request.",
-                Range.withLength(0, 50), lastSet);
+        Assert.assertEquals("Expected request range for 50 items on first request.", Range.withLength(0, 50), lastSet);
 
         dataCommunicator.setRequestedRange(0, 70);
         fakeClientCommunication();
 
-        Assert.assertEquals("Expected request range for 20 new items.",
-                Range.withLength(50, 20), lastSet);
+        Assert.assertEquals("Expected request range for 20 new items.", Range.withLength(50, 20), lastSet);
     }
 
     @Test
@@ -182,8 +174,7 @@ public class DataCommunicatorTest {
         dataCommunicator.setRequestedRange(0, 50);
         fakeClientCommunication();
 
-        Assert.assertEquals("Expected initial full reset.",
-                Range.withLength(0, 50), lastSet);
+        Assert.assertEquals("Expected initial full reset.", Range.withLength(0, 50), lastSet);
         lastSet = null;
 
         element.removeFromParent();
@@ -194,8 +185,7 @@ public class DataCommunicatorTest {
         ui.getElement().appendChild(element);
         fakeClientCommunication();
 
-        Assert.assertEquals("Expected initial full reset after reattach",
-                Range.withLength(0, 50), lastSet);
+        Assert.assertEquals("Expected initial full reset after reattach", Range.withLength(0, 50), lastSet);
     }
 
     @Test
@@ -204,8 +194,7 @@ public class DataCommunicatorTest {
         dataCommunicator.setRequestedRange(0, 50);
         fakeClientCommunication();
 
-        Assert.assertEquals("Expected initial full reset.",
-                Range.withLength(0, 50), lastSet);
+        Assert.assertEquals("Expected initial full reset.", Range.withLength(0, 50), lastSet);
         lastSet = null;
 
         element.removeFromParent();
@@ -227,8 +216,7 @@ public class DataCommunicatorTest {
         Assert.assertEquals(0, dataCommunicator.getKeyMapper().get("1").id);
 
         dataCommunicator.setDataProvider(createDataProvider(), null);
-        Assert.assertNull(
-                "The KeyMapper should be reset when a new DataProvider is set",
+        Assert.assertNull("The KeyMapper should be reset when a new DataProvider is set",
                 dataCommunicator.getKeyMapper().get("1"));
     }
 
@@ -238,17 +226,15 @@ public class DataCommunicatorTest {
         for (int i = 0; i < 2; i++) {
             items.add(new Item(i));
         }
-        DataProvider<Item, Void> dataProvider = DataProvider
-                .fromCallbacks(query -> {
-                    return items.stream();
-                }, query -> {
-                    return items.size();
-                });
+        DataProvider<Item, Void> dataProvider = DataProvider.fromCallbacks(query -> {
+            return items.stream();
+        }, query -> {
+            return items.size();
+        });
         dataCommunicator.setDataProvider(dataProvider, null);
 
         expectedException.expect(IllegalStateException.class);
-        expectedException.expectMessage(CoreMatchers.containsString(
-                "The data provider hasn't ever called getLimit"));
+        expectedException.expectMessage(CoreMatchers.containsString("The data provider hasn't ever called getLimit"));
         dataCommunicator.fetchFromProvider(0, 1);
     }
 
@@ -258,18 +244,16 @@ public class DataCommunicatorTest {
         for (int i = 0; i < 2; i++) {
             items.add(new Item(i));
         }
-        DataProvider<Item, Void> dataProvider = DataProvider
-                .fromCallbacks(query -> {
-                    query.getLimit();
-                    return items.stream();
-                }, query -> {
-                    return items.size();
-                });
+        DataProvider<Item, Void> dataProvider = DataProvider.fromCallbacks(query -> {
+            query.getLimit();
+            return items.stream();
+        }, query -> {
+            return items.size();
+        });
         dataCommunicator.setDataProvider(dataProvider, null);
 
         expectedException.expect(IllegalStateException.class);
-        expectedException.expectMessage(CoreMatchers.containsString(
-                "The data provider hasn't ever called getOffset"));
+        expectedException.expectMessage(CoreMatchers.containsString("The data provider hasn't ever called getOffset"));
         dataCommunicator.fetchFromProvider(1, 1);
     }
 
@@ -279,21 +263,19 @@ public class DataCommunicatorTest {
         for (int i = 0; i < 2; i++) {
             items.add(new Item(i));
         }
-        DataProvider<Item, Void> dataProvider = DataProvider
-                .fromCallbacks(query -> {
-                    query.getOffset();
-                    query.getLimit();
-                    return items.stream();
-                }, query -> {
-                    return items.size();
-                });
+        DataProvider<Item, Void> dataProvider = DataProvider.fromCallbacks(query -> {
+            query.getOffset();
+            query.getLimit();
+            return items.stream();
+        }, query -> {
+            return items.size();
+        });
         dataCommunicator.setDataProvider(dataProvider, null);
 
         Stream<Item> stream = dataCommunicator.fetchFromProvider(0, 1);
 
         expectedException.expect(IllegalStateException.class);
-        expectedException.expectMessage(CoreMatchers.containsString(
-                "exceeds the limit specified by the query (1)."));
+        expectedException.expectMessage(CoreMatchers.containsString("exceeds the limit specified by the query (1)."));
 
         stream.forEach(item -> {
         });
@@ -315,8 +297,7 @@ public class DataCommunicatorTest {
         Item originalItem = items.get(0);
         String key = dataCommunicator.getKeyMapper().key(originalItem);
 
-        Assert.assertSame(originalItem,
-                dataCommunicator.getKeyMapper().get(key));
+        Assert.assertSame(originalItem, dataCommunicator.getKeyMapper().get(key));
 
         Item updatedItem = new Item(originalItem.id, "Updated");
         items.set(0, updatedItem);
@@ -324,14 +305,12 @@ public class DataCommunicatorTest {
 
         fakeClientCommunication();
 
-        Assert.assertSame(updatedItem,
-                dataCommunicator.getKeyMapper().get(key));
+        Assert.assertSame(updatedItem, dataCommunicator.getKeyMapper().get(key));
     }
 
     @Test
     public void dataProviderReturnsLessItemsThanRequested_aNewSizeQueryIsPerformed() {
-        AbstractDataProvider<Item, Object> dataProvider = createDataProviderThatChangesSize(
-                50, 10);
+        AbstractDataProvider<Item, Object> dataProvider = createDataProviderThatChangesSize(50, 10);
         dataProvider = Mockito.spy(dataProvider);
         dataCommunicator.setDataProvider(dataProvider, null);
 
@@ -352,9 +331,8 @@ public class DataCommunicatorTest {
         AtomicInteger listenerInvocationCounter = new AtomicInteger(0);
 
         TestComponent componentWithDataProvider = new TestComponent();
-        dataCommunicator = new DataCommunicator<Item>(dataGenerator,
-                arrayUpdater, data -> {
-                }, componentWithDataProvider.getElement().getNode()) {
+        dataCommunicator = new DataCommunicator<Item>(dataGenerator, arrayUpdater, data -> {
+        }, componentWithDataProvider.getElement().getNode()) {
             @Override
             public void reset() {
                 listenerInvocationCounter.incrementAndGet();
@@ -368,10 +346,8 @@ public class DataCommunicatorTest {
         ui.add(componentWithDataProvider);
         fakeClientCommunication();
 
-        Assert.assertEquals(
-                "Expected two DataCommunicator::reset() invocations: upon "
-                        + "setting the data provider and component attaching",
-                2, listenerInvocationCounter.get());
+        Assert.assertEquals("Expected two DataCommunicator::reset() invocations: upon "
+                + "setting the data provider and component attaching", 2, listenerInvocationCounter.get());
 
         // when
         // the data is being refreshed -> data provider's listeners are being
@@ -388,22 +364,17 @@ public class DataCommunicatorTest {
 
     @Test
     public void setRequestedRange_tooMuchItemsRequested_maxItemsAllowedRequested() {
-        DataProvider<Item, Object> dataProvider = Mockito
-                .spy(createDataProvider(2000));
+        DataProvider<Item, Object> dataProvider = Mockito.spy(createDataProvider(2000));
         dataCommunicator.setDataProvider(dataProvider, null);
         // More than allowed (1000) items requested
         dataCommunicator.setRequestedRange(0, 1001);
         fakeClientCommunication();
 
-        ArgumentCaptor<Query> queryCaptor = ArgumentCaptor
-                .forClass(Query.class);
-        Mockito.verify(dataProvider, Mockito.times(1))
-                .fetch(queryCaptor.capture());
+        ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
+        Mockito.verify(dataProvider, Mockito.times(1)).fetch(queryCaptor.capture());
 
-        Assert.assertEquals(
-                "Expected the requested items count to be limited"
-                        + " to allowed threshold",
-                1000, queryCaptor.getValue().getLimit());
+        Assert.assertEquals("Expected the requested items count to be limited" + " to allowed threshold", 1000,
+                queryCaptor.getValue().getLimit());
     }
 
     private void fakeClientCommunication() {
@@ -412,8 +383,7 @@ public class DataCommunicatorTest {
         });
     }
 
-    private AbstractDataProvider<Item, Object> createDataProviderThatChangesSize(
-            final int size, final int delta) {
+    private AbstractDataProvider<Item, Object> createDataProviderThatChangesSize(final int size, final int delta) {
         return new AbstractDataProvider<Item, Object>() {
             private boolean modifiedCount;
 
@@ -437,8 +407,7 @@ public class DataCommunicatorTest {
                     count -= delta;
                     modifiedCount = true;
                 }
-                return IntStream.range(query.getOffset(), count)
-                        .mapToObj(Item::new);
+                return IntStream.range(query.getOffset(), count).mapToObj(Item::new);
             }
         };
     }
@@ -461,10 +430,7 @@ public class DataCommunicatorTest {
 
             @Override
             public Stream<Item> fetch(Query<Item, Object> query) {
-                return IntStream
-                        .range(query.getOffset(),
-                                query.getLimit() + query.getOffset())
-                        .mapToObj(Item::new);
+                return IntStream.range(query.getOffset(), query.getLimit() + query.getOffset()).mapToObj(Item::new);
             }
         };
     }
@@ -506,12 +472,10 @@ public class DataCommunicatorTest {
 
     public static class MockVaadinSession extends VaadinSession {
         /*
-         * Used to make sure there's at least one reference to the mock session
-         * while it's locked. This is used to prevent the session from being
-         * eaten by GC in tests where @Before creates a session and sets it as
-         * the current instance without keeping any direct reference to it. This
-         * pattern has a chance of leaking memory if the session is not unlocked
-         * in the right way, but it should be acceptable for testing use.
+         * Used to make sure there's at least one reference to the mock session while it's locked. This is used to
+         * prevent the session from being eaten by GC in tests where @Before creates a session and sets it as the
+         * current instance without keeping any direct reference to it. This pattern has a chance of leaking memory if
+         * the session is not unlocked in the right way, but it should be acceptable for testing use.
          */
         private static final ThreadLocal<MockVaadinSession> referenceKeeper = new ThreadLocal<>();
 
@@ -549,6 +513,33 @@ public class DataCommunicatorTest {
         private int closeCount;
 
         private ReentrantLock lock = new ReentrantLock();
+    }
+
+    // Simulates a flush request enqueued during a page reload with
+    // @PreserveOnRefresh
+    // see https://github.com/vaadin/flow/issues/14067
+    @Test
+    public void reattach_differentUI_requestFlushExecuted() {
+        dataCommunicator.setDataProvider(createDataProvider(), null);
+        dataCommunicator.setRequestedRange(0, 50);
+
+        MockUI newUI = new MockUI();
+        // simulates preserve on refresh
+        // DataCommunicator has a flushRequest pending
+        // that should be rescheduled on the new state tree
+        moveToNewUI(ui, newUI.getInternals().getUI());
+        ui = newUI;
+        fakeClientCommunication();
+
+        Assert.assertEquals("Expected initial full reset.", Range.withLength(0, 50), lastSet);
+    }
+
+    private void moveToNewUI(UI oldUI, UI newUI) {
+        final List<Element> uiChildren = oldUI.getElement().getChildren().collect(Collectors.toList());
+        uiChildren.forEach(element -> {
+            element.removeFromTree();
+            newUI.getElement().appendChild(element);
+        });
     }
 
     @Tag("test-component")


### PR DESCRIPTION
fix: Let DataCommunicator#flush keep track of which StateTree is supposed to execute its flushRequest (#14068)

* DataCommunicator#flush can be stuck when moving between UI instances, for instance when the @PreserveOnRefresh annotation is present.

Co-authored-by: Marco Collovati mcollovati@gmail.com

(cherry picked from commit c55bdcc6dd9dac75be42291b5752d1d86d5a9997)
