### PR TITLE
chore: Import require to be future proof

### DIFF
--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -14,6 +14,9 @@ import settings from '#settingsImport#';
 import { defineConfig, mergeConfig, PluginOption, ResolvedConfig, UserConfigFn, OutputOptions, AssetInfo, ChunkInfo } from 'vite';
 import { getManifest } from 'workbox-build';
 
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+
 import * as rollup from 'rollup';
 import brotli from 'rollup-plugin-brotli';
 import replace from '@rollup/plugin-replace';


### PR DESCRIPTION
Using node16 module resolution does not work without this
