### PR TITLE
fix: added HasDynamicTitle checking in parent layouts (#15355) (CP 2.8)

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
+++ b/flow-server/src/main/java/com/vaadin/flow/router/internal/AbstractNavigationStateRenderer.java
@@ -25,9 +25,11 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.function.Supplier;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
@@ -909,14 +911,18 @@ public abstract class AbstractNavigationStateRenderer
 
     private static void updatePageTitle(NavigationEvent navigationEvent,
             Component routeTarget) {
-        String title;
 
-        if (routeTarget instanceof HasDynamicTitle) {
-            title = ((HasDynamicTitle) routeTarget).getPageTitle();
-        } else {
-            title = lookForTitleInTarget(routeTarget).map(PageTitle::value)
-                    .orElse("");
-        }
+        Supplier<String> lookForTitleInTarget = () -> lookForTitleInTarget(
+                routeTarget).map(PageTitle::value).orElse("");
+
+        // check for HasDynamicTitle in current router targets chain
+        String title = navigationEvent.getUI().getInternals()
+                .getActiveRouterTargetsChain().stream()
+                .filter(HasDynamicTitle.class::isInstance)
+                .map(tc -> ((HasDynamicTitle) tc).getPageTitle())
+                .filter(Objects::nonNull).findFirst()
+                .orElseGet(lookForTitleInTarget);
+
         navigationEvent.getUI().getPage().setTitle(title);
     }
 

--- a/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/router/RouterTest.java
@@ -523,6 +523,21 @@ public class RouterTest extends RoutingTestBase {
     public static class ChildWithoutTitle extends Component {
     }
 
+    @RoutePrefix("parent-with-dynamic-title")
+    @Tag(Tag.DIV)
+    public static class ParentWithDynamicTitle extends Component
+            implements RouterLayout, HasDynamicTitle {
+        @Override
+        public String getPageTitle() {
+            return DYNAMIC_TITLE;
+        }
+    }
+
+    @Route(value = "child2", layout = ParentWithDynamicTitle.class)
+    @Tag(Tag.DIV)
+    public static class ChildWithoutTitle2 extends Component {
+    }
+
     @Route("navigation-target-with-dynamic-title")
     @Tag(Tag.DIV)
     public static class NavigationTargetWithDynamicTitle extends Component
@@ -1743,6 +1758,17 @@ public class RouterTest extends RoutingTestBase {
                 NavigationTrigger.PROGRAMMATIC);
 
         Assert.assertEquals("", ui.getInternals().getTitle());
+    }
+
+    @Test
+    public void page_title_set_from_dynamic_title_in_parent()
+            throws InvalidRouteConfigurationException {
+        setNavigationTargets(ChildWithoutTitle2.class);
+
+        router.navigate(ui, new Location("parent-with-dynamic-title/child2"),
+                NavigationTrigger.PROGRAMMATIC);
+
+        Assert.assertEquals(DYNAMIC_TITLE, ui.getInternals().getTitle());
     }
 
     @Test


### PR DESCRIPTION
Checks the navigation targets including parent layouts and takes the page title from the one implementing HasDynamicTitle.

Fixes: #13871