### PR TITLE
fix: Create an individual npm script for compiling convert.ts

### DIFF
--- a/flow-polymer2lit/package.json
+++ b/flow-polymer2lit/package.json
@@ -12,7 +12,7 @@
     "src/main/frontend"
   ],
   "scripts": {
-    "postinstall": "esbuild convert.ts --bundle --platform=node --outdir=src/main/resources/META-INF/frontend/generated/"
+    "compile": "esbuild convert.ts --bundle --platform=node --outdir=src/main/resources/META-INF/frontend/generated/"
   },
   "dependencies": {
     "esbuild": "0.15.12",

--- a/flow-polymer2lit/pom.xml
+++ b/flow-polymer2lit/pom.xml
@@ -76,6 +76,20 @@
                             </arguments>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>converter-compile</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>npm</executable>
+                            <arguments>
+                                <argument>run</argument>
+                                <argument>compile</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>


### PR DESCRIPTION
## Description

The PR creates an individual npm script for compiling `convert.ts` instead of running it on `postinstall` which may happen to be disabled by `ignore-scripts=true` in `.npmrc`.

## Type of change

- [x] Bugfix

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
