### PR TITLE
test: Explicitly set dev mode for Vite basic tests

### DIFF
--- a/flow-tests/test-frontend/vite-basics/pom.xml
+++ b/flow-tests/test-frontend/vite-basics/pom.xml
@@ -67,6 +67,9 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <productionMode>false</productionMode>
+                </configuration>
             </plugin>
             <plugin>
                  <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
`BasicsIT::debugWindowShown` is flaky: dev tool popup is not shown at all in CI, probably because the app is running in prod mode erroneously. 