### PR TITLE
fix: adapt iPad detection for iOS 15

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
@@ -369,8 +369,9 @@ public class ExtendedClientDetails implements Serializable {
      *         information from the browser is present
      */
     public boolean isIPad() {
-        return navigatorPlatform != null
-                && navigatorPlatform.startsWith("iPad");
+        return navigatorPlatform != null && (navigatorPlatform
+                .startsWith("iPad")
+                || (navigatorPlatform.equals("MacIntel") && isTouchDevice()));
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/ExtendedClientDetailsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/ExtendedClientDetailsTest.java
@@ -68,13 +68,17 @@ public class ExtendedClientDetailsTest {
 
         Assert.assertTrue("'iPad' is an iPad", details.isIPad());
 
-        VaadinSession session = Mockito.mock(VaadinSession.class);
-        CurrentInstance.setCurrent(session);
-
-        detailsBuilder.setNavigatorPlatform(null);
+        // See https://github.com/vaadin/flow/issues/14517
+        detailsBuilder.setNavigatorPlatform("MacIntel");
         details = detailsBuilder.buildDetails();
+        Assert.assertFalse("MacIntel on non touch device is not an iPad",
+                details.isIPad());
 
-        CurrentInstance.clearAll();
+        // See https://github.com/vaadin/flow/issues/14517
+        detailsBuilder.setTouchDevice("true");
+        details = detailsBuilder.buildDetails();
+        Assert.assertTrue("MacIntel on touch device is an iPad",
+                details.isIPad());
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/ExtendedClientDetailsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/ExtendedClientDetailsTest.java
@@ -125,7 +125,7 @@ public class ExtendedClientDetailsTest {
     }
 
     @Test
-    public void isIOS_notIPad_deprecatedIsNotIOS_returnsFalse() {
+    public void isIOS_notIPad_notIsIPhone_returnsFalse() {
         ExtendedClientDetails details = Mockito
                 .mock(ExtendedClientDetails.class);
         Mockito.doCallRealMethod().when(details).isIOS();
@@ -135,6 +135,7 @@ public class ExtendedClientDetailsTest {
 
         WebBrowser browser = Mockito.mock(WebBrowser.class);
         Mockito.when(session.getBrowser()).thenReturn(browser);
+        Mockito.when(browser.isIPhone()).thenReturn(false);
 
         Assert.assertFalse(details.isIOS());
     }


### PR DESCRIPTION
## Description
For iPad with iOS 15, navigator platform does not start with iPad anymore but is MacIntel.
This change assumes the device is an iPad when platform is MacIntel, and it is a touch device

Fixes #14517

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
