### PR TITLE
test: use non-prefixed version of text-field

### DIFF
--- a/flow-tests/test-application-theme/test-reusable-as-parent-vite/src/main/java/com/vaadin/flow/uitest/ui/theme/MyPolymerField.java
+++ b/flow-tests/test-application-theme/test-reusable-as-parent-vite/src/main/java/com/vaadin/flow/uitest/ui/theme/MyPolymerField.java
@@ -25,7 +25,7 @@ import com.vaadin.flow.uitest.ui.dependencies.TestVersion;
 /**
  * Polymer version of vaadin text field for testing component theming.
  */
-@JsModule("@vaadin/vaadin-text-field/vaadin-text-field.js")
+@JsModule("@vaadin/text-field/vaadin-text-field.js")
 @Tag("vaadin-text-field")
 @NpmPackage(value = "@vaadin/vaadin-text-field", version = TestVersion.VAADIN)
 public class MyPolymerField extends Component {

--- a/flow-tests/test-application-theme/test-reusable-as-parent/src/main/java/com/vaadin/flow/uitest/ui/theme/MyPolymerField.java
+++ b/flow-tests/test-application-theme/test-reusable-as-parent/src/main/java/com/vaadin/flow/uitest/ui/theme/MyPolymerField.java
@@ -25,7 +25,7 @@ import com.vaadin.flow.uitest.ui.dependencies.TestVersion;
 /**
  * Polymer version of vaadin text field for testing component theming.
  */
-@JsModule("@vaadin/vaadin-text-field/vaadin-text-field.js")
+@JsModule("@vaadin/text-field/vaadin-text-field.js")
 @Tag("vaadin-text-field")
 @NpmPackage(value = "@vaadin/vaadin-text-field", version = TestVersion.VAADIN)
 public class MyPolymerField extends Component {

--- a/flow-tests/test-application-theme/test-theme-reusable-vite/src/main/java/com/vaadin/flow/uitest/ui/theme/MyComponent.java
+++ b/flow-tests/test-application-theme/test-theme-reusable-vite/src/main/java/com/vaadin/flow/uitest/ui/theme/MyComponent.java
@@ -25,7 +25,7 @@ import com.vaadin.flow.uitest.ui.dependencies.TestVersion;
 /**
  * Polymer version of vaadin text field for testing component theming.
  */
-@JsModule("@vaadin/vaadin-text-field/vaadin-text-field.js")
+@JsModule("@vaadin/text-field/vaadin-text-field.js")
 @Tag("vaadin-text-field")
 @NpmPackage(value = "@vaadin/vaadin-text-field", version = TestVersion.VAADIN)
 public class MyComponent extends Component {

--- a/flow-tests/test-application-theme/test-theme-reusable/src/main/java/com/vaadin/flow/uitest/ui/theme/MyComponent.java
+++ b/flow-tests/test-application-theme/test-theme-reusable/src/main/java/com/vaadin/flow/uitest/ui/theme/MyComponent.java
@@ -25,7 +25,7 @@ import com.vaadin.flow.uitest.ui.dependencies.TestVersion;
 /**
  * Polymer version of vaadin text field for testing component theming.
  */
-@JsModule("@vaadin/vaadin-text-field/vaadin-text-field.js")
+@JsModule("@vaadin/text-field/vaadin-text-field.js")
 @Tag("vaadin-text-field")
 @NpmPackage(value = "@vaadin/vaadin-text-field", version = TestVersion.VAADIN)
 public class MyComponent extends Component {

--- a/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/src/main/java/com/vaadin/flow/uitest/ui/theme/MyComponent.java
+++ b/flow-tests/test-custom-frontend-directory/test-themes-custom-frontend-directory/src/main/java/com/vaadin/flow/uitest/ui/theme/MyComponent.java
@@ -25,7 +25,7 @@ import com.vaadin.flow.uitest.ui.dependencies.TestVersion;
 /**
  * Polymer version of vaadin text field for testing component theming.
  */
-@JsModule("@vaadin/vaadin-text-field/vaadin-text-field.js")
+@JsModule("@vaadin/text-field/vaadin-text-field.js")
 @Tag("vaadin-text-field")
 @NpmPackage(value = "@vaadin/vaadin-text-field", version = TestVersion.VAADIN)
 public class MyComponent extends Component {

--- a/flow-tests/test-embedding/test-embedding-application-theme/src/main/java/com/vaadin/flow/webcomponent/MyComponent.java
+++ b/flow-tests/test-embedding/test-embedding-application-theme/src/main/java/com/vaadin/flow/webcomponent/MyComponent.java
@@ -25,7 +25,7 @@ import com.vaadin.flow.uitest.ui.dependencies.TestVersion;
 /**
  * Polymer version of vaadin text field for testing component theming.
  */
-@JsModule("@vaadin/vaadin-text-field/vaadin-text-field.js")
+@JsModule("@vaadin/text-field/vaadin-text-field.js")
 @Tag("vaadin-text-field")
 @NpmPackage(value = "@vaadin/vaadin-text-field", version = TestVersion.VAADIN)
 public class MyComponent extends Component {

--- a/flow-tests/test-embedding/test-embedding-reusable-theme/src/main/java/com/vaadin/flow/webcomponent/MyComponent.java
+++ b/flow-tests/test-embedding/test-embedding-reusable-theme/src/main/java/com/vaadin/flow/webcomponent/MyComponent.java
@@ -25,7 +25,7 @@ import com.vaadin.flow.uitest.ui.dependencies.TestVersion;
 /**
  * Polymer version of vaadin text field for testing component theming.
  */
-@JsModule("@vaadin/vaadin-text-field/vaadin-text-field.js")
+@JsModule("@vaadin/text-field/vaadin-text-field.js")
 @Tag("vaadin-text-field")
 @NpmPackage(value = "@vaadin/vaadin-text-field", version = TestVersion.VAADIN)
 public class MyComponent extends Component {

--- a/flow-tests/test-resources/src/main/java/com/vaadin/flow/uitest/ui/dependencies/ThemableTextField.java
+++ b/flow-tests/test-resources/src/main/java/com/vaadin/flow/uitest/ui/dependencies/ThemableTextField.java
@@ -23,7 +23,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
 /**
  * Custom vaadin text field for testing component theming.
  */
-@JsModule("@vaadin/vaadin-text-field/vaadin-text-field.js")
+@JsModule("@vaadin/text-field/vaadin-text-field.js")
 @Tag("vaadin-text-field")
 @NpmPackage(value = "@vaadin/vaadin-text-field", version = TestVersion.VAADIN)
 public class ThemableTextField extends Component {

--- a/flow-tests/test-themes/src/main/java/com/vaadin/flow/uitest/ui/theme/MyComponent.java
+++ b/flow-tests/test-themes/src/main/java/com/vaadin/flow/uitest/ui/theme/MyComponent.java
@@ -25,7 +25,7 @@ import com.vaadin.flow.uitest.ui.dependencies.TestVersion;
 /**
  * Polymer version of vaadin text field for testing component theming.
  */
-@JsModule("@vaadin/vaadin-text-field/vaadin-text-field.js")
+@JsModule("@vaadin/text-field/vaadin-text-field.js")
 @Tag("vaadin-text-field")
 @NpmPackage(value = "@vaadin/vaadin-text-field", version = TestVersion.VAADIN)
 public class MyComponent extends Component {


### PR DESCRIPTION
## Description

Fixed the package name to get rid of the warning and make it possible to bump `TestVersion.VAADIN` to V24:

```
[main] WARN com.vaadin.testbench.AbstractBrowserTestBase - This message in browser log console may be a potential error: '[2022-11-08T10:30:18.892Z] [WARNING] webpack-internal:///../node_modules/.pnpm/@vaadin+vaadin-text-field@23.3.0-alpha2/node_modules/@vaadin/vaadin-text-field/src/vaadin-text-field.js 19:8 "WARNING: Since Vaadin 23.2, \"@vaadin/vaadin-text-field\" is deprecated. Use \"@vaadin/text-field\" instead."'
```

## Type of change

- Tests