### PR TITLE
fix: use FrontendUtils::deleteNodeModules (#12905) (CP:2.8)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -382,17 +382,13 @@ public class TaskUpdatePackages extends NodeUpdater {
             }
         }
         if (nodeModulesFolder.exists()) {
-            removeDir(nodeModulesFolder);
+            FrontendUtils.deleteNodeModules(nodeModulesFolder);
         }
         File generatedNodeModules = new File(generatedFolder,
                 FrontendUtils.NODE_MODULES);
         if (generatedNodeModules.exists()) {
-            removeDir(generatedNodeModules);
+            FrontendUtils.deleteNodeModules(generatedNodeModules);
         }
-    }
-
-    private void removeDir(File file) throws IOException {
-        Files.walkFileTree(file.toPath(), new RemoveFileVisitor());
     }
 
     private String getExistingShrinkWrapVersion() throws IOException {


### PR DESCRIPTION
TaskUpdatePackage was still using FileUtils.

Fixes #12810

