### PR TITLE
Revert "fix: No client updates when Element::setText does nothing (#14389)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
+++ b/flow-server/src/main/java/com/vaadin/flow/dom/Element.java
@@ -1069,13 +1069,14 @@ public class Element extends Node<Element> {
     }
 
     private void setTextContent(String textContent) {
+        Element child;
         if (getChildCount() == 1 && getChild(0).isTextNode()) {
-            getChild(0).setText(textContent);
+            child = getChild(0).setText(textContent);
         } else {
-            Element child = createText(textContent);
-            removeAllChildren();
-            appendChild(child);
+            child = createText(textContent);
         }
+        removeAllChildren();
+        appendChild(child);
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/dom/ElementTest.java
@@ -35,11 +35,8 @@ import com.vaadin.flow.component.page.PendingJavaScriptResult;
 import com.vaadin.flow.dom.impl.BasicElementStateProvider;
 import com.vaadin.flow.internal.NullOwner;
 import com.vaadin.flow.internal.StateNode;
-import com.vaadin.flow.internal.StateTree;
-import com.vaadin.flow.internal.change.NodeChange;
 import com.vaadin.flow.internal.nodefeature.ComponentMapping;
 import com.vaadin.flow.internal.nodefeature.ElementAttributeMap;
-import com.vaadin.flow.internal.nodefeature.ElementChildrenList;
 import com.vaadin.flow.internal.nodefeature.ElementListenerMap;
 import com.vaadin.flow.internal.nodefeature.ElementListenersTest;
 import com.vaadin.flow.internal.nodefeature.ElementPropertyMap;
@@ -692,36 +689,6 @@ public class ElementTest extends AbstractNodeTest {
 
         Assert.assertNull(child.getParent());
         Assert.assertEquals("foo", element.getTextRecursively());
-    }
-
-    @Test
-    public void testSetTextRepeatedly() {
-        Element element = ElementFactory.createDiv();
-        Element text = Element.createText("foo");
-        element.appendChild(text);
-        new StateTree(new UI().getInternals(), ElementChildrenList.class)
-                .getUI().getElement().appendChild(element);
-        // element must be attached so collectChanges() works
-        StateNode node = element.getNode();
-        StateNode textNode = text.getNode();
-        List<NodeChange> changes = new ArrayList<>();
-        node.collectChanges(ch -> changes.add(ch));// node-attach, put, list-add
-        Assert.assertEquals(3, changes.size());
-        textNode.collectChanges(ch -> changes.add(ch));// node-attach, put
-        Assert.assertEquals(5, changes.size());
-        changes.clear();
-        element.setText("foo");
-        node.collectChanges(ch -> changes.add(ch));
-        textNode.collectChanges(ch -> changes.add(ch));
-        // setting same text again should not trigger any changes
-        Assert.assertEquals(0, changes.size());
-
-        element.setText("bar");
-        node.collectChanges(ch -> changes.add(ch));
-        // replacing text does not trigger change on element
-        Assert.assertEquals(0, changes.size());
-        textNode.collectChanges(ch -> changes.add(ch));// put
-        Assert.assertEquals(1, changes.size());
     }
 
     @Test


### PR DESCRIPTION
This reverts commit 77a64eb8b0b1e0a5924226fed0fdd3d3b30428a5.

The fix made in https://github.com/vaadin/flow/pull/14389 breaks the case when the child nodes are added on the client side, see failing test `ClearNodeChildrenIT.addTextNode_setTextToContainerWithClientSideNodes_allNodesAreRemoved`.
To be reconsidered.
