### PR TITLE
chore!: Require Node 18 (npm 8.6)

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -33,7 +33,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -133,7 +133,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
       - uses: pnpm/action-setup@v2
         with:
           version: '5.15.0'

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -116,10 +116,10 @@ public class FrontendTools {
     private static final FrontendVersion WHITESPACE_ACCEPTING_NPM_VERSION = new FrontendVersion(
             7, 0);
 
-    private static final int SUPPORTED_NODE_MAJOR_VERSION = 16;
-    private static final int SUPPORTED_NODE_MINOR_VERSION = 14;
+    private static final int SUPPORTED_NODE_MAJOR_VERSION = 18;
+    private static final int SUPPORTED_NODE_MINOR_VERSION = 0;
     private static final int SUPPORTED_NPM_MAJOR_VERSION = 8;
-    private static final int SUPPORTED_NPM_MINOR_VERSION = 3;
+    private static final int SUPPORTED_NPM_MINOR_VERSION = 6;
 
     static final FrontendVersion SUPPORTED_NODE_VERSION = new FrontendVersion(
             SUPPORTED_NODE_MAJOR_VERSION, SUPPORTED_NODE_MINOR_VERSION);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -68,6 +68,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @Category(SlowTests.class)
 public class FrontendToolsTest {
 
+    private static final String SUPPORTED_NODE_BUT_OLDER_THAN_AUTOINSTALLED = "18.0.0";
+
     public static final String DEFAULT_NODE = FrontendUtils.isWindows()
             ? "node\\node.exe"
             : "node/node";
@@ -156,18 +158,21 @@ public class FrontendToolsTest {
             throws FrontendUtils.UnknownVersionException {
         settings.setAutoUpdate(false);
         FrontendVersion updatedNodeVersion = getUpdatedAlternativeNodeVersion(
-                "16.14.0", () -> tools.getNodeExecutable());
+                SUPPORTED_NODE_BUT_OLDER_THAN_AUTOINSTALLED,
+                () -> tools.getNodeExecutable());
 
         Assert.assertEquals(
                 "Locate Node version: Node version updated even if it should not have been touched.",
-                "16.14.0", updatedNodeVersion.getFullVersion());
+                SUPPORTED_NODE_BUT_OLDER_THAN_AUTOINSTALLED,
+                updatedNodeVersion.getFullVersion());
     }
 
     @Test
     public void nodeIsBeingLocated_supportedNodeInstalled_autoUpdateTrue_NodeUpdated()
             throws FrontendUtils.UnknownVersionException {
         FrontendVersion updatedNodeVersion = getUpdatedAlternativeNodeVersion(
-                "16.14.0", () -> tools.getNodeExecutable());
+                SUPPORTED_NODE_BUT_OLDER_THAN_AUTOINSTALLED,
+                () -> tools.getNodeExecutable());
 
         Assert.assertEquals(
                 "Locate Node version: Node version was not auto updated.",
@@ -239,18 +244,21 @@ public class FrontendToolsTest {
             throws FrontendUtils.UnknownVersionException {
         settings.setAutoUpdate(false);
         FrontendVersion updatedNodeVersion = getUpdatedAlternativeNodeVersion(
-                "16.14.0", () -> tools.forceAlternativeNodeExecutable());
+                SUPPORTED_NODE_BUT_OLDER_THAN_AUTOINSTALLED,
+                () -> tools.forceAlternativeNodeExecutable());
 
         Assert.assertEquals(
                 "Force alternative directory: Node version updated even if it should not have been touched.",
-                "16.14.0", updatedNodeVersion.getFullVersion());
+                SUPPORTED_NODE_BUT_OLDER_THAN_AUTOINSTALLED,
+                updatedNodeVersion.getFullVersion());
     }
 
     @Test
     public void forceAlternativeDirectory_supportedNodeInstalled_autoUpdateTrue_NodeUpdated()
             throws FrontendUtils.UnknownVersionException {
         FrontendVersion updatedNodeVersion = getUpdatedAlternativeNodeVersion(
-                "16.14.0", () -> tools.forceAlternativeNodeExecutable());
+                SUPPORTED_NODE_BUT_OLDER_THAN_AUTOINSTALLED,
+                () -> tools.forceAlternativeNodeExecutable());
 
         Assert.assertEquals(
                 "Force alternative directory: Node version was not auto updated.",

--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/FrontendStubs.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/FrontendStubs.java
@@ -300,8 +300,8 @@ public class FrontendStubs {
      */
     public static class ToolStubBuilder {
 
-        private static final String DEFAULT_NPM_VERSION = "8.3.0";
-        private static final String DEFAULT_NODE_VERSION = "16.14.0";
+        private static final String DEFAULT_NPM_VERSION = "8.6.0";
+        private static final String DEFAULT_NODE_VERSION = "18.0.0";
 
         private String version;
         private String cacheDir;


### PR DESCRIPTION
Node 18 is the latest LTS version and what everbody should at least have going forward
