### PR TITLE
feat: Improving DX ValidationResult

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/ValidationResult.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/ValidationResult.java
@@ -66,6 +66,36 @@ public interface ValidationResult extends Serializable {
         public Optional<ErrorLevel> getErrorLevel() {
             return Optional.ofNullable(errorLevel);
         }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (!obj.getClass().equals(getClass())) {
+                return false;
+            }
+            SimpleValidationResult that = (SimpleValidationResult) obj;
+            return Objects.equals(that.error, error)
+                    && Objects.equals(that.errorLevel, errorLevel);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(error, errorLevel);
+        }
+
+        @Override
+        public String toString() {
+            if (error == null && errorLevel == null) {
+                return "ValidationResult{ok}";
+            }
+            return "ValidationResult{" + "error='" + error + '\''
+                    + ", errorLevel=" + errorLevel + '}';
+        }
     }
 
     /**

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/ValidationResultTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/ValidationResultTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.data.binder;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class ValidationResultTest {
+
+    @Test
+    public void toStringValidation() {
+        String toString = ValidationResult.ok().toString();
+        assertEquals("ValidationResult{ok}", toString);
+
+        toString = ValidationResult.error("My Error Message").toString();
+        assertEquals(
+                "ValidationResult{error='My Error Message', errorLevel=ERROR}",
+                toString);
+
+        toString = ValidationResult
+                .create("My Critical Message", ErrorLevel.CRITICAL).toString();
+        assertEquals(
+                "ValidationResult{error='My Critical Message', errorLevel=CRITICAL}",
+                toString);
+
+        toString = ValidationResult.create("My Info Message", ErrorLevel.INFO)
+                .toString();
+        assertEquals(
+                "ValidationResult{error='My Info Message', errorLevel=INFO}",
+                toString);
+    }
+
+    @Test
+    public void equalsAndHashCode() {
+        ValidationResult ok1 = ValidationResult.ok();
+        ValidationResult ok2 = ValidationResult.ok();
+        ValidationResult error1 = ValidationResult.error("Msg1");
+        ValidationResult error2 = ValidationResult.error("Msg2");
+        ValidationResult info1 = ValidationResult.create("Info",
+                ErrorLevel.INFO);
+        ValidationResult info2 = ValidationResult.create("Info",
+                ErrorLevel.ERROR);
+        ValidationResult info3 = ValidationResult.create("Info",
+                ErrorLevel.INFO);
+
+        assertEquals(ok1, ok2);
+        assertNotEquals(ok1, error1);
+        assertNotEquals(error1, error2);
+        assertNotEquals(error1, info1);
+        assertNotEquals(info1, info2);
+        assertEquals(info1, info3);
+        assertEquals(ok1.hashCode(), ok2.hashCode());
+        assertEquals(info1.hashCode(), info3.hashCode());
+    }
+}


### PR DESCRIPTION
## Description

Improve developer experience by providing proper `equals`, `hashCode` and `toString` methods for `ValidationResult`. 

Allows developer to use it inside tests without unwrapping it.

```java
    assertThat(validator.apply("valid", valueContext))
      .isEqualTo(ValidationResult.ok());

    assertThat(validator.apply("not valid", valueContext))
      .isEqualTo(ValidationResult.error("Not valid input provided."));

    assertThat(validator.apply("not valid", valueContext))
      .isEqualTo(ValidationResult.create("Not the best input provided.", ErrorLevel.INFO));
```

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
