### PR TITLE
feat: collection based append/remove methods for Node (#13599)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentWrapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentWrapper.java
@@ -89,8 +89,7 @@ public class WebComponentWrapper extends Component {
             WebComponentBinding<?> binding, List<Element> bootstrapElements) {
         this(rootElement, binding);
         // shadow root is attached in this(...)
-        getElement().getShadowRoot().ifPresent(shadow -> shadow
-                .appendChild(bootstrapElements.toArray(new Element[0])));
+        getElement().getShadowRoot().ifPresent(shadow -> shadow.appendChild(bootstrapElements));
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentWrapper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/webcomponent/WebComponentWrapper.java
@@ -89,7 +89,8 @@ public class WebComponentWrapper extends Component {
             WebComponentBinding<?> binding, List<Element> bootstrapElements) {
         this(rootElement, binding);
         // shadow root is attached in this(...)
-        getElement().getShadowRoot().ifPresent(shadow -> shadow.appendChild(bootstrapElements));
+        getElement().getShadowRoot()
+                .ifPresent(shadow -> shadow.appendChild(bootstrapElements));
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/dom/ChildElementConsumer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/ChildElementConsumer.java
@@ -33,7 +33,7 @@ public interface ChildElementConsumer extends Consumer<Element>, Serializable {
 
     /**
      * This callback method is called when the request initiated by the
-     * {@link Node#appendChild(Element...)} method is successfully executed.
+     * {@link Node#appendChild(Element)} method is successfully executed.
      * <p>
      * The parameter value is the element created by the request.
      *

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Node.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Node.java
@@ -150,8 +150,7 @@ public abstract class Node<N extends Node<N>> implements Serializable {
 
     public N appendChild(Element child) {
         if (child == null) {
-            throw new IllegalArgumentException(
-                    THE_CHILD_CANNOT_BE_NULL);
+            throw new IllegalArgumentException(THE_CHILD_CANNOT_BE_NULL);
         }
 
         insertChild(getChildCount(), child);
@@ -198,8 +197,8 @@ public abstract class Node<N extends Node<N>> implements Serializable {
      * Appends the given child as the virtual child of the element.
      * <p>
      * The virtual child is not really a child of the DOM element. The
-     * client-side counterpart is created in the memory, but it's not attached to
-     * the DOM tree. The resulting element is referenced via the server side
+     * client-side counterpart is created in the memory, but it's not attached
+     * to the DOM tree. The resulting element is referenced via the server side
      * {@link Element} in JS function call as usual.
      *
      * @param child
@@ -208,8 +207,7 @@ public abstract class Node<N extends Node<N>> implements Serializable {
      */
     public N appendVirtualChild(Element child) {
         if (child == null) {
-            throw new IllegalArgumentException(
-                    THE_CHILD_CANNOT_BE_NULL);
+            throw new IllegalArgumentException(THE_CHILD_CANNOT_BE_NULL);
         }
 
         Node<?> parentNode = child.getParentNode();
@@ -229,8 +227,8 @@ public abstract class Node<N extends Node<N>> implements Serializable {
      * Appends the given children as the virtual children of the element.
      * <p>
      * The virtual child is not really a child of the DOM element. The
-     * client-side counterpart is created in the memory, but it's not attached to
-     * the DOM tree. The resulting element is referenced via the server side
+     * client-side counterpart is created in the memory, but it's not attached
+     * to the DOM tree. The resulting element is referenced via the server side
      * {@link Element} in JS function call as usual.
      *
      * @param children
@@ -279,12 +277,12 @@ public abstract class Node<N extends Node<N>> implements Serializable {
     }
 
     /**
-     * Removes the given child that has been attached as the virtual
-     * child of this element.
+     * Removes the given child that has been attached as the virtual child of
+     * this element.
      * <p>
      * The virtual child is not really a child of the DOM element. The
-     * client-side counterpart is created in the memory, but it's not attached to
-     * the DOM tree. The resulting element is referenced via the server side
+     * client-side counterpart is created in the memory, but it's not attached
+     * to the DOM tree. The resulting element is referenced via the server side
      * {@link Element} in JS function call as usual. *
      *
      * @param child
@@ -298,8 +296,7 @@ public abstract class Node<N extends Node<N>> implements Serializable {
      */
     public N removeVirtualChild(Element child) {
         if (child == null) {
-            throw new IllegalArgumentException(
-                    THE_CHILD_CANNOT_BE_NULL);
+            throw new IllegalArgumentException(THE_CHILD_CANNOT_BE_NULL);
         }
 
         if (getNode().hasFeature(VirtualChildrenList.class)) {
@@ -404,8 +401,7 @@ public abstract class Node<N extends Node<N>> implements Serializable {
 
     private N insertChild(AtomicInteger index, Element child) {
         if (child == null) {
-            throw new IllegalArgumentException(
-                    THE_CHILD_CANNOT_BE_NULL);
+            throw new IllegalArgumentException(THE_CHILD_CANNOT_BE_NULL);
         }
 
         if (index.get() > getChildCount()) {
@@ -545,8 +541,7 @@ public abstract class Node<N extends Node<N>> implements Serializable {
      */
     public N removeChild(Element child) {
         if (child == null) {
-            throw new IllegalArgumentException(
-                    THE_CHILD_CANNOT_BE_NULL);
+            throw new IllegalArgumentException(THE_CHILD_CANNOT_BE_NULL);
         }
 
         return removeChild(Collections.singleton(child));
@@ -565,9 +560,9 @@ public abstract class Node<N extends Node<N>> implements Serializable {
                     THE_CHILDREN_COLLECTION_CANNOT_BE_NULL);
         }
 
-        children.stream()
-                .peek(child -> ensureChildHasParent(child, false))
-                .forEach(child -> getStateProvider().removeChild(getNode(), child));
+        children.stream().peek(child -> ensureChildHasParent(child, false))
+                .forEach(child -> getStateProvider().removeChild(getNode(),
+                        child));
 
         return getSelf();
     }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/NodeVisitor.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/NodeVisitor.java
@@ -42,7 +42,7 @@ public interface NodeVisitor {
         /**
          * The type of the virtual element: the element which has been created
          * via Element API and attached using
-         * {@link Element#appendVirtualChild(Element...)}.
+         * {@link Element#appendVirtualChild(Element)}.
          */
         VIRTUAL,
         /**

--- a/flow-server/src/test/java/com/vaadin/flow/component/AbstractCompositeFieldTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/AbstractCompositeFieldTest.java
@@ -97,8 +97,8 @@ public class AbstractCompositeFieldTest {
         public MultipleFieldsField() {
             super(null);
 
-            getContent().getElement().appendChild(start.getElement(),
-                    rest.getElement());
+            getContent().getElement().appendChild(start.getElement())
+                    .appendChild(rest.getElement());
 
             start.addValueChangeListener(
                     event -> updateValue(event.isFromClient()));

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
@@ -281,9 +281,8 @@ public class ComponentTest {
         child1SpanComponent = new TestComponent(
                 ElementFactory.createSpan("Span"));
         child2InputComponent = new TestComponent(ElementFactory.createInput());
-        parentDivComponent.getElement().appendChild(
-                child1SpanComponent.getElement(),
-                child2InputComponent.getElement());
+        parentDivComponent.getElement().appendChild(child1SpanComponent.getElement())
+                        .appendChild(child2InputComponent.getElement());
 
         mocks = new MockServletServiceSessionSetup();
 
@@ -395,9 +394,9 @@ public class ComponentTest {
         Element parentElement = parent.getElement();
         parentElement.appendChild(
                 new Element("level1").appendChild(
-                        new Element("level2").appendChild(child1.getElement())),
-                child2.getElement(),
-                new Element("level1b").appendChild(child3.getElement()));
+                        new Element("level2").appendChild(child1.getElement())))
+                .appendChild(child2.getElement())
+                .appendChild(new Element("level1b").appendChild(child3.getElement()));
 
         List<Component> children = parent.getChildren()
                 .collect(Collectors.toList());

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
@@ -281,8 +281,9 @@ public class ComponentTest {
         child1SpanComponent = new TestComponent(
                 ElementFactory.createSpan("Span"));
         child2InputComponent = new TestComponent(ElementFactory.createInput());
-        parentDivComponent.getElement().appendChild(child1SpanComponent.getElement())
-                        .appendChild(child2InputComponent.getElement());
+        parentDivComponent.getElement()
+                .appendChild(child1SpanComponent.getElement())
+                .appendChild(child2InputComponent.getElement());
 
         mocks = new MockServletServiceSessionSetup();
 
@@ -392,11 +393,12 @@ public class ComponentTest {
                 ElementFactory.createDiv("Child2"));
 
         Element parentElement = parent.getElement();
-        parentElement.appendChild(
-                new Element("level1").appendChild(
+        parentElement
+                .appendChild(new Element("level1").appendChild(
                         new Element("level2").appendChild(child1.getElement())))
                 .appendChild(child2.getElement())
-                .appendChild(new Element("level1b").appendChild(child3.getElement()));
+                .appendChild(new Element("level1b")
+                        .appendChild(child3.getElement()));
 
         List<Component> children = parent.getChildren()
                 .collect(Collectors.toList());

--- a/flow-server/src/test/java/com/vaadin/flow/dom/AbstractNodeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/AbstractNodeTest.java
@@ -114,8 +114,7 @@ public abstract class AbstractNodeTest {
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
         Element child3 = new Element("child3");
-        parent.appendChild(child1).appendChild(child2)
-                .appendChild(child3);
+        parent.appendChild(child1).appendChild(child2).appendChild(child3);
         parent.removeChild(child1);
 
         assertChildren(parent, child2, child3);
@@ -127,8 +126,7 @@ public abstract class AbstractNodeTest {
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
         Element child3 = new Element("child3");
-        parent.appendChild(child1).appendChild(child2)
-                .appendChild(child3);
+        parent.appendChild(child1).appendChild(child2).appendChild(child3);
         parent.removeChild(0);
 
         assertChildren(parent, child2, child3);
@@ -140,8 +138,7 @@ public abstract class AbstractNodeTest {
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
         Element child3 = new Element("child3");
-        parent.appendChild(child1).appendChild(child2)
-                .appendChild(child3);
+        parent.appendChild(child1).appendChild(child2).appendChild(child3);
         parent.removeChild(child1).removeChild(child2);
 
         assertChildren(parent, child3);
@@ -153,8 +150,7 @@ public abstract class AbstractNodeTest {
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
         Element child3 = new Element("child3");
-        parent.appendChild(child1).appendChild(child2)
-                .appendChild(child3);
+        parent.appendChild(child1).appendChild(child2).appendChild(child3);
         parent.removeChild(child2);
 
         assertChildren(parent, child1, child3);
@@ -166,8 +162,7 @@ public abstract class AbstractNodeTest {
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
         Element child3 = new Element("child3");
-        parent.appendChild(child1).appendChild(child2)
-                .appendChild(child3);
+        parent.appendChild(child1).appendChild(child2).appendChild(child3);
         parent.removeChild(1);
 
         assertChildren(parent, child1, child3);
@@ -180,8 +175,8 @@ public abstract class AbstractNodeTest {
         Element child2 = new Element("child2");
         Element child3 = new Element("child3");
         Element child4 = new Element("child4");
-        parent.appendChild(child1).appendChild(child2)
-                .appendChild(child3).appendChild(child4);
+        parent.appendChild(child1).appendChild(child2).appendChild(child3)
+                .appendChild(child4);
         parent.removeChild(child2).removeChild(child3);
 
         assertChildren(parent, child1, child4);
@@ -193,8 +188,7 @@ public abstract class AbstractNodeTest {
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
         Element child3 = new Element("child3");
-        parent.appendChild(child1).appendChild(child2)
-                .appendChild(child3);
+        parent.appendChild(child1).appendChild(child2).appendChild(child3);
         parent.removeChild(child3);
 
         assertChildren(parent, child1, child2);
@@ -206,8 +200,7 @@ public abstract class AbstractNodeTest {
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
         Element child3 = new Element("child3");
-        parent.appendChild(child1).appendChild(child2)
-                .appendChild(child3);
+        parent.appendChild(child1).appendChild(child2).appendChild(child3);
         parent.removeChild(2);
 
         assertChildren(parent, child1, child2);
@@ -220,8 +213,8 @@ public abstract class AbstractNodeTest {
         Element child2 = new Element("child2");
         Element child3 = new Element("child3");
         Element child4 = new Element("child4");
-        parent.appendChild(child1).appendChild(child2)
-                .appendChild(child3).appendChild(child4);
+        parent.appendChild(child1).appendChild(child2).appendChild(child3)
+                .appendChild(child4);
         parent.removeChild(child3).removeChild(child4);
 
         assertChildren(parent, child1, child2);
@@ -234,8 +227,8 @@ public abstract class AbstractNodeTest {
         Element child2 = new Element("child2");
         Element child3 = new Element("child3");
         Element child4 = new Element("child4");
-        parent.appendChild(child1).appendChild(child2)
-                .appendChild(child3).appendChild(child4);
+        parent.appendChild(child1).appendChild(child2).appendChild(child3)
+                .appendChild(child4);
         parent.removeAllChildren();
 
         assertChildren(parent);
@@ -257,8 +250,7 @@ public abstract class AbstractNodeTest {
         Element child2 = ElementFactory.createDiv();
         Element child3 = ElementFactory.createDiv();
 
-        parent.appendChild(child1).appendChild(child2)
-                .appendChild(child3);
+        parent.appendChild(child1).appendChild(child2).appendChild(child3);
 
         List<Element> children = parent.getChildren()
                 .collect(Collectors.toList());
@@ -286,8 +278,8 @@ public abstract class AbstractNodeTest {
         Element child2 = new Element("child2");
         Element child3 = new Element("child3");
         Element child4 = new Element("child4");
-        parent.appendChild(child1).appendChild(child2)
-                .appendChild(child3).appendChild(child4);
+        parent.appendChild(child1).appendChild(child2).appendChild(child3)
+                .appendChild(child4);
         Assert.assertEquals(child1, parent.getChild(0));
         Assert.assertEquals(child2, parent.getChild(1));
         Assert.assertEquals(child3, parent.getChild(2));
@@ -441,8 +433,7 @@ public abstract class AbstractNodeTest {
         Element child1 = ElementFactory.createDiv();
         Element child2 = ElementFactory.createAnchor();
         Element child3 = ElementFactory.createButton();
-        parent.appendChild(child1).appendChild(child2)
-                .appendChild(child3);
+        parent.appendChild(child1).appendChild(child2).appendChild(child3);
 
         Assert.assertEquals(1, parent.indexOfChild(child2));
     }

--- a/flow-server/src/test/java/com/vaadin/flow/dom/AbstractNodeTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/AbstractNodeTest.java
@@ -18,9 +18,7 @@ package com.vaadin.flow.dom;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
@@ -35,13 +33,13 @@ public abstract class AbstractNodeTest {
     @Test(expected = IllegalArgumentException.class)
     public void insertWithNullParameter() {
         Node<?> parent = createParentNode();
-        parent.insertChild(0, (Element[]) null);
+        parent.insertChild(0, (Element) null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void insertNullChild() {
         Node<?> parent = createParentNode();
-        parent.insertChild(0, new Element[] { null });
+        parent.insertChild(0, Collections.singleton(null));
     }
 
     @Test
@@ -49,7 +47,7 @@ public abstract class AbstractNodeTest {
         Node<?> parent = createParentNode();
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
-        parent.appendChild(child1, child2);
+        parent.appendChild(child1).appendChild(child2);
 
         assertChildren(parent, child1, child2);
     }
@@ -82,7 +80,7 @@ public abstract class AbstractNodeTest {
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
         Element child3 = new Element("child3");
-        parent.appendChild(child1, child2);
+        parent.appendChild(child1).appendChild(child2);
         parent.insertChild(1, child3);
 
         assertChildren(parent, child1, child3, child2);
@@ -94,7 +92,7 @@ public abstract class AbstractNodeTest {
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
         Element child3 = new Element("child3");
-        parent.appendChild(child1, child2);
+        parent.appendChild(child1).appendChild(child2);
         parent.insertChild(2, child3);
 
         assertChildren(parent, child1, child2, child3);
@@ -106,7 +104,7 @@ public abstract class AbstractNodeTest {
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
         Element child3 = new Element("child3");
-        parent.appendChild(child1, child2);
+        parent.appendChild(child1).appendChild(child2);
         parent.insertChild(3, child3);
     }
 
@@ -116,7 +114,8 @@ public abstract class AbstractNodeTest {
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
         Element child3 = new Element("child3");
-        parent.appendChild(child1, child2, child3);
+        parent.appendChild(child1).appendChild(child2)
+                .appendChild(child3);
         parent.removeChild(child1);
 
         assertChildren(parent, child2, child3);
@@ -128,7 +127,8 @@ public abstract class AbstractNodeTest {
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
         Element child3 = new Element("child3");
-        parent.appendChild(child1, child2, child3);
+        parent.appendChild(child1).appendChild(child2)
+                .appendChild(child3);
         parent.removeChild(0);
 
         assertChildren(parent, child2, child3);
@@ -140,8 +140,9 @@ public abstract class AbstractNodeTest {
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
         Element child3 = new Element("child3");
-        parent.appendChild(child1, child2, child3);
-        parent.removeChild(child1, child2);
+        parent.appendChild(child1).appendChild(child2)
+                .appendChild(child3);
+        parent.removeChild(child1).removeChild(child2);
 
         assertChildren(parent, child3);
     }
@@ -152,7 +153,8 @@ public abstract class AbstractNodeTest {
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
         Element child3 = new Element("child3");
-        parent.appendChild(child1, child2, child3);
+        parent.appendChild(child1).appendChild(child2)
+                .appendChild(child3);
         parent.removeChild(child2);
 
         assertChildren(parent, child1, child3);
@@ -164,7 +166,8 @@ public abstract class AbstractNodeTest {
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
         Element child3 = new Element("child3");
-        parent.appendChild(child1, child2, child3);
+        parent.appendChild(child1).appendChild(child2)
+                .appendChild(child3);
         parent.removeChild(1);
 
         assertChildren(parent, child1, child3);
@@ -177,8 +180,9 @@ public abstract class AbstractNodeTest {
         Element child2 = new Element("child2");
         Element child3 = new Element("child3");
         Element child4 = new Element("child4");
-        parent.appendChild(child1, child2, child3, child4);
-        parent.removeChild(child2, child3);
+        parent.appendChild(child1).appendChild(child2)
+                .appendChild(child3).appendChild(child4);
+        parent.removeChild(child2).removeChild(child3);
 
         assertChildren(parent, child1, child4);
     }
@@ -189,7 +193,8 @@ public abstract class AbstractNodeTest {
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
         Element child3 = new Element("child3");
-        parent.appendChild(child1, child2, child3);
+        parent.appendChild(child1).appendChild(child2)
+                .appendChild(child3);
         parent.removeChild(child3);
 
         assertChildren(parent, child1, child2);
@@ -201,7 +206,8 @@ public abstract class AbstractNodeTest {
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
         Element child3 = new Element("child3");
-        parent.appendChild(child1, child2, child3);
+        parent.appendChild(child1).appendChild(child2)
+                .appendChild(child3);
         parent.removeChild(2);
 
         assertChildren(parent, child1, child2);
@@ -214,8 +220,9 @@ public abstract class AbstractNodeTest {
         Element child2 = new Element("child2");
         Element child3 = new Element("child3");
         Element child4 = new Element("child4");
-        parent.appendChild(child1, child2, child3, child4);
-        parent.removeChild(child3, child4);
+        parent.appendChild(child1).appendChild(child2)
+                .appendChild(child3).appendChild(child4);
+        parent.removeChild(child3).removeChild(child4);
 
         assertChildren(parent, child1, child2);
     }
@@ -227,7 +234,8 @@ public abstract class AbstractNodeTest {
         Element child2 = new Element("child2");
         Element child3 = new Element("child3");
         Element child4 = new Element("child4");
-        parent.appendChild(child1, child2, child3, child4);
+        parent.appendChild(child1).appendChild(child2)
+                .appendChild(child3).appendChild(child4);
         parent.removeAllChildren();
 
         assertChildren(parent);
@@ -249,7 +257,8 @@ public abstract class AbstractNodeTest {
         Element child2 = ElementFactory.createDiv();
         Element child3 = ElementFactory.createDiv();
 
-        parent.appendChild(child1, child2, child3);
+        parent.appendChild(child1).appendChild(child2)
+                .appendChild(child3);
 
         List<Element> children = parent.getChildren()
                 .collect(Collectors.toList());
@@ -277,7 +286,8 @@ public abstract class AbstractNodeTest {
         Element child2 = new Element("child2");
         Element child3 = new Element("child3");
         Element child4 = new Element("child4");
-        parent.appendChild(child1, child2, child3, child4);
+        parent.appendChild(child1).appendChild(child2)
+                .appendChild(child3).appendChild(child4);
         Assert.assertEquals(child1, parent.getChild(0));
         Assert.assertEquals(child2, parent.getChild(1));
         Assert.assertEquals(child3, parent.getChild(2));
@@ -289,7 +299,7 @@ public abstract class AbstractNodeTest {
         Node<?> parent = createParentNode();
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
-        parent.appendChild(child1, child2);
+        parent.appendChild(child1).appendChild(child2);
         parent.getChild(-1);
     }
 
@@ -298,7 +308,7 @@ public abstract class AbstractNodeTest {
         Node<?> parent = createParentNode();
         Element child1 = new Element("child1");
         Element child2 = new Element("child2");
-        parent.appendChild(child1, child2);
+        parent.appendChild(child1).appendChild(child2);
         parent.getChild(2);
     }
 
@@ -314,7 +324,7 @@ public abstract class AbstractNodeTest {
     @Test(expected = IllegalArgumentException.class)
     public void appendNullChild() {
         Node<?> parent = createParentNode();
-        parent.appendChild((Element[]) null);
+        parent.appendChild((Element) null);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -328,7 +338,7 @@ public abstract class AbstractNodeTest {
     @Test(expected = IllegalArgumentException.class)
     public void removeNullChild() {
         Node<?> parent = createParentNode();
-        parent.removeChild((Element[]) null);
+        parent.removeChild((Element) null);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -431,7 +441,8 @@ public abstract class AbstractNodeTest {
         Element child1 = ElementFactory.createDiv();
         Element child2 = ElementFactory.createAnchor();
         Element child3 = ElementFactory.createButton();
-        parent.appendChild(child1, child2, child3);
+        parent.appendChild(child1).appendChild(child2)
+                .appendChild(child3);
 
         Assert.assertEquals(1, parent.indexOfChild(child2));
     }
@@ -449,7 +460,7 @@ public abstract class AbstractNodeTest {
         Node<?> parent = createParentNode();
         Element child1 = ElementFactory.createDiv();
         Element child2 = ElementFactory.createDiv();
-        parent.appendChild(child1, child2);
+        parent.appendChild(child1).appendChild(child2);
 
         parent.appendChild(child1);
         assertChildren(parent, child2, child1);
@@ -460,7 +471,7 @@ public abstract class AbstractNodeTest {
         Node<?> parent = createParentNode();
         Element child1 = ElementFactory.createDiv();
         Element child2 = ElementFactory.createDiv();
-        parent.appendChild(child1, child2);
+        parent.appendChild(child1).appendChild(child2);
 
         parent.appendChild(child2);
         assertChildren(parent, child1, child2);
@@ -471,9 +482,9 @@ public abstract class AbstractNodeTest {
         Node<?> parent = createParentNode();
         Element child1 = ElementFactory.createDiv();
         Element child2 = ElementFactory.createDiv();
-        parent.appendChild(child1, child2);
+        parent.appendChild(child1).appendChild(child2);
 
-        parent.appendChild(child2, child1);
+        parent.appendChild(child2).appendChild(child1);
         // Order should be changed
         assertChildren(parent, child2, child1);
     }
@@ -485,7 +496,7 @@ public abstract class AbstractNodeTest {
         Element child2 = ElementFactory.createDiv();
         parent.appendChild(child1);
 
-        parent.appendChild(child2, child1);
+        parent.appendChild(child2).appendChild(child1);
 
         assertChildren(parent, child2, child1);
     }

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
@@ -2422,11 +2422,9 @@ public class ElementTest extends AbstractNodeTest {
         Element child1 = new Element("main");
         Element child2 = new Element("menu");
 
-        parent.appendVirtualChild(child1)
-                .appendVirtualChild(child2);
+        parent.appendVirtualChild(child1).appendVirtualChild(child2);
 
-        parent.removeVirtualChild(child2)
-                .removeVirtualChild(child1);
+        parent.removeVirtualChild(child2).removeVirtualChild(child1);
 
         Assert.assertNull(child1.getParent());
         Assert.assertFalse(child1.isVirtualChild());

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
@@ -718,8 +718,8 @@ public class ElementTest extends AbstractNodeTest {
     @Test
     public void setInnerHtmlProeprty_setValueAndRemoveAllChildren() {
         Element element = new Element("element");
-        element.appendChild(ElementFactory.createAnchor(),
-                ElementFactory.createDiv());
+        element.appendChild(ElementFactory.createAnchor())
+                .appendChild(ElementFactory.createDiv());
         element.setProperty("innerHTML", "<br>");
 
         Assert.assertEquals(0, element.getChildCount());
@@ -2221,7 +2221,7 @@ public class ElementTest extends AbstractNodeTest {
         Element element = ElementFactory.createDiv();
         Element button = ElementFactory.createButton();
         Element emphasis = ElementFactory.createEmphasis();
-        element.appendChild(button, emphasis);
+        element.appendChild(button).appendChild(emphasis);
 
         ShadowRoot shadow = element.attachShadow();
         Assert.assertNotNull(shadow);
@@ -2422,9 +2422,11 @@ public class ElementTest extends AbstractNodeTest {
         Element child1 = new Element("main");
         Element child2 = new Element("menu");
 
-        parent.appendVirtualChild(child1, child2);
+        parent.appendVirtualChild(child1)
+                .appendVirtualChild(child2);
 
-        parent.removeVirtualChild(child2, child1);
+        parent.removeVirtualChild(child2)
+                .removeVirtualChild(child1);
 
         Assert.assertNull(child1.getParent());
         Assert.assertFalse(child1.isVirtualChild());

--- a/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/ElementListenersTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/ElementListenersTest.java
@@ -405,7 +405,7 @@ public class ElementListenersTest
         Element sibling = new Element("sibling");
         parent.appendChild(child);
         new StateTree(new UI().getInternals(), ElementChildrenList.class)
-                .getUI().getElement().appendChild(parent, sibling);
+                .getUI().getElement().appendChild(parent).appendChild(sibling);
         final String eventType = "click";
         final String expression = "expression";
         final String key = JsonConstants.MAP_STATE_NODE_EVENT_DATA + expression;

--- a/flow-server/src/test/java/com/vaadin/flow/router/EventUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/EventUtilTest.java
@@ -117,13 +117,13 @@ public class EventUtilTest {
     }
 
     @Test
-    public void collectBeforeNavigationObserversFromUI() throws Exception {
+    public void collectBeforeNavigationObserversFromUI() {
         UI ui = UI.getCurrent();
         Element node = ui.getElement();
-        node.appendChild(new Element("main"), new Element("menu"));
+        node.appendChild(new Element("main")).appendChild(new Element("menu"));
         Element nested = new Element("nested");
-        nested.appendChild(new Element("nested-child"),
-                new Element("nested-child-2"));
+        nested.appendChild(new Element("nested-child"))
+                .appendChild(new Element("nested-child-2"));
 
         node.appendChild(nested);
         Component.from(nested, LeaveObserver.class);
@@ -136,14 +136,13 @@ public class EventUtilTest {
     }
 
     @Test
-    public void collectBeforeNavigationObserversFromUI_elementHasVirtualChildren()
-            throws Exception {
+    public void collectBeforeNavigationObserversFromUI_elementHasVirtualChildren() {
         UI ui = UI.getCurrent();
         Element node = ui.getElement();
-        node.appendChild(new Element("main"), new Element("menu"));
+        node.appendChild(new Element("main")).appendChild(new Element("menu"));
         Element nested = new Element("nested");
-        nested.appendVirtualChild(new Element("nested-child"),
-                new Element("nested-child-2"));
+        nested.appendVirtualChild(new Element("nested-child"))
+                .appendVirtualChild(new Element("nested-child-2"));
 
         node.appendChild(nested);
 
@@ -161,18 +160,18 @@ public class EventUtilTest {
     }
 
     @Test
-    public void collectBeforeNavigationObserversFromChains() throws Exception {
+    public void collectBeforeNavigationObserversFromChains() {
         Foo foo = new Foo();
         EnterObserver toBeDetached = new EnterObserver();
-        foo.getElement().appendChild(new EnterObserver().getElement(),
-                toBeDetached.getElement());
+        foo.getElement().appendChild(new EnterObserver().getElement())
+                .appendChild(toBeDetached.getElement());
         Bar bar = new Bar();
 
         Element nested = new Element("nested");
-        nested.appendChild(new Element("nested-child"),
-                new EnterObserver().getElement());
+        nested.appendChild(new Element("nested-child"))
+                .appendChild(new EnterObserver().getElement());
 
-        bar.getElement().appendChild(new Foo().getElement(), nested);
+        bar.getElement().appendChild(new Foo().getElement()).appendChild(nested);
 
         EnterObserver toBeAttached = new EnterObserver();
 
@@ -195,10 +194,10 @@ public class EventUtilTest {
         menu.appendChild(new AfterObserver().getElement());
 
         Element node = ui.getElement();
-        node.appendChild(new Element("main"), menu);
+        node.appendChild(new Element("main")).appendChild(menu);
         Element nested = new Element("nested");
-        nested.appendChild(new Element("nested-child"),
-                new Element("nested-child-2"));
+        nested.appendChild(new Element("nested-child"))
+                .appendChild(new Element("nested-child-2"));
 
         node.appendChild(nested);
         Component.from(nested, AfterObserver.class);
@@ -211,12 +210,12 @@ public class EventUtilTest {
     }
 
     @Test
-    public void inspectChildrenHierarchy() throws Exception {
+    public void inspectChildrenHierarchy() {
         Element node = new Element("root");
-        node.appendChild(new Element("main"), new Element("menu"));
+        node.appendChild(new Element("main")).appendChild(new Element("menu"));
         Element nested = new Element("nested");
-        nested.appendChild(new Element("nested-child"),
-                new Element("nested-child-2"));
+        nested.appendChild(new Element("nested-child"))
+                .appendChild(new Element("nested-child-2"));
 
         node.appendChild(nested);
 
@@ -228,12 +227,12 @@ public class EventUtilTest {
     }
 
     @Test
-    public void inspectChildrenHierarchy_selective() throws Exception {
+    public void inspectChildrenHierarchy_selective() {
         Element node = new Element("root");
-        node.appendChild(new Element("main"), new Element("menu"));
+        node.appendChild(new Element("main")).appendChild(new Element("menu"));
         Element nested = new Element("nested");
-        nested.appendChild(new Element("nested-child"),
-                new Element("nested-child-2"));
+        nested.appendChild(new Element("nested-child"))
+                .appendChild(new Element("nested-child-2"));
 
         node.appendChild(nested);
 
@@ -246,14 +245,15 @@ public class EventUtilTest {
     }
 
     @Test
-    public void inspectMixedChildrenHierarchy() throws Exception {
+    public void inspectMixedChildrenHierarchy() {
         Element node = new Element("root");
-        node.appendVirtualChild(new Element("main"), new Element("menu"));
+        node.appendVirtualChild(new Element("main"))
+                .appendVirtualChild(new Element("menu"));
         Element nested = new Element("nested");
-        nested.appendVirtualChild(new Element("nested-virtual-child"),
-                new Element("nested-virtual-child-2"));
-        nested.appendChild(new Element("nested-child"),
-                new Element("nested-child-2"));
+        nested.appendVirtualChild(new Element("nested-virtual-child"))
+                .appendVirtualChild(new Element("nested-virtual-child-2"));
+        nested.appendChild(new Element("nested-child"))
+                .appendChild(new Element("nested-child-2"));
 
         nested.getStateProvider().appendVirtualChild(nested.getNode(),
                 new Element("attached-by-id"), NodeProperties.INJECT_BY_ID,
@@ -272,12 +272,12 @@ public class EventUtilTest {
     }
 
     @Test
-    public void getImplementingComponents() throws Exception {
+    public void getImplementingComponents() {
         Element node = new Element("root");
-        node.appendChild(new Element("main"), new Element("menu"));
+        node.appendChild(new Element("main")).appendChild(new Element("menu"));
         Element nested = new Element("nested");
-        nested.appendChild(new Element("nested-child"),
-                new Element("nested-child-2"));
+        nested.appendChild(new Element("nested-child"))
+                .appendChild(new Element("nested-child-2"));
 
         node.appendChild(nested);
         Component.from(nested, EnterObserver.class);
@@ -296,13 +296,12 @@ public class EventUtilTest {
     }
 
     @Test
-    public void getImplementingComponents_elementHasVirtualChildren()
-            throws Exception {
+    public void getImplementingComponents_elementHasVirtualChildren() {
         Element node = new Element("root");
-        node.appendChild(new Element("main"), new Element("menu"));
+        node.appendChild(new Element("main")).appendChild(new Element("menu"));
         Element nested = new Element("nested");
-        nested.appendChild(new Element("nested-child"),
-                new Element("nested-child-2"));
+        nested.appendChild(new Element("nested-child"))
+                .appendChild(new Element("nested-child-2"));
 
         node.getStateProvider().appendVirtualChild(node.getNode(), nested,
                 NodeProperties.TEMPLATE_IN_TEMPLATE, "");
@@ -322,12 +321,12 @@ public class EventUtilTest {
     }
 
     @Test
-    public void collectLocaleChangeObserverFromElement() throws Exception {
+    public void collectLocaleChangeObserverFromElement() {
         Element node = new Element("root");
-        node.appendChild(new Element("main"), new Element("menu"));
+        node.appendChild(new Element("main")).appendChild(new Element("menu"));
         Element nested = new Element("nested-locale");
-        nested.appendChild(new Element("nested-child"),
-                new Element("nested-child-2"));
+        nested.appendChild(new Element("nested-child"))
+                .appendChild(new Element("nested-child-2"));
 
         node.appendChild(nested);
         Component.from(nested, Locale.class);
@@ -340,15 +339,14 @@ public class EventUtilTest {
     }
 
     @Test
-    public void collectLocaleChangeObserverFromElement_elementHasVirtualChildren()
-            throws Exception {
+    public void collectLocaleChangeObserverFromElement_elementHasVirtualChildren() {
         Element node = new Element("root");
-        node.appendChild(new Element("main"), new Element("menu"));
-        node.appendVirtualChild(new Element("main-virtual"),
-                new Element("menu-virtual"));
+        node.appendChild(new Element("main")).appendChild(new Element("menu"));
+        node.appendVirtualChild(new Element("main-virtual"))
+                .appendVirtualChild(new Element("menu-virtual"));
         Element nested = new Element("nested-locale");
-        nested.appendVirtualChild(new Element("nested-child"),
-                new Element("nested-child-2"));
+        nested.appendVirtualChild(new Element("nested-child"))
+                .appendVirtualChild(new Element("nested-child-2"));
 
         node.appendVirtualChild(nested);
         Component.from(nested, Locale.class);
@@ -361,17 +359,16 @@ public class EventUtilTest {
     }
 
     @Test
-    public void collectLocaleChangeObserverFromComponentList()
-            throws Exception {
+    public void collectLocaleChangeObserverFromComponentList() {
         Foo foo = new Foo();
         foo.getElement().appendChild(new Locale().getElement());
         Bar bar = new Bar();
 
         Element nested = new Element("nested-locale");
-        nested.appendChild(new Element("nested-child"),
-                new Locale().getElement());
+        nested.appendChild(new Element("nested-child"))
+                .appendChild(new Locale().getElement());
 
-        bar.getElement().appendChild(new Foo().getElement(), nested);
+        bar.getElement().appendChild(new Foo().getElement()).appendChild(nested);
 
         List<LocaleChangeObserver> beforeNavigationObservers = EventUtil
                 .collectLocaleChangeObservers(Arrays.asList(foo, bar));
@@ -381,17 +378,16 @@ public class EventUtilTest {
     }
 
     @Test
-    public void collectLocaleChangeObserverFromComponentList_elementHasVirtualChildren()
-            throws Exception {
+    public void collectLocaleChangeObserverFromComponentList_elementHasVirtualChildren() {
         Foo foo = new Foo();
         foo.getElement().appendChild(new Locale().getElement());
         Bar bar = new Bar();
 
         Element nested = new Element("nested-locale");
-        nested.appendChild(new Element("nested-child"),
-                new Locale().getElement());
+        nested.appendChild(new Element("nested-child"))
+                .appendChild(new Locale().getElement());
 
-        bar.getElement().appendChild(new Foo().getElement(), nested);
+        bar.getElement().appendChild(new Foo().getElement()).appendChild(nested);
 
         List<LocaleChangeObserver> beforeNavigationObservers = EventUtil
                 .collectLocaleChangeObservers(Arrays.asList(foo, bar));

--- a/flow-server/src/test/java/com/vaadin/flow/router/EventUtilTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/EventUtilTest.java
@@ -171,7 +171,8 @@ public class EventUtilTest {
         nested.appendChild(new Element("nested-child"))
                 .appendChild(new EnterObserver().getElement());
 
-        bar.getElement().appendChild(new Foo().getElement()).appendChild(nested);
+        bar.getElement().appendChild(new Foo().getElement())
+                .appendChild(nested);
 
         EnterObserver toBeAttached = new EnterObserver();
 
@@ -368,7 +369,8 @@ public class EventUtilTest {
         nested.appendChild(new Element("nested-child"))
                 .appendChild(new Locale().getElement());
 
-        bar.getElement().appendChild(new Foo().getElement()).appendChild(nested);
+        bar.getElement().appendChild(new Foo().getElement())
+                .appendChild(nested);
 
         List<LocaleChangeObserver> beforeNavigationObservers = EventUtil
                 .collectLocaleChangeObservers(Arrays.asList(foo, bar));
@@ -387,7 +389,8 @@ public class EventUtilTest {
         nested.appendChild(new Element("nested-child"))
                 .appendChild(new Locale().getElement());
 
-        bar.getElement().appendChild(new Foo().getElement()).appendChild(nested);
+        bar.getElement().appendChild(new Foo().getElement())
+                .appendChild(nested);
 
         List<LocaleChangeObserver> beforeNavigationObservers = EventUtil
                 .collectLocaleChangeObservers(Arrays.asList(foo, bar));

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
@@ -226,8 +226,9 @@ public class RouterTest extends RoutingTestBase {
         }
 
         public CombinedObserverTarget() {
-            getElement().appendChild(new Enter().getElement(),
-                    new Leave().getElement(), new Before().getElement());
+            getElement().appendChild(new Enter().getElement())
+                    .appendChild(new Leave().getElement())
+                    .appendChild(new Before().getElement());
         }
     }
 

--- a/flow-tests/test-common/src/main/java/com/vaadin/flow/uitest/servlet/ViewTestLayout.java
+++ b/flow-tests/test-common/src/main/java/com/vaadin/flow/uitest/servlet/ViewTestLayout.java
@@ -80,8 +80,7 @@ public class ViewTestLayout extends Div
             ui.navigate(viewSelect.getProperty("value"));
         }).synchronizeProperty("value");
 
-        element.appendChild(viewSelect)
-                .appendChild(ElementFactory.createHr())
+        element.appendChild(viewSelect).appendChild(ElementFactory.createHr())
                 .appendChild(viewContainer);
 
         getElement().appendChild(element);

--- a/flow-tests/test-common/src/main/java/com/vaadin/flow/uitest/servlet/ViewTestLayout.java
+++ b/flow-tests/test-common/src/main/java/com/vaadin/flow/uitest/servlet/ViewTestLayout.java
@@ -80,8 +80,9 @@ public class ViewTestLayout extends Div
             ui.navigate(viewSelect.getProperty("value"));
         }).synchronizeProperty("value");
 
-        element.appendChild(viewSelect, ElementFactory.createHr(),
-                viewContainer);
+        element.appendChild(viewSelect)
+                .appendChild(ElementFactory.createHr())
+                .appendChild(viewContainer);
 
         getElement().appendChild(element);
     }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/BasicElementView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/BasicElementView.java
@@ -118,8 +118,11 @@ public class BasicElementView extends AbstractDivView {
             elementContainer.removeChild(div2);
         });
 
-        mainElement.appendChild(helloWorldElement, button, input,
-                addRemoveButton, elementContainer);
+        mainElement.appendChild(helloWorldElement)
+                .appendChild(button)
+                .appendChild(input)
+                .appendChild(addRemoveButton)
+                .appendChild(elementContainer);
 
     }
 

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/BasicElementView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/BasicElementView.java
@@ -118,10 +118,8 @@ public class BasicElementView extends AbstractDivView {
             elementContainer.removeChild(div2);
         });
 
-        mainElement.appendChild(helloWorldElement)
-                .appendChild(button)
-                .appendChild(input)
-                .appendChild(addRemoveButton)
+        mainElement.appendChild(helloWorldElement).appendChild(button)
+                .appendChild(input).appendChild(addRemoveButton)
                 .appendChild(elementContainer);
 
     }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DomEventFilterView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DomEventFilterView.java
@@ -97,8 +97,10 @@ public class DomEventFilterView extends AbstractDivView {
                 e -> addMessage("Component: " + e.getValue()), 1000);
 
         messages.setAttribute("id", "messages");
-        getElement().appendChild(space, debounce, component.getElement(),
-                messages);
+        getElement().appendChild(space)
+                .appendChild(debounce)
+                .appendChild(component.getElement())
+                .appendChild(messages);
 
         // tests for#5090
         final AtomicReference<DomListenerRegistration> atomicReference = new AtomicReference<>();

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DomEventFilterView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DomEventFilterView.java
@@ -97,10 +97,8 @@ public class DomEventFilterView extends AbstractDivView {
                 e -> addMessage("Component: " + e.getValue()), 1000);
 
         messages.setAttribute("id", "messages");
-        getElement().appendChild(space)
-                .appendChild(debounce)
-                .appendChild(component.getElement())
-                .appendChild(messages);
+        getElement().appendChild(space).appendChild(debounce)
+                .appendChild(component.getElement()).appendChild(messages);
 
         // tests for#5090
         final AtomicReference<DomListenerRegistration> atomicReference = new AtomicReference<>();

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DomListenerOnAttachView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DomListenerOnAttachView.java
@@ -34,7 +34,6 @@ public class DomListenerOnAttachView extends AbstractDivView {
             status.setText("Event received");
         });
 
-        getElement().appendChild(element)
-                .appendChild(status.getElement());
+        getElement().appendChild(element).appendChild(status.getElement());
     }
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DomListenerOnAttachView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/DomListenerOnAttachView.java
@@ -34,6 +34,7 @@ public class DomListenerOnAttachView extends AbstractDivView {
             status.setText("Event received");
         });
 
-        getElement().appendChild(element, status.getElement());
+        getElement().appendChild(element)
+                .appendChild(status.getElement());
     }
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/FragmentLinkView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/FragmentLinkView.java
@@ -23,7 +23,9 @@ public class FragmentLinkView extends AbstractDivView {
         Element placeholder = ElementFactory.createDiv("Hash Change Events")
                 .setAttribute("id", "placeholder");
 
-        bodyElement.appendChild(scrollLocator, placeholder, new Element("p"));
+        bodyElement.appendChild(scrollLocator)
+                .appendChild(placeholder)
+                .appendChild(new Element("p"));
 
         Element scrollToLink = ElementFactory.createRouterLink(
                 "/view/com.vaadin.flow.uitest.ui.FragmentLinkView#Scroll_Target",
@@ -42,10 +44,19 @@ public class FragmentLinkView extends AbstractDivView {
         Element scrollTarget2 = ElementFactory.createHeading2("Scroll Target 2")
                 .setAttribute("id", "Scroll_Target2");
 
-        bodyElement.appendChild(scrollToLink, new Element("p"), scrollToLink2,
-                new Element("p"), scrollToLinkAnotherView, new Element("p"),
-                linkThatIsOverridden, new Element("p"), createSpacer(),
-                scrollTarget, createSpacer(), scrollTarget2, createSpacer());
+        bodyElement.appendChild(scrollToLink)
+                .appendChild(new Element("p"))
+                .appendChild(scrollToLink2)
+                .appendChild(new Element("p"))
+                .appendChild(scrollToLinkAnotherView)
+                .appendChild(new Element("p"))
+                .appendChild(linkThatIsOverridden)
+                .appendChild(new Element("p"))
+                .appendChild(createSpacer())
+                .appendChild(scrollTarget)
+                .appendChild(createSpacer())
+                .appendChild(scrollTarget2)
+                .appendChild(createSpacer());
 
     }
 

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/FragmentLinkView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/FragmentLinkView.java
@@ -23,8 +23,7 @@ public class FragmentLinkView extends AbstractDivView {
         Element placeholder = ElementFactory.createDiv("Hash Change Events")
                 .setAttribute("id", "placeholder");
 
-        bodyElement.appendChild(scrollLocator)
-                .appendChild(placeholder)
+        bodyElement.appendChild(scrollLocator).appendChild(placeholder)
                 .appendChild(new Element("p"));
 
         Element scrollToLink = ElementFactory.createRouterLink(
@@ -44,19 +43,13 @@ public class FragmentLinkView extends AbstractDivView {
         Element scrollTarget2 = ElementFactory.createHeading2("Scroll Target 2")
                 .setAttribute("id", "Scroll_Target2");
 
-        bodyElement.appendChild(scrollToLink)
-                .appendChild(new Element("p"))
-                .appendChild(scrollToLink2)
-                .appendChild(new Element("p"))
+        bodyElement.appendChild(scrollToLink).appendChild(new Element("p"))
+                .appendChild(scrollToLink2).appendChild(new Element("p"))
                 .appendChild(scrollToLinkAnotherView)
-                .appendChild(new Element("p"))
-                .appendChild(linkThatIsOverridden)
-                .appendChild(new Element("p"))
-                .appendChild(createSpacer())
-                .appendChild(scrollTarget)
-                .appendChild(createSpacer())
-                .appendChild(scrollTarget2)
-                .appendChild(createSpacer());
+                .appendChild(new Element("p")).appendChild(linkThatIsOverridden)
+                .appendChild(new Element("p")).appendChild(createSpacer())
+                .appendChild(scrollTarget).appendChild(createSpacer())
+                .appendChild(scrollTarget2).appendChild(createSpacer());
 
     }
 

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HistoryView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HistoryView.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.uitest.ui;
 
+import java.util.Arrays;
 import java.util.function.BiConsumer;
 
 import com.vaadin.flow.component.ClickEvent;
@@ -94,7 +95,7 @@ public class HistoryView extends AbstractDivView {
     }
 
     private Element addRow(Element... elements) {
-        Element row = ElementFactory.createDiv().appendChild(elements);
+        Element row = ElementFactory.createDiv().appendChild(Arrays.asList(elements));
         getElement().appendChild(row);
         return row;
     }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HistoryView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/HistoryView.java
@@ -95,7 +95,8 @@ public class HistoryView extends AbstractDivView {
     }
 
     private Element addRow(Element... elements) {
-        Element row = ElementFactory.createDiv().appendChild(Arrays.asList(elements));
+        Element row = ElementFactory.createDiv()
+                .appendChild(Arrays.asList(elements));
         getElement().appendChild(row);
         return row;
     }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/NavigationTriggerView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/NavigationTriggerView.java
@@ -54,8 +54,10 @@ public class NavigationTriggerView extends AbstractDivView
                 .navigate(NavigationTriggerView.class, "reroute"));
         rerouteButton.setAttribute("id", "rerouteButton");
 
-        getElement().appendChild(routerLink, navigateButton, forwardButton,
-                rerouteButton);
+        getElement().appendChild(routerLink)
+                .appendChild(navigateButton)
+                .appendChild(forwardButton)
+                .appendChild(rerouteButton);
     }
 
     public static String buildMessage(String path, NavigationTrigger trigger,

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/NavigationTriggerView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/NavigationTriggerView.java
@@ -54,10 +54,8 @@ public class NavigationTriggerView extends AbstractDivView
                 .navigate(NavigationTriggerView.class, "reroute"));
         rerouteButton.setAttribute("id", "rerouteButton");
 
-        getElement().appendChild(routerLink)
-                .appendChild(navigateButton)
-                .appendChild(forwardButton)
-                .appendChild(rerouteButton);
+        getElement().appendChild(routerLink).appendChild(navigateButton)
+                .appendChild(forwardButton).appendChild(rerouteButton);
     }
 
     public static String buildMessage(String path, NavigationTrigger trigger,

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PopStateHandlerView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PopStateHandlerView.java
@@ -9,19 +9,20 @@ public class PopStateHandlerView extends RouterLinkView {
 
     @Override
     protected void addLinks() {
-        getElement().appendChild(createPushStateButtons(
+        getElement()
+                .appendChild(createPushStateButtons(
                         "com.vaadin.flow.uitest.ui.PopStateHandlerUI/another/"))
-                        .appendChild(ElementFactory.createParagraph())
-                        .appendChild(createPushStateButtons(
+                .appendChild(ElementFactory.createParagraph())
+                .appendChild(createPushStateButtons(
                         "com.vaadin.flow.uitest.ui.PopStateHandlerUI/forum/"))
-                        .appendChild(ElementFactory.createParagraph())
-                        .appendChild(createPushStateButtons(
+                .appendChild(ElementFactory.createParagraph())
+                .appendChild(createPushStateButtons(
                         "com.vaadin.flow.uitest.ui.PopStateHandlerUI/forum/#!/category/1"))
-                        .appendChild(ElementFactory.createParagraph())
-                        .appendChild(createPushStateButtons(
+                .appendChild(ElementFactory.createParagraph())
+                .appendChild(createPushStateButtons(
                         "com.vaadin.flow.uitest.ui.PopStateHandlerUI/forum/#!/category/2"))
-                        .appendChild(ElementFactory.createParagraph())
-                        .appendChild(createPushStateButtons(
+                .appendChild(ElementFactory.createParagraph())
+                .appendChild(createPushStateButtons(
                         "com.vaadin.flow.uitest.ui.PopStateHandlerUI/forum/#"));
     }
 

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PopStateHandlerView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PopStateHandlerView.java
@@ -9,19 +9,19 @@ public class PopStateHandlerView extends RouterLinkView {
 
     @Override
     protected void addLinks() {
-        getElement().appendChild(
-                createPushStateButtons(
-                        "com.vaadin.flow.uitest.ui.PopStateHandlerUI/another/"),
-                ElementFactory.createParagraph(),
-                createPushStateButtons(
-                        "com.vaadin.flow.uitest.ui.PopStateHandlerUI/forum/"),
-                ElementFactory.createParagraph(),
-                createPushStateButtons(
-                        "com.vaadin.flow.uitest.ui.PopStateHandlerUI/forum/#!/category/1"),
-                ElementFactory.createParagraph(),
-                createPushStateButtons(
-                        "com.vaadin.flow.uitest.ui.PopStateHandlerUI/forum/#!/category/2"),
-                ElementFactory.createParagraph(), createPushStateButtons(
+        getElement().appendChild(createPushStateButtons(
+                        "com.vaadin.flow.uitest.ui.PopStateHandlerUI/another/"))
+                        .appendChild(ElementFactory.createParagraph())
+                        .appendChild(createPushStateButtons(
+                        "com.vaadin.flow.uitest.ui.PopStateHandlerUI/forum/"))
+                        .appendChild(ElementFactory.createParagraph())
+                        .appendChild(createPushStateButtons(
+                        "com.vaadin.flow.uitest.ui.PopStateHandlerUI/forum/#!/category/1"))
+                        .appendChild(ElementFactory.createParagraph())
+                        .appendChild(createPushStateButtons(
+                        "com.vaadin.flow.uitest.ui.PopStateHandlerUI/forum/#!/category/2"))
+                        .appendChild(ElementFactory.createParagraph())
+                        .appendChild(createPushStateButtons(
                         "com.vaadin.flow.uitest.ui.PopStateHandlerUI/forum/#"));
     }
 

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/RouterLinkView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/RouterLinkView.java
@@ -22,10 +22,8 @@ public class RouterLinkView extends AbstractDivView {
         Element queryParams = ElementFactory.createDiv("no queryParams")
                 .setAttribute("id", "queryParams");
 
-        bodyElement.appendChild(location)
-                .appendChild(new Element("p"));
-        bodyElement.appendChild(queryParams)
-                .appendChild(new Element("p"));
+        bodyElement.appendChild(location).appendChild(new Element("p"));
+        bodyElement.appendChild(queryParams).appendChild(new Element("p"));
 
         addLinks();
 

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/RouterLinkView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/RouterLinkView.java
@@ -22,8 +22,10 @@ public class RouterLinkView extends AbstractDivView {
         Element queryParams = ElementFactory.createDiv("no queryParams")
                 .setAttribute("id", "queryParams");
 
-        bodyElement.appendChild(location, new Element("p"));
-        bodyElement.appendChild(queryParams, new Element("p"));
+        bodyElement.appendChild(location)
+                .appendChild(new Element("p"));
+        bodyElement.appendChild(queryParams)
+                .appendChild(new Element("p"));
 
         addLinks();
 
@@ -53,24 +55,32 @@ public class RouterLinkView extends AbstractDivView {
     }
 
     protected void addLinks() {
-        getElement().appendChild(
+        getElement()
                 // inside servlet mapping
-                ElementFactory.createDiv("inside this servlet"),
-                ElementFactory.createRouterLink("", "empty"), new Element("p"),
-                createRouterLink("foo"), new Element("p"),
-                createRouterLink("foo/bar"), new Element("p"),
-                createRouterLink("./foobar"), new Element("p"),
-                createRouterLink("./foobar?what=not"), new Element("p"),
-                createRouterLink("./foobar?what=not#fragment"),
-                new Element("p"), createRouterLink("/view/baz"),
-                new Element("p"),
+                .appendChild(ElementFactory.createDiv("inside this servlet"))
+                .appendChild(ElementFactory.createRouterLink("", "empty"))
+                .appendChild(new Element("p"))
+                .appendChild(createRouterLink("foo"))
+                .appendChild(new Element("p"))
+                .appendChild(createRouterLink("foo/bar"))
+                .appendChild(new Element("p"))
+                .appendChild(createRouterLink("./foobar"))
+                .appendChild(new Element("p"))
+                .appendChild(createRouterLink("./foobar?what=not"))
+                .appendChild(new Element("p"))
+                .appendChild(createRouterLink("./foobar?what=not#fragment"))
+                .appendChild(new Element("p"))
+                .appendChild(createRouterLink("/view/baz"))
+                .appendChild(new Element("p"))
                 // outside
-                ElementFactory.createDiv("outside this servlet"),
-                createRouterLink("/run"), new Element("p"),
-                createRouterLink("/foo/bar"), new Element("p"),
+                .appendChild(ElementFactory.createDiv("outside this servlet"))
+                .appendChild(createRouterLink("/run"))
+                .appendChild(new Element("p"))
+                .appendChild(createRouterLink("/foo/bar"))
+                .appendChild(new Element("p"))
                 // external
-                ElementFactory.createDiv("external"),
-                createRouterLink("http://example.net/"));
+                .appendChild(ElementFactory.createDiv("external"))
+                .appendChild(createRouterLink("http://example.net/"));
     }
 
     private Element createRouterLink(String target) {

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/scroll/PushStateScrollView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/scroll/PushStateScrollView.java
@@ -36,9 +36,9 @@ public class PushStateScrollView extends AbstractDivView {
 
         History history = UI.getCurrent().getPage().getHistory();
 
-        getElement().appendChild(filler,
-                createButton("push", history::pushState),
-                createButton("replace", history::replaceState));
+        getElement().appendChild(filler)
+                .appendChild(createButton("push", history::pushState))
+                .appendChild(createButton("replace", history::replaceState));
     }
 
     private static Element createButton(String name,

--- a/flow-tests/test-root-ui-context/src/main/java/com/vaadin/flow/uitest/servlet/ErrorTarget.java
+++ b/flow-tests/test-root-ui-context/src/main/java/com/vaadin/flow/uitest/servlet/ErrorTarget.java
@@ -14,8 +14,9 @@ public class ErrorTarget extends RouteNotFoundError {
             ErrorParameter<NotFoundException> parameter) {
         getElement().appendChild(ElementFactory.createDiv(
                 "This is the error view. Next element contains the error path "))
-                .appendChild(ElementFactory.createDiv(event.getLocation().getPath())
-                        .setAttribute("id", "error-path"));
+                .appendChild(
+                        ElementFactory.createDiv(event.getLocation().getPath())
+                                .setAttribute("id", "error-path"));
         return HttpStatusCode.NOT_FOUND.getCode();
     }
 }

--- a/flow-tests/test-root-ui-context/src/main/java/com/vaadin/flow/uitest/servlet/ErrorTarget.java
+++ b/flow-tests/test-root-ui-context/src/main/java/com/vaadin/flow/uitest/servlet/ErrorTarget.java
@@ -13,8 +13,8 @@ public class ErrorTarget extends RouteNotFoundError {
     public int setErrorParameter(BeforeEnterEvent event,
             ErrorParameter<NotFoundException> parameter) {
         getElement().appendChild(ElementFactory.createDiv(
-                "This is the error view. Next element contains the error path "),
-                ElementFactory.createDiv(event.getLocation().getPath())
+                "This is the error view. Next element contains the error path "))
+                .appendChild(ElementFactory.createDiv(event.getLocation().getPath())
                         .setAttribute("id", "error-path"));
         return HttpStatusCode.NOT_FOUND.getCode();
     }

--- a/flow-tests/test-router-custom-context/src/main/java/com/vaadin/flow/contexttest/ui/DependencyLayout.java
+++ b/flow-tests/test-router-custom-context/src/main/java/com/vaadin/flow/contexttest/ui/DependencyLayout.java
@@ -123,8 +123,11 @@ public abstract class DependencyLayout extends Div {
                 }
             }.start();
         });
-        getElement().appendChild(jsOrder, allBlue, runPush,
-                ElementFactory.createHr(), pushWorks);
+        getElement().appendChild(jsOrder)
+                .appendChild(allBlue)
+                .appendChild(runPush)
+                .appendChild(ElementFactory.createHr())
+                .appendChild(pushWorks);
     }
 
     private StreamResource getJsResource() {

--- a/flow-tests/test-router-custom-context/src/main/java/com/vaadin/flow/contexttest/ui/DependencyLayout.java
+++ b/flow-tests/test-router-custom-context/src/main/java/com/vaadin/flow/contexttest/ui/DependencyLayout.java
@@ -123,10 +123,8 @@ public abstract class DependencyLayout extends Div {
                 }
             }.start();
         });
-        getElement().appendChild(jsOrder)
-                .appendChild(allBlue)
-                .appendChild(runPush)
-                .appendChild(ElementFactory.createHr())
+        getElement().appendChild(jsOrder).appendChild(allBlue)
+                .appendChild(runPush).appendChild(ElementFactory.createHr())
                 .appendChild(pushWorks);
     }
 

--- a/flow-tests/vaadin-spring-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/test/DoubleNpmAnnotationView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/test/DoubleNpmAnnotationView.java
@@ -28,7 +28,6 @@ public class DoubleNpmAnnotationView extends Div {
         Element paperInput = new Element("paper-input");
         Element paperCheckbox = new Element("paper-checkbox");
 
-        this.getElement().appendChild(paperInput)
-                .appendChild(paperCheckbox);
+        this.getElement().appendChild(paperInput).appendChild(paperCheckbox);
     }
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/test/DoubleNpmAnnotationView.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/test/DoubleNpmAnnotationView.java
@@ -28,6 +28,7 @@ public class DoubleNpmAnnotationView extends Div {
         Element paperInput = new Element("paper-input");
         Element paperCheckbox = new Element("paper-checkbox");
 
-        this.getElement().appendChild(paperInput, paperCheckbox);
+        this.getElement().appendChild(paperInput)
+                .appendChild(paperCheckbox);
     }
 }


### PR DESCRIPTION
Provides collection based append/remove/insert methods for Node. Deprecates varargs methods.

Fixes #13599

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have ~~added~~ updated tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
