### PR TITLE
test: open java.net module to allow reset of URL URLStreamHandlerFactory

### DIFF
--- a/vaadin-dev-server/pom.xml
+++ b/vaadin-dev-server/pom.xml
@@ -12,6 +12,7 @@
     <packaging>jar</packaging>
 
     <properties>
+        <surefire.argLine>--add-opens=java.base/java.net=ALL-UNNAMED</surefire.argLine>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
URL.setURLStreamHandlerFactory() can be invoked only once per JVM,
otherwise it throws an exception.
To support more tests in the same module using that method, URL.factory
private field should be nullified with reflection, but this fails with
Java 17 with java.lang.reflect.InaccessibleObjectException exception.
To make reflection work, this change add '--add-opens' flag to maven
surefire plugin configuration.