### PR TITLE
test: Rename ConvertPolymerExecutorTest to ConvertPolymerCommandTest

### DIFF
--- a/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/ConvertPolymerCommandTest.java
+++ b/flow-plugins/flow-plugin-base/src/test/java/com/vaadin/flow/plugin/base/ConvertPolymerCommandTest.java
@@ -18,7 +18,7 @@ import org.mockito.MockitoAnnotations;
 import com.vaadin.flow.polymer2lit.FrontendConverter;
 import com.vaadin.flow.polymer2lit.ServerConverter;
 
-public class ConvertPolymerExecutorTest {
+public class ConvertPolymerCommandTest {
     @Rule
     public TemporaryFolder tmpDir = new TemporaryFolder();
 


### PR DESCRIPTION
This is a leftover from some refactoring in #14972 during development.