### PR TITLE
fix: force connectionLost when Atmosphere resource is resumed

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/AtmospherePushConnection.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/AtmospherePushConnection.java
@@ -191,6 +191,15 @@ public class AtmospherePushConnection implements PushConnection {
             } else {
                 state = State.RESPONSE_PENDING;
             }
+        } else if (resource != null && resource.isResumed()) {
+            // This can happen for long polling and will prevent the message to
+            // reach the client
+            // In this case we should not create UIDL to prevent an infinite
+            // resynchronization loop because of serverId never sent to the
+            // client
+            getLogger().debug(
+                    "Cannot push, Atmosphere resource resumed. Disconnecting");
+            connectionLost();
         } else {
             try {
                 JsonObject response = new UidlWriter().createUidl(getUI(),


### PR DESCRIPTION
## Description

When Push is configured with long polling transport, sometimes after server restart
Atmosphere resource is in a 'resumed' state. In this situation the UIDL message
is not set to the client, but the internal serverId counter is incremented, causing
an endless resynchronization loop because of inconsistency with client stored serverId.
This change forces the Push connection to be considered lost when pushing in resumed state,
so that a fresh connection can be established by the client.

Fixes #13660

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
