### PR TITLE
feat: add refresh flag to navigation event (#15324)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/AfterNavigationEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/AfterNavigationEvent.java
@@ -64,4 +64,13 @@ public class AfterNavigationEvent extends EventObject {
     public Router getSource() {
         return (Router) super.getSource();
     }
+
+    /**
+     * Check if event is for a refresh of a preserveOnRefresh view.
+     *
+     * @return true if refresh of a preserve on refresh view
+     */
+    public boolean isRefreshEvent() {
+        return event.getTrigger().equals(NavigationTrigger.REFRESH);
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/BeforeEnterEvent.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/BeforeEnterEvent.java
@@ -150,4 +150,13 @@ public class BeforeEnterEvent extends BeforeEvent {
         super(router, trigger, location, navigationTarget, parameters, ui,
                 layouts);
     }
+
+    /**
+     * Check if event is for a refresh of a preserveOnRefresh view.
+     *
+     * @return true if refresh of a preserve on refresh view
+     */
+    public boolean isRefreshEvent() {
+        return getTrigger().equals(NavigationTrigger.REFRESH);
+    }
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/NavigationTrigger.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/NavigationTrigger.java
@@ -56,5 +56,10 @@ public enum NavigationTrigger {
      * Navigation was triggered via
      * {@link UI#navigate(String, QueryParameters)}. It's for internal use only.
      */
-    UI_NAVIGATE
+    UI_NAVIGATE,
+
+    /**
+     * Navigation is for a reload event on a preserveOnRefresh route.
+     */
+    REFRESH
 }

--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -212,6 +212,13 @@ public abstract class AbstractNavigationStateRenderer
             clearAllPreservedChains(ui);
         }
 
+        // Set navigationTrigger to RELOAD if this is a refresh of a preserve
+        // view.
+        if (preserveOnRefreshTarget && !chain.isEmpty()) {
+            event = new NavigationEvent(event.getSource(), event.getLocation(),
+                    event.getUI(), NavigationTrigger.REFRESH);
+        }
+
         BeforeEnterEvent beforeNavigationActivating = new BeforeEnterEvent(
                 event, routeTargetType, parameters, routeLayoutTypes);
 


### PR DESCRIPTION
Add the isRefreshEvent to BeforeEnterEvent
and AfterNavigationEvent to be make it possible
to distinguish if the event is for a refresh of
a preserve on refresh view.

Fixes #14999
