### PR TITLE
feat: allow disabling validation status change listener registration on binder (CP: 2.7)

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/binder/Binder.java
@@ -940,8 +940,8 @@ public class Binder<BEAN> implements Serializable {
             Objects.requireNonNull(validator, "validator cannot be null");
 
             Validator<? super TARGET> wrappedValidator = ((value, context) -> {
-                if (getBinder().isValidatorsDisabled() ||
-                        (binding != null && binding.isValidatorsDisabled())) {
+                if (getBinder().isValidatorsDisabled() || (binding != null
+                        && binding.isValidatorsDisabled())) {
                     return ValidationResult.ok();
                 } else {
                     return validator.apply(value, context);
@@ -1121,7 +1121,8 @@ public class Binder<BEAN> implements Serializable {
             onValueChange = getField().addValueChangeListener(
                     event -> handleFieldValueChange(event));
 
-            if (getField() instanceof HasValidator) {
+            if (getBinder().isFieldsValidationStatusChangeListenerEnabled()
+                    && getField() instanceof HasValidator) {
                 HasValidator<FIELDVALUE> hasValidatorField = (HasValidator<FIELDVALUE>) getField();
                 onValidationStatusChange = hasValidatorField
                         .addValidationStatusChangeListener(
@@ -1425,7 +1426,8 @@ public class Binder<BEAN> implements Serializable {
         }
 
         @Override
-        public void setConvertBackToPresentation(boolean convertBackToPresentation) {
+        public void setConvertBackToPresentation(
+                boolean convertBackToPresentation) {
             this.convertBackToPresentation = convertBackToPresentation;
         }
 
@@ -1542,6 +1544,8 @@ public class Binder<BEAN> implements Serializable {
     private Set<Binding<BEAN, ?>> changedBindings = new LinkedHashSet<>();
 
     private boolean validatorsDisabled = false;
+
+    private boolean fieldsValidationStatusChangeListenerEnabled = true;
 
     /**
      * Creates a binder using a custom {@link PropertySet} implementation for
@@ -1961,7 +1965,7 @@ public class Binder<BEAN> implements Serializable {
      *            {@code null}
      */
     public void writeBeanAsDraft(BEAN bean) {
-        doWriteDraft(bean, new ArrayList<>(bindings),false);
+        doWriteDraft(bean, new ArrayList<>(bindings), false);
     }
 
     /**
@@ -1981,7 +1985,7 @@ public class Binder<BEAN> implements Serializable {
      *            disable all Validators during write
      */
     public void writeBeanAsDraft(BEAN bean, boolean forced) {
-        doWriteDraft(bean, new ArrayList<>(bindings),forced);
+        doWriteDraft(bean, new ArrayList<>(bindings), forced);
     }
 
     /**
@@ -2090,12 +2094,12 @@ public class Binder<BEAN> implements Serializable {
      *            disable validators during write if true
      */
     @SuppressWarnings({ "unchecked" })
-    private void doWriteDraft(BEAN bean, 
-            Collection<Binding<BEAN, ?>> bindings, boolean forced) {
+    private void doWriteDraft(BEAN bean, Collection<Binding<BEAN, ?>> bindings,
+            boolean forced) {
         Objects.requireNonNull(bean, "bean cannot be null");
 
         if (!forced) {
-             bindings.forEach(binding -> ((BindingImpl<BEAN, ?, ?>) binding)
+            bindings.forEach(binding -> ((BindingImpl<BEAN, ?, ?>) binding)
                     .writeFieldValue(bean));
         } else {
             boolean isDisabled = isValidatorsDisabled();
@@ -3202,7 +3206,7 @@ public class Binder<BEAN> implements Serializable {
     /**
      * Control whether validators including bean level validators are
      * disabled or enabled globally for this Binder.
-     * 
+     *
      * @param validatorsDisabled Boolean value.
      */
     public void setValidatorsDisabled(boolean validatorsDisabled) {
@@ -3212,10 +3216,34 @@ public class Binder<BEAN> implements Serializable {
     /**
      * Returns if the validators including bean level validators
      * are disabled or enabled for this Binder.
-     * 
+     *
      * @return Boolean value
      */
     public boolean isValidatorsDisabled() {
         return validatorsDisabled;
+    }
+
+    /**
+     * Control whether bound fields implementing {@link HasValidator} subscribe
+     * for field's {@code ValidationStatusChangeEvent}s and will
+     * {@code validate} upon receiving them.
+     *
+     * @param fieldsValidationStatusChangeListenerEnabled
+     *            Boolean value.
+     */
+    public void setFieldsValidationStatusChangeListenerEnabled(
+            boolean fieldsValidationStatusChangeListenerEnabled) {
+        this.fieldsValidationStatusChangeListenerEnabled = fieldsValidationStatusChangeListenerEnabled;
+    }
+
+    /**
+     * Returns if the bound fields implementing {@link HasValidator} subscribe
+     * for field's {@code ValidationStatusChangeEvent}s and will
+     * {@code validate} upon receiving them.
+     *
+     * @return Boolean value
+     */
+    public boolean isFieldsValidationStatusChangeListenerEnabled() {
+        return fieldsValidationStatusChangeListenerEnabled;
     }
 }

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderValidationStatusChangeListenerTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderValidationStatusChangeListenerTest.java
@@ -65,6 +65,16 @@ public class BinderValidationStatusChangeListenerTest
     }
 
     @Test
+    public void binderWithFieldsValidationStatusChangeListenerDisabled_bindIsCalled_noValidationStatusListenerIsCalled() {
+        binder.setFieldsValidationStatusChangeListenerEnabled(false);
+        TestHasValidatorDatePicker.DatePickerHasValidatorDefaults field = Mockito
+                .spy(TestHasValidatorDatePicker.DatePickerHasValidatorDefaults.class);
+        binder.bind(field, BIRTH_DATE_PROPERTY);
+        Mockito.verify(field, Mockito.never())
+                .addValidationStatusChangeListener(Mockito.any());
+    }
+
+    @Test
     public void fieldWithHasValidatorOnlyGetDefaultValidatorOverridden_bindIsCalled_addValidationStatusListenerIsCalled() {
         TestHasValidatorDatePicker.DataPickerHasValidatorGetDefaultValidatorOverridden field = Mockito
                 .spy(TestHasValidatorDatePicker.DataPickerHasValidatorGetDefaultValidatorOverridden.class);
@@ -100,6 +110,17 @@ public class BinderValidationStatusChangeListenerTest
         field.fireValidationStatusChangeEvent(false);
         Assert.assertEquals(1, componentErrors.size());
         Assert.assertEquals(INVALID_DATE_FORMAT, componentErrors.get(field));
+    }
+
+    @Test
+    public void binderWithFieldsValidationStatusChangeListenerDisabled_fieldValidationStatusChangesToFalse_binderHandleErrorIsNotCalled() {
+        binder.setFieldsValidationStatusChangeListenerEnabled(false);
+        TestHasValidatorDatePicker.DataPickerHasValidatorOverridden field = new TestHasValidatorDatePicker.DataPickerHasValidatorOverridden();
+        binder.bind(field, BIRTH_DATE_PROPERTY);
+        Assert.assertEquals(0, componentErrors.size());
+
+        field.fireValidationStatusChangeEvent(false);
+        Assert.assertEquals(0, componentErrors.size());
     }
 
     @Test


### PR DESCRIPTION
Add binder-level flag to allow disabling of
validation status change listener registration
for HasValidator fields.

Related to https://github.com/vaadin/flow/pull/13940#issuecomment-1174668400 and https://github.com/vaadin/flow-components/pull/3406#discussion_r908427652

(cherry picked from commit 420498c6f9ab113a4a91d23f19cb7d464be3f6f9)