### PR TITLE
chore: Mainly use Implementation-version

### DIFF
--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/BuildFrontendUtil.java
@@ -546,7 +546,11 @@ public class BuildFrontendUtil {
                 }
                 String cvdlName = attributes.getValue("CvdlName");
                 if (cvdlName != null) {
-                    String version = attributes.getValue("Bundle-Version");
+                    String version = attributes
+                            .getValue("Implementation-Version");
+                    if (version == null) {
+                        version = attributes.getValue("Bundle-Version");
+                    }
                     Product p = new Product(cvdlName, version);
                     components.add(p);
                 }


### PR DESCRIPTION
Fall back to the OSGi bundle-version attribute if there is no implementation version
