### PR TITLE
chore: update github/action file to get rid of the warnings

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -28,7 +28,7 @@ jobs:
           [ -z "$TB_LICENSE" ] \
             && echo "::error::!! ERROR NO TB_LICENSE: Check that this repo has a valid TB_LICENSE secret !!" \
             && exit 1 || exit 0
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-node@v3
@@ -74,7 +74,7 @@ jobs:
       matrix: ${{fromJson(needs.build.outputs.matrix-unit)}}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up JDK 17

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -128,7 +128,7 @@ jobs:
       matrix: ${{fromJson(needs.build.outputs.matrix-it)}}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-node@v3
@@ -206,7 +206,7 @@ jobs:
     needs: [unit-tests, it-tests]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/download-artifact@v3

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -50,8 +50,8 @@ jobs:
       - name: Generate matrices
         id: set-matrix
         run: |
-          echo "::set-output name=matrix-it::$(./scripts/computeMatrix.js it-tests --parallel=13 current module args)"
-          echo "::set-output name=matrix-unit::$(./scripts/computeMatrix.js unit-tests --parallel=1 current module args)"
+          echo "matrix-it=$(./scripts/computeMatrix.js it-tests --parallel=13 current module args)" >> $GITHUB_OUTPUT
+          echo "matrix-unit=$(./scripts/computeMatrix.js unit-tests --parallel=1 current module args)" >> $GITHUB_OUTPUT
       - name: Compile and Install Flow
         run: |
           cmd="mvn install -B -ntp -DskipTests  -pl \!flow-plugins/flow-gradle-plugin"
@@ -110,7 +110,7 @@ jobs:
       - name: Set build status flag
         id: set-failure
         if: ${{ failure() || cancelled() }}
-        run: echo "::set-output name=failure::true"
+        run: echo "failure=true" >> $GITHUB_OUTPUT
       - uses: actions/upload-artifact@v3
         if: ${{ failure() || success() }}
         with:
@@ -187,7 +187,7 @@ jobs:
       - name: Set build status flag
         id: set-failure
         if: ${{ failure() || cancelled() }}
-        run: echo "::set-output name=failure::true"
+        run: echo "failure::true" >> $GITHUB_OUTPUT
       - uses: actions/upload-artifact@v3
         if: ${{ failure() || success() }}
         with:


### PR DESCRIPTION
referenece https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

