### PR TITLE
fix!: Use servlet context path as the default logout url

### DIFF
--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -337,7 +337,7 @@ public abstract class VaadinWebSecurity {
      */
     protected void setLoginView(HttpSecurity http, String hillaLoginViewPath)
             throws Exception {
-        setLoginView(http, hillaLoginViewPath, "/");
+        setLoginView(http, hillaLoginViewPath, servletContextPath);
     }
 
     /**
@@ -387,7 +387,7 @@ public abstract class VaadinWebSecurity {
      */
     protected void setLoginView(HttpSecurity http,
             Class<? extends Component> flowLoginView) throws Exception {
-        setLoginView(http, flowLoginView, "/");
+        setLoginView(http, flowLoginView, servletContextPath);
     }
 
     /**


### PR DESCRIPTION
With a root mapped servlet, this changes nothing. For a servlet with a context path, it assumes that you have the whole application in that context and logging out should take you to the root of that application

This is a breaking change for applications where you want the logout path to be / even if Vaadin is deployed as /something and you then need to set the logout path explicitly to /
