### PR TITLE
test: reduce flakyness of ccdm flow navigation tests

### DIFF
--- a/flow-tests/test-ccdm-flow-navigation/pom.xml
+++ b/flow-tests/test-ccdm-flow-navigation/pom.xml
@@ -50,20 +50,6 @@
                     <productionMode>false</productionMode>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-maven-plugin</artifactId>
-                <version>${jetty.version}</version>
-                <configuration>
-                    <systemProperties>
-                        <!--
-                        Disable dev tools to avoid page reloads caused by debug window
-                        See https://github.com/vaadin/flow/issues/13116
-                        -->
-                        <vaadin.devmode.devTools.enabled>false</vaadin.devmode.devTools.enabled>
-                    </systemProperties>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/flow-tests/test-ccdm-flow-navigation/pom.xml
+++ b/flow-tests/test-ccdm-flow-navigation/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
+        <failsafe.argLine>-Dvaadin.test.developmentMode=true</failsafe.argLine>
     </properties>
 
     <dependencies>

--- a/flow-tests/test-ccdm-flow-navigation/src/main/java/com/vaadin/flow/navigate/ReconnectIntervalConfigurer.java
+++ b/flow-tests/test-ccdm-flow-navigation/src/main/java/com/vaadin/flow/navigate/ReconnectIntervalConfigurer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.navigate;
+
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinServiceInitListener;
+
+/**
+ * Decreases reconnect interval to make offline tests more stable
+ */
+public class ReconnectIntervalConfigurer implements VaadinServiceInitListener {
+    @Override
+    public void serviceInit(ServiceInitEvent event) {
+        event.getSource().addUIInitListener(uiEvent -> uiEvent.getUI()
+                .getReconnectDialogConfiguration().setReconnectInterval(1000));
+    }
+}

--- a/flow-tests/test-ccdm-flow-navigation/src/main/resources/META-INF/services/com.vaadin.flow.server.VaadinServiceInitListener
+++ b/flow-tests/test-ccdm-flow-navigation/src/main/resources/META-INF/services/com.vaadin.flow.server.VaadinServiceInitListener
@@ -1,0 +1,17 @@
+#
+# Copyright 2000-2022 Vaadin Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+
+com.vaadin.flow.navigate.ReconnectIntervalConfigurer

--- a/flow-tests/test-ccdm-flow-navigation/src/test/java/com/vaadin/flow/navigate/ServiceWorkerIT.java
+++ b/flow-tests/test-ccdm-flow-navigation/src/test/java/com/vaadin/flow/navigate/ServiceWorkerIT.java
@@ -311,8 +311,7 @@ public class ServiceWorkerIT extends ChromeDeviceTest {
         waitForDevServer();
         waitForServiceWorkerReady();
 
-        boolean isDevMode = (Boolean) getCommandExecutor()
-                .executeScript("return Vaadin.developmentMode");
+        boolean isDevMode = Boolean.getBoolean("vaadin.test.developmentMode");
         if (isDevMode) {
             // In production mode all views are supposed to be already in the
             // bundle, but in dev mode they are loaded at runtime

--- a/pom.xml
+++ b/pom.xml
@@ -545,6 +545,7 @@
                         </execution>
                     </executions>
                     <configuration>
+                        <argLine>${failsafe.argLine}</argLine>
                         <trimStackTrace>false</trimStackTrace>
                         <enableAssertions>true</enableAssertions>
                         <parallel>all</parallel>


### PR DESCRIPTION
Decreases heartbeat interval to make test more stable
Uses system property to detect development mode, since getting 'Vaadin.developmentMode' from browser returns wrong value in Bender validation job