### PR TITLE
chore!: Use authorizeHttpRequests instead of deprecated authorizeRequests

### DIFF
--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/SecurityConfig.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/SecurityConfig.java
@@ -54,9 +54,9 @@ public class SecurityConfig extends VaadinWebSecurity {
 
     @Override
     public void configure(HttpSecurity http) throws Exception {
-        http.authorizeRequests().requestMatchers("/admin-only/**")
+        http.authorizeHttpRequests().requestMatchers("/admin-only/**")
                 .hasAnyRole(ROLE_ADMIN);
-        http.authorizeRequests().requestMatchers("/public/**").permitAll();
+        http.authorizeHttpRequests().requestMatchers("/public/**").permitAll();
         super.configure(http);
         setLoginView(http, LoginView.class, getLogoutSuccessUrl());
     }

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -36,7 +36,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
-import org.springframework.security.config.annotation.web.configurers.ExpressionUrlAuthorizationConfigurer;
+import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer;
 import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.context.SecurityContextHolderStrategy;
@@ -152,8 +152,8 @@ public abstract class VaadinWebSecurity {
         // login
         http.requestCache().requestCache(vaadinDefaultRequestCache);
 
-        ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry urlRegistry = http
-                .authorizeRequests();
+        AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry urlRegistry = http
+                .authorizeHttpRequests();
         // Vaadin internal requests must always be allowed to allow public Flow
         // pages
         // and/or login page implemented using Flow.


### PR DESCRIPTION
This requires all applications to also change any usage of authorizeRequests to authorizeHttpRequests
