### PR TITLE
Revert "test: update gretty version (#15024) (#15028)"

### DIFF
--- a/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
+++ b/flow-plugins/flow-gradle-plugin/src/functionalTest/kotlin/com/vaadin/gradle/MiscSingleModuleTest.kt
@@ -65,7 +65,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
             """
             plugins {
                 id 'war'
-                id 'org.gretty' version '4.0.3'
+                id 'org.gretty' version '3.0.1'
                 id("com.vaadin")
             }
             repositories {
@@ -99,7 +99,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
             """
             plugins {
                 id 'war'
-                id 'org.gretty' version '4.0.3'
+                id 'org.gretty' version '3.0.1'
                 id("com.vaadin")
             }
             repositories {
@@ -314,7 +314,7 @@ class MiscSingleModuleTest : AbstractGradleTest() {
             """
             plugins {
                 id 'war'
-                id 'org.gretty' version '4.0.3'
+                id 'org.gretty' version '3.0.1'
                 id("com.vaadin")
             }
             repositories {


### PR DESCRIPTION
The new gretty version required jdk11 and is thus not compatible.
3.0.1 is again found online so there must have been an outage somewhere previously.