### PR TITLE
fix!: Use dedicated mapping for Vaadin push endpoint (#15188)

### DIFF
--- a/flow-client/src/main/java/com/vaadin/client/communication/AtmospherePushConnection.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/AtmospherePushConnection.java
@@ -188,10 +188,15 @@ public class AtmospherePushConnection implements PushConnection {
             }
 
         });
-        if (getPushConfiguration().getPushUrl() == null) {
-            url = registry.getApplicationConfiguration().getServiceUrl();
-        } else {
-            url = getPushConfiguration().getPushUrl();
+        url = getPushConfiguration().getPushUrl();
+        // If a specific serviceUrl is defined, prepend pushUrl with it
+        String serviceUrl = registry.getApplicationConfiguration()
+                .getServiceUrl();
+        if (!serviceUrl.equals(".")) {
+            if (!serviceUrl.endsWith("/")) {
+                serviceUrl += "/";
+            }
+            url = serviceUrl + url;
         }
         runWhenAtmosphereLoaded(
                 () -> Scheduler.get().scheduleDeferred(this::connect));

--- a/flow-client/src/main/java/com/vaadin/client/communication/PushConfiguration.java
+++ b/flow-client/src/main/java/com/vaadin/client/communication/PushConfiguration.java
@@ -25,6 +25,7 @@ import com.vaadin.client.flow.nodefeature.NodeMap;
 import com.vaadin.client.flow.reactive.Reactive;
 import com.vaadin.flow.internal.nodefeature.NodeFeatures;
 import com.vaadin.flow.internal.nodefeature.PushConfigurationMap;
+import com.vaadin.flow.server.Constants;
 
 /**
  * Provides the push configuration stored in the root node with an easier to use
@@ -88,19 +89,12 @@ public class PushConfiguration {
     }
 
     /**
-     * Gets the push URL configured on the server.
+     * Gets the fixed push URL.
      *
-     * @return the push URL configured on the server or null if none has been
-     *         configured
+     * @return the fixed push URL (VAADIN/push)
      */
     public String getPushUrl() {
-        if (getConfigurationMap()
-                .hasPropertyValue(PushConfigurationMap.PUSH_URL_KEY)) {
-            return (String) getConfigurationMap()
-                    .getProperty(PushConfigurationMap.PUSH_URL_KEY).getValue();
-        }
-
-        return null;
+        return Constants.PUSH_MAPPING;
     }
 
     /**

--- a/flow-server/src/main/java/com/vaadin/flow/component/PushConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/PushConfiguration.java
@@ -139,27 +139,6 @@ public interface PushConfiguration extends Serializable {
     void setParameter(String parameter, String value);
 
     /**
-     * Sets the URL to use for push requests.
-     * <p>
-     * This is only used when overriding the URL to use. Setting this to null
-     * (the default) will use the default URL.
-     *
-     * @param pushUrl
-     *            The push URL to use
-     */
-    void setPushUrl(String pushUrl);
-
-    /**
-     * Returns the URL to use for push requests.
-     * <p>
-     * This is only used when overriding the URL to use. Returns null (the
-     * default) when the default URL is used.
-     *
-     * @return the URL to use for push requests, or null to use to default
-     */
-    String getPushUrl();
-
-    /**
      * Sets the factory that will be used to create new instances of
      * {@link PushConnection}.
      *
@@ -233,16 +212,6 @@ class PushConfigurationImpl implements PushConfiguration {
             // Nothing to do here if disabling push;
             // the client will close the connection
         }
-    }
-
-    @Override
-    public void setPushUrl(String pushUrl) {
-        getPushConfigurationMap().setPushUrl(pushUrl);
-    }
-
-    @Override
-    public String getPushUrl() {
-        return getPushConfigurationMap().getPushUrl();
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/function/DeploymentConfiguration.java
@@ -124,14 +124,6 @@ public interface DeploymentConfiguration
     PushMode getPushMode();
 
     /**
-     * Returns the URL that bidirectional ("push") client-server communication
-     * should use.
-     *
-     * @return The push URL to use
-     */
-    String getPushURL();
-
-    /**
      * Gets the properties configured for the deployment, e.g. as init
      * parameters to the servlet.
      *

--- a/flow-server/src/main/java/com/vaadin/flow/internal/BootstrapHandlerHelper.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/BootstrapHandlerHelper.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.internal;
 
 import java.io.Serializable;
 
+import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.HandlerHelper;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinSession;
@@ -66,12 +67,8 @@ public final class BootstrapHandlerHelper implements Serializable {
      */
     public static String getPushURL(VaadinSession vaadinSession,
             VaadinRequest vaadinRequest) {
-        String serviceUrl = getServiceUrl(vaadinRequest);
+        String pushURL = Constants.PUSH_MAPPING;
 
-        String pushURL = vaadinSession.getConfiguration().getPushURL();
-        if (pushURL == null) {
-            pushURL = serviceUrl;
-        }
         String contextPath = vaadinRequest.getService()
                 .getContextRootRelativePath(vaadinRequest);
 

--- a/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/PushConfigurationMap.java
+++ b/flow-server/src/main/java/com/vaadin/flow/internal/nodefeature/PushConfigurationMap.java
@@ -58,7 +58,6 @@ public class PushConfigurationMap extends NodeMap implements PushConfiguration {
     public static final String FALLBACK_TRANSPORT_KEY = "fallbackTransport";
     public static final String PUSHMODE_KEY = "pushMode";
     public static final String ALWAYS_USE_XHR_TO_SERVER = "alwaysXhrToServer";
-    public static final String PUSH_URL_KEY = "pushUrl";
     public static final String PARAMETERS_KEY = "parameters";
 
     /**
@@ -136,16 +135,6 @@ public class PushConfigurationMap extends NodeMap implements PushConfiguration {
     @Override
     public PushMode getPushMode() {
         return PushMode.valueOf(get(PUSHMODE_KEY).toString());
-    }
-
-    @Override
-    public void setPushUrl(String pushUrl) {
-        put(PUSH_URL_KEY, pushUrl);
-    }
-
-    @Override
-    public String getPushUrl() {
-        return getOrDefault(PUSH_URL_KEY, null);
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/BootstrapHandler.java
@@ -1525,7 +1525,6 @@ public class BootstrapHandler extends SynchronizedRequestHandler {
                 .orElseGet(deploymentConfiguration::getPushMode);
         setupPushConnectionFactory(pushConfiguration, context);
         pushConfiguration.setPushMode(pushMode);
-        pushConfiguration.setPushUrl(deploymentConfiguration.getPushURL());
         push.map(Push::transport).ifPresent(pushConfiguration::setTransport);
 
         // Set thread local here so it is available in init

--- a/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/Constants.java
@@ -131,13 +131,6 @@ public final class Constants implements Serializable {
     public static final String SERVLET_PARAMETER_PUSH_MODE = InitParameters.SERVLET_PARAMETER_PUSH_MODE;
 
     /**
-     * @deprecated Use {@link InitParameters#SERVLET_PARAMETER_PUSH_URL}
-     *             instead.
-     */
-    @Deprecated
-    public static final String SERVLET_PARAMETER_PUSH_URL = InitParameters.SERVLET_PARAMETER_PUSH_URL;
-
-    /**
      * @deprecated Use {@link InitParameters#SERVLET_PARAMETER_SYNC_ID_CHECK}
      *             instead.
      */
@@ -371,6 +364,11 @@ public final class Constants implements Serializable {
      * The path used in the vaadin servlet for handling static resources.
      */
     public static final String VAADIN_MAPPING = "VAADIN/";
+
+    /**
+     * The path used in the vaadin servlet for handling push.
+     */
+    public static final String PUSH_MAPPING = VAADIN_MAPPING + "push";
 
     /**
      * The static build resources folder.

--- a/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/DefaultDeploymentConfiguration.java
@@ -92,7 +92,6 @@ public class DefaultDeploymentConfiguration
     private int webComponentDisconnect;
     private boolean closeIdleSessions;
     private PushMode pushMode;
-    private String pushURL;
     private boolean syncIdCheck;
     private boolean sendUrlsAsParameters;
     private boolean requestTiming;
@@ -129,7 +128,6 @@ public class DefaultDeploymentConfiguration
         checkWebComponentDisconnectTimeout();
         checkCloseIdleSessions();
         checkPushMode();
-        checkPushURL();
         checkSyncIdCheck();
         checkSendUrlsAsParameters();
 
@@ -255,16 +253,6 @@ public class DefaultDeploymentConfiguration
     @Override
     public PushMode getPushMode() {
         return pushMode;
-    }
-
-    /**
-     * {@inheritDoc}
-     * <p>
-     * The default mode is <code>""</code> which uses the servlet URL.
-     */
-    @Override
-    public String getPushURL() {
-        return pushURL;
     }
 
     /**
@@ -402,11 +390,6 @@ public class DefaultDeploymentConfiguration
             warnings.add(WARNING_PUSH_MODE_NOT_RECOGNIZED);
             pushMode = PushMode.DISABLED;
         }
-    }
-
-    private void checkPushURL() {
-        pushURL = getStringProperty(InitParameters.SERVLET_PARAMETER_PUSH_URL,
-                "");
     }
 
     private void checkSyncIdCheck() {

--- a/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/InitParameters.java
@@ -56,7 +56,6 @@ public class InitParameters implements Serializable {
     public static final String SERVLET_PARAMETER_WEB_COMPONENT_DISCONNECT = "webComponentDisconnect";
     public static final String SERVLET_PARAMETER_CLOSE_IDLE_SESSIONS = "closeIdleSessions";
     public static final String SERVLET_PARAMETER_PUSH_MODE = "pushMode";
-    public static final String SERVLET_PARAMETER_PUSH_URL = "pushURL";
     public static final String SERVLET_PARAMETER_SYNC_ID_CHECK = "syncIdCheck";
     public static final String SERVLET_PARAMETER_SEND_URLS_AS_PARAMETERS = "sendUrlsAsParameters";
     public static final String SERVLET_PARAMETER_PUSH_SUSPEND_TIMEOUT_LONGPOLLING = "pushLongPollingSuspendTimeout";

--- a/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/PropertyDeploymentConfiguration.java
@@ -256,11 +256,6 @@ public class PropertyDeploymentConfiguration
     }
 
     @Override
-    public String getPushURL() {
-        return "";
-    }
-
-    @Override
     public Properties getInitParameters() {
         return allProperties;
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/JavaScriptBootstrapHandler.java
@@ -153,15 +153,9 @@ public class JavaScriptBootstrapHandler extends BootstrapHandler {
         JsonObject config = context.getApplicationParameters();
 
         String requestURL = getRequestUrl(request);
-        String serviceUrl = getServiceUrl(request);
 
-        String pushURL = context.getSession().getConfiguration().getPushURL();
-        if (pushURL == null) {
-            pushURL = serviceUrl;
-        }
         PushConfiguration pushConfiguration = context.getUI()
                 .getPushConfiguration();
-        pushConfiguration.setPushUrl(pushURL);
 
         AppShellRegistry registry = AppShellRegistry
                 .getInstance(session.getService().getContext());

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PushRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PushRequestHandler.java
@@ -18,6 +18,7 @@ package com.vaadin.flow.server.communication;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
+import javax.servlet.ServletRegistration;
 
 import java.io.IOException;
 
@@ -35,6 +36,7 @@ import org.atmosphere.util.VoidAnnotationProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.HandlerHelper;
 import com.vaadin.flow.server.HandlerHelper.RequestType;
 import com.vaadin.flow.server.InitParameters;
@@ -221,6 +223,13 @@ public class PushRequestHandler
         atmosphere.addInitParameter("org.atmosphere.cpr.showSupportMessage",
                 "false");
 
+        atmosphere.addInitParameter(ApplicationConfig.JSR356_MAPPING_PATH,
+                findFirstUrlMapping(vaadinServletConfig)
+                        + Constants.PUSH_MAPPING);
+
+        atmosphere.addInitParameter(
+                ApplicationConfig.JSR356_PATH_MAPPING_LENGTH, "0");
+
         try {
             atmosphere.init(vaadinServletConfig);
 
@@ -234,6 +243,18 @@ public class PushRequestHandler
             throw new RuntimeException("Atmosphere init failed", e);
         }
         return atmosphere;
+    }
+
+    private static String findFirstUrlMapping(ServletConfig config) {
+        String name = config.getServletName();
+        String firstMapping = "/";
+        if (name != null) {
+            ServletRegistration reg = config.getServletContext()
+                    .getServletRegistrations().get(name);
+            firstMapping = reg.getMappings().stream().sorted().findFirst()
+                    .orElse("/");
+        }
+        return firstMapping.replace("/*", "/");
     }
 
     @Override

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/WebComponentBootstrapHandler.java
@@ -21,7 +21,6 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.lang.annotation.Annotation;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -31,13 +30,10 @@ import java.util.regex.Pattern;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Attribute;
-import org.jsoup.nodes.DataNode;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
-import org.jsoup.parser.Tag;
 
 import com.vaadin.experimental.FeatureFlags;
-import com.vaadin.flow.component.PushConfiguration;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.webcomponent.WebComponentUI;
 import com.vaadin.flow.dom.ElementUtil;
@@ -59,7 +55,6 @@ import com.vaadin.flow.shared.ApplicationConstants;
 import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
-
 import static com.vaadin.flow.server.frontend.FrontendUtils.EXPORT_CHUNK;
 import static com.vaadin.flow.shared.ApplicationConstants.CONTENT_TYPE_TEXT_JAVASCRIPT_UTF_8;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -217,23 +212,6 @@ public class WebComponentBootstrapHandler extends BootstrapHandler {
         BootstrapContext context = super.createAndInitUI(WebComponentUI.class,
                 request, response, session);
         JsonObject config = context.getApplicationParameters();
-
-        String pushURL = context.getSession().getConfiguration().getPushURL();
-        if (pushURL == null) {
-            pushURL = serviceUrl;
-        } else {
-            try {
-                URI uri = new URI(serviceUrl);
-                pushURL = uri.resolve(new URI(pushURL)).toASCIIString();
-            } catch (URISyntaxException exception) {
-                throw new IllegalStateException(String.format(
-                        "Can't resolve pushURL '%s' based on the service URL '%s'",
-                        pushURL, serviceUrl), exception);
-            }
-        }
-        PushConfiguration pushConfiguration = context.getUI()
-                .getPushConfiguration();
-        pushConfiguration.setPushUrl(pushURL);
 
         assert serviceUrl.endsWith("/");
         config.put(ApplicationConstants.SERVICE_URL, serviceUrl);

--- a/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/AbstractDeploymentConfigurationTest.java
@@ -116,11 +116,6 @@ public class AbstractDeploymentConfigurationTest {
         }
 
         @Override
-        public String getPushURL() {
-            return "";
-        }
-
-        @Override
         public Properties getInitParameters() {
             return null;
         }

--- a/flow-server/src/test/java/com/vaadin/flow/server/DefaultDeploymentConfigurationTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DefaultDeploymentConfigurationTest.java
@@ -133,25 +133,6 @@ public class DefaultDeploymentConfigurationTest {
     }
 
     @Test
-    public void defaultPushUrl() {
-        Properties initParameters = new Properties();
-        DefaultDeploymentConfiguration config = createDeploymentConfig(
-                initParameters);
-        assertThat(config.getPushURL(), is(""));
-    }
-
-    @Test
-    public void pushUrl() {
-        Properties initParameters = new Properties();
-        initParameters.setProperty(InitParameters.SERVLET_PARAMETER_PUSH_URL,
-                "foo");
-
-        DefaultDeploymentConfiguration config = createDeploymentConfig(
-                initParameters);
-        assertThat(config.getPushURL(), is("foo"));
-    }
-
-    @Test
     public void maxMessageSuspendTimeout_validValue_accepted() {
         Properties initParameters = new Properties();
         initParameters.setProperty(

--- a/flow-server/src/test/java/com/vaadin/flow/server/DeploymentConfigurationFactoryTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/DeploymentConfigurationFactoryTest.java
@@ -337,7 +337,6 @@ public class DeploymentConfigurationFactoryTest {
                 InitParameters.UI_PARAMETER,
                 InitParameters.SERVLET_PARAMETER_REQUEST_TIMING,
                 InitParameters.SERVLET_PARAMETER_HEARTBEAT_INTERVAL,
-                InitParameters.SERVLET_PARAMETER_PUSH_URL,
                 InitParameters.SERVLET_PARAMETER_PUSH_SUSPEND_TIMEOUT_LONGPOLLING,
                 InitParameters.SERVLET_PARAMETER_MAX_MESSAGE_SUSPEND_TIMEOUT,
                 InitParameters.SERVLET_PARAMETER_STATISTICS_JSON,

--- a/flow-server/src/test/java/com/vaadin/tests/util/MockDeploymentConfiguration.java
+++ b/flow-server/src/test/java/com/vaadin/tests/util/MockDeploymentConfiguration.java
@@ -22,7 +22,6 @@ public class MockDeploymentConfiguration
     private int webComponentDisconnect = 300;
     private boolean closeIdleSessions = false;
     private PushMode pushMode = PushMode.DISABLED;
-    private String pushURL = "";
     private Properties initParameters = new Properties();
     private Map<String, String> applicationOrSystemProperty = new HashMap<>();
     private boolean syncIdCheckEnabled = true;
@@ -121,15 +120,6 @@ public class MockDeploymentConfiguration
 
     public void setPushMode(PushMode pushMode) {
         this.pushMode = pushMode;
-    }
-
-    @Override
-    public String getPushURL() {
-        return pushURL;
-    }
-
-    public void setPushURL(String pushURL) {
-        this.pushURL = pushURL;
     }
 
     @Override

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/MockDeploymentConfiguration.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/MockDeploymentConfiguration.java
@@ -22,7 +22,6 @@ public class MockDeploymentConfiguration
     private int webComponentDisconnect = 300;
     private boolean closeIdleSessions = false;
     private PushMode pushMode = PushMode.DISABLED;
-    private String pushURL = "";
     private Properties initParameters = new Properties();
     private Map<String, String> applicationOrSystemProperty = new HashMap<>();
     private boolean syncIdCheckEnabled = true;
@@ -121,15 +120,6 @@ public class MockDeploymentConfiguration
 
     public void setPushMode(PushMode pushMode) {
         this.pushMode = pushMode;
-    }
-
-    @Override
-    public String getPushURL() {
-        return pushURL;
-    }
-
-    public void setPushURL(String pushURL) {
-        this.pushURL = pushURL;
     }
 
     @Override

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringBootAutoConfiguration.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/SpringBootAutoConfiguration.java
@@ -35,6 +35,7 @@ import org.springframework.util.ClassUtils;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.socket.server.standard.ServerEndpointExporter;
 
+import com.vaadin.flow.server.Constants;
 import com.vaadin.flow.server.VaadinServlet;
 
 /**
@@ -81,27 +82,18 @@ public class SpringBootAutoConfiguration {
         String mapping = configurationProperties.getUrlMapping();
         Map<String, String> initParameters = new HashMap<>();
         boolean rootMapping = RootMappedCondition.isRootMapping(mapping);
-        String pushRegistrationPath;
 
         if (rootMapping) {
             mapping = VaadinServletConfiguration.VAADIN_SERVLET_MAPPING;
             initParameters.put(
                     VaadinServlet.INTERNAL_VAADIN_SERVLET_VITE_DEV_MODE_FRONTEND_PATH,
                     "");
-            pushRegistrationPath = "";
-        } else {
-            pushRegistrationPath = mapping.replace("/*", "");
         }
 
-        /*
-         * Tell Atmosphere which servlet to use for the push endpoint. Servlet
-         * mappings are returned as a Set from at least Tomcat so even if
-         * Atmosphere always picks the first, it might end up using /VAADIN/*
-         * and websockets will fail.
-         */
-        initParameters.put(ApplicationConfig.JSR356_MAPPING_PATH,
-                pushRegistrationPath);
-        initParameters.put(ApplicationConfig.JSR356_PATH_MAPPING_LENGTH, "0");
+        String pushUrl = rootMapping ? "" : mapping.replace("/*", "");
+        pushUrl += "/" + Constants.PUSH_MAPPING;
+
+        initParameters.put(ApplicationConfig.JSR356_MAPPING_PATH, pushUrl);
 
         ServletRegistrationBean<SpringServlet> registration = new ServletRegistrationBean<>(
                 new SpringServlet(context, rootMapping), mapping);

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinMVCWebAppInitializer.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/VaadinMVCWebAppInitializer.java
@@ -24,8 +24,6 @@ import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRegistration.Dynamic;
 
-import com.vaadin.flow.server.Constants;
-
 import org.atmosphere.cpr.ApplicationConfig;
 import org.springframework.core.env.Environment;
 import org.springframework.util.ClassUtils;
@@ -33,6 +31,8 @@ import org.springframework.web.WebApplicationInitializer;
 import org.springframework.web.context.ContextLoaderListener;
 import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
 import org.springframework.web.servlet.DispatcherServlet;
+
+import com.vaadin.flow.server.Constants;
 
 /**
  * Abstract Vaadin Spring MVC {@link WebApplicationInitializer}.
@@ -59,7 +59,6 @@ public abstract class VaadinMVCWebAppInitializer
         if (mapping == null) {
             mapping = "/*";
         }
-        String pushRegistrationPath;
 
         boolean rootMapping = RootMappedCondition.isRootMapping(mapping);
         Dynamic registration = servletContext.addServlet(
@@ -71,21 +70,13 @@ public abstract class VaadinMVCWebAppInitializer
                     .addServlet("dispatcher", new DispatcherServlet(context));
             dispatcherRegistration.addMapping("/*");
             mapping = VaadinServletConfiguration.VAADIN_SERVLET_MAPPING;
-            pushRegistrationPath = "";
-        } else {
-            pushRegistrationPath = mapping.replace("/*", "");
         }
         registration.addMapping(mapping);
 
-        /*
-         * Tell Atmosphere which servlet to use for the push endpoint. Servlet
-         * mappings are returned as a Set from at least Tomcat so even if
-         * Atmosphere always picks the first, it might end up using /VAADIN/*
-         * and websockets will fail.
-         */
-        initParameters.put(ApplicationConfig.JSR356_MAPPING_PATH,
-                pushRegistrationPath);
-        initParameters.put(ApplicationConfig.JSR356_PATH_MAPPING_LENGTH, "0");
+        String pushUrl = rootMapping ? "" : mapping.replace("/*", "");
+        pushUrl += "/" + Constants.PUSH_MAPPING;
+
+        initParameters.put(ApplicationConfig.JSR356_MAPPING_PATH, pushUrl);
 
         registration.setInitParameters(initParameters);
 

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringBootAutoConfigurationRootMappedTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringBootAutoConfigurationRootMappedTest.java
@@ -10,6 +10,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.core.env.Environment;
 
+import com.vaadin.flow.server.Constants;
+
 @SpringBootTest(classes = SpringBootAutoConfiguration.class)
 // @ContextConfiguration(SpringBootAutoConfiguration.class)
 public class SpringBootAutoConfigurationRootMappedTest {
@@ -27,7 +29,8 @@ public class SpringBootAutoConfigurationRootMappedTest {
         Assert.assertEquals(
                 Set.of(VaadinServletConfiguration.VAADIN_SERVLET_MAPPING),
                 servletRegistrationBean.getUrlMappings());
-        Assert.assertEquals("", servletRegistrationBean.getInitParameters()
-                .get(ApplicationConfig.JSR356_MAPPING_PATH));
+        Assert.assertEquals("/" + Constants.PUSH_MAPPING,
+                servletRegistrationBean.getInitParameters()
+                        .get(ApplicationConfig.JSR356_MAPPING_PATH));
     }
 }

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringBootAutoConfigurationUrlMappedTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringBootAutoConfigurationUrlMappedTest.java
@@ -11,6 +11,8 @@ import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.core.env.Environment;
 import org.springframework.test.context.TestPropertySource;
 
+import com.vaadin.flow.server.Constants;
+
 @SpringBootTest(classes = SpringBootAutoConfiguration.class)
 @TestPropertySource(properties = { "vaadin.urlMapping = /zing/*" })
 public class SpringBootAutoConfigurationUrlMappedTest {
@@ -26,7 +28,8 @@ public class SpringBootAutoConfigurationUrlMappedTest {
                 .isRootMapping(RootMappedCondition.getUrlMapping(environment)));
         Assert.assertEquals(Set.of("/zing/*"),
                 servletRegistrationBean.getUrlMappings());
-        Assert.assertEquals("/zing", servletRegistrationBean.getInitParameters()
-                .get(ApplicationConfig.JSR356_MAPPING_PATH));
+        Assert.assertEquals("/zing/" + Constants.PUSH_MAPPING,
+                servletRegistrationBean.getInitParameters()
+                        .get(ApplicationConfig.JSR356_MAPPING_PATH));
     }
 }


### PR DESCRIPTION
Removes pushUrl configuration option, and instead maps push always to a dedicated path (/VAADIN/push).

Fixes #14641

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
