### PR TITLE
fix: Make findAncestor return Object for backward compatibility

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/Component.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Component.java
@@ -686,28 +686,27 @@ public abstract class Component
     }
 
     /**
-     * Traverses the component tree up and returns the first component that
-     * matches the given type.
+     * Traverses the component tree up and returns the first ancestor component
+     * that matches the given type.
      *
      * @param componentType
-     *            the class of the component to search for
-     * @return the component as Optional or empty Optional if a parent of given
-     *         type is not found
+     *            the class of the ancestor component to search for
+     * @return The first ancestor that can be assigned to the given class. Null
+     *         if no ancestor with the correct type could be found.
      * @param <T>
-     *            the type of the component to return
+     *            the type of the ancestor component to return
      */
-    @SuppressWarnings("unchecked")
-    public <T> Optional<T> findAncestor(Class<T> componentType) {
-        Optional<Component> parent = getParent();
-        while (parent.isPresent()) {
-            Component component = parent.get();
-            if (componentType.isAssignableFrom(component.getClass())) {
-                return Optional.of((T) component);
+    public <T> T findAncestor(Class<T> componentType) {
+        Optional<Component> optionalParent = getParent();
+        while (optionalParent.isPresent()) {
+            Component parent = optionalParent.get();
+            if (componentType.isAssignableFrom(parent.getClass())) {
+                return componentType.cast(parent);
             } else {
-                parent = component.getParent();
+                optionalParent = parent.getParent();
             }
         }
-        return Optional.empty();
+        return null;
     }
 
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
@@ -1672,12 +1672,10 @@ public class ComponentTest {
         ui.add(componentContainer);
 
         Assert.assertEquals(componentContainer,
-                component.findAncestor(TestComponentContainer.class).get());
-        Assert.assertEquals(ui, component.findAncestor(UI.class).get());
-        Assert.assertEquals(ui,
-                component.findAncestor(PollNotifier.class).get());
-        Assert.assertFalse(
-                component.findAncestor(TestButton.class).isPresent());
+                component.findAncestor(TestComponentContainer.class));
+        Assert.assertEquals(ui, component.findAncestor(UI.class));
+        Assert.assertEquals(ui, component.findAncestor(PollNotifier.class));
+        Assert.assertNull(component.findAncestor(TestButton.class));
 
     }
 


### PR DESCRIPTION
Changes return type to be compatible with classic components package API. Not a breaking change since this method was added recently for 23.2.

Related-to https://github.com/vaadin/classic-components-internal/pull/164