### PR TITLE
chore: use a patch user permission checking

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -13,7 +13,7 @@ jobs:
       matrix-unit: ${{ steps.set-matrix.outputs.matrix-unit }}
       matrix-it: ${{ steps.set-matrix.outputs.matrix-it }}
     steps:
-      - uses: actions-cool/check-user-permission@v2
+      - uses: ZheSun88/check-user-permission@triggering-actor
         id: check
         with:
           require: 'write'


### PR DESCRIPTION
based on a [recent change](https://github.blog/changelog/2022-07-19-differentiating-triggering-actor-from-executing-actor/) the addon that we have used cannot return the user info for GHA rerun any more. 

i have patch-fix the addon, so let us use it for now and updated it later when they have fixed the issue.

**after merging this, please rebase the PRs from external contributors.** 
