### PR TITLE
fix: Use es2020 for Vite, es2019 for webpack

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -896,7 +896,7 @@ public class NodeTasks implements FallibleCommand {
 
     private void addGenerateTsConfigTask(Builder builder) {
         TaskGenerateTsConfig taskGenerateTsConfig = new TaskGenerateTsConfig(
-                builder.npmFolder);
+                builder.npmFolder, builder.getFeatureFlags());
         commands.add(taskGenerateTsConfig);
 
         TaskGenerateTsDefinitions taskGenerateTsDefinitions = new TaskGenerateTsDefinitions(

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/tsconfig.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/tsconfig.json
@@ -8,7 +8,7 @@
     "sourceMap": true,
     "inlineSources": true,
     "module": "esNext",
-    "target": "es2019",
+    "target": "es2020",
     "moduleResolution": "node",
     "strict": true,
     "skipLibCheck": true,

--- a/flow-server/src/main/resources/tsconfig.json
+++ b/flow-server/src/main/resources/tsconfig.json
@@ -3,7 +3,7 @@
     "sourceMap": true,
     "inlineSources": true,
     "module": "esNext",
-    "target": "es2019",
+    "target": "es2020",
     "moduleResolution": "node",
     "strict": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
Fixes #14589
