### PR TITLE
feat: added method to get authenticate principal name

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/AuthenticationContext.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/AuthenticationContext.java
@@ -17,6 +17,7 @@ package com.vaadin.flow.spring.security;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.security.Principal;
 import java.util.List;
 import java.util.Optional;
 
@@ -77,6 +78,23 @@ public class AuthenticationContext implements Serializable {
     public <U> Optional<U> getAuthenticatedUser(Class<U> userType) {
         return getAuthentication().map(Authentication::getPrincipal)
                 .map(userType::cast);
+    }
+
+    /**
+     * Gets an {@link Optional} containing of the authenticated principal name
+     * as defined in {@link Principal#getName()}, or empty if the user is not
+     * authenticated.
+     *
+     * The principal name usually refers to a username or an identifier that can
+     * be used to retrieve additional information for the authenticated user.
+     *
+     * Anonymous users are considered not authenticated.
+     *
+     * @return an {@link Optional} containing of the authenticated principal
+     *         name or empty if not available.
+     */
+    public Optional<String> getPrincipalName() {
+        return getAuthentication().map(Principal::getName);
     }
 
     /**

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/AuthenticationContext.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/AuthenticationContext.java
@@ -89,8 +89,8 @@ public class AuthenticationContext implements Serializable {
      *
      * Anonymous users are considered not authenticated.
      *
-     * @return an {@link Optional} containing of the authenticated principal
-     *         name or empty if not available.
+     * @return an {@link Optional} containing the authenticated principal name
+     *         or an empty optional if not available.
      */
     public Optional<String> getPrincipalName() {
         return getAuthentication().map(Principal::getName);

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/AuthenticationContext.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/AuthenticationContext.java
@@ -81,9 +81,8 @@ public class AuthenticationContext implements Serializable {
     }
 
     /**
-     * Gets an {@link Optional} containing of the authenticated principal name
-     * as defined in {@link Principal#getName()}, or empty if the user is not
-     * authenticated.
+     * Gets an {@link Optional} containing the authenticated principal name, or
+     * an empty optional if the user is not authenticated.
      *
      * The principal name usually refers to a username or an identifier that can
      * be used to retrieve additional information for the authenticated user.

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/AuthenticationContextTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/security/AuthenticationContextTest.java
@@ -96,6 +96,25 @@ public class AuthenticationContextTest {
     }
 
     @Test
+    public void getPrincipalName_notAuthenticated_getsEmpty() {
+        Assert.assertTrue(authContext.getPrincipalName().isEmpty());
+    }
+
+    @Test
+    @WithAnonymousUser
+    public void getPrincipalName_anonymous_getsEmpty() {
+        Assert.assertTrue(authContext.getPrincipalName().isEmpty());
+    }
+
+    @Test
+    @WithMockUser(username = "the-username")
+    public void getPrincipalName_loggedUser_getsAuthenticationName() {
+        Optional<String> maybePrincipalName = authContext.getPrincipalName();
+        Assert.assertTrue(maybePrincipalName.isPresent());
+        Assert.assertEquals("the-username", maybePrincipalName.get());
+    }
+
+    @Test
     @WithMockUser()
     public void logout_handlersEngaged() throws Exception {
         Authentication authentication = SecurityContextHolder.getContext()


### PR DESCRIPTION
## Description

Principal name usually refers to a user identifier that can be used to retrieve additional details.

Fixes #15484 

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
