### PR TITLE
fix: adapt iPad detection for iOS 15

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/ExtendedClientDetails.java
@@ -20,7 +20,6 @@ import java.util.Date;
 import java.util.TimeZone;
 
 import com.vaadin.flow.server.VaadinSession;
-import com.vaadin.flow.server.WebBrowser;
 
 /**
  * Provides extended information about the web browser, such as screen
@@ -370,11 +369,9 @@ public class ExtendedClientDetails implements Serializable {
      *         information from the browser is present
      */
     public boolean isIPad() {
-        if (navigatorPlatform != null) {
-            return navigatorPlatform.startsWith("iPad");
-        }
-        WebBrowser browser = VaadinSession.getCurrent().getBrowser();
-        return browser.isIPad() || (browser.isMacOSX() && isTouchDevice());
+        return navigatorPlatform != null && (navigatorPlatform
+                .startsWith("iPad")
+                || (navigatorPlatform.equals("MacIntel") && isTouchDevice()));
     }
 
     /**
@@ -384,6 +381,8 @@ public class ExtendedClientDetails implements Serializable {
      *         using IOS or if no information from the browser is present
      */
     public boolean isIOS() {
-        return isIPad() || VaadinSession.getCurrent().getBrowser().isIOS();
+        return isIPad() || VaadinSession.getCurrent().getBrowser().isIPhone()
+                || (navigatorPlatform != null
+                        && navigatorPlatform.startsWith("iPod"));
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/page/ExtendedClientDetailsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/page/ExtendedClientDetailsTest.java
@@ -53,32 +53,31 @@ public class ExtendedClientDetailsTest {
 
         Assert.assertTrue("'iPad' is an iPad", details.isIPad());
 
+        // See https://github.com/vaadin/flow/issues/14517
+        detailsBuilder.setNavigatorPlatform("MacIntel");
+        details = detailsBuilder.buildDetails();
+        Assert.assertFalse("MacIntel on non touch device is not an iPad",
+                details.isIPad());
+
+        // See https://github.com/vaadin/flow/issues/14517
+        detailsBuilder.setTouchDevice("true");
+        details = detailsBuilder.buildDetails();
+        Assert.assertTrue("MacIntel on touch device is an iPad",
+                details.isIPad());
+    }
+
+    @Test
+    public void differentNavigatorPlatformDetails_Ipod_isIOSReturnsExpectedValue() {
+        ExtendedClientDetails details = new ExtendBuilder()
+                .setNavigatorPlatform("iPod ..").buildDetails();
+
         VaadinSession session = Mockito.mock(VaadinSession.class);
         CurrentInstance.setCurrent(session);
         WebBrowser browser = Mockito.mock(WebBrowser.class);
         Mockito.when(session.getBrowser()).thenReturn(browser);
+        Mockito.when(browser.isIPhone()).thenReturn(false);
 
-        Mockito.when(browser.isIPad()).thenReturn(true);
-        Mockito.when(browser.isMacOSX()).thenReturn(false);
-
-        detailsBuilder.setNavigatorPlatform(null);
-        details = detailsBuilder.buildDetails();
-
-        Assert.assertTrue("No platform on with iPad is iPad", details.isIPad());
-
-        Mockito.when(browser.isIPad()).thenReturn(false);
-        Assert.assertFalse(
-                "No platform and ipad false on linux should not be an iPad",
-                details.isIPad());
-
-        Mockito.when(browser.isMacOSX()).thenReturn(true);
-        Assert.assertFalse("No platform MacOSX, but not touch is not an iPad",
-                details.isIPad());
-
-        detailsBuilder.setTouchDevice("true");
-        details = detailsBuilder.buildDetails();
-        Assert.assertTrue("No platform on MacOSX with touch is an iPad",
-                details.isIPad());
+        Assert.assertTrue(details.isIOS());
 
         CurrentInstance.clearAll();
     }
@@ -94,7 +93,7 @@ public class ExtendedClientDetailsTest {
     }
 
     @Test
-    public void isIOS_notIPad_deprecatedIsIOS_returnsTrue() {
+    public void isIOS_notIPadIsIPhone_returnsTrue() {
         ExtendedClientDetails details = Mockito
                 .mock(ExtendedClientDetails.class);
         Mockito.doCallRealMethod().when(details).isIOS();
@@ -105,13 +104,13 @@ public class ExtendedClientDetailsTest {
         WebBrowser browser = Mockito.mock(WebBrowser.class);
         Mockito.when(session.getBrowser()).thenReturn(browser);
 
-        Mockito.when(browser.isIOS()).thenReturn(true);
+        Mockito.when(browser.isIPhone()).thenReturn(true);
 
         Assert.assertTrue(details.isIOS());
     }
 
     @Test
-    public void isIOS_notIPad_deprecatedIsNotIOS_returnsFalse() {
+    public void isIOS_notIPad_notIsIPhone_returnsFalse() {
         ExtendedClientDetails details = Mockito
                 .mock(ExtendedClientDetails.class);
         Mockito.doCallRealMethod().when(details).isIOS();
@@ -121,6 +120,7 @@ public class ExtendedClientDetailsTest {
 
         WebBrowser browser = Mockito.mock(WebBrowser.class);
         Mockito.when(session.getBrowser()).thenReturn(browser);
+        Mockito.when(browser.isIPhone()).thenReturn(false);
 
         Assert.assertFalse(details.isIOS());
     }


### PR DESCRIPTION
## Description

For iPad with iOS 15, navigator platform does not start with iPad anymore but is MacIntel. This change assumes device is an iPad when platform is MacIntel and it is a touch device

Fixes #14517

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
