### PR TITLE
fix: linux node installation (#14657) (#14825)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -78,6 +78,10 @@ public class FrontendTools {
     public static final String INSTALL_NODE_LOCALLY = "%n  $ mvn com.github.eirslett:frontend-maven-plugin:1.10.0:install-node-and-npm "
             + "-DnodeVersion=\"" + DEFAULT_NODE_VERSION + "\" ";
 
+    public static final String NPM_BIN_PATH = FrontendUtils.isWindows()
+            ? "node/node_modules/npm/bin/"
+            : "node/lib/node_modules/npm/bin/";
+
     private static final String MSG_PREFIX = "%n%n======================================================================================================";
     private static final String MSG_SUFFIX = "%n======================================================================================================%n";
 
@@ -1062,7 +1066,7 @@ public class FrontendTools {
         // If `node` is not found in PATH, `node/node_modules/npm/bin/npm` will
         // not work because it's a shell or windows script that looks for node
         // and will fail. Thus we look for the `npm-cli` node script instead
-        File file = new File(dir, "node/node_modules/npm/bin/" + scriptName);
+        File file = new File(dir, NPM_BIN_PATH + scriptName);
         List<String> returnCommand = new ArrayList<>();
         if (file.canRead()) {
             // We return a two element list with node binary and npm-cli script

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -15,6 +15,7 @@
  */
 package com.vaadin.flow.server.frontend;
 
+import static com.vaadin.flow.server.frontend.FrontendTools.NPM_BIN_PATH;
 import static com.vaadin.flow.testutil.FrontendStubs.createStubNode;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
@@ -73,9 +74,9 @@ public class FrontendToolsTest {
             ? "node\\node.exe"
             : "node/node";
 
-    public static final String NPM_CLI_STRING = Stream
-            .of("node", "node_modules", "npm", "bin", "npm-cli.js")
-            .collect(Collectors.joining(File.separator));
+    public static final String NPM_CLI_STRING = FrontendUtils.isWindows()
+            ? "node\\node_modules\\npm\\bin\\npm-cli.js"
+            : "node/lib/node_modules/npm/bin/npm-cli.js";
 
     private static final String OLD_PNPM_VERSION = "4.5.0";
 
@@ -130,8 +131,13 @@ public class FrontendToolsTest {
         npmVersionCommand.add("--version");
         FrontendVersion npm = FrontendUtils.getVersion("npm",
                 npmVersionCommand);
-        Assert.assertEquals(FrontendTools.DEFAULT_NPM_VERSION,
-                npm.getFullVersion());
+        final FrontendVersion npmDefault = new FrontendVersion(
+                FrontendTools.DEFAULT_NPM_VERSION);
+
+        Assert.assertEquals("Major version should match",
+                npmDefault.getMajorVersion(), npm.getMajorVersion());
+        Assert.assertEquals("Minor version should match",
+                npmDefault.getMinorVersion(), npm.getMinorVersion());
     }
 
     @Test
@@ -339,17 +345,17 @@ public class FrontendToolsTest {
         String nodeExecutable = installNodeToTempFolder();
         Assert.assertNotNull(nodeExecutable);
 
+        String npmInstallPath = NPM_BIN_PATH + "npm";
+
         Assert.assertTrue("npm should have been copied to node_modules",
-                new File(vaadinHomeDir, "node/node_modules/npm/bin/npm")
-                        .exists());
+                new File(vaadinHomeDir, npmInstallPath).exists());
     }
 
     @Test
     public void installNodeFromFileSystem_ForceAlternativeNodeExecutableInstallsToTargetDirectory()
             throws Exception {
         Assert.assertFalse("npm should not yet be present",
-                new File(vaadinHomeDir, "node/node_modules/npm/bin/npm")
-                        .exists());
+                new File(vaadinHomeDir, NPM_BIN_PATH + "npm").exists());
 
         settings.setNodeDownloadRoot(new File(baseDir).toURI());
         settings.setNodeVersion("v12.10.0");
@@ -357,9 +363,10 @@ public class FrontendToolsTest {
         prepareNodeDownloadableZipAt(baseDir, "v12.10.0");
         tools.forceAlternativeNodeExecutable();
 
+        String npmInstallPath = NPM_BIN_PATH + "npm";
+
         Assert.assertTrue("npm should have been copied to node_modules",
-                new File(vaadinHomeDir, "node/node_modules/npm/bin/npm")
-                        .exists());
+                new File(vaadinHomeDir, npmInstallPath).exists());
     }
 
     @Test
@@ -893,7 +900,8 @@ public class FrontendToolsTest {
     }
 
     private void createFakePnpm(String defaultPnpmVersion) throws Exception {
-        File npxJs = new File(baseDir, "node/node_modules/npm/bin/npx-cli.js");
+        final String npxPath = NPM_BIN_PATH + "npx-cli.js";
+        File npxJs = new File(baseDir, npxPath);
         FileUtils.forceMkdir(npxJs.getParentFile());
 
         FileWriter fileWriter = new FileWriter(npxJs);

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/installer/NodeInstallerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/installer/NodeInstallerTest.java
@@ -92,12 +92,20 @@ public class NodeInstallerTest {
 
         // add a file to node/node_modules_npm that should be cleaned out
         File nodeDirectory = new File(targetDir, "node");
-        File nodeModulesDirectory = new File(nodeDirectory, "node_modules");
+        String nodeModulesPath = platform.isWindows() ? "node_modules"
+                : "lib/node_modules";
+        File nodeModulesDirectory = new File(nodeDirectory, nodeModulesPath);
         File npmDirectory = new File(nodeModulesDirectory, "npm");
         File garbage = new File(npmDirectory, "garbage");
         FileUtils.forceMkdir(npmDirectory);
         Assert.assertTrue("garbage file should be created",
                 garbage.createNewFile());
+
+        File oldNpm = new File(nodeDirectory, "node_modules/npm");
+        File oldGarbage = new File(oldNpm, "oldGarbage");
+        FileUtils.forceMkdir(oldNpm);
+        Assert.assertTrue("oldGarbage file should be created",
+                oldGarbage.createNewFile());
 
         NodeInstaller nodeInstaller = new NodeInstaller(targetDir,
                 Collections.emptyList())
@@ -113,9 +121,15 @@ public class NodeInstallerTest {
 
         Assert.assertTrue("npm should have been copied to node_modules",
                 new File(targetDir, "node/" + nodeExec).exists());
+        String npmInstallPath = platform.isWindows()
+                ? "node/node_modules/npm/bin/npm"
+                : "node/lib/node_modules/npm/bin/npm";
         Assert.assertTrue("npm should have been copied to node_modules",
-                new File(targetDir, "node/node_modules/npm/bin/npm").exists());
+                new File(targetDir, npmInstallPath).exists());
         Assert.assertFalse("old npm files should have been removed",
                 garbage.exists());
+        Assert.assertFalse(
+                "old style node_modules files should have been removed",
+                oldGarbage.exists());
     }
 }

--- a/flow-test-generic/src/main/java/com/vaadin/flow/testutil/FrontendStubs.java
+++ b/flow-test-generic/src/main/java/com/vaadin/flow/testutil/FrontendStubs.java
@@ -30,7 +30,9 @@ public class FrontendStubs {
     public static final String WEBPACK_SERVER = "node_modules/webpack-dev-server/bin/webpack-dev-server.js";
     public static final String WEBPACK_TEST_OUT_FILE = "webpack-out.test";
 
-    private static final String NPM_BIN_PATH = "node/node_modules/npm/bin";
+    private static final String NPM_BIN_PATH = System.getProperty("os.name")
+            .startsWith("Windows") ? "node/node_modules/npm/bin/"
+                    : "node/lib/node_modules/npm/bin/";
     private static final String NPM_CACHE_PATH_STUB = "cache";
 
     /**


### PR DESCRIPTION
Fix installation of node for unix systems.
NodeJS 18 is more strict about where
the contents are located than old versions.

Fixes #14636
