### PR TITLE
fix!: Avoid duplicated field bindings

### DIFF
--- a/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderInstanceFieldTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/binder/BinderInstanceFieldTest.java
@@ -650,4 +650,58 @@ public class BinderInstanceFieldTest {
         // thrown later if the binding is not completed)
         binder.bindInstanceFields(form);
     }
+
+    @Test
+    public void bindInstanceFields_customBindingAfterInvoke_automaticBindingOverwritten() {
+        BindOnlyOneField form = new BindOnlyOneField();
+        form.firstName = new TestTextField();
+        Binder<Person> binder = new Binder<>(Person.class);
+
+        binder.bindInstanceFields(form);
+        Binder.BindingBuilder<Person, String> binding = binder
+                .forField(form.firstName)
+                .withConverter(str -> str.substring(str.length() / 2),
+                        str -> str + str);
+        binding.bind(Person::getFirstName, Person::setFirstName);
+
+        Person person = new Person();
+        person.setFirstName("Hello!");
+        binder.setBean(person);
+        Assert.assertEquals("Hello!Hello!", form.firstName.getValue());
+    }
+
+    @Test
+    public void bindInstanceFields_incompleteBindingBoundAfterInvoke_automaticBindingOverwritten() {
+        BindOnlyOneField form = new BindOnlyOneField();
+        form.firstName = new TestTextField();
+        Binder<Person> binder = new Binder<>(Person.class);
+
+        Binder.BindingBuilder<Person, String> binding = binder
+                .forField(form.firstName)
+                .withConverter(str -> str.substring(str.length() / 2),
+                        str -> str + str);
+        binder.bindInstanceFields(form);
+        binding.bind(Person::getFirstName, Person::setFirstName);
+
+        Person person = new Person();
+        person.setFirstName("Hello!");
+        binder.setBean(person);
+        Assert.assertEquals("Hello!Hello!", form.firstName.getValue());
+    }
+
+    @Test
+    public void bindInstanceFields_incompleteBinding_fieldIgnored() {
+        BindOnlyOneField form = new BindOnlyOneField();
+        form.firstName = new TestTextField();
+        Binder<Person> binder = new Binder<>(Person.class);
+
+        binder.forField(form.firstName).withConverter(
+                str -> str.substring(str.length() / 2), str -> str + str);
+        binder.bindInstanceFields(form);
+
+        Assert.assertFalse(
+                "Expecting incomplete binding to be ignored by Binder, but field was bound",
+                binder.getBinding("firstName").isPresent());
+    }
+    
 }


### PR DESCRIPTION
## Description

Backporting #13340

If custom binding is added or completed after the call to Binder.bindInstanceFields
the field is bound twice and this may lead to potential multiple application
of converters, producing wrong representation and value for the field.
This change ignores incomplete bindings during `bindInstanceFields()`
process and overwrites existing bindings when `Binding.bind()` is
invoked after `bindInstanceFields()`.

Fixes #13314

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
