### PR TITLE
fix: run npm install if folder changes (#14909)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -241,7 +241,7 @@ public class TaskUpdatePackages extends NodeUpdater {
 
         String oldHash = packageJson.getObject(VAADIN_DEP_KEY)
                 .getString(HASH_KEY);
-        String newHash = generatePackageJsonHash(packageJson);
+        String newHash = generatePackageJsonHash(packageJson, npmFolder);
         // update packageJson hash value, if no changes it will not be written
         packageJson.getObject(VAADIN_DEP_KEY).put(HASH_KEY, newHash);
 
@@ -502,9 +502,12 @@ public class TaskUpdatePackages extends NodeUpdater {
      *
      * @param packageJson
      *            JsonObject built in the same format as package.json
+     * @param npmFolder
+     *            project base folder to use in hash
      * @return has for dependencies and devDependencies
      */
-    static String generatePackageJsonHash(JsonObject packageJson) {
+    static String generatePackageJsonHash(JsonObject packageJson,
+            File npmFolder) {
         StringBuilder hashContent = new StringBuilder();
         if (packageJson.hasKey(DEPENDENCIES)) {
             JsonObject dependencies = packageJson.getObject(DEPENDENCIES);
@@ -532,6 +535,10 @@ public class TaskUpdatePackages extends NodeUpdater {
             hashContent.append(sortedDevDependencies);
             hashContent.append("}");
         }
+        if (hashContent.length() > 0) {
+            hashContent.append("\n");
+        }
+        hashContent.append(npmFolder.getAbsolutePath());
         return StringUtil.getHash(hashContent.toString());
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -313,6 +313,20 @@ public class TaskRunNpmInstallTest {
         Mockito.verify(logger).info(getRunningMsg());
     }
 
+    @Test
+    public void differentNpmFolderName_returnsDifferentHash()
+            throws IOException {
+        final JsonObject packageJson = getNodeUpdater().getPackageJson();
+        final String originalHash = TaskUpdatePackages
+                .generatePackageJsonHash(packageJson, npmFolder);
+
+        final String newFolderHash = TaskUpdatePackages.generatePackageJsonHash(
+                packageJson, new File(npmFolder, "change"));
+
+        Assert.assertNotEquals("Changing base folder should change hash value.",
+                originalHash, newFolderHash);
+    }
+
     /**
      * Update the vaadin package hash to match dependencies. The hash is
      * calculated from dependencies and devDependencies but not from the vaadin
@@ -339,8 +353,8 @@ public class TaskRunNpmInstallTest {
         }
         packageJson.put(DEPENDENCIES, dependencies);
         packageJson.put(DEV_DEPENDENCIES, devDependencies);
-        packageJson.getObject(VAADIN_DEP_KEY).put(HASH_KEY,
-                TaskUpdatePackages.generatePackageJsonHash(packageJson));
+        packageJson.getObject(VAADIN_DEP_KEY).put(HASH_KEY, TaskUpdatePackages
+                .generatePackageJsonHash(packageJson, npmFolder));
         packageJson.remove(DEPENDENCIES);
         packageJson.remove(DEV_DEPENDENCIES);
     }


### PR DESCRIPTION
If application folder changes we should
execute npm install to get any folder
references updated.

Fixes #14908
