### PR TITLE
fix!: Security upgrade org.jsoup:jsoup to 1.15.3

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteNotFoundError.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteNotFoundError.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
-import org.jsoup.safety.Whitelist;
+import org.jsoup.safety.Safelist;
 import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.Component;
@@ -56,8 +56,8 @@ public class RouteNotFoundError extends Component
         if (parameter.hasCustomMessage()) {
             additionalInfo = "Reason: " + parameter.getCustomMessage();
         }
-        path = Jsoup.clean(path, Whitelist.none());
-        additionalInfo = Jsoup.clean(additionalInfo, Whitelist.none());
+        path = Jsoup.clean(path, Safelist.none());
+        additionalInfo = Jsoup.clean(additionalInfo, Safelist.none());
 
         boolean productionMode = event.getUI().getSession().getConfiguration()
                 .isProductionMode();

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <flow.dev.dependencies.file>devDependencies.json</flow.dev.dependencies.file>
 
         <!-- Used in OSGi manifests -->
-        <jsoup.version>1.14.3</jsoup.version>
+        <jsoup.version>1.15.3</jsoup.version>
         <!-- Note that this should be kept in sync with the class Constants -->
         <atmosphere.runtime.version>2.7.3.slf4jvaadin4</atmosphere.runtime.version>
 


### PR DESCRIPTION
manual cherry-pick of (#14424)

The following vulnerabilities are fixed with an upgrade:
- https://snyk.io/vuln/SNYK-JAVA-ORGJSOUP-2989728
