### PR TITLE
fix: Add missing general styles to webcomponents shadow dom (#14316)(CP: 23.1)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -1160,7 +1160,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             return null;
         }
 
-        private void setupCss(Element head, BootstrapContext context) {
+        protected void setupCss(Element head, BootstrapContext context) {
             Element styles = head.appendElement("style").attr("type",
                     CSS_TYPE_ATTRIBUTE_VALUE);
             // Add any body style that is defined for the application using

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
@@ -136,6 +136,8 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
                                 getPushScript(context), true));
                     }
 
+                    setupCss(head, context);
+
                     return document;
                 } catch (IOException e) {
                     throw new BootstrapException(

--- a/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/NpmOnlyIndexIT.java
+++ b/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/NpmOnlyIndexIT.java
@@ -32,7 +32,7 @@ public class NpmOnlyIndexIT extends ChromeBrowserTest {
         return Constants.PAGE_CONTEXT + "/index.html";
     }
 
-    // test for #7005
+    // test for #7005, #14256
     @Test
     public void globalStylesAreUnderTheWebComponent() {
         open();

--- a/flow-tests/test-embedding/test-embedding-reusable-theme/pom.xml
+++ b/flow-tests/test-embedding/test-embedding-reusable-theme/pom.xml
@@ -25,7 +25,7 @@
 
     <artifactId>test-embedding-reusable-theme</artifactId>
     <packaging>war</packaging>
-    <name>Flow Embedding resuable application theme tests</name>
+    <name>Flow Embedding reusable application theme tests</name>
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>


### PR DESCRIPTION
The document that is generated by
WebComponentBootstrapHandler was
missing the needed CSS to be added
to the shadow dom while using Vite.

Fixes: #14256

(cherry picked from commit 16959a935433dc024ccc585d0003e7b6bc319d21)
