### PR TITLE
chore: Show statistics after Polymer to Lit conversion

### DIFF
--- a/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/ConvertPolymerCommand.java
+++ b/flow-plugins/flow-plugin-base/src/main/java/com/vaadin/flow/plugin/base/ConvertPolymerCommand.java
@@ -98,37 +98,53 @@ public class ConvertPolymerCommand implements AutoCloseable {
             CommandExecutionException {
         Path lookupPath = getLookupPath();
 
+        int totalCount = 0;
+        int convertedCount = 0;
+        int skippedCount = 0;
+        int failedCount = 0;
+
         for (Path filePath : getFilePathsByGlob(lookupPath, SERVER_GLOB)) {
             try {
+                totalCount++;
                 adapter.logInfo(String.format("Processing %s...", filePath));
                 if (serverConverter.convertFile(filePath)) {
-                    adapter.logInfo(
-                            "The file has been successfully converted.");
+                    adapter.logInfo("The file was successfully converted.");
+                    convertedCount++;
                 } else {
                     adapter.logInfo(
                             "No occurences of PolymerTemplate was found. Skipping.");
+                    skippedCount++;
                 }
             } catch (Exception e) {
                 adapter.logError("An error occurred while processing.", e);
+                failedCount++;
             }
         }
 
         for (Path filePath : getFilePathsByGlob(lookupPath, FRONTEND_GLOB)) {
             try {
+                totalCount++;
                 adapter.logInfo(String.format("Processing %s...", filePath));
                 if (frontendConverter.convertFile(filePath, useLit1,
                         disableOptionalChaining)) {
-                    adapter.logInfo(
-                            "The file has been successfully converted.");
+                    adapter.logInfo("The file was successfully converted.");
+                    convertedCount++;
                 } else {
                     adapter.logInfo(
                             "No occurences of PolymerElement was found. Skipping.");
+                    skippedCount++;
                 }
             } catch (Exception e) {
                 adapter.logError("An error occurred while processing.", e);
+                failedCount++;
             }
-
         }
+
+        adapter.logInfo(
+                "------------------------------------------------------------------------");
+        adapter.logInfo(String.format(
+                "Total: %d | Converted: %d | Failed: %d | Skipped: %d",
+                totalCount, convertedCount, failedCount, skippedCount));
     }
 
     private List<Path> getFilePathsByGlob(Path baseDir, String glob)


### PR DESCRIPTION
## Description

The PR enhances `ConvertPolymerCommand` to make it show some statistics about how many files have been processed and their conversion status.

A follow-up to #14956

## Type of change

- [x] Chore

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
