### PR TITLE
fix: make system property feature flag value always override stored one

### DIFF
--- a/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
+++ b/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
@@ -200,7 +200,8 @@ public class FeatureFlags implements Serializable {
         if (featureFlagFile == null || !featureFlagFile.exists()) {
             // Disable all features if no file exists
             for (Feature f : features) {
-                f.setEnabled(false);
+                f.setEnabled(
+                        Boolean.getBoolean(SYSTEM_PROPERTY_PREFIX + f.getId()));
             }
         } else {
             try (FileInputStream propertiesStream = new FileInputStream(
@@ -213,15 +214,6 @@ public class FeatureFlags implements Serializable {
                         "Failed to read properties file from filesystem", e);
             }
         }
-
-        // Allow users to override a feature flag with a system property
-        for (Feature f : features) {
-            var prop = System.getProperty(SYSTEM_PROPERTY_PREFIX + f.getId());
-
-            if (prop != null) {
-                f.setEnabled(Boolean.parseBoolean(prop));
-            }
-        }
     }
 
     void loadProperties(InputStream propertiesStream) {
@@ -232,9 +224,14 @@ public class FeatureFlags implements Serializable {
                 props.load(propertiesStream);
             }
             for (Feature f : features) {
-                f.setEnabled(Boolean.valueOf(
-                        props.getProperty(getPropertyName(f.getId()))));
+                // Allow users to override a feature flag with a system property
+                var propertyValue = System.getProperty(
+                        SYSTEM_PROPERTY_PREFIX + f.getId(),
+                        props.getProperty(getPropertyName(f.getId())));
+
+                f.setEnabled(Boolean.parseBoolean(propertyValue));
             }
+
         } catch (IOException e) {
             getLogger().error("Unable to read feature flags", e);
         }

--- a/flow-server/src/test/java/com/vaadin/experimental/FeatureFlagsTest.java
+++ b/flow-server/src/test/java/com/vaadin/experimental/FeatureFlagsTest.java
@@ -15,18 +15,11 @@
  */
 package com.vaadin.experimental;
 
+import javax.annotation.concurrent.NotThreadSafe;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-
-import javax.annotation.concurrent.NotThreadSafe;
-
-import com.vaadin.flow.internal.UsageStatistics;
-import com.vaadin.flow.server.MockVaadinContext;
-import com.vaadin.flow.server.VaadinContext;
-import com.vaadin.flow.server.VaadinService;
-import com.vaadin.flow.server.startup.ApplicationConfiguration;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
@@ -35,6 +28,16 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
+
+import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.di.ResourceProvider;
+import com.vaadin.flow.internal.UsageStatistics;
+import com.vaadin.flow.server.MockVaadinContext;
+import com.vaadin.flow.server.VaadinContext;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.startup.ApplicationConfiguration;
+
+import static com.vaadin.experimental.FeatureFlags.PROPERTIES_FILENAME;
 
 @NotThreadSafe
 public class FeatureFlagsTest {
@@ -46,6 +49,7 @@ public class FeatureFlagsTest {
     private FeatureFlags featureFlags;
     private File propertiesDir;
     private ApplicationConfiguration configuration;
+    private File featureFlagsFile;
 
     @Before
     public void before() throws IOException {
@@ -61,6 +65,9 @@ public class FeatureFlagsTest {
         featureFlags.setPropertiesLocation(propertiesDir);
 
         mockResourcesLocation();
+
+        featureFlagsFile = new File(propertiesDir, PROPERTIES_FILENAME);
+        Files.deleteIfExists(featureFlagsFile.toPath());
     }
 
     @Test
@@ -122,9 +129,7 @@ public class FeatureFlagsTest {
                 featureFlags.isEnabled(FeatureFlags.EXAMPLE));
         Assert.assertEquals(
                 "# Example feature. Will be removed once the first real feature flag is added\ncom.vaadin.experimental.exampleFeatureFlag=true\n",
-                FileUtils.readFileToString(
-                        new File(propertiesDir,
-                                FeatureFlags.PROPERTIES_FILENAME),
+                FileUtils.readFileToString(featureFlagsFile,
                         StandardCharsets.UTF_8));
 
         featureFlags.setEnabled(FeatureFlags.EXAMPLE.getId(), false);
@@ -132,10 +137,7 @@ public class FeatureFlagsTest {
                 featureFlags.isEnabled(FeatureFlags.EXAMPLE));
         Assert.assertEquals(
                 "Feature flags file should be empty when no features are enabled",
-                "",
-                FileUtils.readFileToString(
-                        new File(propertiesDir,
-                                FeatureFlags.PROPERTIES_FILENAME),
+                "", FileUtils.readFileToString(featureFlagsFile,
                         StandardCharsets.UTF_8));
     }
 
@@ -202,14 +204,105 @@ public class FeatureFlagsTest {
 
         try {
             System.setProperty(propertyName, "true");
-            createFeatureFlagsFile(String
-                    .format("com.vaadin.experimental.%s=false\n", feature));
+            String fileContents = String
+                    .format("com.vaadin.experimental.%s=false\n", feature);
+            createFeatureFlagsFile(fileContents);
             featureFlags.loadProperties();
             Assert.assertTrue(featureFlags.isEnabled(FeatureFlags.EXAMPLE));
+            Assert.assertEquals(
+                    "Feature flags file should not be overwritten by system property value",
+                    fileContents, FileUtils.readFileToString(featureFlagsFile,
+                            StandardCharsets.UTF_8));
         } finally {
             if (previousValue == null) {
                 System.clearProperty(propertyName);
             } else {
+                System.setProperty(propertyName, previousValue);
+            }
+        }
+    }
+
+    @Test
+    public void featureFlagLoadedByResourceProviderShouldBeOverridableWithSystemProperty()
+            throws IOException {
+        var feature = "exampleFeatureFlag";
+        var propertyName = FeatureFlags.SYSTEM_PROPERTY_PREFIX + feature;
+        var previousValue = System.getProperty(propertyName);
+
+        File flagsFile = new File(propertiesDir,
+                "another-" + PROPERTIES_FILENAME);
+
+        ResourceProvider resourceProvider = Mockito
+                .mock(ResourceProvider.class);
+        Mockito.when(
+                resourceProvider.getApplicationResource(PROPERTIES_FILENAME))
+                .thenReturn(flagsFile.toURI().toURL());
+        Lookup lookup = context.getAttribute(Lookup.class);
+        Mockito.when(lookup.lookup(ResourceProvider.class))
+                .thenReturn(resourceProvider);
+
+        try {
+            String fileContents = String
+                    .format("com.vaadin.experimental.%s=false\n", feature);
+            FileUtils.write(flagsFile, fileContents, StandardCharsets.UTF_8);
+
+            System.setProperty(propertyName, "true");
+            featureFlags.loadProperties();
+            Assert.assertTrue(featureFlags.isEnabled(FeatureFlags.EXAMPLE));
+            Assert.assertFalse(
+                    "Setting feature flag by system properties should not create feature flag file",
+                    featureFlagsFile.exists());
+        } finally {
+            if (previousValue == null) {
+                System.clearProperty(propertyName);
+            } else {
+                System.setProperty(propertyName, previousValue);
+            }
+        }
+    }
+
+    @Test
+    public void noFeatureFlagFile_systemPropertyProvided_featureEnabled()
+            throws IOException {
+        var feature = "exampleFeatureFlag";
+        var propertyName = FeatureFlags.SYSTEM_PROPERTY_PREFIX + feature;
+        var previousValue = System.getProperty(propertyName);
+
+        try {
+            System.setProperty(propertyName, "true");
+            featureFlags.loadProperties();
+            Assert.assertTrue(
+                    "Feature set with system property should be enabled",
+                    featureFlags.isEnabled(FeatureFlags.EXAMPLE));
+            Assert.assertFalse(
+                    "Setting feature flag by system properties should not create feature flag file",
+                    featureFlagsFile.exists());
+        } finally {
+            if (previousValue == null) {
+                System.clearProperty(propertyName);
+            } else {
+                System.setProperty(propertyName, previousValue);
+            }
+        }
+    }
+
+    @Test
+    public void noFeatureFlagFile_noSystemPropertyProvided_allFeatureDisabled()
+            throws IOException {
+        var feature = "exampleFeatureFlag";
+        var propertyName = FeatureFlags.SYSTEM_PROPERTY_PREFIX + feature;
+        var previousValue = System.getProperty(propertyName);
+
+        try {
+            if (previousValue != null) {
+                System.clearProperty(propertyName);
+            }
+            featureFlags.loadProperties();
+            Assert.assertFalse(
+                    "Feature not set with system property should be disabled by default",
+                    featureFlags.isEnabled(FeatureFlags.EXAMPLE));
+        } finally {
+            if (previousValue != null) {
                 System.setProperty(propertyName, previousValue);
             }
         }
@@ -238,8 +331,6 @@ public class FeatureFlagsTest {
     }
 
     private void createFeatureFlagsFile(String data) throws IOException {
-        FileUtils.write(
-                new File(propertiesDir, FeatureFlags.PROPERTIES_FILENAME), data,
-                StandardCharsets.UTF_8);
+        FileUtils.write(featureFlagsFile, data, StandardCharsets.UTF_8);
     }
 }


### PR DESCRIPTION
## Description

Enable or disable a feature flag by providing a system property is not working when feature flags file is loaded by a ResourceProvider. This change makes system properties always take precedence over stored values

Fixes #14679

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
