### PR TITLE
feat: allow to set a feature flag using a system property

### DIFF
--- a/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
+++ b/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
@@ -201,17 +201,25 @@ public class FeatureFlags implements Serializable {
             for (Feature f : features) {
                 f.setEnabled(false);
             }
-            return;
+        } else {
+            try (FileInputStream propertiesStream = new FileInputStream(
+                    featureFlagFile)) {
+                getLogger().debug("Loading properties from file '{}'",
+                        featureFlagFile);
+                loadProperties(propertiesStream);
+            } catch (IOException e) {
+                throw new UncheckedIOException(
+                        "Failed to read properties file from filesystem", e);
+            }
         }
 
-        try (FileInputStream propertiesStream = new FileInputStream(
-                featureFlagFile)) {
-            getLogger().debug("Loading properties from file '{}'",
-                    featureFlagFile);
-            loadProperties(propertiesStream);
-        } catch (IOException e) {
-            throw new UncheckedIOException(
-                    "Failed to read properties file from filesystem", e);
+        // Allow users to override a feature flag with a system property
+        for (Feature f : features) {
+            var prop = System.getProperty("featureFlag-" + f.getId());
+
+            if (prop != null) {
+                f.setEnabled(Boolean.parseBoolean(prop));
+            }
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
+++ b/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
@@ -47,6 +47,7 @@ import org.slf4j.LoggerFactory;
 public class FeatureFlags implements Serializable {
 
     public static final String PROPERTIES_FILENAME = "vaadin-featureflags.properties";
+    public static final String SYSTEM_PROPERTY_PREFIX = "vaadin-";
 
     public static final Feature EXAMPLE = new Feature(
             "Example feature. Will be removed once the first real feature flag is added",
@@ -215,7 +216,7 @@ public class FeatureFlags implements Serializable {
 
         // Allow users to override a feature flag with a system property
         for (Feature f : features) {
-            var prop = System.getProperty("vaadin-" + f.getId());
+            var prop = System.getProperty(SYSTEM_PROPERTY_PREFIX + f.getId());
 
             if (prop != null) {
                 f.setEnabled(Boolean.parseBoolean(prop));

--- a/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
+++ b/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
@@ -215,7 +215,7 @@ public class FeatureFlags implements Serializable {
 
         // Allow users to override a feature flag with a system property
         for (Feature f : features) {
-            var prop = System.getProperty("featureFlag-" + f.getId());
+            var prop = System.getProperty("vaadin-" + f.getId());
 
             if (prop != null) {
                 f.setEnabled(Boolean.parseBoolean(prop));

--- a/flow-server/src/test/java/com/vaadin/experimental/FeatureFlagsTest.java
+++ b/flow-server/src/test/java/com/vaadin/experimental/FeatureFlagsTest.java
@@ -196,7 +196,7 @@ public class FeatureFlagsTest {
     @Test
     public void featureFlagShouldBeOverridableWithSystemProperty()
             throws IOException {
-        System.setProperty("featureFlag-exampleFeatureFlag", "true");
+        System.setProperty("vaadin-exampleFeatureFlag", "true");
         createFeatureFlagsFile(
                 "com.vaadin.experimental.exampleFeatureFlag=false\n");
         featureFlags.loadProperties();

--- a/flow-server/src/test/java/com/vaadin/experimental/FeatureFlagsTest.java
+++ b/flow-server/src/test/java/com/vaadin/experimental/FeatureFlagsTest.java
@@ -197,7 +197,7 @@ public class FeatureFlagsTest {
     public void featureFlagShouldBeOverridableWithSystemProperty()
             throws IOException {
         var feature = "exampleFeatureFlag";
-        var propertyName = "vaadin-" + feature;
+        var propertyName = FeatureFlags.SYSTEM_PROPERTY_PREFIX + feature;
         var previousValue = System.getProperty(propertyName);
 
         try {

--- a/flow-server/src/test/java/com/vaadin/experimental/FeatureFlagsTest.java
+++ b/flow-server/src/test/java/com/vaadin/experimental/FeatureFlagsTest.java
@@ -196,11 +196,23 @@ public class FeatureFlagsTest {
     @Test
     public void featureFlagShouldBeOverridableWithSystemProperty()
             throws IOException {
-        System.setProperty("vaadin-exampleFeatureFlag", "true");
-        createFeatureFlagsFile(
-                "com.vaadin.experimental.exampleFeatureFlag=false\n");
-        featureFlags.loadProperties();
-        Assert.assertTrue(featureFlags.isEnabled(FeatureFlags.EXAMPLE));
+        var feature = "exampleFeatureFlag";
+        var propertyName = "vaadin-" + feature;
+        var previousValue = System.getProperty(propertyName);
+
+        try {
+            System.setProperty(propertyName, "true");
+            createFeatureFlagsFile(String
+                    .format("com.vaadin.experimental.%s=false\n", feature));
+            featureFlags.loadProperties();
+            Assert.assertTrue(featureFlags.isEnabled(FeatureFlags.EXAMPLE));
+        } finally {
+            if (previousValue == null) {
+                System.clearProperty(propertyName);
+            } else {
+                System.setProperty(propertyName, previousValue);
+            }
+        }
     }
 
     private boolean hasUsageStatsEntry(String name) {

--- a/flow-server/src/test/java/com/vaadin/experimental/FeatureFlagsTest.java
+++ b/flow-server/src/test/java/com/vaadin/experimental/FeatureFlagsTest.java
@@ -193,6 +193,16 @@ public class FeatureFlagsTest {
                 hasUsageStatsEntry("flow/featureflags/exampleFeatureFlag"));
     }
 
+    @Test
+    public void featureFlagShouldBeOverridableWithSystemProperty()
+            throws IOException {
+        System.setProperty("featureFlag-exampleFeatureFlag", "true");
+        createFeatureFlagsFile(
+                "com.vaadin.experimental.exampleFeatureFlag=false\n");
+        featureFlags.loadProperties();
+        Assert.assertTrue(featureFlags.isEnabled(FeatureFlags.EXAMPLE));
+    }
+
     private boolean hasUsageStatsEntry(String name) {
         return UsageStatistics.getEntries()
                 .filter(entry -> entry.getName().equals(name)).findFirst()


### PR DESCRIPTION
Accepts a value for a feature flag passed through a system property and overrides existing value.

Closes #14407