### PR TITLE
fix: Do not overwrite generated files with the same content

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractTaskClientGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractTaskClientGenerator.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.server.frontend;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
@@ -66,10 +67,7 @@ public abstract class AbstractTaskClientGenerator implements FallibleCommand {
         File generatedFile = getGeneratedFile();
         try {
             String fileContent = getFileContent();
-            log().debug("writing file '{}'", generatedFile);
-
-            FileUtils.forceMkdirParent(generatedFile);
-            FileUtils.writeStringToFile(generatedFile, fileContent, UTF_8);
+            writeIfChanged(generatedFile, fileContent);
         } catch (IOException exception) {
             String errorMessage = String.format("Error writing '%s'",
                     generatedFile);
@@ -77,7 +75,29 @@ public abstract class AbstractTaskClientGenerator implements FallibleCommand {
         }
     }
 
-    Logger log() {
-        return LoggerFactory.getLogger(getClass());
+    static Logger log() {
+        return LoggerFactory.getLogger(AbstractTaskClientGenerator.class);
+    }
+
+    static void writeIfChanged(File file, String content) throws IOException {
+        String existingFileContent = getExistingFileContent(file);
+        if (content.equals(existingFileContent)) {
+            // Do not write the same contents to avoid frontend recompiles
+            return;
+        }
+
+        log().debug("writing file '{}'", file);
+
+        FileUtils.forceMkdirParent(file);
+        FileUtils.writeStringToFile(file, content, UTF_8);
+    }
+
+    private static String getExistingFileContent(File generatedFile)
+            throws IOException {
+        if (!generatedFile.exists()) {
+            return null;
+        }
+        return FileUtils.readFileToString(generatedFile,
+                StandardCharsets.UTF_8);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractTaskClientGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractTaskClientGenerator.java
@@ -79,17 +79,29 @@ public abstract class AbstractTaskClientGenerator implements FallibleCommand {
         return LoggerFactory.getLogger(AbstractTaskClientGenerator.class);
     }
 
-    static void writeIfChanged(File file, String content) throws IOException {
+    /**
+     * Writes the given content into the given file unless the file already
+     * contains that content.
+     *
+     * @param file
+     *            the file to write to
+     * @param content
+     *            the content to write
+     * @return true if the string was written to the file, false otherwise
+     */
+    static boolean writeIfChanged(File file, String content)
+            throws IOException {
         String existingFileContent = getExistingFileContent(file);
         if (content.equals(existingFileContent)) {
             // Do not write the same contents to avoid frontend recompiles
-            return;
+            return false;
         }
 
         log().debug("writing file '{}'", file);
 
         FileUtils.forceMkdirParent(file);
         FileUtils.writeStringToFile(file, content, UTF_8);
+        return true;
     }
 
     private static String getExistingFileContent(File generatedFile)

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractTaskClientGenerator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractTaskClientGenerator.java
@@ -97,7 +97,6 @@ public abstract class AbstractTaskClientGenerator implements FallibleCommand {
         if (!generatedFile.exists()) {
             return null;
         }
-        return FileUtils.readFileToString(generatedFile,
-                StandardCharsets.UTF_8);
+        return FileUtils.readFileToString(generatedFile, UTF_8);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateThemeImport.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateThemeImport.java
@@ -88,12 +88,12 @@ public class TaskUpdateThemeImport implements FallibleCommand {
         }
 
         try {
-            FileUtils.write(themeImportFile, String.format(
-                    "import {applyTheme as _applyTheme} from './theme-%s.generated.js';%n"
+            AbstractTaskClientGenerator.writeIfChanged(themeImportFile, String
+                    .format("import {applyTheme as _applyTheme} from './theme-%s.generated.js';%n"
                             + "export const applyTheme = _applyTheme;%n",
-                    theme.getName()), StandardCharsets.UTF_8);
-            FileUtils.write(themeImportFileDefinition, EXPORT_MODULES_DEF,
-                    StandardCharsets.UTF_8);
+                            theme.getName()));
+            AbstractTaskClientGenerator.writeIfChanged(
+                    themeImportFileDefinition, EXPORT_MODULES_DEF);
         } catch (IOException e) {
             throw new ExecutionFailedException(
                     "Unable to write theme import file", e);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractTaskClientGeneratorTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractTaskClientGeneratorTest.java
@@ -28,6 +28,8 @@ public class AbstractTaskClientGeneratorTest {
         FileUtils.write(f, TEST_STRING, StandardCharset.UTF_8);
         FileTime modTime = getModificationTime(f);
 
+        Thread.sleep(1);
+
         AbstractTaskClientGenerator.writeIfChanged(f, TEST_STRING + "2");
         Assert.assertNotEquals(modTime, getModificationTime(f));
     }
@@ -37,6 +39,8 @@ public class AbstractTaskClientGeneratorTest {
         File f = File.createTempFile("writeIfChanged", "aaa");
         FileUtils.write(f, TEST_STRING, StandardCharset.UTF_8);
         FileTime modTime = getModificationTime(f);
+
+        Thread.sleep(1);
 
         AbstractTaskClientGenerator.writeIfChanged(f, TEST_STRING);
         Assert.assertEquals(modTime, getModificationTime(f));

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractTaskClientGeneratorTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractTaskClientGeneratorTest.java
@@ -1,0 +1,45 @@
+package com.vaadin.flow.server.frontend;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.nimbusds.jose.util.StandardCharset;
+
+public class AbstractTaskClientGeneratorTest {
+
+    private static final String TEST_STRING = "Hello world";
+
+    private static FileTime getModificationTime(File f) throws IOException {
+        BasicFileAttributes attr = Files.readAttributes(f.toPath(),
+                BasicFileAttributes.class);
+        return attr.lastModifiedTime();
+    }
+
+    @Test
+    public void writeIfChanged_writesWithChanges() throws Exception {
+        File f = File.createTempFile("writeIfChanged", "aaa");
+        FileUtils.write(f, TEST_STRING, StandardCharset.UTF_8);
+        FileTime modTime = getModificationTime(f);
+
+        AbstractTaskClientGenerator.writeIfChanged(f, TEST_STRING + "2");
+        Assert.assertNotEquals(modTime, getModificationTime(f));
+    }
+
+    @Test
+    public void writeIfChanged_doesNotWriteWithoutChanges() throws Exception {
+        File f = File.createTempFile("writeIfChanged", "aaa");
+        FileUtils.write(f, TEST_STRING, StandardCharset.UTF_8);
+        FileTime modTime = getModificationTime(f);
+
+        AbstractTaskClientGenerator.writeIfChanged(f, TEST_STRING);
+        Assert.assertEquals(modTime, getModificationTime(f));
+
+    }
+}

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractTaskClientGeneratorTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractTaskClientGeneratorTest.java
@@ -15,34 +15,20 @@ public class AbstractTaskClientGeneratorTest {
 
     private static final String TEST_STRING = "Hello world";
 
-    private static FileTime getModificationTime(File f) throws IOException {
-        BasicFileAttributes attr = Files.readAttributes(f.toPath(),
-                BasicFileAttributes.class);
-        return attr.lastModifiedTime();
-    }
-
     @Test
     public void writeIfChanged_writesWithChanges() throws Exception {
         File f = File.createTempFile("writeIfChanged", "aaa");
         FileUtils.write(f, TEST_STRING, StandardCharsets.UTF_8);
-        FileTime modTime = getModificationTime(f);
 
-        Thread.sleep(1);
-
-        AbstractTaskClientGenerator.writeIfChanged(f, TEST_STRING + "2");
-        Assert.assertNotEquals(modTime, getModificationTime(f));
+        Assert.assertTrue(AbstractTaskClientGenerator.writeIfChanged(f,
+                TEST_STRING + "2"));
     }
 
     @Test
     public void writeIfChanged_doesNotWriteWithoutChanges() throws Exception {
         File f = File.createTempFile("writeIfChanged", "aaa");
         FileUtils.write(f, TEST_STRING, StandardCharsets.UTF_8);
-        FileTime modTime = getModificationTime(f);
-
-        Thread.sleep(1);
-
-        AbstractTaskClientGenerator.writeIfChanged(f, TEST_STRING);
-        Assert.assertEquals(modTime, getModificationTime(f));
-
+        Assert.assertFalse(
+                AbstractTaskClientGenerator.writeIfChanged(f, TEST_STRING));
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractTaskClientGeneratorTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractTaskClientGeneratorTest.java
@@ -11,7 +11,6 @@ import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
-
 public class AbstractTaskClientGeneratorTest {
 
     private static final String TEST_STRING = "Hello world";

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractTaskClientGeneratorTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractTaskClientGeneratorTest.java
@@ -2,6 +2,7 @@ package com.vaadin.flow.server.frontend;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
@@ -10,7 +11,6 @@ import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.nimbusds.jose.util.StandardCharset;
 
 public class AbstractTaskClientGeneratorTest {
 
@@ -25,7 +25,7 @@ public class AbstractTaskClientGeneratorTest {
     @Test
     public void writeIfChanged_writesWithChanges() throws Exception {
         File f = File.createTempFile("writeIfChanged", "aaa");
-        FileUtils.write(f, TEST_STRING, StandardCharset.UTF_8);
+        FileUtils.write(f, TEST_STRING, StandardCharsets.UTF_8);
         FileTime modTime = getModificationTime(f);
 
         Thread.sleep(1);
@@ -37,7 +37,7 @@ public class AbstractTaskClientGeneratorTest {
     @Test
     public void writeIfChanged_doesNotWriteWithoutChanges() throws Exception {
         File f = File.createTempFile("writeIfChanged", "aaa");
-        FileUtils.write(f, TEST_STRING, StandardCharset.UTF_8);
+        FileUtils.write(f, TEST_STRING, StandardCharsets.UTF_8);
         FileTime modTime = getModificationTime(f);
 
         Thread.sleep(1);


### PR DESCRIPTION
Overwriting the files will cause the frontend tooling to recompile when there is no need to do that

Fixes #14490
