### PR TITLE
Revert "test: Add VAADIN mapping to OSGi servlet registrations (#13855)"

### DIFF
--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/osgi/Activator.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/osgi/Activator.java
@@ -225,10 +225,7 @@ public class Activator {
                 HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_ASYNC_SUPPORTED,
                 true);
         properties.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_PATTERN,
-                // Adds serve static files from VAADIN in the context root
-                // for non-root servlet mapping.
-                // see https://github.com/vaadin/flow/issues/13769
-                new String[] { mapping, "/VAADIN/*" });
+                mapping);
         return properties;
     }
 


### PR DESCRIPTION
Follow-up for https://github.com/vaadin/flow/pull/14357, revert unnecessary `/VAADIN/*` mapping, since the functionality for serving resources from context root has been reverted.

This reverts commit b9d07ebb
