### PR TITLE
fix: execute PushRequestHandler before DevModeHandler

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletService.java
@@ -85,18 +85,6 @@ public class VaadinServletService extends VaadinService {
             throws ServiceException {
         List<RequestHandler> handlers = super.createRequestHandlers();
         handlers.add(0, new FaviconHandler());
-        if (isAtmosphereAvailable()) {
-            try {
-                handlers.add(new PushRequestHandler(this));
-            } catch (ServiceException e) {
-                // Atmosphere init failed. Push won't work but we don't throw a
-                // service exception as we don't want to prevent non-push
-                // applications from working
-                getLogger().warn(
-                        "Error initializing Atmosphere. Push will not work.",
-                        e);
-            }
-        }
 
         if (getDeploymentConfiguration().enableDevServer()) {
             Optional<DevModeHandler> handlerManager = DevModeHandlerManager
@@ -108,6 +96,22 @@ public class VaadinServletService extends VaadinService {
                         .warn("no DevModeHandlerManager implementation found "
                                 + "but dev server enabled. Include the "
                                 + "com.vaadin.vaadin-dev-server dependency.");
+            }
+        }
+
+        // PushRequestHandler should run before DevModeHandler to avoid
+        // responding with html contents when dev mode server is not ready
+        // (e.g. dev-mode-not-ready.html)
+        if (isAtmosphereAvailable()) {
+            try {
+                handlers.add(new PushRequestHandler(this));
+            } catch (ServiceException e) {
+                // Atmosphere init failed. Push won't work but we don't throw a
+                // service exception as we don't want to prevent non-push
+                // applications from working
+                getLogger().warn(
+                        "Error initializing Atmosphere. Push will not work.",
+                        e);
             }
         }
 


### PR DESCRIPTION
When an application with PUSH enabled tries to re-establish the push connection
after a server restart, it may happen that the dev mode handler responds
to the push request with HTML contents (dev-mode-not-ready.html).
In this situation, an error is shown on the browser page, a manual page reload
is required to make the application work again.
This changes the request handlers order so that the PushRequestHandler is
executed before DevModeHandler