### PR TITLE
feat: License checker in Java instead of browser (CP: 2.8)

### DIFF
--- a/flow-client/pom.xml
+++ b/flow-client/pom.xml
@@ -143,11 +143,6 @@
             <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>license-checker</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/flow-client/pom.xml
+++ b/flow-client/pom.xml
@@ -143,7 +143,11 @@
             <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>license-checker</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/flow-client/src/main/resources/META-INF/frontend/License.ts
+++ b/flow-client/src/main/resources/META-INF/frontend/License.ts
@@ -1,0 +1,153 @@
+const noLicenseFallbackTimeout = 1000;
+
+export interface Product {
+  name: string;
+  version: string;
+}
+
+export interface ProductAndMessage {
+  message: string;
+  messageHtml?: string;
+  product: Product;
+}
+
+export const findAll = (element: Element | ShadowRoot | Document, tags: string[]): Element[] => {
+  const lightDom = Array.from(element.querySelectorAll(tags.join(', ')));
+  const shadowDom = Array.from(element.querySelectorAll('*'))
+      .filter((e) => e.shadowRoot)
+      .flatMap((e) => findAll(e.shadowRoot!, tags));
+  return [...lightDom, ...shadowDom];
+};
+
+let licenseCheckListener = false;
+
+const showNoLicenseFallback = (element: Element, productAndMessage: ProductAndMessage) => {
+  if (!licenseCheckListener) {
+    // When a license check has succeeded, refresh so that all elements are properly shown again
+    window.addEventListener(
+        'message',
+        (e) => {
+          if (e.data === 'validate-license') {
+            window.location.reload();
+          }
+        },
+        false
+    );
+    licenseCheckListener = true;
+  }
+  const overlay = (element as any)._overlayElement;
+  if (overlay) {
+    if (overlay.shadowRoot) {
+      const defaultSlot = overlay.shadowRoot.querySelector('slot:not([name])');
+      if (defaultSlot && defaultSlot.assignedElements().length > 0) {
+        showNoLicenseFallback(defaultSlot.assignedElements()[0], productAndMessage);
+        return;
+      }
+    }
+    showNoLicenseFallback(overlay, productAndMessage);
+    return;
+  }
+
+  const htmlMessage = productAndMessage.messageHtml
+      ? productAndMessage.messageHtml
+      : `${productAndMessage.message} <p>Component: ${productAndMessage.product.name} ${productAndMessage.product.version}</p>`.replace(
+          /https:([^ ]*)/g,
+          "<a href='https:$1'>https:$1</a>"
+      );
+
+  if (element.isConnected) {
+    element.outerHTML = `<no-license style="display:flex;align-items:center;text-align:center;justify-content:center;"><div>${htmlMessage}</div></no-license>`;
+  }
+};
+
+const productTagNames: Record<string, string[]> = {};
+const productChecking: Record<string, boolean> = {};
+const productMissingLicense: Record<string, ProductAndMessage> = {};
+const productCheckOk: Record<string, boolean> = {};
+
+const key = (product: Product): string => {
+  return `${product.name}_${product.version}`;
+};
+
+const checkLicenseIfNeeded = (cvdlElement: Element) => {
+  const { cvdlName, version } = cvdlElement.constructor as CustomElementConstructor & {
+    cvdlName: string;
+    version: string;
+  };
+  const product: Product = { name: cvdlName, version };
+  const tagName = cvdlElement.tagName.toLowerCase();
+  productTagNames[cvdlName] = productTagNames[cvdlName] ?? [];
+  productTagNames[cvdlName].push(tagName);
+
+  const failedLicenseCheck = productMissingLicense[key(product)];
+  if (failedLicenseCheck) {
+    // Has been checked and the check failed
+    setTimeout(() => showNoLicenseFallback(cvdlElement, failedLicenseCheck), noLicenseFallbackTimeout);
+  }
+
+  if (productMissingLicense[key(product)] || productCheckOk[key(product)]) {
+    // Already checked
+  } else if (!productChecking[key(product)]) {
+    // Has not been checked
+    productChecking[key(product)] = true;
+    (window as any).Vaadin.devTools.checkLicense(product);
+  }
+};
+
+export const licenseCheckOk = (data: Product) => {
+  productCheckOk[key(data)] = true;
+
+  // eslint-disable-next-line no-console
+  console.debug('License check ok for', data);
+};
+
+export const licenseCheckFailed = (data: ProductAndMessage) => {
+  const productName = data.product.name;
+  productMissingLicense[key(data.product)] = data;
+  // eslint-disable-next-line no-console
+  console.error('License check failed for', productName);
+
+  const tags = productTagNames[productName];
+  if (tags?.length > 0) {
+    findAll(document, tags).forEach((element) => {
+      setTimeout(
+          () => showNoLicenseFallback(element, productMissingLicense[key(data.product)]),
+          noLicenseFallbackTimeout
+      );
+    });
+  }
+};
+
+export const licenseCheckNoKey = (data: ProductAndMessage) => {
+  const keyUrl = data.message;
+
+  const productName = data.product.name;
+  data.messageHtml = `No license found. <a target=_blank onclick="javascript:window.open(this.href);return false;" href="${keyUrl}">Go here to start a trial or retrieve your license.</a>`;
+  productMissingLicense[key(data.product)] = data;
+  // eslint-disable-next-line no-console
+  console.error('No license found when checking', productName);
+
+  const tags = productTagNames[productName];
+  if (tags?.length > 0) {
+    findAll(document, tags).forEach((element) => {
+      setTimeout(
+          () => showNoLicenseFallback(element, productMissingLicense[key(data.product)]),
+          noLicenseFallbackTimeout
+      );
+    });
+  }
+};
+
+export const licenseInit = () => {
+  // Process already registered elements
+  (window as any).Vaadin.devTools.createdCvdlElements.forEach((element: Element) => {
+    checkLicenseIfNeeded(element);
+  });
+
+  // Handle new elements directly
+  (window as any).Vaadin.devTools.createdCvdlElements = {
+    push: (element: Element) => {
+      checkLicenseIfNeeded(element);
+    }
+  };
+};

