### PR TITLE
fix: replace any 'Frontend/' with './'

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/GenerateMainImports.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/GenerateMainImports.java
@@ -145,9 +145,11 @@ public class GenerateMainImports extends AbstractUpdateImports {
         JsonArray statsBundle = statsJson.hasKey("bundleImports")
                 ? statsJson.getArray("bundleImports")
                 : Json.createArray();
+        importName = importName.replace("Frontend/", "./");
 
         for (int i = 0; i < statsBundle.length(); i++) {
-            if (importName.equals(statsBundle.getString(i))) {
+            if (importName.equals(
+                    statsBundle.getString(i).replace("Frontend/", "./"))) {
                 return true;
             }
         }

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuild.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/TaskRunDevBundleBuild.java
@@ -163,8 +163,9 @@ public class TaskRunDevBundleBuild implements FallibleCommand {
     }
 
     private static boolean arrayContainsString(JsonArray array, String string) {
+        string = string.replace("Frontend/", "./");
         for (int i = 0; i < array.length(); i++) {
-            if (string.equals(array.getString(i))) {
+            if (string.equals(array.getString(i).replace("Frontend/", "./"))) {
                 return true;
             }
         }

--- a/flow-tests/test-express-build/test-dev-bundle-no-plugin/src/test/java/com/vaadin/flow/testnpmonlyfeatures/nobuildmojo/NoAppBundleIT.java
+++ b/flow-tests/test-express-build/test-dev-bundle-no-plugin/src/test/java/com/vaadin/flow/testnpmonlyfeatures/nobuildmojo/NoAppBundleIT.java
@@ -1,0 +1,45 @@
+package com.vaadin.flow.testnpmonlyfeatures.nobuildmojo;
+
+import java.io.File;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+
+public class NoAppBundleIT extends ChromeBrowserTest {
+
+    @Before
+    public void init() {
+        open();
+    }
+
+    @Override
+    protected String getTestPath() {
+        return "/run/com.vaadin.flow.testnpmonlyfeatures.nobuildmojo.MultipleNpmPackageAnnotationsView";
+    }
+
+    @Test
+    public void noFrontendFilesCreated() {
+        File baseDir = new File(System.getProperty("user.dir", "."));
+
+        // shouldn't create a dev-bundle
+        Assert.assertFalse("No dev-bundle should be created",
+                new File(baseDir, "dev-bundle").exists());
+        Assert.assertFalse("No node_modules should be created",
+                new File(baseDir, "node_modules").exists());
+
+        // These should not be generated either, but at the moment they are
+        // Assert.assertFalse("No package.json should be created", new
+        // File(baseDir, "package.json").exists());
+        // Assert.assertFalse("No vite generated should be created", new
+        // File(baseDir, "vite.generated.ts").exists());
+        // Assert.assertFalse("No vite config should be created", new
+        // File(baseDir, "vite.config.ts").exists());
+        // Assert.assertFalse("No types should be created", new File(baseDir,
+        // "types.d.ts").exists());
+        // Assert.assertFalse("No tsconfig should be created", new File(baseDir,
+        // "tsconfig.json").exists());
+    }
+}


### PR DESCRIPTION
Stats.json records some handled files as `Frontend/...` where as the requested file may be in the format `./...`
Use each `Frontend/` always as `./`