### PR TITLE
fix: let Vite process theme also on theme.js changes

### DIFF
--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -334,6 +334,8 @@ function themePlugin(opts): PluginOption {
     handleHotUpdate(context) {
       const contextPath = path.resolve(context.file);
       const themePath = path.resolve(themeFolder);
+      // Track also updates on fronted/generated/theme.js to regenerate theme
+      // upon a java live reload when value of @Theme annotation changes.
       const isThemeJS = contextPath === path.resolve(themeOptions.frontendGeneratedFolder, "theme.js");
       if (isThemeJS || contextPath.startsWith(themePath)) {
         const changed = path.relative(themePath, contextPath);

--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -334,12 +334,13 @@ function themePlugin(opts): PluginOption {
     handleHotUpdate(context) {
       const contextPath = path.resolve(context.file);
       const themePath = path.resolve(themeFolder);
-      if (contextPath.startsWith(themePath)) {
+      const isThemeJS = contextPath === path.resolve(themeOptions.frontendGeneratedFolder, "theme.js");
+      if (isThemeJS || contextPath.startsWith(themePath)) {
         const changed = path.relative(themePath, contextPath);
 
         console.debug('Theme file changed', changed);
 
-        if (changed.startsWith(settings.themeName)) {
+        if (isThemeJS || changed.startsWith(settings.themeName)) {
           processThemeResources(fullThemeOptions, console);
         }
       }


### PR DESCRIPTION
Flow theme plugin for Vite processes themes only on changes on files
in active theme directory.
This prevents regeneration with java live reload when changing value of
Theme annotation.
This change also triggers theme processing for updates on theme.js file.
