### PR TITLE
chore: remove not needed dependency since it comes from flow-server

### DIFF
--- a/flow-plugins/flow-maven-plugin/pom.xml
+++ b/flow-plugins/flow-maven-plugin/pom.xml
@@ -66,12 +66,6 @@
             <version>1.21</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.13</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <version>3.6.4</version>


### PR DESCRIPTION
Having this dependency here brings an old and vulnerable version of `commons-codec` 