### PR TITLE
fix: provide correct devMode flag to theme-generator with Vite

### DIFF
--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -325,10 +325,11 @@ export { ${exports.map((binding) => `${binding} as ${binding}`).join(', ')} };`;
 }
 
 function themePlugin(opts): PluginOption {
+  const fullThemeOptions = {...themeOptions, devMode: opts.devMode };
   return {
     name: 'vaadin:theme',
     config() {
-      processThemeResources(themeOptions, console);
+      processThemeResources(fullThemeOptions, console);
     },
     handleHotUpdate(context) {
       const contextPath = path.resolve(context.file);
@@ -339,7 +340,7 @@ function themePlugin(opts): PluginOption {
         console.debug('Theme file changed', changed);
 
         if (changed.startsWith(settings.themeName)) {
-          processThemeResources(themeOptions, console);
+          processThemeResources(fullThemeOptions, console);
         }
       }
     },


### PR DESCRIPTION
## Description

devMode flag was hard-coded to false in theme options, preventing the theme generator
plugin to work correctly when styles.css does not exist

Fixes #14228

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
