### PR TITLE
chore: log server sync id stack at trace level

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/internal/UIInternals.java
@@ -318,8 +318,8 @@ public class UIInternals implements Serializable {
      */
     public void incrementServerId() {
         serverSyncId++;
-        if (getLogger().isDebugEnabled()) {
-            getLogger().debug("Increment syncId:\n{}", Arrays
+        if (getLogger().isTraceEnabled()) {
+            getLogger().trace("Increment syncId:\n{}", Arrays
                     .stream(Thread.currentThread().getStackTrace()).skip(1)
                     .map(String::valueOf)
                     .collect(Collectors.joining(System.lineSeparator())));


### PR DESCRIPTION
Stack trace to debug sync id increment is verbose. Log it at trace level.

Fixes #15396