### PR TITLE
refactor: remove unused code

### DIFF
--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -48,13 +48,6 @@ const themeOptions = {
   frontendGeneratedFolder: path.resolve(frontendFolder, settings.generatedFolder)
 };
 
-const brotliPlugin = brotli();
-brotliPlugin.writeBundle = {
-  order: 'post',
-  sequential: true,
-  handler: brotliPlugin.writeBundle
-}
-
 const hasExportedWebComponents = existsSync(path.resolve(frontendFolder, 'web-component.html'));
 
 // Block debug and trace logs.


### PR DESCRIPTION
## Description

There is an extra brotli plugin instance that I forgot to remove while working on https://github.com/vaadin/flow/pull/14370. It is not used anywhere.

## Type of change

- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
