### PR TITLE
fix: Ensure the correct version of commons-io is used by the plugin

### DIFF
--- a/flow-plugins/flow-maven-plugin/pom.xml
+++ b/flow-plugins/flow-maven-plugin/pom.xml
@@ -66,7 +66,7 @@
             <version>1.22</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
+            <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.11.0</version>
         </dependency>

--- a/flow-plugins/flow-maven-plugin/pom.xml
+++ b/flow-plugins/flow-maven-plugin/pom.xml
@@ -66,6 +66,11 @@
             <version>1.22</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.11.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <version>3.7.0</version>


### PR DESCRIPTION
Hopefully resolves

[ERROR] Failed to execute goal dev.hilla:hilla-maven-plugin:2.0.0.alpha5:prepare-frontend (default) on project starter-wizard: Execution default of goal dev.hilla:hilla-maven-plugin:2.0.0.alpha5:prepare-frontend failed: An API incompatibility was encountered while executing dev.hilla:hilla-maven-plugin:2.0.0.alpha5:prepare-frontend: java.lang.NoSuchMethodError: 'java.io.File org.apache.commons.io.FileUtils.delete(java.io.File)'
