### PR TITLE
feat: Backporting automatically use available converters in Binder 

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/converter/ConverterFactory.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/converter/ConverterFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.data.converter;
+
+import java.io.Serializable;
+import java.util.Optional;
+
+/**
+ * Creates {@link Converter} instances capable to handle conversion between a
+ * model and a presentation type.
+ *
+ * @author Vaadin Ltd
+ * @since
+ */
+public interface ConverterFactory extends Serializable {
+
+    /**
+     * Attempts to create a {@link Converter} instance, capable to handle
+     * conversion between the given presentation and model types.
+     *
+     * An empty {@link Optional} is returned if a conversion cannot be
+     * performed.
+     *
+     * @param presentationType
+     *            presentation type, not {@literal null}.
+     * @param modelType
+     *            model type, not {@literal null}.
+     * @param <P>
+     *            The presentation type.
+     * @param <M>
+     *            The model type.
+     * @return a {@link Converter} instance wrapped into an {@link Optional}, or
+     *         an empty {@link Optional} if no suitable converter is available.
+     */
+    <P, M> Optional<Converter<P, M>> newInstance(Class<P> presentationType,
+                                                 Class<M> modelType);
+}

--- a/flow-data/src/main/java/com/vaadin/flow/data/converter/DefaultConverterFactory.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/converter/DefaultConverterFactory.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.data.converter;
+
+import java.io.Serializable;
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import com.vaadin.flow.data.binder.ErrorMessageProvider;
+import com.vaadin.flow.function.SerializableSupplier;
+import com.vaadin.flow.internal.ReflectTools;
+
+/**
+ * Default implementation of {@link ConverterFactory}, handling all standard
+ * converters defined in {@code com.vaadin.flow.data.converters} package.
+ *
+ * @author Vaadin Ltd
+ * @since
+ */
+public enum DefaultConverterFactory implements ConverterFactory {
+
+    INSTANCE;
+
+    @SuppressWarnings({ "rawtypes", "ImmutableEnumChecker" })
+    private final Map<Key, SerializableSupplier<? extends Converter>> converterMap = new HashMap<>();
+
+    DefaultConverterFactory() {
+        registerConverter(DateToLongConverter.class, DateToLongConverter::new);
+        registerConverter(DateToSqlDateConverter.class,
+                DateToSqlDateConverter::new);
+        registerConverter(LocalDateTimeToDateConverter.class,
+                () -> new LocalDateTimeToDateConverter(ZoneId.systemDefault()));
+        registerConverter(LocalDateToDateConverter.class,
+                LocalDateToDateConverter::new);
+        registerConverterWithMessageProvider(StringToBigDecimalConverter.class,
+                StringToBigDecimalConverter::new);
+        registerConverterWithMessageProvider(StringToBigIntegerConverter.class,
+                StringToBigIntegerConverter::new);
+        registerConverterWithMessageProvider(StringToBooleanConverter.class,
+                StringToBooleanConverter::new);
+        registerConverter(StringToDateConverter.class,
+                StringToDateConverter::new);
+        registerConverterWithMessageProvider(StringToDoubleConverter.class,
+                StringToDoubleConverter::new);
+        registerConverterWithMessageProvider(StringToFloatConverter.class,
+                StringToFloatConverter::new);
+        registerConverterWithMessageProvider(StringToIntegerConverter.class,
+                StringToIntegerConverter::new);
+        registerConverterWithMessageProvider(StringToLongConverter.class,
+                StringToLongConverter::new);
+        registerConverterWithMessageProvider(StringToUuidConverter.class,
+                StringToUuidConverter::new);
+    }
+
+    private <C extends Converter<?, ?>> void registerConverter(
+            Class<C> converterType, SerializableSupplier<C> factory) {
+        List<Class<?>> types = ReflectTools
+                .getGenericInterfaceTypes(converterType, Converter.class);
+        assert !types.isEmpty() && types.stream().allMatch(Objects::nonNull);
+        Key key = new Key(types.get(0), types.get(1));
+        converterMap.put(key, factory);
+    }
+
+    private <C extends Converter<?, ?>> void registerConverterWithMessageProvider(
+            Class<C> converterType, Function<ErrorMessageProvider, C> factory) {
+        registerConverter(converterType, () -> factory.apply(context -> ""));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <P, M> Optional<Converter<P, M>> newInstance(
+            Class<P> presentationType, Class<M> modelType) {
+        if (presentationType == null) {
+            throw new IllegalArgumentException(
+                    "The presentation type cannot be null");
+        }
+        if (modelType == null) {
+            throw new IllegalArgumentException(
+                    "The model type must cannot be null");
+        }
+        return Optional
+                .ofNullable(
+                        converterMap.get(new Key(presentationType, modelType)))
+                .map(Supplier::get);
+    }
+
+    private static final class Key implements Serializable {
+        private final Class<?> presentationType;
+        private final Class<?> modelType;
+
+        private Key(Class<?> presentationType, Class<?> modelType) {
+            assert presentationType != null && modelType != null;
+            this.presentationType = presentationType;
+            this.modelType = ReflectTools.convertPrimitiveType(modelType);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+            Key key = (Key) o;
+            return presentationType.equals(key.presentationType)
+                    && modelType.equals(key.modelType);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(presentationType, modelType);
+        }
+    }
+
+}

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BeanBinderTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BeanBinderTest.java
@@ -15,22 +15,17 @@
  */
 package com.vaadin.flow.data.binder;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import javax.validation.constraints.Digits;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 import java.io.Serializable;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
-
-import javax.validation.constraints.Digits;
-import javax.validation.constraints.Max;
-import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -43,6 +38,12 @@ import com.vaadin.flow.data.binder.BeanBinderTest.RequiredConstraints.SubSubCons
 import com.vaadin.flow.data.binder.testcomponents.TestTextField;
 import com.vaadin.flow.data.converter.StringToIntegerConverter;
 import com.vaadin.flow.tests.data.bean.BeanToValidate;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 
 public class BeanBinderTest
         extends BinderTestBase<Binder<BeanToValidate>, BeanToValidate> {
@@ -210,9 +211,12 @@ public class BeanBinderTest
         otherBinder.forField(testClass.number)
                 .withConverter(new StringToIntegerConverter(""));
 
+        // bindInstanceFields does not throw exceptions for incomplete bindings
+        // because bindings they can be completed after the call.
+        otherBinder.bindInstanceFields(testClass);
         // Should throw an IllegalStateException since the binding for number is
         // not completed with bind
-        otherBinder.bindInstanceFields(testClass);
+        otherBinder.setBean(new TestBean());
     }
 
     @Test(expected = IllegalStateException.class)

--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderInstanceFieldTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderInstanceFieldTest.java
@@ -15,8 +15,11 @@
  */
 package com.vaadin.flow.data.binder;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.time.LocalDate;
 import java.util.Arrays;
+import java.util.UUID;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -32,6 +35,7 @@ import com.vaadin.flow.data.binder.testcomponents.TestTextField;
 import com.vaadin.flow.data.converter.StringToIntegerConverter;
 import com.vaadin.flow.data.validator.StringLengthValidator;
 import com.vaadin.flow.tests.data.bean.Address;
+import com.vaadin.flow.tests.data.bean.ConvertibleValues;
 import com.vaadin.flow.tests.data.bean.Person;
 
 public class BinderInstanceFieldTest {
@@ -110,6 +114,23 @@ public class BinderInstanceFieldTest {
     public static class BindOneFieldRequiresConverter extends TestFormLayout {
         private TestTextField firstName;
         private TestTextField age;
+    }
+
+    public static class BindAutomaticConverter extends TestFormLayout {
+        private TestDatePicker localDateToDate;
+        private TestTextField stringToBigDecimal;
+        private TestTextField stringToBigInteger;
+        private TestTextField stringToBoolean;
+        private TestTextField stringToPrimitiveBoolean;
+        private TestTextField stringToDouble;
+        private TestTextField stringToPrimitiveDouble;
+        private TestTextField stringToFloat;
+        private TestTextField stringToPrimitiveFloat;
+        private TestTextField stringToInteger;
+        private TestTextField stringToPrimitiveInteger;
+        private TestTextField stringToLong;
+        private TestTextField stringToPrimitiveLong;
+        private TestTextField stringToUUID;
     }
 
     public static class BindGeneric<T> extends TestFormLayout {
@@ -649,5 +670,108 @@ public class BinderInstanceFieldTest {
         // anything as there is a binding in progress (an exception will be
         // thrown later if the binding is not completed)
         binder.bindInstanceFields(form);
+    }
+
+    @Test
+    public void bindInstanceFields_fieldsNeedConversion_knownConvertersApplied() {
+        BindAutomaticConverter form = new BindAutomaticConverter();
+        form.stringToInteger = new TestTextField();
+        form.localDateToDate = new TestDatePicker();
+        form.stringToBigDecimal = new TestTextField();
+        form.stringToBigInteger = new TestTextField();
+        form.stringToBoolean = new TestTextField();
+        form.stringToPrimitiveBoolean = new TestTextField();
+        form.stringToDouble = new TestTextField();
+        form.stringToPrimitiveDouble = new TestTextField();
+        form.stringToFloat = new TestTextField();
+        form.stringToPrimitiveFloat = new TestTextField();
+        form.stringToInteger = new TestTextField();
+        form.stringToPrimitiveInteger = new TestTextField();
+        form.stringToLong = new TestTextField();
+        form.stringToPrimitiveLong = new TestTextField();
+        form.stringToUUID = new TestTextField();
+
+        Binder<ConvertibleValues> binder = new Binder<>(
+                ConvertibleValues.class);
+        binder.bindInstanceFields(form);
+
+        LocalDate now = LocalDate.of(2022, 3, 27);
+        UUID uuid = UUID.randomUUID();
+
+        ConvertibleValues data = new ConvertibleValues();
+        data.setStringToBigDecimal(new BigDecimal("20.23"));
+        data.setStringToBigInteger(new BigInteger("30"));
+        data.setStringToDouble(40.56);
+        data.setStringToPrimitiveDouble(50.78);
+        data.setStringToFloat(60.23f);
+        data.setStringToPrimitiveFloat(70.12f);
+        data.setStringToInteger(80);
+        data.setStringToPrimitiveInteger(90);
+        data.setStringToLong(100L);
+        data.setStringToPrimitiveLong(110);
+        data.setStringToBoolean(true);
+        data.setStringToPrimitiveBoolean(false);
+        data.setLocalDateToDate(java.sql.Date.valueOf(now));
+        data.setStringToUUID(uuid);
+
+        binder.setBean(data);
+
+        Assert.assertEquals("20.23", form.stringToBigDecimal.getValue());
+        Assert.assertEquals("30", form.stringToBigInteger.getValue());
+        Assert.assertEquals("40.56", form.stringToDouble.getValue());
+        Assert.assertEquals("50.78", form.stringToPrimitiveDouble.getValue());
+        Assert.assertEquals("60.23", form.stringToFloat.getValue());
+        Assert.assertEquals("70.12", form.stringToPrimitiveFloat.getValue());
+        Assert.assertEquals("80", form.stringToInteger.getValue());
+        Assert.assertEquals("90", form.stringToPrimitiveInteger.getValue());
+        Assert.assertEquals("100", form.stringToLong.getValue());
+        Assert.assertEquals("110", form.stringToPrimitiveLong.getValue());
+        Assert.assertEquals("true", form.stringToBoolean.getValue());
+        Assert.assertEquals("false", form.stringToPrimitiveBoolean.getValue());
+        Assert.assertEquals(now, form.localDateToDate.getValue());
+        Assert.assertEquals(uuid.toString(), form.stringToUUID.getValue());
+    }
+
+    @Test
+    public void bindInstanceFields_fieldsNeedConversion_nullRepresentationIsConfigured() {
+        BindAutomaticConverter form = new BindAutomaticConverter();
+        form.stringToInteger = new TestTextField() {
+            @Override
+            public String getEmptyValue() {
+                return "EMPTY";
+            }
+        };
+
+        Binder<ConvertibleValues> binder = new Binder<>(
+                ConvertibleValues.class);
+        binder.bindInstanceFields(form);
+
+        ConvertibleValues data = new ConvertibleValues();
+        binder.setBean(data);
+
+        Assert.assertEquals("EMPTY", form.stringToInteger.getValue());
+    }
+
+    @Test
+    public void bindInstanceFields_incompleteBinding_converterNotAppliedAutomatically() {
+        BindOneFieldRequiresConverter form = new BindOneFieldRequiresConverter();
+        form.age = new TestTextField();
+        Binder<Person> binder = new Binder<>(Person.class);
+        Binder.BindingBuilder<Person, Integer> ageBinding = binder
+                .forField(form.age)
+                .withConverter(str -> Integer.parseInt(str) / 2,
+                        integer -> Integer.toString(integer * 2));
+        binder.bindInstanceFields(form);
+
+        Assert.assertFalse(
+                "Expecting incomplete binding to be ignored by Binder, but field was bound",
+                binder.getBinding("age").isPresent());
+
+        ageBinding.bind(Person::getAge, Person::setAge);
+
+        Person person = new Person();
+        person.setAge(45);
+        binder.setBean(person);
+        Assert.assertEquals("90", form.age.getValue());
     }
 }

--- a/flow-data/src/test/java/com/vaadin/flow/data/converter/DefaultConverterFactoryTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/converter/DefaultConverterFactoryTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.data.converter;
+
+import java.io.IOException;
+import java.lang.reflect.Modifier;
+import java.sql.Timestamp;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.internal.ReflectTools;
+import com.vaadin.flow.testutil.ClassFinder;
+
+import static org.junit.Assert.*;
+
+public class DefaultConverterFactoryTest {
+
+    private final DefaultConverterFactory factory = DefaultConverterFactory.INSTANCE;
+
+    @Test
+    public void newInstance_unknownConversion_converterNotFound() {
+        assertThatConversionIsNotSupported(Integer.class, Float.class);
+        assertThatConversionIsNotSupported(String.class, ZonedDateTime.class);
+        assertThatConversionIsNotSupported(String.class, Timestamp.class);
+    }
+
+    @Test
+    public void newInstance_knownConversion_converterCreated()
+            throws IOException {
+        Map<Class<? extends Converter<?, ?>>, List<Class<?>>> converters = new ConverterClassFinder()
+                .knownConverters();
+        Assert.assertFalse(
+                "Expecting standard converters to exist, but none found",
+                converters.isEmpty());
+        converters.forEach(
+                (converterType, types) -> assertThatConversionIsSupported(
+                        types.get(0), types.get(1), converterType));
+    }
+
+    @Test
+    public void newInstance_knownConversionPrimitiveTypes_converterCreated()
+            throws IOException {
+        Map<Class<? extends Converter<?, ?>>, List<Class<?>>> converters = new ConverterClassFinder()
+                .knownConverters();
+        converters.replaceAll((converterType, genericTypes) -> genericTypes
+                .stream().map(this::toPrimitiveTypeIfExist)
+                .collect(Collectors.toList()));
+        Assert.assertFalse(
+                "Expecting standard converters to exist, but none found",
+                converters.isEmpty());
+        converters.forEach(
+                (converterType, types) -> assertThatConversionIsSupported(
+                        types.get(0), types.get(1), converterType));
+    }
+
+    @Test
+    public void newInstance_nullArguments_invocationFails() {
+        Assert.assertThrows("Expecting null presentationType not allowed",
+                IllegalArgumentException.class,
+                () -> factory.newInstance(null, String.class));
+        Assert.assertThrows("Expecting null modelType not allowed",
+                IllegalArgumentException.class,
+                () -> factory.newInstance(String.class, null));
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private void assertThatConversionIsSupported(Class presentationType,
+                                                 Class modelType, Class<? extends Converter> expectedConverter) {
+        Optional<Converter> maybeConverter = factory
+                .newInstance(presentationType, modelType);
+        assertTrue(
+                "Expected conversion (" + presentationType + " -> " + modelType
+                        + ") to be handled in "
+                        + DefaultConverterFactory.class.getName() + " by "
+                        + expectedConverter.getName() + ", but was not",
+                maybeConverter.isPresent());
+        Converter instance = maybeConverter.get();
+        assertEquals(
+                "Expecting converter (" + presentationType + " -> " + modelType
+                        + ") to be of type " + expectedConverter.getName()
+                        + ", but was " + instance.getClass().getName(),
+                expectedConverter, instance.getClass());
+    }
+
+    private <P, M> void assertThatConversionIsNotSupported(
+            Class<P> presentationType, Class<M> modelType) {
+        Assert.assertFalse(
+                "Converter (" + presentationType + " -> " + modelType
+                        + ") should not be supported",
+                factory.newInstance(presentationType, modelType).isPresent());
+    }
+
+    private Class<?> toPrimitiveTypeIfExist(Class<?> type) {
+        if (!type.isPrimitive()) {
+            if (type.equals(Boolean.class)) {
+                type = Boolean.TYPE;
+            } else if (type.equals(Integer.class)) {
+                type = Integer.TYPE;
+            } else if (type.equals(Float.class)) {
+                type = Float.TYPE;
+            } else if (type.equals(Double.class)) {
+                type = Double.TYPE;
+            } else if (type.equals(Byte.class)) {
+                type = Byte.TYPE;
+            } else if (type.equals(Character.class)) {
+                type = Character.TYPE;
+            } else if (type.equals(Short.class)) {
+                type = Short.TYPE;
+            } else if (type.equals(Long.class)) {
+                type = Long.TYPE;
+            }
+        }
+        return type;
+    }
+
+    // Helper to get all concrete Converter implementation in
+    // com.vaadin.flow.data.converters package
+    private static class ConverterClassFinder extends ClassFinder {
+
+        @Override
+        protected Stream<String> getBasePackages() {
+            return Stream.of(Converter.class.getPackage().getName());
+        }
+
+        Map<Class<? extends Converter<?, ?>>, List<Class<?>>> knownConverters()
+                throws IOException {
+
+            List<String> rawClasspathEntries = getRawClasspathEntries();
+
+            List<String> classes = new ArrayList<>();
+            for (String location : rawClasspathEntries) {
+                if (!isTestClassPath(location)) {
+                    classes.addAll(findServerClasses(location,
+                            Collections.emptyList()));
+                }
+            }
+
+            Map<Class<? extends Converter<?, ?>>, List<Class<?>>> result = new HashMap<>();
+            for (String className : classes) {
+                try {
+                    Class<?> clazz = Class.forName(className);
+                    // Accept only public top level concrete Converter
+                    // implementations
+                    if (Converter.class.isAssignableFrom(clazz)) {
+                        List<Class<?>> types = ReflectTools
+                                .getGenericInterfaceTypes(clazz,
+                                        Converter.class);
+                        if (types.stream().allMatch(Objects::nonNull)
+                                && Modifier.isPublic(clazz.getModifiers())
+                                && !Modifier.isAbstract(clazz.getModifiers())
+                                && !clazz.isSynthetic() && !clazz.isInterface()
+                                && !clazz.isAnonymousClass()
+                                && !clazz.isMemberClass()
+                                && !clazz.isLocalClass()) {
+                            result.put((Class<? extends Converter<?, ?>>) clazz,
+                                    types);
+                        }
+                    }
+                } catch (ClassNotFoundException ex) {
+                    // ignore
+                }
+            }
+            return result;
+        }
+    }
+
+}

--- a/flow-data/src/test/java/com/vaadin/flow/tests/data/bean/ConvertibleValues.java
+++ b/flow-data/src/test/java/com/vaadin/flow/tests/data/bean/ConvertibleValues.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.tests.data.bean;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Date;
+import java.util.UUID;
+
+public class ConvertibleValues {
+
+    private Long dateToLong;
+    private long dateToPrimitiveLong;
+    private java.sql.Date dateToSqlDate;
+    private Date localDateTimeToDate;
+    private Date localDateToDate;
+    private BigDecimal stringToBigDecimal;
+    private BigInteger stringToBigInteger;
+    private Boolean stringToBoolean;
+    private boolean stringToPrimitiveBoolean;
+    private Date stringToDate;
+    private Double stringToDouble;
+    private double stringToPrimitiveDouble;
+    private Float stringToFloat;
+    private float stringToPrimitiveFloat;
+    private Integer stringToInteger;
+    private int stringToPrimitiveInteger;
+    private Long stringToLong;
+    private long stringToPrimitiveLong;
+    private UUID stringToUUID;
+
+    public Long getDateToLong() {
+        return dateToLong;
+    }
+
+    public void setDateToLong(Long dateToLong) {
+        this.dateToLong = dateToLong;
+    }
+
+    public long getDateToPrimitiveLong() {
+        return dateToPrimitiveLong;
+    }
+
+    public void setDateToPrimitiveLong(long dateToPrimitiveLong) {
+        this.dateToPrimitiveLong = dateToPrimitiveLong;
+    }
+
+    public java.sql.Date getDateToSqlDate() {
+        return dateToSqlDate;
+    }
+
+    public void setDateToSqlDate(java.sql.Date dateToSqlDate) {
+        this.dateToSqlDate = dateToSqlDate;
+    }
+
+    public Date getLocalDateTimeToDate() {
+        return localDateTimeToDate;
+    }
+
+    public void setLocalDateTimeToDate(Date localDateTimeToDate) {
+        this.localDateTimeToDate = localDateTimeToDate;
+    }
+
+    public Date getLocalDateToDate() {
+        return localDateToDate;
+    }
+
+    public void setLocalDateToDate(Date localDateToDate) {
+        this.localDateToDate = localDateToDate;
+    }
+
+    public BigDecimal getStringToBigDecimal() {
+        return stringToBigDecimal;
+    }
+
+    public void setStringToBigDecimal(BigDecimal stringToBigDecimal) {
+        this.stringToBigDecimal = stringToBigDecimal;
+    }
+
+    public BigInteger getStringToBigInteger() {
+        return stringToBigInteger;
+    }
+
+    public void setStringToBigInteger(BigInteger stringToBigInteger) {
+        this.stringToBigInteger = stringToBigInteger;
+    }
+
+    public Boolean getStringToBoolean() {
+        return stringToBoolean;
+    }
+
+    public void setStringToBoolean(Boolean stringToBoolean) {
+        this.stringToBoolean = stringToBoolean;
+    }
+
+    public boolean isStringToPrimitiveBoolean() {
+        return stringToPrimitiveBoolean;
+    }
+
+    public void setStringToPrimitiveBoolean(boolean stringToPrimitiveBoolean) {
+        this.stringToPrimitiveBoolean = stringToPrimitiveBoolean;
+    }
+
+    public Date getStringToDate() {
+        return stringToDate;
+    }
+
+    public void setStringToDate(Date stringToDate) {
+        this.stringToDate = stringToDate;
+    }
+
+    public Double getStringToDouble() {
+        return stringToDouble;
+    }
+
+    public void setStringToDouble(Double stringToDouble) {
+        this.stringToDouble = stringToDouble;
+    }
+
+    public double getStringToPrimitiveDouble() {
+        return stringToPrimitiveDouble;
+    }
+
+    public void setStringToPrimitiveDouble(double stringToPrimitiveDouble) {
+        this.stringToPrimitiveDouble = stringToPrimitiveDouble;
+    }
+
+    public Float getStringToFloat() {
+        return stringToFloat;
+    }
+
+    public void setStringToFloat(Float stringToFloat) {
+        this.stringToFloat = stringToFloat;
+    }
+
+    public float getStringToPrimitiveFloat() {
+        return stringToPrimitiveFloat;
+    }
+
+    public void setStringToPrimitiveFloat(float stringToPrimitiveFloat) {
+        this.stringToPrimitiveFloat = stringToPrimitiveFloat;
+    }
+
+    public Integer getStringToInteger() {
+        return stringToInteger;
+    }
+
+    public void setStringToInteger(Integer stringToInteger) {
+        this.stringToInteger = stringToInteger;
+    }
+
+    public int getStringToPrimitiveInteger() {
+        return stringToPrimitiveInteger;
+    }
+
+    public void setStringToPrimitiveInteger(int stringToPrimitiveInteger) {
+        this.stringToPrimitiveInteger = stringToPrimitiveInteger;
+    }
+
+    public Long getStringToLong() {
+        return stringToLong;
+    }
+
+    public void setStringToLong(Long stringToLong) {
+        this.stringToLong = stringToLong;
+    }
+
+    public long getStringToPrimitiveLong() {
+        return stringToPrimitiveLong;
+    }
+
+    public void setStringToPrimitiveLong(long stringToPrimitiveLong) {
+        this.stringToPrimitiveLong = stringToPrimitiveLong;
+    }
+
+    public UUID getStringToUUID() {
+        return stringToUUID;
+    }
+
+    public void setStringToUUID(UUID stringToUUID) {
+        this.stringToUUID = stringToUUID;
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/internal/ReflectTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/ReflectTools.java
@@ -591,6 +591,30 @@ public class ReflectTools implements Serializable {
     }
 
     /**
+     * Finds the Class type for all parameters defined by the generic interface
+     * class extended by given class if exists.
+     *
+     * @param clazz
+     *            class that should extend interface
+     * @param interfaceType
+     *            class type of interface to get generic for
+     * @return List of Class if found else empty List, never {@literal null}
+     */
+    public static List<Class<?>> getGenericInterfaceTypes(Class<?> clazz,
+                                                          Class<?> interfaceType) {
+        return Stream.of(interfaceType.getTypeParameters())
+                .map(typeParam -> GenericTypeReflector.getTypeParameter(clazz,
+                        typeParam))
+                .map(type -> {
+                    if (type instanceof Class
+                            || type instanceof ParameterizedType) {
+                        return GenericTypeReflector.erase(type);
+                    }
+                    return null;
+                }).collect(Collectors.toList());
+    }
+
+    /**
      * Finds a getter for a property in a bean type.
      *
      * @param beanClass

--- a/flow-server/src/test/java/com/vaadin/flow/internal/ReflectToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/ReflectToolsTest.java
@@ -15,21 +15,22 @@
  */
 package com.vaadin.flow.internal;
 
-import static org.junit.Assert.assertSame;
-
 import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import net.bytebuddy.ByteBuddy;
-import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public class ReflectToolsTest {
 
@@ -206,6 +207,31 @@ public class ReflectToolsTest {
     public static class ChildInterface extends ParentInterface {
     }
 
+    public interface TestInterfaceMulti<T, R, S> {
+
+    }
+
+    public static class HasInterfaceMulti
+            implements TestInterfaceMulti<String, Integer, Double> {
+    }
+
+    public static class ParentInterfacePartial<Z>
+            implements TestInterfaceMulti<Boolean, Z, Long> {
+    }
+
+    public static class ParentInterfaceMulti
+            implements TestInterfaceMulti<Boolean, Float, Long> {
+
+    }
+
+    public static class ChildInterfaceMulti extends ParentInterfaceMulti {
+    }
+
+    public static class ChildInterfacePartial
+            extends ParentInterfacePartial<Short> {
+    }
+
+
     @Test
     public void getGenericInterfaceClass() {
         Class<?> genericInterfaceType = ReflectTools.getGenericInterfaceType(
@@ -217,6 +243,39 @@ public class ReflectToolsTest {
                 ChildInterface.class, TestInterface.class);
 
         Assert.assertEquals(Boolean.class, genericInterfaceType);
+    }
+
+    @Test
+    public void getGenericInterfaceClasses() {
+
+        List<Class<?>> genericInterfaceTypes = ReflectTools
+                .getGenericInterfaceTypes(HasInterface.class,
+                        TestInterface.class);
+        Assert.assertArrayEquals(new Class<?>[] { String.class },
+                genericInterfaceTypes.toArray());
+
+        genericInterfaceTypes = ReflectTools.getGenericInterfaceTypes(
+                ChildInterface.class, TestInterface.class);
+        Assert.assertArrayEquals(new Class<?>[] { Boolean.class },
+                genericInterfaceTypes.toArray());
+
+        genericInterfaceTypes = ReflectTools.getGenericInterfaceTypes(
+                HasInterfaceMulti.class, TestInterfaceMulti.class);
+        Assert.assertArrayEquals(
+                new Class<?>[] { String.class, Integer.class, Double.class },
+                genericInterfaceTypes.toArray());
+
+        genericInterfaceTypes = ReflectTools.getGenericInterfaceTypes(
+                ChildInterfaceMulti.class, TestInterfaceMulti.class);
+        Assert.assertArrayEquals(
+                new Class<?>[] { Boolean.class, Float.class, Long.class },
+                genericInterfaceTypes.toArray());
+
+        genericInterfaceTypes = ReflectTools.getGenericInterfaceTypes(
+                ChildInterfacePartial.class, TestInterfaceMulti.class);
+        Assert.assertArrayEquals(
+                new Class<?>[] { Boolean.class, Short.class, Long.class },
+                genericInterfaceTypes.toArray());
     }
 
     @Test


### PR DESCRIPTION
## Description

When binding a field and a property which do not have the same value type
an exception is thrown. With this change, an attempt is made to
automatically pick a suitable converter from the ones provided by the framework.

It was implemented for Vaadin 23  (#13373) now backporting to version 14

## Type of change

- [ ] Bugfix
- [X] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [X] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
