### PR TITLE
fix: vite module path for windows

### DIFF
--- a/flow-server/src/main/resources/vite.generated.ts
+++ b/flow-server/src/main/resources/vite.generated.ts
@@ -177,7 +177,8 @@ function statsExtracterPlugin(): PluginOption {
     async writeBundle(options: OutputOptions, bundle: { [fileName: string]: AssetInfo | ChunkInfo }) {
       const modules = Object.values(bundle).flatMap((b) => (b.modules ? Object.keys(b.modules) : []));
       const nodeModulesFolders = modules
-          .filter((id) => id.startsWith(nodeModulesFolder))
+          .map((id) => id.replace(/\\/g, '/'))
+          .filter((id) => id.startsWith(nodeModulesFolder.replace(/\\/g, '/')))
           .map(id => id.substring(nodeModulesFolder.length + 1));
       const npmModules = nodeModulesFolders
         .map((id) => id.replace(/\\/g, '/'))


### PR DESCRIPTION
Vite gives modules list as `C:/Users/`
where as the nodeModulesFolder is `C:\Users\`
Unify path separator for both when executing.
