### PR TITLE
fix: set useDefineForClassFields in generated tsconfig.json

### DIFF
--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/tsconfig.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/tsconfig.json
@@ -19,6 +19,7 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "experimentalDecorators": true,
+    "useDefineForClassFields": false,
     "baseUrl": "frontend",
     "paths": {
       "@vaadin/flow-frontend": ["generated/jar-resources"],


### PR DESCRIPTION
## Description

Follow-up to #15165. Looks like I missed to update the other `tsconfig.json` so the build still fails:

![Screenshot 2022-11-18 at 14 22 41](https://user-images.githubusercontent.com/10589913/202704423-49a88289-25ac-4e2b-a83c-9f2bfc913d9a.png)

## Type of change

- Bugfix