### PR TITLE
fix: Use es2019 for TS compiler

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/tsconfig.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/tsconfig.json
@@ -7,6 +7,7 @@
   "compilerOptions": {
     "sourceMap": true,
     "inlineSources": true,
+    "lib": ["es2019"],
     "module": "esNext",
     "target": "es2017",
     "moduleResolution": "node",

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/tsconfig.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/tsconfig.json
@@ -7,7 +7,7 @@
   "compilerOptions": {
     "sourceMap": true,
     "inlineSources": true,
-    "lib": ["es2019"],
+    "lib": ["es2019", "dom"],
     "module": "esNext",
     "target": "es2017",
     "moduleResolution": "node",


### PR DESCRIPTION
Uses `lib` for specifying the version to not break the older browsers support (preserve old JS target ).