### PR TITLE
chore: update the expected default npm version

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -66,7 +66,7 @@ public class FrontendTools {
     /**
      * This is the version shipped with the default Node version.
      */
-    public static final String DEFAULT_NPM_VERSION = "8.15.0";
+    public static final String DEFAULT_NPM_VERSION = "8.19.2";
 
     public static final String DEFAULT_PNPM_VERSION = "5.18.10";
 


### PR DESCRIPTION
Update npm version to match the node
16.18.1 default npm.
