### PR TITLE
chore(deps-dev): bump jaxb-impl from 4.0.0 to 4.0.1 (#14600)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <jackson.databind.version>2.13.4</jackson.databind.version>
         <jakarta.validation.version>3.0.1</jakarta.validation.version>
         <jakarta.annotation.api.version>2.0.0</jakarta.annotation.api.version>
-        <jaxb.version>4.0.0</jaxb.version>
+        <jaxb.version>4.0.1</jaxb.version>
 
         <!-- Plugins -->
         <frontend.maven.plugin.version>1.5</frontend.maven.plugin.version>


### PR DESCRIPTION
Reapplies the old commit which was reverted as part of the Servlet 5 upgrade

Bumps jaxb-impl from 4.0.0 to 4.0.1.

---
updated-dependencies:
- dependency-name: com.sun.xml.bind:jaxb-impl dependency-type: direct:development update-type: version-update:semver-patch ...
