### PR TITLE
fix: Do not assume a /VAADIN/* mapping is the real servlet mapping

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServlet.java
@@ -184,6 +184,10 @@ public class VaadinServlet extends HttpServlet {
                     return;
                 }
                 mappings.addAll(urlPatterns);
+                if (mappings.size() > 1) {
+                    // Avoid using /VAADIN/* as that is a mapping to handle static files
+                    mappings.remove("/VAADIN/*");
+                }
                 Collections.sort(mappings);
                 frontendMapping = mappings.get(0);
                 getLogger().debug("Using mapping " + frontendMapping


### PR DESCRIPTION
Fixes the issue reported in https://stackoverflow.com/questions/73755403/upgrading-to-vaadin-23-2-1-java-net-malformedurlexception-error-at-index-5