### PR TITLE
feat!: Enable license checking for flow-polymer-template

### DIFF
--- a/flow-polymer-template/LICENSE.txt
+++ b/flow-polymer-template/LICENSE.txt
@@ -1,0 +1,262 @@
+Commercial Vaadin Developer License version 4
+
+Terms and Conditions for Use, Reproduction and Distribution
+
+NOTICE TO USER: PLEASE READ THIS LICENSE AGREEMENT CAREFULLY.
+
+BY USING ALL OR ANY PART OF THE LICENSED SOFTWARE YOU ACCEPT ALL THE TERMS AND
+CONDITIONS OF THIS AGREEMENT, INCLUDING, IN PARTICULAR THE RESTRICTIONS ON: USE
+AND TRANSFERABILITY CONTAINED IN CLAUSE 2; WARRANTY IN CLAUSE 6; LIABILITY IN
+CLAUSE 7. YOU ACCEPT THAT THIS AGREEMENT IS ENFORCEABLE LIKE ANY WRITTEN
+NEGOTIATED AGREEMENT DULY SIGNED BY YOU. IF YOU DO NOT AGREE ON ALL THE TERMS
+AND CONDITIONS OF THIS AGREEMENT, STOP THE USE OF THE LICENSED SOFTWARE
+IMMEDIATELY.
+
+1. Definitions
+In this Agreement, unless the context requires otherwise, the following words
+and phrases shall have the following meanings:
+
+  * "Developer" shall mean a software developer, tester, designer or other
+    person developing a software application.
+  * "Vaadin Platform" shall mean the Vaadin web framework, components, themes,
+    tools and libraries that help Developers in building software applications.
+  * "Licensed Software" shall mean an add-on software component, extended
+    support version of Vaadin Platform, library, theme, tool or other software
+    or resource that is part of or adds functionality to Vaadin Platform or
+    helps Developers in developing applications. Licensed Software include, but
+    are not limited to, user interface components, integration components,
+    themes, libraries and development tools.
+  * "Use Licensed Software" shall mean either directly interacting with,
+    including without limitations using the user interface of, running or
+    installing, the Licensed Software during Project or editing Project source
+    code file that refers to or depends on Licensed Software either directly or
+    indirectly. Developer who edits source code that can not be compiled and/or
+    run without a copy of Licensed Software is considered to Use Licensed
+    Software. Interacting with a server that runs Licensed Software as a part
+    of an automated test suite or a design system is not considered as Use of
+    Licensed Software, but the maintainers of the mentioned test suite or
+    design system are considered to Use Licensed Software.
+  * "Agreement" shall mean this Commercial Vaadin Developer License version 4
+    agreement. Previous versions of the agreement were called Commercial Vaadin
+    Add-on License.
+  * "License" shall mean the right to Use Licensed Software according to
+    Agreement by one Developer.
+  * "Intellectual Property Rights" shall mean any and all patent, copyright,
+    trademark, design right, petty patent, service mark, domain name or any
+    other right or trade secret whether registered or not.
+  * "Licensee" shall mean the entity that has subscribed to a Subscription that
+     includes the right to Use Licensed Software.
+  * "Licensor" shall mean Vaadin Ltd. or a third party licensing Licensed
+     Software under the Agreement.
+  * "Parties/Party" shall mean Licensee and Licensor, or either of them.
+  * "Project" shall mean Licensee's software development project during which
+     the participating Developers Use Licensed Software and which aims to
+     produce Project Result.
+  * "Project Result" shall mean the outcome of the Project.
+  * “End User” shall mean a person using Project Result that does not involve
+     changing any source code.
+  * "Subscription" shall mean a subscription offered by Licensor in which
+    Licensor grants rights to Use Licensed Software according to the terms of
+    the subscription agreement and this Agreement.
+
+2. Grant of License
+2.1 Licensor grants to Licensee, against full payment of the Subscription fee, a
+worldwide, royalty-free, non-exclusive limited License to Use Licensed Software
+in Project(s) by a Developer.
+
+2.2 Licensee shall not, unless expressly provided in Agreement or in the
+applicable legislation
+
+2.2.1 rent, lease or loan Licensed Software or any copy of it;
+
+2.2.2 remove, obliterate, deface or in any way alter the notice of Licensor’s or
+a third party’s proprietary rights related to Licensed Software;
+
+2.2.3 grant sub-licenses to Licensed Software or assign its rights or
+obligations under this Agreement to a third party.
+
+2.3 Licensee may grant licenses, for free or against a payment, to the Project
+Result including Licensed Software whether regarded as derivative works or not.
+End Users are not required to have a valid License. If the Project Result is
+further developed or modified by changing its source code or the Project Results
+is used as a software component or framework in a software development project,
+all Developers who Use Licensed Software in such a context need to have a valid
+License. If the Project Result is a software development tool, component or
+environment that provides the functionality of the Licensed Software for use in
+software development projects, all Developers who Use Licensed Software need to
+have a valid License.
+
+3. Intellectual Property Rights
+3.1 All Intellectual Property Rights in and to Licensed Software are and shall
+at all times remain the sole and exclusive property of Licensor and its third
+party licensors, if any.
+
+3.2 Licensee will not at any time do or cause to be done any such act or thing
+which in any way impairs, or intends to impair, any right, title, interest or
+any Intellectual Property Right of Licensor or its third party licensors.
+Licensee shall not in any manner represent that it has any ownership of any kind
+in any of the above mentioned Intellectual Property Rights.
+
+4. Subscription fee and Subscription term
+4.1 In consideration for the Subscription based license granted herein, Licensor
+shall charge a recurring Subscription fee from the Licensee.
+
+4.2 Licensee must have a valid License for all Developers who Use Licensed
+Software in the Project. During the Subscription term, the License may be Used
+in many Projects simultaneously without additional payments. The Project Result
+may be copied an unlimited number of times and deployed to an unlimited number
+of computers without additional payments.
+
+4.3 Licensee's License will be valid starting from the beginning of the
+Subscription term and remain in force until the end of the Subscription term.
+The start date of the Subscription term and its possible renewal mechanism are
+set out in the Subscription agreement or the Licensor’s invoice to the Licensee.
+If no Subscription start date is specified in the Subscription agreement or the
+invoice, the start date shall be the date when the Licensor provides the
+Licensee access to the Licensed Software.
+
+4.4 If License is given without a fee, the License is valid for the time defined
+by the Licensor.
+
+5. Term and termination
+5.1 This Agreement is effective as of the effective date of the Subscription and
+expires on the day that the Subscription term for the Licensed Software has
+expired. Notwithstanding the aforesaid, in the event that the Licensee fails to
+comply with the terms set in this Agreement, the License granted herein shall
+not be valid and Licensee must at once cease the use of Licensed Software and
+any of its rights under Clause 2, and delete all copies of Licensed Software.
+
+5.2 Licensor has the right, in addition and without prejudice to any other
+rights or remedies, to terminate this Agreement immediately as follows:
+
+5.2.1 for any material breach of Agreement, that is not cured within seven (7)
+days of receipt by Licensee in default of a written notice specifying the breach
+and requiring its cure;
+
+5.2.2 upon receiving a written notice, if (a) all or a substantial portion of
+the assets of Licensee are transferred to an assignee for the benefit of
+creditors, or to a receiver or a trustee in bankruptcy, (b) a proceeding is
+commenced by or against Licensee for relief under bankruptcy or similar laws and
+such proceeding is not dismissed within sixty (60) days, or (c) Licensee is
+adjudged bankrupt.
+
+5.3 If and when this Agreement is terminated due to any reason or cause
+whatsoever, the Licensee shall cease to Use Licensed Software and any of its
+rights under Clause 2, and delete all copies of Licensed Software. For clarity,
+the termination of this Agreement shall not affect the validity of any licenses
+granted by the Licensee to End Users with respect to Project Results prior to
+the termination of this Agreement, but the Licensee shall not be entitled to
+Use Licensed Software after the termination of the Agreement.
+
+5.4 Provisions of the Agreement which, by their nature, are intended to survive
+its termination or expiration, shall survive its termination or expiration.
+
+6. Warranties
+THE LICENSED SOFTWARE IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND EXPRESS
+OR IMPLIED, AND TO THE MAXIMUM EXTENT PERMITTED BY THE APPLICABLE LAW. EXCEPT AS
+EXPRESSLY PROVIDED IN THIS CLAUSE, NO WARRANTY, CONDITION, UNDERTAKING,
+LIABILITY OR TERM, EXPRESS OR IMPLIED, STATUTORY OR OTHERWISE, AS TO CONDITION,
+QUALITY, PERFORMANCE, FUNCTIONALITY, INFRINGEMENT, MERCHANTABILITY, DURABILITY
+OR FITNESS FOR PURPOSE, IS GIVEN OR ASSUMED BY VAADIN LTD., LICENSOR OR ITS
+LICENSORS AND ALL SUCH WARRANTIES, CONDITIONS, UNDERTAKINGS AND TERMS ARE HEREBY
+EXCLUDED.
+
+7. Limitation of Liability
+VAADIN LTD. AND/OR LICENSOR WILL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL,
+PUNITIVE OR CONSEQUENTIAL LOSS, DAMAGE, COST OR EXPENSE OF ANY KIND WHATSOEVER
+AND HOWSOEVER CAUSED (INCLUDING BUSINESS INTERRUPTION, OR ANY LOSS OF BUSINESS,
+ANTICIPATED SAVINGS, REVENUE, GOODWILL, MANAGEMENT TIME, LOSS OF PROFITS OR OF
+CONTRACTS, LOSS OF OPERATION TIME, LOSS OF REPUTATION OR OF DATA) INCLUDING
+NEGLIGENCE, WHETHER IN CONTRACT OR TORT, EVEN IF THEY HAVE BEEN ADVISED OF THE
+POSSIBILITY. DEVELOPER AND/OR LICENSEE WILL USE REASONABLE EFFORTS TO MITIGATE
+THEIR LOSS SUFFERED. VAADIN LTD'S AND/OR LICENSOR'S AGGREGATE LIABILITY AND THAT
+OF ITS AFFILIATES AND SUPPLIERS UNDER OR IN CONNECTION WITH THIS LICENSE
+AGREEMENT WILL BE LIMITED TO THE AMOUNT ACTUALLY PAID FOR THE LICENSED SOFTWARE
+DURING THE MOST RECENT SUBSCRIPTION PERIOD.
+
+8. Updates, new versions maintenance and support
+Licensor may, at its sole discretion, during the Subscription term provide
+maintenance releases, updates and upgrades as new versions of the Licensed
+Software.
+
+Licensee is not entitled to receive support for the Licensed Software, but
+Licensor may, at its sole discretion during the Subscription term, provide
+support either for free or for a fee.
+
+9. Miscellaneous
+9.1 No Waiver
+
+The failure of Licensor to exercise any of its rights under this Agreement or to
+require the performance of any term or provision of this Agreement, or any
+waiver by the Licensor of any term or provision or breach of this Agreement,
+shall not prevent a subsequent exercise or enforcement of such right or be
+deemed a waiver of any subsequent breach of the same or any other term or
+provision of this Agreement. Any waiver of the performance of any of the terms
+or conditions of this Agreement shall be effective only if in writing and signed
+by the Party against which such waiver is to be enforced.
+
+9.2 Headings
+
+The headings in this Agreement are for the convenience of the Parties only and
+are not intended to define or limit the scope or interpretation of the Agreement
+or any provision hereof.
+
+9.3 Severability
+
+If any term of this Agreement is invalid or unenforceable, such terms or
+provisions shall not invalidate the rest of the Agreement which shall remain in
+full force and effect as if such invalidated or unenforceable terms or
+conditions had not been made a part of this Agreement. In the event this Clause
+(Severability) becomes operative, Parties agree to attempt to negotiate
+settlement that carries out the economic intent of the terms or provisions found
+invalid or unenforceable.
+
+9.4 Export Control
+
+The Licensed Software may be subject to import and export controls in other
+countries. Licensee agrees to strictly comply with all applicable import and
+export regulations and acknowledge that Licensee has the responsibility to
+obtain licenses to export, re-export, transfer or import Licensed Software.
+
+9.5 Entire Agreement and Assignment
+
+Agreement sets forth the entire agreement between the Parties with respect to
+the subject matter hereof and supersedes any prior proposals and
+representations, whether written or oral. Neither Party shall have the right to
+assign this Agreement to a third party without the prior written consent of the
+other party. However, Licensor shall have the right to assign this Agreement and
+the rights and obligations contained therein to a company belonging to the same
+group of companies as Licensor, and to a third party to which the business of
+Licensor is transferred.
+
+9.6 Governing Law and Jurisdiction
+
+9.6.1 For customers domiciled in the United States
+
+If the Customer’s domicile is in the United States, the Agreement shall be
+governed by and construed in accordance with the substantive laws of the State
+of California. The Agreement shall be construed and enforced without regard to
+the United Nations Convention on the International Sale of Goods (CISG). Any
+dispute or controversy or claim arising out of or relating to this Agreement, or
+the breach, termination or validity thereof, shall be resolved by final and
+binding arbitration in accordance with the International Chamber of Commerce
+Rules of Arbitration, by one (1) arbitrator appointed according to the
+aforementioned rules. The arbitration shall be conducted in the English
+language in San Francisco, California, United States.
+
+9.6.2 For customers domiciled outside the United States
+
+If the Customer’s domicile is outside the United States, the Agreement shall be
+governed by and construed in accordance with the substantive laws of Finland,
+excluding its choice of law provisions and the United Nations Convention on
+Contracts for the International Sale of Goods (CISG). Any dispute, controversy
+or claim arising out of or relating to the Agreement, or the breach, termination
+or validity thereof, shall be finally settled by arbitration in accordance with
+the Arbitration Rules of the Finland Chamber of Commerce. The number of
+arbitrators shall be one. The seat of arbitration shall be Turku, Finland. The
+language of the arbitration shall be English.
+
+9.7 Language
+
+The official text of the Agreement or any notices given or accounts or
+statements required hereby shall be in English.

