### PR TITLE
fix: Return platform version as string

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/ServerInfo.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/ServerInfo.java
@@ -70,7 +70,7 @@ public class ServerInfo implements DebugWindowData {
             if (vaadinVersionsStream != null) {
                 JsonObject vaadinVersions = Json.parse(IOUtils.toString(
                         vaadinVersionsStream, StandardCharsets.UTF_8));
-                return vaadinVersions.get("platform").toJson();
+                return vaadinVersions.get("platform").asString();
             } else {
                 LoggerFactory.getLogger(getClass()).info(
                         "Unable to determine version information. No vaadin_versions.json found");


### PR DESCRIPTION
toJson method led to the extra quotes in the string, thus use asString instead.