### PR TITLE
Increase initial delay to show loading indicator

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/LoadingIndicatorConfigurationMap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/LoadingIndicatorConfigurationMap.java
@@ -29,7 +29,7 @@ import com.vaadin.flow.internal.StateNode;
 public class LoadingIndicatorConfigurationMap extends NodeMap
         implements LoadingIndicatorConfiguration {
     public static final String FIRST_DELAY_KEY = "first";
-    public static final int FIRST_DELAY_DEFAULT = 300;
+    public static final int FIRST_DELAY_DEFAULT = 450;
     public static final String SECOND_DELAY_KEY = "second";
     public static final int SECOND_DELAY_DEFAULT = 1500;
     public static final String THIRD_DELAY_KEY = "third";


### PR DESCRIPTION
The current initial delay to show loading indicator seems quite short. If one deploys an app to another continent, even no op visits can make the indicator "flash". This may kind of just increases the feeling of "broken app". Especially as the indicator in latest versions is bold visually.

Still, at least mine app feels perfectly usable and don't even realise there is a server visit. I don't have the skills to me the indication look less bolder, so I'd just propose to increase the delay a bit. With this level (450ms) all seems to work fine for my app, but maybe it could be even bit longer still 🤷‍♂️

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
