### PR TITLE
chore: Remove warning about stats init

### DIFF
--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/stats/DevModeUsageStatistics.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/stats/DevModeUsageStatistics.java
@@ -87,10 +87,6 @@ public class DevModeUsageStatistics {
         getLogger().debug("Telemetry enabled");
 
         storage.access(() -> {
-            if (instance != null) {
-                getLogger().warn("init should only be called once");
-            }
-
             instance = new DevModeUsageStatistics(projectFolder, storage);
             // Make sure we are tracking the right project
             String projectId = ProjectHelpers.generateProjectId(projectFolder);


### PR DESCRIPTION
initDevModeHandler is called when Spring dev tools restart so this message is logged once per restart for no good reason
