### PR TITLE
fix: Write version.json from the currently constructed package.json

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -619,12 +619,14 @@ public abstract class NodeUpdater implements FallibleCommand {
      * @throws IOException
      *             when file IO fails
      */
-    protected String generateVersionsJson() throws IOException {
+    protected String generateVersionsJson(JsonObject packageJson)
+            throws IOException {
         File versions = new File(generatedFolder, "versions.json");
 
         JsonObject versionsJson = getPlatformPinnedDependencies();
-        JsonObject packageJsonVersions = generateVersionsFromPackageJson();
-        if (versionsJson == null) {
+        JsonObject packageJsonVersions = generateVersionsFromPackageJson(
+                packageJson);
+        if (versionsJson.keys().length == 0) {
             versionsJson = packageJsonVersions;
         } else {
             for (String key : packageJsonVersions.keys()) {
@@ -653,10 +655,10 @@ public abstract class NodeUpdater implements FallibleCommand {
      * @throws IOException
      *             If reading package.json fails
      */
-    private JsonObject generateVersionsFromPackageJson() throws IOException {
+    private JsonObject generateVersionsFromPackageJson(JsonObject packageJson)
+            throws IOException {
         JsonObject versionsJson = Json.createObject();
         // if we don't have versionsJson lock package dependency versions.
-        final JsonObject packageJson = getPackageJson();
         final JsonObject dependencies = packageJson.getObject(DEPENDENCIES);
         final JsonObject devDependencies = packageJson
                 .getObject(DEV_DEPENDENCIES);

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -101,7 +101,7 @@ public class TaskUpdatePackages extends NodeUpdater {
             JsonObject packageJson = getPackageJson();
             modified = updatePackageJsonDependencies(packageJson,
                     scannedApplicationDependencies);
-            versionsPath = generateVersionsJson();
+            versionsPath = generateVersionsJson(packageJson);
             boolean npmVersionLockingUpdated = lockVersionForNpm(packageJson,
                     versionsPath);
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdatePackagesNpmVersionLockingTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdatePackagesNpmVersionLockingTest.java
@@ -173,8 +173,6 @@ public class NodeUpdatePackagesNpmVersionLockingTest
         packageJson.getObject(DEPENDENCIES).put(TEST_DEPENDENCY,
                 PLATFORM_PINNED_DEPENDENCY_VERSION);
         Assert.assertNull(packageJson.getObject(OVERRIDES));
-        FileUtils.write(packageUpdater.getPackageJsonFile(),
-                packageJson.toJson(), StandardCharsets.UTF_8);
 
         String versionsPath = packageUpdater.generateVersionsJson(packageJson);
         File output = new File(packageUpdater.npmFolder, versionsPath);
@@ -183,8 +181,6 @@ public class NodeUpdatePackagesNpmVersionLockingTest
                         .contains(TEST_DEPENDENCY));
 
         packageJson.getObject(DEPENDENCIES).remove(TEST_DEPENDENCY);
-        FileUtils.write(packageUpdater.getPackageJsonFile(),
-                packageJson.toJson(), StandardCharsets.UTF_8);
 
         packageUpdater.generateVersionsJson(packageJson);
         Assert.assertFalse(

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -395,7 +395,8 @@ public class NodeUpdaterTest {
     @Test
     public void generateVersionsJson_noVersions_noDevDeps_versionsGeneratedFromPackageJson()
             throws IOException {
-        final String versions = nodeUpdater.generateVersionsJson();
+        final String versions = nodeUpdater
+                .generateVersionsJson(Json.createObject());
         Assert.assertNotNull(versions);
 
         File generatedVersionsFile = new File(npmFolder, versions);
@@ -438,7 +439,9 @@ public class NodeUpdaterTest {
             + "}", StandardCharsets.UTF_8);
         // @formatter:on
 
-        final String versions = nodeUpdater.generateVersionsJson();
+        final String versions = nodeUpdater.generateVersionsJson(
+                Json.parse(FileUtils.readFileToString(packageJson,
+                        StandardCharsets.UTF_8)));
         Assert.assertNotNull(versions);
 
         File generatedVersionsFile = new File(npmFolder, versions);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskUpdatePackagesNpmTest.java
@@ -387,7 +387,7 @@ public class TaskUpdatePackagesNpmTest {
 
         verifyVersions(PLATFORM_DIALOG_VERSION, expectedElementMixinVersion,
                 null);
-        verifyVersionLockingWithNpmOverrides(false, true, false);
+        verifyVersionLockingWithNpmOverrides(true, true, false);
         final JsonObject packageJson = getOrCreatePackageJson();
         JsonObject dependencies = packageJson.getObject(DEPENDENCIES);
 


### PR DESCRIPTION
The earlier logic was like
1. Read package.json
2. Modify package.json in memory
3. Generate version.json based on package.json file
4. Write modified package.json to file

Where step 3 ignored what was done in step 2
