### PR TITLE
chore: update vaadin-parent to 2.1.0 (24.0)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-parent</artifactId>
-        <version>2.0.5</version>
+        <version>2.1.0</version>
     </parent>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,6 @@
         <osgi.core.version>7.0.0</osgi.core.version>
         <osgi.compendium.version>7.0.0</osgi.compendium.version>
         <osgi.annotation.version>7.0.0</osgi.annotation.version>
-        <nexus.staging.maven.plugin.version>1.6.13</nexus.staging.maven.plugin.version>
 
         <maven.test.skip>false</maven.test.skip>
 
@@ -653,11 +652,6 @@
                     <groupId>org.jboss.bridger</groupId>
                     <artifactId>bridger</artifactId>
                     <version>1.6.Final</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>${nexus.staging.maven.plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
for JDK 17 support