### PR TITLE
test: ensure ComponentTest preconditions

### DIFF
--- a/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/component/ComponentTest.java
@@ -41,6 +41,7 @@ import com.vaadin.flow.component.dependency.StyleSheet;
 import com.vaadin.flow.component.dependency.Uses;
 import com.vaadin.flow.component.internal.DependencyList;
 import com.vaadin.flow.component.internal.UIInternals;
+import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.dom.DisabledUpdateMode;
 import com.vaadin.flow.dom.DomEvent;
 import com.vaadin.flow.dom.Element;
@@ -308,6 +309,8 @@ public class ComponentTest {
     @Test
     public void getComponentLocale_noCurrentUI_returnsDefaultLocale() {
         UI.setCurrent(null);
+        Instantiator instantiator = mocks.getService().getInstantiator();
+        Mockito.when(instantiator.getI18NProvider()).thenReturn(null);
         Component test = new TestButton();
         final Locale locale = test.getLocale();
         Assert.assertEquals("System default locale should be returned",

--- a/flow-server/src/test/java/com/vaadin/flow/server/MockServletServiceSessionSetup.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/MockServletServiceSessionSetup.java
@@ -27,6 +27,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
+import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.di.Lookup;
 import com.vaadin.flow.di.ResourceProvider;
 import com.vaadin.flow.function.DeploymentConfiguration;
@@ -131,6 +132,10 @@ public class MockServletServiceSessionSetup {
             this.context = context;
         }
 
+        @Override
+        protected Instantiator createInstantiator() throws ServiceException {
+            return Mockito.spy(super.createInstantiator());
+        }
     }
 
     public class TestVaadinServlet extends VaadinServlet {


### PR DESCRIPTION
ComponentTest.getComponentLocale_noCurrentUI_returnsDefaultLocale assumes that I18nProvider is null but it may have been initialized by another test. This change makes the Instantiator instance a mockito spy so that it can be instructed by the tests to return a null I18nProvider instance.