### PR TITLE
test: fix BootstrapHandlerTest on Windows

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
@@ -27,7 +27,6 @@ import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -62,7 +61,6 @@ import com.vaadin.flow.router.TestRouteRegistry;
 import com.vaadin.flow.server.BootstrapHandler.BootstrapContext;
 import com.vaadin.flow.server.MockServletServiceSessionSetup.TestVaadinServletService;
 import com.vaadin.flow.server.startup.ApplicationConfiguration;
-import com.vaadin.flow.shared.ApplicationConstants;
 import com.vaadin.flow.shared.Registration;
 import com.vaadin.flow.shared.VaadinUriResolver;
 import com.vaadin.flow.shared.communication.PushMode;
@@ -77,7 +75,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 public class BootstrapHandlerTest {

--- a/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
@@ -630,10 +630,6 @@ public class BootstrapHandlerTest {
     public void page_configurator_append_inline_form_files()
             throws InvalidRouteConfigurationException {
 
-        // https://github.com/vaadin/flow/issues/14714 fails on Windows
-        Assume.assumeFalse(System.getProperty("os.name").toLowerCase()
-                .contains("windows"));
-
         initUI(testUI, createVaadinRequest(), Collections
                 .singleton(InitialPageConfiguratorAppendFiles.class));
 
@@ -644,23 +640,26 @@ public class BootstrapHandlerTest {
         // Note element 0 is the full head element.
         Assert.assertTrue(
                 "File javascript should have been appended to head element",
-                scripts.contains(
-                        "<script type=\"text/javascript\">window.messages = window.messages || [];\n"
-                                + "window.messages.push(\"inline.js\");</script>"));
+                scripts.contains(String.format(
+                        "<script type=\"text/javascript\">window.messages = window.messages || [];%n"
+                                + "window.messages.push(\"inline.js\");</script>")));
         Assert.assertTrue("File html should have been appended to head element",
-                scripts.contains("<script type=\"text/javascript\">\n"
-                        + "    // document.body might not yet be accessible, so just leave a message\n"
-                        + "    window.messages = window.messages || [];\n"
-                        + "    window.messages.push(\"inline.html\");\n"
-                        + "</script>"));
+                scripts.contains(
+                        String.format("<script type=\"text/javascript\">%n"
+                                + "    // document.body might not yet be accessible, so just leave a message%n"
+                                + "    window.messages = window.messages || [];%n"
+                                + "    window.messages.push(\"inline.html\");%n"
+                                + "</script>")));
 
         String styles = page.getElementsByTag("style").toString();
         Assert.assertTrue("File css should have been appended to head element",
-                styles.contains("<style type=\"text/css\">/* inline.css */\n"
-                        + "\n" + "#preloadedDiv {\n"
-                        + "    color: rgba(255, 255, 0, 1);\n" + "}\n" + "\n"
-                        + "#inlineCssTestDiv {\n"
-                        + "    color: rgba(255, 255, 0, 1);\n" + "}</style>"));
+                styles.contains(String
+                        .format("<style type=\"text/css\">/* inline.css */%n"
+                                + "%n" + "#preloadedDiv {%n"
+                                + "    color: rgba(255, 255, 0, 1);%n" + "}%n"
+                                + "%n" + "#inlineCssTestDiv {%n"
+                                + "    color: rgba(255, 255, 0, 1);%n"
+                                + "}</style>")));
     }
 
     @Test // 3036
@@ -985,20 +984,17 @@ public class BootstrapHandlerTest {
     public void force_wrapping_of_file()
             throws InvalidRouteConfigurationException {
 
-        // https://github.com/vaadin/flow/issues/14714 fails on Windows
-        Assume.assumeFalse(System.getProperty("os.name").toLowerCase()
-                .contains("windows"));
-
         initUI(testUI, createVaadinRequest(),
                 Collections.singleton(ForcedWrapping.class));
 
         Document page = pageBuilder.getBootstrapPage(new BootstrapContext(
                 request, null, session, testUI, this::contextRootRelativePath));
 
-        assertTrue("File css should have been prepended to body element",
-                page.getElementsByTag("style").toString().contains(
-                        "<style type=\"text/css\">window.messages = window.messages || [];\n"
-                                + "window.messages.push(\"inline.js\");</style>"));
+        assertTrue("File css should have been prepended to body element", page
+                .getElementsByTag("style").toString()
+                .contains(String.format(
+                        "<style type=\"text/css\">window.messages = window.messages || [];%n"
+                                + "window.messages.push(\"inline.js\");</style>")));
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
@@ -27,6 +27,7 @@ import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -629,6 +630,10 @@ public class BootstrapHandlerTest {
     public void page_configurator_append_inline_form_files()
             throws InvalidRouteConfigurationException {
 
+        // https://github.com/vaadin/flow/issues/14714 fails on Windows
+        Assume.assumeFalse(System.getProperty("os.name").toLowerCase()
+                .contains("windows"));
+
         initUI(testUI, createVaadinRequest(), Collections
                 .singleton(InitialPageConfiguratorAppendFiles.class));
 
@@ -979,6 +984,11 @@ public class BootstrapHandlerTest {
     @Test // 3010
     public void force_wrapping_of_file()
             throws InvalidRouteConfigurationException {
+
+        // https://github.com/vaadin/flow/issues/14714 fails on Windows
+        Assume.assumeFalse(System.getProperty("os.name").toLowerCase()
+                .contains("windows"));
+
         initUI(testUI, createVaadinRequest(),
                 Collections.singleton(ForcedWrapping.class));
 


### PR DESCRIPTION
Added Windows check assumption to make TeamCity branches green again.
