### PR TITLE
fix: defer location and query tracking (#14742) (CP: 2.8)

### DIFF
--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/navigation/FirstView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/navigation/FirstView.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.navigation;
+
+import java.util.Collections;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Label;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.BeforeEvent;
+import com.vaadin.flow.router.HasUrlParameter;
+import com.vaadin.flow.router.OptionalParameter;
+import com.vaadin.flow.router.QueryParameters;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "com.vaadin.flow.uitest.ui.navigation.FirstView")
+public class FirstView extends Div implements HasUrlParameter<String> {
+
+    static final String PARAM_NAV_BUTTON_ID = "firstViewPramNavButton";
+    static final String NAV_BUTTON_ID = "firstViewNavButton";
+    static final String QUERY_LABEL_ID = "query";
+
+    private final Label queryLabel;
+
+    public FirstView() {
+        queryLabel = new Label();
+        queryLabel.setId(QUERY_LABEL_ID);
+        add(queryLabel);
+
+        NativeButton button = new NativeButton("Change query parameter",
+                e -> UI.getCurrent().navigate(
+                        "com.vaadin.flow.uitest.ui.navigation.FirstView/1",
+                        QueryParameters.simple(
+                                Collections.singletonMap("query", "bar"))));
+        button.setId(PARAM_NAV_BUTTON_ID);
+        add(button);
+
+        button = new NativeButton("Change view", e -> UI.getCurrent()
+                .navigate("com.vaadin.flow.uitest.ui.navigation.SecondView"));
+        button.setId(NAV_BUTTON_ID);
+        add(button);
+
+    }
+
+    @Override
+    public void setParameter(BeforeEvent beforeEvent,
+            @OptionalParameter String param) {
+        queryLabel.setText(beforeEvent.getLocation().getQueryParameters()
+                .getQueryString());
+    }
+}

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/navigation/SecondView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/navigation/SecondView.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.navigation;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.NativeButton;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "com.vaadin.flow.uitest.ui.navigation.SecondView")
+public class SecondView extends Div {
+
+    static final String BUTTON_ID = "secondViewButton";
+
+    public SecondView() {
+        NativeButton button = new NativeButton("Change query parameter",
+                e -> UI.getCurrent().navigate(
+                        "com.vaadin.flow.uitest.ui.navigation.FirstView"));
+        button.setId(BUTTON_ID);
+        add(button);
+    }
+
+}

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/navigation/BrowserNavigationServerRoundTripIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/navigation/BrowserNavigationServerRoundTripIT.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.uitest.ui.navigation;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class BrowserNavigationServerRoundTripIT extends ChromeBrowserTest {
+
+    @Override
+    protected String getTestPath() {
+        return "/view/com.vaadin.flow.uitest.ui.navigation.FirstView";
+    }
+
+    @Test
+    public void testForwardingToViewInSetParameter() {
+        getDriver().get(getRootURL() + getTestPath() + "/1?query=foo");
+        waitForDevServer();
+
+        WebElement button = findElement(By.id(FirstView.PARAM_NAV_BUTTON_ID));
+        button.click();
+
+        final String queryValue0 = findElement(By.id(FirstView.QUERY_LABEL_ID))
+                .getText();
+        Assert.assertEquals("should have received query parameter value 'bar'",
+                "query=bar", queryValue0);
+
+        getDriver().navigate().back();
+
+        final String queryValue1 = findElement(By.id(FirstView.QUERY_LABEL_ID))
+                .getText();
+        Assert.assertEquals("should have received query parameter value 'foo'",
+                "query=foo", queryValue1);
+    }
+
+    @Test
+    public void backAndForwardBrowserButton_triggerServerSideRoundTrip() {
+        open();
+        waitForDevServer();
+
+        WebElement button = findElement(By.id(FirstView.NAV_BUTTON_ID));
+        button.click();
+
+        waitForElementPresent(By.id(SecondView.BUTTON_ID));
+
+        getDriver().navigate().back();
+
+        waitForElementPresent(By.id(FirstView.NAV_BUTTON_ID));
+
+        getDriver().navigate().forward();
+
+        waitForElementPresent(By.id(SecondView.BUTTON_ID));
+    }
+}


### PR DESCRIPTION
Track of location and query string after response from server happens too early when handling server side navigation, because history.pushState is executed within a setTimeout. This change defers the tracking to the next event loop cycle in order to get the correct values.

Fixes #14323
