### PR TITLE
fix: remove clear condition for hierarchical data

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicationController.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicationController.java
@@ -210,7 +210,7 @@ public class HierarchicalCommunicationController<T> implements Serializable {
     }
 
     private void clear(int start, int length, HierarchicalUpdate update) {
-        if (length == 0 || start >= assumedSize) {
+        if (length == 0) {
             return;
         }
         if (parentKey == null) {

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicatorDataTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicatorDataTest.java
@@ -19,7 +19,9 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
+import com.vaadin.flow.function.SerializablePredicate;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -81,7 +83,10 @@ public class HierarchicalCommunicatorDataTest {
     private MockUI ui;
     private Element element;
 
-    private static class UpdateQueue implements HierarchicalUpdate {
+    private boolean parentClearCalled = false;
+
+    private class UpdateQueue implements HierarchicalUpdate {
+
         @Override
         public void clear(int start, int length) {
         }
@@ -104,6 +109,7 @@ public class HierarchicalCommunicatorDataTest {
 
         @Override
         public void clear(int start, int length, String parentKey) {
+            parentClearCalled = true;
         }
 
         @Override
@@ -211,6 +217,28 @@ public class HierarchicalCommunicatorDataTest {
                 .forEach(i -> Assert.assertNotNull("Expected key '" + i
                         + "' to be generated when unique key provider is not set",
                         communicator.getKeyMapper().get(i)));
+    }
+
+    @Test
+    public void expandRoot_filterOutAllChildren_clearCalled() {
+        parentClearCalled = false;
+
+        communicator.expand(ROOT);
+        fakeClientCommunication();
+
+        communicator.setParentRequestedRange(0, 50, ROOT);
+        fakeClientCommunication();
+
+        SerializablePredicate<Item> filter = item -> ROOT.equals(item);
+        communicator.setFilter(filter);
+        fakeClientCommunication();
+
+        dataProvider.refreshItem(ROOT, true);
+        fakeClientCommunication();
+
+        communicator.reset();
+
+        Assert.assertTrue(parentClearCalled);
     }
 
     private void fakeClientCommunication() {


### PR DESCRIPTION
## Description

For hierarchical data, even when the child components are filtered out, the `clear` method on `ArrayUpdater.Update` in `HierarchicalCommunicationController` is never called. This is caused by an if check, in which the start index of `previousActive` is compared to the newly calculated `assumedSize`. Since there might be items to clear, the newly calculated size should have no effect on whether we clear the items or not. This check is not present in the `DataCommunicator` counterpart within the method `collectChangesToSend`.

This PR removes the aforementioned clear condition. Add test to ensure that the expanded children are cleared properly when filtered out.

Fixes #[4132](https://github.com/vaadin/flow-components/issues/4132)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.