### PR TITLE
fix: add build resource dir to classpath element to scan

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
@@ -312,12 +312,14 @@ class VaadinSmokeTest : AbstractGradleTest() {
             package org.vaadin.example;
 
             import com.vaadin.flow.component.dependency.CssImport;
+            import com.vaadin.flow.component.dependency.NpmPackage;
             import com.vaadin.flow.component.html.Div;
             import com.vaadin.flow.component.html.Span;
             import com.vaadin.flow.router.Route;
 
             @Route("")
             @CssImport("./mystyle.css")
+            @NpmPackage(value = "@vaadin/vaadin-themable-mixin", version = "23.3.0-alpha1")
             public class MainView extends Div {
 
                 public MainView() {

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
@@ -53,6 +53,9 @@ internal class GradlePluginAdapter(val project: Project, private val isBeforePro
             .toList()
             .filter { it.exists() }
 
+        val resourcesDir: List<File> = listOfNotNull(sourceSet.getByName("main").output.resourcesDir)
+                .filter { it.exists() }
+
         // for Spring Boot project there is no "providedCompile" scope: the WAR plugin brings that in.
         val providedDeps: Configuration? = project.configurations.findByName("providedCompile")
         val servletJar: List<File> = providedDeps
@@ -60,7 +63,7 @@ internal class GradlePluginAdapter(val project: Project, private val isBeforePro
             ?.toList()
             ?: listOf()
 
-        val apis: Set<File> = (runtimeClasspathJars + classesDirs + servletJar).toSet()
+        val apis: Set<File> = (runtimeClasspathJars + classesDirs + resourcesDir + servletJar).toSet()
 
         // eagerly check that all the files/folders exist, to avoid spamming the console later on
         // see https://github.com/vaadin/vaadin-gradle-plugin/issues/38 for more details


### PR DESCRIPTION
## Description

ClassFinder used for frontend build is missing build resources directory. This change adds it to the list of elements to scan during build.

Fixes #14420

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
