### PR TITLE
Revert "test: workaround for internal selenium grid (#14174)"

### DIFF
--- a/flow-tests/test-frontend/vite-pwa-custom-offline-path/pom-production.xml
+++ b/flow-tests/test-frontend/vite-pwa-custom-offline-path/pom-production.xml
@@ -24,22 +24,6 @@
         </dependencies>
     </dependencyManagement>
 
-    <dependencies>
-        <!-- Temporary fix to workaround errors with internal selenium grid -->
-        <dependency>
-            <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-devtools-v100</artifactId>
-            <version>4.2.2</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-    </dependencies>
-
     <build>
         <defaultGoal>jetty:run</defaultGoal>
         <plugins>

--- a/flow-tests/test-frontend/vite-pwa-custom-offline-path/pom.xml
+++ b/flow-tests/test-frontend/vite-pwa-custom-offline-path/pom.xml
@@ -20,19 +20,6 @@
             <artifactId>vaadin-dev-server</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <!-- Temporary fix to workaround errors with internal selenium grid -->
-        <dependency>
-            <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-devtools-v100</artifactId>
-            <version>4.2.2</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 
     <build>

--- a/flow-tests/test-frontend/vite-pwa-production/pom.xml
+++ b/flow-tests/test-frontend/vite-pwa-production/pom.xml
@@ -31,20 +31,6 @@
             <artifactId>flow-test-lumo</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <!-- Temporary fix to workaround errors with internal selenium grid -->
-        <dependency>
-            <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-devtools-v100</artifactId>
-            <version>4.2.2</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
     </dependencies>
 
     <build>

--- a/flow-tests/test-frontend/vite-pwa/pom.xml
+++ b/flow-tests/test-frontend/vite-pwa/pom.xml
@@ -35,19 +35,6 @@
             <artifactId>flow-test-lumo</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <!-- Temporary fix to workaround errors with internal selenium grid -->
-        <dependency>
-            <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-devtools-v100</artifactId>
-            <version>4.2.2</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Selenium grid now has chrome 103
This reverts commit 7f6155a19e39ee7fce06d4be4c6580253ae74912.
