### PR TITLE
chore: Update nexus-staging-maven-plugin version

### DIFF
--- a/flow-tests/pom.xml
+++ b/flow-tests/pom.xml
@@ -180,6 +180,7 @@
                 <plugin>
                     <groupId>org.sonatype.plugins</groupId>
                     <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>${nexus.staging.maven.plugin.version}</version>
                     <configuration>
                         <skipNexusStagingDeployMojo>true
                         </skipNexusStagingDeployMojo>

--- a/flow-tests/vaadin-spring-tests/pom.xml
+++ b/flow-tests/vaadin-spring-tests/pom.xml
@@ -274,6 +274,7 @@
                 <plugin>
                     <groupId>org.sonatype.plugins</groupId>
                     <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>${nexus.staging.maven.plugin.version}</version>
                     <configuration>
                         <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,7 @@
         <osgi.core.version>7.0.0</osgi.core.version>
         <osgi.compendium.version>7.0.0</osgi.compendium.version>
         <osgi.annotation.version>7.0.0</osgi.annotation.version>
+        <nexus.staging.maven.plugin.version>1.6.13</nexus.staging.maven.plugin.version>
 
         <maven.test.skip>false</maven.test.skip>
 
@@ -701,6 +702,6 @@
 		    </plugin>
 	        </plugins>
 	    </build>
-        </profile>	    
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
This should fix this [issue with nexus-staging-maven-plugin](https://stackoverflow.com/questions/70153962/nexus-staging-maven-plugin-maven-deploy-failed-an-api-incompatibility-was-enco)