### PR TITLE
fix!: Make Component::findAncestor compatible with Classic components

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/Component.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Component.java
@@ -697,7 +697,7 @@ public abstract class Component
      *            the type of the component to return
      */
     @SuppressWarnings("unchecked")
-    public <T> Optional<T> findAncestor(Class<T> componentType) {
+    public <T> Optional<T> findOptionalAncestor(Class<T> componentType) {
         Optional<Component> parent = getParent();
         while (parent.isPresent()) {
             Component component = parent.get();

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
@@ -1664,7 +1664,7 @@ public class ComponentTest {
     }
 
     @Test
-    public void findAncestorTest() {
+    public void findOptionalAncestorTest() {
         UI ui = new UI();
         TestComponentContainer componentContainer = new TestComponentContainer();
         TestComponent component = new TestComponent();
@@ -1672,12 +1672,12 @@ public class ComponentTest {
         ui.add(componentContainer);
 
         Assert.assertEquals(componentContainer,
-                component.findAncestor(TestComponentContainer.class).get());
-        Assert.assertEquals(ui, component.findAncestor(UI.class).get());
+                component.findOptionalAncestor(TestComponentContainer.class).get());
+        Assert.assertEquals(ui, component.findOptionalAncestor(UI.class).get());
         Assert.assertEquals(ui,
-                component.findAncestor(PollNotifier.class).get());
+                component.findOptionalAncestor(PollNotifier.class).get());
         Assert.assertFalse(
-                component.findAncestor(TestButton.class).isPresent());
+                component.findOptionalAncestor(TestButton.class).isPresent());
 
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
@@ -1671,8 +1671,8 @@ public class ComponentTest {
         componentContainer.add(component);
         ui.add(componentContainer);
 
-        Assert.assertEquals(componentContainer,
-                component.findOptionalAncestor(TestComponentContainer.class).get());
+        Assert.assertEquals(componentContainer, component
+                .findOptionalAncestor(TestComponentContainer.class).get());
         Assert.assertEquals(ui, component.findOptionalAncestor(UI.class).get());
         Assert.assertEquals(ui,
                 component.findOptionalAncestor(PollNotifier.class).get());


### PR DESCRIPTION
## Description

Renames Component::findAncestor to be compatible with the existing method in Classic Components https://github.com/vaadin/classic-components-internal/blob/3cc3033934a9bb24744bdbe6ce4b50b013be2883/vaadin-classic-components-flow/src/main/java/com/vaadin/classic/v8/ui/AbstractComponent.java#L158 .

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
