### PR TITLE
fix: Component locale works without UI and i18n

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/Component.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/Component.java
@@ -747,7 +747,13 @@ public abstract class Component
         UI currentUi = UI.getCurrent();
         Locale locale = currentUi == null ? null : currentUi.getLocale();
         if (locale == null) {
-            List<Locale> locales = getI18NProvider().getProvidedLocales();
+            final I18NProvider i18NProvider = getI18NProvider();
+            // If a i18nProvider is not defined we should just return the
+            // default locale.
+            if (i18NProvider == null) {
+                return Locale.getDefault();
+            }
+            List<Locale> locales = i18NProvider.getProvidedLocales();
             if (locales != null && !locales.isEmpty()) {
                 locale = locales.get(0);
             } else {

--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
@@ -306,6 +306,15 @@ public class ComponentTest {
     }
 
     @Test
+    public void getComponentLocale_noCurrentUI_returnsDefaultLocale() {
+        UI.setCurrent(null);
+        Component test = new TestButton();
+        final Locale locale = test.getLocale();
+        Assert.assertEquals("System default locale should be returned",
+                Locale.getDefault(), locale);
+    }
+
+    @Test
     public void getElement() {
         Assert.assertEquals(Tag.DIV,
                 divWithTextComponent.getElement().getTag());


### PR DESCRIPTION
Component locale should return a locale
even when UI and i18nProvider are not
available.

Fixes #15313
