### PR TITLE
fix: Use KeyMapper by default to generate unique keys (#13883) (CP:2.8)

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
@@ -67,28 +67,6 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
 
     private final Map<String, HierarchicalCommunicationController<T>> dataControllers = new HashMap<>();
 
-    private KeyMapper<T> uniqueKeyMapper = new KeyMapper<T>() {
-
-        private T object;
-
-        @Override
-        public String key(T o) {
-            this.object = o;
-            try {
-                return super.key(o);
-            } finally {
-                this.object = null;
-            }
-        }
-
-        @Override
-        protected String createKey() {
-            return Optional.ofNullable(uniqueKeyProviderSupplier.get())
-                    .map(provider -> provider.apply(object))
-                    .orElse(super.createKey());
-        }
-    };
-
     /**
      * Construct a new hierarchical data communicator backed by a
      * {@link TreeDataProvider}.
@@ -115,16 +93,16 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
         this.stateNode = stateNode;
         this.uniqueKeyProviderSupplier = uniqueKeyProviderSupplier;
 
-        setKeyMapper(uniqueKeyMapper);
+        KeyMapperWrapper<T> keyMapperWrapper = new KeyMapperWrapper<>();
+        setKeyMapper(keyMapperWrapper);
 
         dataGenerator.addDataGenerator(this::generateTreeData);
         setDataProvider(new TreeDataProvider<>(new TreeData<>()), null);
     }
 
     private void generateTreeData(T item, JsonObject jsonObject) {
-        Optional.ofNullable(getParentItem(item))
-                .ifPresent(parent -> jsonObject.put("parentUniqueKey",
-                        uniqueKeyProviderSupplier.get().apply(parent)));
+        Optional.ofNullable(getParentItem(item)).ifPresent(parent -> jsonObject
+                .put("parentUniqueKey", getKeyMapper().key(parent)));
     }
 
     private void requestFlush(HierarchicalUpdate update) {
@@ -184,7 +162,7 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
         if (event.isRefreshChildren()) {
             T item = event.getItem();
             if (isExpanded(item)) {
-                String parentKey = uniqueKeyProviderSupplier.get().apply(item);
+                String parentKey = getKeyMapper().key(item);
 
                 if (!dataControllers.containsKey(parentKey)) {
                     setParentRequestedRange(0, mapper.countChildItems(item), item);
@@ -207,7 +185,7 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
     }
 
     public void setParentRequestedRange(int start, int length, T parentItem) {
-        String parentKey = uniqueKeyProviderSupplier.get().apply(parentItem);
+        String parentKey = getKeyMapper().key(parentItem);
 
         HierarchicalCommunicationController<T> controller = dataControllers
                 .computeIfAbsent(parentKey,
@@ -561,6 +539,39 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
         JsonObject json = Json.createObject();
         json.put("key", getKeyMapper().key(item));
         return json;
+    }
+
+    /**
+     * KeyMapper extension delegating row key creation to the
+     * <code>uniqueKeyProviderSupplier</code> passed to the hierarchical data
+     * communicator constructor from the component.
+     * <p>
+     * If <code>uniqueKeyProviderSupplier</code> is not present, this class uses
+     * {@link KeyMapper#createKey()} for key creation.
+     *
+     * @param <V>
+     *            the bean type
+     */
+    private class KeyMapperWrapper<V> extends KeyMapper<T> {
+
+        private T object;
+
+        @Override
+        public String key(T o) {
+            this.object = o;
+            try {
+                return super.key(o);
+            } finally {
+                this.object = null;
+            }
+        }
+
+        @Override
+        protected String createKey() {
+            return Optional.ofNullable(uniqueKeyProviderSupplier.get())
+                    .map(provider -> provider.apply(object))
+                    .orElse(super.createKey());
+        }
     }
 
     private Collection<T> getHierarchyMapperExpandedItems() {


### PR DESCRIPTION
* fix: Use KeyMapper by default for unique keys

* fix: Use KeyMapper by default to generate unique keys

Delegates to regular KeyMapper whenever the unique key provider is not present and a unique key is needed for a row.

Part-of: https://github.com/vaadin/flow-components/issues/3156

(cherry picked from commit 570244d9afadfd185689f9ec0d3ef40e985c02d2)

