### PR TITLE
fix: avoid infinite recursion on imported directories

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -474,6 +474,11 @@ abstract class AbstractUpdateImports implements Runnable {
         return getFile(base, path).isFile();
     }
 
+    private boolean isFileOrDirectory(File base, String... path) {
+        File file = getFile(base, path);
+        return file.isFile() || file.isDirectory();
+    }
+
     private boolean addCssLines(Collection<String> lines, CssData cssData,
             int i) {
         String cssFile = resolveResource(cssData.getValue());
@@ -540,7 +545,8 @@ abstract class AbstractUpdateImports implements Runnable {
     private String toValidBrowserImport(String jsImport) {
         if (jsImport.startsWith(NodeUpdater.GENERATED_PREFIX)) {
             return generatedResourcePathIntoRelativePath(jsImport);
-        } else if (isFile(options.getFrontendDirectory(), jsImport)) {
+        } else if (isFileOrDirectory(options.getFrontendDirectory(),
+                jsImport)) {
             if (!jsImport.startsWith("./")) {
                 getLogger().warn(
                         "Use the './' prefix for files in the '{}' folder: '{}', please update your annotations.",
@@ -613,7 +619,8 @@ abstract class AbstractUpdateImports implements Runnable {
             return;
         }
         Path filePath = file.toPath();
-        String normalizedPath = filePath.normalize().toString().replace("\\", "/");
+        String normalizedPath = filePath.normalize().toString().replace("\\",
+                "/");
         if (!visitedImports.add(normalizedPath)) {
             return;
         }
@@ -642,8 +649,13 @@ abstract class AbstractUpdateImports implements Runnable {
      */
     private String resolve(String importedPath, Path moduleFile, String path) {
         String pathPrefix = moduleFile.toString();
-        pathPrefix = pathPrefix.substring(0,
-                pathPrefix.length() - path.length());
+        int pathLength = path.length();
+        // path may have been resolved as `path/index.js`, if path points to a
+        // directory
+        if (!moduleFile.endsWith(path) && moduleFile.endsWith("index.js")) {
+            pathLength += 9;
+        }
+        pathPrefix = pathPrefix.substring(0, pathPrefix.length() - pathLength);
         try {
             String resolvedPath = moduleFile.getParent().resolve(importedPath)
                     .toString();

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java
@@ -613,7 +613,10 @@ abstract class AbstractUpdateImports implements Runnable {
             return;
         }
         Path filePath = file.toPath();
-        visitedImports.add(filePath.normalize().toString().replace("\\", "/"));
+        String normalizedPath = filePath.normalize().toString().replace("\\", "/");
+        if (!visitedImports.add(normalizedPath)) {
+            return;
+        }
         try {
             visitImportsRecursively(filePath, path, theme, imports,
                     visitedImports);


### PR DESCRIPTION
Close #15595

## Description

The check of whether the file has already been visited should be done after converting a directory to `directory/index.js` by `getImportedFrontendFile` (#15023). Otherwise, `directory` would never be found in `visitedPath`, and it will enter infinite recursion.

https://github.com/vaadin/flow/blob/444befa9c3ad393ed80174c5ccc3c13c5bfb8591/flow-server/src/main/java/com/vaadin/flow/server/frontend/AbstractUpdateImports.java#L631-L639


## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
