### PR TITLE
fix: ignore nonexistent nodes during resync (#14749)

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/flow/StateTree.java
+++ b/flow-client/src/main/java/com/vaadin/client/flow/StateTree.java
@@ -50,6 +50,7 @@ public class StateTree {
     private JsMap<Integer, String> nodeFeatureDebugName;
 
     private boolean updateInProgress;
+    private boolean resync;
 
     /**
      * Creates a new instance connected to the given registry.
@@ -158,6 +159,26 @@ public class StateTree {
                 }
             }
         });
+        setResync(true);
+    }
+
+    /**
+     * Check if tree is resynchronizing after a {@link #prepareForResync}
+     *
+     * @return true if resync called
+     */
+    public boolean isResync() {
+        return resync;
+    }
+
+    /**
+     * Set the resynchronization state for the StateTree.
+     *
+     * @param resync
+     *            resynchronization state to set
+     */
+    public void setResync(boolean resync) {
+        this.resync = resync;
     }
 
     /**
@@ -477,5 +498,4 @@ public class StateTree {
             return "Unknown node feature: " + id;
         }
     }
-
 }

--- a/flow-client/src/test/java/com/vaadin/client/flow/TreeChangeProcessorTest.java
+++ b/flow-client/src/test/java/com/vaadin/client/flow/TreeChangeProcessorTest.java
@@ -64,6 +64,21 @@ public class TreeChangeProcessorTest {
     }
 
     @Test
+    public void resync_withDetachForNonexistentNode_noAssertionFailure() {
+        StateNode child = new StateNode(2, tree);
+
+        JsonObject change = detachChange(child.getId());
+
+        tree.prepareForResync();
+
+        try {
+            TreeChangeProcessor.processChange(tree, change);
+        } catch (AssertionError ae) {
+            Assert.fail("Should not fail for an nonexistent node on resync");
+        }
+    }
+
+    @Test
     public void testMapRemoveChange() {
         MapProperty property = tree.getRootNode().getMap(ns).getProperty(myKey);
         property.setValue(myValue);


### PR DESCRIPTION
Ignore changes for nodes that are not
available in the tree when a resync is underway.

This will get the page to a working
condition after a resync as all changes for
existing nodes are executed.

Fixes #14232
Fixes #14470