### PR TITLE
chore: update NpmPackage.version javadocs

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/dependency/NpmPackage.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/dependency/NpmPackage.java
@@ -58,8 +58,9 @@ public @interface NpmPackage {
      * 'd.d.d-suffix' pattern.
      * <p>
      * Troubleshooting: when two or more annotations with the same package value
-     * are found in the class-path, and their versions do not match the build
-     * process will fail.
+     * are found in the class-path, and their versions do not match, the build
+     * process will print a warning message informing about found versions and
+     * which one will be used.
      *
      * @return npm package version
      */


### PR DESCRIPTION
Updated javadocs to align it with current handling of duplicated versions. Build process does not fail, but it prints a warning

Ref #14381
