### PR TITLE
fix: handle duplicated root entries in manifest

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/sw.ts
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/sw.ts
@@ -21,8 +21,11 @@ declare var VITE_ENABLED: boolean; // defined by Webpack/Vite
 // Combine manifest entries injected at compile-time by Webpack/Vite
 // with ones that Flow injects at runtime through `sw-runtime-resources-precache.js`.
 let manifestEntries: PrecacheEntry[] = self.__WB_MANIFEST || [];
+// If injected entries contains element for root, then discard the one from Flow
+// may only happen when running in development mode, but after a frontend build
+let hasRootEntry = manifestEntries.findIndex((entry) => entry.url === '.') >= 0;
 if (self.additionalManifestEntries?.length) {
-  manifestEntries.push(...self.additionalManifestEntries);
+  manifestEntries.push(...self.additionalManifestEntries.filter( (entry) => entry.url !== '.' || !hasRootEntry));
 }
 
 const offlinePath = OFFLINE_PATH;


### PR DESCRIPTION
Duplicated root entry in manifest happens when running application
in development mode but after a frontend build.
This change removes the entry potentially added by flow
if compile-time manifest already added it