### PR TITLE
fix: clean commented css before handling

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/default/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/default/package.json
@@ -20,6 +20,7 @@
     "glob": "7.2.3",
     "typescript": "4.7.4",
     "workbox-core": "6.5.0",
-    "workbox-precaching": "6.5.0"
+    "workbox-precaching": "6.5.0",
+    "strip-comments": "2.0.1"
   }
 }

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/default/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/default/package.json
@@ -21,6 +21,6 @@
     "typescript": "4.7.4",
     "workbox-core": "6.5.0",
     "workbox-precaching": "6.5.0",
-    "strip-comments": "2.0.1"
+    "strip-css-comments": "5.0.0"
   }
 }

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
@@ -50,7 +50,7 @@ const createLinkReferences = (css, target) => {
   // Only cleanup if comment exist
   if(/\\/\\*(.|[\\r\\n])*?\\*\\//gm.exec(css) != null) {
     // clean up comments
-    css = strip(css, { line: false });
+    css = stripCssComments(css);
   }
   
   var match;
@@ -123,7 +123,7 @@ function generateThemeFile(themeFolder, themeName, themeProperties, productionMo
   if (themeProperties.parent) {
     themeFile += `import {applyTheme as applyBaseTheme} from './theme-${themeProperties.parent}.generated.js';\n`;
   }
-  themeFile += `import strip from 'strip-comments';\n`;
+  themeFile += `import stripCssComments from 'strip-css-comments';\n`;
 
   themeFile += createLinkReferences;
   themeFile += injectGlobalCssMethod;

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
@@ -34,6 +34,69 @@ const stylesCssFile = 'styles.css';
 const headerImport = `import 'construct-style-sheets-polyfill';
 `;
 
+// Strip comments is made according to StringUtil.removeComments that is tested in StringUtilTest
+// No line comments accepted checked as css only supports block comments!
+const stripCommentsMethod = `
+const State = Object.freeze({
+  NORMAL: Symbol("normal"),
+  IN_BLOCK_COMMENT: Symbol("block_comment"),
+  IN_STRING: Symbol("string"),
+  IN_STRING_APOSTROPHE: Symbol("string_apostrophe")
+});
+
+const removeComments = (code) => {
+  var state = State.NORMAL;
+  var result = "";
+  for (var i = 0; i < code.length; i++) {
+    var character = code.charAt(i);
+    switch (state) {
+      case State.NORMAL:
+        if(character == "/" && (i+1) < code.length) {
+          i++;
+          var nextCharacter = code.charAt(i);
+          if(nextCharacter == "*") {
+            state = State.IN_BLOCK_COMMENT;
+          } else {
+            result += character + nextCharacter;
+          }
+        } else {
+          result += character;
+          if(character == "\\"") {
+            state = State.IN_STRING;
+          } else if(character == "'") {
+            state = State.IN_STRING_APOSTROPHE;
+          }
+        }
+        break;
+      case State.IN_STRING:
+        result += character;
+        if(character == "\\"") {
+          state = State.NORMAL;
+        } else if(character == "\\\\" && (i+1) < code.length) {
+          result += code.charAt(i+1);
+          i++;
+        }
+        break;
+      case State.IN_STRING_APOSTROPHE:
+        result += character;
+        if(character == "'") {
+          state = State.NORMAL;
+        } else if(character == "\\\\" && (i+1) < code.length) {
+          result += code.charAt(i+1);
+          i++;
+        }
+        break;
+      case State.IN_BLOCK_COMMENT:
+        if(character == "*" && (i+1) < code.length && code.charAt(i+1) == "/") {
+          i++;
+          state = State.NORMAL;
+        }
+    }
+  }
+  return result;
+};
+`;
+
 const createLinkReferences = `
 const createLinkReferences = (css, target) => {
   // Unresolved urls are written as '@import url(text);' or '@import "text";' to the css
@@ -46,6 +109,12 @@ const createLinkReferences = (css, target) => {
   // [4] matches the url in '@import "..."'
   // [5] matches media query on @import statement
   const importMatcher = /(?:@media\\s(.+?))?(?:\\s{)?\\@import\\s*(?:url\\(\\s*['"]?(.+?)['"]?\\s*\\)|(["'])((?:\\\\.|[^\\\\])*?)\\3)([^;]*);(?:})?/g
+  
+  // Only cleanup if comment exist
+  if(/\\/\\*(.|[\\r\\n])*?\\*\\//gm.exec(css) != null) {
+    // clean up comments
+    css = removeComments(css);
+  }
   
   var match;
   var styleCss = css;
@@ -118,6 +187,7 @@ function generateThemeFile(themeFolder, themeName, themeProperties, productionMo
     themeFile += `import {applyTheme as applyBaseTheme} from './theme-${themeProperties.parent}.generated.js';`;
   }
 
+  themeFile += stripCommentsMethod;
   themeFile += createLinkReferences;
   themeFile += injectGlobalCssMethod;
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -177,6 +177,7 @@ public class NodeUpdaterTest {
         expectedDependencies.add("mkdirp");
         expectedDependencies.add("workbox-build");
         expectedDependencies.add("transform-ast");
+        expectedDependencies.add("strip-comments");
 
         Set<String> actualDependendencies = defaultDeps.keySet();
 
@@ -208,6 +209,7 @@ public class NodeUpdaterTest {
         expectedDependencies.add("loader-utils");
         expectedDependencies.add("workbox-webpack-plugin");
         expectedDependencies.add("chokidar");
+        expectedDependencies.add("strip-comments");
 
         Set<String> actualDependendencies = defaultDeps.keySet();
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/NodeUpdaterTest.java
@@ -177,7 +177,7 @@ public class NodeUpdaterTest {
         expectedDependencies.add("mkdirp");
         expectedDependencies.add("workbox-build");
         expectedDependencies.add("transform-ast");
-        expectedDependencies.add("strip-comments");
+        expectedDependencies.add("strip-css-comments");
 
         Set<String> actualDependendencies = defaultDeps.keySet();
 
@@ -209,7 +209,7 @@ public class NodeUpdaterTest {
         expectedDependencies.add("loader-utils");
         expectedDependencies.add("workbox-webpack-plugin");
         expectedDependencies.add("chokidar");
-        expectedDependencies.add("strip-comments");
+        expectedDependencies.add("strip-css-comments");
 
         Set<String> actualDependendencies = defaultDeps.keySet();
 


### PR DESCRIPTION
Remove any comment blocks in CSS
before creating link references.

Fixes #14770
