### PR TITLE
fix: use access and not lock

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/VaadinSession.java
@@ -210,15 +210,12 @@ public class VaadinSession implements HttpSessionBindingListener, Serializable {
         // the latter case the session field should be set to {@code null}
         // immediately to avoid using HTTP session object which is invalid (all
         // methods throw exceptions).
-        lock();
-        try {
+        access(() -> {
             if (getAttribute(CLOSE_SESSION_EXPLICITLY) == null) {
                 session = null;
             }
             setAttribute(CLOSE_SESSION_EXPLICITLY, null);
-        } finally {
-            unlock();
-        }
+        });
     }
 
     /**

--- a/flow-server/src/test/java/com/vaadin/flow/server/VaadinSessionTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/VaadinSessionTest.java
@@ -27,6 +27,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
@@ -412,6 +413,12 @@ public class VaadinSessionTest {
                 return lock;
             }
 
+            @Override
+            public Future<Void> accessSession(VaadinSession session,
+                    Command command) {
+                command.execute();
+                return Mockito.mock(Future.class);
+            }
         };
 
         VaadinSession vaadinSession = new VaadinSession(mockService) {


### PR DESCRIPTION
Use access so that we do not
block with the lock

Fixes vaadin/multiplatform-runtime#101