### PR TITLE
feat: Allow specifying vaadin.devServerPort to connect to an already running dev server

### DIFF
--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -45,6 +45,7 @@
         <vaadin.eagerServerLoad>false</vaadin.eagerServerLoad>
         <!-- make sure we do not leave webpack-dev-server running after IT -->
         <vaadin.reuseDevServer>false</vaadin.reuseDevServer>
+        <vaadin.devServerPort>0</vaadin.devServerPort>
     </properties>
 
     <dependencies>
@@ -224,6 +225,7 @@
                             <vaadin.devmode.liveReload.enabled>${vaadin.devmode.liveReload.enabled}</vaadin.devmode.liveReload.enabled>
                             <vaadin.allow.appshell.annotations>${vaadin.allow.appshell.annotations}</vaadin.allow.appshell.annotations>
 			    <vaadin.eagerServerLoad>${vaadin.eagerServerLoad}</vaadin.eagerServerLoad>
+			    <vaadin.devServerPort>${vaadin.devServerPort}</vaadin.devServerPort>
                             <jetty.scantrigger>${jetty.scantrigger}</jetty.scantrigger>
                             <!-- Allow test clients not on localhost to connect to Vite-->
                             <vaadin.devmode.vite.options>${vaadin.devmode.vite.options}</vaadin.devmode.vite.options>

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
@@ -367,12 +367,14 @@ public class DevModeInitializer implements Serializable {
 
         Lookup devServerLookup = Lookup.compose(lookup,
                 Lookup.of(config, ApplicationConfiguration.class));
+        int port = Integer
+                .parseInt(config.getStringProperty("devServerPort", "0"));
         if (featureFlags.isEnabled(FeatureFlags.WEBPACK)) {
-            return new WebpackHandler(devServerLookup, 0,
+            return new WebpackHandler(devServerLookup, port,
                     builder.getNpmFolder(), nodeTasksFuture);
         } else {
-            return new ViteHandler(devServerLookup, 0, builder.getNpmFolder(),
-                    nodeTasksFuture);
+            return new ViteHandler(devServerLookup, port,
+                    builder.getNpmFolder(), nodeTasksFuture);
         }
     }
 


### PR DESCRIPTION
This is only meant for debugging the dev server itself and the connection to it
