### PR TITLE
fix: Strip servlet path from path when serving static files (#14239)

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/StaticFileServerTest.java
@@ -277,7 +277,7 @@ public class StaticFileServerTest implements Serializable {
     @Test
     public void isResourceRequest() throws Exception {
         fileServer.writeResponse = false;
-        setupRequestURI("", "/static", "/file.png");
+        setupRequestURI("", "/static", "/static/file.png");
         Mockito.when(servletService.getStaticResource("/static/file.png"))
                 .thenReturn(new URL("file:///static/file.png"));
         Assert.assertTrue(fileServer.serveStaticResource(request, response));
@@ -286,7 +286,7 @@ public class StaticFileServerTest implements Serializable {
     @Test
     public void isResourceRequestWithContextPath() throws Exception {
         fileServer.writeResponse = false;
-        setupRequestURI("/foo", "/static", "/file.png");
+        setupRequestURI("/foo", "/static", "/static/file.png");
         Mockito.when(servletService.getStaticResource("/static/file.png"))
                 .thenReturn(new URL("file:///static/file.png"));
         Assert.assertTrue(fileServer.serveStaticResource(request, response));
@@ -818,7 +818,7 @@ public class StaticFileServerTest implements Serializable {
 
     @Test
     public void serveStaticResource() throws IOException {
-        setupRequestURI("", "/some", "/file.js");
+        setupRequestURI("", "/some", "/some/file.js");
         String fileData = "function() {eval('foo');};";
 
         Mockito.when(servletService.getStaticResource("/some/file.js"))
@@ -1103,7 +1103,7 @@ public class StaticFileServerTest implements Serializable {
         long browserLatest = 123L;
         long fileModified = 123L;
 
-        setupRequestURI("", "/some", "/file.js");
+        setupRequestURI("", "/some", "/some/file.js");
         Mockito.when(request.getDateHeader("If-Modified-Since"))
                 .thenReturn(browserLatest);
 


### PR DESCRIPTION
## Description

When the Vaadin servlet tries to serve static files from classpath resources, it needs to strip off the servlet path, if any, associated with the request before trying to find them, because the servlet is located relative to the servlet path in the HTTP URI request space. But the `StaticFileServer` is not doing that.

When the Vaadin servlet is mapped to `/*` then this bug has no impact, because the servlet path is the empty string.

But in any other scenario, e.g., servlet mapped to `/myapp`, then classpath resources will not be found because Vaadin will try to find classpath resource `/foo/bar.gif` at classpath location `/myapp/foo/bar.gif`, which doesn't exist.

For example, this bug causes any add-on that includes JS or CSS files (which is most of them) to fail.

Fixes #14239

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

NOTE: A couple of existing unit tests were wrong (in my opinion) and had to be corrected. They now serve as unit tests for this fix.

Obviously, I'm unsure about "correcting" an existing unit test. But basically they seemed obviously wrong to me because they were trying to access a static resource from the servlet, but without using the servlet's servlet path, which makes no sense.