### PR TITLE
fix: Fix removal of windows junctions

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -1263,6 +1263,17 @@ public class FrontendUtils {
         deleteDirectory(nodeModules);
     }
 
+    /**
+     * Recursively delete given directory and contents.
+     * <p>
+     * Will not delete contents of symlink or junction directories, only the
+     * link file.
+     *
+     * @param directory
+     *            directory to delete
+     * @throws IOException
+     *             on failure to delete or read any one file
+     */
     public static void deleteDirectory(File directory) throws IOException {
         if (!directory.exists() || !directory.isDirectory()) {
             return;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -1268,7 +1268,8 @@ public class FrontendUtils {
             return;
         }
 
-        if (!(Files.isSymbolicLink(directory.toPath()) || isJunction(directory.toPath()))) {
+        if (!(Files.isSymbolicLink(directory.toPath())
+                || isJunction(directory.toPath()))) {
             cleanDirectory(directory);
         }
 
@@ -1279,14 +1280,20 @@ public class FrontendUtils {
     }
 
     /**
-     * Check that directory is not a windows junction which is basically a symlink.
-     * @param directory directory path to check
+     * Check that directory is not a windows junction which is basically a
+     * symlink.
+     *
+     * @param directory
+     *            directory path to check
      * @return true if directory is a windows junction
-     * @throws IOException if an I/O error occurs
+     * @throws IOException
+     *             if an I/O error occurs
      */
     private static boolean isJunction(Path directory) throws IOException {
-        boolean isWindows = System.getProperty("os.name").toLowerCase().contains("windows");
-        BasicFileAttributes attrs = Files.readAttributes(directory, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+        boolean isWindows = System.getProperty("os.name").toLowerCase()
+                .contains("windows");
+        BasicFileAttributes attrs = Files.readAttributes(directory,
+                BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
         return isWindows && attrs.isDirectory() && attrs.isOther();
     }
 
@@ -1302,7 +1309,7 @@ public class FrontendUtils {
         }
 
         File[] files = directory.listFiles();
-        if (files == null) {  // null if security restricted
+        if (files == null) { // null if security restricted
             throw new IOException("Failed to list contents of " + directory);
         }
 
@@ -1327,10 +1334,10 @@ public class FrontendUtils {
             boolean filePresent = file.exists();
             if (!file.delete()) {
                 if (!filePresent) {
-                    throw new FileNotFoundException("File does not exist: " + file);
+                    throw new FileNotFoundException(
+                            "File does not exist: " + file);
                 }
-                String message =
-                        "Unable to delete file: " + file;
+                String message = "Unable to delete file: " + file;
                 throw new IOException(message);
             }
         }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -421,7 +421,7 @@ public class FrontendUtilsTest {
         FrontendUtils.deleteNodeModules(new File(npmFolder, "node_modules"));
 
         Assert.assertTrue(
-                "File from linked folder was removed, even if only link folder should be touched.",
+                "Linked folder contents should not be removed.",
                 linkFolderFile.exists());
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -420,8 +420,7 @@ public class FrontendUtilsTest {
 
         FrontendUtils.deleteNodeModules(new File(npmFolder, "node_modules"));
 
-        Assert.assertTrue(
-                "Linked folder contents should not be removed.",
+        Assert.assertTrue("Linked folder contents should not be removed.",
                 linkFolderFile.exists());
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -373,7 +373,8 @@ public class FrontendUtilsTest {
     }
 
     @Test
-    public void symlinkByNpm_deleteDirectory_doesNotDeleteSymlinkFolderFiles() throws IOException, ExecutionFailedException {
+    public void symlinkByNpm_deleteDirectory_doesNotDeleteSymlinkFolderFiles()
+            throws IOException, ExecutionFailedException {
         File npmFolder = tmpDir.newFolder();
 
         File generatedPath = new File(npmFolder, "generated");
@@ -387,15 +388,15 @@ public class FrontendUtilsTest {
         final JsonObject packageJson = Json.createObject();
         packageJson.put(DEPENDENCIES, Json.createObject());
 
-        packageJson.getObject(DEPENDENCIES).put("@symbolic/link", "./" + symbolic.getName());
+        packageJson.getObject(DEPENDENCIES).put("@symbolic/link",
+                "./" + symbolic.getName());
 
         FileUtils.writeStringToFile(new File(npmFolder, PACKAGE_JSON),
                 packageJson.toJson(), StandardCharsets.UTF_8);
 
         ClassFinder finder = Mockito.mock(ClassFinder.class);
 
-        Logger logger = Mockito
-                .spy(LoggerFactory.getLogger(NodeUpdater.class));
+        Logger logger = Mockito.spy(LoggerFactory.getLogger(NodeUpdater.class));
 
         NodeUpdater nodeUpdater = new NodeUpdater(finder,
                 Mockito.mock(FrontendDependencies.class), npmFolder,
@@ -419,7 +420,9 @@ public class FrontendUtilsTest {
 
         FrontendUtils.deleteNodeModules(new File(npmFolder, "node_modules"));
 
-        Assert.assertTrue("File from linked folder was removed, even if only link folder should be touched.", linkFolderFile.exists());
+        Assert.assertTrue(
+                "File from linked folder was removed, even if only link folder should be touched.",
+                linkFolderFile.exists());
     }
 
     private ResourceProvider mockResourceProvider(VaadinService service) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -18,10 +18,12 @@ package com.vaadin.flow.server.frontend;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
@@ -31,21 +33,33 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.di.ResourceProvider;
 import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.MockVaadinServletService;
 import com.vaadin.flow.server.ServiceException;
 import com.vaadin.flow.server.VaadinContext;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServlet;
 import com.vaadin.flow.server.VaadinServletService;
+import com.vaadin.flow.server.frontend.installer.NodeInstaller;
+import com.vaadin.flow.server.frontend.scanner.ClassFinder;
+import com.vaadin.flow.server.frontend.scanner.FrontendDependencies;
 import com.vaadin.tests.util.MockDeploymentConfiguration;
 
+import elemental.json.Json;
+import elemental.json.JsonObject;
+import static com.vaadin.flow.server.Constants.PACKAGE_JSON;
 import static com.vaadin.flow.server.Constants.STATISTICS_JSON_DEFAULT;
+import static com.vaadin.flow.server.Constants.TARGET;
 import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_STATISTICS_JSON;
+import static com.vaadin.flow.server.frontend.NodeUpdater.DEPENDENCIES;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -356,6 +370,56 @@ public class FrontendUtilsTest {
 
         Assert.assertFalse(nodeModules.exists());
         Assert.assertTrue(externalLicense.exists());
+    }
+
+    @Test
+    public void symlinkByNpm_deleteDirectory_doesNotDeleteSymlinkFolderFiles() throws IOException, ExecutionFailedException {
+        File npmFolder = tmpDir.newFolder();
+
+        File generatedPath = new File(npmFolder, "generated");
+        generatedPath.mkdir();
+
+        File symbolic = new File(npmFolder, "symbolic");
+        symbolic.mkdir();
+        File linkFolderFile = new File(symbolic, "symbol.txt");
+        linkFolderFile.createNewFile();
+
+        final JsonObject packageJson = Json.createObject();
+        packageJson.put(DEPENDENCIES, Json.createObject());
+
+        packageJson.getObject(DEPENDENCIES).put("@symbolic/link", "./" + symbolic.getName());
+
+        FileUtils.writeStringToFile(new File(npmFolder, PACKAGE_JSON),
+                packageJson.toJson(), StandardCharsets.UTF_8);
+
+        ClassFinder finder = Mockito.mock(ClassFinder.class);
+
+        Logger logger = Mockito
+                .spy(LoggerFactory.getLogger(NodeUpdater.class));
+
+        NodeUpdater nodeUpdater = new NodeUpdater(finder,
+                Mockito.mock(FrontendDependencies.class), npmFolder,
+                generatedPath, null, TARGET, Mockito.mock(FeatureFlags.class)) {
+
+            @Override
+            public void execute() {
+            }
+
+            @Override
+            Logger log() {
+                return logger;
+            }
+
+        };
+
+        new TaskRunNpmInstall(nodeUpdater, false, false,
+                FrontendTools.DEFAULT_NODE_VERSION,
+                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT), false,
+                false, Collections.emptyList()).execute();
+
+        FrontendUtils.deleteNodeModules(new File(npmFolder, "node_modules"));
+
+        Assert.assertTrue("File from linked folder was removed, even if only link folder should be touched.", linkFolderFile.exists());
     }
 
     private ResourceProvider mockResourceProvider(VaadinService service) {


### PR DESCRIPTION
Fix removal of node_modules so that
symlink and Windows junction directory
contents are not deleted also.

Fixes #14138
Closes #11177