### PR TITLE
fix: initialize PwaHandler only once

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PwaHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PwaHandler.java
@@ -123,7 +123,6 @@ public class PwaHandler implements RequestHandler {
                     }
                     return true;
                 });
-        isInitialized = true;
     }
 
     @Override
@@ -139,6 +138,7 @@ public class PwaHandler implements RequestHandler {
                 requestHandlerMap.clear();
             } else if (!isInitialized && hasPwa) {
                 init(pwaRegistry);
+                isInitialized = true;
             }
 
             if (hasPwa) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PwaHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PwaHandler.java
@@ -123,6 +123,7 @@ public class PwaHandler implements RequestHandler {
                     }
                     return true;
                 });
+        isInitialized = true;
     }
 
     @Override

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/PwaHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/PwaHandlerTest.java
@@ -72,4 +72,25 @@ public class PwaHandlerTest {
         Assert.assertTrue(handler.handleRequest(session, request, response));
     }
 
+    @Test
+    public void handleRequest_pwaRegistryConfigIsEnabled_handlerIsInitializedOnce()
+            throws IOException {
+
+        PwaRegistry registry = Mockito.mock(PwaRegistry.class);
+        PwaConfiguration configuration = Mockito.mock(PwaConfiguration.class);
+        Mockito.when(registry.getPwaConfiguration()).thenReturn(configuration);
+        Mockito.when(configuration.isEnabled()).thenReturn(true);
+        PwaHandler handler = new PwaHandler(() -> registry);
+
+        Mockito.when(response.getWriter())
+                .thenReturn(new PrintWriter(new StringWriter()));
+        Mockito.when(registry.getRuntimeServiceWorkerJs()).thenReturn("");
+        Mockito.when(request.getPathInfo())
+                .thenReturn("/sw-runtime-resources-precache.js");
+
+        Assert.assertTrue(handler.handleRequest(session, request, response));
+        Assert.assertTrue(handler.handleRequest(session, request, response));
+
+        Mockito.verify(registry, Mockito.times(1)).getIcons();
+    }
 }


### PR DESCRIPTION
PwaHandler has an isInitialized flag that is checked on handleRequest method,
but never initialized, causing init method to be invoked on every request.
This change sets the flag within init method.