### PR TITLE
fix: Not start watching theme if no theme is used

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/communication/IndexHtmlRequestHandler.java
@@ -164,7 +164,7 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
      * which is served in express build mode by static file server directly from
      * frontend/themes folder.
      * </p>
-     * Example: <link rel="stylesheet" href="themes/hello-speed-foo/styles.css">
+     * Example: <link rel="stylesheet" href="themes/my-theme/styles.css">
      *
      * @param config
      *            deployment configuration
@@ -175,14 +175,19 @@ public class IndexHtmlRequestHandler extends JavaScriptBootstrapHandler {
      */
     private void addStylesCssLink(DeploymentConfiguration config,
             Document indexDocument) throws IOException {
-        String themeName = FrontendUtils
+        Optional<String> themeName = FrontendUtils
                 .getThemeName(config.getProjectFolder());
-        if (themeName != null) {
-            Element element = new Element("link");
-            element.attr("rel", "stylesheet");
-            element.attr("href", "themes/" + themeName + "/styles.css");
-            indexDocument.head().appendChild(element);
+
+        if (themeName.isEmpty()) {
+            getLogger().debug("Found no custom theme in the project. "
+                    + "Skipping adding a link tag for styles.css");
+            return;
         }
+
+        Element element = new Element("link");
+        element.attr("rel", "stylesheet");
+        element.attr("href", "themes/" + themeName.get() + "/styles.css");
+        indexDocument.head().appendChild(element);
     }
 
     private void catchErrorsInDevMode(Document indexDocument) {

--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/FrontendUtils.java
@@ -1215,21 +1215,32 @@ public class FrontendUtils {
         return IOUtils.toString(statsJson, StandardCharsets.UTF_8);
     }
 
-    public static String getThemeName(File projectFolder) throws IOException {
+    /**
+     * Gets the custom theme name if the custom theme is used in the project.
+     * <p>
+     * Should be only used in the development mode.
+     *
+     * @param projectFolder
+     *            the project root folder
+     * @return custom theme name or empty optional if no theme is used
+     * @throws IOException
+     *             if I/O exceptions occur while trying to extract the theme
+     *             name.
+     */
+    public static Optional<String> getThemeName(File projectFolder)
+            throws IOException {
         File themeJs = new File(projectFolder, FrontendUtils.FRONTEND
                 + FrontendUtils.GENERATED + FrontendUtils.THEME_IMPORTS_NAME);
 
         if (!themeJs.exists()) {
-            getLogger().debug(
-                    "Couldn't find file 'theme.js'. A link tag for styles.css won't be added");
-            return null;
+            return Optional.empty();
         }
 
         String themeJsContent = FileUtils.readFileToString(themeJs,
                 StandardCharsets.UTF_8);
         Matcher matcher = THEME_GENERATED_FILE_PATTERN.matcher(themeJsContent);
         if (matcher.find()) {
-            return matcher.group(1);
+            return Optional.of(matcher.group(1));
         } else {
             throw new IllegalStateException(
                     "Couldn't extract theme name from theme imports file 'theme.js'");

--- a/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerManagerImpl.java
+++ b/vaadin-dev-server/src/main/java/com/vaadin/base/devserver/DevModeHandlerManagerImpl.java
@@ -106,13 +106,20 @@ public class DevModeHandlerManagerImpl implements DevModeHandlerManager {
 
         try {
             File projectFolder = config.getProjectFolder();
-            String themeName = FrontendUtils.getThemeName(projectFolder);
+            Optional<String> themeName = FrontendUtils
+                    .getThemeName(projectFolder);
+
+            if (themeName.isEmpty()) {
+                getLogger().debug("Found no custom theme in the project. "
+                        + "Skipping watching the theme files");
+                return;
+            }
 
             // TODO: frontend folder to be taken from config
             // see https://github.com/vaadin/flow/pull/15552
             File watchDirectory = new File(projectFolder,
                     Path.of(FrontendUtils.FRONTEND,
-                            Constants.APPLICATION_THEME_ROOT, themeName)
+                            Constants.APPLICATION_THEME_ROOT, themeName.get())
                             .toString());
 
             Optional<BrowserLiveReload> liveReload = BrowserLiveReloadAccessor


### PR DESCRIPTION
Does not add a link tag for theme styles and does not watch the theme folder if no theme is used in the project.