### PR TITLE
fix: apply variant when using default theme

### DIFF
--- a/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
+++ b/flow-server/src/main/java/com/vaadin/flow/server/frontend/scanner/FrontendDependencies.java
@@ -331,6 +331,7 @@ public class FrontendDependencies extends AbstractDependenciesScanner {
                 .filter(data -> data.getTheme().getThemeClass() != null
                         || (data.getTheme().getThemeName() != null
                                 && !data.getTheme().getThemeName().isEmpty())
+                        || !data.getTheme().getVariant().isEmpty()
                         || data.getTheme().isNotheme())
                 .map(EndPointData::getTheme)
                 // Remove duplicates by returning a set

--- a/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
+++ b/flow-server/src/test/java/com/vaadin/flow/server/frontend/scanner/FrontendDependenciesTest.java
@@ -178,6 +178,21 @@ public class FrontendDependenciesTest {
     }
 
     @Test
+    public void onlyThemeVariantDefined_getsLumoAsTheme_preserveVariant() {
+        Mockito.when(classFinder.getSubTypesOf(AppShellConfigurator.class))
+                .thenReturn(Collections.singleton(ThemeVariantOnly.class));
+
+        FrontendDependencies dependencies = new FrontendDependencies(
+                classFinder, false);
+
+        Assert.assertEquals("Faulty default theme received", FakeLumo.class,
+                dependencies.getThemeDefinition().getTheme());
+        Assert.assertEquals("Faulty variant received", "dark",
+                dependencies.getThemeDefinition().getVariant());
+
+    }
+
+    @Test
     public void hasErrorParameterComponent_endpointIsCollected() {
         Mockito.when(classFinder.getSubTypesOf(HasErrorParameter.class))
                 .thenReturn(Collections.singleton(ErrorComponent.class));
@@ -369,6 +384,10 @@ public class FrontendDependenciesTest {
 
     @Theme(value = "my-theme", themeClass = FakeLumo.class)
     public static class FaultyThemeAnnotation implements AppShellConfigurator {
+    }
+
+    @Theme(variant = "dark")
+    public static class ThemeVariantOnly implements AppShellConfigurator {
     }
 
     @JsModule("reference.js")


### PR DESCRIPTION
## Description

If Theme annotation specifies a variant but not theme name or class, the production build applies the default Lumo theme but without the variant. This change makes the variant work even when theme name or class are not specified.

Fixes #15638

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