--- a/flow-polymer-template/bnd.bnd
+++ b/flow-polymer-template/bnd.bnd
@@ -2,6 +2,6 @@ Bundle-SymbolicName: ${project.groupId}.flow.polymer-template
 Bundle-Name: Vaadin Flow Polymer Templates Support
 Bundle-Version: ${osgi.bundle.version}
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Bundle-License: http://www.apache.org/licenses/LICENSE-2.0
+Bundle-License: https://vaadin.com/license/cvdl-4.0
 Export-Package: com.vaadin.flow.component.polymertemplate,\
     com.vaadin.flow.templatemodel,;-noimport:=true

--- a/flow-polymer-template/bnd.bnd
+++ b/flow-polymer-template/bnd.bnd
@@ -5,3 +5,4 @@ Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-License: https://vaadin.com/license/cvdl-4.0
 Export-Package: com.vaadin.flow.component.polymertemplate,\
     com.vaadin.flow.templatemodel,;-noimport:=true
+CvdlName: ${cvdlName}

--- a/flow-polymer-template/pom.xml
+++ b/flow-polymer-template/pom.xml
@@ -13,6 +13,7 @@
     <packaging>jar</packaging>
 
     <properties>
+        <cvdlName>flow-polymer-template</cvdlName>
     </properties>
 
     <dependencies>
