### PR TITLE
chore: Upgrade to Spring Boot 3 RC2

### DIFF
--- a/flow-commons-upload/pom.xml
+++ b/flow-commons-upload/pom.xml
@@ -19,6 +19,7 @@
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
     <build>

--- a/flow-lit-template/pom.xml
+++ b/flow-lit-template/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/flow-plugins/flow-plugin-base/pom.xml
+++ b/flow-plugins/flow-plugin-base/pom.xml
@@ -44,6 +44,7 @@
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/flow-polymer-template/pom.xml
+++ b/flow-polymer-template/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/flow-server/src/test/java/com/vaadin/flow/server/MockServletContext.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/MockServletContext.java
@@ -141,52 +141,10 @@ public class MockServletContext implements ServletContext {
     /*
      * (non-Javadoc)
      *
-     * @see jakarta.servlet.ServletContext#getServlet(java.lang.String)
-     */
-    @Override
-    public Servlet getServlet(String name) throws ServletException {
-        return null;
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see jakarta.servlet.ServletContext#getServlets()
-     */
-    @Override
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    public Enumeration getServlets() {
-        return Collections.enumeration(Collections.EMPTY_SET);
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see jakarta.servlet.ServletContext#getServletNames()
-     */
-    @Override
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    public Enumeration getServletNames() {
-        return null;
-    }
-
-    /*
-     * (non-Javadoc)
-     *
      * @see jakarta.servlet.ServletContext#log(java.lang.String)
      */
     @Override
     public void log(String msg) {
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see jakarta.servlet.ServletContext#log(java.lang.Exception,
-     * java.lang.String)
-     */
-    @Override
-    public void log(Exception exception, String msg) {
     }
 
     /*

--- a/flow-tests/test-memory-leaks/pom.xml
+++ b/flow-tests/test-memory-leaks/pom.xml
@@ -56,6 +56,7 @@
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/flow-tests/vaadin-spring-tests/test-spring-boot-only-prepare/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot-only-prepare/pom.xml
@@ -37,6 +37,16 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-tomcat</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jetty</artifactId>
         </dependency>
 
         <dependency>

--- a/flow-tests/vaadin-spring-tests/test-spring-boot/pom.xml
+++ b/flow-tests/vaadin-spring-tests/test-spring-boot/pom.xml
@@ -37,6 +37,16 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-tomcat</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jetty</artifactId>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -85,18 +85,18 @@
         <failOnMissingWebXml>false</failOnMissingWebXml>
 
         <!-- Dependencies -->
-        <spring.version>6.0.0-RC2</spring.version>
-        <spring.boot.version>3.0.0-RC1</spring.boot.version>
-        <spring.security.version>6.0.0-RC1</spring.security.version>
+        <spring.version>6.0.0-RC4</spring.version>
+        <spring.boot.version>3.0.0-RC2</spring.boot.version>
+        <spring.security.version>6.0.0-RC2</spring.security.version>
         <spring.security.oauth2.authorization.server.version>1.0.0-RC1</spring.security.oauth2.authorization.server.version>
         <gwt.version>2.9.0</gwt.version>
-        <hibernate.validator.version>7.0.5.Final</hibernate.validator.version>
+        <hibernate.validator.version>8.0.0.Final</hibernate.validator.version>
         <slf4j.version>2.0.3</slf4j.version>
         <polymer.version>2.6.1</polymer.version>
-        <jackson.version>2.14.0-rc2</jackson.version>
-        <jackson.databind.version>2.14.0-rc2</jackson.databind.version>
+        <jackson.version>2.14.0</jackson.version>
+        <jackson.databind.version>2.14.0</jackson.databind.version>
         <jakarta.validation.version>3.0.2</jakarta.validation.version>
-        <jakarta.annotation.api.version>2.0.0</jakarta.annotation.api.version>
+        <jakarta.annotation.api.version>2.1.1</jakarta.annotation.api.version>
         <jaxb.version>4.0.1</jaxb.version>
 
         <!-- Plugins -->

--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
             <dependency>
                 <groupId>jakarta.servlet</groupId>
                 <artifactId>jakarta.servlet-api</artifactId>
-                <version>5.0.0</version>
+                <version>6.0.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
As Spring Boot now uses Tomcat 10.1, we cannot mix Jetty 11 (servlet 5) and Tomcat 10.1 (servlet 6) in the same test modules so they are all run with Jetty 11 for now.