### PR TITLE
Fix Javadoc rendering in AppShellConfigurator

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/page/AppShellConfigurator.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/AppShellConfigurator.java
@@ -53,6 +53,9 @@ import com.vaadin.flow.server.AppShellSettings;
  * application shell class.
  * <p>
  *
+ * Example:
+ *
+ * <pre>
  * <code>
  * &#64;Meta(name = "Author", content = "Donald Duck")
  * &#64;PWA(name = "My Fun Application", shortName = "fun-app")
@@ -64,6 +67,7 @@ import com.vaadin.flow.server.AppShellSettings;
  * public class AppShell implements AppShellConfigurator {
  * }
  * </code>
+ * </pre>
  *
  * @since 3.0
  */

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -78,13 +78,16 @@ import com.vaadin.flow.spring.security.stateless.VaadinStatelessSecurityConfigur
  * annotate it with <code>@EnableWebSecurity</code> and
  * <code>@Configuration</code>.
  * <p>
- * For example <code>
-&#64;EnableWebSecurity
-&#64;Configuration
-public class MyWebSecurity extends VaadinWebSecurity {
-
-}
+ * For example:
+ *
+ * <pre>
+ * <code>
+ * &#64;EnableWebSecurity
+ * &#64;Configuration
+ * public class MyWebSecurity extends VaadinWebSecurity {
+ * }
  * </code>
+ * </pre>
  */
 public abstract class VaadinWebSecurity {
 

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurityConfigurerAdapter.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurityConfigurerAdapter.java
@@ -72,13 +72,16 @@ import com.vaadin.flow.spring.security.stateless.VaadinStatelessSecurityConfigur
  * annotate it with <code>@EnableWebSecurity</code> and
  * <code>@Configuration</code>.
  * <p>
- * For example <code>
-&#64;EnableWebSecurity
-&#64;Configuration
-public class MySecurityConfigurerAdapter extends VaadinWebSecurityConfigurerAdapter {
-
-}
+ * For example:
+ *
+ * <pre>
+ * <code>
+ * &#64;EnableWebSecurity
+ * &#64;Configuration
+ * public class MySecurityConfigurerAdapter extends VaadinWebSecurityConfigurerAdapter {
+ * }
  * </code>
+ * </pre>
  *
  * @deprecated Use component-based security configuration
  *             {@link VaadinWebSecurity}


### PR DESCRIPTION
## Description

Fixes rendering issue of the example code in the Javadoc for the `AppShellConfigurator` class.
See [Javadoc.io](https://javadoc.io/doc/com.vaadin/flow-server/latest/com/vaadin/flow/component/page/AppShellConfigurator.html) and note how the example code in the class header comment is rendered as one long line.

Fixes #14794.


## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
