### PR TITLE
feat!: Fully enable new license checker

### DIFF
--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -27,14 +27,12 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 
-import com.fasterxml.jackson.annotation.JsonFormat.Feature;
 import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.server.Constants;
@@ -45,7 +43,6 @@ import com.vaadin.flow.server.frontend.FrontendTools;
 import com.vaadin.flow.server.frontend.FrontendToolsSettings;
 import com.vaadin.flow.server.frontend.FrontendUtils;
 import com.vaadin.flow.server.frontend.NodeTasks;
-import com.vaadin.flow.server.frontend.TaskUpdateImports;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.scanner.ReflectionsClassFinder;
 import com.vaadin.flow.utils.FlowFileUtils;
@@ -364,7 +361,7 @@ public class BuildFrontendUtil {
         FeatureFlags featureFlags = getFeatureFlags(adapter);
 
         LicenseChecker.setStrictOffline(
-                featureFlags.isEnabled(FeatureFlags.OFFLINE_LICENSE_CHECKER));
+                !featureFlags.isEnabled(FeatureFlags.OLD_LICENSE_CHECKER));
 
         FrontendToolsSettings settings = getFrontendToolsSettings(adapter);
         FrontendTools tools = new FrontendTools(settings);

--- a/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
+++ b/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
@@ -67,9 +67,9 @@ public class FeatureFlags implements Serializable {
     public static final Feature HILLA_ENGINE = new Feature(
             "Multi-module engine in Hilla", "hillaEngine",
             "https://github.com/vaadin/flow/issues/9010", true, null);
-    public static final Feature OFFLINE_LICENSE_CHECKER = new Feature(
-            "Offline license checker", "newLicenseChecker",
-            "https://github.com/vaadin/platform/issues/2938", false, null);
+    public static final Feature OLD_LICENSE_CHECKER = new Feature(
+            "Old license checker", "oldLicenseChecker",
+            "https://github.com/vaadin/platform/issues/2984", false, null);
     public static final Feature COLLABORATION_ENGINE_BACKEND = new Feature(
             "Collaboration Engine backend for clustering support",
             "collaborationEngineBackend",
@@ -98,7 +98,7 @@ public class FeatureFlags implements Serializable {
         features.add(new Feature(SPREADSHEET_COMPONENT));
         features.add(new Feature(HILLA_PUSH));
         features.add(new Feature(HILLA_ENGINE));
-        features.add(new Feature(OFFLINE_LICENSE_CHECKER));
+        features.add(new Feature(OLD_LICENSE_CHECKER));
         features.add(new Feature(COLLABORATION_ENGINE_BACKEND));
         features.add(new Feature(WEBPACK));
         features.add(new Feature(ENFORCE_FIELD_VALIDATION));

--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
             <dependency>
                 <groupId>com.vaadin</groupId>
                 <artifactId>license-checker</artifactId>
-                <version>1.5.2</version>
+                <version>1.6.0</version>
             </dependency>
 
             <!-- Test dependencies -->

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
@@ -205,7 +205,7 @@ public class DevModeInitializer implements Serializable {
         // this call
         FeatureFlags featureFlags = FeatureFlags.get(context);
         LicenseChecker.setStrictOffline(
-                featureFlags.isEnabled(FeatureFlags.OFFLINE_LICENSE_CHECKER));
+                !featureFlags.isEnabled(FeatureFlags.OLD_LICENSE_CHECKER));
 
         featureFlags.setPropertiesLocation(config.getJavaResourceFolder());
 


### PR DESCRIPTION
The new license checker is triggered also for production builds and requires an offline license for development in an offline environment. It no longer relies on third party cookies to resolve all browser compatibility issues.

Fixes https://github.com/vaadin/platform/issues/2984
