### PR TITLE
fix: do not remove expanded items from key mapper

### DIFF
--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -1321,11 +1321,16 @@ public class DataCommunicator<T> implements Serializable {
             update.commit(updateId);
 
             // Finally clear any passivated items that have now been confirmed
-            oldActive.removeAll(activeKeyOrder);
-            if (!oldActive.isEmpty()) {
-                passivatedByUpdate.put(Integer.valueOf(updateId), oldActive);
+            Set<String> passivatedKeys = getPassivatedKeys(oldActive);
+            if (!passivatedKeys.isEmpty()) {
+                passivatedByUpdate.put(Integer.valueOf(updateId), passivatedKeys);
             }
         }
+    }
+
+    protected Set<String> getPassivatedKeys(Set<String> oldActive) {
+        oldActive.removeAll(activeKeyOrder);
+        return oldActive;
     }
 
     private boolean collectChangesToSend(final Range previousActive,

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/DataCommunicator.java
@@ -1323,7 +1323,8 @@ public class DataCommunicator<T> implements Serializable {
             // Finally clear any passivated items that have now been confirmed
             Set<String> passivatedKeys = getPassivatedKeys(oldActive);
             if (!passivatedKeys.isEmpty()) {
-                passivatedByUpdate.put(Integer.valueOf(updateId), passivatedKeys);
+                passivatedByUpdate.put(Integer.valueOf(updateId),
+                        passivatedKeys);
             }
         }
     }

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
@@ -19,9 +19,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.vaadin.flow.data.provider.CompositeDataGenerator;
@@ -537,6 +540,13 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
         JsonObject json = Json.createObject();
         json.put("key", getKeyMapper().key(item));
         return json;
+    }
+
+    @Override
+    protected Set<String> getPassivatedKeys(Set<String> oldActive) {
+        return super.getPassivatedKeys(oldActive).stream().filter(key ->
+                !isExpanded(getKeyMapper().get(key)))
+                .collect(Collectors.toCollection(HashSet::new));
     }
 
     /**

--- a/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
+++ b/flow-data/src/main/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalDataCommunicator.java
@@ -544,8 +544,8 @@ public class HierarchicalDataCommunicator<T> extends DataCommunicator<T> {
 
     @Override
     protected Set<String> getPassivatedKeys(Set<String> oldActive) {
-        return super.getPassivatedKeys(oldActive).stream().filter(key ->
-                !isExpanded(getKeyMapper().get(key)))
+        return super.getPassivatedKeys(oldActive).stream()
+                .filter(key -> !isExpanded(getKeyMapper().get(key)))
                 .collect(Collectors.toCollection(HashSet::new));
     }
 

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicatorDataTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicatorDataTest.java
@@ -266,7 +266,8 @@ public class HierarchicalCommunicatorDataTest {
         String initialKey = communicator.getKeyMapper().key(itemToTest);
 
         communicator.expand(itemToTest);
-        communicator.setRequestedRange(requestedRangeLength * 2, requestedRangeLength);
+        communicator.setRequestedRange(requestedRangeLength * 2,
+                requestedRangeLength);
         fakeClientCommunication();
         assertKeyItemPairIsPresentInKeyMapper(initialKey, itemToTest);
 

--- a/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicatorDataTest.java
+++ b/flow-data/src/test/java/com/vaadin/flow/data/provider/hierarchy/HierarchicalCommunicatorDataTest.java
@@ -19,7 +19,6 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import com.vaadin.flow.function.SerializablePredicate;
 import org.junit.Assert;
@@ -85,6 +84,8 @@ public class HierarchicalCommunicatorDataTest {
 
     private boolean parentClearCalled = false;
 
+    private int committedUpdateId;
+
     private class UpdateQueue implements HierarchicalUpdate {
 
         @Override
@@ -97,6 +98,7 @@ public class HierarchicalCommunicatorDataTest {
 
         @Override
         public void commit(int updateId) {
+            committedUpdateId = updateId;
         }
 
         @Override
@@ -239,6 +241,45 @@ public class HierarchicalCommunicatorDataTest {
         communicator.reset();
 
         Assert.assertTrue(parentClearCalled);
+    }
+
+    @Test
+    public void expandItem_requestNonOverlappingRange_expandedItemPersistsInKeyMapper() {
+        committedUpdateId = -1;
+
+        int indexToTest = 2;
+        int requestedRangeLength = 5;
+
+        treeData = new TreeData<>();
+        for (int id = 0; id < requestedRangeLength * 4; id++) {
+            treeData.addItems(null, new Item(id, "Item " + id));
+        }
+        Item itemToTest = treeData.getRootItems().get(indexToTest);
+        treeData.addItems(itemToTest, new Item(treeData.getRootItems().size(),
+                "Item " + indexToTest + "_" + 0));
+        dataProvider = new TreeDataProvider<>(treeData);
+        communicator.setDataProvider(dataProvider, null);
+
+        communicator.setRequestedRange(0, requestedRangeLength);
+        fakeClientCommunication();
+        Assert.assertTrue(communicator.getKeyMapper().has(itemToTest));
+        String initialKey = communicator.getKeyMapper().key(itemToTest);
+
+        communicator.expand(itemToTest);
+        communicator.setRequestedRange(requestedRangeLength * 2, requestedRangeLength);
+        fakeClientCommunication();
+        assertKeyItemPairIsPresentInKeyMapper(initialKey, itemToTest);
+
+        communicator.confirmUpdate(committedUpdateId);
+        fakeClientCommunication();
+        assertKeyItemPairIsPresentInKeyMapper(initialKey, itemToTest);
+
+        communicator.reset();
+    }
+
+    private void assertKeyItemPairIsPresentInKeyMapper(String key, Item item) {
+        Assert.assertTrue(communicator.getKeyMapper().has(item));
+        Assert.assertEquals(key, communicator.getKeyMapper().key(item));
     }
 
     private void fakeClientCommunication() {


### PR DESCRIPTION
## Description

With a `TreeGrid`, the expanded state of a root item gets lost when scrolled enough to request a new range. The cause for this is the updated key of the returned item. The expanded state for the items except the root items do not get lost. 

This PR makes sure that the key-value pair for a root item persists in the `KeyMapper` if the item is expanded. This change only affects hierarchical data. A test is added to ensure that the fix solves the issue.

While this refactoring is less than ideal in terms of clean code, I think that the alternative requires a much larger refactoring. The logic in the regular and hierarchical data communicators are mostly both coupled and duplicated with private methods at this time. Therefore, this PR is as atomic as possible.

Fixes #[4133](https://github.com/vaadin/flow-components/issues/4133)

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.