### PR TITLE
chore: fix gradle profile activation

### DIFF
--- a/flow-plugins/pom.xml
+++ b/flow-plugins/pom.xml
@@ -23,7 +23,7 @@
 		<profile>
 			<id>gradle</id>
 			<activation>
-				<jdk>(,17]</jdk>
+				<jdk>(,18)</jdk>
 			</activation>
 			<modules>
 				<module>flow-gradle-plugin</module>


### PR DESCRIPTION
Upper bound '17]' does not match correctly JDK 17. Quote from Maven docs:
> Note: an upper bound such as ,1.5] is likely not to include most releases of
> 1.5, since they will have an additional 'patch' release such as _05 that is
> not taken into consideration in the above range.'

Updating range to catch every version lower than 18