### PR TITLE
fix: Do not log null if servlet deployer is disabled

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletDeployer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/startup/ServletDeployer.java
@@ -217,7 +217,9 @@ public class ServletDeployer implements ServletContextListener {
         if (servletCreation == null || productionMode) {
             // the servlet creation is explicitly disabled or production mode
             // activated - just info
-            logger.info(servletCreationMessage);
+            if (servletCreationMessage != null) {
+                logger.info(servletCreationMessage);
+            }
         } else if (servletCreation == VaadinServletCreation.NO_CREATION) {
             // debug mode and servlet not created for some reason - make it more
             // visible with warning


### PR DESCRIPTION
Fixes #15053
