### PR TITLE
fix: Add tsconfig to vaadin-dev-server to avoid IDE errors

### DIFF
--- a/vaadin-dev-server/tsconfig.json
+++ b/vaadin-dev-server/tsconfig.json
@@ -1,0 +1,22 @@
+// This is included to allow decorators in TS files
+{
+  "compilerOptions": {
+    "sourceMap": true,
+    "jsx": "react-jsx",
+    "inlineSources": true,
+    "module": "esNext",
+    "target": "es2020",
+    "moduleResolution": "node",
+    "strict": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "experimentalDecorators": true,
+    "useDefineForClassFields": false,
+    "skipLibCheck": true,
+    "baseUrl": "."
+  }
+}


### PR DESCRIPTION
Experimental decorators are off by default for tsc
