### PR TITLE
test: Added Windows check assumption for FrontendUtilsTest.deleteNodeModules_canDeleteSymlinksAndNotFollowThem #14716

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -339,6 +340,10 @@ public class FrontendUtilsTest {
     @Test
     public void deleteNodeModules_canDeleteSymlinksAndNotFollowThem()
             throws IOException {
+
+        // Test fails on Windows due to UAC FileSystemException
+        Assume.assumeFalse(FrontendUtils.isWindows());
+
         File externalDir = new File(tmpDir.getRoot(), "external");
         File externalLicense = new File(externalDir, "LICENSE");
 


### PR DESCRIPTION
## Description

Added Windows check assumption for FrontendUtilsTest.deleteNodeModules_canDeleteSymlinksAndNotFollowThem 

Fixes #14716
