### PR TITLE
feat: Add the authentication context API to the Vaadin Web Security

### DIFF
--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/SecurityConfig.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/SecurityConfig.java
@@ -16,6 +16,9 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.internal.UrlUtil;
+import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.spring.RootMappedCondition;
 import com.vaadin.flow.spring.VaadinConfigurationProperties;
 import com.vaadin.flow.spring.flowsecurity.data.UserInfo;
@@ -63,6 +66,11 @@ public class SecurityConfig extends VaadinWebSecurity {
                 .permitAll();
         super.configure(http);
         setLoginView(http, LoginView.class, getLogoutSuccessUrl());
+        http.logout().addLogoutHandler((request, response, authentication) -> {
+            UI ui = UI.getCurrent();
+            ui.accessSynchronously(() -> ui.getPage().setLocation(UrlUtil
+                    .getServletPathRelative(getLogoutSuccessUrl(), request)));
+        });
     }
 
     @Bean

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/SecurityUtils.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/SecurityUtils.java
@@ -6,9 +6,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
-import com.vaadin.flow.component.UI;
-import com.vaadin.flow.internal.UrlUtil;
-import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.spring.flowsecurity.data.UserInfo;
 import com.vaadin.flow.spring.flowsecurity.service.UserInfoService;
 import com.vaadin.flow.spring.security.AuthenticationContext;
@@ -34,9 +31,6 @@ public class SecurityUtils {
 
     public void logout() {
         authenticationContext.logout();
-        UI.getCurrent().getPage().setLocation(UrlUtil.getServletPathRelative(
-                securityConfig.getLogoutSuccessUrl(),
-                VaadinServletRequest.getCurrent().getHttpServletRequest()));
     }
 
 }

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/SecurityUtils.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/SecurityUtils.java
@@ -1,10 +1,9 @@
 package com.vaadin.flow.spring.flowsecurity;
 
+import java.util.Optional;
+
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.stereotype.Component;
 
 import com.vaadin.flow.component.UI;
