### PR TITLE
chore: Bump commons-fileupload version to 1.4.0

### DIFF
--- a/flow-server/pom.xml
+++ b/flow-server/pom.xml
@@ -57,8 +57,8 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.3.3</version>
-            <!-- commons-fileupload:1.3.3 depends on commons-io:2.2, override
+            <version>1.4.0</version>
+            <!-- commons-fileupload depends on commons-io, override
                 it with Flow declaration -->
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
The same change has been done in Vaadin 23 earlier.