### PR TITLE
fix: Only map websockets to servlet path and not any sub paths (#14638) (CP 23.2)

### DIFF
--- a/flow-tests/vaadin-spring-tests/pom.xml
+++ b/flow-tests/vaadin-spring-tests/pom.xml
@@ -129,6 +129,11 @@
             <version>2.3.1</version>
         </dependency>
         <dependency>
+            <groupId>javax.websocket</groupId>
+            <artifactId>javax.websocket-api</artifactId>
+            <version>1.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
             <version>2.3.6</version>

--- a/flow-tests/vaadin-spring-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/test/CustomWebSocket.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/src/main/java/com/vaadin/flow/spring/test/CustomWebSocket.java
@@ -1,0 +1,54 @@
+package com.vaadin.flow.spring.test;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.WebSocketMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@Configuration
+@EnableWebSocket
+public class CustomWebSocket implements WebSocketConfigurer {
+
+    public static final String WEBSOCKET_URL = "/customWebSocket";
+
+    public static final String WEBSOCKET_RESPONSE_TEXT = "This is a response from Web Socket!";
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry.addHandler(new WebSocketHandler() {
+
+            @Override
+            public void afterConnectionEstablished(WebSocketSession session) {
+            }
+
+            @Override
+            public void handleMessage(WebSocketSession session,
+                    WebSocketMessage<?> message) throws Exception {
+                session.sendMessage(new TextMessage(WEBSOCKET_RESPONSE_TEXT));
+            }
+
+            @Override
+            public void handleTransportError(WebSocketSession session,
+                    Throwable exception) {
+
+            }
+
+            @Override
+            public void afterConnectionClosed(WebSocketSession session,
+                    CloseStatus closeStatus) {
+
+            }
+
+            @Override
+            public boolean supportsPartialMessages() {
+                return false;
+            }
+        }, WEBSOCKET_URL);
+    }
+
+}

--- a/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/CustomWebSocketIT.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-common/src/test/java/com/vaadin/flow/spring/test/CustomWebSocketIT.java
@@ -1,0 +1,72 @@
+package com.vaadin.flow.spring.test;
+
+import javax.websocket.ClientEndpoint;
+import javax.websocket.CloseReason;
+import javax.websocket.ContainerProvider;
+import javax.websocket.OnClose;
+import javax.websocket.OnMessage;
+import javax.websocket.Session;
+import javax.websocket.WebSocketContainer;
+import java.io.IOException;
+import java.net.URI;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(SpringBootOnly.class)
+public class CustomWebSocketIT extends AbstractSpringTest {
+
+    @ClientEndpoint
+    public class CustomWebSocketEndpoint {
+
+        private final CountDownLatch closureLatch = new CountDownLatch(1);
+
+        private String message;
+
+        @OnMessage
+        public void onMessage(Session session, String message)
+                throws IOException {
+            this.message = message;
+            session.close();
+        }
+
+        @OnClose
+        public void onClose(CloseReason reason) {
+            closureLatch.countDown();
+        }
+
+        public String waitForMessage() throws InterruptedException {
+            closureLatch.await(1, TimeUnit.SECONDS);
+            return message;
+        }
+    }
+
+    @Test
+    public void properWebsocketResponseIsReceived() throws Exception {
+        WebSocketContainer container = ContainerProvider
+                .getWebSocketContainer();
+
+        String testUrl = getTestURL().replace("http://", "ws://");
+        URI uri = URI.create(testUrl + CustomWebSocket.WEBSOCKET_URL);
+
+        try {
+            CustomWebSocketEndpoint clientEndpoint = new CustomWebSocketEndpoint();
+            Session session = container.connectToServer(clientEndpoint, uri);
+            session.getBasicRemote().sendText("Hello");
+            Assert.assertEquals(CustomWebSocket.WEBSOCKET_RESPONSE_TEXT,
+                    clientEndpoint.waitForMessage());
+            session.close();
+        } catch (Exception ex) {
+            throw ex;
+        }
+    }
+
+    @Override
+    protected String getTestPath() {
+        return "";
+    }
+
+}

--- a/flow-tests/vaadin-spring-tests/test-spring-war/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-war/pom.xml
@@ -59,6 +59,34 @@
             </exclusions>
         </dependency>
         <!-- End Spring -->
+
+        <!-- Jetty Websocket client side dependencies  -->
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-client</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-util</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-http</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-io</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.websocket</groupId>
+            <artifactId>websocket-javax-client</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringBootAutoConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringBootAutoConfiguration.java
@@ -101,6 +101,7 @@ public class SpringBootAutoConfiguration {
          */
         initParameters.put(ApplicationConfig.JSR356_MAPPING_PATH,
                 pushRegistrationPath);
+        initParameters.put(ApplicationConfig.JSR356_PATH_MAPPING_LENGTH, "0");
 
         ServletRegistrationBean<SpringServlet> registration = new ServletRegistrationBean<>(
                 new SpringServlet(context, rootMapping), mapping);

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinMVCWebAppInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinMVCWebAppInitializer.java
@@ -85,6 +85,7 @@ public abstract class VaadinMVCWebAppInitializer
          */
         initParameters.put(ApplicationConfig.JSR356_MAPPING_PATH,
                 pushRegistrationPath);
+        initParameters.put(ApplicationConfig.JSR356_PATH_MAPPING_LENGTH, "0");
 
         registration.setInitParameters(initParameters);
 


### PR DESCRIPTION
(cherry picked from commit f4c7497e260c42940c049d8f82c383bbfacc9b78)

<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Please list all relevant dependencies in this section and provide summary of the change, motivation and context.

Fixes # (issue)

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
