### PR TITLE
chore: Remove special jar resources allow

### DIFF
--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -461,7 +461,6 @@ let spaMiddlewareForceRemoved = false;
 
 const allowedFrontendFolders = [
   frontendFolder,
-  jarResourcesFolder,
   path.resolve(generatedFlowImportsFolder), // Contains only generated-flow-imports
   path.resolve(__dirname, 'node_modules')
 ];


### PR DESCRIPTION
The generated jar-resources are now inside the frontend folder so no special case should be needed