--- a/flow-client/src/test/frontend/VaadinDevmodeGizmoTests.js
+++ b/flow-client/src/test/frontend/VaadinDevmodeGizmoTests.js
@@ -1,7 +1,7 @@
 const { describe, it } = intern.getPlugin('interface.bdd');
 const { assert } = intern.getPlugin("chai");
 
-import { VaadinDevmodeGizmo } from "../../main/frontend/VaadinDevmodeGizmo";
+import { VaadinDevmodeGizmo } from "../../main/resources/META-INF/frontend/VaadinDevmodeGizmo";
 
 describe('VaadinDevmodeGizmo', () => {
 

--- a/flow-client/tsconfig.json
+++ b/flow-client/tsconfig.json
@@ -3,7 +3,7 @@
     "sourceMap": true,
     "inlineSources": true,
     "module": "esNext",
-    "target": "es2015",
+    "target": "es2019",
     "moduleResolution": "node",
     "strict": true,
     "noFallthroughCasesInSwitch": true,

--- a/flow-data/pom.xml
+++ b/flow-data/pom.xml
@@ -81,11 +81,6 @@
             <version>1.2.0</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>license-checker</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/flow-data/pom.xml
+++ b/flow-data/pom.xml
@@ -81,6 +81,11 @@
             <version>1.2.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>license-checker</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/flow-html-components/pom.xml
+++ b/flow-html-components/pom.xml
@@ -38,12 +38,6 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>license-checker</artifactId>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/flow-html-components/pom.xml
+++ b/flow-html-components/pom.xml
@@ -38,6 +38,12 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>license-checker</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/flow-lit-template/pom.xml
+++ b/flow-lit-template/pom.xml
@@ -39,7 +39,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-        
+
         <!-- Library dependencies -->
 
         <!-- Jsoup for Template, ... -->
@@ -67,6 +67,12 @@
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.core</artifactId>
             <version>${osgi.core.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>license-checker</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/flow-lit-template/pom.xml
+++ b/flow-lit-template/pom.xml
@@ -70,12 +70,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>com.vaadin</groupId>
-            <artifactId>license-checker</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
     </dependencies>
     <build>
         <plugins>

--- a/flow-maven-plugin/pom.xml
+++ b/flow-maven-plugin/pom.xml
@@ -47,7 +47,7 @@
             <artifactId>frontend-plugin-core</artifactId>
             <version>1.6</version>
         </dependency>
-        
+
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>flow-migration</artifactId>
@@ -84,6 +84,11 @@
             <artifactId>plexus-build-api</artifactId>
             <version>0.0.7</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>license-checker</artifactId>
+        </dependency>
     </dependencies>
 
     <!-- Needed for lambdas in Mojos -->
@@ -108,6 +113,6 @@
                 </plugin>
             </plugins>
         </pluginManagement>
-        
+
     </build>
 </project>

--- a/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
+++ b/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/PrepareFrontendMojo.java
@@ -173,7 +173,8 @@ public class PrepareFrontendMojo extends FlowModeAbstractMojo {
                             .runNpmInstall(false)
                             .withNodeVersion(nodeVersion)
                             .withNodeDownloadRoot(nodeDownloadRootURI)
-                            .withHomeNodeExecRequired(requireHomeNodeExec);
+                            .withHomeNodeExecRequired(requireHomeNodeExec)
+                            .withProductionMode(productionMode);
             // If building a jar project copy jar artifact contents now as we might
             // not be able to read files from jar path.
             if("jar".equals(project.getPackaging())) {

--- a/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
+++ b/flow-maven-plugin/src/test/java/com/vaadin/flow/plugin/maven/BuildFrontendMojoTest.java
@@ -17,6 +17,7 @@
 package com.vaadin.flow.plugin.maven;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URL;
@@ -36,6 +37,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.maven.model.Build;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -156,6 +158,16 @@ public class BuildFrontendMojoTest {
         createExpectedImports(frontendDirectory, nodeModulesPath);
         FileUtils.fileWrite(packageJson, "UTF-8",
                 TestUtils.getInitalPackageJson().toJson());
+
+        File resourceOutput = new File(npmFolder, "resOut");
+        ReflectionUtils.setVariableValueInObject(mojo, "webpackOutputDirectory",
+                resourceOutput);
+        File statsJson = new File(new File(resourceOutput, "config"),
+                "stats.json");
+        statsJson.getParentFile().mkdirs();
+        try (FileOutputStream out = new FileOutputStream(statsJson)) {
+            IOUtils.write("{\"npmModules\":[]}", out, StandardCharsets.UTF_8);
+        }
     }
 
     @After

--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -43,6 +43,11 @@
         </dependency>
 
         <!-- Library dependencies -->
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>license-checker</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>com.vaadin.external.gwt</groupId>

--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -46,7 +46,6 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>license-checker</artifactId>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReload.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/BrowserLiveReload.java
@@ -82,4 +82,14 @@ public interface BrowserLiveReload {
      */
     void reload();
 
+    /**
+     * Called when any message is received through the connection.
+     *
+     * @param resource
+     *            the atmosphere resource that received the message
+     * @param msg
+     *            the received message
+     */
+    void onMessage(AtmosphereResource resource, String msg);
+
 }

--- a/flow-server/src/main/java/com/vaadin/flow/internal/DebugWindowData.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/DebugWindowData.java
@@ -21,6 +21,7 @@ import java.io.Serializable;
  * Defines data that can be converted to a JSON message and sent to the debug
  * window.
  */
+@FunctionalInterface
 public interface DebugWindowData extends Serializable {
     /**
      * Converts data object to a JSON string.

--- a/flow-server/src/main/java/com/vaadin/flow/internal/ProductAndMessage.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/ProductAndMessage.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.internal;
+
+import com.vaadin.pro.licensechecker.Product;
+
+public class ProductAndMessage implements DebugWindowData {
+    private final Product product;
+    private final String message;
+
+    public ProductAndMessage(Product product, String message) {
+        this.product = product;
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public Product getProduct() {
+        return product;
+    }
+
+    @Override
+    public String toJson() {
+        return String.format(
+                "{\"product\": {\"name\": \"%s\", \"version\": \"%s\"}, \"message\": \"%s\"}",
+                product.getName(), product.getVersion(), message);
+    }
+}

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -1002,7 +1002,7 @@ public abstract class AbstractNavigationStateRenderer
         if (!configuration.isProductionMode()
                 && configuration.isDevModeLiveReloadEnabled()) {
             ui.getPage().executeJs(
-                    "Vaadin.Flow.devModeGizmo.showNotification('warning', '@PreserveOnRefresh enabled', 'When refreshing the page in the browser, the server-side Java view instance is reused rather than being recreated.', null, 'preserveOnRefreshWarning')");
+                    "Vaadin.devTools.showNotification('warning', '@PreserveOnRefresh enabled', 'When refreshing the page in the browser, the server-side Java view instance is reused rather than being recreated.', null, 'preserveOnRefreshWarning')");
         }
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PushHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PushHandler.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.Collection;
 
+import org.apache.commons.io.IOUtils;
 import org.atmosphere.cpr.AtmosphereRequest;
 import org.atmosphere.cpr.AtmosphereResource;
 import org.atmosphere.cpr.AtmosphereResource.TRANSPORT;
@@ -527,9 +528,31 @@ public class PushHandler {
      */
     void onMessage(AtmosphereResource resource) {
         if (isDebugWindowConnection(resource)) {
-            getLogger().debug("Received live reload heartbeat");
+            handleDebugWindowMessage(resource);
         } else {
             callWithUi(resource, receiveCallback);
+        }
+    }
+
+    private void handleDebugWindowMessage(AtmosphereResource resource) {
+        AtmosphereRequest req = resource.getRequest();
+        VaadinServletRequest vaadinRequest = new VaadinServletRequest(req,
+                service);
+        service.setCurrentInstances(vaadinRequest, null);
+        try {
+            String msg = IOUtils.toString(req.getReader());
+            BrowserLiveReload browserLiveReload = getBrowserLiveReload();
+            if (browserLiveReload != null) {
+                browserLiveReload.onMessage(resource, msg);
+            } else {
+                getLogger().error(
+                        "Received message for debug window but there is no debug window connection available");
+            }
+        } catch (IOException e) {
+            getLogger().error(
+                    "Unable to read contents of debug connection message", e);
+        } finally {
+            CurrentInstance.clearAll();
         }
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/CvdlProducts.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/CvdlProducts.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.server.frontend;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import com.vaadin.pro.licensechecker.LicenseChecker;
+import com.vaadin.pro.licensechecker.LocalProKey;
+import com.vaadin.pro.licensechecker.Product;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import elemental.json.Json;
+import elemental.json.JsonObject;
+
+/** Utilities for commercial product handling. */
+public class CvdlProducts {
+
+    private static final String CVDL_PACKAGE_KEY = "cvdlName";
+
+    /**
+     * Returns product information if the given npm module refers to a Vaadin
+     * commercial component.
+     *
+     * @param nodeModules
+     *            the node modules folder
+     * @param npmModule
+     *            the name of the npm module to check
+     */
+    public static Product getProductIfCvdl(File nodeModules, String npmModule) {
+        File packageJsonFile = new File(new File(nodeModules, npmModule),
+                "package.json");
+        if (!packageJsonFile.exists()) {
+            return null;
+        }
+
+        try {
+            JsonObject packageJson = Json.parse(FileUtils
+                    .readFileToString(packageJsonFile, StandardCharsets.UTF_8));
+            if (packageJson.hasKey(CVDL_PACKAGE_KEY)) {
+                return new Product(packageJson.getString(CVDL_PACKAGE_KEY),
+                        packageJson.getString("version"));
+            } else if (packageJson.hasKey("license")) {
+                String packageName = packageJson.getString("name");
+                String license = packageJson.getString("license");
+                if (packageName.startsWith("@vaadin/") && license
+                        .startsWith("https://raw.githubusercontent.com")) {
+                    // Free components have "Apache-2.0"
+                    String cvdlName = packageName;
+                    cvdlName = cvdlName.replace("@", "");
+                    cvdlName = cvdlName.replace("/", "-");
+                    cvdlName = cvdlName.replace("charts", "chart");
+                    return new Product(cvdlName,
+                            packageJson.getString("version"));
+                }
+            }
+            return null;
+        } catch (IOException e) {
+            throw new RuntimeException(
+                    "Unable to read package.json file " + packageJsonFile, e);
+        }
+    }
+
+    public static boolean includeInFallbackBundle(String module,
+            File nodeModules) {
+        if (module.startsWith(".") || module.startsWith("Frontend/")) {
+            // Project internal file
+            return true;
+        }
+
+        String npmModule = getNpmModule(module);
+        if (npmModule == null) {
+            // Unclear when this would happen
+            return true;
+        }
+
+        Product product = CvdlProducts.getProductIfCvdl(nodeModules, npmModule);
+        if (product != null) {
+            if (LocalProKey.get() == null) {
+                // No proKey, do not bother free users with a license check
+                getLogger().debug(
+                        "No proKey found. Dropping '{}' from the fallback bundle without asking for validation",
+                        module);
+                return false;
+            } else {
+                try {
+                    LicenseChecker.checkLicense(product.getName(),
+                            product.getVersion());
+                    return true;
+                } catch (Exception e) {
+                    // Silently drop from the fallback bundle (it is a
+                    // production build).
+                    // Otherwise we would bother all free users with a license
+                    // check
+                    getLogger().debug(
+                            "License check failed. Dropping '{}' from the fallback bundle",
+                            module, e);
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private static String getNpmModule(String module) {
+        // npm modules are either @org/pkg or pkg
+        String[] parts = module.split("/", -1);
+        if (parts.length < 2) {
+            // What would this be?
+            return null;
+        }
+        if (parts[0].startsWith("@")) {
+            return parts[0] + "/" + parts[1];
+        } else {
+            return parts[0];
+        }
+
+    }
+
+    private static Logger getLogger() {
+        return LoggerFactory.getLogger(CvdlProducts.class);
+    }
+
+}

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -122,6 +122,12 @@ public class NodeTasks implements FallibleCommand {
                 .create(Platform.guess().getNodeDownloadRoot());
 
         /**
+         * Default is true here so we do not accidentally include development
+         * stuff into production.
+         */
+        private boolean productionMode = true;
+
+        /**
          * Create a builder instance given an specific npm folder.
          *
          * @param classFinder
@@ -390,7 +396,7 @@ public class NodeTasks implements FallibleCommand {
          * gizmo module
          * (<code>@vaadin/flow-frontend/VaadinDevModeGizmo.js</code>) is added
          * via this mechanism.
-         * 
+         *
          * @param frontendModules
          *            List of module names.
          * @return the builder, for chaining
@@ -429,6 +435,19 @@ public class NodeTasks implements FallibleCommand {
             this.nodeDownloadRoot = Objects.requireNonNull(nodeDownloadRoot);
             return this;
         }
+
+        /**
+         * Sets the production mode.
+         *
+         * @param productionMode
+         *            <code>true</code> to enable production mode, otherwise
+         *            <code>false</code>
+         * @return this builder
+         */
+        public Builder withProductionMode(boolean productionMode) {
+            this.productionMode = productionMode;
+            return this;
+        }
     }
 
     private final Collection<FallibleCommand> commands = new ArrayList<>();
@@ -453,8 +472,7 @@ public class NodeTasks implements FallibleCommand {
                         frontendDependencies.getThemeDefinition());
             }
 
-            commands.add(new TaskGenerateTsFiles(builder.npmFolder,
-                    frontendDependencies.getModules()));
+            commands.add(new TaskGenerateTsFiles(builder.npmFolder));
         }
 
         if (builder.createMissingPackageJson) {
@@ -505,7 +523,7 @@ public class NodeTasks implements FallibleCommand {
                             builder.npmFolder, builder.generatedFolder,
                             builder.frontendDirectory, builder.tokenFile,
                             builder.tokenFileData, builder.enablePnpm,
-                            builder.additionalFrontendModules));
+                            builder.additionalFrontendModules, builder.productionMode));
 
             commands.add(new TaskUpdateThemeImport(builder.npmFolder,
                     frontendDependencies.getThemeDefinition(),

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsFiles.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsFiles.java
@@ -40,28 +40,24 @@ public class TaskGenerateTsFiles implements FallibleCommand {
     private static final String TSCONFIG_JSON = "tsconfig.json";
     private static final String TS_DEFINITIONS = "types.d.ts";
     private final File npmFolder;
-    private final List<String> modules;
 
     /**
      * Create a task to generate <code>tsconfig.json</code> file.
      *
      * @param npmFolder
      *            project folder where the file will be generated.
-     * @param modules
      */
-    TaskGenerateTsFiles(File npmFolder, List<String> modules) {
+    TaskGenerateTsFiles(File npmFolder) {
         this.npmFolder = npmFolder;
-        this.modules = modules;
     }
 
     /**
-     * Only generate if there exists typescript modules in the project.
+     * Generate typescript config if it doesn't exist.
      *
-     * @return if we have modules for typescript files
+     * @return if typescript config file should be created
      */
     protected boolean shouldGenerate() {
-        return modules.stream().filter(file -> file.endsWith(".ts"))
-                .count() >= 1;
+        return !new File(npmFolder, TSCONFIG_JSON).exists();
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdateImports.java
@@ -29,9 +29,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
-
-import org.apache.commons.io.FileUtils;
-import org.slf4j.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.vaadin.flow.component.dependency.HtmlImport;
 import com.vaadin.flow.component.dependency.JsModule;
@@ -42,6 +41,9 @@ import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
 import com.vaadin.flow.theme.AbstractTheme;
 import com.vaadin.flow.theme.Theme;
 import com.vaadin.flow.theme.ThemeDefinition;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
 
 import elemental.json.Json;
 import elemental.json.JsonArray;
@@ -78,6 +80,7 @@ public class TaskUpdateImports extends NodeUpdater {
     private final JsonObject tokenFileData;
 
     private final boolean disablePnpm;
+    private final boolean productionMode;
     private final List<String> additionalFrontendModules;
 
     private class UpdateMainImportsFile extends AbstractUpdateImports {
@@ -266,7 +269,7 @@ public class TaskUpdateImports extends NodeUpdater {
             LinkedHashSet<String> set = new LinkedHashSet<>(
                     fallbackScanner.getModules());
             set.removeAll(frontDeps.getModules());
-            return new ArrayList<String>(set);
+            return filter(set.stream()).collect(Collectors.toList());
         }
 
         @Override
@@ -274,7 +277,7 @@ public class TaskUpdateImports extends NodeUpdater {
             LinkedHashSet<String> set = new LinkedHashSet<>(
                     fallbackScanner.getScripts());
             set.removeAll(frontDeps.getScripts());
-            return set;
+            return filter(set.stream()).collect(Collectors.toSet());
         }
 
         @Override
@@ -350,10 +353,10 @@ public class TaskUpdateImports extends NodeUpdater {
             FrontendDependenciesScanner frontendDepScanner,
             SerializableFunction<ClassFinder, FrontendDependenciesScanner> fallBackScannerProvider,
             File npmFolder, File generatedPath, File frontendDirectory,
-            File tokenFile, boolean disablePnpm) {
+            File tokenFile, boolean disablePnpm, boolean productionMode) {
         this(finder, frontendDepScanner, fallBackScannerProvider, npmFolder,
                 generatedPath, frontendDirectory, tokenFile, null, disablePnpm,
-                Collections.emptyList());
+                Collections.emptyList(), productionMode);
     }
 
     /**
@@ -384,7 +387,7 @@ public class TaskUpdateImports extends NodeUpdater {
             SerializableFunction<ClassFinder, FrontendDependenciesScanner> fallBackScannerProvider,
             File npmFolder, File generatedPath, File frontendDirectory,
             File tokenFile, JsonObject tokenFileData, boolean disablePnpm,
-            List<String> additionalFrontendModules) {
+            List<String> additionalFrontendModules, boolean productionMode) {
         super(finder, frontendDepScanner, npmFolder, generatedPath);
         this.frontendDirectory = frontendDirectory;
         fallbackScanner = fallBackScannerProvider.apply(finder);
@@ -393,6 +396,7 @@ public class TaskUpdateImports extends NodeUpdater {
         this.tokenFileData = tokenFileData;
         this.disablePnpm = disablePnpm;
         this.additionalFrontendModules = additionalFrontendModules;
+        this.productionMode = productionMode;
     }
 
     @Override
@@ -496,6 +500,14 @@ public class TaskUpdateImports extends NodeUpdater {
 
         }
         return array;
+    }
+
+    private Stream<String> filter(Stream<String> modules) {
+        if (!productionMode) {
+            return modules;
+        }
+        return modules.filter(module -> CvdlProducts
+                .includeInFallbackBundle(module, nodeModulesFolder));
     }
 
     private JsonArray makeFallbackCssImports(AbstractUpdateImports updater) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/DevModeInitializer.java
@@ -95,7 +95,6 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_FRONTEND_DIR
 import static com.vaadin.flow.server.frontend.FrontendUtils.DEFAULT_GENERATED_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_FRONTEND_DIR;
 import static com.vaadin.flow.server.frontend.FrontendUtils.PARAM_GENERATED_DIR;
-import static com.vaadin.flow.server.frontend.FrontendUtils.WEBPACK_GENERATED;
 
 /**
  * Servlet initializer starting node updaters as well as the webpack-dev-mode
@@ -326,7 +325,8 @@ public class DevModeInitializer
                 .enableImportsUpdate(true).runNpmInstall(true)
                 .populateTokenFileData(tokenFileData)
                 .withEmbeddableWebComponents(true).enablePnpm(enablePnpm)
-                .withHomeNodeExecRequired(useHomeNodeExec).build();
+                .withHomeNodeExecRequired(useHomeNodeExec)
+                .withProductionMode(config.isProductionMode()).build();
 
         // Check whether executor is provided by the caller (framework)
         Object service = config.getInitParameters().get(Executor.class);

--- a/flow-server/src/main/resources/plugins/stats-plugin/stats-plugin.js
+++ b/flow-server/src/main/resources/plugins/stats-plugin/stats-plugin.js
@@ -45,11 +45,28 @@ class StatsPlugin {
       // Collect accepted chunks and their modules
       const chunks = collectChunks(statsJson, acceptedKeys);
 
+      const nodeModulesFolders = statsJson.modules
+          .map((module) => module.identifier)
+          .filter((id) => id.includes('node_modules'));
+      const npmModules = nodeModulesFolders
+          .map((id) => id.replace(/.*node_modules./, ''))
+          .map((id) => {
+            const parts = id.split('/');
+            if (id.startsWith('@')) {
+              return parts[0] + '/' + parts[1];
+            } else {
+              return parts[0];
+            }
+          })
+          .sort()
+          .filter((value, index, self) => self.indexOf(value) === index);
+
       let customStats = {
         hash: statsJson.hash,
         assetsByChunkName: statsJson.assetsByChunkName,
         chunks: chunks,
-        modules: modules
+        modules: modules,
+        npmModules: npmModules
       };
 
       if (!this.options.devMode) {

--- a/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/BootstrapHandlerTest.java
@@ -652,7 +652,7 @@ public class BootstrapHandlerTest {
                 "Content javascript should have been prepended to head element",
                 "<script type=\"text/javascript\">window.messages = window.messages || [];\n"
                         + "window.messages.push(\"content script\");</script>",
-                allElements.get(1).toString());
+                allElements.get(2).toString());
     }
 
     @Test // 3036
@@ -671,7 +671,7 @@ public class BootstrapHandlerTest {
                 "Content javascript should have been prepended to head element",
                 "<script type=\"text/javascript\">window.messages = window.messages || [];\n"
                         + "window.messages.push(\"inline.js\");</script>",
-                allElements.get(1).toString());
+                allElements.get(2).toString());
     }
 
     @Test // 3036
@@ -743,7 +743,7 @@ public class BootstrapHandlerTest {
         Elements allElements = page.head().getAllElements();
 
         Assert.assertEquals("<meta name=\"theme-color\" content=\"#227aef\">",
-                allElements.get(1).toString());
+                allElements.get(2).toString());
     }
 
     @Test // 3203
@@ -943,7 +943,7 @@ public class BootstrapHandlerTest {
                 "File javascript should have been prepended to head element",
                 "<script type=\"text/javascript\">window.messages = window.messages || [];\n"
                         + "window.messages.push(\"inline.js\");</script>",
-                allElements.get(1).toString());
+                allElements.get(2).toString());
         assertStringEquals(
                 "File html should have been prepended to head element",
                 "<script type=\"text/javascript\">\n"
@@ -951,7 +951,7 @@ public class BootstrapHandlerTest {
                         + "    window.messages = window.messages || [];\n"
                         + "    window.messages.push(\"inline.html\");\n"
                         + "</script>",
-                allElements.get(2).toString());
+                allElements.get(3).toString());
         assertStringEquals(
                 "File css should have been prepended to head element",
                 "<style type=\"text/css\">/* inline.css */\n" + "\n"
@@ -959,7 +959,7 @@ public class BootstrapHandlerTest {
                         + "    color: rgba(255, 255, 0, 1);\n" + "}\n" + "\n"
                         + "#inlineCssTestDiv {\n"
                         + "    color: rgba(255, 255, 0, 1);\n" + "}</style>",
-                allElements.get(3).toString());
+                allElements.get(4).toString());
     }
 
     @Test // 3010

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/AbstractNodeUpdateImportsTest.java
@@ -82,7 +82,7 @@ public abstract class AbstractNodeUpdateImportsTest extends NodeUpdateTestUtil {
         ClassFinder classFinder = getClassFinder();
         updater = new TaskUpdateImports(classFinder, getScanner(classFinder),
                 finder -> null, tmpRoot, generatedPath, frontendDirectory, null,
-                null, false, Collections.emptyList()) {
+                null, false, Collections.emptyList(), true) {
             @Override
             Logger log() {
                 return logger;

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdateImportsTest.java
@@ -113,7 +113,7 @@ public class NodeUpdateImportsTest extends NodeUpdateTestUtil {
                 finder -> new FrontendDependenciesScannerFactory()
                         .createScanner(true, finder, true),
                 tmpRoot, generatedPath, frontendDirectory, tokenFile,
-                fallBackData, false, Collections.emptyList()) {
+                fallBackData, false, Collections.emptyList(), true) {
             @Override
             Logger log() {
                 return logger;
@@ -237,7 +237,7 @@ public class NodeUpdateImportsTest extends NodeUpdateTestUtil {
                 finder -> new FrontendDependenciesScannerFactory()
                         .createScanner(true, finder, true),
                 tmpRoot, generatedPath, frontendDirectory, tokenFile, null,
-                false, Collections.emptyList()) {
+                false, Collections.emptyList(), true) {
             @Override
             Logger log() {
                 return logger;
@@ -306,7 +306,7 @@ public class NodeUpdateImportsTest extends NodeUpdateTestUtil {
                 new FrontendDependenciesScannerFactory().createScanner(false,
                         classFinder, true),
                 finder -> null, tmpRoot, generatedPath, frontendDirectory,
-                tokenFile, null, false, Collections.emptyList()) {
+                tokenFile, null, false, Collections.emptyList(), true) {
             @Override
             Logger log() {
                 return logger;
@@ -351,7 +351,7 @@ public class NodeUpdateImportsTest extends NodeUpdateTestUtil {
                 new FrontendDependenciesScannerFactory().createScanner(false,
                         classFinder, true),
                 finder -> null, tmpRoot, generatedPath, frontendDirectory,
-                tokenFile, null, false, Collections.emptyList()) {
+                tokenFile, null, false, Collections.emptyList(), true) {
             @Override
             Logger log() {
                 return logger;

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/UpdateThemedImportsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/UpdateThemedImportsTest.java
@@ -143,7 +143,7 @@ public class UpdateThemedImportsTest extends NodeUpdateTestUtil {
         };
         updater = new TaskUpdateImports(finder, deps, cf -> null, tmpRoot,
                 generatedPath, frontendDirectory, null, null, false,
-                Collections.emptyList());
+                Collections.emptyList(), true);
     }
 
     @Test

--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/ClassesSerializableTest.java
@@ -195,6 +195,7 @@ public abstract class ClassesSerializableTest extends ClassFinder {
                 "com\\.vaadin\\.flow\\.server\\.frontend\\.TaskUpdatePackages",
                 "com\\.vaadin\\.flow\\.server\\.frontend\\.TaskUpdateThemeImport",
                 "com\\.vaadin\\.flow\\.server\\.frontend\\.TaskUpdateWebpack",
+                "com\\.vaadin\\.flow\\.server\\.frontend\\.CvdlProducts",
 
                 // Node downloader classes
                 "com\\.vaadin\\.flow\\.server\\.frontend\\.installer\\.DefaultArchiveExtractor",

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <apache.httpclient.version>4.5.13</apache.httpclient.version>
         <jackson.databind.version>2.13.3</jackson.databind.version>
         <guava.version>31.1-jre</guava.version>
-        <bouncycastle.version>1.70</bouncycastle.version>       
+        <bouncycastle.version>1.70</bouncycastle.version>
         <jaxb.version>2.3.5</jaxb.version>
 
         <!-- Plugins -->
@@ -243,6 +243,12 @@
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy</artifactId>
                 <version>1.11.22</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.vaadin</groupId>
+                <artifactId>license-checker</artifactId>
+                <version>1.10.1</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
For development mode: 
- Checks the license from the Java side to avoid cookies 
- Replaces commercial components with a login/validation link if the subscription could not be validated  

For production mode: 
- Requires a license during a production build for commercial components 
- Removes commercial components from the fallback bundle if there is no license 
- Speeds up production build for free users as charts/maps/... are not compiled in the fallback bundle  

(cherry picked from commit d21f695d46c06545c4e0751082aa8ad635017c77)

Made upon of https://github.com/vaadin/flow/pull/14836

Part-of https://github.com/vaadin/flow/issues/14633