### PR TITLE
fix: avoid duplicate JS const declaration on license checker script

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
@@ -194,7 +194,7 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
                 "window.Vaadin.devTools = window.Vaadin.devTools || {};"
                 + "window.Vaadin.devTools.createdCvdlElements = window.Vaadin.devTools.createdCvdlElements || [];"
                 + //
-                "const originalCustomElementDefineFn = window.customElements.define;"
+                "window.Vaadin.originalCustomElementDefineFn = window.Vaadin.originalCustomElementDefineFn || window.customElements.define;"
                 + //
                 "window.customElements.define = function (tagName, constructor, ...args) {"
                 + //
@@ -209,7 +209,7 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
                 "  }" + //
                 "}" + //
 
-                "originalCustomElementDefineFn.call(this, tagName, constructor, ...args);"
+                "window.Vaadin.originalCustomElementDefineFn.call(this, tagName, constructor, ...args);"
                 + //
                 "};");
 


### PR DESCRIPTION
## Description

When adding license checker script a global constant name originalCustomElementDefineFn is declared. This produces browser errors in portlet addon, because the script may be added multiple times on the same page.

This patch stores the originalCustomElementDefineFn reference under window.Vaadin container and adds a guard to set it only if not already present.

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
