### PR TITLE
fix: long parameter regex

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/ParameterDeserializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/ParameterDeserializer.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.googlecode.gentyref.GenericTypeReflector;
+import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.internal.ReflectTools;
 
@@ -69,7 +70,18 @@ public final class ParameterDeserializer {
         } else if (parameterType.isAssignableFrom(Integer.class)) {
             return (T) Integer.valueOf(parameter);
         } else if (parameterType.isAssignableFrom(Long.class)) {
-            return (T) Long.valueOf(parameter);
+            try {
+                return (T) Long.valueOf(parameter);
+            } catch (NumberFormatException nfe) {
+                // RouteParameterRegex.LONG accepts value outside Long.MAX and
+                // Long.MIN so inform this clearly in the exception.
+                final String error = String.format(
+                        "Received faulty Long value '%s' for class %s.",
+                        parameter, targetClass);
+                LoggerFactory.getLogger(ParameterDeserializer.class)
+                        .error(error);
+                throw new IllegalArgumentException(error);
+            }
         } else if (parameterType.isAssignableFrom(Boolean.class)) {
             return (T) Boolean.valueOf(parameter);
         } else {

--- a/flow-server/src/main/java/com/vaadin/flow/router/RouteParameterRegex.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/RouteParameterRegex.java
@@ -30,7 +30,7 @@ public class RouteParameterRegex implements Serializable {
     /**
      * Long type regex.
      */
-    public static final String LONG = "^[+-]?[0-8]?[0-9]{1,18}$";
+    public static final String LONG = "^[+-]?[0-9]{1,19}$";
 
     /**
      * Boolean type regex.

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
@@ -2247,21 +2247,21 @@ public class RouterTest extends RoutingTestBase {
                 NavigationTrigger.PROGRAMMATIC);
         Assert.assertEquals("Expected event amount was wrong", 1,
                 IntegerParameter.events.size());
-        Assert.assertEquals("Parameter should the one in url", 5,
+        Assert.assertEquals("Parameter should match the one in url", 5,
                 IntegerParameter.param.intValue());
 
         router.navigate(ui, new Location("long/5"),
                 NavigationTrigger.PROGRAMMATIC);
         Assert.assertEquals("Expected event amount was wrong", 1,
                 LongParameter.events.size());
-        Assert.assertEquals("Parameter should the one in url", 5,
+        Assert.assertEquals("Parameter should match the one in url", 5,
                 LongParameter.param.longValue());
 
         router.navigate(ui, new Location("boolean/true"),
                 NavigationTrigger.PROGRAMMATIC);
         Assert.assertEquals("Expected event amount was wrong", 1,
                 BooleanParameter.events.size());
-        Assert.assertEquals("Parameter should the one in url", true,
+        Assert.assertEquals("Parameter should match the one in url", true,
                 BooleanParameter.param);
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
@@ -2230,7 +2230,7 @@ public class RouterTest extends RoutingTestBase {
 
         Assert.assertEquals("Expected event amount was wrong", 1,
                 RootParameter.events.size());
-        Assert.assertEquals("Parameter should be empty", "hello",
+        Assert.assertEquals("Parameter should match the one in url", "hello",
                 RootParameter.param);
     }
 
@@ -2244,22 +2244,49 @@ public class RouterTest extends RoutingTestBase {
                 NavigationTrigger.PROGRAMMATIC);
         Assert.assertEquals("Expected event amount was wrong", 1,
                 IntegerParameter.events.size());
-        Assert.assertEquals("Parameter should be empty", 5,
+        Assert.assertEquals("Parameter should the one in url", 5,
                 IntegerParameter.param.intValue());
 
         router.navigate(ui, new Location("long/5"),
                 NavigationTrigger.PROGRAMMATIC);
         Assert.assertEquals("Expected event amount was wrong", 1,
                 LongParameter.events.size());
-        Assert.assertEquals("Parameter should be empty", 5,
+        Assert.assertEquals("Parameter should the one in url", 5,
                 LongParameter.param.longValue());
 
         router.navigate(ui, new Location("boolean/true"),
                 NavigationTrigger.PROGRAMMATIC);
         Assert.assertEquals("Expected event amount was wrong", 1,
                 BooleanParameter.events.size());
-        Assert.assertEquals("Parameter should be empty", true,
+        Assert.assertEquals("Parameter should the one in url", true,
                 BooleanParameter.param);
+    }
+
+    @Test
+    public void longParameter_deserialization()
+            throws InvalidRouteConfigurationException {
+        setNavigationTargets(LongParameter.class);
+
+        router.navigate(ui, new Location("long/+" + Long.MAX_VALUE),
+                NavigationTrigger.PROGRAMMATIC);
+        Assert.assertEquals("Expected event amount was wrong", 1,
+                LongParameter.events.size());
+        Assert.assertEquals("Parameter should accept long max with +",
+                Long.MAX_VALUE, LongParameter.param.longValue());
+
+        router.navigate(ui, new Location("long/" + Long.MIN_VALUE),
+                NavigationTrigger.PROGRAMMATIC);
+        Assert.assertEquals("Expected negative and positive event", 2,
+                LongParameter.events.size());
+        Assert.assertEquals("Parameter should accept long max with +",
+                Long.MIN_VALUE, LongParameter.param.longValue());
+
+        // Navigation will give a 404 not found if the deserialization fails.
+        Assert.assertEquals(404,
+                router.navigate(ui, new Location("long/9223372036854775817"),
+                        NavigationTrigger.PROGRAMMATIC));
+        Assert.assertEquals("No faulty event recorded", 2,
+                LongParameter.events.size());
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
@@ -409,7 +409,7 @@ public class RouterTest extends RoutingTestBase {
     public static class IntegerParameter extends Component
             implements HasUrlParameter<Integer> {
 
-        private static List<BeforeEvent> events = new ArrayList<>();
+        protected static List<BeforeEvent> events = new ArrayList<>();
 
         private static Integer param;
 
@@ -425,7 +425,7 @@ public class RouterTest extends RoutingTestBase {
     public static class LongParameter extends Component
             implements HasUrlParameter<Long> {
 
-        private static List<BeforeEvent> events = new ArrayList<>();
+        protected static List<BeforeEvent> events = new ArrayList<>();
 
         private static Long param;
 
@@ -441,7 +441,7 @@ public class RouterTest extends RoutingTestBase {
     public static class BooleanParameter extends Component
             implements HasUrlParameter<Boolean> {
 
-        private static List<BeforeEvent> events = new ArrayList<>();
+        protected static List<BeforeEvent> events = new ArrayList<>();
 
         private static Boolean param;
 
@@ -2237,6 +2237,9 @@ public class RouterTest extends RoutingTestBase {
     @Test
     public void has_url_with_supported_parameters_navigation()
             throws InvalidRouteConfigurationException {
+        IntegerParameter.events.clear();
+        LongParameter.events.clear();
+        BooleanParameter.events.clear();
         setNavigationTargets(IntegerParameter.class, LongParameter.class,
                 BooleanParameter.class);
 
@@ -2265,6 +2268,7 @@ public class RouterTest extends RoutingTestBase {
     @Test
     public void longParameter_deserialization()
             throws InvalidRouteConfigurationException {
+        LongParameter.events.clear();
         setNavigationTargets(LongParameter.class);
 
         router.navigate(ui, new Location("long/+" + Long.MAX_VALUE),


### PR DESCRIPTION
HasUrlParameter<Long> now accepts all valid
long values and throws in the case where
value is out of Long range.

Fixes #14747

