### PR TITLE
test: restore user.home system property after test

### DIFF
--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/stats/ProjectHelpersTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/stats/ProjectHelpersTest.java
@@ -13,10 +13,24 @@ import java.nio.file.Files;
 import com.vaadin.flow.testutil.TestUtils;
 
 import org.apache.commons.io.IOUtils;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 public class ProjectHelpersTest {
+
+    private String userHome;
+
+    @Before
+    public void saveUserHome() {
+        userHome = System.getProperty("user.home");
+    }
+
+    @After
+    public void restoreUserHome() {
+        System.setProperty("user.home", userHome);
+    }
 
     @Test
     public void readUserKey() throws IOException {


### PR DESCRIPTION
ProjectHelpersTest tests sets user.home system property
to a custom value, but they do not reset it after execution,
causing other tests to potentially fail or behave incorrectly.

This change resets user.home at original value after each test