### PR TITLE
fix: Be more sensible when adding changes to list of pending changes (#14478) (CP: 2.8)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/change/AbstractListChange.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/change/AbstractListChange.java
@@ -34,7 +34,7 @@ import com.vaadin.flow.internal.nodefeature.NodeList;
 public abstract class AbstractListChange<T extends Serializable>
         extends NodeFeatureChange {
 
-    private final int index;
+    private int index;
     private final NodeList<T> list;
 
     /**
@@ -77,4 +77,18 @@ public abstract class AbstractListChange<T extends Serializable>
      * @return a copy of the change based on new index
      */
     public abstract AbstractListChange<T> copy(int index);
+
+    /**
+     * Sets the index of this change in the change list.
+     * <p>
+     * Note: This should be used only when list of changes is being re-indexed
+     * after adding a new change.
+     *
+     * @param index
+     *            Integer value.
+     */
+    public void setIndex(int index) {
+        assert (index > -1) : "Index can't be negative.";
+        this.index = index;
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/change/ListAddChange.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/change/ListAddChange.java
@@ -73,7 +73,7 @@ public class ListAddChange<T extends Serializable>
      *
      * @return the added items
      */
-    public List<T> getNewItems() {
+    public List<? extends T> getNewItems() {
         return Collections.unmodifiableList(newItems);
     }
 
@@ -127,6 +127,21 @@ public class ListAddChange<T extends Serializable>
         JsonArray newItemsJson = newItems.stream().map(mapper)
                 .collect(JsonUtils.asArray());
         json.put(addKey, newItemsJson);
+    }
+
+    /**
+     * Removes item from the change list.
+     * <p>
+     * Note: This should be used only when list of changes is being re-indexed
+     * after adding a new change.
+     *
+     * @param item
+     *            Item to be removed.
+     */
+    public void removeItem(T item) {
+        assert (newItems.size() > 1)
+                : "Item list can't be empty after item removal";
+        newItems.remove(item);
     }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/NodeList.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/NodeList.java
@@ -21,10 +21,9 @@ import java.util.AbstractSet;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.IdentityHashMap;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -277,10 +276,78 @@ public abstract class NodeList<T extends Serializable> extends NodeFeature {
     private void addChange(AbstractListChange<T> change) {
         getNode().markAsDirty();
 
-        // XXX combine with previous changes if possible
+        // If removing pending "add" change, prune it from "ListAddChange"
+        // instead
+        if (change instanceof ListRemoveChange) {
+
+            ListRemoveChange<T> removeChange = (ListRemoveChange<T>) change;
+            T item = removeChange.getRemovedItem();
+            List<AbstractListChange<T>> tracker = getChangeTracker();
+
+            for (int nextChangeIndex = 0; nextChangeIndex < tracker
+                    .size(); nextChangeIndex++) {
+                AbstractListChange<T> nextChange = tracker.get(nextChangeIndex);
+
+                // If next change in the change list is an "Add" change,
+                // it potentially might include a change that is being removed
+                // later in the change list, so needs to be checked
+                if (nextChange instanceof ListAddChange) {
+
+                    ListAddChange<T> addChange = (ListAddChange<T>) nextChange;
+                    if (addChange.getNewItems().contains(item)) {
+
+                        int indexToCorrect = removeFromListAddChange(addChange,
+                                item);
+
+                        // indexToCorrect shows where to start the re-indexing,
+                        // i.e. from where to shift all items by one position
+                        // back
+                        reindexChanges(tracker, nextChangeIndex,
+                                indexToCorrect);
+                        return;
+                    }
+                }
+            }
+        }
+
+        // If clearing, previous pending changes can be pruned
+        if (change instanceof ListClearChange) {
+            getChangeTracker().clear();
+        }
+
         getChangeTracker().add(change);
 
         // TODO Fire some listeners
+    }
+
+    private void reindexChanges(List<AbstractListChange<T>> tracker,
+            int startFrom, int indexToCorrect) {
+        // Shift (re-index) all the changes back by 1 position, starting from a
+        // given position in the list and having a given indexes
+
+        for (int nextIndex = startFrom; nextIndex < tracker
+                .size(); nextIndex++) {
+            AbstractListChange<T> listChange = tracker.get(nextIndex);
+            if (listChange.getIndex() > indexToCorrect) {
+                listChange.setIndex(listChange.getIndex() - 1);
+            }
+        }
+    }
+
+    private int removeFromListAddChange(ListAddChange<T> listAddChange,
+            T item) {
+        int indexToCorrect = 0;
+        if (listAddChange.getNewItems().size() == 1) {
+            // remove the change completely, if it has only one item and this
+            // item is the one that removed
+            getChangeTracker().remove(listAddChange);
+        } else {
+            indexToCorrect = listAddChange.getNewItems().indexOf(item);
+            assert indexToCorrect != -1;
+            listAddChange.removeItem(item);
+        }
+        indexToCorrect += listAddChange.getIndex();
+        return indexToCorrect;
     }
 
     private void setAccessed() {
@@ -289,46 +356,12 @@ public abstract class NodeList<T extends Serializable> extends NodeFeature {
 
     @Override
     public void collectChanges(Consumer<NodeChange> collector) {
-        // This map contains items wrapped by AbstractListChanges as keys and
-        // index in the following allChanges list as a value (it allows to get
-        // AbstractListChange by the index)
-        Map<Object, Integer> indices = new IdentityHashMap<>();
-
-        // This list contains all changes in the tracker. These changes will be
-        // modified: each "remove" change following by a corresponding "add"
-        // will be replaced by null and "add" will be adjusted. Indeces in
-        // changes in between will be adjusted
-        List<AbstractListChange<T>> allChanges = new ArrayList<>();
-        int index = 0;
+        Collection<AbstractListChange<T>> changes = new LinkedList<>();
         for (AbstractListChange<T> change : getChangeTracker()) {
-            if (change instanceof ListRemoveChange<?>) {
-                // the remove change => find an appropriate "add" event, adjust
-                // it and adjust everything in between
-                adjustChanges(index, (ListRemoveChange<T>) change, indices,
-                        allChanges);
-            } else if (change instanceof ListAddChange<?>) {
-                allChanges.add(change);
-                int i = index;
-                // put all items into "indices" as keys and "index" as a value
-                // so that the "change" can be retrieved from the "allChanges"
-                // by the index
-                ((ListAddChange<T>) change).getNewItems()
-                        .forEach(item -> indices.put(item, i));
-            } else if (change instanceof ListClearChange<?>) {
-                allChanges.clear();
-                indices.clear();
-                index = 0;
-                allChanges.add(change);
-            } else {
-                assert false : "AbstractListChange has only three subtypes: add, remove and clear";
+            if (acceptChange(change)) {
+                changes.add(change);
             }
-            index++;
         }
-
-        List<AbstractListChange<T>> changes;
-
-        changes = allChanges.stream().filter(this::acceptChange)
-                .collect(Collectors.toList());
 
         if (isPopulated) {
             changes.forEach(collector);
@@ -422,58 +455,6 @@ public abstract class NodeList<T extends Serializable> extends NodeFeature {
             return Collections.<T> emptyList().iterator();
         }
         return new NodeListIterator();
-    }
-
-    private void adjustChanges(int removeChangeIndex,
-            ListRemoveChange<T> change, Map<Object, Integer> indices,
-            List<AbstractListChange<T>> allChanges) {
-        T removedItem = change.getRemovedItem();
-        // retrieve index of the item (it's supposed to be the index of an Add
-        // change)
-        Integer addChangeIndex = indices.get(removedItem);
-        if (addChangeIndex == null) {
-            // if there is no suitable "add" change then just add "remove"
-            // change as is
-            allChanges.add(change);
-        } else {
-            // retrieve the "add" change by the index
-            AbstractListChange<T> addChange = allChanges.get(addChangeIndex);
-            assert addChange instanceof ListAddChange<?>;
-
-            ListAddChange<T> add = (ListAddChange<T>) addChange;
-            // "add" change has to be adjusted : we need to remove "removedItem"
-            // from it
-            int indexToCorrect = add.getNewItems().indexOf(removedItem);
-            assert indexToCorrect != -1;
-            indexToCorrect += add.getIndex();
-            // replace "add" change whose index is "addChangeIndex" with a new
-            // change which is the copy of the original one but has newItems
-            allChanges.set(addChangeIndex,
-                    add.copy(add.getNewItems().stream()
-                            .filter(item -> item != removedItem)
-                            .collect(Collectors.toList())));
-
-            // now go through all the changes in between "add" and "remove" and
-            // reindex them
-            for (int i = addChangeIndex + 1; i < removeChangeIndex; i++) {
-                AbstractListChange<T> listChange = allChanges.get(i);
-                // listChange can be null for handled "removed" changes ( see
-                // the code below the cycle)
-                if (listChange != null
-                        && listChange.getIndex() > indexToCorrect) {
-                    // make a copy with the adjusted index in case change has an
-                    // index which is greater than index of the discarded item
-                    allChanges.set(i,
-                            listChange.copy(listChange.getIndex() - 1));
-                    // listChange can't be ListRemoveChange actually here since
-                    // it has to have the index greater than "indexToCorrect".
-                    // But it means that there was a corresponding ListAddChange
-                    // which has been already adjusted previously and the
-                    // "remove" has been replaced with "null".
-                }
-            }
-            allChanges.add(null);
-        }
     }
 
     @Override

--- a/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/NodeListAddRemoveTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/internal/nodefeature/NodeListAddRemoveTest.java
@@ -3,6 +3,7 @@ package com.vaadin.flow.internal.nodefeature;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
@@ -10,6 +11,7 @@ import org.junit.Test;
 
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.internal.StateTree;
+import com.vaadin.flow.internal.change.AbstractListChange;
 import com.vaadin.flow.internal.change.ListAddChange;
 import com.vaadin.flow.internal.change.ListClearChange;
 import com.vaadin.flow.internal.change.ListRemoveChange;
@@ -114,7 +116,16 @@ public class NodeListAddRemoveTest
         nodeList.add("bar1");
 
         int index = items.size();
+        String item = nodeList.get(index);
         nodeList.remove(index);
+        // verify that nodelist is adjusted immediately to avoid memory leaks
+        Optional<AbstractListChange<String>> optionalChange = nodeList
+                .getChangeTracker().stream().filter(change -> {
+                    ListAddChange<String> addChange = (ListAddChange<String>) change;
+                    return addChange.getNewItems().contains(item);
+                }).findFirst();
+        Assert.assertFalse(optionalChange.isPresent());
+        Assert.assertEquals(2, nodeList.getChangeTracker().size());
 
         List<NodeChange> changes = collectChanges(nodeList);
 


### PR DESCRIPTION
Makes memory consumption optimisation for collecting state tree changes on the server-side: change list is checked and re-indexed (if needed) on each change, making removed objects be eligible for garbage collecting.

Fixes: #13851

(cherry picked from commit 317be63b69fa1cec4a48fd49a98c1e0989945764)