### PR TITLE
feat: Allow setting content of the Html component

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/Html.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Html.java
@@ -147,7 +147,7 @@ public class Html extends Component {
 
         doc.outputSettings().prettyPrint(false);
         setInnerHtml(root.html());
-    }    
+    }
 
     private void setOuterHtml(String outerHtml) {
         Document doc = Jsoup.parseBodyFragment(outerHtml);

--- a/flow-server/src/main/java/com/vaadin/flow/component/Html.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Html.java
@@ -123,7 +123,7 @@ public class Html extends Component {
      * Any heading or trailing whitespace is removed while parsing but any
      * whitespace inside the root tag is preserved.
      *
-     * @param outerHtml
+     * @param html
      *            the HTML to wrap
      */
     public void setHtmlContent(String html) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/Html.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Html.java
@@ -113,6 +113,42 @@ public class Html extends Component {
         setOuterHtml(outerHtml);
     }
 
+    /**
+     * Sets the content based on the given HTML fragment. The fragment must have
+     * exactly one root element.
+     * <p>
+     * A best effort is done to parse broken HTML but no guarantees are given
+     * for how invalid HTML is handled.
+     * <p>
+     * Any heading or trailing whitespace is removed while parsing but any
+     * whitespace inside the root tag is preserved.
+     *
+     * @param outerHtml
+     *            the HTML to wrap
+     */
+    public void setHtmlContent(String html) {
+        Document doc = Jsoup.parseBodyFragment(html);
+        int nrChildren = doc.body().children().size();
+        if (nrChildren != 1) {
+            String message = "HTML must contain exactly one top level element (ignoring text nodes). Found "
+                    + nrChildren;
+            if (nrChildren > 1) {
+                String tagNames = doc.body().children().stream()
+                        .map(org.jsoup.nodes.Element::tagName)
+                        .collect(Collectors.joining(", "));
+                message += " elements with the tag names " + tagNames;
+            }
+            throw new IllegalArgumentException(message);
+        }
+
+        org.jsoup.nodes.Element root = doc.body().child(0);
+        Attributes attrs = root.attributes();
+        attrs.forEach(this::setAttribute);
+
+        doc.outputSettings().prettyPrint(false);
+        setInnerHtml(root.html());
+    }    
+
     private void setOuterHtml(String outerHtml) {
         Document doc = Jsoup.parseBodyFragment(outerHtml);
         int nrChildren = doc.body().children().size();

--- a/flow-server/src/main/java/com/vaadin/flow/component/Html.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Html.java
@@ -115,7 +115,7 @@ public class Html extends Component {
 
     /**
      * Sets the content based on the given HTML fragment. The fragment must have
-     * exactly one root element.
+     * exactly one root element, which matches the existing one.
      * <p>
      * A best effort is done to parse broken HTML but no guarantees are given
      * for how invalid HTML is handled.
@@ -144,6 +144,12 @@ public class Html extends Component {
         org.jsoup.nodes.Element root = doc.body().child(0);
         Attributes attrs = root.attributes();
         attrs.forEach(this::setAttribute);
+
+        if (!root.tagName().equals(getElement().getTag())) {
+            throw new IllegalStateException(
+                    "Existing root tag '" + getElement().getTag()
+                            + "' can't be changed to '" + root.tagName() + "'");
+        }
 
         doc.outputSettings().prettyPrint(false);
         setInnerHtml(root.html());

--- a/flow-server/src/test/java/com/vaadin/flow/component/HTMLTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HTMLTest.java
@@ -74,6 +74,15 @@ public class HTMLTest {
         Assert.assertEquals("world", html.getInnerHtml());
     }
 
+    @Test(expected = IllegalStateException.class)
+    public void setHtmlContent_tagMismatch() {
+        Html html = new Html("<span>hello</span>");
+        Assert.assertEquals(Tag.SPAN, html.getElement().getTag());
+        Assert.assertEquals("hello", html.getInnerHtml());
+        html.setHtmlContent("<div>world</div>");
+        Assert.assertEquals("world", html.getInnerHtml());
+    }
+
     @Test
     public void rootAttributes() {
         Html html = new Html("<span foo='bar'>hello</span>");

--- a/flow-server/src/test/java/com/vaadin/flow/component/HTMLTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HTMLTest.java
@@ -66,6 +66,15 @@ public class HTMLTest {
     }
 
     @Test
+    public void setHtmlContent() {
+        Html html = new Html("<span>hello</span>");
+        Assert.assertEquals(Tag.SPAN, html.getElement().getTag());
+        Assert.assertEquals("hello", html.getInnerHtml());
+        html.setHtmlContent("<span>world</span>");
+        Assert.assertEquals("world", html.getInnerHtml());
+    }    
+
+    @Test
     public void rootAttributes() {
         Html html = new Html("<span foo='bar'>hello</span>");
         Assert.assertEquals(Tag.SPAN, html.getElement().getTag());

--- a/flow-server/src/test/java/com/vaadin/flow/component/HTMLTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/HTMLTest.java
@@ -72,7 +72,7 @@ public class HTMLTest {
         Assert.assertEquals("hello", html.getInnerHtml());
         html.setHtmlContent("<span>world</span>");
         Assert.assertEquals("world", html.getInnerHtml());
-    }    
+    }
 
     @Test
     public void rootAttributes() {


### PR DESCRIPTION
When using Html component as replacement for Vaadin 8's Label /w html content allowed, it is quite common use case to alter the content programmatically.