### PR TITLE
feat: add configuration to `TaskGenerateHilla`

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -796,7 +796,8 @@ public class NodeTasks implements FallibleCommand {
             // use the new Hilla generator if available, otherwise the old
             // generator.
             if (hillaTask != null) {
-                commands.add(hillaTask);
+                hillaTask.configure(builder.getNpmFolder(),
+                        builder.getBuildDirectory());
             } else {
                 if (builder.endpointSourceFolder != null
                         && builder.endpointSourceFolder.exists()

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -798,6 +798,7 @@ public class NodeTasks implements FallibleCommand {
             if (hillaTask != null) {
                 hillaTask.configure(builder.getNpmFolder(),
                         builder.getBuildDirectory());
+                commands.add(hillaTask);
             } else {
                 if (builder.endpointSourceFolder != null
                         && builder.endpointSourceFolder.exists()

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateHilla.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateHilla.java
@@ -24,6 +24,16 @@ import java.io.File;
  * For internal use only. May be renamed or removed in a future release.
  */
 public interface TaskGenerateHilla extends FallibleCommand {
+    /**
+     * Configures the task by passing it some parameters.
+     *
+     * @param projectDirectory
+     *            the project root directory. In a Maven multi-module project,
+     *            this is the module root, not the main project one.
+     * @param buildDirectoryName
+     *            the name of the build directory (i.e.&nbsp;"build" or
+     *            "target").
+     */
     default void configure(File projectDirectory, String buildDirectoryName) {
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateHilla.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateHilla.java
@@ -15,6 +15,8 @@
  */
 package com.vaadin.flow.server.frontend;
 
+import java.io.File;
+
 /**
  * Generate the Vaadin TS files for endpoints, and the Client API file. It uses
  * the new Maven/Gradle plugin based generator.
@@ -22,5 +24,5 @@ package com.vaadin.flow.server.frontend;
  * For internal use only. May be renamed or removed in a future release.
  */
 public interface TaskGenerateHilla extends FallibleCommand {
-
+    void configure(File projectDirectory, String buildDirectoryName);
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateHilla.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateHilla.java
@@ -31,7 +31,7 @@ public interface TaskGenerateHilla extends FallibleCommand {
      *            the project root directory. In a Maven multi-module project,
      *            this is the module root, not the main project one.
      * @param buildDirectoryName
-     *            the name of the build directory (i.e.&nbsp;"build" or
+     *            the name of the build directory (i.e. "build" or
      *            "target").
      */
     default void configure(File projectDirectory, String buildDirectoryName) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateHilla.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateHilla.java
@@ -24,5 +24,6 @@ import java.io.File;
  * For internal use only. May be renamed or removed in a future release.
  */
 public interface TaskGenerateHilla extends FallibleCommand {
-    void configure(File projectDirectory, String buildDirectoryName);
+    default void configure(File projectDirectory, String buildDirectoryName) {
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateHilla.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateHilla.java
@@ -31,8 +31,7 @@ public interface TaskGenerateHilla extends FallibleCommand {
      *            the project root directory. In a Maven multi-module project,
      *            this is the module root, not the main project one.
      * @param buildDirectoryName
-     *            the name of the build directory (i.e. "build" or
-     *            "target").
+     *            the name of the build directory (i.e. "build" or "target").
      */
     default void configure(File projectDirectory, String buildDirectoryName) {
     }


### PR DESCRIPTION
Adds a method to `TaskGenerateHilla` that allows implementations to get some configuration, notably the path of the current Maven project.

Closes #14218