### PR TITLE
fix!: Security upgrade of org.jsoup:jsoup to 1.15.3

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteNotFoundError.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteNotFoundError.java
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
-import org.jsoup.safety.Whitelist;
+import org.jsoup.safety.Safelist;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,8 +63,8 @@ public class RouteNotFoundError extends Component
         if (parameter.hasCustomMessage()) {
             additionalInfo = "Reason: " + parameter.getCustomMessage();
         }
-        path = Jsoup.clean(path, Whitelist.none());
-        additionalInfo = Jsoup.clean(additionalInfo, Whitelist.none());
+        path = Jsoup.clean(path, Safelist.none());
+        additionalInfo = Jsoup.clean(additionalInfo, Safelist.none());
 
         boolean productionMode = event.getUI().getSession().getConfiguration()
                 .isProductionMode();

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <flow.dev.dependencies.file>devDependencies.json</flow.dev.dependencies.file>
 
         <!-- Used in OSGi manifests -->
-        <jsoup.version>1.14.3</jsoup.version>
+        <jsoup.version>1.15.3</jsoup.version>
         <!-- Note that this should be kept in sync with the class Constants -->
         <atmosphere.runtime.version>2.7.3.slf4jvaadin4</atmosphere.runtime.version>
         <atmosphere.client.version>3.1.3</atmosphere.client.version>


### PR DESCRIPTION
manual cherry-pick of (#14424)

Fixes https://github.com/vaadin/platform/issues/3187

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JAVA-ORGJSOUP-2989728

