### PR TITLE
fix: Remove presence check on item refresh

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataView.java
@@ -21,7 +21,6 @@ import java.util.stream.Stream;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.ComponentUtil;
-import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.function.SerializableSupplier;
 import com.vaadin.flow.shared.Registration;
 
@@ -124,11 +123,7 @@ public abstract class AbstractDataView<T> implements DataView<T> {
     @Override
     public void refreshItem(T item) {
         Objects.requireNonNull(item, NULL_ITEM_ERROR_MESSAGE);
-        SerializablePredicate<T> filter = i -> equals(item, i);
-        if (dataProviderSupplier.get().fetch(new Query(filter)).findAny()
-                .isPresent()) {
-            dataProviderSupplier.get().refreshItem(item);
-        }
+        dataProviderSupplier.get().refreshItem(item);
     }
 
     @Override

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataView.java
@@ -21,6 +21,7 @@ import java.util.stream.Stream;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.ComponentUtil;
+import com.vaadin.flow.function.SerializablePredicate;
 import com.vaadin.flow.function.SerializableSupplier;
 import com.vaadin.flow.shared.Registration;
 
@@ -123,12 +124,11 @@ public abstract class AbstractDataView<T> implements DataView<T> {
     @Override
     public void refreshItem(T item) {
         Objects.requireNonNull(item, NULL_ITEM_ERROR_MESSAGE);
-        //@formatter:off
-        getItems()
-                .filter(i -> equals(item, i))
-                .findFirst()
-                .ifPresent(i -> dataProviderSupplier.get().refreshItem(item));
-        //@formatter:on
+        SerializablePredicate<T> filter = i -> item.equals(i);
+        if (dataProviderSupplier.get().fetch(new Query(filter)).findAny()
+                .isPresent()) {
+            dataProviderSupplier.get().refreshItem(item);
+        }
     }
 
     @Override

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataView.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/AbstractDataView.java
@@ -124,7 +124,7 @@ public abstract class AbstractDataView<T> implements DataView<T> {
     @Override
     public void refreshItem(T item) {
         Objects.requireNonNull(item, NULL_ITEM_ERROR_MESSAGE);
-        SerializablePredicate<T> filter = i -> item.equals(i);
+        SerializablePredicate<T> filter = i -> equals(item, i);
         if (dataProviderSupplier.get().fetch(new Query(filter)).findAny()
                 .isPresent()) {
             dataProviderSupplier.get().refreshItem(item);

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractListDataViewTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/AbstractListDataViewTest.java
@@ -859,25 +859,6 @@ public class AbstractListDataViewTest {
     }
 
     @Test
-    public void refreshItem_itemNotPresent_itemNotRefreshed() {
-        Collection<Item> items = getTestItems();
-
-        ListDataProvider<Item> dataProvider = Mockito
-                .spy(DataProvider.ofCollection(items));
-
-        ItemListDataView dataView = new ItemListDataView(() -> dataProvider,
-                component);
-
-        Item updatedItem = new Item(42L, "updated", "descr1");
-        dataView.refreshItem(updatedItem);
-        Mockito.verify(dataProvider, Mockito.times(0)).refreshItem(updatedItem);
-
-        updatedItem = new Item(1L, "updated", "descr1");
-        dataView.refreshItem(updatedItem);
-        Mockito.verify(dataProvider, Mockito.times(0)).refreshItem(updatedItem);
-    }
-
-    @Test
     public void getItem_correctIndex_itemFound() {
         Assert.assertEquals("Wrong item returned for index", "first",
                 dataView.getItem(0));


### PR DESCRIPTION
## Description

Moved item presence check to dataProvider to prevent fetching all items

Fixes #14170 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
