### PR TITLE
fix: ensure default logout url starts with '/'

### DIFF
--- a/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/SecurityConfig.java
+++ b/flow-tests/vaadin-spring-tests/test-spring-security-flow/src/main/java/com/vaadin/flow/spring/flowsecurity/SecurityConfig.java
@@ -64,7 +64,12 @@ public class SecurityConfig extends VaadinWebSecurity {
                 .requestMatchers(new AntPathRequestMatcher("/public/**"))
                 .permitAll();
         super.configure(http);
-        setLoginView(http, LoginView.class, getLogoutSuccessUrl());
+        if (getLogoutSuccessUrl().equals("/")) {
+            // Test the default url with empty context path
+            setLoginView(http, LoginView.class);
+        } else {
+            setLoginView(http, LoginView.class, getLogoutSuccessUrl());
+        }
         http.logout().addLogoutHandler((request, response, authentication) -> {
             UI ui = UI.getCurrent();
             ui.accessSynchronously(() -> ui.getPage().setLocation(UrlUtil

--- a/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
+++ b/vaadin-spring/src/main/java/com/vaadin/flow/spring/security/VaadinWebSecurity.java
@@ -337,7 +337,7 @@ public abstract class VaadinWebSecurity {
      */
     protected void setLoginView(HttpSecurity http, String hillaLoginViewPath)
             throws Exception {
-        setLoginView(http, hillaLoginViewPath, servletContextPath);
+        setLoginView(http, hillaLoginViewPath, getDefaultLogoutUrl());
     }
 
     /**
@@ -387,7 +387,7 @@ public abstract class VaadinWebSecurity {
      */
     protected void setLoginView(HttpSecurity http,
             Class<? extends Component> flowLoginView) throws Exception {
-        setLoginView(http, flowLoginView, servletContextPath);
+        setLoginView(http, flowLoginView, getDefaultLogoutUrl());
     }
 
     /**
@@ -546,6 +546,11 @@ public abstract class VaadinWebSecurity {
         logoutSuccessHandler.setDefaultTargetUrl(logoutSuccessUrl);
         logoutSuccessHandler.setRedirectStrategy(new UidlRedirectStrategy());
         http.logout().logoutSuccessHandler(logoutSuccessHandler);
+    }
+
+    private String getDefaultLogoutUrl() {
+        return servletContextPath.startsWith("/") ? servletContextPath
+                : "/" + servletContextPath;
     }
 
     private VaadinSavedRequestAwareAuthenticationSuccessHandler getVaadinSavedRequestAwareAuthenticationSuccessHandler(


### PR DESCRIPTION
Spring Security requires logout url to start with `/`, otherwise throws
with `defaultTarget must start with '/' or with 'http(s)'`.

Our default value is using servlet context path, which could be empty. This
change adds the `/` prefix for the serlvet context path when using it for
logout url.