### PR TITLE
test: Always run postinstall for esbuild in flow-client

### DIFF
--- a/flow-client/pom.xml
+++ b/flow-client/pom.xml
@@ -349,6 +349,19 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>install-esbuild</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>node</executable>
+                            <arguments>
+                                <argument>node_modules/esbuild/install.js</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>typescript-compile</id>
                         <phase>compile</phase>
                         <goals>


### PR DESCRIPTION
Makes the build work even when you are using --ignore-scripts
