### PR TITLE
fix: Use current folder when prepare-frontend has not run

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/AbstractConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AbstractConfiguration.java
@@ -17,6 +17,8 @@ package com.vaadin.flow.server;
 
 import java.io.File;
 import java.io.Serializable;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import com.vaadin.flow.server.frontend.FrontendUtils;
 
@@ -160,9 +162,33 @@ public interface AbstractConfiguration extends Serializable {
      * @return the project root folder, or {@code null} if unknown
      */
     default File getProjectFolder() {
+        if (isProductionMode()) {
+            return null;
+        }
+
         String folder = getStringProperty(FrontendUtils.PROJECT_BASEDIR, null);
         if (folder == null) {
-            return new File("").getAbsoluteFile();
+            /*
+             * Accept user.dir or cwd as a fallback only if the directory seems
+             * to be a Maven or Gradle project. Check to avoid cluttering server
+             * directories (see tickets #8249, #8403).
+             */
+            String baseDirCandidate = System.getProperty("user.dir", ".");
+            Path path = Paths.get(baseDirCandidate);
+            if (path.toFile().isDirectory()
+                    && (path.resolve("pom.xml").toFile().exists() || path
+                            .resolve("build.gradle").toFile().exists())) {
+                return path.toAbsolutePath().toFile();
+            } else {
+                throw new IllegalStateException(String.format(
+                        "Failed to determine project directory for dev mode. "
+                                + "Directory '%s' does not look like a Maven or "
+                                + "Gradle project. Ensure that you have run the "
+                                + "prepare-frontend Maven goal, which generates "
+                                + "'flow-build-info.json', prior to deploying your "
+                                + "application",
+                        path.toString()));
+            }
         }
         return new File(folder);
     }

--- a/flow-server/src/main/java/com/vaadin/flow/server/AbstractConfiguration.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/AbstractConfiguration.java
@@ -162,7 +162,7 @@ public interface AbstractConfiguration extends Serializable {
     default File getProjectFolder() {
         String folder = getStringProperty(FrontendUtils.PROJECT_BASEDIR, null);
         if (folder == null) {
-            return null;
+            return new File("").getAbsoluteFile();
         }
         return new File(folder);
     }

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/startup/DevModeInitializer.java
@@ -203,11 +203,7 @@ public class DevModeInitializer implements Serializable {
 
         featureFlags.setPropertiesLocation(config.getJavaResourceFolder());
 
-        String baseDir = config.getStringProperty(FrontendUtils.PROJECT_BASEDIR,
-                null);
-        if (baseDir == null) {
-            baseDir = getBaseDirectoryFallback();
-        }
+        String baseDir = config.getProjectFolder().getAbsolutePath();
 
         // Initialize the usage statistics if enabled
         if (config.isUsageStatisticsEnabled()) {
@@ -383,30 +379,6 @@ public class DevModeInitializer implements Serializable {
 
     private static Logger log() {
         return LoggerFactory.getLogger(DevModeStartupListener.class);
-    }
-
-    /*
-     * Accept user.dir or cwd as a fallback only if the directory seems to be a
-     * Maven or Gradle project. Check to avoid cluttering server directories
-     * (see tickets #8249, #8403).
-     */
-    private static String getBaseDirectoryFallback() {
-        String baseDirCandidate = System.getProperty("user.dir", ".");
-        Path path = Paths.get(baseDirCandidate);
-        if (path.toFile().isDirectory()
-                && (path.resolve("pom.xml").toFile().exists()
-                        || path.resolve("build.gradle").toFile().exists())) {
-            return path.toString();
-        } else {
-            throw new IllegalStateException(String.format(
-                    "Failed to determine project directory for dev mode. "
-                            + "Directory '%s' does not look like a Maven or "
-                            + "Gradle project. Ensure that you have run the "
-                            + "prepare-frontend Maven goal, which generates "
-                            + "'flow-build-info.json', prior to deploying your "
-                            + "application",
-                    path.toString()));
-        }
     }
 
     /*

--- a/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/AbstractDevModeTest.java
+++ b/vaadin-dev-server/src/test/java/com/vaadin/base/devserver/startup/AbstractDevModeTest.java
@@ -57,7 +57,7 @@ public abstract class AbstractDevModeTest {
         npmFolder = temporaryFolder.getRoot();
 
         Boolean enablePnpm = Boolean.TRUE;
-        appConfig = Mockito.mock(ApplicationConfiguration.class);
+        appConfig = Mockito.spy(ApplicationConfiguration.class);
 
         servletContext = Mockito.mock(ServletContext.class);
         Mockito.when(servletContext


### PR DESCRIPTION
When you launch a Spring Boot Application class directly from the IDE, there is no PROJECT_BASEDIR info available
