### PR TITLE
fix: locking on FeatureFlags instead of VaadinContext (#13962)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
+++ b/flow-server/src/main/java/com/vaadin/experimental/FeatureFlags.java
@@ -147,7 +147,7 @@ public class FeatureFlags implements Serializable {
         assert context != null;
 
         FeatureFlagsWrapper attribute;
-        synchronized (context) {
+        synchronized (FeatureFlags.class) {
             attribute = context.getAttribute(FeatureFlagsWrapper.class);
 
             if (attribute == null) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletContext.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletContext.java
@@ -67,7 +67,7 @@ public class VaadinServletContext implements VaadinContext {
     @Override
     public <T> T getAttribute(Class<T> type, Supplier<T> defaultValueSupplier) {
         ensureServletContext();
-        synchronized (getContext()) {
+        synchronized (this) {
             Object result = getContext().getAttribute(type.getName());
             if (result == null && defaultValueSupplier != null) {
                 result = defaultValueSupplier.get();
@@ -82,7 +82,7 @@ public class VaadinServletContext implements VaadinContext {
         if (value == null) {
             removeAttribute(clazz);
         } else {
-            synchronized (getContext()) {
+            synchronized (this) {
                 checkLookupDuplicate(clazz);
                 getContext().setAttribute(clazz.getName(), value);
             }
@@ -91,7 +91,7 @@ public class VaadinServletContext implements VaadinContext {
 
     @Override
     public void removeAttribute(Class<?> clazz) {
-        synchronized (getContext()) {
+        synchronized (this) {
             checkLookupDuplicate(clazz);
             getContext().removeAttribute(clazz.getName());
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletContext.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinServletContext.java
@@ -67,7 +67,7 @@ public class VaadinServletContext implements VaadinContext {
     @Override
     public <T> T getAttribute(Class<T> type, Supplier<T> defaultValueSupplier) {
         ensureServletContext();
-        synchronized (this) {
+        synchronized (getContext()) {
             Object result = getContext().getAttribute(type.getName());
             if (result == null && defaultValueSupplier != null) {
                 result = defaultValueSupplier.get();
@@ -82,7 +82,7 @@ public class VaadinServletContext implements VaadinContext {
         if (value == null) {
             removeAttribute(clazz);
         } else {
-            synchronized (this) {
+            synchronized (getContext()) {
                 checkLookupDuplicate(clazz);
                 getContext().setAttribute(clazz.getName(), value);
             }
@@ -91,7 +91,7 @@ public class VaadinServletContext implements VaadinContext {
 
     @Override
     public void removeAttribute(Class<?> clazz) {
-        synchronized (this) {
+        synchronized (getContext()) {
             checkLookupDuplicate(clazz);
             getContext().removeAttribute(clazz.getName());
         }


### PR DESCRIPTION
## Description

> Potential solutions (I did not really think these through):
> 
> Lock on vaadin context in getCachedIndexHtmlDocument to avoid locking in another order. Seems quite fragile and there might be other similar cases here and there.
> Use the same object for locking in all cases. Can't see why we really need to synchronize on different ones for these operations

Only lock on FeatureFlags when checking for wrapper and initializing

Fixes #13962 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
