### PR TITLE
fix: use full scan for ts task

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeTasks.java
@@ -453,8 +453,15 @@ public class NodeTasks implements FallibleCommand {
                         frontendDependencies.getThemeDefinition());
             }
 
-            commands.add(new TaskGenerateTsFiles(builder.npmFolder,
-                    frontendDependencies.getModules()));
+            final FrontendDependenciesScanner fallbackScanner = getFallbackScanner(
+                    builder, classFinder);
+            if(fallbackScanner == null) {
+                commands.add(new TaskGenerateTsFiles(builder.npmFolder,
+                        frontendDependencies.getModules()));
+            } else {
+                commands.add(new TaskGenerateTsFiles(builder.npmFolder,
+                        fallbackScanner.getModules()));
+            }
         }
 
         if (builder.createMissingPackageJson) {


### PR DESCRIPTION
Always use the allDependencies scan
for checking for creation of ts files.
This means that for a production build
we check the fallback dependencies for
ts files also.

Closes #14733