### PR TITLE
fix: suppress error handler for upload

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/StreamReceiverHandler.java
@@ -389,7 +389,11 @@ public class StreamReceiverHandler implements Serializable {
                 cleanStreamVariable(session, streamReceiver);
             }
             return result.getSecond() == UploadStatus.OK;
-        } catch (Exception e) {
+        } catch (IOException ioe) {
+            // Mostly premature closing of stream from client that throws on
+            // close
+            getLogger().debug("Exception closing inputStream", ioe);
+        } catch (UploadException e) {
             session.lock();
             try {
                 session.getErrorHandler().error(new ErrorEvent(e));
@@ -536,7 +540,7 @@ public class StreamReceiverHandler implements Serializable {
             // IOException happens
             onStreamingFailed(session, filename, type, contentLength,
                     streamVariable, out, totalBytes, e);
-            // Interrupted exception and IOEXception are not thrown forward:
+            // Interrupted exception and IOException are not thrown forward:
             // it's enough to fire them via streamVariable
         } catch (final Exception e) {
             onStreamingFailed(session, filename, type, contentLength,

--- a/flow-server/src/test/java/com/vaadin/flow/server/communication/StreamReceiverHandlerTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/communication/StreamReceiverHandlerTest.java
@@ -420,6 +420,26 @@ public class StreamReceiverHandlerTest {
     }
 
     @Test
+    public void handleFileUploadValidationAndData_inputStreamThrowsIOExceptionOnClose_exceptionIsNotRethrown_exceptionIsNotHandlerByErrorHandler()
+            throws UploadException {
+        InputStream inputStream = new InputStream() {
+            @Override
+            public int read() {
+                return -1;
+            }
+
+            @Override
+            public void close() throws IOException {
+                throw new IOException();
+            }
+        };
+        handler.handleFileUploadValidationAndData(session, inputStream,
+                streamReceiver, null, null, 0, stateNode);
+
+        Mockito.verifyNoInteractions(errorHandler);
+    }
+
+    @Test
     public void doHandleMultipartFileUpload_IOExceptionIsThrown_exceptionIsNotRethrown_exceptionIsNotHandlerByErrorHandler()
             throws IOException, ServletException {
         VaadinServletRequest request = Mockito.mock(VaadinServletRequest.class);


### PR DESCRIPTION
Do not call the error handler for upload
io exceptions. Only inform as streaming
failed.

Fixes #13736
