### PR TITLE
fix: ignore nonexistent nodes during resync

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/flow/StateTree.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/StateTree.java
@@ -158,6 +158,7 @@ public class StateTree {
 
     /**
      * Check if tree is resynchronizing after a {@link #prepareForResync}
+     *
      * @return true if resync called
      */
     public boolean isResync() {
@@ -166,7 +167,9 @@ public class StateTree {
 
     /**
      * Set the resynchronization state for the StateTree.
-     * @param resync resynchronization state to set
+     *
+     * @param resync
+     *            resynchronization state to set
      */
     public void setResync(boolean resync) {
         this.resync = resync;

--- a/flow-client/src/main/java/com/vaadin/client/flow/StateTree.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/StateTree.java
@@ -50,6 +50,7 @@ public class StateTree {
     private JsMap<Integer, String> nodeFeatureDebugName;
 
     private boolean updateInProgress;
+    private boolean resync;
 
     /**
      * Creates a new instance connected to the given registry.
@@ -152,6 +153,23 @@ public class StateTree {
                 node.setParent(null);
             }
         });
+        setResync(true);
+    }
+
+    /**
+     * Check if tree is resynchronizing after a {@link #prepareForResync}
+     * @return true if resync called
+     */
+    public boolean isResync() {
+        return resync;
+    }
+
+    /**
+     * Set the resynchronization state for the StateTree.
+     * @param resync resynchronization state to set
+     */
+    public void setResync(boolean resync) {
+        this.resync = resync;
     }
 
     /**
@@ -482,5 +500,4 @@ public class StateTree {
             return "Unknown node feature: " + id;
         }
     }
-
 }

--- a/flow-client/src/main/java/com/vaadin/client/flow/TreeChangeProcessor.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/TreeChangeProcessor.java
@@ -65,7 +65,7 @@ public class TreeChangeProcessor {
                 JsonObject change = changes.getObject(i);
                 if (!isAttach(change)) {
                     final StateNode value = processChange(tree, change);
-                    if(value != null) {
+                    if (value != null) {
                         nodes.add(value);
                     }
                 }

--- a/flow-client/src/main/java/com/vaadin/client/flow/TreeChangeProcessor.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/TreeChangeProcessor.java
@@ -64,12 +64,16 @@ public class TreeChangeProcessor {
             for (int i = 0; i < length; i++) {
                 JsonObject change = changes.getObject(i);
                 if (!isAttach(change)) {
-                    nodes.add(processChange(tree, change));
+                    final StateNode value = processChange(tree, change);
+                    if(value != null) {
+                        nodes.add(value);
+                    }
                 }
             }
             return nodes;
         } finally {
             tree.setUpdateInProgress(false);
+            tree.setResync(false);
         }
     }
 
@@ -112,7 +116,11 @@ public class TreeChangeProcessor {
         int nodeId = (int) change.getNumber(JsonConstants.CHANGE_NODE);
 
         StateNode node = tree.getNode(nodeId);
-        assert node != null;
+        if (node == null && tree.isResync()) {
+            // Resync should not stop handling changes
+            return node;
+        }
+        assert node != null : "No attached node found";
 
         switch (type) {
         case JsonConstants.CHANGE_TYPE_NOOP:

--- a/flow-client/src/test/java/com/vaadin/client/flow/TreeChangeProcessorTest.java
+++ b/flow-client/src/test/java/com/vaadin/client/flow/TreeChangeProcessorTest.java
@@ -64,6 +64,21 @@ public class TreeChangeProcessorTest {
     }
 
     @Test
+    public void resync_withDetachForNonexistentNode_noAssertionFailure() {
+        StateNode child = new StateNode(2, tree);
+
+        JsonObject change = detachChange(child.getId());
+
+        tree.prepareForResync();
+
+        try {
+            TreeChangeProcessor.processChange(tree, change);
+        }catch (AssertionError ae) {
+            Assert.fail("Should not fail for an nonexistent node on resync");
+        }
+    }
+
+    @Test
     public void testMapRemoveChange() {
         MapProperty property = tree.getRootNode().getMap(ns).getProperty(myKey);
         property.setValue(myValue);

--- a/flow-client/src/test/java/com/vaadin/client/flow/TreeChangeProcessorTest.java
+++ b/flow-client/src/test/java/com/vaadin/client/flow/TreeChangeProcessorTest.java
@@ -73,7 +73,7 @@ public class TreeChangeProcessorTest {
 
         try {
             TreeChangeProcessor.processChange(tree, change);
-        }catch (AssertionError ae) {
+        } catch (AssertionError ae) {
             Assert.fail("Should not fail for an nonexistent node on resync");
         }
     }


### PR DESCRIPTION
Ignore changes for nodes that are not
available in the tree when a resync is underway.

This will get the page to a working
condition after a resync as all changes for
existing nodes are executed.

Fixes #14232
Fixes #14470

