### PR TITLE
doc: Use more appropriate prepositions

### DIFF
--- a/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/ConvertPolymerMojo.java
+++ b/flow-plugins/flow-maven-plugin/src/main/java/com/vaadin/flow/plugin/maven/ConvertPolymerMojo.java
@@ -22,7 +22,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import com.vaadin.flow.plugin.base.ConvertPolymerCommand;
 
 /**
- * A Maven goal that converts Polymer-based source files into Lit.
+ * A Maven goal that converts Polymer-based source files to Lit.
  */
 @Mojo(name = "convert-polymer")
 public class ConvertPolymerMojo extends FlowModeAbstractMojo {

--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/ConvertPolymerCommand.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/ConvertPolymerCommand.java
@@ -34,7 +34,7 @@ import com.vaadin.flow.polymer2lit.ServerConverter;
 
 /**
  * A tool-independent implementation of a {@code convert-polymer} command that
- * converts Polymer-based source files into Lit. The command is supposed to be
+ * converts Polymer-based source files to Lit. The command is supposed to be
  * called by the corresponding Mojo and Gradle tasks.
  */
 public class ConvertPolymerCommand implements AutoCloseable {

--- a/flow-polymer2lit/README.md
+++ b/flow-polymer2lit/README.md
@@ -26,7 +26,7 @@ The converter accepts the following arguments:
 
 **-Dvaadin.path=path/to/your/file**
 
-By default, the converter scans all the files that match `**/*.js` and `**/*.java` and tries to convert them into Lit.
+By default, the converter scans all the files that match `**/*.js` and `**/*.java` and tries to convert them to Lit.
 
 To limit conversion to a specific file or directory, you can use the `path` argument:
 

--- a/flow-polymer2lit/src/main/java/com/vaadin/flow/polymer2lit/FrontendConverter.java
+++ b/flow-polymer2lit/src/main/java/com/vaadin/flow/polymer2lit/FrontendConverter.java
@@ -25,7 +25,7 @@ import com.vaadin.flow.server.frontend.FrontendTools;
 import com.vaadin.flow.server.frontend.FrontendUtils;
 
 /**
- * A converter that converts Polymer-based {@code *.js} source files into Lit.
+ * A converter that converts Polymer-based {@code *.js} source files to Lit.
  *
  * Effectively, this is a wrapper around the {@code convert.ts} script.
  */

--- a/flow-polymer2lit/src/main/java/com/vaadin/flow/polymer2lit/ServerConverter.java
+++ b/flow-polymer2lit/src/main/java/com/vaadin/flow/polymer2lit/ServerConverter.java
@@ -37,7 +37,7 @@ import org.jboss.forge.roaster.model.source.MemberSource;
 import org.jboss.forge.roaster.model.source.MethodSource;
 
 /**
- * A server converter that converts Polymer-based *.java source files into Lit.
+ * A server converter that converts Polymer-based *.java source files to Lit.
  */
 public class ServerConverter {
 


### PR DESCRIPTION
Corrects `convert into Lit` to `convert to Lit` in the context of `source files` in JSDoc and README.