### PR TITLE
fix: moved JSR356 atmosphere parameters set to PushRequestHandler

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PushRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PushRequestHandler.java
@@ -221,6 +221,15 @@ public class PushRequestHandler
         atmosphere.addInitParameter("org.atmosphere.cpr.showSupportMessage",
                 "false");
 
+        String pushUrl = vaadinServletConfig
+                .getInitParameter(InitParameters.SERVLET_PARAMETER_PUSH_URL);
+        if (pushUrl != null) {
+            atmosphere.addInitParameter(ApplicationConfig.JSR356_MAPPING_PATH,
+                    pushUrl);
+        }
+        atmosphere.addInitParameter(
+                ApplicationConfig.JSR356_PATH_MAPPING_LENGTH, "0");
+
         try {
             atmosphere.init(vaadinServletConfig);
 

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringBootAutoConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringBootAutoConfiguration.java
@@ -34,7 +34,6 @@ import org.springframework.util.ClassUtils;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.socket.server.standard.ServerEndpointExporter;
 
-import com.vaadin.flow.router.internal.PathUtil;
 import com.vaadin.flow.server.VaadinServlet;
 
 import static com.vaadin.flow.server.Constants.VAADIN_PREFIX;
@@ -94,13 +93,13 @@ public class SpringBootAutoConfiguration {
 
         String pushUrl = context.getEnvironment()
                 .getProperty(VAADIN_PREFIX + SERVLET_PARAMETER_PUSH_URL);
-        if (pushUrl != null) {
-            if (!pushUrl.startsWith("/")) {
-                pushUrl = (rootMapping ? ""
-                        : PathUtil.trimSegmentsString(mapping)) + "/" + pushUrl;
-            }
-            initParameters.put(SERVLET_PARAMETER_PUSH_URL, pushUrl);
+        String defaultPushUrl = rootMapping ? "" : mapping.replace("/*", "");
+        if (pushUrl == null) {
+            pushUrl = defaultPushUrl;
+        } else if (!pushUrl.startsWith("/")) {
+            pushUrl = defaultPushUrl + "/" + pushUrl;
         }
+        initParameters.put(SERVLET_PARAMETER_PUSH_URL, pushUrl);
 
         ServletRegistrationBean<SpringServlet> registration = new ServletRegistrationBean<>(
                 new SpringServlet(context, rootMapping), mapping);

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinMVCWebAppInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinMVCWebAppInitializer.java
@@ -30,8 +30,6 @@ import org.springframework.web.context.ContextLoaderListener;
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
 import org.springframework.web.servlet.DispatcherServlet;
 
-import com.vaadin.flow.router.internal.PathUtil;
-
 import static com.vaadin.flow.server.Constants.VAADIN_PREFIX;
 import static com.vaadin.flow.server.InitParameters.SERVLET_PARAMETER_PUSH_URL;
 
@@ -74,15 +72,15 @@ public abstract class VaadinMVCWebAppInitializer
         }
         registration.addMapping(mapping);
 
-        String pushUrl = env
+        String pushUrl = context.getEnvironment()
                 .getProperty(VAADIN_PREFIX + SERVLET_PARAMETER_PUSH_URL);
-        if (pushUrl != null) {
-            if (!pushUrl.startsWith("/")) {
-                pushUrl = (rootMapping ? ""
-                        : PathUtil.trimSegmentsString(mapping)) + "/" + pushUrl;
-            }
-            initParameters.put(SERVLET_PARAMETER_PUSH_URL, pushUrl);
+        String defaultPushUrl = rootMapping ? "" : mapping.replace("/*", "");
+        if (pushUrl == null) {
+            pushUrl = defaultPushUrl;
+        } else if (!pushUrl.startsWith("/")) {
+            pushUrl = defaultPushUrl + "/" + pushUrl;
         }
+        initParameters.put(SERVLET_PARAMETER_PUSH_URL, pushUrl);
 
         registration.setInitParameters(initParameters);
 

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringBootAutoConfigurationRootMappedTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringBootAutoConfigurationRootMappedTest.java
@@ -2,7 +2,6 @@ package com.vaadin.flow.spring;
 
 import java.util.Set;
 
-import org.atmosphere.cpr.ApplicationConfig;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,7 +26,5 @@ public class SpringBootAutoConfigurationRootMappedTest {
         Assert.assertEquals(
                 Set.of(VaadinServletConfiguration.VAADIN_SERVLET_MAPPING),
                 servletRegistrationBean.getUrlMappings());
-        Assert.assertEquals("", servletRegistrationBean.getInitParameters()
-                .get(ApplicationConfig.JSR356_MAPPING_PATH));
     }
 }

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringBootAutoConfigurationUrlMappedTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringBootAutoConfigurationUrlMappedTest.java
@@ -2,7 +2,6 @@ package com.vaadin.flow.spring;
 
 import java.util.Set;
 
-import org.atmosphere.cpr.ApplicationConfig;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,7 +25,5 @@ public class SpringBootAutoConfigurationUrlMappedTest {
                 .isRootMapping(RootMappedCondition.getUrlMapping(environment)));
         Assert.assertEquals(Set.of("/zing/*"),
                 servletRegistrationBean.getUrlMappings());
-        Assert.assertEquals("/zing", servletRegistrationBean.getInitParameters()
-                .get(ApplicationConfig.JSR356_MAPPING_PATH));
     }
 }


### PR DESCRIPTION
## Description

Moved setting JSR356 url mapping parameters to `PushRequestHandler`. Supports both `SpringServlet` and `VaadinServlet` parameters.

`pushURL` does not work with custom `contextPath`.

Fixes #14641

## Type of change

- [x] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
