### PR TITLE
feat: Add Gradle support for polymer2lit

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinConvertPolymerTask.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinConvertPolymerTask.kt
@@ -1,0 +1,48 @@
+/**
+ *    Copyright 2000-2022 Vaadin Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vaadin.gradle
+
+import com.vaadin.flow.plugin.base.ConvertPolymerCommand
+import org.gradle.api.DefaultTask
+import org.gradle.api.Task
+import org.gradle.api.artifacts.ProjectDependency
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * This task converts Polymer-based source files into Lit.
+ * By default, the task tries to convert all `*.js` and `*.java` files.
+ */
+public open class VaadinConvertPolymerTask : DefaultTask() {
+
+    init {
+        group = "Vaadin"
+        description = "converts Polymer-based source files into Lit."
+    }
+
+    @TaskAction
+    public fun vaadinConvertPolymer() {
+        val extension: VaadinFlowPluginExtension = VaadinFlowPluginExtension.get(project)
+        logger.info("Running the vaadinConvertPolymer task with effective configuration $extension")
+        val adapter = GradlePluginAdapter(project, true)
+
+        val pathProperty: String = System.getProperty("path") ?: ""
+        val useLit1Property: Boolean = project.getBooleanProperty("useLit1") ?: false
+        val disableOptionalChainingProperty: Boolean = project.getBooleanProperty("disableOptionalChaining") ?: false
+
+        ConvertPolymerCommand(adapter, pathProperty, useLit1Property, disableOptionalChainingProperty)
+            .use { it.execute() }
+    }
+}

--- a/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinPlugin.kt
+++ b/flow-plugins/flow-gradle-plugin/src/main/kotlin/com/vaadin/gradle/VaadinPlugin.kt
@@ -40,6 +40,7 @@ public class VaadinPlugin : Plugin<Project> {
             register("vaadinClean", VaadinCleanTask::class.java)
             register("vaadinPrepareFrontend", VaadinPrepareFrontendTask::class.java)
             register("vaadinBuildFrontend", VaadinBuildFrontendTask::class.java)
+            register("vaadinConvertPolymer", VaadinConvertPolymerTask::class.java)
         }
 
         project.afterEvaluate {

--- a/flow-polymer2lit/README.md
+++ b/flow-polymer2lit/README.md
@@ -13,6 +13,9 @@ Run the converter in your project's root folder as follows:
 ```bash
 mvn vaadin:convert-polymer
 ```
+```bash
+./gradlew vaadinConvertPolymer
+```
 
 If your project is using an older Flow version < 24.0, use the full Maven goal instead:
 
@@ -20,40 +23,58 @@ If your project is using an older Flow version < 24.0, use the full Maven goal i
 mvn com.vaadin:vaadin-maven-plugin:24.0-SNAPSHOT:convert-polymer
 ```
 
+Or, in the case of Gradle, add the following to `build.gradle`:
+
+```gradle
+buildscript {
+  repositories {
+    classpath 'com.vaadin:flow-gradle-plugin:24.0-SNAPSHOT'
+  }
+}
+```
+
 ## Configuring
 
 The converter accepts the following arguments:
 
-**-Dvaadin.path=path/to/your/file**
+### -Dvaadin.path=path/to/your/file
 
 By default, the converter scans all the files that match `**/*.js` and `**/*.java` and tries to convert them into Lit.
 
-To limit conversion to a specific file or directory, you can use the `path` argument:
+To limit conversion to a specific file or directory, you can use the `vaadin.path` argument:
 
 ```bash
-mvn vaadin:convert-polymer -Dpath=path/to/your/file
+mvn vaadin:convert-polymer -Dvaadin.path=path/to/your/file
+```
+```bash
+./gradlew vaadinConvertPolymer -Dvaadin.path=path/to/your/file
 ```
 
 The path is always relative to your project's root folder.
 
-**-Dvaadin.useLit1**
+### -Dvaadin.useLit1
 
 By default, the converter transforms Polymer imports into their Lit 2 equivalents.
 
-If your project is using Lit 1, you can use the `useLit1` argument to enforce Lit 1 compatible imports:
+If your project is using Lit 1, you can use the `vaadin.useLit1` argument to enforce Lit 1 compatible imports:
 
 ```bash
-mvn vaadin:convert-polymer -DuseLit1
+mvn vaadin:convert-polymer -Dvaadin.useLit1
+```
+```bash
+./gradlew vaadinConvertPolymer -Dvaadin.useLit1
 ```
 
-**-Dvaadin.disableOptionalChaining**
+### -Dvaadin.disableOptionalChaining**
 
 By default, the converter transforms `[[prop.sub.something]]` expressions into `${prop?.sub?.something}`.
 
-If your project is using the Vaadin Webpack config, which doesn't support the optional chaining operator, you can use the `disableOptionalChaining` argument:
+If your project is using the Vaadin Webpack config, which doesn't support the optional chaining operator, you can use the `vaadin.disableOptionalChaining` argument:
 
 ```bash
-mvn vaadin:convert-polymer -DdisableOptionalChaining
+mvn vaadin:convert-polymer -Dvaadin.disableOptionalChaining
 ```
-
+```bash
+./gradlew vaadinConvertPolymer -Dvaadin.disableOptionalChaining
+```
 


### PR DESCRIPTION
The PR adds a `./gradlew vaadinConvertPolymer` Gradle task that converts Polymer-based sources to Lit.

**The following parameters are supported:**

- **`-Dvaadin.useLit1`** forces the converter to use `lit-element` rather than `lit` imports.

- **`-Dvaadin.disableOptionalChaining`** disables the usage of the optional chaining operator which can be helpful for projects still based on Webpack.

- **`-Dvaadin.path=/path/to/directory/or/file`** allows specifying the path to a file or directory that needs to be converted. By default, the converter scans all `**/*.js` and `**/*.java` files in the project.

A follow-up to #14972 