### PR TITLE
refactor: Record project folder inside node_modules instead

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -97,6 +97,7 @@ public abstract class NodeUpdater implements FallibleCommand {
     protected static final String DEP_NAME_FLOW_JARS = "@vaadin/flow-frontend";
 
     static final String VAADIN_VERSION = "vaadinVersion";
+    static final String PROJECT_FOLDER = "projectFolder";
 
     /**
      * Base directory for {@link Constants#PACKAGE_JSON},

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -260,8 +260,10 @@ public class TaskRunNpmInstall implements FallibleCommand {
                     return true;
                 }
 
-                if (!packageUpdater.npmFolder.getAbsolutePath().equals(
-                        nodeModulesVaadinJson.getString(PROJECT_FOLDER))) {
+                if (nodeModulesVaadinJson.hasKey(PROJECT_FOLDER)
+                        && !packageUpdater.npmFolder.getAbsolutePath()
+                                .equals(nodeModulesVaadinJson
+                                        .getString(PROJECT_FOLDER))) {
                     return true;
                 }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -45,6 +45,7 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.commandToString;
 import static com.vaadin.flow.server.frontend.NodeUpdater.HASH_KEY;
 import static com.vaadin.flow.server.frontend.NodeUpdater.VAADIN_DEP_KEY;
 import static com.vaadin.flow.server.frontend.NodeUpdater.VAADIN_VERSION;
+import static com.vaadin.flow.server.frontend.NodeUpdater.PROJECT_FOLDER;;
 
 /**
  * Run <code>npm install</code> after dependencies have been updated.
@@ -201,7 +202,7 @@ public class TaskRunNpmInstall implements FallibleCommand {
      * node_modules/.vaadin/vaadin.json
      * </pre>
      *
-     * with package.json hash and the platform version.
+     * with package.json hash, project folder and the platform version.
      * <p>
      * This is for handling updated package to the code repository by another
      * developer as then the hash is updated and we may just be missing one
@@ -222,6 +223,8 @@ public class TaskRunNpmInstall implements FallibleCommand {
             updates.put(HASH_KEY, hash);
             Platform.getVaadinVersion()
                     .ifPresent(s -> updates.put(VAADIN_VERSION, s));
+            updates.put(PROJECT_FOLDER,
+                    packageUpdater.npmFolder.getAbsolutePath());
             packageUpdater.updateVaadinJsonContents(updates);
         } catch (IOException e) {
             packageUpdater.log().warn("Failed to update node_modules hash.", e);
@@ -240,18 +243,29 @@ public class TaskRunNpmInstall implements FallibleCommand {
         if (installedPackages.length == 0) {
             // Nothing installed
             return true;
-        } else {
-            return isVaadinHashUpdated();
         }
+
+        return isVaadinHashOrProjectFolderUpdated();
     }
 
-    private boolean isVaadinHashUpdated() {
+    boolean isVaadinHashOrProjectFolderUpdated() {
         try {
-            JsonObject content = packageUpdater.getVaadinJsonContents();
-            if (content.hasKey(HASH_KEY)) {
+            JsonObject nodeModulesVaadinJson = packageUpdater
+                    .getVaadinJsonContents();
+            if (nodeModulesVaadinJson.hasKey(HASH_KEY)) {
                 final JsonObject packageJson = packageUpdater.getPackageJson();
-                return !content.getString(HASH_KEY).equals(packageJson
-                        .getObject(VAADIN_DEP_KEY).getString(HASH_KEY));
+                if (!nodeModulesVaadinJson.getString(HASH_KEY)
+                        .equals(packageJson.getObject(VAADIN_DEP_KEY)
+                                .getString(HASH_KEY))) {
+                    return true;
+                }
+
+                if (!packageUpdater.npmFolder.getAbsolutePath().equals(
+                        nodeModulesVaadinJson.getString(PROJECT_FOLDER))) {
+                    return true;
+                }
+
+                return false;
             }
         } catch (IOException e) {
             packageUpdater.log()

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -307,7 +307,7 @@ public class TaskUpdatePackages extends NodeUpdater {
 
         String oldHash = packageJson.getObject(VAADIN_DEP_KEY)
                 .getString(HASH_KEY);
-        String newHash = generatePackageJsonHash(packageJson, npmFolder);
+        String newHash = generatePackageJsonHash(packageJson);
         // update packageJson hash value, if no changes it will not be written
         packageJson.getObject(VAADIN_DEP_KEY).put(HASH_KEY, newHash);
 
@@ -474,12 +474,9 @@ public class TaskUpdatePackages extends NodeUpdater {
      *
      * @param packageJson
      *            JsonObject built in the same format as package.json
-     * @param npmFolder
-     *            project base folder to use in hash
      * @return has for dependencies and devDependencies
      */
-    static String generatePackageJsonHash(JsonObject packageJson,
-            File npmFolder) {
+    static String generatePackageJsonHash(JsonObject packageJson) {
         StringBuilder hashContent = new StringBuilder();
         if (packageJson.hasKey(DEPENDENCIES)) {
             JsonObject dependencies = packageJson.getObject(DEPENDENCIES);
@@ -507,10 +504,6 @@ public class TaskUpdatePackages extends NodeUpdater {
             hashContent.append(sortedDevDependencies);
             hashContent.append("}");
         }
-        if (hashContent.length() > 0) {
-            hashContent.append("\n");
-        }
-        hashContent.append(npmFolder.getAbsolutePath());
         return StringUtil.getHash(hashContent.toString());
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -306,20 +306,6 @@ public class TaskRunNpmInstallTest {
         Mockito.verify(logger).info(getRunningMsg());
     }
 
-    @Test
-    public void differentNpmFolderName_returnsDifferentHash()
-            throws IOException {
-        final JsonObject packageJson = getNodeUpdater().getPackageJson();
-        final String originalHash = TaskUpdatePackages
-                .generatePackageJsonHash(packageJson, npmFolder);
-
-        final String newFolderHash = TaskUpdatePackages.generatePackageJsonHash(
-                packageJson, new File(npmFolder, "change"));
-
-        Assert.assertNotEquals("Changing base folder should change hash value.",
-                originalHash, newFolderHash);
-    }
-
     protected void setupEsbuildAndFooInstallation() throws IOException {
         File nodeModules = getNodeUpdater().nodeModulesFolder;
         nodeModules.mkdir();
@@ -442,8 +428,8 @@ public class TaskRunNpmInstallTest {
         }
         packageJson.put(DEPENDENCIES, dependencies);
         packageJson.put(DEV_DEPENDENCIES, devDependencies);
-        packageJson.getObject(VAADIN_DEP_KEY).put(HASH_KEY, TaskUpdatePackages
-                .generatePackageJsonHash(packageJson, npmFolder));
+        packageJson.getObject(VAADIN_DEP_KEY).put(HASH_KEY,
+                TaskUpdatePackages.generatePackageJsonHash(packageJson));
         packageJson.remove(DEPENDENCIES);
         packageJson.remove(DEV_DEPENDENCIES);
     }

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/TaskRunNpmInstallTest.java
@@ -20,6 +20,7 @@ import static com.vaadin.flow.server.Constants.TARGET;
 import static com.vaadin.flow.server.frontend.NodeUpdater.DEPENDENCIES;
 import static com.vaadin.flow.server.frontend.NodeUpdater.DEV_DEPENDENCIES;
 import static com.vaadin.flow.server.frontend.NodeUpdater.HASH_KEY;
+import static com.vaadin.flow.server.frontend.NodeUpdater.PROJECT_FOLDER;
 import static com.vaadin.flow.server.frontend.NodeUpdater.VAADIN_DEP_KEY;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -400,6 +401,27 @@ public class TaskRunNpmInstallTest {
         Assert.assertTrue("Postinstall for 'foo' was not run",
                 new File(new File(getNodeUpdater().nodeModulesFolder, "foo"),
                         "postinstall-file.txt").exists());
+    }
+
+    @Test
+    public void shouldRunNpmInstallWhenFolderChanges() throws Exception {
+        setupEsbuildAndFooInstallation();
+
+        String packageJsonHash = getNodeUpdater().getPackageJson()
+                .getObject(VAADIN_DEP_KEY).getString(HASH_KEY);
+        JsonObject vaadinJson = Json.createObject();
+        vaadinJson.put(HASH_KEY, packageJsonHash);
+        vaadinJson.put(PROJECT_FOLDER,
+                getNodeUpdater().npmFolder.getAbsolutePath());
+        File vaadinJsonFile = getNodeUpdater().getVaadinJsonFile();
+
+        FileUtils.writeStringToFile(vaadinJsonFile, vaadinJson.toJson(), UTF_8);
+
+        Assert.assertFalse(task.isVaadinHashOrProjectFolderUpdated());
+        vaadinJson.put(PROJECT_FOLDER,
+                getNodeUpdater().npmFolder.getAbsolutePath() + "foo");
+        FileUtils.writeStringToFile(vaadinJsonFile, vaadinJson.toJson(), UTF_8);
+        Assert.assertTrue(task.isVaadinHashOrProjectFolderUpdated());
     }
 
     /**


### PR DESCRIPTION
The package.json hash is now again a hash of the contents and can be used by other tools to check if the content (installed packages) has changed

Fixes #14908 in a different way
