### PR TITLE
refactor: Record project folder inside node_modules instead (#15216) (CP: 23.2)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/NodeUpdater.java
@@ -102,6 +102,7 @@ public abstract class NodeUpdater implements FallibleCommand {
     protected static final String POLYMER_VERSION = "3.5.1";
 
     static final String VAADIN_VERSION = "vaadinVersion";
+    static final String PROJECT_FOLDER = "projectFolder";
 
     /**
      * Base directory for {@link Constants#PACKAGE_JSON},

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -46,7 +46,7 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.commandToString;
 import static com.vaadin.flow.server.frontend.NodeUpdater.HASH_KEY;
 import static com.vaadin.flow.server.frontend.NodeUpdater.VAADIN_DEP_KEY;
 import static com.vaadin.flow.server.frontend.NodeUpdater.VAADIN_VERSION;
-import static com.vaadin.flow.server.frontend.NodeUpdater.PROJECT_FOLDER;;
+import static com.vaadin.flow.server.frontend.NodeUpdater.PROJECT_FOLDER;
 
 /**
  * Run <code>npm install</code> after dependencies have been updated.

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunNpmInstall.java
@@ -46,6 +46,7 @@ import static com.vaadin.flow.server.frontend.FrontendUtils.commandToString;
 import static com.vaadin.flow.server.frontend.NodeUpdater.HASH_KEY;
 import static com.vaadin.flow.server.frontend.NodeUpdater.VAADIN_DEP_KEY;
 import static com.vaadin.flow.server.frontend.NodeUpdater.VAADIN_VERSION;
+import static com.vaadin.flow.server.frontend.NodeUpdater.PROJECT_FOLDER;;
 
 /**
  * Run <code>npm install</code> after dependencies have been updated.
@@ -202,7 +203,7 @@ public class TaskRunNpmInstall implements FallibleCommand {
      * node_modules/.vaadin/vaadin.json
      * </pre>
      *
-     * with package.json hash and the platform version.
+     * with package.json hash, project folder and the platform version.
      * <p>
      * This is for handling updated package to the code repository by another
      * developer as then the hash is updated and we may just be missing one
@@ -223,6 +224,8 @@ public class TaskRunNpmInstall implements FallibleCommand {
             updates.put(HASH_KEY, hash);
             Platform.getVaadinVersion()
                     .ifPresent(s -> updates.put(VAADIN_VERSION, s));
+            updates.put(PROJECT_FOLDER,
+                    packageUpdater.npmFolder.getAbsolutePath());
             packageUpdater.updateVaadinJsonContents(updates);
         } catch (IOException e) {
             packageUpdater.log().warn("Failed to update node_modules hash.", e);
@@ -245,18 +248,31 @@ public class TaskRunNpmInstall implements FallibleCommand {
                 .startsWith(installedPackages[0].getName())) {
             // Only flow-frontend installed
             return true;
-        } else {
-            return isVaadinHashUpdated();
         }
+
+        return isVaadinHashOrProjectFolderUpdated();
     }
 
-    private boolean isVaadinHashUpdated() {
+    boolean isVaadinHashOrProjectFolderUpdated() {
         try {
-            JsonObject content = packageUpdater.getVaadinJsonContents();
-            if (content.hasKey(HASH_KEY)) {
+            JsonObject nodeModulesVaadinJson = packageUpdater
+                    .getVaadinJsonContents();
+            if (nodeModulesVaadinJson.hasKey(HASH_KEY)) {
                 final JsonObject packageJson = packageUpdater.getPackageJson();
-                return !content.getString(HASH_KEY).equals(packageJson
-                        .getObject(VAADIN_DEP_KEY).getString(HASH_KEY));
+                if (!nodeModulesVaadinJson.getString(HASH_KEY)
+                        .equals(packageJson.getObject(VAADIN_DEP_KEY)
+                                .getString(HASH_KEY))) {
+                    return true;
+                }
+
+                if (nodeModulesVaadinJson.hasKey(PROJECT_FOLDER)
+                        && !packageUpdater.npmFolder.getAbsolutePath()
+                                .equals(nodeModulesVaadinJson
+                                        .getString(PROJECT_FOLDER))) {
+                    return true;
+                }
+
+                return false;
             }
         } catch (IOException e) {
             packageUpdater.log()

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskUpdatePackages.java
@@ -310,7 +310,7 @@ public class TaskUpdatePackages extends NodeUpdater {
 
         String oldHash = packageJson.getObject(VAADIN_DEP_KEY)
                 .getString(HASH_KEY);
-        String newHash = generatePackageJsonHash(packageJson, npmFolder);
+        String newHash = generatePackageJsonHash(packageJson);
         // update packageJson hash value, if no changes it will not be written
         packageJson.getObject(VAADIN_DEP_KEY).put(HASH_KEY, newHash);
 
@@ -499,12 +499,9 @@ public class TaskUpdatePackages extends NodeUpdater {
      *
      * @param packageJson
      *            JsonObject built in the same format as package.json
-     * @param npmFolder
-     *            project base folder to use in hash
      * @return has for dependencies and devDependencies
      */
-    static String generatePackageJsonHash(JsonObject packageJson,
-            File npmFolder) {
+    static String generatePackageJsonHash(JsonObject packageJson) {
         StringBuilder hashContent = new StringBuilder();
         if (packageJson.hasKey(DEPENDENCIES)) {
             JsonObject dependencies = packageJson.getObject(DEPENDENCIES);
@@ -532,10 +529,6 @@ public class TaskUpdatePackages extends NodeUpdater {
             hashContent.append(sortedDevDependencies);
             hashContent.append("}");
         }
-        if (hashContent.length() > 0) {
-            hashContent.append("\n");
-        }
-        hashContent.append(npmFolder.getAbsolutePath());
         return StringUtil.getHash(hashContent.toString());
     }
 


### PR DESCRIPTION
* Revert "fix: run npm install if folder changes (#14909)"

This reverts commit abc08f863924001b16be838cfb16f0cd8d922e5d.

The earlier patch is not needed as target/flow-frontend is no longer used. Additionally using a hash that is dependent on the project folder makes the hash unusable for other purposes, such as determining if the package.json contents has changed.

The package.json hash is now again a hash of the contents and can be used by other tools to check if the content (installed packages) has changed

Fixes #14908 in a different way
