### PR TITLE
fix: hange prefix to `vaadin.` for feature flag system properties

### DIFF
--- a/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
+++ b/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
 public class FeatureFlags implements Serializable {
 
     public static final String PROPERTIES_FILENAME = "vaadin-featureflags.properties";
-    public static final String SYSTEM_PROPERTY_PREFIX = "vaadin-";
+    public static final String SYSTEM_PROPERTY_PREFIX = "vaadin.";
 
     public static final Feature EXAMPLE = new Feature(
             "Example feature. Will be removed once the first real feature flag is added",


### PR DESCRIPTION
I'm amending #14408 here. I realized that it is way more common to use dots than dashes as separator in system property names.

While there is no change in functionality, I'd prefer to follow the standards.

I'm sorry for that :)