### PR TITLE
fix: stats in development mode

### DIFF
--- a/flow-server/src/main/resources/plugins/stats-plugin/package.json
+++ b/flow-server/src/main/resources/plugins/stats-plugin/package.json
@@ -5,7 +5,7 @@
   ],
   "repository": "vaadin/flow",
   "name": "@vaadin/stats-plugin",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "stats-plugin.js",
   "author": "Vaadin Ltd",
   "license": "Apache-2.0",

--- a/flow-server/src/main/resources/plugins/stats-plugin/stats-plugin.js
+++ b/flow-server/src/main/resources/plugins/stats-plugin/stats-plugin.js
@@ -103,7 +103,7 @@ function collectChunks(statsJson, acceptedChunks) {
         const modules = [];
         // Add all modules for chunk as slimmed down modules
         chunk.modules.forEach(function (module) {
-          if(module.name.includes("flow-frontend")) {
+          if(module.name.includes("flow-frontend") || module.name.startsWith("./")) {
             const slimModule = {
               id: module.id,
               name: module.name,


### PR DESCRIPTION
In development mode the local
frontend stat files got left out
from the cleaned stats that
webpack served

