### PR TITLE
fix: Empty alt in costructor should add property (#15292) (2.8)

### DIFF
--- a/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
+++ b/flow-html-components/src/main/java/com/vaadin/flow/component/html/Image.java
@@ -49,6 +49,9 @@ public class Image extends HtmlContainer implements ClickNotifier<Image> {
 
     /**
      * Creates an image with the given URL and an alternative text.
+     * <p>
+     * The alternative text given to constructor is always set even if it is the
+     * default empty string which is not retained with {@link #setAlt(String)}.
      *
      * @param src
      *            the image URL
@@ -60,11 +63,14 @@ public class Image extends HtmlContainer implements ClickNotifier<Image> {
      */
     public Image(String src, String alt) {
         setSrc(src);
-        setAlt(alt);
+        getElement().setProperty("alt", alt);
     }
 
     /**
      * Creates an image with the given stream resource and an alternative text.
+     * <p>
+     * The alternative text given to constructor is always set even if it is the
+     * default empty string which is not retained with {@link #setAlt(String)}.
      *
      * @param src
      *            the resource value, not null
@@ -76,7 +82,7 @@ public class Image extends HtmlContainer implements ClickNotifier<Image> {
      */
     public Image(AbstractStreamResource src, String alt) {
         setSrc(src);
-        setAlt(alt);
+        getElement().setProperty("alt", alt);
     }
 
     /**

--- a/flow-html-components/src/test/java/com/vaadin/flow/component/html/ImageTest.java
+++ b/flow-html-components/src/test/java/com/vaadin/flow/component/html/ImageTest.java
@@ -15,6 +15,9 @@
  */
 package com.vaadin.flow.component.html;
 
+import org.junit.Assert;
+import org.junit.Test;
+
 public class ImageTest extends ComponentTest {
 
     // Actual test methods in super class
@@ -25,4 +28,16 @@ public class ImageTest extends ComponentTest {
         addStringProperty("src", "");
     }
 
+    @Test
+    public void setEmptyAltInConstructor_altPropertExists() {
+        Image img = new Image("test.png", "");
+        Assert.assertTrue(
+                "'alt' property should have been retained with constructor",
+                img.getElement().hasProperty("alt"));
+
+        img.setAlt("");
+
+        Assert.assertTrue("'alt' property should have been cleared with setAlt",
+                img.getElement().hasProperty("alt"));
+    }
 }


### PR DESCRIPTION
Giving the alternate text in the constructor
should generate a property to the image.

Fixes #14880
