### PR TITLE
fix: Do not use a fixed download root (#14632)

### DIFF
--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/BuildFrontendMojo.java
@@ -46,6 +46,7 @@ import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.frontend.FrontendTools;
 import com.vaadin.flow.server.frontend.FrontendUtils;
 import com.vaadin.flow.server.frontend.NodeTasks;
+import com.vaadin.flow.server.frontend.installer.Platform;
 import com.vaadin.flow.theme.Theme;
 
 import elemental.json.JsonObject;
@@ -176,6 +177,9 @@ public class BuildFrontendMojo extends FlowModeAbstractMojo {
                 .map(Artifact::getFile).collect(Collectors.toSet());
 
         final URI nodeDownloadRootURI;
+        if(nodeDownloadRoot == null) {
+            nodeDownloadRoot = Platform.guess().getNodeDownloadRoot();
+        }
         try {
             nodeDownloadRootURI = new URI(nodeDownloadRoot);
         } catch (URISyntaxException e) {

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/FlowModeAbstractMojo.java
@@ -108,7 +108,7 @@ public abstract class FlowModeAbstractMojo extends AbstractMojo {
      * <p></p>
      * Example: <code>"https://nodejs.org/dist/"</code>.
      */
-    @Parameter(property = NODE_DOWNLOAD_ROOT, defaultValue = NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT)
+    @Parameter(property = NODE_DOWNLOAD_ROOT)
     protected String nodeDownloadRoot;
 
     /**

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
@@ -42,6 +42,7 @@ import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.frontend.FrontendTools;
 import com.vaadin.flow.server.frontend.FrontendUtils;
 import com.vaadin.flow.server.frontend.NodeTasks;
+import com.vaadin.flow.server.frontend.installer.Platform;
 
 import elemental.json.Json;
 import elemental.json.JsonObject;
@@ -125,6 +126,10 @@ public class PrepareFrontendMojo extends FlowModeAbstractMojo {
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         super.execute();
+
+        if(nodeDownloadRoot == null) {
+            nodeDownloadRoot = Platform.guess().getNodeDownloadRoot();
+        }
 
         // propagate info via System properties and token file
         propagateBuildInfo();

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -42,6 +42,7 @@ import com.vaadin.flow.server.frontend.FrontendUtils.CommandExecutionException;
 import com.vaadin.flow.server.frontend.FrontendUtils.UnknownVersionException;
 import com.vaadin.flow.server.frontend.installer.InstallationException;
 import com.vaadin.flow.server.frontend.installer.NodeInstaller;
+import com.vaadin.flow.server.frontend.installer.Platform;
 import com.vaadin.flow.server.frontend.installer.ProxyConfig;
 
 /**
@@ -189,7 +190,7 @@ public class FrontendTools {
     public FrontendTools(String baseDir, Supplier<String> alternativeDirGetter,
             boolean forceAlternativeNode) {
         this(baseDir, alternativeDirGetter, DEFAULT_NODE_VERSION,
-                URI.create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT),
+                URI.create(Platform.guess().getNodeDownloadRoot()),
                 forceAlternativeNode);
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -27,6 +27,7 @@ import java.util.Set;
 
 import com.vaadin.flow.server.ExecutionFailedException;
 import com.vaadin.flow.server.frontend.installer.NodeInstaller;
+import com.vaadin.flow.server.frontend.installer.Platform;
 import com.vaadin.flow.server.frontend.scanner.ClassFinder;
 import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 
@@ -118,7 +119,7 @@ public class NodeTasks implements FallibleCommand {
          * {@link NodeInstaller#DEFAULT_NODEJS_DOWNLOAD_ROOT}.
          */
         private URI nodeDownloadRoot = URI
-                .create(NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT);
+                .create(Platform.guess().getNodeDownloadRoot());
 
         /**
          * Create a builder instance given an specific npm folder.


### PR DESCRIPTION
As the default download root might be
different depending on the used system
we should not use a hardcoded default if
user has not given a download root.

Fixes #13837
