### PR TITLE
Revert "fix: run npm install if folder changes (#14909)"

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -307,7 +307,7 @@ public class TaskUpdatePackages extends NodeUpdater {
 
         String oldHash = packageJson.getObject(VAADIN_DEP_KEY)
                 .getString(HASH_KEY);
-        String newHash = generatePackageJsonHash(packageJson, npmFolder);
+        String newHash = generatePackageJsonHash(packageJson);
         // update packageJson hash value, if no changes it will not be written
         packageJson.getObject(VAADIN_DEP_KEY).put(HASH_KEY, newHash);
 
@@ -474,12 +474,9 @@ public class TaskUpdatePackages extends NodeUpdater {
      *
      * @param packageJson
      *            JsonObject built in the same format as package.json
-     * @param npmFolder
-     *            project base folder to use in hash
      * @return has for dependencies and devDependencies
      */
-    static String generatePackageJsonHash(JsonObject packageJson,
-            File npmFolder) {
+    static String generatePackageJsonHash(JsonObject packageJson) {
         StringBuilder hashContent = new StringBuilder();
         if (packageJson.hasKey(DEPENDENCIES)) {
             JsonObject dependencies = packageJson.getObject(DEPENDENCIES);
@@ -507,10 +504,6 @@ public class TaskUpdatePackages extends NodeUpdater {
             hashContent.append(sortedDevDependencies);
             hashContent.append("}");
         }
-        if (hashContent.length() > 0) {
-            hashContent.append("\n");
-        }
-        hashContent.append(npmFolder.getAbsolutePath());
         return StringUtil.getHash(hashContent.toString());
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -306,20 +306,6 @@ public class TaskRunNpmInstallTest {
         Mockito.verify(logger).info(getRunningMsg());
     }
 
-    @Test
-    public void differentNpmFolderName_returnsDifferentHash()
-            throws IOException {
-        final JsonObject packageJson = getNodeUpdater().getPackageJson();
-        final String originalHash = TaskUpdatePackages
-                .generatePackageJsonHash(packageJson, npmFolder);
-
-        final String newFolderHash = TaskUpdatePackages.generatePackageJsonHash(
-                packageJson, new File(npmFolder, "change"));
-
-        Assert.assertNotEquals("Changing base folder should change hash value.",
-                originalHash, newFolderHash);
-    }
-
     protected void setupEsbuildAndFooInstallation() throws IOException {
         File nodeModules = getNodeUpdater().nodeModulesFolder;
         nodeModules.mkdir();
@@ -442,8 +428,8 @@ public class TaskRunNpmInstallTest {
         }
         packageJson.put(DEPENDENCIES, dependencies);
         packageJson.put(DEV_DEPENDENCIES, devDependencies);
-        packageJson.getObject(VAADIN_DEP_KEY).put(HASH_KEY, TaskUpdatePackages
-                .generatePackageJsonHash(packageJson, npmFolder));
+        packageJson.getObject(VAADIN_DEP_KEY).put(HASH_KEY,
+                TaskUpdatePackages.generatePackageJsonHash(packageJson));
         packageJson.remove(DEPENDENCIES);
         packageJson.remove(DEV_DEPENDENCIES);
     }


### PR DESCRIPTION
This reverts commit abc08f863924001b16be838cfb16f0cd8d922e5d.

The earlier patch is not needed as target/flow-frontend is no longer used. Additionally using a hash that is dependent on the project folder makes the hash unusable for other purposes, such as determining if the package.json contents has changed.
