### PR TITLE
chore: Add dependency needed to properly compile VaadinWebSecurity

### DIFF
--- a/vaadin-spring/pom.xml
+++ b/vaadin-spring/pom.xml
@@ -78,6 +78,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-client</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
             <optional>true</optional>


### PR DESCRIPTION
Without this you get

The type org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter cannot be resolved. It is indirectly referenced from required type org.springframework.security.config.annotation.web.configurers.oauth2.client.OAuth2LoginConfigurer
