### PR TITLE
chore: Align TS version in flow-client with flow-server

### DIFF
--- a/flow-client/package.json
+++ b/flow-client/package.json
@@ -44,7 +44,7 @@
     "prettier": "2.2.1",
     "sinon": "7.5.0",
     "sinon-chai": "3.6.0",
-    "typescript": "4.0.3",
+    "typescript": "4.4.3",
     "webpack": "4.46.0",
     "webpack-cli": "4.10.0",
     "workbox-core": "5.1.4",


### PR DESCRIPTION
@types/express-serve-static-core requires typescript version >= 4.1, see https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51262