### PR TITLE
fix: clean commented css before handling (#14924)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -451,6 +451,7 @@ public abstract class NodeUpdater implements FallibleCommand {
         defaults.put("workbox-precaching", WORKBOX_VERSION);
         defaults.put("glob", "7.2.3");
         defaults.put("async", "3.2.2");
+        defaults.put("strip-css-comments", "5.0.0");
 
         return defaults;
     }

--- a/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
+++ b/flow-server/src/main/resources/plugins/application-theme-plugin/theme-generator.js
@@ -47,6 +47,12 @@ const createLinkReferences = (css, target) => {
   // [5] matches media query on @import statement
   const importMatcher = /(?:@media\\s(.+?))?(?:\\s{)?\\@import\\s*(?:url\\(\\s*['"]?(.+?)['"]?\\s*\\)|(["'])((?:\\\\.|[^\\\\])*?)\\3)([^;]*);(?:})?/g
   
+  // Only cleanup if comment exist
+  if(/\\/\\*(.|[\\r\\n])*?\\*\\//gm.exec(css) != null) {
+    // clean up comments
+    css = stripCssComments(css);
+  }
+  
   var match;
   var styleCss = css;
   
@@ -115,8 +121,9 @@ function generateThemeFile(themeFolder, themeName, themeProperties, productionMo
   }
 
   if (themeProperties.parent) {
-    themeFile += `import {applyTheme as applyBaseTheme} from './theme-${themeProperties.parent}.generated.js';`;
+    themeFile += `import {applyTheme as applyBaseTheme} from './theme-${themeProperties.parent}.generated.js';\n`;
   }
+  themeFile += `import stripCssComments from 'strip-css-comments';\n`;
 
   themeFile += createLinkReferences;
   themeFile += injectGlobalCssMethod;


### PR DESCRIPTION
Remove any comment blocks in CSS
before creating link references.

Fixes #14770