### PR TITLE
chore: Show command output when it fails

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -1014,6 +1014,23 @@ public class FrontendUtils {
         }
 
         /**
+         * Constructs an exception telling what code the command execution
+         * process was exited with and the output that it produced.
+         *
+         * @param processExitCode
+         *            process exit code
+         * @param output
+         *            the output from the command
+         * @param errorOutput
+         *            the error output from the command
+         */
+        public CommandExecutionException(int processExitCode, String output,
+                String errorOutput) {
+            super("Process execution failed with exit code " + processExitCode
+                    + "\nOutput: " + output + "\nError output: " + errorOutput);
+        }
+
+        /**
          * Constructs an exception telling what was the original exception the
          * command execution process failed with.
          *
@@ -1062,7 +1079,9 @@ public class FrontendUtils {
                     .start();
             int exitCode = process.waitFor();
             if (exitCode != 0) {
-                throw new CommandExecutionException(exitCode);
+                throw new CommandExecutionException(exitCode,
+                        streamToString(process.getInputStream()),
+                        streamToString(process.getErrorStream()));
             }
             return streamToString(process.getInputStream());
         } catch (IOException | InterruptedException e) {


### PR DESCRIPTION
Makes debugging easier when you know e.g. why npm --version exited with code 254
