### PR TITLE
feat(hilla): make tsconfig.json React compatible

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsConfig.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskGenerateTsConfig.java
@@ -48,8 +48,8 @@ public class TaskGenerateTsConfig extends AbstractTaskClientGenerator {
     private static final String VERSION = "flow_version";
     private static final String ES_TARGET_VERSION = "target";
     private static final String TSCONFIG_JSON_OLDER_VERSIONS_TEMPLATE = "tsconfig-%s.json";
-    private static final String[] vaadinVersions = { "latest", "v23.2", "v23.1",
-            "v22", "v14", "osgi" };
+    private static final String[] vaadinVersions = { "latest", "v23.3.0",
+            "v23.2", "v23.1", "v22", "v14", "osgi" };
 
     //@formatter:off
     static final String ERROR_MESSAGE =

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/tsconfig-v23.3.0.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/tsconfig-v23.3.0.json
@@ -4,10 +4,9 @@
 // You might want to change the configurations to fit your preferences
 // For more information about the configurations, please refer to http://www.typescriptlang.org/docs/handbook/tsconfig-json.html
 {
-  "flow_version": "23.3.1",
+  "flow_version": "23.3.0",
   "compilerOptions": {
     "sourceMap": true,
-    "jsx": "react-jsx",
     "inlineSources": true,
     "module": "esNext",
     "target": "es2020",
@@ -30,7 +29,8 @@
     }
   },
   "include": [
-    "frontend/**/*",
+    "frontend/**/*.ts",
+    "frontend/index.js",
     "types.d.ts"
   ],
   "exclude": []

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/tsconfig.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/tsconfig.json
@@ -7,6 +7,7 @@
   "flow_version": "23.3.0",
   "compilerOptions": {
     "sourceMap": true,
+    "jsx": "react-jsx",
     "inlineSources": true,
     "module": "esNext",
     "target": "es2020",
@@ -29,8 +30,7 @@
     }
   },
   "include": [
-    "frontend/**/*.ts",
-    "frontend/index.js",
+    "frontend/**/*",
     "types.d.ts"
   ],
   "exclude": []

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/tsconfig.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/tsconfig.json
@@ -4,7 +4,7 @@
 // You might want to change the configurations to fit your preferences
 // For more information about the configurations, please refer to http://www.typescriptlang.org/docs/handbook/tsconfig-json.html
 {
-  "flow_version": "23.3.0",
+  "flow_version": "23.3.1",
   "compilerOptions": {
     "sourceMap": true,
     "jsx": "react-jsx",

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/tsconfig.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/tsconfig.json
@@ -4,7 +4,7 @@
 // You might want to change the configurations to fit your preferences
 // For more information about the configurations, please refer to http://www.typescriptlang.org/docs/handbook/tsconfig-json.html
 {
-  "flow_version": "23.3.1",
+  "flow_version": "23.3.0.1",
   "compilerOptions": {
     "sourceMap": true,
     "jsx": "react-jsx",

--- a/flow-server/src/main/resources/tsconfig.json
+++ b/flow-server/src/main/resources/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "sourceMap": true,
+    "jsx": "react-jsx",
     "inlineSources": true,
     "module": "esNext",
     "target": "es2020",

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateTsConfigTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateTsConfigTest.java
@@ -38,7 +38,7 @@ import com.vaadin.flow.server.ExecutionFailedException;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class TaskGenerateTsConfigTest {
-    static private String LATEST_VERSION = "23.3.1";
+    static private String LATEST_VERSION = "23.3.0.1";
 
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateTsConfigTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskGenerateTsConfigTest.java
@@ -38,6 +38,8 @@ import com.vaadin.flow.server.ExecutionFailedException;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class TaskGenerateTsConfigTest {
+    static private String LATEST_VERSION = "23.3.1";
+
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -186,7 +188,8 @@ public class TaskGenerateTsConfigTest {
                 + "Please also: 1. Increment version in tsconfig.json (\"flow_version\" property) "
                 + "2. create a new tsconfig-vX.Y.json template in flow-server resources and put the old content there "
                 + "3. update vaadinVersion array in TaskGenerateTsConfig with X.Y "
-                + "4. put a new content in tsconfig-reference.json in tests",
+                + "4. put a new content in tsconfig-reference.json in tests "
+                + "5. update LATEST_VERSION in TaskGenerateTsConfigTest",
                 testTsConfig, tsConfigLatest);
 
     }
@@ -196,17 +199,19 @@ public class TaskGenerateTsConfigTest {
             throws IOException, ExecutionFailedException {
         File tsconfig = new File(npmFolder, "tsconfig.json");
         Files.createFile(tsconfig.toPath());
-        FileUtils.writeStringToFile(tsconfig, "{\"flow_version\": \"23.3.0\"}",
-                UTF_8);
+        FileUtils.writeStringToFile(tsconfig,
+                "{\"flow_version\": \"" + LATEST_VERSION + "\"}", UTF_8);
         taskGenerateTsConfig.execute();
 
         String tsConfigString = FileUtils.readFileToString(tsconfig, UTF_8);
 
-        String expected = IOUtils.toString(
-                Objects.requireNonNull(TaskGenerateTsConfigTest.class
-                        .getClassLoader()
-                        .getResourceAsStream("tsconfig-latest-version.json")),
-                StandardCharsets.UTF_8);
+        String expected = IOUtils
+                .toString(
+                        Objects.requireNonNull(TaskGenerateTsConfigTest.class
+                                .getClassLoader().getResourceAsStream(
+                                        "tsconfig-latest-version.json")),
+                        StandardCharsets.UTF_8)
+                .replace("latest", LATEST_VERSION);
 
         Assert.assertEquals(expected, tsConfigString);
     }

--- a/flow-server/src/test/resources/tsconfig-latest-version.json
+++ b/flow-server/src/test/resources/tsconfig-latest-version.json
@@ -1,1 +1,1 @@
-{"flow_version": "23.3.0"}
+{"flow_version": "latest"}

--- a/flow-server/src/test/resources/tsconfig-reference.json
+++ b/flow-server/src/test/resources/tsconfig-reference.json
@@ -7,6 +7,7 @@
   "flow_version": "23.3.0",
   "compilerOptions": {
     "sourceMap": true,
+    "jsx": "react-jsx",
     "inlineSources": true,
     "module": "esNext",
     "target": "es2020",
@@ -29,8 +30,7 @@
     }
   },
   "include": [
-    "frontend/**/*.ts",
-    "frontend/index.js",
+    "frontend/**/*",
     "types.d.ts"
   ],
   "exclude": []

--- a/flow-server/src/test/resources/tsconfig-reference.json
+++ b/flow-server/src/test/resources/tsconfig-reference.json
@@ -4,7 +4,7 @@
 // You might want to change the configurations to fit your preferences
 // For more information about the configurations, please refer to http://www.typescriptlang.org/docs/handbook/tsconfig-json.html
 {
-  "flow_version": "23.3.1",
+  "flow_version": "23.3.0.1",
   "compilerOptions": {
     "sourceMap": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
Summary of changes:

- Added a good default for `jsx` setting
- Relaxed file extensions for TypeScript, so that `.tsx` and such are considered

This should not interfere with existing TypeScript / Lit-based code.