@@ -81,6 +82,9 @@
                         <manifest>
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                         </manifest>
+                        <manifestEntries>
+                            <CvdlName>${cvdlName}</CvdlName>
+                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>

--- a/flow-polymer-template/pom.xml
+++ b/flow-polymer-template/pom.xml
@@ -25,6 +25,10 @@
             <artifactId>flow-server</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>license-checker</artifactId>
+        </dependency>
 
 
         <!-- TESTING DEPENDENCIES -->
@@ -71,6 +75,15 @@
         </dependency>
     </dependencies>
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>**/version.properties</include>
+                </includes>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/flow-polymer-template/pom.xml
+++ b/flow-polymer-template/pom.xml
@@ -75,15 +75,6 @@
         </dependency>
     </dependencies>
     <build>
-        <resources>
-            <resource>
-                <directory>src/main/resources</directory>
-                <filtering>true</filtering>
-                <includes>
-                    <include>**/version.properties</include>
-                </includes>
-            </resource>
-        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/flow-polymer-template/pom.xml
+++ b/flow-polymer-template/pom.xml
@@ -95,9 +95,6 @@
                         <manifest>
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                         </manifest>
-                        <manifestEntries>
-                            <CvdlName>${cvdlName}</CvdlName>
-                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/AbstractTemplate.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/AbstractTemplate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/AbstractTemplate.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/AbstractTemplate.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 
 package com.vaadin.flow.component.polymertemplate;

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/BundleParser.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/BundleParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/BundleParser.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/BundleParser.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.component.polymertemplate;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/EventHandler.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/EventHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/EventHandler.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/EventHandler.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.component.polymertemplate;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/Id.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/Id.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/Id.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/Id.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.component.polymertemplate;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/IdCollector.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/IdCollector.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/IdCollector.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/IdCollector.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.component.polymertemplate;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/IdMapper.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/IdMapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/IdMapper.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/IdMapper.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.component.polymertemplate;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/InjectablePolymerElementInitializer.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/InjectablePolymerElementInitializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/InjectablePolymerElementInitializer.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/InjectablePolymerElementInitializer.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.component.polymertemplate;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/JsoupUtils.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/JsoupUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/JsoupUtils.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/JsoupUtils.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.component.polymertemplate;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/ModelItem.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/ModelItem.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/ModelItem.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/ModelItem.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.component.polymertemplate;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/NpmTemplateParser.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/NpmTemplateParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/NpmTemplateParser.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/NpmTemplateParser.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.component.polymertemplate;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/PolymerTemplate.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/PolymerTemplate.java
@@ -65,8 +65,7 @@ public abstract class PolymerTemplate<M extends TemplateModel>
                     .getResourceAsStream("version.properties"));
         } catch (Exception e) {
             LoggerFactory.getLogger(PolymerTemplate.class.getName())
-                    .warn("Unable to read the version.properties file.", e);
-            throw new ExceptionInInitializerError(e);
+                    .error("Unable to read the version.properties file.", e);
         }
 
         LicenseChecker.checkLicenseFromStaticBlock("flow-polymer-template",

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/PolymerTemplate.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/PolymerTemplate.java
@@ -64,8 +64,8 @@ public abstract class PolymerTemplate<M extends TemplateModel>
             properties.load(PolymerTemplate.class
                     .getResourceAsStream("version.properties"));
         } catch (Exception e) {
-            LoggerFactory.getLogger(PolymerTemplate.class.getName()).warn(
-                    "Unable to read the version.properties file.", e);
+            LoggerFactory.getLogger(PolymerTemplate.class.getName())
+                    .warn("Unable to read the version.properties file.", e);
             throw new ExceptionInInitializerError(e);
         }
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/PolymerTemplate.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/PolymerTemplate.java
@@ -9,11 +9,8 @@
  */
 package com.vaadin.flow.component.polymertemplate;
 
