### PR TITLE
feat: Register VaadinSecurityContextHolderStrategy as a bean (#14631)

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -39,6 +39,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.annotation.web.configurers.ExpressionUrlAuthorizationConfigurer;
 import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextHolderStrategy;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
@@ -131,11 +132,6 @@ public abstract class VaadinWebSecurity {
      *             if an error occurs
      */
     protected void configure(HttpSecurity http) throws Exception {
-        // Use a security context holder that can find the context from Vaadin
-        // specific classes
-        SecurityContextHolder.setStrategyName(
-                VaadinAwareSecurityContextHolderStrategy.class.getName());
-
         // Respond with 401 Unauthorized HTTP status code for unauthorized
         // requests for protected Hilla endpoints, so that the response could
         // be handled on the client side using e.g. `InvalidSessionMiddleware`.
@@ -181,6 +177,23 @@ public abstract class VaadinWebSecurity {
 
         // Enable view access control
         viewAccessChecker.enable();
+    }
+
+    /**
+     * Registers {@link SecurityContextHolderStrategy} bean.
+     * <p>
+     * Beans of this type will automatically be used by
+     * {@link org.springframework.security.config.annotation.method.configuration.GlobalMethodSecurityConfiguration}
+     * to configure the current {@link SecurityContextHolderStrategy}.
+     */
+    @Bean
+    public SecurityContextHolderStrategy securityContextHolderStrategy() {
+        VaadinAwareSecurityContextHolderStrategy vaadinAwareSecurityContextHolderStrategy = new VaadinAwareSecurityContextHolderStrategy();
+        // Use a security context holder that can find the context from Vaadin
+        // specific classes
+        SecurityContextHolder.setContextHolderStrategy(
+                vaadinAwareSecurityContextHolderStrategy);
+        return vaadinAwareSecurityContextHolderStrategy;
     }
 
     /**

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -186,7 +186,7 @@ public abstract class VaadinWebSecurity {
      * {@link org.springframework.security.config.annotation.method.configuration.GlobalMethodSecurityConfiguration}
      * to configure the current {@link SecurityContextHolderStrategy}.
      */
-    @Bean
+    @Bean(name = "VaadinSecurityContextHolderStrategy")
     public SecurityContextHolderStrategy securityContextHolderStrategy() {
         VaadinAwareSecurityContextHolderStrategy vaadinAwareSecurityContextHolderStrategy = new VaadinAwareSecurityContextHolderStrategy();
         // Use a security context holder that can find the context from Vaadin

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurityConfigurerAdapter.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurityConfigurerAdapter.java
@@ -28,6 +28,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -36,6 +37,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.config.annotation.web.configurers.ExpressionUrlAuthorizationConfigurer;
 import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextHolderStrategy;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.access.AccessDeniedHandlerImpl;
@@ -114,11 +116,6 @@ public abstract class VaadinWebSecurityConfigurerAdapter
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        // Use a security context holder that can find the context from Vaadin
-        // specific classes
-        SecurityContextHolder.setStrategyName(
-                VaadinAwareSecurityContextHolderStrategy.class.getName());
-
         // Respond with 401 Unauthorized HTTP status code for unauthorized
         // requests for protected Hilla endpoints, so that the response could
         // be handled on the client side using e.g. `InvalidSessionMiddleware`.
@@ -159,6 +156,23 @@ public abstract class VaadinWebSecurityConfigurerAdapter
 
         // Enable view access control
         viewAccessChecker.enable();
+    }
+
+    /**
+     * Registers {@link SecurityContextHolderStrategy} bean.
+     * <p>
+     * Beans of this type will automatically be used by
+     * {@link org.springframework.security.config.annotation.method.configuration.GlobalMethodSecurityConfiguration}
+     * to configure the current {@link SecurityContextHolderStrategy}.
+     */
+    @Bean
+    public SecurityContextHolderStrategy securityContextHolderStrategy() {
+        VaadinAwareSecurityContextHolderStrategy vaadinAwareSecurityContextHolderStrategy = new VaadinAwareSecurityContextHolderStrategy();
+        // Use a security context holder that can find the context from Vaadin
+        // specific classes
+        SecurityContextHolder.setContextHolderStrategy(
+                vaadinAwareSecurityContextHolderStrategy);
+        return vaadinAwareSecurityContextHolderStrategy;
     }
 
     /**

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurityConfigurerAdapter.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurityConfigurerAdapter.java
@@ -165,7 +165,7 @@ public abstract class VaadinWebSecurityConfigurerAdapter
      * {@link org.springframework.security.config.annotation.method.configuration.GlobalMethodSecurityConfiguration}
      * to configure the current {@link SecurityContextHolderStrategy}.
      */
-    @Bean
+    @Bean(name = "VaadinSecurityContextHolderStrategy")
     public SecurityContextHolderStrategy securityContextHolderStrategy() {
         VaadinAwareSecurityContextHolderStrategy vaadinAwareSecurityContextHolderStrategy = new VaadinAwareSecurityContextHolderStrategy();
         // Use a security context holder that can find the context from Vaadin


### PR DESCRIPTION
When configuring global method security the GlobalMethodSecurityConfiguration picks up the wrong SecurityContextHolderStrategy because it gets the SecurityContextHolderStrategy from the SecurityContextHolder befor the vaadin security configuration has overridden it. If the GlobalMethodSecurityConfiguration finds a SecurityContextHolderStrategy bean it will use that as the strategy instead of the default picked up from the SecurityContextHolder.

Fixes #14585