### PR TITLE
refactor: Align the polymer2lit Prettier config with the web-components one

### DIFF
--- a/flow-polymer2lit/convert.ts
+++ b/flow-polymer2lit/convert.ts
@@ -698,6 +698,11 @@ function convertFile(filename: string, useLit1: boolean, useOptionalChaining: bo
   output = output.replace(/this.\$\[['"]([^;., ()]*['"]\])/g, `this.renderRoot.querySelector("#$1")`);
   output = output.replace(/this\.\$\.([^;., ()]*)/g, `this.renderRoot.querySelector("#$1")`);
   const prettified = prettier.format(output, {
+    bracketSpacing: true,
+    printWidth: 120,
+    trailingComma: 'all',
+    tabWidth: 2,
+    singleQuote: true,
     parser: 'typescript'
   });
   fs.writeFileSync(jsOutputFile, prettified);

--- a/flow-polymer2lit/src/test/resources/frontend/expected/basic-bindings-with-lit1.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/basic-bindings-with-lit1.js
@@ -1,4 +1,4 @@
-import { html, LitElement, css } from "lit-element";
+import { html, LitElement, css } from 'lit-element';
 
 class BasicBindings extends LitElement {
   render() {
@@ -12,7 +12,7 @@ class BasicBindings extends LitElement {
   }
 
   static get is() {
-    return "basic-bindings";
+    return 'basic-bindings';
   }
 }
 

--- a/flow-polymer2lit/src/test/resources/frontend/expected/basic-bindings.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/basic-bindings.js
@@ -1,4 +1,4 @@
-import { html, LitElement, css } from "lit";
+import { html, LitElement, css } from 'lit';
 
 class BasicBindings extends LitElement {
   render() {
@@ -12,7 +12,7 @@ class BasicBindings extends LitElement {
   }
 
   static get is() {
-    return "basic-bindings";
+    return 'basic-bindings';
   }
 }
 

--- a/flow-polymer2lit/src/test/resources/frontend/expected/computed-property.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/computed-property.js
@@ -1,4 +1,4 @@
-import { html, LitElement, css } from "lit";
+import { html, LitElement, css } from 'lit';
 
 class ComputedProperty extends LitElement {
   render() {
@@ -22,11 +22,11 @@ class ComputedProperty extends LitElement {
   }
 
   computeFullName(first, last) {
-    return first + " " + last;
+    return first + ' ' + last;
   }
 
   static get is() {
-    return "computed-property";
+    return 'computed-property';
   }
   get fullName() {
     return this.computeFullName(this.first, this.last);

--- a/flow-polymer2lit/src/test/resources/frontend/expected/disabled-using-method.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/disabled-using-method.js
@@ -1,4 +1,4 @@
-import { html, LitElement, css } from "lit";
+import { html, LitElement, css } from 'lit';
 
 class DisabledUsingMethod extends LitElement {
   render() {
@@ -11,19 +11,11 @@ class DisabledUsingMethod extends LitElement {
           @click="${this.submit}"
           >Sign Up</vaadin-button
         >
-        <vaadin-button
-          id="cancelSignUpBtn"
-          theme="tertiary"
-          @click="${this.cancelButtonClicked}"
-          >Cancel</vaadin-button
-        >
+        <vaadin-button id="cancelSignUpBtn" theme="tertiary" @click="${this.cancelButtonClicked}">Cancel</vaadin-button>
       </vaadin-vertical-layout>
 
       <span class="payment-notes">Month-to-month @ $500 / month</span>
-      <a
-        class="support"
-        .href="${this.contactLink}"
-        @href-changed="${(e) => (this.contactLink = e.target.value)}"
+      <a class="support" .href="${this.contactLink}" @href-changed="${(e) => (this.contactLink = e.target.value)}"
         >Contact Support</a
       >
     `;
@@ -34,7 +26,7 @@ class DisabledUsingMethod extends LitElement {
   }
 
   static get is() {
-    return "disabled-using-method";
+    return 'disabled-using-method';
   }
 
   static get properties() {

--- a/flow-polymer2lit/src/test/resources/frontend/expected/dom-if.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/dom-if.js
@@ -1,6 +1,6 @@
-import { html, LitElement, css } from "lit";
+import { html, LitElement, css } from 'lit';
 
-import "@vaadin/vaadin-vertical-layout";
+import '@vaadin/vaadin-vertical-layout';
 
 class DomIfTest extends LitElement {
   render() {
@@ -23,7 +23,7 @@ class DomIfTest extends LitElement {
   }
 
   static get is() {
-    return "dom-if-test";
+    return 'dom-if-test';
   }
 }
 

--- a/flow-polymer2lit/src/test/resources/frontend/expected/dom-repeat-disabled-optional-chaining.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/dom-repeat-disabled-optional-chaining.js
@@ -1,6 +1,6 @@
-import { html, LitElement, css } from "lit";
+import { html, LitElement, css } from 'lit';
 
-import "@vaadin/vaadin-vertical-layout";
+import '@vaadin/vaadin-vertical-layout';
 
 class DomRepeatTest extends LitElement {
   render() {
@@ -11,14 +11,14 @@ class DomRepeatTest extends LitElement {
           <div><br /># ${index}</div>
           <div>Given name: <span>${item.given}</span></div>
           <div>Family name: <span>${item.family}</span></div>
-        `
+        `,
       )}
       ${(this.employees && this.employees.list ? this.employees.list : []).map(
         (item, index) => html`
           <div><br /># ${index}</div>
           <div>Given name: <span>${item.given}</span></div>
           <div>Family name: <span>${item.family}</span></div>
-        `
+        `,
       )}
     `;
   }
@@ -32,14 +32,14 @@ class DomRepeatTest extends LitElement {
   }
 
   static get is() {
-    return "dom-repeat-test";
+    return 'dom-repeat-test';
   }
   constructor() {
     super();
     this.employees = {
       list: [
-        { given: "Kamil", family: "Smith" },
-        { given: "Sally", family: "Johnson" },
+        { given: 'Kamil', family: 'Smith' },
+        { given: 'Sally', family: 'Johnson' },
       ],
     };
   }

--- a/flow-polymer2lit/src/test/resources/frontend/expected/dom-repeat.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/dom-repeat.js
@@ -1,6 +1,6 @@
-import { html, LitElement, css } from "lit";
+import { html, LitElement, css } from 'lit';
 
-import "@vaadin/vaadin-vertical-layout";
+import '@vaadin/vaadin-vertical-layout';
 
 class DomRepeatTest extends LitElement {
   render() {
@@ -11,14 +11,14 @@ class DomRepeatTest extends LitElement {
           <div><br /># ${index}</div>
           <div>Given name: <span>${item.given}</span></div>
           <div>Family name: <span>${item.family}</span></div>
-        `
+        `,
       )}
       ${(this.employees?.list ?? []).map(
         (item, index) => html`
           <div><br /># ${index}</div>
           <div>Given name: <span>${item.given}</span></div>
           <div>Family name: <span>${item.family}</span></div>
-        `
+        `,
       )}
     `;
   }
@@ -32,14 +32,14 @@ class DomRepeatTest extends LitElement {
   }
 
   static get is() {
-    return "dom-repeat-test";
+    return 'dom-repeat-test';
   }
   constructor() {
     super();
     this.employees = {
       list: [
-        { given: "Kamil", family: "Smith" },
-        { given: "Sally", family: "Johnson" },
+        { given: 'Kamil', family: 'Smith' },
+        { given: 'Sally', family: 'Johnson' },
       ],
     };
   }

--- a/flow-polymer2lit/src/test/resources/frontend/expected/event-handlers.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/event-handlers.js
@@ -1,4 +1,4 @@
-import { html, LitElement, css } from "lit";
+import { html, LitElement, css } from 'lit';
 
 class EventHandlers extends LitElement {
   render() {
@@ -28,15 +28,15 @@ class EventHandlers extends LitElement {
   }
 
   static get is() {
-    return "event-handlers";
+    return 'event-handlers';
   }
 
   submit() {
-    console.log("Submit clicked");
+    console.log('Submit clicked');
   }
 
   formUpdated() {
-    console.log("Form updated");
+    console.log('Form updated');
   }
 }
 

--- a/flow-polymer2lit/src/test/resources/frontend/expected/grid-columns.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/grid-columns.js
@@ -1,35 +1,19 @@
-import {
-  columnBodyRenderer,
-  columnFooterRenderer,
-  columnHeaderRenderer,
-} from "@vaadin/grid/lit.js";
-import { html, LitElement, css } from "lit";
+import { columnBodyRenderer, columnFooterRenderer, columnHeaderRenderer } from '@vaadin/grid/lit.js';
+import { html, LitElement, css } from 'lit';
 
-import "@vaadin/vaadin-grid";
-import "@vaadin/vaadin-grid/vaadin-grid-selection-column";
+import '@vaadin/vaadin-grid';
+import '@vaadin/vaadin-grid/vaadin-grid-selection-column';
 
 class GridColumns extends LitElement {
   render() {
     return html`
-      <vaadin-grid
-        aria-label="Basic example"
-        column-reordering-allowed
-        multi-sort
-        .items="${this.users}"
-      >
-        <vaadin-grid-selection-column
-          auto-select
-        ></vaadin-grid-selection-column>
+      <vaadin-grid aria-label="Basic example" column-reordering-allowed multi-sort .items="${this.users}">
+        <vaadin-grid-selection-column auto-select></vaadin-grid-selection-column>
 
         <vaadin-grid-column
           width="9em"
           ${columnHeaderRenderer(
-            (column) =>
-              html`
-                <vaadin-grid-sorter path="firstName"
-                  >First Name</vaadin-grid-sorter
-                >
-              `
+            (column) => html` <vaadin-grid-sorter path="firstName">First Name</vaadin-grid-sorter> `,
           )}
           ${columnBodyRenderer((item) => html`${item.firstName}`)}
           ${columnFooterRenderer((column) => html`First Name`)}
@@ -39,12 +23,7 @@ class GridColumns extends LitElement {
         <vaadin-grid-column
           width="9em"
           ${columnHeaderRenderer(
-            (column) =>
-              html`
-                <vaadin-grid-sorter path="lastName"
-                  >Last Name</vaadin-grid-sorter
-                >
-              `
+            (column) => html` <vaadin-grid-sorter path="lastName">Last Name</vaadin-grid-sorter> `,
           )}
           ${columnBodyRenderer((item) => html`${item.lastName}`)}
           ${columnFooterRenderer((column) => html`Last Name`)}
@@ -55,16 +34,9 @@ class GridColumns extends LitElement {
           width="15em"
           flex-grow="2"
           ${columnHeaderRenderer(
-            (column) =>
-              html`
-                <vaadin-grid-sorter path="address.street"
-                  >Address</vaadin-grid-sorter
-                >
-              `
+            (column) => html` <vaadin-grid-sorter path="address.street">Address</vaadin-grid-sorter> `,
           )}
-          ${columnBodyRenderer(
-            (item) => html`${item.address?.street}, ${item.address?.city}`
-          )}
+          ${columnBodyRenderer((item) => html`${item.address?.street}, ${item.address?.city}`)}
           ${columnFooterRenderer((column) => html`Address`)}
         >
         </vaadin-grid-column>
@@ -73,7 +45,7 @@ class GridColumns extends LitElement {
   }
 
   static get is() {
-    return "grid-columns";
+    return 'grid-columns';
   }
   static get properties() {
     return {
@@ -86,14 +58,14 @@ class GridColumns extends LitElement {
     super();
     this.users = [
       {
-        firstName: "John",
-        lastName: "Short",
-        address: { street: "Homestreet 1", city: "Boston" },
+        firstName: 'John',
+        lastName: 'Short',
+        address: { street: 'Homestreet 1', city: 'Boston' },
       },
       {
-        firstName: "Lea",
-        lastName: "Green",
-        address: { street: "Faraway 22", city: "Cairo" },
+        firstName: 'Lea',
+        lastName: 'Green',
+        address: { street: 'Faraway 22', city: 'Cairo' },
       },
     ];
   }

--- a/flow-polymer2lit/src/test/resources/frontend/expected/inline-styles.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/inline-styles.js
@@ -1,21 +1,21 @@
-import { unsafeCSS } from "lit";
-import { html, LitElement, css } from "lit";
+import { unsafeCSS } from 'lit';
+import { html, LitElement, css } from 'lit';
 
-import "@vaadin/vaadin-horizontal-layout";
-import "@vaadin/vaadin-vertical-layout";
+import '@vaadin/vaadin-horizontal-layout';
+import '@vaadin/vaadin-vertical-layout';
 
 class InlineStyles extends LitElement {
   static get styles() {
     const includedStyles = {};
-    includedStyles["shared-styles"] =
-      document.querySelector("dom-module[id='shared-styles']")
-        ?.firstElementChild?.content?.firstElementChild?.innerText ?? "";
-    includedStyles["something-else"] =
-      document.querySelector("dom-module[id='something-else']")
-        ?.firstElementChild?.content?.firstElementChild?.innerText ?? "";
+    includedStyles['shared-styles'] =
+      document.querySelector("dom-module[id='shared-styles']")?.firstElementChild?.content?.firstElementChild
+        ?.innerText ?? '';
+    includedStyles['something-else'] =
+      document.querySelector("dom-module[id='something-else']")?.firstElementChild?.content?.firstElementChild
+        ?.innerText ?? '';
     return [
-      unsafeCSS(includedStyles["shared-styles"]),
-      unsafeCSS(includedStyles["something-else"]),
+      unsafeCSS(includedStyles['shared-styles']),
+      unsafeCSS(includedStyles['something-else']),
       css`
         :host {
           display: block;
@@ -48,7 +48,7 @@ class InlineStyles extends LitElement {
   }
 
   static get is() {
-    return "inline-styles";
+    return 'inline-styles';
   }
 }
 

--- a/flow-polymer2lit/src/test/resources/frontend/expected/light-dom.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/light-dom.js
@@ -1,4 +1,4 @@
-import { html, LitElement, css } from "lit";
+import { html, LitElement, css } from 'lit';
 
 /**
  * Docs docs and more docs
@@ -12,7 +12,7 @@ class LightDom extends LitElement {
   }
 
   static get is() {
-    return "light-dom";
+    return 'light-dom';
   }
 
   // This allows us to keep the view element in the light DOM.

--- a/flow-polymer2lit/src/test/resources/frontend/expected/multiple-bindings.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/multiple-bindings.js
@@ -1,29 +1,21 @@
-import { html, LitElement, css } from "lit";
+import { html, LitElement, css } from 'lit';
 
 class MultipleBindings extends LitElement {
   render() {
     return html`
       <vaadin-vertical-layout id="buttons">
-        <vaadin-button .id="${this.buttonId}"
-          >${this.buttonText1} ${this.buttonText2}</vaadin-button
-        >
-        <vaadin-button .id="${"hello " + (this.buttonId ?? "")}"
-          >${this.buttonText1} ${this.buttonText2}</vaadin-button
-        >
+        <vaadin-button .id="${this.buttonId}">${this.buttonText1} ${this.buttonText2}</vaadin-button>
+        <vaadin-button .id="${'hello ' + (this.buttonId ?? '')}">${this.buttonText1} ${this.buttonText2}</vaadin-button>
         <vaadin-text-field
-          .value="${(this.textfieldValue1 ?? "") +
-          "-" +
-          (this.textfieldValue2 ?? "")}"
+          .value="${(this.textfieldValue1 ?? '') + '-' + (this.textfieldValue2 ?? '')}"
         ></vaadin-text-field>
-        <vaadin-text-field
-          .value="${(this.sub?.value1 ?? "") + "-" + (this.sub?.value2 ?? "")}"
-        ></vaadin-text-field>
+        <vaadin-text-field .value="${(this.sub?.value1 ?? '') + '-' + (this.sub?.value2 ?? '')}"></vaadin-text-field>
       </vaadin-vertical-layout>
     `;
   }
 
   static get is() {
-    return "multiple-bindings";
+    return 'multiple-bindings';
   }
 }
 

--- a/flow-polymer2lit/src/test/resources/frontend/expected/nested-dom-repeat-disabled-optional-chaining.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/nested-dom-repeat-disabled-optional-chaining.js
@@ -1,6 +1,6 @@
-import { html, LitElement, css } from "lit";
+import { html, LitElement, css } from 'lit';
 
-import "@vaadin/vaadin-vertical-layout";
+import '@vaadin/vaadin-vertical-layout';
 
 class DomRepeatTest extends LitElement {
   render() {
@@ -14,12 +14,10 @@ class DomRepeatTest extends LitElement {
           ${(item.employees ? item.employees : []).map(
             (item, index) => html`
               <div><br />Employee # ${index}</div>
-              <div>
-                Employee name: <span>${item.given} ${item.family}</span>
-              </div>
-            `
+              <div>Employee name: <span>${item.given} ${item.family}</span></div>
+            `,
           )}
-        `
+        `,
       )}
     `;
   }
@@ -33,13 +31,13 @@ class DomRepeatTest extends LitElement {
   }
 
   static get is() {
-    return "dom-repeat-test";
+    return 'dom-repeat-test';
   }
   constructor() {
     super();
     this.employees = [
-      { given: "Kamil", family: "Smith" },
-      { given: "Sally", family: "Johnson" },
+      { given: 'Kamil', family: 'Smith' },
+      { given: 'Sally', family: 'Johnson' },
     ];
   }
 }

--- a/flow-polymer2lit/src/test/resources/frontend/expected/nested-dom-repeat.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/nested-dom-repeat.js
@@ -1,6 +1,6 @@
-import { html, LitElement, css } from "lit";
+import { html, LitElement, css } from 'lit';
 
-import "@vaadin/vaadin-vertical-layout";
+import '@vaadin/vaadin-vertical-layout';
 
 class DomRepeatTest extends LitElement {
   render() {
@@ -14,12 +14,10 @@ class DomRepeatTest extends LitElement {
           ${(item.employees ?? []).map(
             (item, index) => html`
               <div><br />Employee # ${index}</div>
-              <div>
-                Employee name: <span>${item.given} ${item.family}</span>
-              </div>
-            `
+              <div>Employee name: <span>${item.given} ${item.family}</span></div>
+            `,
           )}
-        `
+        `,
       )}
     `;
   }
@@ -33,13 +31,13 @@ class DomRepeatTest extends LitElement {
   }
 
   static get is() {
-    return "dom-repeat-test";
+    return 'dom-repeat-test';
   }
   constructor() {
     super();
     this.employees = [
-      { given: "Kamil", family: "Smith" },
-      { given: "Sally", family: "Johnson" },
+      { given: 'Kamil', family: 'Smith' },
+      { given: 'Sally', family: 'Johnson' },
     ];
   }
 }

--- a/flow-polymer2lit/src/test/resources/frontend/expected/order-card-from-bakery.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/order-card-from-bakery.js
@@ -1,17 +1,17 @@
-import { unsafeCSS } from "lit";
-import { html, LitElement, css } from "lit";
+import { unsafeCSS } from 'lit';
+import { html, LitElement, css } from 'lit';
 
-import "../../../styles/shared-styles.js";
-import "./order-status-badge.js";
+import '../../../styles/shared-styles.js';
+import './order-status-badge.js';
 
 class OrderCard extends LitElement {
   static get styles() {
     const includedStyles = {};
-    includedStyles["shared-styles"] =
-      document.querySelector("dom-module[id='shared-styles']")
-        ?.firstElementChild?.content?.firstElementChild?.innerText ?? "";
+    includedStyles['shared-styles'] =
+      document.querySelector("dom-module[id='shared-styles']")?.firstElementChild?.content?.firstElementChild
+        ?.innerText ?? '';
     return [
-      unsafeCSS(includedStyles["shared-styles"]),
+      unsafeCSS(includedStyles['shared-styles']),
       css`
         :host {
           display: block;
@@ -26,10 +26,7 @@ class OrderCard extends LitElement {
 
         .wrapper {
           background: var(--lumo-base-color);
-          background-image: linear-gradient(
-            var(--lumo-tint-5pct),
-            var(--lumo-tint-5pct)
-          );
+          background-image: linear-gradient(var(--lumo-tint-5pct), var(--lumo-tint-5pct));
           box-shadow: 0 3px 5px var(--lumo-shade-10pct);
           border-bottom: 1px solid var(--lumo-shade-10pct);
           display: flex;
@@ -152,10 +149,7 @@ class OrderCard extends LitElement {
         </div>
         <div class="wrapper" @click="${this._cardClick}">
           <div class="info-wrapper">
-            <order-status-badge
-              class="badge"
-              .status="${this.orderCard?.state}"
-            ></order-status-badge>
+            <order-status-badge class="badge" .status="${this.orderCard?.state}"></order-status-badge>
             <div class="time-place">
               <h3 class="time">${this.orderCard?.time}</h3>
               <h3 class="short-day">${this.orderCard?.shortDay}</h3>
@@ -174,7 +168,7 @@ class OrderCard extends LitElement {
                     <span class="count">${item.quantity}</span>
                     <div>${item.product?.name}</div>
                   </div>
-                `
+                `,
               )}
             </div>
           </div>
@@ -184,11 +178,11 @@ class OrderCard extends LitElement {
   }
 
   static get is() {
-    return "order-card";
+    return 'order-card';
   }
 
   _cardClick() {
-    this.dispatchEvent(new CustomEvent("card-click"));
+    this.dispatchEvent(new CustomEvent('card-click'));
   }
 }
 

--- a/flow-polymer2lit/src/test/resources/frontend/expected/ready-callback.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/ready-callback.js
@@ -1,4 +1,4 @@
-import { html, LitElement, css } from "lit";
+import { html, LitElement, css } from 'lit';
 
 class ReadyCallback extends LitElement {
   render() {
@@ -14,16 +14,16 @@ class ReadyCallback extends LitElement {
   }
 
   static get is() {
-    return "ready-callback";
+    return 'ready-callback';
   }
 
   firstUpdated(_changedProperties) {
     super.firstUpdated(_changedProperties);
 
-    div = document.createElement("div");
-    div.innerText = "Created in ready()";
-    this.renderRoot.querySelector("#container").appendChild(div);
-    this.property = "Value set in ready()";
+    div = document.createElement('div');
+    div.innerText = 'Created in ready()';
+    this.renderRoot.querySelector('#container').appendChild(div);
+    this.property = 'Value set in ready()';
   }
 }
 

--- a/flow-polymer2lit/src/test/resources/frontend/expected/simple-observer.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/simple-observer.js
@@ -1,4 +1,4 @@
-import { html, LitElement, css } from "lit";
+import { html, LitElement, css } from 'lit';
 
 class SimpleObserver extends LitElement {
   render() {
@@ -18,8 +18,7 @@ class SimpleObserver extends LitElement {
       previousLast: String,
       example: {
         type: String,
-        /* TODO: Convert this complex observer manually */
-        observer: "userListChanged(users.*, filter)",
+        /* TODO: Convert this complex observer manually */ observer: 'userListChanged(users.*, filter)',
       },
     };
   }
@@ -33,18 +32,14 @@ class SimpleObserver extends LitElement {
   }
 
   static get is() {
-    return "simple-observer";
+    return 'simple-observer';
   }
   set first(newValue) {
     const oldValue = this.first;
     this._first = newValue;
     if (oldValue !== newValue) {
       this._firstChanged(newValue, oldValue);
-      this.requestUpdateInternal(
-        "first",
-        oldValue,
-        this.constructor.properties.first
-      );
+      this.requestUpdateInternal('first', oldValue, this.constructor.properties.first);
     }
   }
   get first() {
@@ -56,11 +51,7 @@ class SimpleObserver extends LitElement {
     this._last = newValue;
     if (oldValue !== newValue) {
       this._lastChanged(newValue, oldValue);
-      this.requestUpdateInternal(
-        "last",
-        oldValue,
-        this.constructor.properties.last
-      );
+      this.requestUpdateInternal('last', oldValue, this.constructor.properties.last);
     }
   }
   get last() {

--- a/flow-polymer2lit/src/test/resources/frontend/expected/sub-properties-with-disabled-optional-chaining.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/sub-properties-with-disabled-optional-chaining.js
@@ -1,25 +1,17 @@
-import { html, LitElement, css } from "lit";
+import { html, LitElement, css } from 'lit';
 
 class SubProperties extends LitElement {
   render() {
     return html`
-      <div>
-        ${this.prop && this.prop.sub ? this.prop.sub.something : undefined}
-      </div>
+      <div>${this.prop && this.prop.sub ? this.prop.sub.something : undefined}</div>
       <div>
         Method:
         ${this.abc(
           this.prop && this.prop.sub ? this.prop.sub.something : undefined,
-          this.prop ? this.prop.value : undefined
+          this.prop ? this.prop.value : undefined,
         )}
       </div>
-      <div
-        .foo="${this.prop && this.prop.sub
-          ? this.prop.sub.something
-          : undefined}"
-      >
-        maybe with foo
-      </div>
+      <div .foo="${this.prop && this.prop.sub ? this.prop.sub.something : undefined}">maybe with foo</div>
     `;
   }
 
@@ -28,7 +20,7 @@ class SubProperties extends LitElement {
   }
 
   static get is() {
-    return "sub-properties";
+    return 'sub-properties';
   }
 }
 

--- a/flow-polymer2lit/src/test/resources/frontend/expected/sub-properties.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/sub-properties.js
@@ -1,12 +1,10 @@
-import { html, LitElement, css } from "lit";
+import { html, LitElement, css } from 'lit';
 
 class SubProperties extends LitElement {
   render() {
     return html`
       <div>${this.prop?.sub?.something}</div>
-      <div>
-        Method: ${this.abc(this.prop?.sub?.something, this.prop?.value)}
-      </div>
+      <div>Method: ${this.abc(this.prop?.sub?.something, this.prop?.value)}</div>
       <div .foo="${this.prop?.sub?.something}">maybe with foo</div>
     `;
   }
@@ -16,7 +14,7 @@ class SubProperties extends LitElement {
   }
 
   static get is() {
-    return "sub-properties";
+    return 'sub-properties';
   }
 }
 

--- a/flow-polymer2lit/src/test/resources/frontend/expected/this-dollar-mapped-element-ids.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/this-dollar-mapped-element-ids.js
@@ -1,7 +1,7 @@
-import { html, LitElement, css } from "lit";
+import { html, LitElement, css } from 'lit';
 
-import "@vaadin/vaadin-grid/src/vaadin-grid.js";
-import "@vaadin/vaadin-dialog/src/vaadin-dialog.js";
+import '@vaadin/vaadin-grid/src/vaadin-grid.js';
+import '@vaadin/vaadin-dialog/src/vaadin-dialog.js';
 
 class ThisDollarMappedElement extends LitElement {
   render() {
@@ -10,23 +10,19 @@ class ThisDollarMappedElement extends LitElement {
 
       <vaadin-grid id="grid" theme="orders no-row-borders"></vaadin-grid>
 
-      <vaadin-dialog
-        id="dialog"
-        theme="orders"
-        @opened-changed="${this._onDialogOpen}"
-      ></vaadin-dialog>
+      <vaadin-dialog id="dialog" theme="orders" @opened-changed="${this._onDialogOpen}"></vaadin-dialog>
     `;
   }
 
   static get is() {
-    return "this-dollar-mapped-element";
+    return 'this-dollar-mapped-element';
   }
 
   firstUpdated(_changedProperties) {
     super.firstUpdated(_changedProperties);
 
-    const grid = this.renderRoot.querySelector("#grid");
-    console.log("Grid is ", grid);
+    const grid = this.renderRoot.querySelector('#grid');
+    console.log('Grid is ', grid);
   }
 
   // Workaround for styling the dialog content https://github.com/vaadin/vaadin-dialog-flow/issues/69
@@ -34,12 +30,9 @@ class ThisDollarMappedElement extends LitElement {
     if (!e.detail.value) {
       return;
     }
-    var content = this.renderRoot.querySelector("#dialog").$.overlay.content;
-    console.log("content is ", content);
+    var content = this.renderRoot.querySelector('#dialog').$.overlay.content;
+    console.log('content is ', content);
   }
 }
 
-window.customElements.define(
-  ThisDollarMappedElement.is,
-  ThisDollarMappedElement
-);
+window.customElements.define(ThisDollarMappedElement.is, ThisDollarMappedElement);

--- a/flow-polymer2lit/src/test/resources/frontend/expected/two-way-binding.js
+++ b/flow-polymer2lit/src/test/resources/frontend/expected/two-way-binding.js
@@ -1,4 +1,4 @@
-import { html, LitElement, css } from "lit";
+import { html, LitElement, css } from 'lit';
 
 class TwoWayBinding extends LitElement {
   render() {
@@ -30,11 +30,11 @@ class TwoWayBinding extends LitElement {
   }
 
   formUpdated() {
-    console.log("Form updated");
+    console.log('Form updated');
   }
 
   static get is() {
-    return "two-way-binding";
+    return 'two-way-binding';
   }
 }
 


### PR DESCRIPTION
## Description

The PR aligns the polymer2lit Prettier config with the web-components one to make the former use single quotes and etc.

## Type of change

- [x] Refactor

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x]  have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
