### PR TITLE
Make Lit import rewrites lazy

### DIFF
--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -407,12 +407,12 @@ function lenientLitImportPlugin(): PluginOption {
     name: 'vaadin:lenient-lit-import',
     async transform(code, id) {
       const decoratorImports = [
-        /import (.*) from (['"])(lit\/decorators)(['"])/,
-        /import (.*) from (['"])(lit-element\/decorators)(['"])/
+        /import (.*?) from (['"])(lit\/decorators)(['"])/,
+        /import (.*?) from (['"])(lit-element\/decorators)(['"])/
       ];
       const directiveImports = [
-        /import (.*) from (['"])(lit\/directives\/)([^\\.]*)(['"])/,
-        /import (.*) from (['"])(lit-html\/directives\/)([^\\.]*)(['"])/
+        /import (.*?) from (['"])(lit\/directives\/)([^\\.]*?)(['"])/,
+        /import (.*?) from (['"])(lit-html\/directives\/)([^\\.]*?)(['"])/
       ];
 
       decoratorImports.forEach((decoratorImport) => {

--- a/flow-tests/test-frontend/vite-production/frontend/lit-invalid-imports.ts
+++ b/flow-tests/test-frontend/vite-production/frontend/lit-invalid-imports.ts
@@ -1,0 +1,7 @@
+import { customElement } from 'lit/decorators';
+import { customElement as ce2, property } from 'lit/decorators';
+import { state, customElement as ce3, property as p2 } from 'lit/decorators';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html';
+import { classMap } from 'lit-html/directives/class-map';
+
+console.log(customElement, ce2, ce3, property, p2, state, unsafeHTML, classMap);

--- a/flow-tests/test-frontend/vite-production/package.json
+++ b/flow-tests/test-frontend/vite-production/package.json
@@ -13,17 +13,19 @@
     "@vaadin/vaadin-lumo-styles": "23.2.0-alpha5",
     "@vaadin/vaadin-text-field": "23.2.0-alpha5",
     "construct-style-sheets-polyfill": "3.1.0",
-    "lit": "2.2.7"
+    "lit": "2.3.0"
   },
   "devDependencies": {
     "@rollup/plugin-replace": "3.1.0",
+    "@rollup/pluginutils": "4.1.0",
     "async": "3.2.2",
     "glob": "7.2.3",
     "mkdirp": "1.0.4",
     "rollup-plugin-brotli": "3.1.0",
+    "transform-ast": "2.4.4",
     "typescript": "4.7.4",
-    "vite": "v3.0.2",
-    "vite-plugin-checker": "0.4.6",
+    "vite": "v3.0.9",
+    "vite-plugin-checker": "0.4.9",
     "workbox-build": "6.5.0",
     "workbox-core": "6.5.0",
     "workbox-precaching": "6.5.0"
@@ -36,21 +38,23 @@
       "@vaadin/vaadin-lumo-styles": "23.2.0-alpha5",
       "@vaadin/vaadin-text-field": "23.2.0-alpha5",
       "construct-style-sheets-polyfill": "3.1.0",
-      "lit": "2.2.7"
+      "lit": "2.3.0"
     },
     "devDependencies": {
       "@rollup/plugin-replace": "3.1.0",
+      "@rollup/pluginutils": "4.1.0",
       "async": "3.2.2",
       "glob": "7.2.3",
       "mkdirp": "1.0.4",
       "rollup-plugin-brotli": "3.1.0",
+      "transform-ast": "2.4.4",
       "typescript": "4.7.4",
-      "vite": "v3.0.2",
-      "vite-plugin-checker": "0.4.6",
+      "vite": "v3.0.9",
+      "vite-plugin-checker": "0.4.9",
       "workbox-build": "6.5.0",
       "workbox-core": "6.5.0",
       "workbox-precaching": "6.5.0"
     },
-    "hash": "d9973f4f4fd94ba692927888d08f03934a1f7631e35bc377c9956d65c4756e88"
+    "hash": "ed2eeb6c914fe8364797a5d0ef8f2acb470e6e6c2f00d79f8e90c469a899c2fe"
   }
 }

--- a/flow-tests/test-frontend/vite-production/src/main/java/com/vaadin/viteapp/views/empty/MainView.java
+++ b/flow-tests/test-frontend/vite-production/src/main/java/com/vaadin/viteapp/views/empty/MainView.java
@@ -12,6 +12,7 @@ import com.vaadin.flow.router.Route;
 @Route("")
 @JsModule("@testscope/button")
 @JsModule("@testscope/map")
+@JsModule("./lit-invalid-imports.ts")
 public class MainView extends Div {
 
     public static final String PLANT = "plant";


### PR DESCRIPTION
The import rewrites must only match one row and not a similar import on the following row

Fixes https://github.com/vaadin/component-starter-flow/issues/369
