### PR TITLE
feat: Add the Authentication Context bean to the Vaadin Web Security (#15129) (CP: 23.3)

### DIFF
--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/SecurityConfig.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/SecurityConfig.java
@@ -15,6 +15,9 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.internal.UrlUtil;
+import com.vaadin.flow.server.VaadinServletRequest;
 import com.vaadin.flow.spring.RootMappedCondition;
 import com.vaadin.flow.spring.VaadinConfigurationProperties;
 import com.vaadin.flow.spring.flowsecurity.data.UserInfo;
@@ -59,6 +62,11 @@ public class SecurityConfig extends VaadinWebSecurity {
         http.authorizeRequests().antMatchers("/public/**").permitAll();
         super.configure(http);
         setLoginView(http, LoginView.class, getLogoutSuccessUrl());
+        http.logout().addLogoutHandler((request, response, authentication) -> {
+            UI ui = UI.getCurrent();
+            ui.accessSynchronously(() -> ui.getPage().setLocation(UrlUtil
+                    .getServletPathRelative(getLogoutSuccessUrl(), request)));
+        });
     }
 
     @Bean

--- a/vaadin-spring/pom.xml
+++ b/vaadin-spring/pom.xml
@@ -109,6 +109,11 @@
             <artifactId>spring-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/AuthenticationContext.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/AuthenticationContext.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.spring.security;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Optional;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.logout.CompositeLogoutHandler;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.server.VaadinServletRequest;
+import com.vaadin.flow.server.VaadinServletResponse;
+
+/**
+ * The authentication context of the application.
+ * <p>
+ * An instance of this class is available for injection as bean in view and
+ * layout classes.
+ *
+ * It allows to access authenticated user information and to initiate the logout
+ * process.
+ *
+ * @author Vaadin Ltd
+ * @since 23.3
+ */
+public class AuthenticationContext implements Serializable {
+
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(AuthenticationContext.class);
+
+    private transient LogoutSuccessHandler logoutSuccessHandler;
+
+    private transient CompositeLogoutHandler logoutHandler;
+
+    /**
+     * Gets an {@link Optional} with an instance of the current user if it has
+     * been authenticated, or empty if the user is not authenticated.
+     *
+     * Anonymous users are considered not authenticated.
+     *
+     * @param <U>
+     *            the type parameter of the expected user instance
+     * @param userType
+     *            the type of the expected user instance
+     * @return an {@link Optional} with the current authenticated user, or empty
+     *         if none available
+     * @throws ClassCastException
+     *             if the current user instance does not match the given
+     *             {@code userType}.
+     */
+    public <U> Optional<U> getAuthenticatedUser(Class<U> userType) {
+        return getAuthentication().map(Authentication::getPrincipal)
+                .map(userType::cast);
+    }
+
+    /**
+     * Indicates whether a user is currently authenticated.
+     *
+     * Anonymous users are considered not authenticated.
+     *
+     * @return {@literal true} if a user is currently authenticated, otherwise
+     *         {@literal false}
+     */
+    public boolean isAuthenticated() {
+        return getAuthentication().map(Authentication::isAuthenticated)
+                .orElse(false);
+    }
+
+    /**
+     * Initiates the logout process of the current authenticated user by
+     * invalidating the local session and then notifying
+     * {@link org.springframework.security.web.authentication.logout.LogoutHandler}.
+     */
+    public void logout() {
+        HttpServletRequest request = VaadinServletRequest.getCurrent()
+                .getHttpServletRequest();
+        HttpServletResponse response = VaadinServletResponse.getCurrent()
+                .getHttpServletResponse();
+        Authentication auth = SecurityContextHolder.getContext()
+                .getAuthentication();
+
+        final UI ui = UI.getCurrent();
+        logoutHandler.logout(request, response, auth);
+        ui.accessSynchronously(() -> {
+            try {
+                logoutSuccessHandler.onLogoutSuccess(request, response, auth);
+            } catch (IOException | ServletException e) {
+                // Raise a warning log message about the failure.
+                LOGGER.warn(
+                        "There was an error notifying the logout handler about the user logout",
+                        e);
+            }
+        });
+    }
+
+    /**
+     * Sets component to handle logout process.
+     *
+     * This method should be invoked after deserialization to refresh required
+     * transient fields.
+     *
+     * @param logoutSuccessHandler
+     *            {@link LogoutSuccessHandler} instance, not {@literal null}.
+     * @param logoutHandlers
+     *            {@link LogoutHandler}s list, not {@literal null}.
+     */
+    void setLogoutHandlers(LogoutSuccessHandler logoutSuccessHandler,
+            List<LogoutHandler> logoutHandlers) {
+        this.logoutSuccessHandler = logoutSuccessHandler;
+        this.logoutHandler = new CompositeLogoutHandler(logoutHandlers);
+    }
+
+    private static Optional<Authentication> getAuthentication() {
+        return Optional.of(SecurityContextHolder.getContext())
+                .map(SecurityContext::getAuthentication)
+                .filter(auth -> !(auth instanceof AnonymousAuthenticationToken));
+    }
+
+    /* For testing purposes */
+    LogoutSuccessHandler getLogoutSuccessHandler() {
+        return logoutSuccessHandler;
+    }
+
+    /* For testing purposes */
+    CompositeLogoutHandler getLogoutHandler() {
+        return logoutHandler;
+    }
+
+}

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/UidlRedirectStrategy.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/UidlRedirectStrategy.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.spring.security;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import org.slf4j.LoggerFactory;
+import org.springframework.security.web.DefaultRedirectStrategy;
+
+import com.vaadin.flow.component.UI;
+
+/**
+ * A strategy to handle redirects which is aware of UIDL requests.
+ *
+ * @author Vaadin Ltd
+ * @since 1.0
+ */
+public class UidlRedirectStrategy extends DefaultRedirectStrategy {
+
+    private final RequestUtil requestUtil;
+
+    public UidlRedirectStrategy(RequestUtil requestUtil) {
+        this.requestUtil = requestUtil;
+    }
+
+    @Override
+    public void sendRedirect(HttpServletRequest request,
+            HttpServletResponse response, String url) throws IOException {
+        if (requestUtil.isFrameworkInternalRequest(request)) {
+            UI ui = UI.getCurrent();
+            if (ui != null) {
+                ui.getPage().setLocation(url);
+            } else {
+                LoggerFactory.getLogger(UidlRedirectStrategy.class).warn(
+                        "A redirect to {} was request during a Vaadin request, "
+                                + "but it was not possible to get the UI instance to perform the action.",
+                        url);
+            }
+        } else {
+            super.sendRedirect(request, response, url);
+        }
+    }
+}

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringClassesSerializableTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringClassesSerializableTest.java
@@ -96,6 +96,7 @@ public class SpringClassesSerializableTest extends ClassesSerializableTest {
                 "com\\.vaadin\\.flow\\.spring\\.security\\.VaadinWebSecurityConfigurerAdapter",
                 "com\\.vaadin\\.flow\\.spring\\.security\\.VaadinWebSecurityConfigurerAdapter\\$Http401UnauthorizedAccessDeniedHandler",
                 "com\\.vaadin\\.flow\\.spring\\.security\\.VaadinDefaultRequestCache",
+                "com\\.vaadin\\.flow\\.spring\\.security\\.UidlRedirectStrategy",
                 "com\\.vaadin\\.flow\\.spring\\.security\\.VaadinSavedRequestAwareAuthenticationSuccessHandler",
                 "com\\.vaadin\\.flow\\.spring\\.security\\.VaadinSavedRequestAwareAuthenticationSuccessHandler\\$RedirectStrategy",
                 "com\\.vaadin\\.flow\\.spring\\.security\\.stateless\\.JwtSecurityContextRepository",

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/AuthenticationContextTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/AuthenticationContextTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.spring.security;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.springframework.security.core.AuthenticatedPrincipal;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.internal.CurrentInstance;
+import com.vaadin.flow.server.Command;
+import com.vaadin.flow.server.VaadinRequest;
+import com.vaadin.flow.server.VaadinResponse;
+import com.vaadin.flow.server.VaadinServletRequest;
+import com.vaadin.flow.server.VaadinServletResponse;
+
+@RunWith(SpringRunner.class)
+// @ContextConfiguration
+public class AuthenticationContextTest {
+
+    private final AuthenticationContext authContext = new AuthenticationContext();
+
+    @Test
+    public void isAuthenticated_notAuthenticated_false() {
+        Assert.assertFalse(authContext.isAuthenticated());
+    }
+
+    @Test
+    @WithAnonymousUser
+    public void isAuthenticated_anonymous_false() {
+        Assert.assertFalse(authContext.isAuthenticated());
+    }
+
+    @Test
+    @WithMockUser
+    public void isAuthenticated_loggedUser_true() {
+        Assert.assertTrue(authContext.isAuthenticated());
+    }
+
+    @Test
+    public void getAuthenticatedUser_notAuthenticated_getsEmpty() {
+        Assert.assertTrue(
+                authContext.getAuthenticatedUser(Object.class).isEmpty());
+    }
+
+    @Test
+    @WithAnonymousUser
+    public void getAuthenticatedUser_anonymous_getsEmpty() {
+        Assert.assertTrue(
+                authContext.getAuthenticatedUser(Object.class).isEmpty());
+    }
+
+    @Test
+    @WithMockUser()
+    public void getAuthenticatedUser_loggedUser_getsUserInstance() {
+        Optional<User> maybeUser = authContext.getAuthenticatedUser(User.class);
+        Assert.assertTrue(maybeUser.isPresent());
+        Assert.assertEquals("user", maybeUser.get().getUsername());
+    }
+
+    @Test
+    @WithMockUser()
+    public void getAuthenticatedUser_loggedUserWrongUserType_throws() {
+        Assert.assertThrows(ClassCastException.class, () -> authContext
+                .getAuthenticatedUser(AuthenticatedPrincipal.class));
+    }
+
+    @Test
+    @WithMockUser()
+    public void logout_handlersEngaged() throws Exception {
+        Authentication authentication = SecurityContextHolder.getContext()
+                .getAuthentication();
+
+        LogoutSuccessHandler successHandler = Mockito
+                .mock(LogoutSuccessHandler.class);
+        LogoutHandler handler1 = Mockito.mock(LogoutHandler.class);
+        LogoutHandler handler2 = Mockito.mock(LogoutHandler.class);
+        authContext.setLogoutHandlers(successHandler,
+                List.of(handler2, handler1));
+
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        VaadinServletRequest vaadinRequest = Mockito
+                .mock(VaadinServletRequest.class);
+        Mockito.when(vaadinRequest.getHttpServletRequest()).thenReturn(request);
+
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+        VaadinServletResponse vaadinResponse = Mockito
+                .mock(VaadinServletResponse.class);
+        Mockito.when(vaadinResponse.getHttpServletResponse())
+                .thenReturn(response);
+
+        UI ui = Mockito.mock(UI.class);
+        Mockito.doAnswer(i -> {
+            i.<Command> getArgument(0).execute();
+            return null;
+        }).when(ui).accessSynchronously(ArgumentMatchers.any());
+
+        try {
+            CurrentInstance.set(VaadinRequest.class, vaadinRequest);
+            CurrentInstance.set(VaadinResponse.class, vaadinResponse);
+            UI.setCurrent(ui);
+            authContext.logout();
+
+            Mockito.verify(successHandler).onLogoutSuccess(request, response,
+                    authentication);
+            Mockito.verify(handler2).logout(request, response, authentication);
+            Mockito.verify(handler1).logout(request, response, authentication);
+        } finally {
+            CurrentInstance.clearAll();
+        }
+    }
+}

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/UidlRedirectStrategyTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/UidlRedirectStrategyTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.spring.security;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.page.Page;
+import com.vaadin.flow.internal.CurrentInstance;
+import com.vaadin.flow.server.HandlerHelper;
+import com.vaadin.flow.shared.ApplicationConstants;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class UidlRedirectStrategyTest {
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private HttpServletRequest request;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private HttpServletResponse response;
+
+    private UidlRedirectStrategy strategy;
+
+    @BeforeEach
+    public void setup() {
+        RequestUtil requestUtil = mock(RequestUtil.class);
+        strategy = new UidlRedirectStrategy(requestUtil);
+        doAnswer(i -> HandlerHelper.isFrameworkInternalRequest("/",
+                i.getArgument(0))).when(requestUtil)
+                .isFrameworkInternalRequest(any());
+    }
+
+    @AfterEach
+    public void cleanup() {
+        CurrentInstance.clearAll();
+    }
+
+    @Test
+    public void isInternalRequest_setPageLocation()
+            throws IOException, ServletException {
+        when(request.getParameter(ApplicationConstants.REQUEST_TYPE_PARAMETER))
+                .thenReturn(ApplicationConstants.REQUEST_TYPE_UIDL);
+
+        var ui = mock(UI.class, Answers.RETURNS_DEEP_STUBS);
+        CurrentInstance.set(UI.class, ui);
+
+        var page = mock(Page.class);
+        when(ui.getPage()).thenReturn(page);
+
+        strategy.sendRedirect(request, response, "/foo");
+
+        verify(page).setLocation("/foo");
+    }
+
+    @Test
+    public void isExternalRequest_useDefaultRedirect()
+            throws IOException, ServletException {
+        when(request.getContextPath()).thenReturn("");
+        when(response.encodeRedirectURL(anyString()))
+                .thenAnswer(i -> i.getArguments()[0]);
+
+        strategy.sendRedirect(request, response, "/foo");
+
+        verify(response).sendRedirect("/foo");
+    }
+}

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/VaadinWebSecurityTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/VaadinWebSecurityTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2000-2022 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.spring.security;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.security.config.annotation.ObjectPostProcessor;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.configuration.ObjectPostProcessorConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.CompositeLogoutHandler;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = ObjectPostProcessorConfiguration.class)
+public class VaadinWebSecurityTest {
+    @Autowired
+    ObjectPostProcessor<Object> postProcessor;
+
+    @Autowired
+    ApplicationContext appCtx;
+
+    @Test
+    public void filterChain_additionalLogoutHandlers_configured()
+            throws Exception {
+        HttpSecurity httpSecurity = new HttpSecurity(postProcessor,
+                new AuthenticationManagerBuilder(postProcessor),
+                Map.of(ApplicationContext.class, appCtx));
+        TestConfig testConfig = new VaadinWebSecurityTest.TestConfig();
+        testConfig.filterChain(httpSecurity);
+
+        Assert.assertTrue("VaadinWebSecurity HTTP configuration invoked",
+                testConfig.httpConfigured);
+
+        AuthenticationContext authContext = testConfig
+                .getAuthenticationContext();
+        CompositeLogoutHandler logoutHandler = authContext.getLogoutHandler();
+
+        logoutHandler.logout(mock(HttpServletRequest.class),
+                mock(HttpServletResponse.class), mock(Authentication.class));
+        Mockito.verify(testConfig.handler1).logout(any(), any(), any());
+        Mockito.verify(testConfig.handler2).logout(any(), any(), any());
+    }
+
+    static class TestConfig extends VaadinWebSecurity {
+        LogoutHandler handler1 = mock(LogoutHandler.class);
+        LogoutHandler handler2 = mock(LogoutHandler.class);
+
+        boolean httpConfigured;
+        boolean webConfigured;
+
+        @Override
+        protected void configure(WebSecurity web) throws Exception {
+            webConfigured = true;
+        }
+
+        @Override
+        protected void configure(HttpSecurity http) throws Exception {
+            httpConfigured = true;
+        }
+
+        protected void addLogoutHandlers(Consumer<LogoutHandler> registry) {
+            registry.accept(handler1);
+            registry.accept(handler2);
+        }
+    }
+
+}

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/stateless/JwtSecurityContextRepositoryTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/stateless/JwtSecurityContextRepositoryTest.java
@@ -46,6 +46,7 @@ import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextHolderStrategy;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -92,6 +93,7 @@ public class JwtSecurityContextRepositoryTest {
 
     @Mock
     private HttpServletResponse response;
+    private SecurityContextHolderStrategy originalontextHolderStrategy;
 
     private HttpRequestResponseHolder holder;
 
@@ -118,6 +120,8 @@ public class JwtSecurityContextRepositoryTest {
     public void setup() throws Exception {
         MockitoAnnotations.openMocks(this);
 
+        originalontextHolderStrategy = SecurityContextHolder
+                .getContextHolderStrategy();
         SecurityContextHolder.setStrategyName(
                 TestSecurityContextHolderStrategy.class.getName());
 
@@ -138,6 +142,12 @@ public class JwtSecurityContextRepositoryTest {
     public void teardown() {
         Mockito.verifyNoInteractions(request);
         Mockito.verifyNoInteractions(response);
+        if (originalontextHolderStrategy != null) {
+            SecurityContextHolder
+                    .setContextHolderStrategy(originalontextHolderStrategy);
+        } else {
+            SecurityContextHolder.setStrategyName(null);
+        }
     }
 
     @Test


### PR DESCRIPTION
- AuthenticationContext is a concrete class that gets access to the authenticated user and allows performing logout integrated with Spring Security
- AuthenticationContext is an injectable managed bean
- Developers can plug additional LogoutHandlers in VaadinWebSecurity.addLogoutHandlers()
- VaadinWebSecurity configures a LogoutSuccessHandler with a redirect strategy that can handle also XHR UIDL requests (UidlRedirectStrategy)

Fixes #14958