### PR TITLE
fix: Do not use a fixed download root (#14632)

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
@@ -158,7 +158,8 @@ public open class VaadinFlowPluginExtension(project: Project) {
      *
      * Example: `"https://nodejs.org/dist/"`.
      */
-    public var nodeDownloadRoot: String = NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT
+    public var nodeDownloadRoot: String =
+        com.vaadin.flow.server.frontend.installer.Platform.guess().getNodeDownloadRoot()
 
     /**
      * Allow automatic update of node installed to alternate location. Default `false`

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -41,6 +41,7 @@ import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.frontend.FrontendTools;
 import com.vaadin.flow.server.frontend.installer.NodeInstaller;
+import com.vaadin.flow.server.frontend.installer.Platform;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 
 /**
@@ -109,7 +110,7 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
      * </p>
      * Example: <code>"https://nodejs.org/dist/"</code>.
      */
-    @Parameter(property = InitParameters.NODE_DOWNLOAD_ROOT, defaultValue = NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT)
+    @Parameter(property = InitParameters.NODE_DOWNLOAD_ROOT)
     private String nodeDownloadRoot;
 
     /**
@@ -351,7 +352,9 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
 
     @Override
     public URI nodeDownloadRoot() throws URISyntaxException {
-
+        if (nodeDownloadRoot == null) {
+            nodeDownloadRoot = Platform.guess().getNodeDownloadRoot();
+        }
         try {
             return new URI(nodeDownloadRoot);
         } catch (URISyntaxException e) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -43,6 +43,7 @@ import com.vaadin.flow.server.frontend.FrontendUtils.CommandExecutionException;
 import com.vaadin.flow.server.frontend.FrontendUtils.UnknownVersionException;
 import com.vaadin.flow.server.frontend.installer.InstallationException;
 import com.vaadin.flow.server.frontend.installer.NodeInstaller;
+import com.vaadin.flow.server.frontend.installer.Platform;
 import com.vaadin.flow.server.frontend.installer.ProxyConfig;
 import com.vaadin.flow.server.startup.ApplicationConfiguration;
 
@@ -237,7 +238,7 @@ public class FrontendTools {
     public FrontendTools(String baseDir,
             Supplier<String> alternativeDirGetter) {
         this(baseDir, alternativeDirGetter, DEFAULT_NODE_VERSION,
-                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT), false,
+                URI.create(Platform.guess().getNodeDownloadRoot()), false,
                 false);
     }
 
@@ -267,7 +268,7 @@ public class FrontendTools {
     public FrontendTools(String baseDir, Supplier<String> alternativeDirGetter,
             boolean forceAlternativeNode) {
         this(baseDir, alternativeDirGetter, DEFAULT_NODE_VERSION,
-                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT),
+                URI.create(Platform.guess().getNodeDownloadRoot()),
                 forceAlternativeNode, false);
     }
 
@@ -425,7 +426,7 @@ public class FrontendTools {
                 NODE_VERSION, FrontendTools.DEFAULT_NODE_VERSION);
         final String nodeDownloadRoot = applicationConfiguration
                 .getStringProperty(NODE_DOWNLOAD_ROOT,
-                        NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT);
+                        Platform.guess().getNodeDownloadRoot());
 
         FrontendToolsSettings settings = new FrontendToolsSettings(
                 projectRoot.getAbsolutePath(),

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsSettings.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsSettings.java
@@ -23,6 +23,7 @@ import java.util.function.Supplier;
 import com.vaadin.flow.function.SerializableSupplier;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.frontend.installer.NodeInstaller;
+import com.vaadin.flow.server.frontend.installer.Platform;
 
 import static com.vaadin.flow.server.frontend.FrontendTools.DEFAULT_NODE_VERSION;
 
@@ -39,7 +40,7 @@ public class FrontendToolsSettings implements Serializable {
 
     private String nodeVersion = DEFAULT_NODE_VERSION;
     private URI nodeDownloadRoot = URI
-            .create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT);
+            .create(Platform.guess().getNodeDownloadRoot());
 
     private boolean ignoreVersionChecks;
     private boolean forceAlternativeNode = Constants.DEFAULT_REQUIRE_HOME_NODE_EXECUTABLE;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -34,6 +34,7 @@ import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.PwaConfiguration;
 import com.vaadin.flow.server.frontend.installer.NodeInstaller;
+import com.vaadin.flow.server.frontend.installer.Platform;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 
@@ -140,7 +141,7 @@ public class NodeTasks implements FallibleCommand {
          * {@link NodeInstaller#DEFAULT_NODEJS_DOWNLOAD_ROOT}.
          */
         private URI nodeDownloadRoot = URI
-                .create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT);
+                .create(Platform.guess().getNodeDownloadRoot());
 
         private boolean nodeAutoUpdate = false;
 


### PR DESCRIPTION
As the default download root might be
different depending on the used system
we should not use a hardcoded default if
user has not given a download root.

Fixes #13837
