### PR TITLE
fix: Use root servlet mapping for push url in OSGi case

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PushRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PushRequestHandler.java
@@ -231,7 +231,7 @@ public class PushRequestHandler
                     findFirstUrlMapping(servletRegistration.get())
                             + Constants.PUSH_MAPPING);
         } else {
-            getLogger().warn(
+            getLogger().debug(
                     "Unable to determine servlet registration for {}. "
                             + "Using root mapping for push",
                     vaadinServletConfig.getServletName());

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PushRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PushRequestHandler.java
@@ -20,6 +20,7 @@ import jakarta.servlet.ServletConfig;
 import jakarta.servlet.ServletException;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import jakarta.servlet.ServletRegistration;
 import org.atmosphere.cache.UUIDBroadcasterCache;
@@ -223,9 +224,18 @@ public class PushRequestHandler
         atmosphere.addInitParameter("org.atmosphere.cpr.showSupportMessage",
                 "false");
 
-        atmosphere.addInitParameter(ApplicationConfig.JSR356_MAPPING_PATH,
-                findFirstUrlMapping(vaadinServletConfig)
-                        + Constants.PUSH_MAPPING);
+        Optional<ServletRegistration> servletRegistration = getServletRegistration(
+                vaadinServletConfig);
+        if (servletRegistration.isPresent()) {
+            atmosphere.addInitParameter(ApplicationConfig.JSR356_MAPPING_PATH,
+                    findFirstUrlMapping(servletRegistration.get())
+                            + Constants.PUSH_MAPPING);
+        } else {
+            getLogger().warn(
+                    "Unable to determine servlet registration for {}. "
+                            + "Using root mapping for push",
+                    vaadinServletConfig.getServletName());
+        }
 
         atmosphere.addInitParameter(
                 ApplicationConfig.JSR356_PATH_MAPPING_LENGTH, "0");
@@ -245,15 +255,21 @@ public class PushRequestHandler
         return atmosphere;
     }
 
-    private static String findFirstUrlMapping(ServletConfig config) {
+    private static Optional<ServletRegistration> getServletRegistration(
+            ServletConfig config) {
         String name = config.getServletName();
-        String firstMapping = "/";
         if (name != null) {
-            ServletRegistration reg = config.getServletContext()
-                    .getServletRegistrations().get(name);
-            firstMapping = reg.getMappings().stream().sorted().findFirst()
-                    .orElse("/");
+            return Optional.ofNullable(config.getServletContext()
+                    .getServletRegistrations().get(name));
         }
+        return Optional.empty();
+    }
+
+    private static String findFirstUrlMapping(
+            ServletRegistration registration) {
+        String firstMapping = "/";
+        firstMapping = registration.getMappings().stream().sorted().findFirst()
+                .orElse("/");
         return firstMapping.replace("/*", "/");
     }
 

--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/PushRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/PushRequestHandler.java
@@ -267,9 +267,8 @@ public class PushRequestHandler
 
     private static String findFirstUrlMapping(
             ServletRegistration registration) {
-        String firstMapping = "/";
-        firstMapping = registration.getMappings().stream().sorted().findFirst()
-                .orElse("/");
+        String firstMapping = registration.getMappings().stream().sorted()
+                .findFirst().orElse("/");
         return firstMapping.replace("/*", "/");
     }
 


### PR DESCRIPTION
Fallback to a root mapping for push in case if not servlet registration is available (OSGi runtime).