### PR TITLE
fix: set useDefineForClassFields to false in tsconfig.json

### DIFF
--- a/flow-server/src/main/resources/tsconfig.json
+++ b/flow-server/src/main/resources/tsconfig.json
@@ -13,6 +13,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "experimentalDecorators": true,
+    "useDefineForClassFields": false,
     "skipLibCheck": true,
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
## Description

Related to Vite 3.2 issue: https://github.com/vitejs/vite/issues/10296 

## Type of change

- Bugfix