### PR TITLE
feat: Adapt to a new auto configuration in Spring Boot

### DIFF
--- a/vaadin-spring/src/main/resources/META-INF/spring.factories
+++ b/vaadin-spring/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,1 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=com.vaadin.flow.spring.SpringBootAutoConfiguration,com.vaadin.flow.spring.SpringSecurityAutoConfiguration,com.vaadin.flow.spring.VaadinScopesConfig
 org.springframework.boot.SpringApplicationRunListener=com.vaadin.flow.spring.DevModeBrowserLauncher

--- a/vaadin-spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/vaadin-spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,3 @@
+com.vaadin.flow.spring.SpringBootAutoConfiguration
+com.vaadin.flow.spring.SpringSecurityAutoConfiguration
+com.vaadin.flow.spring.VaadinScopesConfig

--- a/vaadin-spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/vaadin-spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,3 +1,4 @@
 com.vaadin.flow.spring.SpringBootAutoConfiguration
 com.vaadin.flow.spring.SpringSecurityAutoConfiguration
 com.vaadin.flow.spring.VaadinScopesConfig
+


### PR DESCRIPTION
## Description

Spring Boot introduced a new location for auto configuration entries in spring boot 2.7.0. The new location is `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`. This has until spring boot 3.0.0-M5 worked in parallel with the spring.factories configuration.
The spring.factories support was removed in spring boot 3.0.0-M5 so this move has to be done now in order for the auto configuration to be picked up.

Fixes #14628

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
