### PR TITLE
fix: Request Desktop Site feature with only MajorVersion

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/shared/BrowserDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/BrowserDetails.java
@@ -296,12 +296,30 @@ public class BrowserDetails implements Serializable {
             } else {
                 i += CHROME.length();
             }
-
-            parseVersionString(safeSubstring(userAgent, i, i + 5));
+            int versionBreak = getVersionStringLength(userAgent, i);
+            parseVersionString(safeSubstring(userAgent, i, i + versionBreak));
         } else {
             i += 7;
-            parseVersionString(safeSubstring(userAgent, i, i + 6));
+            int versionBreak = getVersionStringLength(userAgent, i);
+            parseVersionString(safeSubstring(userAgent, i, i + versionBreak));
         }
+    }
+
+    /**
+     * Get the full version string until space.
+     *
+     * @param userAgent
+     *            user agent string
+     * @param i
+     *            version index
+     * @return length of version number
+     */
+    private static int getVersionStringLength(String userAgent, int i) {
+        int versionBreak = userAgent.substring(i).indexOf(" ");
+        if (versionBreak == -1) {
+            versionBreak = userAgent.substring(i).length();
+        }
+        return versionBreak;
     }
 
     private void parseAndroidVersion(String userAgent) {
@@ -360,6 +378,11 @@ public class BrowserDetails implements Serializable {
 
         int idx2 = versionString.indexOf('.', idx + 1);
         if (idx2 < 0) {
+            // If string only contains major version, set minor to 0.
+            if (versionString.substring(idx).length() == 0) {
+                browserMinorVersion = 0;
+                return;
+            }
             idx2 = versionString.length();
         }
         String minorVersionPart = safeSubstring(versionString, idx + 1, idx2)

--- a/flow-server/src/main/java/com/vaadin/flow/shared/BrowserDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/shared/BrowserDetails.java
@@ -288,7 +288,8 @@ public class BrowserDetails implements Serializable {
     }
 
     private void parseChromeVersion(String userAgent) {
-        int i = userAgent.indexOf(" crios/");
+        final String crios = " crios/";
+        int i = userAgent.indexOf(crios);
         if (i == -1) {
             i = userAgent.indexOf(CHROME);
             if (i == -1) {
@@ -299,7 +300,7 @@ public class BrowserDetails implements Serializable {
             int versionBreak = getVersionStringLength(userAgent, i);
             parseVersionString(safeSubstring(userAgent, i, i + versionBreak));
         } else {
-            i += 7;
+            i += crios.length(); // move index to version string start
             int versionBreak = getVersionStringLength(userAgent, i);
             parseVersionString(safeSubstring(userAgent, i, i + versionBreak));
         }
@@ -310,14 +311,16 @@ public class BrowserDetails implements Serializable {
      *
      * @param userAgent
      *            user agent string
-     * @param i
-     *            version index
+     * @param startIndex
+     *            index for version string start
      * @return length of version number
      */
-    private static int getVersionStringLength(String userAgent, int i) {
-        int versionBreak = userAgent.substring(i).indexOf(" ");
+    private static int getVersionStringLength(String userAgent,
+            int startIndex) {
+        final String versionSubString = userAgent.substring(startIndex);
+        int versionBreak = versionSubString.indexOf(" ");
         if (versionBreak == -1) {
-            versionBreak = userAgent.substring(i).length();
+            versionBreak = versionSubString.length();
         }
         return versionBreak;
     }

--- a/flow-server/src/test/java/com/vaadin/flow/shared/BrowserDetailsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/shared/BrowserDetailsTest.java
@@ -58,6 +58,8 @@ public class BrowserDetailsTest extends TestCase {
     private static final String CHROME_IOS = "Mozilla/5.0 (iPhone; CPU iPhone OS 9_2_1 like Mac OS X) AppleWebKit/601.1 (KHTML, like Gecko) CriOS/49.0.2623.73 Mobile/13D15 Safari/601.1.46";
     private static final String CHROME_40_ON_CHROMEOS = "Mozilla/5.0 (X11; CrOS x86_64 6457.31.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.38 Safari/537.36";
 
+    private static final String CHROME_IOS_DESKTOP = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_5) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/85 Version/11.1.1 Safari/605.1.15";
+
     private static final String SAFARI3_WINDOWS = "Mozilla/5.0 (Windows; U; Windows NT 5.1; cs-CZ) AppleWebKit/525.28.3 (KHTML, like Gecko) Version/3.2.3 Safari/525.29";
     private static final String SAFARI4_MAC = "Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10_5_8; en-us) AppleWebKit/531.22.7 (KHTML, like Gecko) Version/4.0.5 Safari/531.22.7";
     private static final String SAFARI10_WINDOWS = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.1.2 Safari/603.3.8";
@@ -267,6 +269,15 @@ public class BrowserDetailsTest extends TestCase {
         assertBrowserMajorVersion(bd, 49);
         assertBrowserMinorVersion(bd, 0);
         assertEngineVersion(bd, 601.1f);
+    }
+
+    public void testChromeIOSDesktopSiteFeature() {
+        BrowserDetails bd = new BrowserDetails(CHROME_IOS_DESKTOP);
+        assertWebKit(bd);
+        assertChrome(bd);
+        assertBrowserMajorVersion(bd, 85);
+        assertBrowserMinorVersion(bd, 0);
+        assertEngineVersion(bd, 605.1f);
     }
 
     public void testChromeChromeOS() {


### PR DESCRIPTION
Fixes User Agent in Chrome for iOS when the
Request Desktop Site feature is enabled.
At this time the version only consists of the major version.

part of #13921
