### PR TITLE
fix: Prevent adding an extra dot to expressions consisting of one non-null variable

### DIFF
--- a/flow-polymer2lit/convert.ts
+++ b/flow-polymer2lit/convert.ts
@@ -777,16 +777,18 @@ function convertFile(filename: string, useLit1: boolean, useOptionalChaining: bo
     // webpack 4 does not support ?. so to be compati
     if (useOptionalChaining) {
       const parts = name.split('.');
-      if (parts.length === 1) {
-        // index -> index
-        return parts[0];
-      } else if (assumedNonNull.includes(parts[0])) {
+      if (assumedNonNull.includes(parts[0])) {
+        if (parts.length === 1) {
+          // index -> index
+          return parts[0]
+        }
+
         // item.user.name -> item.user?.name
         return `${parts[0]}.${parts.slice(1).join('?.')}`;
-      } else {
-        // item.user.name -> item?.user?.name
-        return parts.join('?.');
       }
+
+      // item.user.name -> item?.user?.name
+      return parts.join('?.');
     } else {
       // this.a -> this.a
       // this.a.b -> (this.a) ? this.a.b : undefined

--- a/flow-polymer2lit/convert.ts
+++ b/flow-polymer2lit/convert.ts
@@ -781,14 +781,14 @@ function convertFile(filename: string, useLit1: boolean, useOptionalChaining: bo
         if (parts.length === 1) {
           // index -> index
           return parts[0]
+        } else {
+          // item.user.name -> item.user?.name
+          return `${parts[0]}.${parts.slice(1).join('?.')}`;
         }
-
-        // item.user.name -> item.user?.name
-        return `${parts[0]}.${parts.slice(1).join('?.')}`;
+      } else {
+        // item.user.name -> item?.user?.name
+        return parts.join('?.');
       }
-
-      // item.user.name -> item?.user?.name
-      return parts.join('?.');
     } else {
       // this.a -> this.a
       // this.a.b -> (this.a) ? this.a.b : undefined

--- a/flow-polymer2lit/convert.ts
+++ b/flow-polymer2lit/convert.ts
@@ -776,11 +776,17 @@ function convertFile(filename: string, useLit1: boolean, useOptionalChaining: bo
     // Polymer allows using "a.b.c" when "a" or "b" is undefined
     // webpack 4 does not support ?. so to be compati
     if (useOptionalChaining) {
-      const first = name.split('.')[0];
-      if (assumedNonNull.includes(first)) {
-        return first + '.' + name.substring(first.length + 1).replace(/\./g, '?.');
+      const parts = name.split('.');
+      if (parts.length === 1) {
+        // index -> index
+        return parts[0];
+      } else if (assumedNonNull.includes(parts[0])) {
+        // item.user.name -> item.user?.name
+        return `${parts[0]}.${parts.slice(1).join('?.')}`;
+      } else {
+        // item.user.name -> item?.user?.name
+        return parts.join('?.');
       }
-      return name.replace(/\./g, '?.');
     } else {
       // this.a -> this.a
       // this.a.b -> (this.a) ? this.a.b : undefined

--- a/flow-polymer2lit/src/test/java/com/vaadin/flow/polymer2lit/FrontendConverterTest.java
+++ b/flow-polymer2lit/src/test/java/com/vaadin/flow/polymer2lit/FrontendConverterTest.java
@@ -70,6 +70,11 @@ public class FrontendConverterTest {
     }
 
     @Test
+    public void domRepeat_disabledOptionalChaining() throws IOException, InterruptedException {
+        convertFile_outputFileMatchesExpectedOne("dom-repeat-disabled-optional-chaining.js");
+    }
+
+    @Test
     public void eventHandlers() throws IOException, InterruptedException {
         convertFile_outputFileMatchesExpectedOne("event-handlers.js");
     }

--- a/flow-polymer2lit/src/test/java/com/vaadin/flow/polymer2lit/FrontendConverterTest.java
+++ b/flow-polymer2lit/src/test/java/com/vaadin/flow/polymer2lit/FrontendConverterTest.java
@@ -70,8 +70,10 @@ public class FrontendConverterTest {
     }
 
     @Test
-    public void domRepeat_disabledOptionalChaining() throws IOException, InterruptedException {
-        convertFile_outputFileMatchesExpectedOne("dom-repeat-disabled-optional-chaining.js");
+    public void domRepeat_disabledOptionalChaining()
+            throws IOException, InterruptedException {
+        convertFile_outputFileMatchesExpectedOne("dom-repeat.js",
+                "dom-repeat-disabled-optional-chaining.js", false, true);
     }
 
     @Test
@@ -102,6 +104,13 @@ public class FrontendConverterTest {
     @Test
     public void nestedDomRepeat() throws IOException, InterruptedException {
         convertFile_outputFileMatchesExpectedOne("nested-dom-repeat.js");
+    }
+
+    @Test
+    public void nestedDomRepeatDisabledOptionalChaining()
+            throws IOException, InterruptedException {
+        convertFile_outputFileMatchesExpectedOne("nested-dom-repeat.js",
+                "nested-dom-repeat-disabled-optional-chaining.js", false, true);
     }
 
     @Test

--- a/flow-polymer2lit/src/test/resources/frontend/expected/dom-repeat-disabled-optional-chaining.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/dom-repeat-disabled-optional-chaining.js
@@ -6,19 +6,18 @@ class DomRepeatTest extends LitElement {
   render() {
     return html`
       <div>Employee list:</div>
-      ${(this.managers ? this.managers : []).map(
+      ${(this.employees?.list).map(
         (item, index) => html`
           <div><br /># ${index}</div>
           <div>Given name: <span>${item.given}</span></div>
           <div>Family name: <span>${item.family}</span></div>
-          ${(item.employees ? item.employees : []).map(
-            (item, index) => html`
-              <div><br />Employee # ${index}</div>
-              <div>
-                Employee name: <span>${item.given} ${item.family}</span>
-              </div>
-            `
-          )}
+        `
+      )}
+      ${(this.employees?.list).map(
+        (item, index) => html`
+          <div><br /># ${index}</div>
+          <div>Given name: <span>${item.given}</span></div>
+          <div>Family name: <span>${item.family}</span></div>
         `
       )}
     `;
@@ -27,7 +26,7 @@ class DomRepeatTest extends LitElement {
   static get properties() {
     return {
       employees: {
-        type: Array,
+        type: Object,
       },
     };
   }
@@ -37,10 +36,12 @@ class DomRepeatTest extends LitElement {
   }
   constructor() {
     super();
-    this.employees = [
-      { given: "Kamil", family: "Smith" },
-      { given: "Sally", family: "Johnson" },
-    ];
+    this.employees = {
+      list: [
+        { given: "Kamil", family: "Smith" },
+        { given: "Sally", family: "Johnson" },
+      ],
+    };
   }
 }
 

--- a/flow-polymer2lit/src/test/resources/frontend/expected/dom-repeat-disabled-optional-chaining.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/dom-repeat-disabled-optional-chaining.js
@@ -6,14 +6,14 @@ class DomRepeatTest extends LitElement {
   render() {
     return html`
       <div>Employee list:</div>
-      ${(this.employees?.list).map(
+      ${(this.employees && this.employees.list ? this.employees.list : []).map(
         (item, index) => html`
           <div><br /># ${index}</div>
           <div>Given name: <span>${item.given}</span></div>
           <div>Family name: <span>${item.family}</span></div>
         `
       )}
-      ${(this.employees?.list).map(
+      ${(this.employees && this.employees.list ? this.employees.list : []).map(
         (item, index) => html`
           <div><br /># ${index}</div>
           <div>Given name: <span>${item.given}</span></div>

--- a/flow-polymer2lit/src/test/resources/frontend/expected/dom-repeat.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/dom-repeat.js
@@ -1,23 +1,25 @@
-import { html, PolymerElement } from "@polymer/polymer/polymer-element.js";
-import "@vaadin/vaadin-vertical-layout";
-import "@polymer/polymer/lib/elements/dom-repeat.js";
+import { html, LitElement, css } from "lit";
 
-class DomRepeatTest extends PolymerElement {
-  static get template() {
+import "@vaadin/vaadin-vertical-layout";
+
+class DomRepeatTest extends LitElement {
+  render() {
     return html`
       <div>Employee list:</div>
-      <template is="dom-repeat" items="{{employees.list}}">
-        <div><br /># [[index]]</div>
-        <div>Given name: <span>[[item.given]]</span></div>
-        <div>Family name: <span>[[item.family]]</span></div>
-      </template>
-      <dom-repeat items="{{employees.list}}">
-        <template>
-          <div><br /># [[index]]</div>
-          <div>Given name: <span>[[item.given]]</span></div>
-          <div>Family name: <span>[[item.family]]</span></div>
-        </template>
-      </dom-repeat>
+      ${(this.employees && this.employees.list ? this.employees.list : []).map(
+        (item, index) => html`
+          <div><br /># ${index}</div>
+          <div>Given name: <span>${item.given}</span></div>
+          <div>Family name: <span>${item.family}</span></div>
+        `
+      )}
+      ${(this.employees && this.employees.list ? this.employees.list : []).map(
+        (item, index) => html`
+          <div><br /># ${index}</div>
+          <div>Given name: <span>${item.given}</span></div>
+          <div>Family name: <span>${item.family}</span></div>
+        `
+      )}
     `;
   }
 
@@ -25,20 +27,21 @@ class DomRepeatTest extends PolymerElement {
     return {
       employees: {
         type: Object,
-        value() {
-          return {
-            list: [
-              { given: "Kamil", family: "Smith" },
-              { given: "Sally", family: "Johnson" },
-            ],
-          };
-        },
       },
     };
   }
 
   static get is() {
     return "dom-repeat-test";
+  }
+  constructor() {
+    super();
+    this.employees = {
+      list: [
+        { given: "Kamil", family: "Smith" },
+        { given: "Sally", family: "Johnson" },
+      ],
+    };
   }
 }
 

--- a/flow-polymer2lit/src/test/resources/frontend/expected/nested-dom-repeat-disabled-optional-chaining.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/nested-dom-repeat-disabled-optional-chaining.js
@@ -6,18 +6,19 @@ class DomRepeatTest extends LitElement {
   render() {
     return html`
       <div>Employee list:</div>
-      ${(this.employees?.list).map(
+      ${(this.managers ? this.managers : []).map(
         (item, index) => html`
           <div><br /># ${index}</div>
           <div>Given name: <span>${item.given}</span></div>
           <div>Family name: <span>${item.family}</span></div>
-        `
-      )}
-      ${(this.employees?.list).map(
-        (item, index) => html`
-          <div><br /># ${index}</div>
-          <div>Given name: <span>${item.given}</span></div>
-          <div>Family name: <span>${item.family}</span></div>
+          ${(item.employees ? item.employees : []).map(
+            (item, index) => html`
+              <div><br />Employee # ${index}</div>
+              <div>
+                Employee name: <span>${item.given} ${item.family}</span>
+              </div>
+            `
+          )}
         `
       )}
     `;
@@ -26,7 +27,7 @@ class DomRepeatTest extends LitElement {
   static get properties() {
     return {
       employees: {
-        type: Object,
+        type: Array,
       },
     };
   }
@@ -36,12 +37,10 @@ class DomRepeatTest extends LitElement {
   }
   constructor() {
     super();
-    this.employees = {
-      list: [
-        { given: "Kamil", family: "Smith" },
-        { given: "Sally", family: "Johnson" },
-      ],
-    };
+    this.employees = [
+      { given: "Kamil", family: "Smith" },
+      { given: "Sally", family: "Johnson" },
+    ];
   }
 }
 

--- a/flow-polymer2lit/src/test/resources/frontend/expected/nested-dom-repeat.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/nested-dom-repeat.js
@@ -6,12 +6,12 @@ class DomRepeatTest extends LitElement {
   render() {
     return html`
       <div>Employee list:</div>
-      ${(this.managers ? this.managers : []).map(
+      ${this.managers.map(
         (item, index) => html`
           <div><br /># ${index}</div>
           <div>Given name: <span>${item.given}</span></div>
           <div>Family name: <span>${item.family}</span></div>
-          ${(item.employees ? item.employees : []).map(
+          ${item.employees.map(
             (item, index) => html`
               <div><br />Employee # ${index}</div>
               <div>


### PR DESCRIPTION
## Description

This PR prevents adding an extra dot to expressions that consist of only one variable that is assumed to never be null. This could occur before when running the converter with the enabled optional chaining operator.

```diff
${this.items.map(
  (item, index) => html`
-    <div>${index.}</div>
+    <div>${index}</div>
  `
)}
```

A follow-up #14972

## Type of change

- [x] Bugfix