-import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Stream;
-
-import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasComponents;

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/PolymerTemplate.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/PolymerTemplate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/PolymerTemplate.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/PolymerTemplate.java
@@ -15,8 +15,11 @@
  */
 package com.vaadin.flow.component.polymertemplate;
 
+import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Stream;
+
+import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasComponents;
@@ -28,6 +31,7 @@ import com.vaadin.flow.internal.Template;
 import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.templatemodel.TemplateModel;
+import com.vaadin.pro.licensechecker.LicenseChecker;
 
 /**
  * Component for an HTML element declared as a polymer component. The HTML
@@ -60,6 +64,19 @@ public abstract class PolymerTemplate<M extends TemplateModel>
 
     static {
         UsageStatistics.markAsUsed("flow/PolymerTemplate", null);
+
+        Properties properties = new Properties();
+        try {
+            properties.load(PolymerTemplate.class
+                    .getResourceAsStream("version.properties"));
+        } catch (Exception e) {
+            LoggerFactory.getLogger(PolymerTemplate.class.getName()).warn(
+                    "Unable to read the version.properties file.", e);
+            throw new ExceptionInInitializerError(e);
+        }
+
+        LicenseChecker.checkLicenseFromStaticBlock("flow-polymer-template",
+                properties.getProperty("polymertemplate.version"), null);
     }
 
     /**

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/PolymerTemplate.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/PolymerTemplate.java
@@ -65,7 +65,8 @@ public abstract class PolymerTemplate<M extends TemplateModel>
                     .getResourceAsStream("version.properties"));
         } catch (Exception e) {
             LoggerFactory.getLogger(PolymerTemplate.class.getName())
-                    .error("Unable to read the version.properties file.", e);
+                    .error("Unable to read the version.properties file.");
+            throw new ExceptionInInitializerError(e);
         }
 
         LicenseChecker.checkLicenseFromStaticBlock("flow-polymer-template",

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/PolymerTemplate.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/PolymerTemplate.java
@@ -24,6 +24,7 @@ import com.vaadin.flow.dom.Element;
 import com.vaadin.flow.internal.Template;
 import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.Version;
 import com.vaadin.flow.templatemodel.TemplateModel;
 import com.vaadin.pro.licensechecker.LicenseChecker;
 
@@ -59,18 +60,8 @@ public abstract class PolymerTemplate<M extends TemplateModel>
     static {
         UsageStatistics.markAsUsed("flow/PolymerTemplate", null);
 
-        Properties properties = new Properties();
-        try {
-            properties.load(PolymerTemplate.class
-                    .getResourceAsStream("version.properties"));
-        } catch (Exception e) {
-            LoggerFactory.getLogger(PolymerTemplate.class.getName())
-                    .error("Unable to read the version.properties file.");
-            throw new ExceptionInInitializerError(e);
-        }
-
         LicenseChecker.checkLicenseFromStaticBlock("flow-polymer-template",
-                properties.getProperty("polymertemplate.version"), null);
+                Version.getFullVersion(), null);
     }
 
     /**

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/PolymerTemplate.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/PolymerTemplate.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.component.polymertemplate;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/RepeatIndex.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/RepeatIndex.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/RepeatIndex.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/RepeatIndex.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 
 package com.vaadin.flow.component.polymertemplate;

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/TemplateDataAnalyzer.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/TemplateDataAnalyzer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/TemplateDataAnalyzer.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/TemplateDataAnalyzer.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.component.polymertemplate;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/TemplateInitializer.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/TemplateInitializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/TemplateInitializer.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/TemplateInitializer.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.component.polymertemplate;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/TemplateParser.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/TemplateParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/TemplateParser.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/TemplateParser.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.component.polymertemplate;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/rpc/PolymerPublishedEventRpcHandler.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/rpc/PolymerPublishedEventRpcHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/rpc/PolymerPublishedEventRpcHandler.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/component/polymertemplate/rpc/PolymerPublishedEventRpcHandler.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.component.polymertemplate.rpc;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/AbstractBasicModelType.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/AbstractBasicModelType.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.templatemodel;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/AbstractBasicModelType.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/AbstractBasicModelType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/AllowClientUpdates.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/AllowClientUpdates.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.templatemodel;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/AllowClientUpdates.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/AllowClientUpdates.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/BasicComplexModelType.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/BasicComplexModelType.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.templatemodel;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/BasicComplexModelType.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/BasicComplexModelType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/BasicModelType.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/BasicModelType.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.templatemodel;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/BasicModelType.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/BasicModelType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/BeanModelType.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/BeanModelType.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.templatemodel;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/BeanModelType.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/BeanModelType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/ClientUpdateMode.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/ClientUpdateMode.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.templatemodel;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/ClientUpdateMode.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/ClientUpdateMode.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/ComplexModelType.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/ComplexModelType.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.templatemodel;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/ComplexModelType.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/ComplexModelType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/ConvertedModelType.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/ConvertedModelType.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.templatemodel;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/ConvertedModelType.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/ConvertedModelType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/Encode.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/Encode.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.templatemodel;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/Encode.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/Encode.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/Exclude.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/Exclude.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.templatemodel;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/Exclude.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/Exclude.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/Include.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/Include.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.templatemodel;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/Include.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/Include.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/InvalidTemplateModelException.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/InvalidTemplateModelException.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.templatemodel;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/InvalidTemplateModelException.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/InvalidTemplateModelException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/ListModelType.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/ListModelType.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.templatemodel;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/ListModelType.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/ListModelType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/ModelDescriptor.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/ModelDescriptor.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.templatemodel;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/ModelDescriptor.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/ModelDescriptor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/ModelEncoder.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/ModelEncoder.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.templatemodel;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/ModelEncoder.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/ModelEncoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/ModelType.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/ModelType.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.templatemodel;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/ModelType.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/ModelType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/PathLookup.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/PathLookup.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.templatemodel;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/PathLookup.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/PathLookup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/PropertyFilter.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/PropertyFilter.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.templatemodel;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/PropertyFilter.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/PropertyFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/PropertyMapBuilder.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/PropertyMapBuilder.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.templatemodel;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/PropertyMapBuilder.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/PropertyMapBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/TemplateModel.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/TemplateModel.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.templatemodel;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/TemplateModel.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/TemplateModel.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/TemplateModelListProxy.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/TemplateModelListProxy.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.templatemodel;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/TemplateModelListProxy.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/TemplateModelListProxy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/TemplateModelProxyHandler.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/TemplateModelProxyHandler.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.templatemodel;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/TemplateModelProxyHandler.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/TemplateModelProxyHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/TemplateModelUtil.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/TemplateModelUtil.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.templatemodel;
 

--- a/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/TemplateModelUtil.java
+++ b/flow-polymer-template/src/main/java/com/vaadin/flow/templatemodel/TemplateModelUtil.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/main/resources/com/vaadin/flow/component/polymertemplate/version.properties
+++ b/flow-polymer-template/src/main/resources/com/vaadin/flow/component/polymertemplate/version.properties
@@ -1,1 +1,0 @@
-polymertemplate.version=${project.version}

--- a/flow-polymer-template/src/main/resources/com/vaadin/flow/component/polymertemplate/version.properties
+++ b/flow-polymer-template/src/main/resources/com/vaadin/flow/component/polymertemplate/version.properties
@@ -1,0 +1,1 @@
+polymertemplate.version=${project.version}

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/component/AbstractTemplateTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/component/AbstractTemplateTest.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.component;
 

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/component/AbstractTemplateTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/component/AbstractTemplateTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/component/DeprecatedIdTemplateComponentTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/component/DeprecatedIdTemplateComponentTest.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.component;
 

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/component/DeprecatedIdTemplateComponentTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/component/DeprecatedIdTemplateComponentTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/component/TemplateComponentTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/component/TemplateComponentTest.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.component;
 

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/component/TemplateComponentTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/component/TemplateComponentTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/HasCurrentService.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/HasCurrentService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/HasCurrentService.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/HasCurrentService.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.component.polymertemplate;
 

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/InjectablePolymerElementInitializerTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/InjectablePolymerElementInitializerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/InjectablePolymerElementInitializerTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/InjectablePolymerElementInitializerTest.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.component.polymertemplate;
 

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/NpmTemplateParserTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/NpmTemplateParserTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/NpmTemplateParserTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/NpmTemplateParserTest.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.component.polymertemplate;
 

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/PolymerTemplateTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/PolymerTemplateTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/PolymerTemplateTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/PolymerTemplateTest.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 
 package com.vaadin.flow.component.polymertemplate;

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/TemplateInitializerTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/TemplateInitializerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/TemplateInitializerTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/TemplateInitializerTest.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 
 package com.vaadin.flow.component.polymertemplate;

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/rpc/PolymerPublishedEventRpcHandlerTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/rpc/PolymerPublishedEventRpcHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/rpc/PolymerPublishedEventRpcHandlerTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/component/polymertemplate/rpc/PolymerPublishedEventRpcHandlerTest.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 
 package com.vaadin.flow.component.polymertemplate.rpc;

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/server/MockVaadinServletService.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/server/MockVaadinServletService.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.server;
 

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/server/MockVaadinServletService.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/server/MockVaadinServletService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/server/communication/rpc/PublishedServerEventHandlerRpcHandlerTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/server/communication/rpc/PublishedServerEventHandlerRpcHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/server/communication/rpc/PublishedServerEventHandlerRpcHandlerTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/server/communication/rpc/PublishedServerEventHandlerRpcHandlerTest.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.server.communication.rpc;
 

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/templatemodel/BeanModelTypeTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/templatemodel/BeanModelTypeTest.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.templatemodel;
 

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/templatemodel/BeanModelTypeTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/templatemodel/BeanModelTypeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/templatemodel/KnownUnsupportedTypesTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/templatemodel/KnownUnsupportedTypesTest.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.templatemodel;
 

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/templatemodel/KnownUnsupportedTypesTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/templatemodel/KnownUnsupportedTypesTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/templatemodel/ModelDescriptorTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/templatemodel/ModelDescriptorTest.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.templatemodel;
 

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/templatemodel/ModelDescriptorTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/templatemodel/ModelDescriptorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/templatemodel/PropertyFilterTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/templatemodel/PropertyFilterTest.java
@@ -1,17 +1,11 @@
-/*
- * Copyright 2000-2022 Vaadin Ltd.
+/**
+ * Copyright (C) 2020 Vaadin Ltd
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
+ * This program is available under Commercial Vaadin Developer License
+ * 4.0 (CVDLv4).
  *
- * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * For the full License, see <https://vaadin.com/license/cvdl-4.0>.
  */
 package com.vaadin.flow.templatemodel;
 

--- a/flow-polymer-template/src/test/java/com/vaadin/flow/templatemodel/PropertyFilterTest.java
+++ b/flow-polymer-template/src/test/java/com/vaadin/flow/templatemodel/PropertyFilterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Vaadin Ltd
+ * Copyright (C) 2022 Vaadin Ltd
  *
  * This program is available under Commercial Vaadin Developer License
  * 4.0 (CVDLv4).


### PR DESCRIPTION
## Description

The PR enables license checking for the `flow-polymer-template` module as, starting with Vaadin 24, it is only available for Prime+ customers.

Fixes #15137

## Type of change

- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
