### PR TITLE
fix: No client updates when Element::setText does nothing

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -1071,7 +1071,11 @@ public class Element extends Node<Element> {
     private void setTextContent(String textContent) {
         Element child;
         if (getChildCount() == 1 && getChild(0).isTextNode()) {
-            child = getChild(0).setText(textContent);
+            Element oneChild = getChild(0);
+            child = oneChild.setText(textContent);
+            if (oneChild == child) {
+                return;
+            }
         } else {
             child = createText(textContent);
         }

--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -1069,18 +1069,13 @@ public class Element extends Node<Element> {
     }
 
     private void setTextContent(String textContent) {
-        Element child;
         if (getChildCount() == 1 && getChild(0).isTextNode()) {
-            Element oneChild = getChild(0);
-            child = oneChild.setText(textContent);
-            if (oneChild == child) {
-                return;
-            }
+            getChild(0).setText(textContent);
         } else {
-            child = createText(textContent);
+            Element child = createText(textContent);
+            removeAllChildren();
+            appendChild(child);
         }
-        removeAllChildren();
-        appendChild(child);
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
@@ -35,8 +35,11 @@ import com.vaadin.flow.component.page.PendingJavaScriptResult;
 import com.vaadin.flow.dom.impl.BasicElementStateProvider;
 import com.vaadin.flow.internal.NullOwner;
 import com.vaadin.flow.internal.StateNode;
+import com.vaadin.flow.internal.StateTree;
+import com.vaadin.flow.internal.change.NodeChange;
 import com.vaadin.flow.internal.nodefeature.ComponentMapping;
 import com.vaadin.flow.internal.nodefeature.ElementAttributeMap;
+import com.vaadin.flow.internal.nodefeature.ElementChildrenList;
 import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
 import com.vaadin.flow.internal.nodefeature.ElementListenersTest;
 import com.vaadin.flow.internal.nodefeature.ElementPropertyMap;
@@ -689,6 +692,36 @@ public class ElementTest extends AbstractNodeTest {
 
         Assert.assertNull(child.getParent());
         Assert.assertEquals("foo", element.getTextRecursively());
+    }
+
+    @Test
+    public void testSetTextRepeatedly() {
+	    Element element = ElementFactory.createDiv();
+	    Element text = Element.createText("foo");
+	    element.appendChild(text);
+	    new StateTree(new UI().getInternals(), ElementChildrenList.class)
+                .getUI().getElement().appendChild(element);   
+                // element must be attached so collectChanges() works
+        StateNode node = element.getNode();
+        StateNode textNode = text.getNode();
+        List<NodeChange> changes = new ArrayList<>();
+        node.collectChanges(ch -> changes.add(ch));// node-attach, put, list-add
+        Assert.assertEquals(3, changes.size());
+        textNode.collectChanges(ch -> changes.add(ch));// node-attach, put
+        Assert.assertEquals(5, changes.size());
+        changes.clear();
+        element.setText("foo");
+        node.collectChanges(ch -> changes.add(ch));
+        textNode.collectChanges(ch -> changes.add(ch));
+        // setting same text again should not trigger any changes
+        Assert.assertEquals(0, changes.size());
+
+        element.setText("bar");
+        node.collectChanges(ch -> changes.add(ch));
+        // replacing text does not trigger change on element
+        Assert.assertEquals(0, changes.size());
+        textNode.collectChanges(ch -> changes.add(ch));// put
+        Assert.assertEquals(1, changes.size());
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
@@ -696,12 +696,12 @@ public class ElementTest extends AbstractNodeTest {
 
     @Test
     public void testSetTextRepeatedly() {
-	    Element element = ElementFactory.createDiv();
-	    Element text = Element.createText("foo");
-	    element.appendChild(text);
-	    new StateTree(new UI().getInternals(), ElementChildrenList.class)
-                .getUI().getElement().appendChild(element);   
-                // element must be attached so collectChanges() works
+        Element element = ElementFactory.createDiv();
+        Element text = Element.createText("foo");
+        element.appendChild(text);
+        new StateTree(new UI().getInternals(), ElementChildrenList.class)
+                .getUI().getElement().appendChild(element);
+        // element must be attached so collectChanges() works
         StateNode node = element.getNode();
         StateNode textNode = text.getNode();
         List<NodeChange> changes = new ArrayList<>();


### PR DESCRIPTION
## Description
when invoking setText(sometext) on an Element, using the same text as before, this still triggers some dom changes being sent to browser, even though nothing changes. This causes unnecessary network traffic and browser code to run.
The same situation is handled correctly for setProperty(prop,value) etc., so it should work the same way also for setText().

Fixes #14388

## Type of change

- [x] Bugfix
- [ ] Feature


## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

