### PR TITLE
Skip IBMRestServlet when checking for VaadinServlet

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/JSR356WebsocketInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/JSR356WebsocketInitializer.java
@@ -238,7 +238,8 @@ public class JSR356WebsocketInitializer implements ServletContextListener {
                 // dynamically added
                 return false;
             }
-            if (servletClassName.equals("com.ibm.websphere.jaxrs.server.IBMRestServlet")) {
+            if (servletClassName
+                    .equals("com.ibm.websphere.jaxrs.server.IBMRestServlet")) {
                 // Websphere servlet which implements websocket endpoints,
                 // dynamically added
                 return false;

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/JSR356WebsocketInitializer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/JSR356WebsocketInitializer.java
@@ -238,6 +238,12 @@ public class JSR356WebsocketInitializer implements ServletContextListener {
                 // dynamically added
                 return false;
             }
+            if (servletClassName.equals("com.ibm.websphere.jaxrs.server.IBMRestServlet")) {
+                // Websphere servlet which implements websocket endpoints,
+                // dynamically added
+                return false;
+            }
+
             // Must use servletContext class loader to load servlet class to
             // work correctly in an OSGi environment (#20024)
             Class<?> servletClass = servletContext.getClassLoader()


### PR DESCRIPTION
Fixes #14889

The fix is similar to what is already there for `WsocServlet`, and is far from optimal. This should be revisited when considering #15086.