### PR TITLE
feat: add refresh flag to navigation event

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/AfterNavigationEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/AfterNavigationEvent.java
@@ -30,7 +30,6 @@ import com.vaadin.flow.component.HasElement;
 public class AfterNavigationEvent extends EventObject {
 
     private final LocationChangeEvent event;
-    private final boolean refreshEvent;
 
     /**
      * Construct event from a NavigationEvent.
@@ -41,22 +40,6 @@ public class AfterNavigationEvent extends EventObject {
     public AfterNavigationEvent(LocationChangeEvent event) {
         super(event.getSource());
         this.event = event;
-        this.refreshEvent = false;
-    }
-
-    /**
-     * Construct event from a NavigationEvent.
-     *
-     * @param event
-     *            NavigationEvent that is on going
-     * @param refreshEvent
-     *            if event for refresh of a preserve on refresh view
-     */
-    public AfterNavigationEvent(LocationChangeEvent event,
-            boolean refreshEvent) {
-        super(event.getSource());
-        this.event = event;
-        this.refreshEvent = refreshEvent;
     }
 
     /**
@@ -97,6 +80,6 @@ public class AfterNavigationEvent extends EventObject {
      * @return true if refresh of a preserve on refresh view
      */
     public boolean isRefreshEvent() {
-        return refreshEvent;
+        return event.getTrigger().equals(NavigationTrigger.REFRESH);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/AfterNavigationEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/AfterNavigationEvent.java
@@ -30,6 +30,7 @@ import com.vaadin.flow.component.HasElement;
 public class AfterNavigationEvent extends EventObject {
 
     private final LocationChangeEvent event;
+    private final boolean refreshEvent;
 
     /**
      * Construct event from a NavigationEvent.
@@ -40,6 +41,22 @@ public class AfterNavigationEvent extends EventObject {
     public AfterNavigationEvent(LocationChangeEvent event) {
         super(event.getSource());
         this.event = event;
+        this.refreshEvent = false;
+    }
+
+    /**
+     * Construct event from a NavigationEvent.
+     *
+     * @param event
+     *            NavigationEvent that is on going
+     * @param refreshEvent
+     *            if event for refresh of a preserve on refresh view
+     */
+    public AfterNavigationEvent(LocationChangeEvent event,
+            boolean refreshEvent) {
+        super(event.getSource());
+        this.event = event;
+        this.refreshEvent = refreshEvent;
     }
 
     /**
@@ -72,5 +89,14 @@ public class AfterNavigationEvent extends EventObject {
     @Override
     public Router getSource() {
         return (Router) super.getSource();
+    }
+
+    /**
+     * Check if event is for a refresh of a preserveOnRefresh view.
+     *
+     * @return true if refresh of a preserve on refresh view
+     */
+    public boolean isRefreshEvent() {
+        return refreshEvent;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/BeforeEnterEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/BeforeEnterEvent.java
@@ -27,6 +27,8 @@ import com.vaadin.flow.component.UI;
  */
 public class BeforeEnterEvent extends BeforeEvent {
 
+    private boolean refreshEvent = false;
+
     /**
      * Constructs event from a NavigationEvent.
      *
@@ -110,5 +112,25 @@ public class BeforeEnterEvent extends BeforeEvent {
             List<Class<? extends RouterLayout>> layouts) {
         super(router, trigger, location, navigationTarget, parameters, ui,
                 layouts);
+    }
+
+    /**
+     * Check if event is for a refresh of a preserveOnRefresh view.
+     *
+     * @return true if refresh of a preserve on refresh view
+     */
+    public boolean isRefreshEvent() {
+        return refreshEvent;
+    }
+
+    /**
+     * Sets the event flag that it has been fired for a refresh on a view with
+     * preserveOnRefresh.
+     *
+     * @param refreshEvent
+     *            if event is for a page refresh
+     */
+    public void setRefreshEvent(boolean refreshEvent) {
+        this.refreshEvent = refreshEvent;
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/BeforeEnterEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/BeforeEnterEvent.java
@@ -27,8 +27,6 @@ import com.vaadin.flow.component.UI;
  */
 public class BeforeEnterEvent extends BeforeEvent {
 
-    private boolean refreshEvent = false;
-
     /**
      * Constructs event from a NavigationEvent.
      *
@@ -120,17 +118,6 @@ public class BeforeEnterEvent extends BeforeEvent {
      * @return true if refresh of a preserve on refresh view
      */
     public boolean isRefreshEvent() {
-        return refreshEvent;
-    }
-
-    /**
-     * Sets the event flag that it has been fired for a refresh on a view with
-     * preserveOnRefresh.
-     *
-     * @param refreshEvent
-     *            if event is for a page refresh
-     */
-    public void setRefreshEvent(boolean refreshEvent) {
-        this.refreshEvent = refreshEvent;
+        return getTrigger().equals(NavigationTrigger.REFRESH);
     }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/NavigationTrigger.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/NavigationTrigger.java
@@ -63,5 +63,10 @@ public enum NavigationTrigger {
      *
      * @see com.vaadin.flow.component.internal.JavaScriptBootstrapUI
      */
-    CLIENT_SIDE
+    CLIENT_SIDE,
+
+    /**
+     * Navigation is for a reload event on a preserveOnRefresh route.
+     */
+    REFRESH
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -198,6 +198,9 @@ public abstract class AbstractNavigationStateRenderer
 
         BeforeEnterEvent beforeNavigationActivating = new BeforeEnterEvent(
                 event, routeTargetType, parameters, routeLayoutTypes);
+        final boolean isRefreshEvent = preserveOnRefreshTarget
+                && !chain.isEmpty();
+        beforeNavigationActivating.setRefreshEvent(isRefreshEvent);
 
         result = createChainIfEmptyAndExecuteBeforeEnterNavigation(
                 beforeNavigationActivating, event, chain);
@@ -232,7 +235,7 @@ public abstract class AbstractNavigationStateRenderer
                 .addAll(EventUtil.collectAfterNavigationObservers(ui));
 
         fireAfterNavigationListeners(
-                new AfterNavigationEvent(locationChangeEvent),
+                new AfterNavigationEvent(locationChangeEvent, isRefreshEvent),
                 afterNavigationHandlers);
 
         updatePageTitle(event, componentInstance);

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -189,6 +189,13 @@ public abstract class AbstractNavigationStateRenderer
             clearAllPreservedChains(ui);
         }
 
+        // Set navigationTrigger to RELOAD if this is a refresh of a preserve
+        // view.
+        if (preserveOnRefreshTarget && !chain.isEmpty()) {
+            event = new NavigationEvent(event.getSource(), event.getLocation(),
+                    event.getUI(), NavigationTrigger.REFRESH);
+        }
+
         // If the navigation is postponed, using BeforeLeaveEvent#postpone,
         // pushing history state shouldn't be done. So, it's done here to make
         // sure that when history state is pushed the navigation is not
@@ -198,9 +205,6 @@ public abstract class AbstractNavigationStateRenderer
 
         BeforeEnterEvent beforeNavigationActivating = new BeforeEnterEvent(
                 event, routeTargetType, parameters, routeLayoutTypes);
-        final boolean isRefreshEvent = preserveOnRefreshTarget
-                && !chain.isEmpty();
-        beforeNavigationActivating.setRefreshEvent(isRefreshEvent);
 
         result = createChainIfEmptyAndExecuteBeforeEnterNavigation(
                 beforeNavigationActivating, event, chain);
@@ -235,7 +239,7 @@ public abstract class AbstractNavigationStateRenderer
                 .addAll(EventUtil.collectAfterNavigationObservers(ui));
 
         fireAfterNavigationListeners(
-                new AfterNavigationEvent(locationChangeEvent, isRefreshEvent),
+                new AfterNavigationEvent(locationChangeEvent),
                 afterNavigationHandlers);
 
         updatePageTitle(event, componentInstance);

--- a/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/internal/NavigationStateRendererTest.java
@@ -43,6 +43,11 @@ import com.vaadin.flow.component.page.History;
 import com.vaadin.flow.component.page.Page;
 import com.vaadin.flow.component.page.PendingJavaScriptResult;
 import com.vaadin.flow.dom.Element;
+import com.vaadin.flow.router.AfterNavigationEvent;
+import com.vaadin.flow.router.AfterNavigationObserver;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.BeforeEnterObserver;
+import com.vaadin.flow.router.BeforeLeaveEvent;
 import com.vaadin.flow.router.Location;
 import com.vaadin.flow.router.NavigationEvent;
 import com.vaadin.flow.router.NavigationState;
@@ -79,6 +84,29 @@ public class NavigationStateRendererTest {
     private static class PreservedView extends Text {
         PreservedView() {
             super("");
+        }
+    }
+
+    @Route(value = "preserved")
+    @PreserveOnRefresh
+    private static class PreservedEventView extends Text
+            implements BeforeEnterObserver, AfterNavigationObserver {
+        static boolean refreshBeforeEnter;
+        static boolean refreshAfterNavigation;
+
+        PreservedEventView() {
+            super("");
+        }
+
+        @Override
+        public void beforeEnter(BeforeEnterEvent event) {
+            refreshBeforeEnter = event.isRefreshEvent();
+        }
+
+        @Override
+        public void afterNavigation(AfterNavigationEvent event) {
+            refreshAfterNavigation = event.isRefreshEvent();
+
         }
     }
 
@@ -322,6 +350,59 @@ public class NavigationStateRendererTest {
         Assert.assertFalse("Session expected to not have cached view",
                 AbstractNavigationStateRenderer.hasPreservedChainOfLocation(
                         session, new Location("preserved")));
+    }
+
+    @Test
+    public void handle_preserveOnRefresh_refreshIsFlaggedInEvent() {
+        // given a service with instantiator
+        MockVaadinServletService service = createMockServiceWithInstantiator();
+
+        // given a locked session
+        MockVaadinSession session = new AlwaysLockedVaadinSession(service);
+        session.setConfiguration(new MockDeploymentConfiguration());
+
+        // given a UI that contain a window name ROOT.123
+        MockUI ui = new MockUI(session);
+        ExtendedClientDetails details = Mockito
+                .mock(ExtendedClientDetails.class);
+        Mockito.when(details.getWindowName()).thenReturn("ROOT.123");
+        ui.getInternals().setExtendedClientDetails(details);
+
+        // given a NavigationStateRenderer mapping to PreservedEventView
+        NavigationStateRenderer renderer = new NavigationStateRenderer(
+                navigationStateFromTarget(PreservedEventView.class));
+
+        // when a navigation event reaches the renderer
+        renderer.handle(new NavigationEvent(new Router(new TestRouteRegistry()),
+                new Location("preserved"), ui, NavigationTrigger.PAGE_LOAD));
+
+        // then the session has a cached record of the view
+        Assert.assertTrue("Session expected to have cached view",
+                AbstractNavigationStateRenderer.getPreservedChain(session,
+                        "ROOT.123", new Location("preserved")).isPresent());
+
+        // given the recently instantiated view
+        final PreservedEventView view = (PreservedEventView) ui.getInternals()
+                .getActiveRouterTargetsChain().get(0);
+        Assert.assertFalse(
+                "Initial view load should not be a refresh for before",
+                view.refreshBeforeEnter);
+        Assert.assertFalse(
+                "Initial view load should not be a refresh for after",
+                view.refreshAfterNavigation);
+
+        // when another navigation targets the same location
+        renderer.handle(new NavigationEvent(new Router(new TestRouteRegistry()),
+                new Location("preserved"), ui, NavigationTrigger.PAGE_LOAD));
+
+        // then the same view is routed to
+        Assert.assertEquals("Expected same view", view,
+                ui.getInternals().getActiveRouterTargetsChain().get(0));
+
+        Assert.assertTrue("Reload should be flagged for before",
+                view.refreshBeforeEnter);
+        Assert.assertTrue("Reload should be flagged for after",
+                view.refreshAfterNavigation);
     }
 
     @Test


### PR DESCRIPTION
Add the isRefreshEvent to BeforeEnterEvent
and AfterNavigationEvent to be make it possible
to diustinguish if the event is for a refresh of
a preserve on refresh view.

Fixes #14999
