### PR TITLE
chore: Upgrade license checker to 1.11.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,7 @@
             <dependency>
                 <groupId>com.vaadin</groupId>
                 <artifactId>license-checker</artifactId>
-                <version>1.11.1</version>
+                <version>1.11.2</version>
             </dependency>
 
             <!-- Test dependencies -->


### PR DESCRIPTION
Fixes OSGi compatibility
