### PR TITLE
feat: Added a shorthand to remove a component from its parent

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/Component.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Component.java
@@ -788,5 +788,12 @@ public abstract class Component
         }
         return null;
     }
+ 
+    /**
+     * Removes the component from its parent.
+     */
+    public void removeFromParent() {
+        findAncestor(HasComponents.class).remove(this);
+    }
 
 }

--- a/flow-server/src/main/java/com/vaadin/flow/component/Component.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Component.java
@@ -788,7 +788,7 @@ public abstract class Component
         }
         return null;
     }
- 
+
     /**
      * Removes the component from its parent.
      */

--- a/flow-server/src/main/java/com/vaadin/flow/component/Component.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Component.java
@@ -793,7 +793,7 @@ public abstract class Component
      * Removes the component from its parent.
      */
     public void removeFromParent() {
-        findAncestor(HasComponents.class).remove(this);
+        getElement().removeFromParent();
     }
 
 }

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
@@ -1676,6 +1676,28 @@ public class ComponentTest {
         Assert.assertEquals(ui, component.findAncestor(UI.class));
         Assert.assertEquals(ui, component.findAncestor(PollNotifier.class));
         Assert.assertNull(component.findAncestor(TestButton.class));
+    }
+
+    @Test
+    public void removeFromParentTest() {
+        UI ui = new UI();
+        TestComponentContainer componentContainer = new TestComponentContainer();
+        TestComponent component = new TestComponent();
+        componentContainer.add(component);
+        ui.add(componentContainer);
+
+        Assert.assertEquals(componentContainer, component.getParent().get());
+        Assert.assertEquals(1, componentContainer.getChildren().count());
+        Assert.assertEquals(ui, componentContainer.getParent().get());
+        Assert.assertEquals(1, ui.getChildren().count());
+
+        component.removeFromParent();
+        Assert.assertTrue(component.getParent().isEmpty());
+        Assert.assertEquals(0, componentContainer.getChildren().count());
+
+        componentContainer.removeFromParent();
+        Assert.assertTrue(componentContainer.getParent().isEmpty());
+        Assert.assertEquals(0, ui.getChildren().count());
 
     }
 


### PR DESCRIPTION
Reduces coupling between UI components (and/or ugly code)

## Type of change

- [ ] Bugfix
- [X] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
