### PR TITLE
fix: Resync listener issue

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/StateNode.java
@@ -251,7 +251,9 @@ public class StateNode implements Serializable {
      */
     public void setParent(StateNode parent) {
         if (hasDetached()) {
-            this.parent = null;
+            if (parent == null) {
+                this.parent = null;
+            }
             return;
         }
         boolean attachedBefore = isRegistered();

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ResyncListenerView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/ResyncListenerView.java
@@ -1,0 +1,25 @@
+package com.vaadin.flow.uitest.ui;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.notification.Notification;
+import com.vaadin.flow.router.Route;
+
+@Route("resync-listener")
+public class ResyncListenerView extends Div {
+
+    public ResyncListenerView() {
+        Button resynch = new Button("Resynchronize",
+                event -> UI.getCurrent().getInternals().incrementServerId());
+        resynch.setId("resync");
+
+        Button button = new Button("Click me");
+        button.addClickListener(event -> {
+            Notification.show("Works");
+        });
+        button.setId("button");
+
+        add(resynch, button);
+    }
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ResyncListenerIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/ResyncListenerIT.java
@@ -1,0 +1,22 @@
+package com.vaadin.flow.uitest.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.vaadin.flow.component.button.testbench.ButtonElement;
+import com.vaadin.flow.component.notification.testbench.NotificationElement;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class ResyncListenerIT extends ChromeBrowserTest {
+
+    @Test
+    public void listenerWorksAfterResync() {
+        open();
+        $(ButtonElement.class).id("resync").click();
+        open();
+        $(ButtonElement.class).id("button").click();
+        NotificationElement notification = $(NotificationElement.class).first();
+        Assert.assertEquals("Works", notification.getText());
+    }
+
+}


### PR DESCRIPTION
This PR causes regression, listeners not getting fired after resync: https://github.com/vaadin/flow/pull/14276
