### PR TITLE
feat: Register VaadinSecurityContextHolderStrategy as a bean

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -180,8 +180,7 @@ public abstract class VaadinWebSecurity {
      */
     @Bean
     public SecurityContextHolderStrategy securityContextHolderStrategy() {
-        VaadinAwareSecurityContextHolderStrategy vaadinAwareSecurityContextHolderStrategy =
-                new VaadinAwareSecurityContextHolderStrategy();
+        VaadinAwareSecurityContextHolderStrategy vaadinAwareSecurityContextHolderStrategy = new VaadinAwareSecurityContextHolderStrategy();
         // Use a security context holder that can find the context from Vaadin
         // specific classes
         SecurityContextHolder.setContextHolderStrategy(

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -37,6 +37,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.annotation.web.configurers.ExpressionUrlAuthorizationConfigurer;
 import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextHolderStrategy;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
@@ -123,11 +124,6 @@ public abstract class VaadinWebSecurity {
      *             if an error occurs
      */
     protected void configure(HttpSecurity http) throws Exception {
-        // Use a security context holder that can find the context from Vaadin
-        // specific classes
-        SecurityContextHolder.setStrategyName(
-                VaadinAwareSecurityContextHolderStrategy.class.getName());
-
         // Respond with 401 Unauthorized HTTP status code for unauthorized
         // requests for protected Hilla endpoints, so that the response could
         // be handled on the client side using e.g. `InvalidSessionMiddleware`.
@@ -173,6 +169,24 @@ public abstract class VaadinWebSecurity {
 
         // Enable view access control
         viewAccessChecker.enable();
+    }
+
+    /**
+     * Registers {@link SecurityContextHolderStrategy} bean.
+     * <p>
+     * Beans of this type will automatically be used by
+     * {@link org.springframework.security.config.annotation.method.configuration.GlobalMethodSecurityConfiguration}
+     * to configure the current {@link SecurityContextHolderStrategy}.
+     */
+    @Bean
+    public SecurityContextHolderStrategy securityContextHolderStrategy() {
+        VaadinAwareSecurityContextHolderStrategy vaadinAwareSecurityContextHolderStrategy =
+                new VaadinAwareSecurityContextHolderStrategy();
+        // Use a security context holder that can find the context from Vaadin
+        // specific classes
+        SecurityContextHolder.setContextHolderStrategy(
+                vaadinAwareSecurityContextHolderStrategy);
+        return vaadinAwareSecurityContextHolderStrategy;
     }
 
     /**

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurityConfigurerAdapter.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurityConfigurerAdapter.java
@@ -164,8 +164,7 @@ public abstract class VaadinWebSecurityConfigurerAdapter
      */
     @Bean
     public SecurityContextHolderStrategy securityContextHolderStrategy() {
-        VaadinAwareSecurityContextHolderStrategy vaadinAwareSecurityContextHolderStrategy =
-                new VaadinAwareSecurityContextHolderStrategy();
+        VaadinAwareSecurityContextHolderStrategy vaadinAwareSecurityContextHolderStrategy = new VaadinAwareSecurityContextHolderStrategy();
         // Use a security context holder that can find the context from Vaadin
         // specific classes
         SecurityContextHolder.setContextHolderStrategy(

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurityConfigurerAdapter.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurityConfigurerAdapter.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -36,6 +37,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.annotation.web.configurers.ExpressionUrlAuthorizationConfigurer;
 import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextHolderStrategy;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.access.AccessDeniedHandlerImpl;
@@ -111,11 +113,6 @@ public abstract class VaadinWebSecurityConfigurerAdapter
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        // Use a security context holder that can find the context from Vaadin
-        // specific classes
-        SecurityContextHolder.setStrategyName(
-                VaadinAwareSecurityContextHolderStrategy.class.getName());
-
         // Respond with 401 Unauthorized HTTP status code for unauthorized
         // requests for protected Hilla endpoints, so that the response could
         // be handled on the client side using e.g. `InvalidSessionMiddleware`.
@@ -156,6 +153,24 @@ public abstract class VaadinWebSecurityConfigurerAdapter
 
         // Enable view access control
         viewAccessChecker.enable();
+    }
+
+    /**
+     * Registers {@link SecurityContextHolderStrategy} bean.
+     * <p>
+     * Beans of this type will automatically be used by
+     * {@link org.springframework.security.config.annotation.method.configuration.GlobalMethodSecurityConfiguration}
+     * to configure the current {@link SecurityContextHolderStrategy}.
+     */
+    @Bean
+    public SecurityContextHolderStrategy securityContextHolderStrategy() {
+        VaadinAwareSecurityContextHolderStrategy vaadinAwareSecurityContextHolderStrategy =
+                new VaadinAwareSecurityContextHolderStrategy();
+        // Use a security context holder that can find the context from Vaadin
+        // specific classes
+        SecurityContextHolder.setContextHolderStrategy(
+                vaadinAwareSecurityContextHolderStrategy);
+        return vaadinAwareSecurityContextHolderStrategy;
     }
 
     /**


### PR DESCRIPTION
## Description

When configuring global method security the `GlobalMethodSecurityConfiguration` picks up the wrong `SecurityContextHolderStrategy` because it gets the `SecurityContextHolderStrategy` from the `SecurityContextHolder` befor the vaadin security configuration has overridden it. If the `GlobalMethodSecurityConfiguration` finds a `SecurityContextHolderStrategy` bean it will use that as the strategy instead of the default picked up from the `SecurityContextHolder`.

Fixes #14585

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
