### PR TITLE
feat: add API to fetch page direction

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -675,11 +675,10 @@ public class Page implements Serializable {
      *            to be notified when the direction is resolved.
      */
     public void fetchPageDirection(SerializableConsumer<Direction> callback) {
-        UI.getCurrent().getPage().executeJs("return document.dir")
-                .then(String.class, dir -> {
-                    Direction direction = getDirectionByClientName(dir);
-                    callback.accept(direction);
-                });
+        executeJs("return document.dir").then(String.class, dir -> {
+            Direction direction = getDirectionByClientName(dir);
+            callback.accept(direction);
+        });
     }
 
     private Direction getDirectionByClientName(String directionClientName) {

--- a/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
+++ b/flow-server/src/main/java/com/vaadin/flow/component/page/Page.java
@@ -24,12 +24,14 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.Function;
 
 import com.vaadin.flow.component.ClientCallable;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEvent;
+import com.vaadin.flow.component.Direction;
 import com.vaadin.flow.component.Tag;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.dependency.JavaScript;
@@ -654,5 +656,36 @@ public class Page implements Serializable {
                         "Error while encoding the URL from client", e);
             }
         });
+    }
+
+    /**
+     * Retrieves {@code document.dir} of the current UI from the browser and
+     * passes it to the {@code callback} parameter. If the {@code document.dir}
+     * has not been set explicitly, then {@code Direction.LEFT_TO_RIGHT} will be
+     * the fallback value.
+     * <p>
+     * Note that direction is fetched from the browser in an asynchronous
+     * request and passed to the callback.
+     * <p>
+     * In case you need more control over the execution you can use
+     * {@link #executeJs(String, Serializable...)} by passing
+     * {@code return document.dir}.
+     *
+     * @param callback
+     *            to be notified when the direction is resolved.
+     */
+    public void fetchPageDirection(SerializableConsumer<Direction> callback) {
+        UI.getCurrent().getPage().executeJs("return document.dir")
+                .then(String.class, dir -> {
+                    Direction direction = getDirectionByClientName(dir);
+                    callback.accept(direction);
+                });
+    }
+
+    private Direction getDirectionByClientName(String directionClientName) {
+        return Arrays.stream(Direction.values())
+                .filter(direction -> direction.getClientName()
+                        .equals(directionClientName))
+                .findFirst().orElse(Direction.LEFT_TO_RIGHT);
     }
 }

--- a/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PageView.java
+++ b/flow-tests/test-root-context/src/main/java/com/vaadin/flow/uitest/ui/PageView.java
@@ -1,8 +1,10 @@
 package com.vaadin.flow.uitest.ui;
 
+import com.vaadin.flow.component.Direction;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.IFrame;
 import com.vaadin.flow.component.html.Input;
+import com.vaadin.flow.component.html.Label;
 import com.vaadin.flow.component.html.NativeButton;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.Route;
@@ -78,6 +80,32 @@ public class PageView extends AbstractDivView {
                         .info(currentUrl.toString());
             }));
         }));
+
+        Label directionLbl = new Label();
+        directionLbl.setId("direction-value");
+        add(directionLbl);
+
+        Div fetchDirectionButton = new Div();
+        fetchDirectionButton.setId("fetch-direction");
+        fetchDirectionButton.setText("Fetch Page Direction");
+        fetchDirectionButton.addClickListener(
+                e -> getUI().ifPresent(ui -> ui.getPage().fetchPageDirection(
+                        direction -> directionLbl.setText(direction.name()))));
+        add(fetchDirectionButton);
+
+        Div setRTLDirectionButton = new Div();
+        setRTLDirectionButton.setId("set-RTL-direction");
+        setRTLDirectionButton.setText("Set RTL Direction");
+        setRTLDirectionButton.addClickListener(e -> getUI()
+                .ifPresent(ui -> ui.setDirection(Direction.RIGHT_TO_LEFT)));
+        add(setRTLDirectionButton);
+
+        Div setLTRDirectionButton = new Div();
+        setLTRDirectionButton.setId("set-LTR-direction");
+        setLTRDirectionButton.setText("Set LTR Direction");
+        setLTRDirectionButton.addClickListener(e -> getUI()
+                .ifPresent(ui -> ui.setDirection(Direction.LEFT_TO_RIGHT)));
+        add(setLTRDirectionButton);
     }
 
 }

--- a/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PageIT.java
+++ b/flow-tests/test-root-context/src/test/java/com/vaadin/flow/uitest/ui/PageIT.java
@@ -109,6 +109,49 @@ public class PageIT extends ChromeBrowserTest {
                 Matchers.endsWith(BaseHrefView.class.getName()));
     }
 
+    @Test
+    public void fetchPageDirection_noDirectionSetExplicitly_leftToRightIsPassedToCallback() {
+        open();
+
+        Assert.assertEquals("",
+                findElement(By.id("direction-value")).getText());
+
+        findElement(By.id("fetch-direction")).click();
+
+        Assert.assertEquals("LEFT_TO_RIGHT",
+                findElement(By.id("direction-value")).getText());
+    }
+
+    @Test
+    public void fetchPageDirection_setRTLDirection_rightToLeftIsPassedToCallback() {
+        open();
+
+        Assert.assertEquals("",
+                findElement(By.id("direction-value")).getText());
+
+        findElement(By.id("set-RTL-direction")).click();
+
+        findElement(By.id("fetch-direction")).click();
+
+        Assert.assertEquals("RIGHT_TO_LEFT",
+                findElement(By.id("direction-value")).getText());
+    }
+
+    @Test
+    public void fetchPageDirection_setLTRDirection_leftToRightIsPassedToCallback() {
+        open();
+
+        Assert.assertEquals("",
+                findElement(By.id("direction-value")).getText());
+
+        findElement(By.id("set-LTR-direction")).click();
+
+        findElement(By.id("fetch-direction")).click();
+
+        Assert.assertEquals("LEFT_TO_RIGHT",
+                findElement(By.id("direction-value")).getText());
+    }
+
     private String getIframeUrl() {
         return (String) ((JavascriptExecutor) driver).executeScript(
                 "return document.getElementById('newWindow').contentWindow.location.href;");


### PR DESCRIPTION
## Description

Add API to fetch the document.dir from browser
and pass it to the provided callback.

Fixes #15597 

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
