### PR TITLE
fix: set load-on-startup for automatically registered Vaadin servlet

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletDeployer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletDeployer.java
@@ -336,6 +336,7 @@ public class ServletDeployer implements ServletContextListener {
 
         registration.setAsyncSupported(true);
         registration.addMapping(path);
+        registration.setLoadOnStartup(1);
         return VaadinServletCreation.SERVLET_CREATED;
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/ServletDeployerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/ServletDeployerTest.java
@@ -39,6 +39,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 public class ServletDeployerTest {
@@ -46,6 +47,7 @@ public class ServletDeployerTest {
 
     private List<String> servletNames;
     private List<String> servletMappings;
+    private List<Integer> servletLoadOnStartup;
 
     private boolean disableAutomaticServletRegistration = false;
 
@@ -84,6 +86,7 @@ public class ServletDeployerTest {
     public void clearCaptures() {
         servletNames = new ArrayList<>();
         servletMappings = new ArrayList<>();
+        servletLoadOnStartup = new ArrayList<>();
     }
 
     @Test
@@ -93,6 +96,7 @@ public class ServletDeployerTest {
 
         assertMappingsCount(1, 1);
         assertMappingIsRegistered(ServletDeployer.class.getName(), "/*");
+        assertLoadOnStartupSet();
     }
 
     @Test
@@ -114,6 +118,7 @@ public class ServletDeployerTest {
                         singletonList("/test/*"), Collections.emptyMap())));
 
         assertMappingsCount(1, 1);
+        assertLoadOnStartupSet();
     }
 
     @Test
@@ -126,6 +131,7 @@ public class ServletDeployerTest {
 
         assertMappingsCount(1, 1);
         assertMappingIsRegistered(ServletDeployer.class.getName(), "/*");
+        assertLoadOnStartupSet();
     }
 
     @Test
@@ -135,6 +141,7 @@ public class ServletDeployerTest {
 
         assertMappingsCount(1, 1);
         assertMappingIsRegistered(ServletDeployer.class.getName(), "/*");
+        assertLoadOnStartupSet();
     }
 
     @Test
@@ -156,6 +163,7 @@ public class ServletDeployerTest {
 
         assertMappingsCount(1, 1);
         assertMappingIsRegistered(ServletDeployer.class.getName(), "/*");
+        assertLoadOnStartupSet();
     }
 
     private void assertMappingsCount(int numServlets, int numMappings) {
@@ -184,6 +192,21 @@ public class ServletDeployerTest {
                 pathIndex, servletNameIndex);
     }
 
+    private void assertLoadOnStartupSet() {
+        assertEquals("Servlet loadOnStartup should be invoked only once", 1,
+                servletLoadOnStartup.size());
+        assertEquals(
+                String.format(
+                        "Expected servlet loadOnStartup to be '%d' but was '%d",
+                        1, servletLoadOnStartup.get(0)),
+                (Integer) 1, servletLoadOnStartup.get(0));
+    }
+
+    private void assertLoadOnStartupNotSet() {
+        assertTrue("Servlet loadOnStartup should not have been invoked ",
+                servletLoadOnStartup.isEmpty());
+    }
+
     @SuppressWarnings({ "unchecked", "rawtypes" })
     private ServletContextEvent getContextEvent(
             ServletRegistration... servletRegistrations) throws Exception {
@@ -196,6 +219,8 @@ public class ServletDeployerTest {
                     this.servletMappings.addAll(Arrays.asList(mappings));
                     return Collections.emptySet();
                 });
+        Mockito.doAnswer(i -> this.servletLoadOnStartup.add(i.getArgument(0)))
+                .when(dynamicMock).setLoadOnStartup(ArgumentMatchers.anyInt());
 
         ServletContext contextMock = Mockito.mock(ServletContext.class);
 


### PR DESCRIPTION
## Description

When using Vite, DevModeInitializer blocks dev-server startup until a VaadinServlet is deployed because it needs to get the servlet path to use. If the container lazily loads servlets, Vite will not start until the first HTTP request for the Vaadin servlet is received.
This change sets load-on-startup feature for automatically deployed Vaadin servlet, to ensure that the servlet and Vite are loaded on the startup of the Web application

Part of #14479

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
