### PR TITLE
fix!: Revert always load static files from context root (#13795)

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/communication/AtmospherePushConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/AtmospherePushConnection.java
@@ -727,7 +727,7 @@ public class AtmospherePushConnection implements PushConnection {
             Console.log("Loading " + pushJs);
             ResourceLoader loader = registry.getResourceLoader();
             String pushScriptUrl = registry.getApplicationConfiguration()
-                    .getContextRootUrl() + pushJs;
+                    .getServiceUrl() + pushJs;
             ResourceLoadListener loadListener = new ResourceLoadListener() {
                 @Override
                 public void onLoad(ResourceLoadEvent event) {

--- a/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/UrlUtil.java
@@ -20,10 +20,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
-import javax.servlet.http.HttpServletRequest;
-
-import com.vaadin.flow.server.VaadinRequest;
-
 /**
  * Internal utility class for URL handling.
  * <p>
@@ -106,42 +102,4 @@ public class UrlUtil {
         }
     }
 
-    /**
-     * Gets the path info for a /VAADIN/something request.
-     *
-     * @param request
-     *            the servlet request
-     * @return the path info starting with /VAADIN/ or <code>null</code> if no
-     *         path information is available
-     */
-    public static String getStaticVaadinPathInfo(VaadinRequest request) {
-        if (request instanceof HttpServletRequest) {
-            return getStaticVaadinPathInfo(((HttpServletRequest) request));
-        }
-
-        return request.getPathInfo();
-    }
-
-    /**
-     * Gets the path info for a /VAADIN/something request.
-     *
-     * @param request
-     *            the servlet request
-     * @return the path info starting with /VAADIN/ or <code>null</code> if no
-     *         path information is available
-     */
-    public static String getStaticVaadinPathInfo(HttpServletRequest request) {
-        String pathInfo = request.getPathInfo();
-        if (pathInfo == null) {
-            return null;
-        }
-
-        if ("/VAADIN".equals(request.getServletPath())) {
-            // If the servlet is deployed with a separate /VAADIN/* mapping, we
-            // need to add the missing /VAADIN/
-            String prefix = pathInfo.startsWith("/") ? "/VAADIN" : "/VAADIN/";
-            pathInfo = prefix + pathInfo;
-        }
-        return pathInfo;
-    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -1019,9 +1019,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                     .matcher(index);
             while (scriptMatcher.find()) {
                 Element script = createJavaScriptModuleElement(
-                        context.getUriResolver().resolveVaadinUri("context://"
-                                + "VAADIN/build/" + scriptMatcher.group(1)),
-                        false);
+                        "VAADIN/build/" + scriptMatcher.group(1), false);
                 head.appendChild(script.attr("async", true)
                         // Fixes basic auth in Safari #6560
                         .attr("crossorigin", true));
@@ -1033,8 +1031,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                     .matcher(index);
             while (cssMatcher.find()) {
                 Element link = createStylesheetElement(
-                        context.getUriResolver().resolveVaadinUri("context://"
-                                + "VAADIN/build/" + cssMatcher.group(1)));
+                        "VAADIN/build/" + cssMatcher.group(1));
                 head.appendChild(link);
             }
         }
@@ -1684,8 +1681,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
         // Parameter appended to JS to bypass caches after version upgrade.
         String versionQueryParam = "?v=" + Version.getFullVersion();
         // Load client-side dependencies for push support
-        String pushJSPath = context.getService()
-                .getContextRootRelativePath(request);
+        String pushJSPath = BootstrapHandlerHelper.getServiceUrl(request) + "/";
 
         if (request.getService().getDeploymentConfiguration()
                 .isProductionMode()) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
@@ -598,9 +598,9 @@ public class VaadinServlet extends HttpServlet {
     /**
      * For internal use only.
      *
-     * @return the first vaadin servlet that was reqistered
+     * @return the vaadin servlet used for frontend files in development mode
      */
-    public static String getFirstMapping() {
+    public static String getFrontendMapping() {
         return frontendMapping;
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
@@ -140,10 +140,14 @@ public class VaadinServlet extends HttpServlet {
 
             synchronized (VaadinServlet.class) {
                 if (frontendMapping == null) {
-                    String definedPath = getService()
-                            .getDeploymentConfiguration().getInitParameters()
-                            .getProperty(
-                                    INTERNAL_VAADIN_SERVLET_VITE_DEV_MODE_FRONTEND_PATH);
+                    String definedPath = null;
+                    DeploymentConfiguration deploymentConfiguration = getService()
+                            .getDeploymentConfiguration();
+                    if (deploymentConfiguration != null) {
+                        definedPath = deploymentConfiguration
+                                .getInitParameters().getProperty(
+                                        INTERNAL_VAADIN_SERVLET_VITE_DEV_MODE_FRONTEND_PATH);
+                    }
                     if (definedPath != null) {
                         frontendMapping = definedPath;
                     } else {

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.server;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
+import javax.servlet.ServletRegistration;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -28,6 +29,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import com.vaadin.flow.component.UI;
@@ -133,11 +135,16 @@ public class VaadinServlet extends HttpServlet {
             synchronized (VaadinServlet.class) {
                 if (firstMapping == null) {
                     List<String> mappings = new ArrayList<>();
-                    mappings.addAll(
-                            this.getServletContext().getServletRegistrations()
-                                    .get(this.getServletName()).getMappings());
-                    Collections.sort(mappings);
-                    firstMapping = mappings.get(0);
+                    Map<String, ? extends ServletRegistration> servletRegistrations = this
+                            .getServletContext().getServletRegistrations();
+                    if (servletRegistrations != null
+                            && !servletRegistrations.isEmpty()) {
+                        // This should only happen in unit tests
+                        mappings.addAll(servletRegistrations
+                                .get(this.getServletName()).getMappings());
+                        firstMapping = mappings.get(0);
+                        Collections.sort(mappings);
+                    }
                 }
             }
             servletInitialized();

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
@@ -23,6 +23,9 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -144,6 +147,7 @@ public class VaadinServlet extends HttpServlet {
                                 .get(this.getServletName()).getMappings());
                         firstMapping = mappings.get(0);
                         Collections.sort(mappings);
+                        getLogger().debug("Using mapping "+firstMapping+" from servlet "+getClass().getSimpleName()+" as the frontend servlet because this was the first deployed VaadinServlet");
                     }
                 }
             }
@@ -151,6 +155,10 @@ public class VaadinServlet extends HttpServlet {
         } finally {
             CurrentInstance.clearAll();
         }
+    }
+
+    private Logger getLogger() {
+        return LoggerFactory.getLogger(getClass());
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
@@ -147,7 +147,9 @@ public class VaadinServlet extends HttpServlet {
                                 .get(this.getServletName()).getMappings());
                         firstMapping = mappings.get(0);
                         Collections.sort(mappings);
-                        getLogger().debug("Using mapping "+firstMapping+" from servlet "+getClass().getSimpleName()+" as the frontend servlet because this was the first deployed VaadinServlet");
+                        getLogger().debug("Using mapping " + firstMapping
+                                + " from servlet " + getClass().getSimpleName()
+                                + " as the frontend servlet because this was the first deployed VaadinServlet");
                     }
                 }
             }

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
@@ -25,6 +25,9 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 
 import com.vaadin.flow.component.UI;
@@ -56,6 +59,7 @@ public class VaadinServlet extends HttpServlet {
     private StaticFileHandler staticFileHandler;
 
     private volatile boolean isServletInitialized;
+    private static String firstMapping = null;
 
     /**
      * Called by the servlet container to indicate to a servlet that the servlet
@@ -126,6 +130,16 @@ public class VaadinServlet extends HttpServlet {
 
             staticFileHandler = createStaticFileHandler(servletService);
 
+            synchronized (VaadinServlet.class) {
+                if (firstMapping == null) {
+                    List<String> mappings = new ArrayList<>();
+                    mappings.addAll(
+                            this.getServletContext().getServletRegistrations()
+                                    .get(this.getServletName()).getMappings());
+                    Collections.sort(mappings);
+                    firstMapping = mappings.get(0);
+                }
+            }
             servletInitialized();
         } finally {
             CurrentInstance.clearAll();
@@ -546,6 +560,15 @@ public class VaadinServlet extends HttpServlet {
             initializer.initialize(vaadinServletContext);
         }
         return vaadinServletContext;
+    }
+
+    /**
+     * For internal use only.
+     *
+     * @return the first vaadin servlet that was reqistered
+     */
+    public static String getFirstMapping() {
+        return firstMapping;
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
@@ -159,8 +159,8 @@ public class VaadinServlet extends HttpServlet {
                             // This should only happen in unit tests
                             mappings.addAll(servletRegistrations
                                     .get(this.getServletName()).getMappings());
-                            frontendMapping = mappings.get(0);
                             Collections.sort(mappings);
+                            frontendMapping = mappings.get(0);
                             getLogger().debug("Using mapping " + frontendMapping
                                     + " from servlet "
                                     + getClass().getSimpleName()

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
@@ -83,10 +83,6 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
                 : getIndexHtmlDocument(service);
 
         prependBaseHref(request, indexDocument);
-        String contextRootRelativePath = request.getService()
-                .getContextRootRelativePath(request);
-        rewriteBundleImportToContextRoot(indexDocument,
-                contextRootRelativePath);
 
         JsonObject initialJson = Json.createObject();
 
@@ -305,16 +301,6 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
             indexDocument.head().prependElement("base").attr("href", baseHref);
         } else {
             base.first().attr("href", baseHref);
-        }
-    }
-
-    private static void rewriteBundleImportToContextRoot(Document indexDocument,
-            String contextRootRelativePath) {
-        Elements bundleScripts = indexDocument.head()
-                .getElementsByAttributeValueStarting("src", "VAADIN/");
-        for (Element bundleScript : bundleScripts) {
-            bundleScript.attr("src", bundleScript.attr("src").replaceFirst(
-                    "VAADIN", contextRootRelativePath + "VAADIN"));
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamRequestHandler.java
@@ -70,7 +70,8 @@ public class StreamRequestHandler implements RequestHandler {
     @Override
     public boolean handleRequest(VaadinSession session, VaadinRequest request,
             VaadinResponse response) throws IOException {
-        String pathInfo = UrlUtil.getStaticVaadinPathInfo(request);
+
+        String pathInfo = request.getPathInfo();
         if (pathInfo == null) {
             return false;
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -1367,7 +1367,7 @@ public class FrontendUtils {
      *         with a slash
      */
     public static String getFrontendServletPath(ServletContext servletContext) {
-        String mapping = VaadinServlet.getFirstMapping();
+        String mapping = VaadinServlet.getFrontendMapping();
         if (mapping.endsWith("/*")) {
             mapping = mapping.replace("/*", "");
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -35,11 +35,14 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Scanner;
 import java.util.stream.Stream;
+
+import javax.servlet.ServletContext;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -55,6 +58,7 @@ import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.VaadinContext;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinServlet;
 import com.vaadin.flow.server.frontend.FallbackChunk.CssImportData;
 
 import elemental.json.JsonArray;
@@ -1353,4 +1357,22 @@ public class FrontendUtils {
             }
         }
     }
+
+    /**
+     * Gets the servlet path (excluding the context path) for the servlet used
+     * for serving the VAADIN frontend bundle.
+     *
+     * @return the path to the servlet used for the frontend bundle. Empty for a
+     *         /* mapping, otherwise always starts with a slash but never ends
+     *         with a slash
+     */
+    public static String getFrontendServletPath(ServletContext servletContext) {
+        String mapping = VaadinServlet.getFirstMapping();
+        if (mapping.endsWith("/*")) {
+            mapping = mapping.replace("/*", "");
+        }
+
+        return mapping;
+    }
+
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
@@ -1777,11 +1777,11 @@ public class BootstrapHandlerTest {
         Assert.assertTrue(
                 "Bundle should be gotten from index and added to bootstrap page",
                 bootstrapPage.head().toString()
-                        .contains("src=\"./VAADIN/build/main.d253dd35.js\""));
+                        .contains("src=\"VAADIN/build/main.d253dd35.js\""));
         Assert.assertTrue(
                 "Bundled css should be gotten from index and added to bootstrap page",
                 bootstrapPage.head().toString()
-                        .contains("href=\"./VAADIN/build/main.688a5538.css\""));
+                        .contains("href=\"VAADIN/build/main.688a5538.css\""));
     }
 
     private void enableWebpackFeature() {

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandlerTest.java
@@ -220,7 +220,7 @@ public class JavaScriptBootstrapHandlerTest {
 
         // Using regex, because version depends on the build
         Assert.assertTrue(json.getString("pushScript").matches(
-                "^\\./\\.\\./VAADIN/static/push/vaadinPush\\.js\\?v=[\\w\\.\\-]+$"));
+                "^\\./VAADIN/static/push/vaadinPush\\.js\\?v=[\\w\\.\\-]+$"));
     }
 
     @Test

--- a/flow-tests/test-ccdm-flow-navigation/src/test/java/com/vaadin/flow/navigate/ServiceWorkerOnNestedMappingIT.java
+++ b/flow-tests/test-ccdm-flow-navigation/src/test/java/com/vaadin/flow/navigate/ServiceWorkerOnNestedMappingIT.java
@@ -1,7 +1,9 @@
 package com.vaadin.flow.navigate;
 
 import org.junit.After;
+import org.junit.Ignore;
 
+@Ignore("Service worker not working on nested path with VITE. See https://github.com/vaadin/flow/issues/14227")
 public class ServiceWorkerOnNestedMappingIT extends ServiceWorkerIT {
 
     @Override

--- a/flow-tests/test-ccdm-flow-navigation/src/test/java/com/vaadin/flow/navigate/ServiceWorkerOnNestedMappingIT.java
+++ b/flow-tests/test-ccdm-flow-navigation/src/test/java/com/vaadin/flow/navigate/ServiceWorkerOnNestedMappingIT.java
@@ -1,9 +1,7 @@
 package com.vaadin.flow.navigate;
 
 import org.junit.After;
-import org.junit.Ignore;
 
-@Ignore("Service worker not working on nested path with VITE. See https://github.com/vaadin/flow/issues/14227")
 public class ServiceWorkerOnNestedMappingIT extends ServiceWorkerIT {
 
     @Override

--- a/flow-tests/test-common/src/main/java/com/vaadin/flow/uitest/servlet/ViewTestServlet.java
+++ b/flow-tests/test-common/src/main/java/com/vaadin/flow/uitest/servlet/ViewTestServlet.java
@@ -22,8 +22,8 @@ import javax.servlet.annotation.WebServlet;
 
 import com.vaadin.flow.server.VaadinServlet;
 
-@WebServlet(asyncSupported = true, urlPatterns = { "/view/*",
-        "/VAADIN/*" }, initParams = @WebInitParam(name = "productionMode", value = "false"))
+@WebServlet(asyncSupported = true, urlPatterns = {
+        "/view/*" }, initParams = @WebInitParam(name = "productionMode", value = "false"))
 public class ViewTestServlet extends VaadinServlet {
 
     private static ViewClassLocator viewLocator;

--- a/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/src/main/java/com/vaadin/flow/uitest/ui/servlets/ServletWithPath.java
+++ b/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/src/main/java/com/vaadin/flow/uitest/ui/servlets/ServletWithPath.java
@@ -19,7 +19,8 @@ import javax.servlet.annotation.WebServlet;
 
 import com.vaadin.flow.server.VaadinServlet;
 
-@WebServlet("/path/*")
+// Load on startup is set to 1 to ensure this servlet is used as the frontend servlet to paths are always the same in the tests
+@WebServlet(urlPatterns = "/path/*", loadOnStartup = 1)
 public class ServletWithPath extends VaadinServlet {
 
 }

--- a/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/src/test-webpack/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
+++ b/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/src/test-webpack/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
@@ -50,8 +50,7 @@ public class ThemeIT extends ChromeBrowserTest {
 
         checkLogsForErrors();
 
-        final TestBenchElement helloWorld = $(TestBenchElement.class).first()
-                .findElement(By.tagName("hello-world-view"));
+        final TestBenchElement helloWorld = $("hello-world-view").waitForFirst();
 
         Assert.assertEquals("hello-world-view", helloWorld.getTagName());
 
@@ -98,6 +97,7 @@ public class ThemeIT extends ChromeBrowserTest {
                 driver.getPageSource().contains("HTTP ERROR 404 Not Found"));
 
         getDriver().get(getRootURL() + "/path/themes/no-copy/no-copy.txt");
+        waitForDevServer();
         String source = driver.getPageSource();
         Matcher m = Pattern.compile(
                 ".*Could not navigate to.*themes/no-copy/no-copy.txt.*",

--- a/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/src/test-webpack/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
+++ b/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/src/test-webpack/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
@@ -50,7 +50,8 @@ public class ThemeIT extends ChromeBrowserTest {
 
         checkLogsForErrors();
 
-        final TestBenchElement helloWorld = $("hello-world-view").waitForFirst();
+        final TestBenchElement helloWorld = $("hello-world-view")
+                .waitForFirst();
 
         Assert.assertEquals("hello-world-view", helloWorld.getTagName());
 

--- a/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/src/test-webpack/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
+++ b/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/src/test-webpack/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
@@ -115,7 +115,7 @@ public class ThemeIT extends ChromeBrowserTest {
         // Note themes/app-theme gets VAADIN/static from the file-loader
         Assert.assertEquals("body background-image should come from styles.css",
                 "url(\"" + getRootURL()
-                        + "/path/VAADIN/static/themes/app-theme/img/bg.jpg\")",
+                        + "/view/VAADIN/static/themes/app-theme/img/bg.jpg\")",
                 body.getCssValue("background-image"));
 
         Assert.assertEquals("body font-family should come from styles.css",
@@ -126,7 +126,7 @@ public class ThemeIT extends ChromeBrowserTest {
 
         // Note themes/app-theme gets VAADIN/static from the file-loader
         getDriver().get(getRootURL()
-                + "/path/VAADIN/static/themes/app-theme/img/bg.jpg");
+                + "/view/VAADIN/static/themes/app-theme/img/bg.jpg");
         Assert.assertFalse("app-theme background file should be served",
                 driver.getPageSource().contains("Could not navigate"));
     }
@@ -201,7 +201,7 @@ public class ThemeIT extends ChromeBrowserTest {
         // Note themes/app-theme gets VAADIN/static from the file-loader
         Assert.assertEquals("Imported css file URLs should have been handled.",
                 "url(\"" + getRootURL()
-                        + "/path/VAADIN/static/themes/app-theme/icons/archive.png\")",
+                        + "/view/VAADIN/static/themes/app-theme/icons/archive.png\")",
                 $(SpanElement.class).id(SUB_COMPONENT_ID)
                         .getCssValue("background-image"));
     }

--- a/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/src/test-webpack/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
+++ b/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/src/test-webpack/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
@@ -115,7 +115,7 @@ public class ThemeIT extends ChromeBrowserTest {
         // Note themes/app-theme gets VAADIN/static from the file-loader
         Assert.assertEquals("body background-image should come from styles.css",
                 "url(\"" + getRootURL()
-                        + "/view/VAADIN/static/themes/app-theme/img/bg.jpg\")",
+                        + "/path/VAADIN/static/themes/app-theme/img/bg.jpg\")",
                 body.getCssValue("background-image"));
 
         Assert.assertEquals("body font-family should come from styles.css",
@@ -126,7 +126,7 @@ public class ThemeIT extends ChromeBrowserTest {
 
         // Note themes/app-theme gets VAADIN/static from the file-loader
         getDriver().get(getRootURL()
-                + "/view/VAADIN/static/themes/app-theme/img/bg.jpg");
+                + "/path/VAADIN/static/themes/app-theme/img/bg.jpg");
         Assert.assertFalse("app-theme background file should be served",
                 driver.getPageSource().contains("Could not navigate"));
     }
@@ -201,7 +201,7 @@ public class ThemeIT extends ChromeBrowserTest {
         // Note themes/app-theme gets VAADIN/static from the file-loader
         Assert.assertEquals("Imported css file URLs should have been handled.",
                 "url(\"" + getRootURL()
-                        + "/view/VAADIN/static/themes/app-theme/icons/archive.png\")",
+                        + "/path/VAADIN/static/themes/app-theme/icons/archive.png\")",
                 $(SpanElement.class).id(SUB_COMPONENT_ID)
                         .getCssValue("background-image"));
     }

--- a/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
+++ b/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
@@ -112,13 +112,11 @@ public class ThemeIT extends ChromeBrowserTest {
         // No exception for bg-image should exist
         checkLogsForErrors();
 
-        // Vite ignores servlet path and assumes servlet with custom mapping
-        // also covers /VAADIN/*
-
         final WebElement body = findElement(By.tagName("body"));
+        // Note themes/app-theme gets VAADIN/static from the file-loader
         Assert.assertEquals("body background-image should come from styles.css",
                 "url(\"" + getRootURL()
-                        + "/VAADIN/themes/app-theme/img/bg.jpg\")",
+                        + "/path/VAADIN/static/themes/app-theme/img/bg.jpg\")",
                 body.getCssValue("background-image"));
 
         Assert.assertEquals("body font-family should come from styles.css",
@@ -127,7 +125,9 @@ public class ThemeIT extends ChromeBrowserTest {
         Assert.assertEquals("html color from styles.css should be applied.",
                 "rgba(0, 0, 0, 1)", body.getCssValue("color"));
 
-        getDriver().get(getRootURL() + "/VAADIN/themes/app-theme/img/bg.jpg");
+        // Note themes/app-theme gets VAADIN/static from the file-loader
+        getDriver().get(getRootURL()
+                + "/path/VAADIN/static/themes/app-theme/img/bg.jpg");
         Assert.assertFalse("app-theme background file should be served",
                 driver.getPageSource().contains("Could not navigate"));
     }
@@ -199,11 +199,10 @@ public class ThemeIT extends ChromeBrowserTest {
         open();
         checkLogsForErrors();
 
-        // Vite ignores servlet path and assumes servlet with custom mapping
-        // also covers /VAADIN/*
+        // Note themes/app-theme gets VAADIN/static from the file-loader
         Assert.assertEquals("Imported css file URLs should have been handled.",
                 "url(\"" + getRootURL()
-                        + "/VAADIN/themes/app-theme/icons/archive.png\")",
+                        + "/path/VAADIN/static/themes/app-theme/icons/archive.png\")",
                 $(SpanElement.class).id(SUB_COMPONENT_ID)
                         .getCssValue("background-image"));
     }

--- a/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
+++ b/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
@@ -50,7 +50,8 @@ public class ThemeIT extends ChromeBrowserTest {
 
         checkLogsForErrors();
 
-        final TestBenchElement helloWorld = $("hello-world-view").waitForFirst();
+        final TestBenchElement helloWorld = $("hello-world-view")
+                .waitForFirst();
 
         Assert.assertEquals("hello-world-view", helloWorld.getTagName());
 
@@ -123,8 +124,8 @@ public class ThemeIT extends ChromeBrowserTest {
         Assert.assertEquals("html color from styles.css should be applied.",
                 "rgba(0, 0, 0, 1)", body.getCssValue("color"));
 
-        getDriver().get(getRootURL()
-                + "/path/VAADIN/themes/app-theme/img/bg.jpg");
+        getDriver()
+                .get(getRootURL() + "/path/VAADIN/themes/app-theme/img/bg.jpg");
         Assert.assertFalse("app-theme background file should be served",
                 driver.getPageSource().contains("Could not navigate"));
     }
@@ -198,7 +199,7 @@ public class ThemeIT extends ChromeBrowserTest {
 
         Assert.assertEquals("Imported css file URLs should have been handled.",
                 "url(\"" + getRootURL()
-                        + "/path/VAADIN/themes/app-theme/icons/archive.png\")",
+                        + "/view/VAADIN/themes/app-theme/icons/archive.png\")",
                 $(SpanElement.class).id(SUB_COMPONENT_ID)
                         .getCssValue("background-image"));
     }

--- a/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
+++ b/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
@@ -256,6 +256,26 @@ public class ThemeIT extends ChromeBrowserTest {
     }
 
     @Test
+    public void documentCssImport_onlyExternalAddedToHeadAsLink() {
+        open();
+        checkLogsForErrors();
+
+        final WebElement documentHead = getDriver()
+                .findElement(By.xpath("/html/head"));
+        final List<WebElement> links = documentHead
+                .findElements(By.tagName("link"));
+
+        List<String> linkUrls = links.stream()
+                .map(link -> link.getAttribute("href"))
+                .collect(Collectors.toList());
+
+        Assert.assertTrue("Missing link for external url", linkUrls
+                .contains("https://fonts.googleapis.com/css?family=Itim"));
+        Assert.assertFalse("Found import that webpack should have resolved",
+                linkUrls.contains("sub-css/sub.css"));
+    }
+
+    @Test
     public void customFrontendDirectory_generatedFilesNotInDefaultFrontendFolder() {
         open();
 
@@ -279,26 +299,6 @@ public class ThemeIT extends ChromeBrowserTest {
                             + ", but was not",
                     new File(defaultGeneratedFolder, generatedFile).exists());
         }
-    }
-
-    @Test
-    public void documentCssImport_onlyExternalAddedToHeadAsLink() {
-        open();
-        checkLogsForErrors();
-
-        final WebElement documentHead = getDriver()
-                .findElement(By.xpath("/html/head"));
-        final List<WebElement> links = documentHead
-                .findElements(By.tagName("link"));
-
-        List<String> linkUrls = links.stream()
-                .map(link -> link.getAttribute("href"))
-                .collect(Collectors.toList());
-
-        Assert.assertTrue("Missing link for external url", linkUrls
-                .contains("https://fonts.googleapis.com/css?family=Itim"));
-        Assert.assertFalse("Found import that webpack should have resolved",
-                linkUrls.contains("sub-css/sub.css"));
     }
 
     @Override

--- a/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
+++ b/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
@@ -27,7 +27,6 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.component.html.testbench.ImageElement;
 import com.vaadin.flow.component.html.testbench.SpanElement;
 import com.vaadin.flow.testutil.ChromeBrowserTest;
@@ -51,8 +50,7 @@ public class ThemeIT extends ChromeBrowserTest {
 
         checkLogsForErrors();
 
-        final TestBenchElement helloWorld = $(TestBenchElement.class).first()
-                .findElement(By.tagName("hello-world-view"));
+        final TestBenchElement helloWorld = $("hello-world-view").waitForFirst();
 
         Assert.assertEquals("hello-world-view", helloWorld.getTagName());
 
@@ -99,6 +97,7 @@ public class ThemeIT extends ChromeBrowserTest {
                 driver.getPageSource().contains("HTTP ERROR 404 Not Found"));
 
         getDriver().get(getRootURL() + "/path/themes/no-copy/no-copy.txt");
+        waitForDevServer();
         String source = driver.getPageSource();
         Matcher m = Pattern.compile(
                 ".*Could not navigate to.*themes/no-copy/no-copy.txt.*",
@@ -113,10 +112,9 @@ public class ThemeIT extends ChromeBrowserTest {
         checkLogsForErrors();
 
         final WebElement body = findElement(By.tagName("body"));
-        // Note themes/app-theme gets VAADIN/static from the file-loader
         Assert.assertEquals("body background-image should come from styles.css",
                 "url(\"" + getRootURL()
-                        + "/path/VAADIN/static/themes/app-theme/img/bg.jpg\")",
+                        + "/path/VAADIN/themes/app-theme/img/bg.jpg\")",
                 body.getCssValue("background-image"));
 
         Assert.assertEquals("body font-family should come from styles.css",
@@ -125,9 +123,8 @@ public class ThemeIT extends ChromeBrowserTest {
         Assert.assertEquals("html color from styles.css should be applied.",
                 "rgba(0, 0, 0, 1)", body.getCssValue("color"));
 
-        // Note themes/app-theme gets VAADIN/static from the file-loader
         getDriver().get(getRootURL()
-                + "/path/VAADIN/static/themes/app-theme/img/bg.jpg");
+                + "/path/VAADIN/themes/app-theme/img/bg.jpg");
         Assert.assertFalse("app-theme background file should be served",
                 driver.getPageSource().contains("Could not navigate"));
     }
@@ -148,7 +145,7 @@ public class ThemeIT extends ChromeBrowserTest {
                 "\"\uf0f4\"", iconUnicode);
 
         getDriver().get(getRootURL()
-                + "/path/VAADIN/static/@fortawesome/fontawesome-free/webfonts/fa-solid-900.svg");
+                + "/path/VAADIN/@fortawesome/fontawesome-free/webfonts/fa-solid-900.svg");
         Assert.assertFalse("Font resource should be available",
                 driver.getPageSource().contains("HTTP ERROR 404 Not Found"));
     }
@@ -199,10 +196,9 @@ public class ThemeIT extends ChromeBrowserTest {
         open();
         checkLogsForErrors();
 
-        // Note themes/app-theme gets VAADIN/static from the file-loader
         Assert.assertEquals("Imported css file URLs should have been handled.",
                 "url(\"" + getRootURL()
-                        + "/path/VAADIN/static/themes/app-theme/icons/archive.png\")",
+                        + "/path/VAADIN/themes/app-theme/icons/archive.png\")",
                 $(SpanElement.class).id(SUB_COMPONENT_ID)
                         .getCssValue("background-image"));
     }

--- a/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
+++ b/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
@@ -50,8 +50,7 @@ public class ThemeIT extends ChromeBrowserTest {
 
         checkLogsForErrors();
 
-        final TestBenchElement helloWorld = $("hello-world-view")
-                .waitForFirst();
+        final TestBenchElement helloWorld = $("hello-world-view").waitForFirst();
 
         Assert.assertEquals("hello-world-view", helloWorld.getTagName());
 
@@ -124,8 +123,7 @@ public class ThemeIT extends ChromeBrowserTest {
         Assert.assertEquals("html color from styles.css should be applied.",
                 "rgba(0, 0, 0, 1)", body.getCssValue("color"));
 
-        getDriver()
-                .get(getRootURL() + "/path/VAADIN/themes/app-theme/img/bg.jpg");
+        getDriver().get(getRootURL() + "/path/VAADIN/themes/app-theme/img/bg.jpg");
         Assert.assertFalse("app-theme background file should be served",
                 driver.getPageSource().contains("Could not navigate"));
     }
@@ -146,7 +144,7 @@ public class ThemeIT extends ChromeBrowserTest {
                 "\"\uf0f4\"", iconUnicode);
 
         getDriver().get(getRootURL()
-                + "/path/VAADIN/@fortawesome/fontawesome-free/webfonts/fa-solid-900.svg");
+                + "/path/VAADIN/static/@fortawesome/fontawesome-free/webfonts/fa-solid-900.svg");
         Assert.assertFalse("Font resource should be available",
                 driver.getPageSource().contains("HTTP ERROR 404 Not Found"));
     }
@@ -199,7 +197,7 @@ public class ThemeIT extends ChromeBrowserTest {
 
         Assert.assertEquals("Imported css file URLs should have been handled.",
                 "url(\"" + getRootURL()
-                        + "/view/VAADIN/themes/app-theme/icons/archive.png\")",
+                        + "/path/VAADIN/themes/app-theme/icons/archive.png\")",
                 $(SpanElement.class).id(SUB_COMPONENT_ID)
                         .getCssValue("background-image"));
     }

--- a/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
+++ b/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
@@ -50,7 +50,8 @@ public class ThemeIT extends ChromeBrowserTest {
 
         checkLogsForErrors();
 
-        final TestBenchElement helloWorld = $("hello-world-view").waitForFirst();
+        final TestBenchElement helloWorld = $("hello-world-view")
+                .waitForFirst();
 
         Assert.assertEquals("hello-world-view", helloWorld.getTagName());
 
@@ -123,7 +124,8 @@ public class ThemeIT extends ChromeBrowserTest {
         Assert.assertEquals("html color from styles.css should be applied.",
                 "rgba(0, 0, 0, 1)", body.getCssValue("color"));
 
-        getDriver().get(getRootURL() + "/path/VAADIN/themes/app-theme/img/bg.jpg");
+        getDriver()
+                .get(getRootURL() + "/path/VAADIN/themes/app-theme/img/bg.jpg");
         Assert.assertFalse("app-theme background file should be served",
                 driver.getPageSource().contains("Could not navigate"));
     }

--- a/flow-tests/test-frontend/vite-production/src/test/java/com/vaadin/viteapp/CompressionIT.java
+++ b/flow-tests/test-frontend/vite-production/src/test/java/com/vaadin/viteapp/CompressionIT.java
@@ -40,7 +40,7 @@ public class CompressionIT {
     private String getJsBundleName() throws Exception {
         String indexHtml = IOUtils.toString(
                 new URL(getRootURL() + "/index.html"), StandardCharsets.UTF_8);
-        Pattern p = Pattern.compile(".* src=\"VAADIN/build/([^\"]*).*",
+        Pattern p = Pattern.compile(".* src=\"./VAADIN/build/([^\"]*).*",
                 Pattern.DOTALL);
 
         Matcher m = p.matcher(indexHtml);

--- a/flow-tests/test-frontend/vite-production/src/test/java/com/vaadin/viteapp/CompressionIT.java
+++ b/flow-tests/test-frontend/vite-production/src/test/java/com/vaadin/viteapp/CompressionIT.java
@@ -40,7 +40,7 @@ public class CompressionIT {
     private String getJsBundleName() throws Exception {
         String indexHtml = IOUtils.toString(
                 new URL(getRootURL() + "/index.html"), StandardCharsets.UTF_8);
-        Pattern p = Pattern.compile(".* src=\"./VAADIN/build/([^\"]*).*",
+        Pattern p = Pattern.compile(".* src=\"VAADIN/build/([^\"]*).*",
                 Pattern.DOTALL);
 
         Matcher m = p.matcher(indexHtml);

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/VaadinPushScriptIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/VaadinPushScriptIT.java
@@ -34,7 +34,7 @@ public class VaadinPushScriptIT extends ChromeBrowserTest {
         getDriver().get(
                 getRootURL() + "/view/" + PushSettingsView.class.getName());
         waitForDevServer();
-        assertThatPushScriptUrlIsRelativeToContextRoot(
+        assertThatPushScriptUrlIsRelativeToUrlMapping(
                 findElement(By.tagName("body")));
     }
 
@@ -46,11 +46,11 @@ public class VaadinPushScriptIT extends ChromeBrowserTest {
                 getRootURL() + "/view/" + ActivatePushView.class.getName());
         waitForDevServer();
 
-        assertThatPushScriptUrlIsRelativeToContextRoot(
+        assertThatPushScriptUrlIsRelativeToUrlMapping(
                 findElement(By.tagName("head")));
     }
 
-    private void assertThatPushScriptUrlIsRelativeToContextRoot(
+    private void assertThatPushScriptUrlIsRelativeToUrlMapping(
             WebElement scriptContainer) {
         String pushScriptUrl = scriptContainer
                 .findElements(By.tagName("script")).stream()
@@ -61,10 +61,9 @@ public class VaadinPushScriptIT extends ChromeBrowserTest {
 
         Assert.assertNotNull(ApplicationConstants.VAADIN_PUSH_DEBUG_JS
                 + " script not loaded by page", pushScriptUrl);
-        Assert.assertTrue(
-                "Push script not relative to context root: " + pushScriptUrl,
+        Assert.assertTrue("Push script not relative to Vaadin servlet mapping",
                 pushScriptUrl.contains(
-                        ":8888/" + ApplicationConstants.VAADIN_PUSH_DEBUG_JS));
+                        "/view/" + ApplicationConstants.VAADIN_PUSH_DEBUG_JS));
     }
 
 }

--- a/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
+++ b/flow-tests/test-themes/src/test/java/com/vaadin/flow/uitest/ui/theme/ThemeIT.java
@@ -114,9 +114,6 @@ public class ThemeIT extends ChromeBrowserTest {
         // No exception for bg-image should exist
         checkLogsForErrors();
 
-        // Vite ignores servlet path and assumes servlet with custom mapping
-        // also covers /VAADIN/*
-
         final WebElement body = findElement(By.tagName("body"));
         // Note themes/app-theme resources are served from VAADIN/build in
         // production mode

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/AbstractDevServerRunner.java
@@ -677,13 +677,11 @@ public abstract class AbstractDevServerRunner implements DevModeHandler {
         }
         // Since we have 'publicPath=/VAADIN/' in the dev server config,
         // a valid request for the dev server should start with '/VAADIN/'
-
-        String requestFilename = UrlUtil.getStaticVaadinPathInfo(request);
+        String requestFilename = request.getPathInfo();
 
         if (HandlerHelper.isPathUnsafe(requestFilename)
-                || WEBPACK_ILLEGAL_CHAR_PATTERN.matcher(requestFilename).find())
-
-        {
+                || WEBPACK_ILLEGAL_CHAR_PATTERN.matcher(requestFilename)
+                        .find()) {
             getLogger().info("Blocked attempt to access file: {}",
                     requestFilename);
             response.setStatus(HttpStatusCode.FORBIDDEN.getCode());

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
@@ -347,11 +347,17 @@ public class DevModeInitializer implements Serializable {
 
         Runnable runnable = () -> {
             runNodeTasks(context, tokenFileData, tasks);
-            // WAit
-            while (VaadinServlet.getFirstMapping() == null) {
-                try {
-                    Thread.sleep(100);
-                } catch (InterruptedException e) {
+            if (!featureFlags.isEnabled(FeatureFlags.WEBPACK)) {
+                // For Vite, wait until a VaadinServlet is deployed so we know
+                // which frontend servlet path to use
+                if (VaadinServlet.getFirstMapping() == null) {
+                    log().debug("Waiting for a VaadinServlet to be deployed");
+                    while (VaadinServlet.getFirstMapping() == null) {
+                        try {
+                            Thread.sleep(100);
+                        } catch (InterruptedException e) {
+                        }
+                    }
                 }
             }
         };

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
@@ -350,9 +350,9 @@ public class DevModeInitializer implements Serializable {
             if (!featureFlags.isEnabled(FeatureFlags.WEBPACK)) {
                 // For Vite, wait until a VaadinServlet is deployed so we know
                 // which frontend servlet path to use
-                if (VaadinServlet.getFirstMapping() == null) {
+                if (VaadinServlet.getFrontendMapping() == null) {
                     log().debug("Waiting for a VaadinServlet to be deployed");
-                    while (VaadinServlet.getFirstMapping() == null) {
+                    while (VaadinServlet.getFrontendMapping() == null) {
                         try {
                             Thread.sleep(100);
                         } catch (InterruptedException e) {

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
@@ -75,6 +75,7 @@ import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.VaadinContext;
+import com.vaadin.flow.server.VaadinServlet;
 import com.vaadin.flow.server.frontend.EndpointGeneratorTaskFactory;
 import com.vaadin.flow.server.frontend.FallbackChunk;
 import com.vaadin.flow.server.frontend.FrontendUtils;
@@ -344,7 +345,16 @@ public class DevModeInitializer implements Serializable {
                         Arrays.asList(additionalPostinstallPackages))
                 .build();
 
-        Runnable runnable = () -> runNodeTasks(context, tokenFileData, tasks);
+        Runnable runnable = () -> {
+            runNodeTasks(context, tokenFileData, tasks);
+            // WAit
+            while (VaadinServlet.getFirstMapping() == null) {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                }
+            }
+        };
 
         CompletableFuture<Void> nodeTasksFuture = CompletableFuture
                 .runAsync(runnable);

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/DevModeEndpointTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/DevModeEndpointTest.java
@@ -7,7 +7,6 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_CONNECT_OPEN
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_PROJECT_FRONTEND_GENERATED_DIR;
 import static com.vaadin.flow.testutil.FrontendStubs.createStubNode;
 import static com.vaadin.flow.testutil.FrontendStubs.createStubViteServer;
-import static com.vaadin.flow.testutil.FrontendStubs.createStubWebpackServer;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/AbstractDevModeTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/AbstractDevModeTest.java
@@ -53,7 +53,7 @@ public abstract class AbstractDevModeTest {
     @Before
     public void setup() throws Exception {
         Field firstMapping = VaadinServlet.class
-                .getDeclaredField("firstMapping");
+                .getDeclaredField("frontendMapping");
         firstMapping.setAccessible(true);
         firstMapping.set(null, "/fake-test-mapping");
         baseDir = temporaryFolder.getRoot().getPath();

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/AbstractDevModeTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/AbstractDevModeTest.java
@@ -23,6 +23,7 @@ import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.StaticFileHandlerFactory;
 import com.vaadin.flow.server.StaticFileServer;
 import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinServlet;
 import com.vaadin.flow.server.VaadinServletContext;
 import com.vaadin.flow.server.frontend.FrontendUtils;
 import com.vaadin.flow.server.startup.ApplicationConfiguration;
@@ -51,6 +52,10 @@ public abstract class AbstractDevModeTest {
 
     @Before
     public void setup() throws Exception {
+        Field firstMapping = VaadinServlet.class
+                .getDeclaredField("firstMapping");
+        firstMapping.setAccessible(true);
+        firstMapping.set(null, "/fake-test-mapping");
         baseDir = temporaryFolder.getRoot().getPath();
         npmFolder = temporaryFolder.getRoot();
 

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringBootAutoConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringBootAutoConfiguration.java
@@ -79,7 +79,6 @@ public class SpringBootAutoConfiguration {
         String mapping = configurationProperties.getUrlMapping();
         Map<String, String> initParameters = new HashMap<>();
         boolean rootMapping = RootMappedCondition.isRootMapping(mapping);
-        String[] urlMappings;
         String pushRegistrationPath;
 
         if (rootMapping) {
@@ -89,7 +88,6 @@ public class SpringBootAutoConfiguration {
             pushRegistrationPath = mapping.replace("/*", "");
         }
 
-        urlMappings = new String[] { mapping, "/VAADIN/*" };
         /*
          * Tell Atmosphere which servlet to use for the push endpoint. Servlet
          * mappings are returned as a Set from at least Tomcat so even if
@@ -100,7 +98,7 @@ public class SpringBootAutoConfiguration {
                 pushRegistrationPath);
 
         ServletRegistrationBean<SpringServlet> registration = new ServletRegistrationBean<>(
-                new SpringServlet(context, rootMapping), urlMappings);
+                new SpringServlet(context, rootMapping), mapping);
         registration.setInitParameters(initParameters);
         registration
                 .setAsyncSupported(configurationProperties.isAsyncSupported());

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringBootAutoConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringBootAutoConfiguration.java
@@ -35,6 +35,8 @@ import org.springframework.util.ClassUtils;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.socket.server.standard.ServerEndpointExporter;
 
+import com.vaadin.flow.server.VaadinServlet;
+
 /**
  * Spring boot auto-configuration class for Flow.
  *
@@ -83,6 +85,9 @@ public class SpringBootAutoConfiguration {
 
         if (rootMapping) {
             mapping = VaadinServletConfiguration.VAADIN_SERVLET_MAPPING;
+            initParameters.put(
+                    VaadinServlet.INTERNAL_VAADIN_SERVLET_VITE_DEV_MODE_FRONTEND_PATH,
+                    "");
             pushRegistrationPath = "";
         } else {
             pushRegistrationPath = mapping.replace("/*", "");

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinMVCWebAppInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinMVCWebAppInitializer.java
@@ -59,6 +59,8 @@ public abstract class VaadinMVCWebAppInitializer
         if (mapping == null) {
             mapping = "/*";
         }
+        String pushRegistrationPath;
+
         boolean rootMapping = RootMappedCondition.isRootMapping(mapping);
         Dynamic registration = servletContext.addServlet(
                 ClassUtils.getShortNameAsProperty(SpringServlet.class),
@@ -68,11 +70,10 @@ public abstract class VaadinMVCWebAppInitializer
             Dynamic dispatcherRegistration = servletContext
                     .addServlet("dispatcher", new DispatcherServlet(context));
             dispatcherRegistration.addMapping("/*");
-            initParameters.put(Constants.SERVLET_PARAMETER_PUSH_URL,
-                    makeContextRelative(mapping.replace("*", "")));
-        }
-        if (rootMapping) {
             mapping = VaadinServletConfiguration.VAADIN_SERVLET_MAPPING;
+            pushRegistrationPath = "";
+        } else {
+            pushRegistrationPath = mapping.replace("/*", "");
         }
         registration.addMapping(mapping);
 
@@ -83,7 +84,7 @@ public abstract class VaadinMVCWebAppInitializer
          * and websockets will fail.
          */
         initParameters.put(ApplicationConfig.JSR356_MAPPING_PATH,
-                mapping.replace("/*", ""));
+                pushRegistrationPath);
 
         registration.setInitParameters(initParameters);
 

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurityConfigurerAdapter.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurityConfigurerAdapter.java
@@ -185,12 +185,6 @@ public abstract class VaadinWebSecurityConfigurerAdapter
                 .map(path -> RequestUtil.applyUrlMapping(urlMapping, path))
                 .forEach(paths::add);
 
-        String mappedRoot = RequestUtil.applyUrlMapping(urlMapping, "");
-        if (!"/".equals(mappedRoot)) {
-            // When using an url path, static resources are still fetched from
-            // /VAADIN/ in the context root
-            paths.add("/VAADIN/**");
-        }
         return new OrRequestMatcher(paths.build()
                 .map(AntPathRequestMatcher::new).collect(Collectors.toList()));
     }

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringBootAutoConfigurationRootMappedTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringBootAutoConfigurationRootMappedTest.java
@@ -25,8 +25,7 @@ public class SpringBootAutoConfigurationRootMappedTest {
         Assert.assertTrue(RootMappedCondition
                 .isRootMapping(RootMappedCondition.getUrlMapping(environment)));
         Assert.assertEquals(
-                Set.of(VaadinServletConfiguration.VAADIN_SERVLET_MAPPING,
-                        "/VAADIN/*"),
+                Set.of(VaadinServletConfiguration.VAADIN_SERVLET_MAPPING),
                 servletRegistrationBean.getUrlMappings());
         Assert.assertEquals("", servletRegistrationBean.getInitParameters()
                 .get(ApplicationConfig.JSR356_MAPPING_PATH));

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringBootAutoConfigurationUrlMappedTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringBootAutoConfigurationUrlMappedTest.java
@@ -24,7 +24,7 @@ public class SpringBootAutoConfigurationUrlMappedTest {
     public void urlMappingPassedToAtmosphere() {
         Assert.assertFalse(RootMappedCondition
                 .isRootMapping(RootMappedCondition.getUrlMapping(environment)));
-        Assert.assertEquals(Set.of("/zing/*", "/VAADIN/*"),
+        Assert.assertEquals(Set.of("/zing/*"),
                 servletRegistrationBean.getUrlMappings());
         Assert.assertEquals("/zing", servletRegistrationBean.getInitParameters()
                 .get(ApplicationConfig.JSR356_MAPPING_PATH));


### PR DESCRIPTION
Changes static files loading so that:
1. The overall behavior is reverted to that in 23.0, i.e. static files are loaded from /context/servlet/VAADIN instead of /context/VAADIN
2. When using Vite in dev mode, uses the first deployed `VaadinServlet` to serve static resources. If you have both a `/foo/*` and a `/bar/*`mapped servlet, then if `/foo` is the servlet deployed first, also `/bar/` requests will use `/foo/VAADIN` for static resources.

This reverts commit af975389 

Fixes https://github.com/vaadin/flow/issues/14239
Fixes #13190