### PR TITLE
feat: swallow exceptions on unparseable NPM package versions

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -518,7 +518,9 @@ public abstract class NodeUpdater implements FallibleCommand {
                     .contains(VAADIN_FORM_PKG_LEGACY_VERSION)) {
                 return true;
             } else {
-                throw e;
+                log().warn("Package {} has unparseable version {}", pkg,
+                        e.getMessage());
+                return false;
             }
         }
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -518,6 +518,10 @@ public abstract class NodeUpdater implements FallibleCommand {
                     .contains(VAADIN_FORM_PKG_LEGACY_VERSION)) {
                 return true;
             } else {
+                // NPM package versions are not always easy to parse, see
+                // https://docs.npmjs.com/cli/v8/configuring-npm/package-json#dependencies
+                // for some examples. So let's return false for unparsable
+                // versions, as we don't want them to be updated.
                 log().warn("Package {} has unparseable version {}", pkg,
                         e.getMessage());
                 return false;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -522,7 +522,7 @@ public abstract class NodeUpdater implements FallibleCommand {
                 // https://docs.npmjs.com/cli/v8/configuring-npm/package-json#dependencies
                 // for some examples. So let's return false for unparsable
                 // versions, as we don't want them to be updated.
-                log().warn("Package {} has unparseable version {}", pkg,
+                log().warn("Package {} has unparseable version: {}", pkg,
                         e.getMessage());
                 return false;
             }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -509,8 +509,9 @@ public abstract class NodeUpdater implements FallibleCommand {
 
     private boolean isNewerVersion(JsonObject json, String pkg,
             String version) {
+        FrontendVersion newVersion = new FrontendVersion(version);
+
         try {
-            FrontendVersion newVersion = new FrontendVersion(version);
             FrontendVersion existingVersion = toVersion(json, pkg);
             return newVersion.isNewerThan(existingVersion);
         } catch (NumberFormatException e) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -263,14 +263,13 @@ public class NodeUpdaterTest {
 
         dependencies.put(formPackage, existingVersion);
 
-        try {
-            nodeUpdater.addDependency(packageJson, NodeUpdater.DEPENDENCIES,
-                    formPackage, newVersion);
-            Assert.fail("Expected NumberFormatException");
-        } catch (NumberFormatException e) {
-            Assert.assertTrue(
-                    e.getMessage().contains("is not a valid version"));
-        }
+        NumberFormatException expectedException = Assert
+                .assertThrows(NumberFormatException.class,
+                        () -> nodeUpdater.addDependency(packageJson,
+                                NodeUpdater.DEPENDENCIES, formPackage,
+                                newVersion));
+        Assert.assertTrue(expectedException.getMessage()
+                .contains("is not a valid version"));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -249,6 +249,31 @@ public class NodeUpdaterTest {
     }
 
     @Test
+    public void shouldThrowExceptionOnNewVersionNonParsable() {
+        JsonObject packageJson = Json.createObject();
+        JsonObject dependencies = Json.createObject();
+        packageJson.put(NodeUpdater.DEPENDENCIES, dependencies);
+        JsonObject vaadinDependencies = Json.createObject();
+        vaadinDependencies.put(NodeUpdater.DEPENDENCIES, Json.createObject());
+        packageJson.put(NodeUpdater.VAADIN_DEP_KEY, vaadinDependencies);
+
+        String formPackage = "@vaadin/form";
+        String existingVersion = "2.0.0";
+        String newVersion = "../../../some/local/path";
+
+        dependencies.put(formPackage, existingVersion);
+
+        try {
+            nodeUpdater.addDependency(packageJson, NodeUpdater.DEPENDENCIES,
+                    formPackage, newVersion);
+            Assert.fail("Expected NumberFormatException");
+        } catch (NumberFormatException e) {
+            Assert.assertTrue(
+                    e.getMessage().contains("is not a valid version"));
+        }
+    }
+
+    @Test
     public void getJsonFileContent_incorrectPackageJsonContent_throwsExceptionWithFileName()
             throws IOException {
         File brokenPackageJsonFile = temporaryFolder

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -227,6 +227,28 @@ public class NodeUpdaterTest {
     }
 
     @Test
+    public void shouldSkipUpdatingNonParsableVersions() throws IOException {
+        JsonObject packageJson = Json.createObject();
+        JsonObject dependencies = Json.createObject();
+        packageJson.put(NodeUpdater.DEPENDENCIES, dependencies);
+        JsonObject vaadinDependencies = Json.createObject();
+        vaadinDependencies.put(NodeUpdater.DEPENDENCIES, Json.createObject());
+        packageJson.put(NodeUpdater.VAADIN_DEP_KEY, vaadinDependencies);
+
+        String formPackage = "@vaadin/form";
+        String existingVersion = "../../../some/local/path";
+        String newVersion = "2.0.0";
+
+        dependencies.put(formPackage, existingVersion);
+
+        nodeUpdater.addDependency(packageJson, NodeUpdater.DEPENDENCIES,
+                formPackage, newVersion);
+
+        Assert.assertEquals(existingVersion, packageJson
+                .getObject(NodeUpdater.DEPENDENCIES).getString(formPackage));
+    }
+
+    @Test
     public void getJsonFileContent_incorrectPackageJsonContent_throwsExceptionWithFileName()
             throws IOException {
         File brokenPackageJsonFile = temporaryFolder


### PR DESCRIPTION
When checking for new NPM package versions, let's skip all versions that we do not understand.

Closes #14217