### PR TITLE
chore: Use env instead of custom parameter to webpack (#9934) (CP: 2.8)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
@@ -658,6 +658,8 @@ public final class DevModeHandler implements RequestHandler {
         long start = System.nanoTime();
 
         processBuilder.command(command);
+        processBuilder.environment().put("watchDogPort",
+                Integer.toString(watchDog.get().getWatchDogPort()));
         try {
             webpackProcess.set(
                     processBuilder.redirectError(ProcessBuilder.Redirect.PIPE)
@@ -734,8 +736,6 @@ public final class DevModeHandler implements RequestHandler {
         // request to localhost. See https://github.com/vaadin/flow/issues/12546
         command.add("--host=127.0.0.1");
 
-        command.add("--env");
-        command.add("watchDogPort=" + watchDog.get().getWatchDogPort());
         command.addAll(Arrays.asList(config
                 .getStringProperty(SERVLET_PARAMETER_DEVMODE_WEBPACK_OPTIONS,
                         "-d --inline=false")

--- a/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DevModeHandler.java
@@ -730,12 +730,12 @@ public final class DevModeHandler implements RequestHandler {
         command.add(webpackConfig.getAbsolutePath());
         command.add("--port");
         command.add(String.valueOf(port));
-        command.add("--watchDogPort=" + watchDog.get().getWatchDogPort());
-
         // Workaround for issue with Node 17 webpack dev server denying
         // request to localhost. See https://github.com/vaadin/flow/issues/12546
         command.add("--host=127.0.0.1");
 
+        command.add("--env");
+        command.add("watchDogPort=" + watchDog.get().getWatchDogPort());
         command.addAll(Arrays.asList(config
                 .getStringProperty(SERVLET_PARAMETER_DEVMODE_WEBPACK_OPTIONS,
                         "-d --inline=false")

--- a/flow-server/src/main/resources/webpack.generated.js
+++ b/flow-server/src/main/resources/webpack.generated.js
@@ -70,11 +70,11 @@ let stats;
 
 const transpile = !devMode || process.argv.find(v => v.indexOf('--transpile-es5') >= 0);
 
-const watchDogPrefix = '--watchDogPort=';
-let watchDogPort = devMode && process.argv.find(v => v.indexOf(watchDogPrefix) >= 0);
+// Open a connection with the Java dev-mode handler in order to finish
+// webpack-dev-mode when it exits or crashes.
+const watchDogPort = devMode && process.env.watchDogPort;
 let client;
 if (watchDogPort) {
-  watchDogPort = watchDogPort.substr(watchDogPrefix.length);
   const runWatchDog = () => {
     client = new require('net').Socket();
     client.setEncoding('utf8');

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -244,14 +244,13 @@ public class FrontendUtilsTest {
         List<String> command = Arrays.asList("./node/node",
                 "./node_modules/webpack-dev-server/bin/webpack-dev-server.js",
                 "--config", "./webpack.config.js", "--port 57799",
-"--env watchDogPort=57798", "-d", "--inline=false", "--progress",
+"-d", "--inline=false", "--progress",
                 "--colors");
         String wrappedCommand = FrontendUtils.commandToString(".", command);
         Assert.assertEquals("\n" + "./node/node \\ \n"
                 + "    ./node_modules/webpack-dev-server/bin/webpack-dev-server.js \\ \n"
-                + "    --config ./webpack.config.js --port 57799 \\ \n"
-                + "    --env watchDogPort=57798 -d --inline=false \\ \n"
-                + "    --progress --colors \n", wrappedCommand);
+                + "    --config ./webpack.config.js --port 57799 -d \\ \n"
+                + "    --inline=false --progress --colors \n", wrappedCommand);
     }
 
     @Test

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendUtilsTest.java
@@ -244,14 +244,14 @@ public class FrontendUtilsTest {
         List<String> command = Arrays.asList("./node/node",
                 "./node_modules/webpack-dev-server/bin/webpack-dev-server.js",
                 "--config", "./webpack.config.js", "--port 57799",
-                "--watchDogPort=57798", "-d", "--inline=false", "--progress",
+"--env watchDogPort=57798", "-d", "--inline=false", "--progress",
                 "--colors");
         String wrappedCommand = FrontendUtils.commandToString(".", command);
         Assert.assertEquals("\n" + "./node/node \\ \n"
                 + "    ./node_modules/webpack-dev-server/bin/webpack-dev-server.js \\ \n"
                 + "    --config ./webpack.config.js --port 57799 \\ \n"
-                + "    --watchDogPort=57798 -d --inline=false --progress \\ \n"
-                + "    --colors \n", wrappedCommand);
+                + "    --env watchDogPort=57798 -d --inline=false \\ \n"
+                + "    --progress --colors \n", wrappedCommand);
     }
 
     @Test


### PR DESCRIPTION
This is compatible with Webpack 5
