### PR TITLE
fix: support import without url keyword in theme generator

### DIFF
--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
@@ -36,11 +36,12 @@ const headerImport = `import 'construct-style-sheets-polyfill';
 
 const createLinkReferences = `
 const createLinkReferences = (css, target) => {
-  // Unresolved urls are written as '@import url(text);' to the css
+  // Unresolved urls are written as '@import url(text);' or '@import "text";' to the css
+  // Note that with Vite production build there is no space between @import and "text"
   // [0] is the full match
   // [1] matches the media query
   // [2] matches the url
-  const importMatcher = /(?:@media\\s(.+?))?(?:\\s{)?\\@import\\surl\\(\\s*['"]?(.+?)['"]?\\s*\\);(?:})?/g;
+  const importMatcher = /(?:@media\\s(.+?))?(?:\\s{)?\\@import(?:\\surl\\(\\s*)?['"]?(.+?)['"]?(?:\\s*\\))?;(?:})?/g;
   
   var match;
   var styleCss = css;

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
@@ -44,7 +44,7 @@ const createLinkReferences = (css, target) => {
   // [2] matches the url
   // [3] matches the quote char surrounding in '@import "..."'
   // [4] matches the url in '@import "..."'
-  // [5] matcher media query on @import statement
+  // [5] matches media query on @import statement
   const importMatcher = /(?:@media\\s(.+?))?(?:\\s{)?\\@import\\s*(?:url\\(\\s*['"]?(.+?)['"]?\\s*\\)|(["'])((?:\\\\.|[^\\\\])*?)\\3)([^;]*);(?:})?/g
   
   var match;

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
@@ -37,11 +37,15 @@ const headerImport = `import 'construct-style-sheets-polyfill';
 const createLinkReferences = `
 const createLinkReferences = (css, target) => {
   // Unresolved urls are written as '@import url(text);' or '@import "text";' to the css
+  // media query can be present on @media tag or on @import directive after url
   // Note that with Vite production build there is no space between @import and "text"
   // [0] is the full match
   // [1] matches the media query
   // [2] matches the url
-  const importMatcher = /(?:@media\\s(.+?))?(?:\\s{)?\\@import(?:\\surl\\(\\s*)?['"]?(.+?)['"]?(?:\\s*\\))?;(?:})?/g;
+  // [3] matches the quote char surrounding in '@import "..."'
+  // [4] matches the url in '@import "..."'
+  // [5] matcher media query on @import statement
+  const importMatcher = /(?:@media\\s(.+?))?(?:\\s{)?\\@import\\s*(?:url\\(\\s*['"]?(.+?)['"]?\\s*\\)|(["'])((?:\\\\.|[^\\\\])*?)\\3)([^;]*);(?:})?/g
   
   var match;
   var styleCss = css;
@@ -51,9 +55,10 @@ const createLinkReferences = (css, target) => {
     styleCss = styleCss.replace(match[0], "");
     const link = document.createElement('link');
     link.rel = 'stylesheet';
-    link.href = match[2];
-    if (match[1]) {
-      link.media = match[1];
+    link.href = match[2] || match[4];
+    const media = match[1] || match[5];
+    if (media) {
+      link.media = media;
     }
     // For target document append to head else append to target
     if (target === document) {


### PR DESCRIPTION
With Vite it may happend that '@import url(...)' in CSS are rewritten
as '@import ...', that is a valid CSS statement.
Currently the theme generator does not handle the case and this prevents
the resource to be added to the head section. A warning is also
logged on browser console, stating import rules not allowed when
creating stylesheets.
This change updates the importMatcher regex to handle @import without url
In addition it also handles media query declared in import statements.