### PR TITLE
fix: Add a default value to expressions when optional chaining is enabled

### DIFF
--- a/flow-polymer2lit/convert.ts
+++ b/flow-polymer2lit/convert.ts
@@ -792,7 +792,7 @@ function convertFile(filename: string, useLit1: boolean, useOptionalChaining: bo
       }
 
       if (undefinedValue !== 'undefined') {
-        return `(${result} || ${undefinedValue})`;
+        return `(${result} ?? ${undefinedValue})`;
       } else {
         return result;
       }

--- a/flow-polymer2lit/convert.ts
+++ b/flow-polymer2lit/convert.ts
@@ -777,17 +777,24 @@ function convertFile(filename: string, useLit1: boolean, useOptionalChaining: bo
     // webpack 4 does not support ?. so to be compati
     if (useOptionalChaining) {
       const parts = name.split('.');
+      let result: string;
       if (assumedNonNull.includes(parts[0])) {
         if (parts.length === 1) {
           // index -> index
-          return parts[0]
+          result = parts[0]
         } else {
           // item.user.name -> item.user?.name
-          return `${parts[0]}.${parts.slice(1).join('?.')}`;
+          result = `${parts[0]}.${parts.slice(1).join('?.')}`;
         }
       } else {
         // item.user.name -> item?.user?.name
-        return parts.join('?.');
+        result = parts.join('?.');
+      }
+
+      if (undefinedValue !== 'undefined') {
+        return `(${result} || ${undefinedValue})`;
+      } else {
+        return result;
       }
     } else {
       // this.a -> this.a
@@ -822,8 +829,7 @@ function convertFile(filename: string, useLit1: boolean, useOptionalChaining: bo
         }
       }
       if (condition) {
-        const ret = `(${condition}) ? ${name} : ${undefinedValue}`;
-        return ret;
+        return `(${condition}) ? ${name} : ${undefinedValue}`;
       } else {
         return name;
       }

--- a/flow-polymer2lit/src/test/resources/frontend/expected/dom-repeat.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/dom-repeat.js
@@ -6,14 +6,14 @@ class DomRepeatTest extends LitElement {
   render() {
     return html`
       <div>Employee list:</div>
-      ${(this.employees?.list || []).map(
+      ${(this.employees?.list ?? []).map(
         (item, index) => html`
           <div><br /># ${index}</div>
           <div>Given name: <span>${item.given}</span></div>
           <div>Family name: <span>${item.family}</span></div>
         `
       )}
-      ${(this.employees?.list || []).map(
+      ${(this.employees?.list ?? []).map(
         (item, index) => html`
           <div><br /># ${index}</div>
           <div>Given name: <span>${item.given}</span></div>

--- a/flow-polymer2lit/src/test/resources/frontend/expected/dom-repeat.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/dom-repeat.js
@@ -6,14 +6,14 @@ class DomRepeatTest extends LitElement {
   render() {
     return html`
       <div>Employee list:</div>
-      ${(this.employees?.list).map(
+      ${(this.employees?.list || []).map(
         (item, index) => html`
           <div><br /># ${index}</div>
           <div>Given name: <span>${item.given}</span></div>
           <div>Family name: <span>${item.family}</span></div>
         `
       )}
-      ${(this.employees?.list).map(
+      ${(this.employees?.list || []).map(
         (item, index) => html`
           <div><br /># ${index}</div>
           <div>Given name: <span>${item.given}</span></div>

--- a/flow-polymer2lit/src/test/resources/frontend/expected/inline-styles.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/inline-styles.js
@@ -9,10 +9,10 @@ class InlineStyles extends LitElement {
     const includedStyles = {};
     includedStyles["shared-styles"] =
       document.querySelector("dom-module[id='shared-styles']")
-        ?.firstElementChild?.content?.firstElementChild?.innerText || "";
+        ?.firstElementChild?.content?.firstElementChild?.innerText ?? "";
     includedStyles["something-else"] =
       document.querySelector("dom-module[id='something-else']")
-        ?.firstElementChild?.content?.firstElementChild?.innerText || "";
+        ?.firstElementChild?.content?.firstElementChild?.innerText ?? "";
     return [
       unsafeCSS(includedStyles["shared-styles"]),
       unsafeCSS(includedStyles["something-else"]),

--- a/flow-polymer2lit/src/test/resources/frontend/expected/inline-styles.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/inline-styles.js
@@ -7,12 +7,12 @@ import "@vaadin/vaadin-vertical-layout";
 class InlineStyles extends LitElement {
   static get styles() {
     const includedStyles = {};
-    includedStyles["shared-styles"] = document.querySelector(
-      "dom-module[id='shared-styles']"
-    )?.firstElementChild?.content?.firstElementChild?.innerText;
-    includedStyles["something-else"] = document.querySelector(
-      "dom-module[id='something-else']"
-    )?.firstElementChild?.content?.firstElementChild?.innerText;
+    includedStyles["shared-styles"] =
+      document.querySelector("dom-module[id='shared-styles']")
+        ?.firstElementChild?.content?.firstElementChild?.innerText || "";
+    includedStyles["something-else"] =
+      document.querySelector("dom-module[id='something-else']")
+        ?.firstElementChild?.content?.firstElementChild?.innerText || "";
     return [
       unsafeCSS(includedStyles["shared-styles"]),
       unsafeCSS(includedStyles["something-else"]),

--- a/flow-polymer2lit/src/test/resources/frontend/expected/multiple-bindings.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/multiple-bindings.js
@@ -7,16 +7,16 @@ class MultipleBindings extends LitElement {
         <vaadin-button .id="${this.buttonId}"
           >${this.buttonText1} ${this.buttonText2}</vaadin-button
         >
-        <vaadin-button .id="${"hello " + (this.buttonId || "")}"
+        <vaadin-button .id="${"hello " + (this.buttonId ?? "")}"
           >${this.buttonText1} ${this.buttonText2}</vaadin-button
         >
         <vaadin-text-field
-          .value="${(this.textfieldValue1 || "") +
+          .value="${(this.textfieldValue1 ?? "") +
           "-" +
-          (this.textfieldValue2 || "")}"
+          (this.textfieldValue2 ?? "")}"
         ></vaadin-text-field>
         <vaadin-text-field
-          .value="${(this.sub?.value1 || "") + "-" + (this.sub?.value2 || "")}"
+          .value="${(this.sub?.value1 ?? "") + "-" + (this.sub?.value2 ?? "")}"
         ></vaadin-text-field>
       </vaadin-vertical-layout>
     `;

--- a/flow-polymer2lit/src/test/resources/frontend/expected/multiple-bindings.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/multiple-bindings.js
@@ -7,14 +7,16 @@ class MultipleBindings extends LitElement {
         <vaadin-button .id="${this.buttonId}"
           >${this.buttonText1} ${this.buttonText2}</vaadin-button
         >
-        <vaadin-button .id="${"hello " + this.buttonId}"
+        <vaadin-button .id="${"hello " + (this.buttonId || "")}"
           >${this.buttonText1} ${this.buttonText2}</vaadin-button
         >
         <vaadin-text-field
-          .value="${this.textfieldValue1 + "-" + this.textfieldValue2}"
+          .value="${(this.textfieldValue1 || "") +
+          "-" +
+          (this.textfieldValue2 || "")}"
         ></vaadin-text-field>
         <vaadin-text-field
-          .value="${this.sub?.value1 + "-" + this.sub?.value2}"
+          .value="${(this.sub?.value1 || "") + "-" + (this.sub?.value2 || "")}"
         ></vaadin-text-field>
       </vaadin-vertical-layout>
     `;

--- a/flow-polymer2lit/src/test/resources/frontend/expected/nested-dom-repeat.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/nested-dom-repeat.js
@@ -6,12 +6,12 @@ class DomRepeatTest extends LitElement {
   render() {
     return html`
       <div>Employee list:</div>
-      ${this.managers.map(
+      ${(this.managers || []).map(
         (item, index) => html`
           <div><br /># ${index}</div>
           <div>Given name: <span>${item.given}</span></div>
           <div>Family name: <span>${item.family}</span></div>
-          ${item.employees.map(
+          ${(item.employees || []).map(
             (item, index) => html`
               <div><br />Employee # ${index}</div>
               <div>

--- a/flow-polymer2lit/src/test/resources/frontend/expected/nested-dom-repeat.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/nested-dom-repeat.js
@@ -6,12 +6,12 @@ class DomRepeatTest extends LitElement {
   render() {
     return html`
       <div>Employee list:</div>
-      ${(this.managers || []).map(
+      ${(this.managers ?? []).map(
         (item, index) => html`
           <div><br /># ${index}</div>
           <div>Given name: <span>${item.given}</span></div>
           <div>Family name: <span>${item.family}</span></div>
-          ${(item.employees || []).map(
+          ${(item.employees ?? []).map(
             (item, index) => html`
               <div><br />Employee # ${index}</div>
               <div>

--- a/flow-polymer2lit/src/test/resources/frontend/expected/order-card-from-bakery.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/order-card-from-bakery.js
@@ -9,7 +9,7 @@ class OrderCard extends LitElement {
     const includedStyles = {};
     includedStyles["shared-styles"] =
       document.querySelector("dom-module[id='shared-styles']")
-        ?.firstElementChild?.content?.firstElementChild?.innerText || "";
+        ?.firstElementChild?.content?.firstElementChild?.innerText ?? "";
     return [
       unsafeCSS(includedStyles["shared-styles"]),
       css`
@@ -168,7 +168,7 @@ class OrderCard extends LitElement {
           <div class="name-items">
             <h3 class="name">${this.orderCard?.fullName}</h3>
             <div class="goods">
-              ${(this.orderCard?.items || []).map(
+              ${(this.orderCard?.items ?? []).map(
                 (item, index) => html`
                   <div class="goods-item">
                     <span class="count">${item.quantity}</span>

--- a/flow-polymer2lit/src/test/resources/frontend/expected/order-card-from-bakery.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/order-card-from-bakery.js
@@ -7,9 +7,9 @@ import "./order-status-badge.js";
 class OrderCard extends LitElement {
   static get styles() {
     const includedStyles = {};
-    includedStyles["shared-styles"] = document.querySelector(
-      "dom-module[id='shared-styles']"
-    )?.firstElementChild?.content?.firstElementChild?.innerText;
+    includedStyles["shared-styles"] =
+      document.querySelector("dom-module[id='shared-styles']")
+        ?.firstElementChild?.content?.firstElementChild?.innerText || "";
     return [
       unsafeCSS(includedStyles["shared-styles"]),
       css`
@@ -168,7 +168,7 @@ class OrderCard extends LitElement {
           <div class="name-items">
             <h3 class="name">${this.orderCard?.fullName}</h3>
             <div class="goods">
-              ${(this.orderCard?.items).map(
+              ${(this.orderCard?.items || []).map(
                 (item, index) => html`
                   <div class="goods-item">
                     <span class="count">${item.quantity}</span>


### PR DESCRIPTION
## Description

The PR makes the converter add a default value to expressions that are built with the optional chaining operator. Before, the converter used to add a default value only in the case optional chaining was disabled.

```diff
<div>
- ${account?.info?.friends.map((name) => name)}
+ ${(account?.info?.friends || []).map((name) => name)}
</div>
```

A follow-up to #14972 

## Type of change

- [x] Bugfix
