### PR TITLE
chore: re-enable the check for outside collaborators

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -15,12 +15,21 @@ jobs:
       matrix-unit: ${{ steps.set-matrix.outputs.matrix-unit }}
       matrix-it: ${{ steps.set-matrix.outputs.matrix-it }}
     steps:
-      - name: Check Secrets
+      - uses: actions-cool/check-user-permission@main
+        id: checkUser
+        with:
+          username: ${{github.triggering_actor}}
+          require: 'write'
+      - name: Fail on external workflow triggering
+        if: ${{ steps.checkUser.outputs.require-result != 'true' }}
         run: |
-          TB_LICENSE="${{secrets.TB_LICENSE}}"
-          [ -z "$TB_LICENSE" ] \
-            && echo "::error::!! ERROR NO TB_LICENSE: Check that this repo has a valid TB_LICENSE secret !!" \
-            && exit 1 || exit 0
+          echo "🚫 **${{ github.actor }}** is an external contributor, a **${{github.repository}}** team member has to review this changes and re-run this build" \
+            | tee -a $GITHUB_STEP_SUMMARY && exit 1
+      - name: Check secrets
+        run: |
+          [ -z "${{secrets.TB_LICENSE}}" ] \
+            && echo "🚫 **TB_LICENSE** is not defined, check that **${{github.repository}}** repo has a valid secret" \
+            | tee -a $GITHUB_STEP_SUMMARY && exit 1 || exit 0
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
This PR reverts partially https://github.com/vaadin/flow/pull/15261 because it still does not prevent outside collaborators running the workflow as it's demonstrated in the PR https://github.com/vaadin/flow/pull/15433 that was able to run all the workflow steps in the action https://github.com/vaadin/flow/actions/runs/3670083099

The problem is that the 'Require approval for outside collaborators' flag in the github 'settings -> actions' section only 
applies for `pull_request` event, but we still need to configure our projects to use `pull_request_target` one, since we need that the secret for the TB license is available for running ITs in the contribution branch.

As a bonus, this PR removes the need of using a forked version of the  `ZheSun88/check-user-permission` action in `ZheSun88` 