### PR TITLE
fix: remove Serializable interface from AuthenticationContext

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/AuthenticationContext.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/AuthenticationContext.java
@@ -46,7 +46,7 @@ import com.vaadin.flow.server.VaadinServletResponse;
  *
  * An instance of this class is available for injection as bean in view and
  * layout classes. The class is not {@link java.io.Serializable}, so potential
- * referencing fields in Vaadin view should be defined {@literal transient}.
+ * referencing fields in Vaadin views should be defined {@literal transient}.
  *
  * @author Vaadin Ltd
  * @since 23.3

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/AuthenticationContext.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/AuthenticationContext.java
@@ -40,23 +40,25 @@ import com.vaadin.flow.server.VaadinServletResponse;
 /**
  * The authentication context of the application.
  * <p>
- * An instance of this class is available for injection as bean in view and
- * layout classes.
  *
  * It allows to access authenticated user information and to initiate the logout
  * process.
  *
+ * An instance of this class is available for injection as bean in view and
+ * layout classes. The class is not {@link java.io.Serializable}, so potential
+ * referencing fields in Vaadin view should be defined {@literal transient}.
+ *
  * @author Vaadin Ltd
  * @since 23.3
  */
-public class AuthenticationContext implements Serializable {
+public class AuthenticationContext {
 
     private static final Logger LOGGER = LoggerFactory
             .getLogger(AuthenticationContext.class);
 
-    private transient LogoutSuccessHandler logoutSuccessHandler;
+    private LogoutSuccessHandler logoutSuccessHandler;
 
-    private transient CompositeLogoutHandler logoutHandler;
+    private CompositeLogoutHandler logoutHandler;
 
     /**
      * Gets an {@link Optional} with an instance of the current user if it has
@@ -121,9 +123,6 @@ public class AuthenticationContext implements Serializable {
 
     /**
      * Sets component to handle logout process.
-     *
-     * This method should be invoked after deserialization to refresh required
-     * transient fields.
      *
      * @param logoutSuccessHandler
      *            {@link LogoutSuccessHandler} instance, not {@literal null}.

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -125,8 +125,6 @@ public abstract class VaadinWebSecurity {
     @Bean(name = "VaadinSecurityFilterChainBean")
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         configure(http);
-        // Keeps a reference to LogoutConfigurer in case AuthenticationContext
-        // needs to refresh transient fields after deserialization
         logoutConfigurer = http.logout();
         logoutConfigurer.invalidateHttpSession(true);
         addLogoutHandlers(logoutConfigurer::addLogoutHandler);

--- a/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringClassesSerializableTest.java
+++ b/vaadin-spring/src/test/java/com/vaadin/flow/spring/SpringClassesSerializableTest.java
@@ -91,6 +91,7 @@ public class SpringClassesSerializableTest extends ClassesSerializableTest {
                 "com\\.vaadin\\.flow\\.spring\\.scopes\\.VaadinSessionScope",
                 "com\\.vaadin\\.flow\\.spring\\.scopes\\.AbstractScope",
                 "com\\.vaadin\\.flow\\.spring\\.scopes\\.VaadinUIScope",
+                "com\\.vaadin\\.flow\\.spring\\.security\\.AuthenticationContext",
                 "com\\.vaadin\\.flow\\.spring\\.security\\.VaadinAwareSecurityContextHolderStrategy",
                 "com\\.vaadin\\.flow\\.spring\\.security\\.VaadinWebSecurity",
                 "com\\.vaadin\\.flow\\.spring\\.security\\.VaadinWebSecurity\\$Http401UnauthorizedAccessDeniedHandler",


### PR DESCRIPTION
The AuthenticationContext component is Serializable because the idea was to potentially inject it into Vaadin views, but this may cause several issues:

* a single instance of that class per application is expected, but if deserializating views we may end up with many of them
* logoutSuccessHandler and logoutHandler are transient, but they are not Spring beans, and we do not provide a simple way to inject them upon deserialization
* for the above reasons, AuthenticationContext may not work correctly with Kubernetes Kit

This change removes the implementation of Serializable interface and updates javadocs.