### PR TITLE
fix: add build resource dir to classpath element to scan (#14536) (CP: 9.0)

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
@@ -168,4 +168,49 @@ class VaadinSmokeTest : AbstractGradleTest() {
         expect(false) { tsconfigJson.exists() }
         expect(false) { typesDTs.exists() }
     }
+
+    /**
+     * Tests that build works with resources from classpath, not only from
+     * frontend directory
+     *
+     * https://github.com/vaadin/flow/issues/14420
+     */
+    @Test
+    fun vaadinBuildFrontendShouldScanForResourcesOnClasspath() {
+        testProject.newFile("src/main/java/org/vaadin/example/MainView.java", """
+            package org.vaadin.example;
+
+            import com.vaadin.flow.component.dependency.CssImport;
+            import com.vaadin.flow.component.dependency.NpmPackage;
+            import com.vaadin.flow.component.html.Div;
+            import com.vaadin.flow.component.html.Span;
+            import com.vaadin.flow.router.Route;
+
+            @Route("")
+            @CssImport("./mystyle.css")
+            @NpmPackage(value = "@vaadin/vaadin-themable-mixin", version = "23.3.0-alpha1")
+            public class MainView extends Div {
+
+                public MainView() {
+                    add(new Span("It works!"));
+                }
+            }
+        """.trimIndent())
+        testProject.newFile("src/main/resources/META-INF/resources/frontend/mystyle.css", """
+            #testme {
+                background-color: red;
+                width: 100px;
+                height: 100px;
+                display: block;
+            }
+        """.trimIndent())
+
+        val result: BuildResult = testProject.build("-Pvaadin.productionMode", "build")
+        result.expectTaskSucceded("vaadinPrepareFrontend")
+        result.expectTaskSucceded("vaadinBuildFrontend")
+
+        val cssFile = File(testProject.dir, "build/flow-frontend/mystyle.css")
+        expect(true, cssFile.toString()) { cssFile.exists() }
+
+    }
 }

--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/VaadinSmokeTest.kt
@@ -188,7 +188,7 @@ class VaadinSmokeTest : AbstractGradleTest() {
 
             @Route("")
             @CssImport("./mystyle.css")
-            @NpmPackage(value = "@vaadin/vaadin-themable-mixin", version = "23.3.0-alpha1")
+            @NpmPackage(value = "@vaadin/vaadin-themable-mixin", version = "22.0.0-alpha9")
             public class MainView extends Div {
 
                 public MainView() {

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/GradlePluginAdapter.kt
@@ -53,6 +53,9 @@ internal class GradlePluginAdapter(val project: Project, private val isBeforePro
             .toList()
             .filter { it.exists() }
 
+        val resourcesDir: List<File> = listOfNotNull(sourceSet.getByName("main").output.resourcesDir)
+                .filter { it.exists() }
+
         // for Spring Boot project there is no "providedCompile" scope: the WAR plugin brings that in.
         val providedDeps: Configuration? = project.configurations.findByName("providedCompile")
         val servletJar: List<File> = providedDeps
@@ -60,7 +63,7 @@ internal class GradlePluginAdapter(val project: Project, private val isBeforePro
             ?.toList()
             ?: listOf()
 
-        val apis: Set<File> = (runtimeClasspathJars + classesDirs + servletJar).toSet()
+        val apis: Set<File> = (runtimeClasspathJars + classesDirs + resourcesDir + servletJar).toSet()
 
         // eagerly check that all the files/folders exist, to avoid spamming the console later on
         // see https://github.com/vaadin/vaadin-gradle-plugin/issues/38 for more details


### PR DESCRIPTION
ClassFinder used for frontend build is missing build resources directory. This change adds it to the list of elements to scan during build.

Fixes #14420