### PR TITLE
chore: Revert "chore(deps)!: bump slf4j.version from 1.7.36 to 2.0.0 (#14409)"

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/startup/VaadinAppShellInitializerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/startup/VaadinAppShellInitializerTest.java
@@ -28,7 +28,7 @@ import org.mockito.Mockito;
 import org.slf4j.ILoggerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.simple.SimpleLoggerFactory;
+import org.slf4j.impl.SimpleLoggerFactory;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.PushConfiguration;

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <spring.security.version>5.7.2</spring.security.version>
         <gwt.version>2.9.0</gwt.version>
         <hibernate.validator.version>6.2.4.Final</hibernate.validator.version>
-        <slf4j.version>2.0.1</slf4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
         <polymer.version>2.6.1</polymer.version>
         <jackson.version>2.13.4</jackson.version>
         <jackson.databind.version>2.13.4</jackson.databind.version>


### PR DESCRIPTION
Reverted because 2.0 is not fully supported by Spring and might cause a breaking changes rather than package names.