### PR TITLE
fix: linux node installation

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -77,6 +77,10 @@ public class FrontendTools {
     public static final String INSTALL_NODE_LOCALLY = "%n  $ mvn com.github.eirslett:frontend-maven-plugin:1.10.0:install-node-and-npm "
             + "-DnodeVersion=\"" + DEFAULT_NODE_VERSION + "\" ";
 
+    public static final String NPM_BIN_PATH = FrontendUtils.isWindows()
+            ? "node/node_modules/npm/bin/"
+            : "node/lib/node_modules/npm/bin/";
+
     private static final String MSG_PREFIX = "%n%n======================================================================================================";
     private static final String MSG_SUFFIX = "%n======================================================================================================%n";
 
@@ -1061,7 +1065,7 @@ public class FrontendTools {
         // If `node` is not found in PATH, `node/node_modules/npm/bin/npm` will
         // not work because it's a shell or windows script that looks for node
         // and will fail. Thus we look for the `npm-cli` node script instead
-        File file = new File(dir, "node/node_modules/npm/bin/" + scriptName);
+        File file = new File(dir, NPM_BIN_PATH + scriptName);
         List<String> returnCommand = new ArrayList<>();
         if (file.canRead()) {
             // We return a two element list with node binary and npm-cli script

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -70,7 +70,7 @@ public class FrontendTools {
     /**
      * This is the version shipped with the default Node version.
      */
-    public static final String DEFAULT_NPM_VERSION = "8.19.1";
+    public static final String DEFAULT_NPM_VERSION = "8.19.2";
 
     public static final String DEFAULT_PNPM_VERSION = "5.18.10";
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -70,7 +70,7 @@ public class FrontendTools {
     /**
      * This is the version shipped with the default Node version.
      */
-    public static final String DEFAULT_NPM_VERSION = "8.19.2";
+    public static final String DEFAULT_NPM_VERSION = "8.19.1";
 
     public static final String DEFAULT_PNPM_VERSION = "5.18.10";
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
@@ -327,6 +327,13 @@ public class NodeInstaller {
         if (nodeModulesDirectory.exists()) {
             FileUtils.deleteDirectory(nodeModulesDirectory);
         }
+        // delete old/windows type node_modules so it is not messing
+        // up the installation
+        final File oldNodeModulesDirectory = new File(destinationDirectory
+                + File.separator + FrontendUtils.NODE_MODULES);
+        if (oldNodeModulesDirectory.exists()) {
+            FileUtils.deleteDirectory(oldNodeModulesDirectory);
+        }
 
         FileUtils.copyDirectory(tmpNodeModulesDir, nodeModulesDirectory);
         // create a copy of the npm scripts next to the node executable

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/installer/NodeInstaller.java
@@ -289,7 +289,7 @@ public class NodeInstaller {
                             + nodeBinary);
         }
 
-        File destinationDirectory = getNodeInstallDirectory();
+        File destinationDirectory = getNodeBinaryInstallDirectory();
 
         File destination = new File(destinationDirectory,
                 data.getNodeExecutable());
@@ -302,8 +302,10 @@ public class NodeInstaller {
                             + destination + " executable.");
         }
 
+        createSymbolicLinkToBinary(destination, data.getNodeExecutable());
+
         if (npmProvided()) {
-            extractUnixNpm(data, destinationDirectory);
+            extractUnixNpm(data, getNodeInstallDirectory());
         }
 
         deleteTempDirectory(data.getTmpDirectory());
@@ -315,7 +317,8 @@ public class NodeInstaller {
         File tmpNodeModulesDir = new File(data.getTmpDirectory(),
                 data.getNodeFilename() + File.separator + "lib" + File.separator
                         + FrontendUtils.NODE_MODULES);
-        File nodeModulesDirectory = new File(destinationDirectory,
+        File nodeModulesDirectory = new File(
+                destinationDirectory + File.separator + "lib",
                 FrontendUtils.NODE_MODULES);
         File npmDirectory = new File(nodeModulesDirectory, "npm");
 
@@ -398,11 +401,15 @@ public class NodeInstaller {
     }
 
     public String getInstallDirectory() {
-        return new File(installDirectory, INSTALL_PATH).getPath();
+        return getInstallDirectoryFile().getPath();
+    }
+
+    private File getInstallDirectoryFile() {
+        return new File(installDirectory, INSTALL_PATH);
     }
 
     private File getNodeInstallDirectory() {
-        File nodeInstallDirectory = new File(installDirectory, INSTALL_PATH);
+        File nodeInstallDirectory = getInstallDirectoryFile();
         if (!nodeInstallDirectory.exists()) {
             getLogger().debug("Creating install directory {}",
                     nodeInstallDirectory);
@@ -412,6 +419,34 @@ public class NodeInstaller {
             }
         }
         return nodeInstallDirectory;
+    }
+
+    private File getNodeBinaryInstallDirectory() {
+        File nodeInstallDirectory = new File(getInstallDirectoryFile(), "bin");
+        if (!nodeInstallDirectory.exists()) {
+            getLogger().debug("Creating install directory {}",
+                    nodeInstallDirectory);
+            boolean success = nodeInstallDirectory.mkdirs();
+            if (!success) {
+                getLogger().debug("Failed to create install directory");
+            }
+        }
+        return nodeInstallDirectory;
+    }
+
+    private void createSymbolicLinkToBinary(File destination,
+            String nodeExecutable) throws InstallationException, IOException {
+        final File symLink = new File(getInstallDirectory(), nodeExecutable);
+        if (symLink.exists()) {
+            FileUtils.delete(symLink);
+        }
+        try {
+            Files.createSymbolicLink(symLink.toPath(), destination.toPath());
+        } catch (IOException e) {
+            throw new InstallationException(String.format(
+                    "Could not install Node: Was not allowed to create symbolic link %s for %s",
+                    symLink, destination), e);
+        }
     }
 
     private void deleteTempDirectory(File tmpDirectory) throws IOException {

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -131,8 +131,13 @@ public class FrontendToolsTest {
         npmVersionCommand.add("--version");
         FrontendVersion npm = FrontendUtils.getVersion("npm",
                 npmVersionCommand);
-        Assert.assertEquals(FrontendTools.DEFAULT_NPM_VERSION,
-                npm.getFullVersion());
+        final FrontendVersion npmDefault = new FrontendVersion(
+                FrontendTools.DEFAULT_NPM_VERSION);
+
+        Assert.assertEquals("Major version should match",
+                npmDefault.getMajorVersion(), npm.getMajorVersion());
+        Assert.assertEquals("Minor version should match",
+                npmDefault.getMinorVersion(), npm.getMinorVersion());
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -339,8 +339,12 @@ public class FrontendToolsTest {
         String nodeExecutable = installNodeToTempFolder();
         Assert.assertNotNull(nodeExecutable);
 
+        String npmInstallPath = FrontendUtils.isWindows()
+                ? "node/node_modules/npm/bin/npm"
+                : "node/lib/node_modules/npm/bin/npm";
+
         Assert.assertTrue("npm should have been copied to node_modules",
-                new File(vaadinHomeDir, "node/node_modules/npm/bin/npm")
+                new File(vaadinHomeDir, npmInstallPath)
                         .exists());
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -360,9 +360,12 @@ public class FrontendToolsTest {
         prepareNodeDownloadableZipAt(baseDir, "v12.10.0");
         tools.forceAlternativeNodeExecutable();
 
+        String npmInstallPath = FrontendUtils.isWindows()
+                ? "node/node_modules/npm/bin/npm"
+                : "node/lib/node_modules/npm/bin/npm";
+
         Assert.assertTrue("npm should have been copied to node_modules",
-                new File(vaadinHomeDir, "node/node_modules/npm/bin/npm")
-                        .exists());
+                new File(vaadinHomeDir, npmInstallPath).exists());
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -344,8 +344,7 @@ public class FrontendToolsTest {
                 : "node/lib/node_modules/npm/bin/npm";
 
         Assert.assertTrue("npm should have been copied to node_modules",
-                new File(vaadinHomeDir, npmInstallPath)
-                        .exists());
+                new File(vaadinHomeDir, npmInstallPath).exists());
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.server.frontend;
 
+import static com.vaadin.flow.server.frontend.FrontendTools.NPM_BIN_PATH;
 import static com.vaadin.flow.testutil.FrontendStubs.createStubNode;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
@@ -73,9 +74,9 @@ public class FrontendToolsTest {
             ? "node\\node.exe"
             : "node/node";
 
-    public static final String NPM_CLI_STRING = Stream
-            .of("node", "node_modules", "npm", "bin", "npm-cli.js")
-            .collect(Collectors.joining(File.separator));
+    public static final String NPM_CLI_STRING = FrontendUtils.isWindows()
+            ? "node\\node_modules\\npm\\bin\\npm-cli.js"
+            : "node/lib/node_modules/npm/bin/npm-cli.js";
 
     private static final String OLD_PNPM_VERSION = "4.5.0";
 
@@ -339,9 +340,7 @@ public class FrontendToolsTest {
         String nodeExecutable = installNodeToTempFolder();
         Assert.assertNotNull(nodeExecutable);
 
-        String npmInstallPath = FrontendUtils.isWindows()
-                ? "node/node_modules/npm/bin/npm"
-                : "node/lib/node_modules/npm/bin/npm";
+        String npmInstallPath = NPM_BIN_PATH + "npm";
 
         Assert.assertTrue("npm should have been copied to node_modules",
                 new File(vaadinHomeDir, npmInstallPath).exists());
@@ -351,8 +350,7 @@ public class FrontendToolsTest {
     public void installNodeFromFileSystem_ForceAlternativeNodeExecutableInstallsToTargetDirectory()
             throws Exception {
         Assert.assertFalse("npm should not yet be present",
-                new File(vaadinHomeDir, "node/node_modules/npm/bin/npm")
-                        .exists());
+                new File(vaadinHomeDir, NPM_BIN_PATH + "npm").exists());
 
         settings.setNodeDownloadRoot(new File(baseDir).toURI());
         settings.setNodeVersion("v12.10.0");
@@ -360,9 +358,7 @@ public class FrontendToolsTest {
         prepareNodeDownloadableZipAt(baseDir, "v12.10.0");
         tools.forceAlternativeNodeExecutable();
 
-        String npmInstallPath = FrontendUtils.isWindows()
-                ? "node/node_modules/npm/bin/npm"
-                : "node/lib/node_modules/npm/bin/npm";
+        String npmInstallPath = NPM_BIN_PATH + "npm";
 
         Assert.assertTrue("npm should have been copied to node_modules",
                 new File(vaadinHomeDir, npmInstallPath).exists());
@@ -899,7 +895,8 @@ public class FrontendToolsTest {
     }
 
     private void createFakePnpm(String defaultPnpmVersion) throws Exception {
-        File npxJs = new File(baseDir, "node/node_modules/npm/bin/npx-cli.js");
+        final String npxPath = NPM_BIN_PATH + "npx-cli.js";
+        File npxJs = new File(baseDir, npxPath);
         FileUtils.forceMkdir(npxJs.getParentFile());
 
         FileWriter fileWriter = new FileWriter(npxJs);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/installer/NodeInstallerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/installer/NodeInstallerTest.java
@@ -101,6 +101,12 @@ public class NodeInstallerTest {
         Assert.assertTrue("garbage file should be created",
                 garbage.createNewFile());
 
+        File oldNpm = new File(nodeDirectory, "node_modules/npm");
+        File oldGarbage = new File(oldNpm, "oldGarbage");
+        FileUtils.forceMkdir(oldNpm);
+        Assert.assertTrue("oldGarbage file should be created",
+                oldGarbage.createNewFile());
+
         NodeInstaller nodeInstaller = new NodeInstaller(targetDir,
                 Collections.emptyList())
                 .setNodeVersion(FrontendTools.DEFAULT_NODE_VERSION)
@@ -121,5 +127,8 @@ public class NodeInstallerTest {
                 new File(targetDir, npmInstallPath).exists());
         Assert.assertFalse("old npm files should have been removed",
                 garbage.exists());
+        Assert.assertFalse(
+                "old style node_modules files should have been removed",
+                oldGarbage.exists());
     }
 }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/installer/NodeInstallerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/installer/NodeInstallerTest.java
@@ -92,7 +92,9 @@ public class NodeInstallerTest {
 
         // add a file to node/node_modules_npm that should be cleaned out
         File nodeDirectory = new File(targetDir, "node");
-        File nodeModulesDirectory = new File(nodeDirectory, "node_modules");
+        String nodeModulesPath = platform.isWindows() ? "node_modules"
+                : "lib/node_modules";
+        File nodeModulesDirectory = new File(nodeDirectory, nodeModulesPath);
         File npmDirectory = new File(nodeModulesDirectory, "npm");
         File garbage = new File(npmDirectory, "garbage");
         FileUtils.forceMkdir(npmDirectory);
@@ -112,8 +114,11 @@ public class NodeInstallerTest {
 
         Assert.assertTrue("npm should have been copied to node_modules",
                 new File(targetDir, "node/" + nodeExec).exists());
+        String npmInstallPath = platform.isWindows()
+                ? "node/node_modules/npm/bin/npm"
+                : "node/lib/node_modules/npm/bin/npm";
         Assert.assertTrue("npm should have been copied to node_modules",
-                new File(targetDir, "node/node_modules/npm/bin/npm").exists());
+                new File(targetDir, npmInstallPath).exists());
         Assert.assertFalse("old npm files should have been removed",
                 garbage.exists());
     }

--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/FrontendStubs.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/FrontendStubs.java
@@ -33,7 +33,9 @@ public class FrontendStubs {
     public static final String VITE_SERVER = "node_modules/vite/bin/vite.js";
     public static final String VITE_TEST_OUT_FILE = "vite-out.test";
 
-    private static final String NPM_BIN_PATH = "node/node_modules/npm/bin";
+    private static final String NPM_BIN_PATH = System.getProperty("os.name")
+            .startsWith("Windows") ? "node/node_modules/npm/bin/"
+                    : "node/lib/node_modules/npm/bin/";
     private static final String NPM_CACHE_PATH_STUB = "cache";
 
     /**


### PR DESCRIPTION
Fix installation of node for unix systems.
NodeJS 18 is more strict about where
the contents are located than old versions.

Fixes #14636

