### PR TITLE
fix: Do not use a fixed download root (#14632)

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinFlowPluginExtension.kt
@@ -170,7 +170,8 @@ public open class VaadinFlowPluginExtension(project: Project) {
      *
      * Example: `"https://nodejs.org/dist/"`.
      */
-    public var nodeDownloadRoot: String = NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT
+    public var nodeDownloadRoot: String =
+        com.vaadin.flow.server.frontend.installer.Platform.guess().getNodeDownloadRoot()
 
     /**
      * Allow automatic update of node installed to alternate location. Default `false`

--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -41,6 +41,7 @@ import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.frontend.FrontendTools;
 import com.vaadin.flow.server.frontend.installer.NodeInstaller;
+import com.vaadin.flow.server.frontend.installer.Platform;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 
 /**
@@ -109,7 +110,7 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
      * </p>
      * Example: <code>"https://nodejs.org/dist/"</code>.
      */
-    @Parameter(property = "node.download.root", defaultValue = NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT)
+    @Parameter(property = "node.download.root")
     private String nodeDownloadRoot;
 
     /**
@@ -342,7 +343,9 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo
 
     @Override
     public URI nodeDownloadRoot() throws URISyntaxException {
-
+        if (nodeDownloadRoot == null) {
+            nodeDownloadRoot = Platform.guess().getNodeDownloadRoot();
+        }
         try {
             return new URI(nodeDownloadRoot);
         } catch (URISyntaxException e) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -42,6 +42,7 @@ import com.vaadin.flow.server.frontend.FrontendUtils.CommandExecutionException;
 import com.vaadin.flow.server.frontend.FrontendUtils.UnknownVersionException;
 import com.vaadin.flow.server.frontend.installer.InstallationException;
 import com.vaadin.flow.server.frontend.installer.NodeInstaller;
+import com.vaadin.flow.server.frontend.installer.Platform;
 import com.vaadin.flow.server.frontend.installer.ProxyConfig;
 
 /**
@@ -235,7 +236,7 @@ public class FrontendTools {
     public FrontendTools(String baseDir,
             Supplier<String> alternativeDirGetter) {
         this(baseDir, alternativeDirGetter, DEFAULT_NODE_VERSION,
-                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT), false,
+                URI.create(Platform.guess().getNodeDownloadRoot()), false,
                 false);
     }
 
@@ -265,7 +266,7 @@ public class FrontendTools {
     public FrontendTools(String baseDir, Supplier<String> alternativeDirGetter,
             boolean forceAlternativeNode) {
         this(baseDir, alternativeDirGetter, DEFAULT_NODE_VERSION,
-                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT),
+                URI.create(Platform.guess().getNodeDownloadRoot()),
                 forceAlternativeNode, false);
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsSettings.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendToolsSettings.java
@@ -23,6 +23,7 @@ import java.util.function.Supplier;
 import com.vaadin.flow.function.SerializableSupplier;
 import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.frontend.installer.NodeInstaller;
+import com.vaadin.flow.server.frontend.installer.Platform;
 
 import static com.vaadin.flow.server.frontend.FrontendTools.DEFAULT_NODE_VERSION;
 
@@ -39,7 +40,7 @@ public class FrontendToolsSettings implements Serializable {
 
     private String nodeVersion = DEFAULT_NODE_VERSION;
     private URI nodeDownloadRoot = URI
-            .create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT);
+            .create(Platform.guess().getNodeDownloadRoot());
 
     private boolean ignoreVersionChecks;
     private boolean forceAlternativeNode = Constants.DEFAULT_REQUIRE_HOME_NODE_EXECUTABLE;

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -33,6 +33,7 @@ import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.PwaConfiguration;
 import com.vaadin.flow.server.frontend.installer.NodeInstaller;
+import com.vaadin.flow.server.frontend.installer.Platform;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 
@@ -141,7 +142,7 @@ public class NodeTasks implements FallibleCommand {
          * {@link NodeInstaller#DEFAULT_NODEJS_DOWNLOAD_ROOT}.
          */
         private URI nodeDownloadRoot = URI
-                .create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT);
+                .create(Platform.guess().getNodeDownloadRoot());
 
         private boolean nodeAutoUpdate = false;
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateImportsTest.java
@@ -435,35 +435,36 @@ public class NodeUpdateImportsTest extends NodeUpdateTestUtil {
         Assert.assertEquals(expectedJsModules, jsModules.toJson());
         Assert.assertEquals(expectedCssImports, cssImports.toJson());
 
-        String actual = FileUtils.readFileToString(tokenFile, StandardCharsets.UTF_8);
-        String expected = "{\n"+ //
-        "  \"chunks\": {\n"+ //
-        "    \"fallback\": {\n"+ //
-        "      \"jsModules\": [\n"+ //
-        "        \"@polymer/e.js\",\n"+ //
-        "        \"@polymer/D.js\",\n"+ //
-        "        \"@polymer/c.js\",\n"+ //
-        "        \"@polymer/b.js\",\n"+ //
-        "        \"@polymer/a.js\",\n"+ //
-        "        \"./extra-javascript.js\"\n"+ //
-        "      ],\n"+ //
-        "      \"cssImports\": [\n"+ //
-        "        {\n"+ //
-        "          \"value\": \"./b-css.css\"\n"+ //
-        "        },\n"+ //
-        "        {\n"+ //
-        "          \"include\": \"a-a\",\n"+ //
-        "          \"value\": \"./a-css.css\"\n"+ //
-        "        },\n"+ //
-        "        {\n"+ //
-        "          \"include\": \"extra-bar\",\n"+ //
-        "          \"themeFor\": \"extra-foo\",\n"+ //
-        "          \"value\": \"./extra-css.css\"\n"+ //
-        "        }\n"+ //
-        "      ]\n"+ //
-        "    }\n"+ //
-        "  }\n"+ //
-        "}";
+        String actual = FileUtils.readFileToString(tokenFile,
+                StandardCharsets.UTF_8);
+        String expected = "{\n" + //
+                "  \"chunks\": {\n" + //
+                "    \"fallback\": {\n" + //
+                "      \"jsModules\": [\n" + //
+                "        \"@polymer/e.js\",\n" + //
+                "        \"@polymer/D.js\",\n" + //
+                "        \"@polymer/c.js\",\n" + //
+                "        \"@polymer/b.js\",\n" + //
+                "        \"@polymer/a.js\",\n" + //
+                "        \"./extra-javascript.js\"\n" + //
+                "      ],\n" + //
+                "      \"cssImports\": [\n" + //
+                "        {\n" + //
+                "          \"value\": \"./b-css.css\"\n" + //
+                "        },\n" + //
+                "        {\n" + //
+                "          \"include\": \"a-a\",\n" + //
+                "          \"value\": \"./a-css.css\"\n" + //
+                "        },\n" + //
+                "        {\n" + //
+                "          \"include\": \"extra-bar\",\n" + //
+                "          \"themeFor\": \"extra-foo\",\n" + //
+                "          \"value\": \"./extra-css.css\"\n" + //
+                "        }\n" + //
+                "      ]\n" + //
+                "    }\n" + //
+                "  }\n" + //
+                "}";
         Assert.assertEquals(expected, actual);
 
     }


### PR DESCRIPTION
As the default download root might be
different depending on the used system
we should not use a hardcoded default if
user has not given a download root.

Fixes #13837
