### PR TITLE
fix: Add missing general styles to webcomponents shadow dom (#14316) (CP: 23.0)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -1162,7 +1162,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             return null;
         }
 
-        private void setupCss(Element head, BootstrapContext context) {
+        protected void setupCss(Element head, BootstrapContext context) {
             Element styles = head.appendElement("style").attr("type",
                     CSS_TYPE_ATTRIBUTE_VALUE);
             // Add any body style that is defined for the application using
@@ -1208,7 +1208,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                     context.getPwaRegistry().orElse(null));
         }
 
-        private Element createInlineJavaScriptElement(
+        protected Element createInlineJavaScriptElement(
                 String javaScriptContents) {
             // defer makes no sense without src:
             // https://developer.mozilla.org/en/docs/Web/HTML/Element/script
@@ -1222,7 +1222,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
             return createJavaScriptElement(sourceUrl, defer, "text/javascript");
         }
 
-        private static Element createJavaScriptModuleElement(String sourceUrl,
+        protected static Element createJavaScriptModuleElement(String sourceUrl,
                 boolean defer) {
             return createJavaScriptElement(sourceUrl, defer, "module");
         }
@@ -1294,7 +1294,7 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                     "You have to enable javascript in your browser to use this web site.");
         }
 
-        private Element getBootstrapScript(JsonValue initialUIDL,
+        protected Element getBootstrapScript(JsonValue initialUIDL,
                 BootstrapContext context) {
             return createInlineJavaScriptElement("//<![CDATA[\n"
                     + getBootstrapJS(initialUIDL, context) + "//]]>");

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
@@ -29,23 +29,28 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 
+import org.jsoup.Jsoup;
 import org.jsoup.nodes.Attribute;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 
+import com.vaadin.experimental.FeatureFlags;
 import com.vaadin.flow.component.PushConfiguration;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.webcomponent.WebComponentUI;
 import com.vaadin.flow.dom.ElementUtil;
 import com.vaadin.flow.internal.JsonUtils;
+import com.vaadin.flow.server.BootstrapException;
 import com.vaadin.flow.server.BootstrapHandler;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.HandlerHelper;
 import com.vaadin.flow.server.PwaRegistry;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
+import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.server.VaadinSession;
+import com.vaadin.flow.server.frontend.FrontendUtils;
 import com.vaadin.flow.server.webcomponent.WebComponentConfigurationRegistry;
 import com.vaadin.flow.shared.ApplicationConstants;
 
@@ -97,6 +102,50 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
 
     private static class WebComponentBootstrapPageBuilder
             extends BootstrapPageBuilder {
+        @Override
+        public Document getBootstrapPage(BootstrapContext context) {
+            VaadinService service = context.getSession().getService();
+
+            if (FeatureFlags.get(service.getContext())
+                    .isEnabled(FeatureFlags.VITE)) {
+                try {
+                    Document document = Jsoup.parse(
+                            FrontendUtils.getWebComponentHtmlContent(service));
+                    Element head = document.head();
+
+                    // Specify the application ID for scripts of the
+                    // web-component.html
+                    head.select("script[src]").attr("data-app-id",
+                            context.getUI().getInternals().getAppId());
+
+                    // Add `crossorigin` to fix basic auth in Safari #6560
+                    head.select("script[src], link[href]").attr("crossorigin",
+                            "true");
+
+                    JsonObject initialUIDL = getInitialUidl(context.getUI());
+
+                    head.prependChild(createInlineJavaScriptElement(
+                            "window.JSCompiler_renameProperty = function(a) { return a; }"));
+
+                    head.prependChild(getBootstrapScript(initialUIDL, context));
+
+                    if (context.getPushMode().isEnabled()) {
+                        head.prependChild(createJavaScriptModuleElement(
+                                getPushScript(context), true));
+                    }
+
+                    setupCss(head, context);
+
+                    return document;
+                } catch (IOException e) {
+                    throw new BootstrapException(
+                            "Unable to read the web-component.html file.", e);
+                }
+            }
+
+            return super.getBootstrapPage(context);
+        }
+
         @Override
         protected List<String> getChunkKeys(JsonObject chunks) {
             if (chunks.hasKey(EXPORT_CHUNK)) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -216,6 +216,11 @@ public class FrontendUtils {
     public static final String INDEX_HTML = "index.html";
 
     /**
+     * File name of the web-component.html in client side.
+     */
+    public static final String WEB_COMPONENT_HTML = "web-component.html";
+
+    /**
      * File name of the index.ts in client side.
      */
     public static final String INDEX_TS = "index.ts";
@@ -477,6 +482,29 @@ public class FrontendUtils {
     public static String getIndexHtmlContent(VaadinService service)
             throws IOException {
         return getFileContent(service, INDEX_HTML);
+    }
+
+    /**
+     * Gets the content of the <code>frontend/web-component.html</code> file
+     * which is served by webpack or vite in dev-mode and read from classpath in
+     * production mode.
+     * <p>
+     * NOTE: In dev mode, the file content is fetched using an http request so
+     * that we don't need to have a separate web-component.html's content
+     * watcher. Auto-reloading will work automatically, like other files managed
+     * by webpack in `frontend/` folder.
+     *
+     * @param service
+     *            the vaadin service
+     * @return the content of the web-component.html file as a string, null if
+     *         not found.
+     * @throws IOException
+     *             on error when reading file
+     *
+     */
+    public static String getWebComponentHtmlContent(VaadinService service)
+            throws IOException {
+        return getFileContent(service, WEB_COMPONENT_HTML);
     }
 
     private static String getFileContent(VaadinService service, String path)

--- a/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/NpmOnlyIndexIT.java
+++ b/flow-tests/test-embedding/embedding-test-assets/src/test/java/com/vaadin/flow/webcomponent/NpmOnlyIndexIT.java
@@ -32,7 +32,7 @@ public class NpmOnlyIndexIT extends ChromeBrowserTest {
         return Constants.PAGE_CONTEXT + "/index.html";
     }
 
-    // test for #7005
+    // test for #7005, #14256
     @Test
     public void globalStylesAreUnderTheWebComponent() {
         open();

--- a/flow-tests/test-embedding/test-embedding-reusable-theme/pom.xml
+++ b/flow-tests/test-embedding/test-embedding-reusable-theme/pom.xml
@@ -25,7 +25,7 @@
 
     <artifactId>test-embedding-reusable-theme</artifactId>
     <packaging>war</packaging>
-    <name>Flow Embedding resuable application theme tests</name>
+    <name>Flow Embedding reusable application theme tests</name>
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>


### PR DESCRIPTION
The document that is generated by
WebComponentBootstrapHandler was
missing the needed CSS to be added
to the shadow dom while using Vite.

Fixes: #14256

(manually cherry picked from commit 16959a935433dc024ccc585d0003e7b6bc319d21
and updates were made to FrontendUtils and
BootstrapHandler to make it compatible)

