### PR TITLE
test: set --host Vite flag in development mode

### DIFF
--- a/flow-tests/vaadin-spring-tests/test-spring-boot-only-prepare/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-only-prepare/pom.xml
@@ -132,6 +132,9 @@
                 <configuration>
                     <maxAttempts>100</maxAttempts>
                     <wait>2500</wait>
+                    <jvmArguments>
+                        -Dvaadin.devmode.vite.options=${vaadin.devmode.vite.options}
+                    </jvmArguments>
                 </configuration>
                 <executions>
                     <!-- start and stop application when running


### PR DESCRIPTION
When running in development mode we need to add Vite --host flag
so Vite client websocket connection will work when tests are
executed on a remote browser
