### PR TITLE
test: Redirect test output to test-output.log instead of stderr

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -113,6 +113,7 @@ jobs:
           name: saved-outputs
           path: |
             **/target/*-reports/*
+            **/test-output.log
             mvn-*.out
   it-tests:
     needs: build
@@ -191,6 +192,7 @@ jobs:
           path: |
             **/target/*-reports/*
             **/error-screenshots/*.png
+            **/test-output.log
             mvn-*.out
   test-results:
     if: ${{ failure() || success() }}
@@ -225,6 +227,7 @@ jobs:
           path: |
             **/target/*-reports/*
             **/error-screenshots/*.png
+            **/test-output.log
             mvn-*.out
       - name: Check Failure Status
         run: |

--- a/pom.xml
+++ b/pom.xml
@@ -523,6 +523,9 @@
                         <threadCount>4</threadCount>
 -->
                         <failIfNoTests>false</failIfNoTests>
+                        <systemPropertyVariables>
+                            <org.slf4j.simpleLogger.logFile>test-output.log</org.slf4j.simpleLogger.logFile>
+                        </systemPropertyVariables>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -546,8 +549,8 @@
                         <!-- export test server port to integration tests -->
                         <systemPropertyVariables>
                             <serverPort>${server.port}</serverPort>
-                            <webdriver.chrome.driver>${webdriver.chrome.driver}
-                            </webdriver.chrome.driver>
+                            <webdriver.chrome.driver>${webdriver.chrome.driver}</webdriver.chrome.driver>
+                            <org.slf4j.simpleLogger.logFile>test-output.log</org.slf4j.simpleLogger.logFile>
                         </systemPropertyVariables>
                         <excludes>
                             <exclude>**/*$*</exclude>


### PR DESCRIPTION
This reduces log pollution and makes it easier to see what actually fails. 
Reduces `mvn test` output in `flow-server` from 2621 to 708 rows.
