### PR TITLE
fix: use rollup-plugin-postcss-lit with Vite

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -438,6 +438,7 @@ public abstract class NodeUpdater implements FallibleCommand {
             defaults.put("vite", "v3.0.2");
             defaults.put("@rollup/plugin-replace", "3.1.0");
             defaults.put("rollup-plugin-brotli", "3.1.0");
+            defaults.put("rollup-plugin-postcss-lit", "2.0.0");
             defaults.put("vite-plugin-checker", "0.4.9");
             defaults.put("mkdirp", "1.0.4"); // for application-theme-plugin
             defaults.put("workbox-build", WORKBOX_VERSION);

--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -18,6 +18,7 @@ import * as rollup from 'rollup';
 import brotli from 'rollup-plugin-brotli';
 import replace from '@rollup/plugin-replace';
 import checker from 'vite-plugin-checker';
+import postcssLit from 'rollup-plugin-postcss-lit';
 
 const appShellUrl = '.';
 
@@ -485,6 +486,10 @@ export const vaadinConfig: UserConfigFn = (env) => {
       settings.offlineEnabled && injectManifestToSWPlugin(),
       !devMode && statsExtracterPlugin(),
       themePlugin({devMode}),
+      postcssLit({
+        include: ['**/*.css', '**/*.css\?*'],
+        exclude: [`${themeFolder}/**/*.css`, `${themeFolder}/**/*.css\?*`]
+      }),
       {
         name: 'vaadin:force-remove-spa-middleware',
         transformIndexHtml: {

--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -488,7 +488,13 @@ export const vaadinConfig: UserConfigFn = (env) => {
       themePlugin({devMode}),
       postcssLit({
         include: ['**/*.css', '**/*.css\?*'],
-        exclude: [`${themeFolder}/**/*.css`, `${themeFolder}/**/*.css\?*`, '**/*\?html-proxy*']
+        exclude: [
+          `${themeFolder}/**/*.css`,
+          `${themeFolder}/**/*.css\?*`,
+          `${themeResourceFolder}/**/*.css`,
+          `${themeResourceFolder}/**/*.css\?*`,
+          '**/*\?html-proxy*'
+        ]
       }),
       {
         name: 'vaadin:force-remove-spa-middleware',

--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -488,7 +488,7 @@ export const vaadinConfig: UserConfigFn = (env) => {
       themePlugin({devMode}),
       postcssLit({
         include: ['**/*.css', '**/*.css\?*'],
-        exclude: [`${themeFolder}/**/*.css`, `${themeFolder}/**/*.css\?*`]
+        exclude: [`${themeFolder}/**/*.css`, `${themeFolder}/**/*.css\?*`, '**/*\?html-proxy*']
       }),
       {
         name: 'vaadin:force-remove-spa-middleware',

--- a/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
+++ b/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
@@ -22,7 +22,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
@@ -45,7 +44,6 @@ import static com.vaadin.flow.uitest.ui.theme.ThemeView.SUB_COMPONENT_ID;
 
 public class ThemeIT extends ChromeBrowserTest {
 
-    @Ignore("Vite issue with web components styles https://github.com/vaadin/flow/issues/14142")
     @Test
     public void typeScriptCssImport_stylesAreApplied() {
         getDriver().get(getRootURL() + "/path/hello");

--- a/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
+++ b/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
@@ -26,7 +26,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
@@ -48,7 +47,6 @@ import static com.vaadin.flow.uitest.ui.theme.ThemeView.SUB_COMPONENT_ID;
 
 public class ThemeIT extends ChromeBrowserTest {
 
-    @Ignore("Vite issue with web components styles https://github.com/vaadin/flow/issues/14142")
     @Test
     public void typeScriptCssImport_stylesAreApplied() {
         getDriver().get(getRootURL() + "/path/hello");


### PR DESCRIPTION
## Description

Fixes #14142

Added `rollup-plugin-postcss-lit` and configured it to handle all CSS files except those under theme folder.
Note the extra entry with `?` is necessary until https://github.com/umbopepato/rollup-plugin-postcss-lit/issues/49 fixed.

Another entry added to `excludes` to workaround https://github.com/umbopepato/rollup-plugin-postcss-lit/issues/52

## Type of change

- Bugfix