### PR TITLE
fix: postpone http request on online listener

### DIFF
--- a/flow-client/src/main/frontend/Flow.ts
+++ b/flow-client/src/main/frontend/Flow.ts
@@ -386,7 +386,9 @@ export class Flow {
         http.onerror = () => {
           $wnd.Vaadin.connectionState.state = ConnectionState.CONNECTION_LOST;
         };
-        http.send();
+        // Postpone request to reduce potential net::ERR_INTERNET_DISCONNECTED
+        // errors that sometimes occurs even if browser says it is online
+        setTimeout(() => http.send(), 50);
       }
     });
     $wnd.addEventListener('offline', () => {

--- a/flow-tests/test-ccdm-flow-navigation/src/test/java/com/vaadin/flow/navigate/ServiceWorkerIT.java
+++ b/flow-tests/test-ccdm-flow-navigation/src/test/java/com/vaadin/flow/navigate/ServiceWorkerIT.java
@@ -262,9 +262,7 @@ public class ServiceWorkerIT extends ChromeDeviceTest {
 
     @Test
     public void offlineStub_backOnline_stubRemoved_serverViewShown() {
-        getDriver().get(getRootURL() + "/");
-        waitForDevServer();
-        waitForServiceWorkerReady();
+        openPageAndPreCacheWhenDevelopmentMode("/");
         getDevTools().setOfflineEnabled(true);
 
         try {


### PR DESCRIPTION
## Description

It sometimes happens that when window online listener is invoked, http
request to sw.js fails anyway with net::ERR_INTERNET_DISCONNECTED error,
even if navigator.onLine flag is true.
To reduce the possibility of a network failure in the online event listener,
the request is postponed by a little number of milliseconds.

Fixes #14364

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
