### PR TITLE
fix: Fix navigation to secured view with oauth2 without router-ignore

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/auth/ViewAccessChecker.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/auth/ViewAccessChecker.java
@@ -21,6 +21,7 @@ import java.util.function.Function;
 import javax.annotation.security.DenyAll;
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
 import com.vaadin.flow.component.Component;

--- a/flow-server/src/test/java/com/vaadin/flow/server/auth/AccessAnnotationCheckerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/auth/AccessAnnotationCheckerTest.java
@@ -57,6 +57,7 @@ public class AccessAnnotationCheckerTest {
             return "John Doe";
         }
     };
+    static final String REQUEST_URL = "http://localhost:8080/myapp/";
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
@@ -364,6 +365,8 @@ public class AccessAnnotationCheckerTest {
                 .thenAnswer(query -> {
                     return roleSet.contains(query.getArguments()[0]);
                 });
+        Mockito.when(request.getRequestURL())
+                .thenReturn(new StringBuffer(REQUEST_URL));
         return request;
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/auth/ViewAccessCheckerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/auth/ViewAccessCheckerTest.java
@@ -1,5 +1,7 @@
 package com.vaadin.flow.server.auth;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 import java.lang.reflect.Field;
 import java.security.Principal;
 import java.util.ArrayList;
@@ -7,8 +9,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
@@ -34,24 +38,19 @@ import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.server.auth.AccessControlTestClasses.AnonymousAllowedView;
 import com.vaadin.flow.server.auth.AccessControlTestClasses.DenyAllView;
+import com.vaadin.flow.server.auth.AccessControlTestClasses.NoAnnotationAnonymousAllowedByGrandParentView;
+import com.vaadin.flow.server.auth.AccessControlTestClasses.NoAnnotationAnonymousAllowedByParentView;
+import com.vaadin.flow.server.auth.AccessControlTestClasses.NoAnnotationDenyAllAsInterfacesIgnoredView;
+import com.vaadin.flow.server.auth.AccessControlTestClasses.NoAnnotationDenyAllByGrandParentView;
+import com.vaadin.flow.server.auth.AccessControlTestClasses.NoAnnotationPermitAllByGrandParentAsInterfacesIgnoredView;
+import com.vaadin.flow.server.auth.AccessControlTestClasses.NoAnnotationPermitAllByGrandParentView;
+import com.vaadin.flow.server.auth.AccessControlTestClasses.NoAnnotationRolesAllowedAdminByGrandParentView;
+import com.vaadin.flow.server.auth.AccessControlTestClasses.NoAnnotationRolesAllowedUserByGrandParentView;
 import com.vaadin.flow.server.auth.AccessControlTestClasses.NoAnnotationView;
 import com.vaadin.flow.server.auth.AccessControlTestClasses.PermitAllView;
 import com.vaadin.flow.server.auth.AccessControlTestClasses.RolesAllowedAdminView;
 import com.vaadin.flow.server.auth.AccessControlTestClasses.RolesAllowedUserView;
 import com.vaadin.flow.server.auth.AccessControlTestClasses.TestLoginView;
-import com.vaadin.flow.server.auth.AccessControlTestClasses.NoAnnotationAnonymousAllowedByParentView;
-import com.vaadin.flow.server.auth.AccessControlTestClasses.NoAnnotationAnonymousAllowedByGrandParentView;
-import com.vaadin.flow.server.auth.AccessControlTestClasses.NoAnnotationPermitAllByGrandParentView;
-import com.vaadin.flow.server.auth.AccessControlTestClasses.NoAnnotationDenyAllByGrandParentView;
-import com.vaadin.flow.server.auth.AccessControlTestClasses.NoAnnotationRolesAllowedUserByGrandParentView;
-import com.vaadin.flow.server.auth.AccessControlTestClasses.NoAnnotationRolesAllowedAdminByGrandParentView;
-import com.vaadin.flow.server.auth.AccessControlTestClasses.NoAnnotationDenyAllAsInterfacesIgnoredView;
-import com.vaadin.flow.server.auth.AccessControlTestClasses.NoAnnotationPermitAllByGrandParentAsInterfacesIgnoredView;
-
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
 
 public class ViewAccessCheckerTest {
 
@@ -236,6 +235,9 @@ public class ViewAccessCheckerTest {
         Assert.assertEquals(
                 AccessAnnotationCheckerTest.REQUEST_URL
                         + getRoute(RolesAllowedAdminView.class),
+                result.sessionAttributes.get(
+                        ViewAccessChecker.SESSION_STORED_REDIRECT_ABSOLUTE));
+        Assert.assertEquals(getRoute(RolesAllowedAdminView.class),
                 result.sessionAttributes
                         .get(ViewAccessChecker.SESSION_STORED_REDIRECT));
     }
@@ -247,6 +249,8 @@ public class ViewAccessCheckerTest {
         Assert.assertFalse(result.wasTargetViewRendered());
         Assert.assertNull(result.sessionAttributes
                 .get(ViewAccessChecker.SESSION_STORED_REDIRECT));
+        Assert.assertNull(result.sessionAttributes
+                .get(ViewAccessChecker.SESSION_STORED_REDIRECT_ABSOLUTE));
     }
 
     @Test
@@ -661,13 +665,13 @@ public class ViewAccessCheckerTest {
                 .thenReturn(httpServletRequest);
         Mockito.when(vaadinServletRequest.getUserPrincipal())
                 .thenAnswer(answer -> httpServletRequest.getUserPrincipal());
+        Mockito.when(vaadinServletRequest.getSession())
+                .thenAnswer(answer -> httpServletRequest.getSession());
         Mockito.when(vaadinServletRequest.isUserInRole(Mockito.any()))
                 .thenAnswer(answer -> httpServletRequest
                         .isUserInRole(answer.getArgument(0)));
-        Mockito.when(vaadinServletRequest.getSession())
-                .thenAnswer(answer -> httpServletRequest.getSession());
-        Mockito.when(vaadinServletRequest.getRequestURL())
-                .thenReturn(new StringBuffer("http://localhost:8080/"));
+        Mockito.when(vaadinServletRequest.getRequestURL()).thenReturn(
+                new StringBuffer(AccessAnnotationCheckerTest.REQUEST_URL));
 
         CurrentInstance.set(VaadinRequest.class, vaadinServletRequest);
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/auth/ViewAccessCheckerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/auth/ViewAccessCheckerTest.java
@@ -233,7 +233,9 @@ public class ViewAccessCheckerTest {
     public void redirectUrlStoredForAnonymousUsers() {
         Result result = checkAccess(RolesAllowedAdminView.class, null);
         Assert.assertFalse(result.wasTargetViewRendered());
-        Assert.assertEquals(getRoute(RolesAllowedAdminView.class),
+        Assert.assertEquals(
+                AccessAnnotationCheckerTest.REQUEST_URL
+                        + getRoute(RolesAllowedAdminView.class),
                 result.sessionAttributes
                         .get(ViewAccessChecker.SESSION_STORED_REDIRECT));
     }
@@ -658,7 +660,7 @@ public class ViewAccessCheckerTest {
         Mockito.when(vaadinServletRequest.getHttpServletRequest())
                 .thenReturn(httpServletRequest);
         Mockito.when(vaadinServletRequest.getUserPrincipal())
-                .thenAnswer(anasert -> httpServletRequest.getUserPrincipal());
+                .thenAnswer(answer -> httpServletRequest.getUserPrincipal());
         Mockito.when(vaadinServletRequest.isUserInRole(Mockito.any()))
                 .thenAnswer(answer -> httpServletRequest
                         .isUserInRole(answer.getArgument(0)));

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinSavedRequestAwareAuthenticationSuccessHandler.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinSavedRequestAwareAuthenticationSuccessHandler.java
@@ -128,6 +128,12 @@ public class VaadinSavedRequestAwareAuthenticationSuccessHandler
     public void onAuthenticationSuccess(HttpServletRequest request,
             HttpServletResponse response, Authentication authentication)
             throws ServletException, IOException {
+
+        if (isTypescriptLogin(request)) {
+            response.setHeader(DEFAULT_URL_HEADER,
+                    determineTargetUrl(request, response));
+        }
+
         SavedRequest savedRequest = this.requestCache.getRequest(request,
                 response);
         String fullySavedRequestUrl = getStoredServerNavigation(request);
@@ -138,6 +144,7 @@ public class VaadinSavedRequestAwareAuthenticationSuccessHandler
                             request.getParameter(targetUrlParameter)))) {
                 this.clearAuthenticationAttributes(request);
                 String targetUrl = savedRequest.getRedirectUrl();
+                response.setHeader(SAVED_URL_HEADER, targetUrl);
                 this.getRedirectStrategy().sendRedirect(request, response,
                         targetUrl);
                 return;
@@ -146,11 +153,6 @@ public class VaadinSavedRequestAwareAuthenticationSuccessHandler
             }
         } else if (fullySavedRequestUrl != null) {
             response.setHeader(SAVED_URL_HEADER, fullySavedRequestUrl);
-        }
-
-        if (isTypescriptLogin(request)) {
-            response.setHeader(DEFAULT_URL_HEADER,
-                    determineTargetUrl(request, response));
         }
 
         super.onAuthenticationSuccess(request, response, authentication);

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -28,6 +28,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
@@ -95,6 +96,9 @@ public abstract class VaadinWebSecurity {
 
     @Autowired
     private ViewAccessChecker viewAccessChecker;
+
+    @Value("#{servletContext.contextPath}")
+    private String servletContextPath;
 
     /**
      * Registers default {@link SecurityFilterChain} bean.
@@ -381,6 +385,27 @@ public abstract class VaadinWebSecurity {
                 new LoginUrlAuthenticationEntryPoint(loginPath),
                 AnyRequestMatcher.INSTANCE);
         viewAccessChecker.setLoginView(flowLoginView);
+    }
+
+    /**
+     * Sets up the login page URI of the OAuth2 provider on the specified
+     * HttpSecurity instance.
+     *
+     * @param http
+     *            the http security from {@link #filterChain(HttpSecurity)}
+     * @param oauth2LoginPage
+     *            the login page of the OAuth2 provider. This Specifies the URL
+     *            to send users to if login is required.
+     * @throws Exception
+     *             Re-throws the possible exceptions while activating
+     *             OAuth2LoginConfigurer
+     */
+    protected void setOAuth2LoginPage(HttpSecurity http, String oauth2LoginPage)
+            throws Exception {
+        http.oauth2Login().loginPage(oauth2LoginPage).successHandler(
+                getVaadinSavedRequestAwareAuthenticationSuccessHandler(http))
+                .permitAll();
+        viewAccessChecker.setLoginView(servletContextPath + oauth2LoginPage);
     }
 
     /**

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/VaadinSavedRequestAwareAuthenticationSuccessHandlerTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/VaadinSavedRequestAwareAuthenticationSuccessHandlerTest.java
@@ -12,6 +12,8 @@ import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.security.web.csrf.DefaultCsrfToken;
 import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
 
+import com.vaadin.flow.server.auth.ViewAccessChecker;
+
 public class VaadinSavedRequestAwareAuthenticationSuccessHandlerTest {
 
     private VaadinSavedRequestAwareAuthenticationSuccessHandler vaadinSavedRequestAwareAuthenticationSuccessHandler;
@@ -122,6 +124,53 @@ public class VaadinSavedRequestAwareAuthenticationSuccessHandlerTest {
         Assert.assertNull(loginResponse.getHeader("Result"));
         Assert.assertEquals(302, loginResponse.getStatus());
         Assert.assertEquals("http://localhost/the-saved-url",
+                loginResponse.getHeader("Location"));
+    }
+
+    @Test
+    public void viewAccessCheckerSavedUrl_nonTypescriptClients_redirectToSessionStoredUrl()
+            throws Exception {
+
+        MockHttpServletRequest loginRequest = RequestUtilTest
+                .createRequest("/login");
+        HttpSession session = loginRequest.getSession();
+        // Simulate ViewAccessChecker
+        session.setAttribute(ViewAccessChecker.SESSION_STORED_REDIRECT_ABSOLUTE,
+                "http://localhost/last-route");
+        MockHttpServletResponse loginResponse = new MockHttpServletResponse();
+        vaadinSavedRequestAwareAuthenticationSuccessHandler
+                .onAuthenticationSuccess(loginRequest, loginResponse,
+                        new UsernamePasswordAuthenticationToken("foo", "bar"));
+
+        Assert.assertNull(loginResponse.getHeader("Result"));
+        Assert.assertEquals(302, loginResponse.getStatus());
+        Assert.assertEquals("http://localhost/last-route",
+                loginResponse.getHeader("Location"));
+    }
+
+    @Test
+    public void savedUrlAndViewAccessCheckerSavedUrl_nonTypescriptClients_redirectToSavedUrl()
+            throws Exception {
+        HttpSessionRequestCache cache = new HttpSessionRequestCache();
+        MockHttpServletRequest firstRequest = RequestUtilTest
+                .createRequest("/a-previous-saved-url");
+        HttpSession session = firstRequest.getSession();
+        cache.saveRequest(firstRequest, new MockHttpServletResponse());
+        // Simulate ViewAccessChecker
+        session.setAttribute(ViewAccessChecker.SESSION_STORED_REDIRECT_ABSOLUTE,
+                "http://localhost/last-route");
+
+        MockHttpServletRequest loginRequest = RequestUtilTest
+                .createRequest("/login");
+        loginRequest.setSession(session);
+        MockHttpServletResponse loginResponse = new MockHttpServletResponse();
+        vaadinSavedRequestAwareAuthenticationSuccessHandler
+                .onAuthenticationSuccess(loginRequest, loginResponse,
+                        new UsernamePasswordAuthenticationToken("foo", "bar"));
+
+        Assert.assertNull(loginResponse.getHeader("Result"));
+        Assert.assertEquals(302, loginResponse.getStatus());
+        Assert.assertEquals("http://localhost/a-previous-saved-url",
                 loginResponse.getHeader("Location"));
     }
 


### PR DESCRIPTION
## Description
This is to fix the problem of navigating to a secured view
from a public view before login in while using the OAuth2 external
login page. Prior to this, it was needed to set "router-ignore" 
attribute on the links from public pages to skip vaadin-router and 
let the spring-security forward the user to the external login page. 

Fixes #14253

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
