### PR TITLE
fix: Send new csrf cookie in login response

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinSavedRequestAwareAuthenticationSuccessHandler.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinSavedRequestAwareAuthenticationSuccessHandler.java
@@ -30,6 +30,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.web.DefaultRedirectStrategy;
 import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
 import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.security.web.csrf.CsrfTokenRepository;
 import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
 import org.springframework.security.web.savedrequest.RequestCache;
 import org.springframework.security.web.savedrequest.SavedRequest;
@@ -117,6 +118,8 @@ public class VaadinSavedRequestAwareAuthenticationSuccessHandler
      */
     private RequestCache requestCache = new HttpSessionRequestCache();
 
+    private CsrfTokenRepository csrfTokenRepository;
+
     /**
      * Creates a new instance.
      */
@@ -167,6 +170,12 @@ public class VaadinSavedRequestAwareAuthenticationSuccessHandler
         if (isTypescriptLogin(request)) {
             response.setHeader(DEFAULT_URL_HEADER,
                     determineTargetUrl(request, response));
+            if (this.csrfTokenRepository != null) {
+                this.csrfTokenRepository.saveToken(
+                        csrfTokenRepository.generateToken(request), request,
+                        response);
+            }
+
         }
 
         SavedRequest savedRequest = this.requestCache.getRequest(request,
@@ -256,5 +265,18 @@ public class VaadinSavedRequestAwareAuthenticationSuccessHandler
     public void setRequestCache(RequestCache requestCache) {
         super.setRequestCache(requestCache);
         this.requestCache = requestCache;
+    }
+
+    /**
+     * Sets the csrf token repository which is used to generate the csrf token
+     * when using a cookie based (stateless) csrf store.
+     *
+     * @param csrfTokenRepository
+     *            the csrf token repository
+     */
+    public void setCsrfTokenRepository(
+            CsrfTokenRepository csrfTokenRepository) {
+        this.csrfTokenRepository = csrfTokenRepository;
+
     }
 }

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -514,6 +514,9 @@ public abstract class VaadinWebSecurity {
             vaadinSavedRequestAwareAuthenticationSuccessHandler
                     .setRequestCache(requestCache);
         }
+        http.setSharedObject(
+                VaadinSavedRequestAwareAuthenticationSuccessHandler.class,
+                vaadinSavedRequestAwareAuthenticationSuccessHandler);
         return vaadinSavedRequestAwareAuthenticationSuccessHandler;
     }
 

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/stateless/VaadinStatelessSecurityConfigurer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/stateless/VaadinStatelessSecurityConfigurer.java
@@ -39,6 +39,7 @@ import org.springframework.security.web.savedrequest.CookieRequestCache;
 import org.springframework.security.web.savedrequest.RequestCache;
 
 import com.vaadin.flow.spring.security.VaadinDefaultRequestCache;
+import com.vaadin.flow.spring.security.VaadinSavedRequestAwareAuthenticationSuccessHandler;
 
 /**
  * Enables authentication that relies on JWT instead of sessions.
@@ -63,6 +64,10 @@ import com.vaadin.flow.spring.security.VaadinDefaultRequestCache;
  * <li>{@link VaadinDefaultRequestCache} - if present, this uses
  * {@link VaadinDefaultRequestCache#setDelegateRequestCache(RequestCache)} to
  * delegate saving requests to {@link CookieRequestCache}</li>
+ * <li>{@link VaadinSavedRequestAwareAuthenticationSuccessHandler} - if present,
+ * this uses
+ * {@link VaadinSavedRequestAwareAuthenticationSuccessHandler#setCsrfTokenRepository(CsrfTokenRepository)}
+ * to allow the success handler to set the new csrf cookie</li>
  * </ul>
  *
  * @param <H>
@@ -96,9 +101,13 @@ public final class VaadinStatelessSecurityConfigurer<H extends HttpSecurityBuild
         if (csrf != null) {
             // Use cookie for storing CSRF token, as it does not require a
             // session (double-submit cookie pattern)
-            CsrfTokenRepository csrfTokenRepository = new LazyCsrfTokenRepository(
-                    CookieCsrfTokenRepository.withHttpOnlyFalse());
+            CsrfTokenRepository csrfTokenRepository = CookieCsrfTokenRepository
+                    .withHttpOnlyFalse();
             csrf.csrfTokenRepository(csrfTokenRepository);
+            http.getSharedObject(
+                    VaadinSavedRequestAwareAuthenticationSuccessHandler.class)
+                    .setCsrfTokenRepository(csrfTokenRepository);
+
         }
     }
 


### PR DESCRIPTION
This is needed when the login response is an xhr and does not cause a page reload. The csrf token is needed immediately after the login request e.g. to be able to query the user info from an endpoint in Hilla

In earlier Spring Security versions, the new csrf was automatically generated and sent in [CsrfAuthenticationStrategy](https://github.com/spring-projects/spring-security/blob/aed7a869dfbba4f545ecd59174a83e19728227a9/web/src/main/java/org/springframework/security/web/csrf/CsrfAuthenticationStrategy.java#L59-L60) when authentication succeeded but this was removed in Spring Security 6.0 RC1