@@ -25,12 +24,12 @@ public class SecurityUtils {
     private AuthenticationContext authenticationContext;
 
     public UserInfo getAuthenticatedUserInfo() {
-        UserDetails details = authenticationContext.getAuthenticatedUser()
-                .orElseThrow();
-        if (details == null) {
+        Optional<UserDetails> userDetails = authenticationContext
+                .getAuthenticatedUser(UserDetails.class);
+        if (userDetails.isEmpty()) {
             return null;
         }
-        return userInfoService.findByUsername(details.getUsername());
+        return userInfoService.findByUsername(userDetails.get().getUsername());
     }
 
     public void logout() {

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/SecurityUtils.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/SecurityUtils.java
@@ -25,7 +25,8 @@ public class SecurityUtils {
     private AuthenticationContext authenticationContext;
 
     public UserInfo getAuthenticatedUserInfo() {
-        UserDetails details = authenticationContext.getAuthenticatedUser().orElseThrow();
+        UserDetails details = authenticationContext.getAuthenticatedUser()
+                .orElseThrow();
         if (details == null) {
             return null;
         }

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/service/BankService.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/service/BankService.java
@@ -3,8 +3,8 @@ package com.vaadin.flow.spring.flowsecurity.service;
 import java.math.BigDecimal;
 import java.util.Optional;
 
-import com.vaadin.flow.spring.flowsecurity.SecurityUtils;
 import com.vaadin.flow.spring.flowsecurity.data.Account;
+import com.vaadin.flow.spring.security.AuthenticationContext;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -16,7 +16,7 @@ public class BankService {
     private AccountService accountService;
 
     @Autowired
-    private SecurityUtils utils;
+    private AuthenticationContext authenticationContext;
 
     public void applyForLoan() {
         applyForLoan(10000);
@@ -26,14 +26,14 @@ public class BankService {
         applyForLoan(1000000);
         try {
             Thread.sleep(3000);
-        } catch (InterruptedException e) {
+        } catch (InterruptedException ignored) {
         }
     }
 
     private void applyForLoan(int amount) {
-        String name = utils.getAuthenticatedUser().getUsername();
+        String name = authenticationContext.getAuthenticatedUser().orElseThrow().getUsername();
         Optional<Account> acc = accountService.findByOwner(name);
-        if (!acc.isPresent()) {
+        if (acc.isEmpty()) {
             return;
         }
         Account account = acc.get();
@@ -42,7 +42,7 @@ public class BankService {
     }
 
     public BigDecimal getBalance() {
-        String name = utils.getAuthenticatedUser().getUsername();
+        String name = authenticationContext.getAuthenticatedUser().orElseThrow().getUsername();
         return accountService.findByOwner(name).map(Account::getBalance)
                 .orElse(null);
     }

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/service/BankService.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/service/BankService.java
@@ -31,7 +31,8 @@ public class BankService {
     }
 
     private void applyForLoan(int amount) {
-        String name = authenticationContext.getAuthenticatedUser().orElseThrow().getUsername();
+        String name = authenticationContext.getAuthenticatedUser().orElseThrow()
+                .getUsername();
         Optional<Account> acc = accountService.findByOwner(name);
         if (acc.isEmpty()) {
             return;
@@ -42,7 +43,8 @@ public class BankService {
     }
 
     public BigDecimal getBalance() {
-        String name = authenticationContext.getAuthenticatedUser().orElseThrow().getUsername();
+        String name = authenticationContext.getAuthenticatedUser().orElseThrow()
+                .getUsername();
         return accountService.findByOwner(name).map(Account::getBalance)
                 .orElse(null);
     }

--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/service/BankService.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/service/BankService.java
@@ -7,6 +7,7 @@ import com.vaadin.flow.spring.flowsecurity.data.Account;
 import com.vaadin.flow.spring.security.AuthenticationContext;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -31,9 +32,13 @@ public class BankService {
     }
 
     private void applyForLoan(int amount) {
-        String name = authenticationContext.getAuthenticatedUser().orElseThrow()
-                .getUsername();
-        Optional<Account> acc = accountService.findByOwner(name);
+        Optional<UserDetails> authenticatedUser = authenticationContext
+                .getAuthenticatedUser(UserDetails.class);
+        if (authenticatedUser.isEmpty()) {
+            return;
+        }
+        Optional<Account> acc = accountService
+                .findByOwner(authenticatedUser.get().getUsername());
         if (acc.isEmpty()) {
             return;
         }
@@ -43,10 +48,13 @@ public class BankService {
     }
 
     public BigDecimal getBalance() {
-        String name = authenticationContext.getAuthenticatedUser().orElseThrow()
-                .getUsername();
-        return accountService.findByOwner(name).map(Account::getBalance)
-                .orElse(null);
+        Optional<UserDetails> authenticatedUser = authenticationContext
+                .getAuthenticatedUser(UserDetails.class);
+        if (authenticatedUser.isEmpty()) {
+            return null;
+        }
+        return accountService.findByOwner(authenticatedUser.get().getUsername())
+                .map(Account::getBalance).orElse(null);
     }
 
 }

--- a/vaadin-spring/pom.xml
+++ b/vaadin-spring/pom.xml
@@ -109,6 +109,11 @@
             <artifactId>spring-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/AuthenticationContext.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/AuthenticationContext.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.spring.security;
+
+import java.util.Optional;
+
+import org.springframework.security.core.userdetails.UserDetails;
+
+/**
+ * An interface to access the authentication context of the application.
+ * <p>
+ * An instance of this interface is available for injection as bean in view and
+ * layout classes.
+ *
+ * @author Vaadin Ltd
+ * @since 23.3
+ */
+public interface AuthenticationContext {
+
+    /**
+     * Gets an {@link Optional} with an instance of the current user if it has
+     * been authenticated, or empty if the user is not authenticated.
+     *
+     * @param <U>
+     *            the type parameter of the expected user instance
+     * @param userType
+     *            the type of the expected user instance, a subclass of
+     *            {@link UserDetails}
+     * @return an {@link Optional} with the current authenticated user, or
+     *         empty if none available
+     */
+    <U extends UserDetails> Optional<U> getAuthenticatedUser(Class<U> userType);
+
+    /**
+     * Gets an {@link Optional} with an instance of the current user if it has
+     * been authenticated, or empty if the user is not authenticated.
+     *
+     * @return an {@link Optional} with the current authenticated user, or
+     *         empty if none available
+     */
+    default Optional<UserDetails> getAuthenticatedUser() {
+        return getAuthenticatedUser(UserDetails.class);
+    }
+
+    /**
+     * Initiates the logout process of the current authenticated user by
+     * invalidating the local session and then notifying
+     * {@link org.springframework.security.web.authentication.logout.LogoutHandler}.
+     */
+    void logout();
+}

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/AuthenticationContext.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/AuthenticationContext.java
@@ -39,8 +39,8 @@ public interface AuthenticationContext {
      * @param userType
      *            the type of the expected user instance, a subclass of
      *            {@link UserDetails}
-     * @return an {@link Optional} with the current authenticated user, or
-     *         empty if none available
+     * @return an {@link Optional} with the current authenticated user, or empty
+     *         if none available
      */
     <U extends UserDetails> Optional<U> getAuthenticatedUser(Class<U> userType);
 
@@ -48,8 +48,8 @@ public interface AuthenticationContext {
      * Gets an {@link Optional} with an instance of the current user if it has
      * been authenticated, or empty if the user is not authenticated.
      *
-     * @return an {@link Optional} with the current authenticated user, or
-     *         empty if none available
+     * @return an {@link Optional} with the current authenticated user, or empty
+     *         if none available
      */
     default Optional<UserDetails> getAuthenticatedUser() {
         return getAuthenticatedUser(UserDetails.class);

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/AuthenticationContext.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/AuthenticationContext.java
@@ -17,7 +17,7 @@ package com.vaadin.flow.spring.security;
 
 import java.util.Optional;
 
-import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.AuthenticatedPrincipal;
 
 /**
  * An interface to access the authentication context of the application.
@@ -37,22 +37,22 @@ public interface AuthenticationContext {
      * @param <U>
      *            the type parameter of the expected user instance
      * @param userType
-     *            the type of the expected user instance, a subclass of
-     *            {@link UserDetails}
+     *            the type of the expected user instance
      * @return an {@link Optional} with the current authenticated user, or empty
      *         if none available
      */
-    <U extends UserDetails> Optional<U> getAuthenticatedUser(Class<U> userType);
+    <U> Optional<U> getAuthenticatedUser(Class<U> userType);
 
     /**
-     * Gets an {@link Optional} with an instance of the current user if it has
-     * been authenticated, or empty if the user is not authenticated.
+     * Gets an {@link Optional} subclass of {@link AuthenticatedPrincipal} with
+     * an instance of the current user if it has been authenticated, or empty if
+     * the user is not authenticated.
      *
      * @return an {@link Optional} with the current authenticated user, or empty
      *         if none available
      */
-    default Optional<UserDetails> getAuthenticatedUser() {
-        return getAuthenticatedUser(UserDetails.class);
+    default Optional<AuthenticatedPrincipal> getAuthenticatedUser() {
+        return getAuthenticatedUser(AuthenticatedPrincipal.class);
     }
 
     /**

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/UidlRedirectStrategy.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/UidlRedirectStrategy.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+import org.slf4j.LoggerFactory;
 import org.springframework.security.web.DefaultRedirectStrategy;
 
 import com.vaadin.flow.component.UI;
@@ -22,7 +23,15 @@ public class UidlRedirectStrategy extends DefaultRedirectStrategy {
             HttpServletResponse response, String url) throws IOException {
         final var servletMapping = request.getHttpServletMapping().getPattern();
         if (HandlerHelper.isFrameworkInternalRequest(servletMapping, request)) {
-            UI.getCurrent().getPage().setLocation(url);
+            UI ui = UI.getCurrent();
+            if (ui != null) {
+                ui.getPage().setLocation(url);
+            } else {
+                LoggerFactory.getLogger(UidlRedirectStrategy.class).warn(
+                        "A redirect to {} was request during a Vaadin request, "
+                                + "but it was not possible to get the UI instance to perform the action.",
+                        url);
+            }
         } else {
             super.sendRedirect(request, response, url);
         }

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/UidlRedirectStrategy.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/UidlRedirectStrategy.java
@@ -1,0 +1,30 @@
+package com.vaadin.flow.spring.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import org.springframework.security.web.DefaultRedirectStrategy;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.server.HandlerHelper;
+
+/**
+ * A strategy to handle redirects which is aware of UIDL requests.
+ *
+ * @author Vaadin Ltd
+ * @since 1.0
+ */
+public class UidlRedirectStrategy extends DefaultRedirectStrategy {
+
+    @Override
+    public void sendRedirect(HttpServletRequest request,
+            HttpServletResponse response, String url) throws IOException {
+        final var servletMapping = request.getHttpServletMapping().getPattern();
+        if (HandlerHelper.isFrameworkInternalRequest(servletMapping, request)) {
+            UI.getCurrent().getPage().setLocation(url);
+        } else {
+            super.sendRedirect(request, response, url);
+        }
+    }
+}

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -49,6 +50,7 @@ import org.springframework.security.web.access.DelegatingAccessDeniedHandler;
 import org.springframework.security.web.access.RequestMatcherDelegatingAccessDeniedHandler;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.security.web.authentication.logout.SimpleUrlLogoutSuccessHandler;
 import org.springframework.security.web.csrf.CsrfException;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
@@ -127,6 +129,7 @@ public abstract class VaadinWebSecurity {
         // needs to refresh transient fields after deserialization
         logoutConfigurer = http.logout();
         logoutConfigurer.invalidateHttpSession(true);
+        addLogoutHandlers(logoutConfigurer::addLogoutHandler);
         DefaultSecurityFilterChain securityFilterChain = http.build();
 
         authenticationContext.setLogoutHandlers(
@@ -526,6 +529,17 @@ public abstract class VaadinWebSecurity {
      */
     protected ViewAccessChecker getViewAccessChecker() {
         return viewAccessChecker;
+    }
+
+    /**
+     * Sets additional {@link LogoutHandler}s that will participate in logout
+     * process.
+     *
+     * @param registry
+     *            used to add custom handlers.
+     */
+    protected void addLogoutHandlers(Consumer<LogoutHandler> registry) {
+
     }
 
     private void configureLogout(HttpSecurity http, String logoutSuccessUrl)

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -141,10 +141,10 @@ public abstract class VaadinWebSecurity {
      * @return the authentication-context bean
      */
     @Bean(name = "VaadinAuthenticationContext")
-    public AuthenticationContext getAuthenticationContext(HttpSecurity http) throws Exception {
+    public AuthenticationContext getAuthenticationContext(HttpSecurity http)
+            throws Exception {
         LogoutConfigurer<HttpSecurity> logoutConfigurer = http.logout();
-        DefaultAuthenticationContext authenticationContext =
-                new DefaultAuthenticationContext();
+        DefaultAuthenticationContext authenticationContext = new DefaultAuthenticationContext();
         authenticationContext.setLogoutHandlers(
                 logoutConfigurer.getLogoutSuccessHandler(),
                 logoutConfigurer.getLogoutHandlers());
@@ -609,16 +609,19 @@ public abstract class VaadinWebSecurity {
             logoutHandler.logout(request, response, auth);
             ui.accessSynchronously(() -> {
                 try {
-                    logoutSuccessHandler.onLogoutSuccess(request, response, auth);
+                    logoutSuccessHandler.onLogoutSuccess(request, response,
+                            auth);
                 } catch (IOException | ServletException e) {
                     // Raise a warning log message about the failure.
-                    LOGGER.warn("There was an error notifying the logout handler about the user logout", e);
+                    LOGGER.warn(
+                            "There was an error notifying the logout handler about the user logout",
+                            e);
                 }
             });
         }
 
         void setLogoutHandlers(LogoutSuccessHandler logoutSuccessHandler,
-                               List<LogoutHandler> logoutHandlers) {
+                List<LogoutHandler> logoutHandlers) {
             this.logoutSuccessHandler = logoutSuccessHandler;
             this.logoutHandler = new CompositeLogoutHandler(logoutHandlers);
         }

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringClassesSerializableTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringClassesSerializableTest.java
@@ -97,6 +97,7 @@ public class SpringClassesSerializableTest extends ClassesSerializableTest {
                 "com\\.vaadin\\.flow\\.spring\\.security\\.VaadinWebSecurityConfigurerAdapter",
                 "com\\.vaadin\\.flow\\.spring\\.security\\.VaadinWebSecurityConfigurerAdapter\\$Http401UnauthorizedAccessDeniedHandler",
                 "com\\.vaadin\\.flow\\.spring\\.security\\.VaadinDefaultRequestCache",
+                "com\\.vaadin\\.flow\\.spring\\.security\\.UidlRedirectStrategy",
                 "com\\.vaadin\\.flow\\.spring\\.security\\.VaadinSavedRequestAwareAuthenticationSuccessHandler",
                 "com\\.vaadin\\.flow\\.spring\\.security\\.VaadinSavedRequestAwareAuthenticationSuccessHandler\\$RedirectStrategy",
                 "com\\.vaadin\\.flow\\.spring\\.security\\.stateless\\.JwtSecurityContextRepository",

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/AuthenticationContextTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/AuthenticationContextTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.spring.security;
+
+import java.util.List;
+import java.util.Optional;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.springframework.security.core.AuthenticatedPrincipal;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.internal.CurrentInstance;
+import com.vaadin.flow.server.Command;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinResponse;
+import com.vaadin.flow.server.VaadinServletRequest;
+import com.vaadin.flow.server.VaadinServletResponse;
+
+@RunWith(SpringRunner.class)
+// @ContextConfiguration
+public class AuthenticationContextTest {
+
+    private final AuthenticationContext authContext = new AuthenticationContext();
+
+    @Test
+    public void isAuthenticated_notAuthenticated_false() {
+        Assert.assertFalse(authContext.isAuthenticated());
+    }
+
+    @Test
+    @WithAnonymousUser
+    public void isAuthenticated_anonymous_false() {
+        Assert.assertFalse(authContext.isAuthenticated());
+    }
+
+    @Test
+    @WithMockUser
+    public void isAuthenticated_loggedUser_true() {
+        Assert.assertTrue(authContext.isAuthenticated());
+    }
+
+    @Test
+    public void getAuthenticatedUser_notAuthenticated_getsEmpty() {
+        Assert.assertTrue(
+                authContext.getAuthenticatedUser(Object.class).isEmpty());
+    }
+
+    @Test
+    @WithAnonymousUser
+    public void getAuthenticatedUser_anonymous_getsEmpty() {
+        Assert.assertTrue(
+                authContext.getAuthenticatedUser(Object.class).isEmpty());
+    }
+
+    @Test
+    @WithMockUser()
+    public void getAuthenticatedUser_loggedUser_getsUserInstance() {
+        Optional<User> maybeUser = authContext.getAuthenticatedUser(User.class);
+        Assert.assertTrue(maybeUser.isPresent());
+        Assert.assertEquals("user", maybeUser.get().getUsername());
+    }
+
+    @Test
+    @WithMockUser()
+    public void getAuthenticatedUser_loggedUserWrongUserType_throws() {
+        Assert.assertThrows(ClassCastException.class, () -> authContext
+                .getAuthenticatedUser(AuthenticatedPrincipal.class));
+    }
+
+    @Test
+    @WithMockUser()
+    public void logout_handlersEngaged() throws Exception {
+        Authentication authentication = SecurityContextHolder.getContext()
+                .getAuthentication();
+
+        LogoutSuccessHandler successHandler = Mockito
+                .mock(LogoutSuccessHandler.class);
+        LogoutHandler handler1 = Mockito.mock(LogoutHandler.class);
+        LogoutHandler handler2 = Mockito.mock(LogoutHandler.class);
+        authContext.setLogoutHandlers(successHandler,
+                List.of(handler2, handler1));
+
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        VaadinServletRequest vaadinRequest = Mockito
+                .mock(VaadinServletRequest.class);
+        Mockito.when(vaadinRequest.getHttpServletRequest()).thenReturn(request);
+
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+        VaadinServletResponse vaadinResponse = Mockito
+                .mock(VaadinServletResponse.class);
+        Mockito.when(vaadinResponse.getHttpServletResponse())
+                .thenReturn(response);
+
+        UI ui = Mockito.mock(UI.class);
+        Mockito.doAnswer(i -> {
+            i.<Command> getArgument(0).execute();
+            return null;
+        }).when(ui).accessSynchronously(ArgumentMatchers.any());
+
+        try {
+            CurrentInstance.set(VaadinRequest.class, vaadinRequest);
+            CurrentInstance.set(VaadinResponse.class, vaadinResponse);
+            UI.setCurrent(ui);
+            authContext.logout();
+
+            Mockito.verify(successHandler).onLogoutSuccess(request, response,
+                    authentication);
+            Mockito.verify(handler2).logout(request, response, authentication);
+            Mockito.verify(handler1).logout(request, response, authentication);
+        } finally {
+            CurrentInstance.clearAll();
+        }
+    }
+}

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/UidlRedirectStrategyTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/UidlRedirectStrategyTest.java
@@ -1,0 +1,76 @@
+package com.vaadin.flow.spring.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.page.Page;
+import com.vaadin.flow.internal.CurrentInstance;
+import com.vaadin.flow.shared.ApplicationConstants;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class UidlRedirectStrategyTest {
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private HttpServletRequest request;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private HttpServletResponse response;
+
+    private UidlRedirectStrategy strategy;
+
+    @BeforeEach
+    public void setup() {
+        strategy = new UidlRedirectStrategy();
+        when(request.getHttpServletMapping().getPattern()).thenReturn("/");
+    }
+
+    @AfterEach
+    public void cleanup() {
+        CurrentInstance.clearAll();
+    }
+
+    @Test
+    public void isInternalRequest_setPageLocation()
+            throws IOException, ServletException {
+        when(request.getParameter(ApplicationConstants.REQUEST_TYPE_PARAMETER))
+                .thenReturn(ApplicationConstants.REQUEST_TYPE_UIDL);
+
+        var ui = mock(UI.class, Answers.RETURNS_DEEP_STUBS);
+        CurrentInstance.set(UI.class, ui);
+
+        var page = mock(Page.class);
+        when(ui.getPage()).thenReturn(page);
+
+        strategy.sendRedirect(request, response, "/foo");
+
+        verify(page).setLocation("/foo");
+    }
+
+    @Test
+    public void isExternalRequest_useDefaultRedirect()
+            throws IOException, ServletException {
+        when(request.getContextPath()).thenReturn("");
+        when(response.encodeRedirectURL(anyString()))
+                .thenAnswer(i -> i.getArguments()[0]);
+
+        strategy.sendRedirect(request, response, "/foo");
+
+        verify(response).sendRedirect("/foo");
+    }
+}

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/VaadinWebSecurityTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/VaadinWebSecurityTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.spring.security;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.security.config.annotation.ObjectPostProcessor;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.configuration.ObjectPostProcessorConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.CompositeLogoutHandler;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = ObjectPostProcessorConfiguration.class)
+public class VaadinWebSecurityTest {
+    @Autowired
+    ObjectPostProcessor<Object> postProcessor;
+
+    @Autowired
+    ApplicationContext appCtx;
+
+    @Test
+    public void filterChain_additionalLogoutHandlers_configured()
+            throws Exception {
+        HttpSecurity httpSecurity = new HttpSecurity(postProcessor,
+                new AuthenticationManagerBuilder(postProcessor),
+                Map.of(ApplicationContext.class, appCtx));
+        TestConfig testConfig = new VaadinWebSecurityTest.TestConfig();
+        testConfig.filterChain(httpSecurity);
+
+        Assert.assertTrue("VaadinWebSecurity HTTP configuration invoked",
+                testConfig.httpConfigured);
+
+        AuthenticationContext authContext = testConfig
+                .getAuthenticationContext();
+        CompositeLogoutHandler logoutHandler = authContext.getLogoutHandler();
+
+        logoutHandler.logout(mock(HttpServletRequest.class),
+                mock(HttpServletResponse.class), mock(Authentication.class));
+        Mockito.verify(testConfig.handler1).logout(any(), any(), any());
+        Mockito.verify(testConfig.handler2).logout(any(), any(), any());
+    }
+
+    static class TestConfig extends VaadinWebSecurity {
+        LogoutHandler handler1 = mock(LogoutHandler.class);
+        LogoutHandler handler2 = mock(LogoutHandler.class);
+
+        boolean httpConfigured;
+        boolean webConfigured;
+
+        @Override
+        protected void configure(WebSecurity web) throws Exception {
+            webConfigured = true;
+        }
+
+        @Override
+        protected void configure(HttpSecurity http) throws Exception {
+            httpConfigured = true;
+        }
+
+        protected void addLogoutHandlers(Consumer<LogoutHandler> registry) {
+            registry.accept(handler1);
+            registry.accept(handler2);
+        }
+    }
+
+}

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/stateless/JwtSecurityContextRepositoryTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/stateless/JwtSecurityContextRepositoryTest.java
@@ -46,6 +46,7 @@ import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextHolderStrategy;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -90,6 +91,7 @@ public class JwtSecurityContextRepositoryTest {
 
     @Mock
     private HttpServletResponse response;
+    private SecurityContextHolderStrategy originalontextHolderStrategy;
 
     private static JWTClaimsSet.Builder getClaimsSetBuilder() {
         return new JWTClaimsSet.Builder().issueTime(Date.from(TEST_PAST))
@@ -114,6 +116,8 @@ public class JwtSecurityContextRepositoryTest {
     public void setup() throws Exception {
         MockitoAnnotations.openMocks(this);
 
+        originalontextHolderStrategy = SecurityContextHolder
+                .getContextHolderStrategy();
         SecurityContextHolder.setStrategyName(
                 TestSecurityContextHolderStrategy.class.getName());
 
@@ -133,6 +137,12 @@ public class JwtSecurityContextRepositoryTest {
     public void teardown() {
         Mockito.verifyNoInteractions(request);
         Mockito.verifyNoInteractions(response);
+        if (originalontextHolderStrategy != null) {
+            SecurityContextHolder
+                    .setContextHolderStrategy(originalontextHolderStrategy);
+        } else {
+            SecurityContextHolder.setStrategyName(null);
+        }
     }
 
     @Test


### PR DESCRIPTION
AuthenticationContext bean provides an API for getting authenticated user details and logout capabilities.

Fixes https://github.com/vaadin/flow/issues/14958