### PR TITLE
fix: Make serialization work when server is stopping

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
@@ -134,6 +134,8 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
 
     private final StreamResourceRegistry resourceRegistry;
 
+    private boolean serializeUIs = true;
+
     /**
      * Creates a new VaadinSession tied to a VaadinService.
      *
@@ -143,6 +145,12 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
     public VaadinSession(VaadinService service) {
         this.service = service;
         resourceRegistry = createStreamResourceRegistry();
+        ApplicationConfiguration appConfiguration = ApplicationConfiguration
+                .get(getService().getContext());
+        if (!appConfiguration.isProductionMode()
+                && !appConfiguration.isDevModeSessionSerializationEnabled()) {
+            serializeUIs = false;
+        }
     }
 
     /**
@@ -1064,20 +1072,6 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
 
     private void writeObject(java.io.ObjectOutputStream stream)
             throws IOException {
-        boolean serializeUIs = true;
-
-        // If service is null it has just been deserialized and should be
-        // serialized in
-        // the same way again
-        if (getService() != null) {
-            ApplicationConfiguration appConfiguration = ApplicationConfiguration
-                    .get(getService().getContext());
-            if (!appConfiguration.isProductionMode() && !appConfiguration
-                    .isDevModeSessionSerializationEnabled()) {
-                serializeUIs = false;
-            }
-        }
-
         stream.defaultWriteObject();
         if (serializeUIs) {
             stream.writeObject(uIs);


### PR DESCRIPTION
When server is stopping there is not necessarily any context information available and serialization can fail with

```
java.lang.IllegalStateException: The application Lookup instance is not found in the interface com.vaadin.flow.server.VaadinContext instance. It means that the container has not executed Lookup initialization code: so either the container is not Servlet 3.0 compatible or project configuration is broken.
        at com.vaadin.flow.server.startup.ApplicationConfiguration.lambda$get$0(ApplicationConfiguration.java:56) ~[flow-server-23.3.sess-SNAPSHOT.jar:23.3.sess-SNAPSHOT]
        at com.vaadin.flow.server.VaadinServletContext.getAttribute(VaadinServletContext.java:73) ~[flow-server-23.3.sess-SNAPSHOT.jar:23.3.sess-SNAPSHOT]
        at com.vaadin.flow.server.startup.ApplicationConfiguration.get(ApplicationConfiguration.java:48) ~[flow-server-23.3.sess-SNAPSHOT.jar:23.3.sess-SNAPSHOT]
        at com.vaadin.flow.server.VaadinSession.writeObject(VaadinSession.java:1080) ~[flow-server-23.3.sess-SNAPSHOT.jar:23.3.sess-SNAPSHOT]
```
