### PR TITLE
chore: Upgrade to Vite v4.0.0-alpha.6

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendTools.java
@@ -974,6 +974,7 @@ public class FrontendTools {
         returnCommand.add("--no-update-notifier");
         returnCommand.add("--no-audit");
         returnCommand.add("--scripts-prepend-node-path=true");
+        returnCommand.add("--legacy-peer-deps");
 
         if (removePnpmLock) {
             // remove pnpm-lock.yaml which contains pnpm as a dependency.

--- a/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
+++ b/flow-server/src/main/resources/com/vaadin/flow/server/frontend/dependencies/vite/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "dependencies": {},
   "devDependencies": {
-    "vite": "v3.2.4",
+    "vite": "v4.0.0-alpha.6",
     "@rollup/plugin-replace": "3.1.0",
     "rollup-plugin-brotli": "3.1.0",
     "vite-plugin-checker": "0.5.1",

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/FrontendToolsTest.java
@@ -414,7 +414,7 @@ public class FrontendToolsTest {
                 not(containsString(vaadinHomeDir)));
         assertThat(tools.getNodeExecutable(), not(containsString(baseDir)));
 
-        assertEquals(4, tools.getNpmExecutable().size());
+        assertEquals(5, tools.getNpmExecutable().size());
         assertThat(tools.getNpmExecutable().get(0), containsString("npm"));
         assertThat(tools.getNpmExecutable().get(1),
                 containsString("--no-update-notifier"));


### PR DESCRIPTION
Vite 4 final is targeted for December so it fits the Vaadin 24 release plan
